### PR TITLE
QUE-1370: Convert AccordionList to TypeScript

### DIFF
--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
@@ -1,7 +1,9 @@
 import cx from "classnames";
 import { useCallback, useMemo } from "react";
 
-import AccordionList from "metabase/core/components/AccordionList";
+import AccordionList, {
+  type Section,
+} from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import { Icon } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
@@ -30,11 +32,6 @@ type Item = {
   database: Database;
 };
 
-type Section = {
-  name?: JSX.Element;
-  items?: Item[];
-};
-
 const DataSelectorDatabasePicker = ({
   databases,
   selectedDatabase,
@@ -44,10 +41,13 @@ const DataSelectorDatabasePicker = ({
   hasInitialFocus,
 }: DataSelectorDatabasePickerProps) => {
   const sections = useMemo(() => {
-    const sections: Section[] = [];
+    const sections: Section<Item>[] = [];
 
     if (onBack) {
-      sections.push({ name: <RawDataBackButton /> });
+      sections.push({
+        name: <RawDataBackButton />,
+        items: [],
+      });
     }
 
     sections.push({
@@ -62,7 +62,7 @@ const DataSelectorDatabasePicker = ({
   }, [databases, onBack]);
 
   const handleChangeSection = useCallback(
-    (section: Section, sectionIndex: number) => {
+    (_section: Section<Item>, sectionIndex: number) => {
       const isNavigationSection = onBack && sectionIndex === 0;
       if (isNavigationSection) {
         onBack();
@@ -77,7 +77,7 @@ const DataSelectorDatabasePicker = ({
   }
 
   return (
-    <AccordionList
+    <AccordionList<Item>
       id="DatabasePicker"
       key="databasePicker"
       className={CS.textBrand}
@@ -85,7 +85,7 @@ const DataSelectorDatabasePicker = ({
       sections={sections}
       onChange={(item: Item) => onChangeDatabase(item.database)}
       onChangeSection={handleChangeSection}
-      itemIsSelected={(item: Item) =>
+      itemIsSelected={(item) =>
         selectedDatabase && item.database.id === selectedDatabase.id
       }
       renderItemIcon={() => (

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
@@ -1,7 +1,8 @@
 import cx from "classnames";
 import { useCallback, useMemo } from "react";
 
-import AccordionList, {
+import {
+  AccordionList,
   type Section,
 } from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
@@ -24,7 +24,6 @@ type DataSelectorDatabasePickerProps = {
   selectedSchema?: Schema;
   onBack?: () => void;
   onChangeDatabase: (database: Database) => void;
-  onChangeSchema: (item: { schema?: Schema }) => void;
 };
 
 type Item = {
@@ -84,7 +83,7 @@ const DataSelectorDatabasePicker = ({
       className={CS.textBrand}
       hasInitialFocus={hasInitialFocus}
       sections={sections}
-      onChange={(item: Item) => onChangeDatabase(item.database)}
+      onChange={(item) => onChangeDatabase(item.database)}
       onChangeSection={handleChangeSection}
       itemIsSelected={(item) =>
         selectedDatabase && item.database.id === selectedDatabase.id

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabasePicker/DataSelectorDatabasePicker.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabasePicker/DataSelectorDatabasePicker.unit.spec.tsx
@@ -22,7 +22,6 @@ const setup = () => {
     <DataSelectorDatabasePicker
       databases={[database]}
       onChangeDatabase={jest.fn()}
-      onChangeSchema={jest.fn()}
     />,
   );
 };

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -123,7 +123,9 @@ const DataSelectorDatabaseSchemaPicker = ({
       renderItemIcon={() => <Icon name="folder" size={16} />}
       initiallyOpenSection={openSection}
       alwaysTogglable={true}
-      showSpinner={(x) => "active" in x && x.active === false}
+      showSpinner={(itemOrSection) =>
+        "active" in itemOrSection && itemOrSection.active === false
+      }
       showItemArrows={hasNextStep}
       maxHeight={Infinity}
     />

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -1,7 +1,8 @@
 import cx from "classnames";
 import { t } from "ttag";
 
-import AccordionList, {
+import {
+  AccordionList,
   type Section,
 } from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -1,11 +1,11 @@
 import cx from "classnames";
-import type * as React from "react";
 import { t } from "ttag";
 
-import AccordionList from "metabase/core/components/AccordionList";
+import AccordionList, {
+  type Section,
+} from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import { isSyncCompleted } from "metabase/lib/syncing";
-import type { IconName } from "metabase/ui";
 import { Icon } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type Schema from "metabase-lib/v1/metadata/Schema";
@@ -27,20 +27,10 @@ type DataSelectorDatabaseSchemaPicker = {
   onChangeSchema: (item: { schema?: Schema }) => void;
 };
 
-type Section = {
-  name: string | React.ReactElement;
-  items?: {
-    schema: Schema;
-    name: string;
-  }[];
-  className?: string | null;
-  icon?: IconName;
-  loading?: boolean;
-  active: boolean;
-  type?: string;
+type Item = {
+  schema: Schema;
+  name: string;
 };
-
-type Sections = Section[];
 
 const DataSelectorDatabaseSchemaPicker = ({
   databases,
@@ -58,7 +48,7 @@ const DataSelectorDatabaseSchemaPicker = ({
     return <DataSelectorLoading />;
   }
 
-  const sections: Sections = databases.map((database) => ({
+  const sections: Section<Item>[] = databases.map((database) => ({
     name: database.is_saved_questions ? t`Saved Questions` : database.name,
     items:
       !database.is_saved_questions && database.getSchemas().length > 1
@@ -95,12 +85,10 @@ const DataSelectorDatabaseSchemaPicker = ({
     return true;
   };
 
-  const showSpinner = ({ active }: { active?: boolean }) => active === false;
-
-  const renderSectionIcon = ({ icon }: { icon?: IconName }) =>
-    icon && (
+  const renderSectionIcon = ({ icon }: Section) =>
+    icon ? (
       <Icon className={cx("Icon", CS.textDefault)} name={icon} size={18} />
-    );
+    ) : null;
 
   if (hasBackButton) {
     sections.unshift({
@@ -121,7 +109,7 @@ const DataSelectorDatabaseSchemaPicker = ({
   }
 
   return (
-    <AccordionList
+    <AccordionList<Item>
       id="DatabaseSchemaPicker"
       key="databaseSchemaPicker"
       className={CS.textBrand}
@@ -129,12 +117,12 @@ const DataSelectorDatabaseSchemaPicker = ({
       sections={sections}
       onChange={({ schema }: any) => onChangeSchema(schema)}
       onChangeSection={handleChangeSection}
-      itemIsSelected={(schema: Schema) => schema === selectedSchema}
+      itemIsSelected={({ schema }) => schema === selectedSchema}
       renderSectionIcon={renderSectionIcon}
       renderItemIcon={() => <Icon name="folder" size={16} />}
       initiallyOpenSection={openSection}
       alwaysTogglable={true}
-      showSpinner={showSpinner}
+      showSpinner={(x) => "active" in x && x.active === false}
       showItemArrows={hasNextStep}
       maxHeight={Infinity}
     />

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorSchemaPicker/DataSelectorSchemaPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorSchemaPicker/DataSelectorSchemaPicker.tsx
@@ -1,4 +1,4 @@
-import AccordionList from "metabase/core/components/AccordionList";
+import { AccordionList } from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import { Box, Icon } from "metabase/ui";
 import type Schema from "metabase-lib/v1/metadata/Schema";

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -110,8 +110,8 @@ const DataSelectorTablePicker = ({
       <HoverParent>{content}</HoverParent>
     );
 
-    const showSpinner = (x: Item | Section<Item>) =>
-      "table" in x && !isSyncCompleted(x.table);
+    const showSpinner = (itemOrSection: Item | Section<Item>) =>
+      "table" in itemOrSection && !isSyncCompleted(itemOrSection.table);
 
     const handleChange = ({ table }: { table: Table }) => onChangeTable(table);
 

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -7,7 +7,8 @@ import {
   HoverParent,
   TableInfoIcon,
 } from "metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
-import AccordionList, {
+import {
+  AccordionList,
   type Section,
 } from "metabase/core/components/AccordionList";
 import ExternalLink from "metabase/core/components/ExternalLink";

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -7,7 +7,9 @@ import {
   HoverParent,
   TableInfoIcon,
 } from "metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
-import AccordionList from "metabase/core/components/AccordionList";
+import AccordionList, {
+  type Section,
+} from "metabase/core/components/AccordionList";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
@@ -34,6 +36,12 @@ type DataSelectorTablePickerProps = {
   tables: Table[];
   onBack?: () => void;
   onChangeTable: (table: Table) => void;
+};
+
+type Item = {
+  name: string;
+  table: Table;
+  database: Database;
 };
 
 type HeaderProps = Pick<
@@ -75,7 +83,7 @@ const DataSelectorTablePicker = ({
   );
 
   if (tables.length > 0 || isLoading) {
-    const sections = [
+    const sections: Section<Item>[] = [
       {
         name: header,
         items: tables.filter(isNotNull).map((table) => ({
@@ -101,8 +109,8 @@ const DataSelectorTablePicker = ({
       <HoverParent>{content}</HoverParent>
     );
 
-    const showSpinner = ({ table }: { table: Table }) =>
-      Boolean(table && !isSyncCompleted(table));
+    const showSpinner = (x: Item | Section<Item>) =>
+      "table" in x && !isSyncCompleted(x.table);
 
     const handleChange = ({ table }: { table: Table }) => onChangeTable(table);
 
@@ -111,7 +119,7 @@ const DataSelectorTablePicker = ({
     return (
       <DelayGroup>
         <Box w={rem(300)} style={{ overflowY: "auto" }}>
-          <AccordionList
+          <AccordionList<Item>
             id="TablePicker"
             key="tablePicker"
             className={CS.textBrand}

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionOptionsButton.jsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 
 import { canonicalCollectionId } from "metabase/collections/utils";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
-import AccordionList from "metabase/core/components/AccordionList";
+import { AccordionList } from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import { Icon } from "metabase/ui";
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -53,7 +53,7 @@ type MetricListItem = Lib.MetricDisplayInfo & {
   selected: boolean;
 };
 
-type ListItem = OperatorListItem | MetricListItem;
+type Item = OperatorListItem | MetricListItem;
 
 export function AggregationPicker({
   className,
@@ -111,7 +111,7 @@ export function AggregationPicker({
   );
 
   const sections = useMemo(() => {
-    const sections: Section<ListItem>[] = [];
+    const sections: Section<Item>[] = [];
 
     const metrics = Lib.availableMetrics(query, stageIndex);
     const databaseId = Lib.databaseID(query);
@@ -164,10 +164,7 @@ export function AggregationPicker({
     allowCustomExpressions,
   ]);
 
-  const checkIsItemSelected = useCallback(
-    (item: ListItem) => item.selected,
-    [],
-  );
+  const checkIsItemSelected = useCallback((item: Item) => item.selected, []);
 
   const handleOperatorSelect = useCallback(
     (item: OperatorListItem) => {
@@ -208,7 +205,7 @@ export function AggregationPicker({
   );
 
   const handleChange = useCallback(
-    (item: ListItem) => {
+    (item: Item) => {
       if (item.type === "operator") {
         handleOperatorSelect(item);
       } else if (item.type === "metric") {
@@ -281,7 +278,7 @@ export function AggregationPicker({
 
   return (
     <Box className={className} c="summarize" data-testid="aggregation-picker">
-      <AccordionList<ListItem>
+      <AccordionList<Item>
         sections={sections}
         onChange={handleChange}
         onChangeSection={handleSectionChange}
@@ -319,7 +316,7 @@ function ColumnPickerHeader({
   );
 }
 
-function renderItemName(item: ListItem) {
+function renderItemName(item: Item) {
   return item.displayName;
 }
 
@@ -327,7 +324,7 @@ function renderItemWrapper(content: ReactNode) {
   return <HoverParent>{content}</HoverParent>;
 }
 
-function renderItemIcon(item: ListItem) {
+function renderItemIcon(item: Item) {
   if (item.type !== "metric") {
     return null;
   }

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -7,7 +7,8 @@ import {
   PopoverHoverTarget,
 } from "metabase/components/MetadataInfo/InfoIcon";
 import { Popover } from "metabase/components/MetadataInfo/Popover";
-import AccordionList, {
+import {
+  AccordionList,
   type Section,
 } from "metabase/core/components/AccordionList";
 import Markdown from "metabase/core/components/Markdown";

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -7,7 +7,9 @@ import {
   PopoverHoverTarget,
 } from "metabase/components/MetadataInfo/InfoIcon";
 import { Popover } from "metabase/components/MetadataInfo/Popover";
-import AccordionList from "metabase/core/components/AccordionList";
+import AccordionList, {
+  type Section,
+} from "metabase/core/components/AccordionList";
 import Markdown from "metabase/core/components/Markdown";
 import { useToggle } from "metabase/hooks/use-toggle";
 import { useSelector } from "metabase/lib/redux";
@@ -51,14 +53,6 @@ type MetricListItem = Lib.MetricDisplayInfo & {
 };
 
 type ListItem = OperatorListItem | MetricListItem;
-
-type Section = {
-  name?: string;
-  key: string;
-  items: ListItem[];
-  icon?: string;
-  type?: string;
-};
 
 export function AggregationPicker({
   className,
@@ -116,7 +110,7 @@ export function AggregationPicker({
   );
 
   const sections = useMemo(() => {
-    const sections: Section[] = [];
+    const sections: Section<ListItem>[] = [];
 
     const metrics = Lib.availableMetrics(query, stageIndex);
     const databaseId = Lib.databaseID(query);
@@ -286,7 +280,7 @@ export function AggregationPicker({
 
   return (
     <Box className={className} c="summarize" data-testid="aggregation-picker">
-      <AccordionList
+      <AccordionList<ListItem>
         sections={sections}
         onChange={handleChange}
         onChangeSection={handleSectionChange}

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-import AccordionList from "metabase/core/components/AccordionList";
+import { AccordionList } from "metabase/core/components/AccordionList";
 import { color } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -6,14 +6,16 @@ import {
   HoverParent,
   QueryColumnInfoIcon,
 } from "metabase/components/MetadataInfo/ColumnInfoIcon";
+import AccordionList, {
+  type Section,
+} from "metabase/core/components/AccordionList";
+import { color } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
-import type { IconName } from "metabase/ui";
 import { DelayGroup } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { BucketPickerPopover } from "./BucketPickerPopover";
 import S from "./QueryColumnPicker.module.css";
-import { StyledAccordionList } from "./QueryColumnPicker.styled";
 
 export type ColumnListItem = Lib.ColumnDisplayInfo & {
   column: Lib.ColumnMetadata;
@@ -40,12 +42,6 @@ export interface QueryColumnPickerProps {
   disableSearch?: boolean;
 }
 
-type Sections = {
-  name: string;
-  items: ColumnListItem[];
-  icon?: IconName;
-};
-
 export function QueryColumnPicker({
   className,
   query,
@@ -55,7 +51,7 @@ export function QueryColumnPicker({
   hasTemporalBucketing = false,
   withDefaultBucketing = true,
   withInfoIcons = false,
-  color = "brand",
+  color: colorProp = "brand",
   checkIsColumnSelected,
   onSelect,
   onClose,
@@ -65,7 +61,7 @@ export function QueryColumnPicker({
   alwaysExpanded,
   disableSearch,
 }: QueryColumnPickerProps) {
-  const sections: Sections[] = useMemo(
+  const sections: Section<ColumnListItem>[] = useMemo(
     () =>
       columnGroups.map((group) => {
         const groupInfo = Lib.displayInfo(query, stageIndex, group);
@@ -161,7 +157,7 @@ export function QueryColumnPicker({
             hasBinning={hasBinning}
             hasTemporalBucketing={hasTemporalBucketing}
             hasChevronDown={withInfoIcons}
-            color={color}
+            color={colorProp}
             onSelect={handleSelect}
           />
         )
@@ -174,7 +170,7 @@ export function QueryColumnPicker({
       hasBinning,
       hasTemporalBucketing,
       withInfoIcons,
-      color,
+      colorProp,
       handleSelect,
     ],
   );
@@ -193,7 +189,7 @@ export function QueryColumnPicker({
 
   return (
     <DelayGroup>
-      <StyledAccordionList
+      <AccordionList<ColumnListItem>
         className={className}
         sections={sections}
         alwaysExpanded={alwaysExpanded}
@@ -204,7 +200,9 @@ export function QueryColumnPicker({
         renderItemExtra={renderItemExtra}
         renderItemDescription={omitItemDescription}
         renderItemIcon={renderItemIcon}
-        color={color}
+        style={{
+          color: color(colorProp),
+        }}
         maxHeight={Infinity}
         data-testid={dataTestId}
         searchProp={["name", "displayName"]}

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -6,7 +6,8 @@ import {
   HoverParent,
   QueryColumnInfoIcon,
 } from "metabase/components/MetadataInfo/ColumnInfoIcon";
-import AccordionList, {
+import {
+  AccordionList,
   type Section,
 } from "metabase/core/components/AccordionList";
 import { color } from "metabase/lib/colors";

--- a/frontend/src/metabase/components/MetadataInfo/InfoIcon/InfoIcon.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/InfoIcon/InfoIcon.styled.tsx
@@ -7,7 +7,7 @@ export const PopoverHoverTarget = styled(Icon)`
   flex-shrink: 0;
   display: none;
 
-  [aria-expanded="true"] & {
+  [aria-expanded="true"] > & {
     display: block;
   }
 `;
@@ -15,7 +15,7 @@ export const PopoverHoverTarget = styled(Icon)`
 export const PopoverDefaultIcon = styled(Icon)`
   display: block;
 
-  [aria-expanded="true"] & {
+  [aria-expanded="true"] > & {
     display: none;
   }
 `;

--- a/frontend/src/metabase/components/MetadataInfo/InfoIcon/InfoIcon.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/InfoIcon/InfoIcon.styled.tsx
@@ -7,7 +7,7 @@ export const PopoverHoverTarget = styled(Icon)`
   flex-shrink: 0;
   display: none;
 
-  [aria-expanded="true"] > & {
+  [aria-expanded="true"] & {
     display: block;
   }
 `;
@@ -15,7 +15,7 @@ export const PopoverHoverTarget = styled(Icon)`
 export const PopoverDefaultIcon = styled(Icon)`
   display: block;
 
-  [aria-expanded="true"] > & {
+  [aria-expanded="true"] & {
     display: none;
   }
 `;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.module.css
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.module.css
@@ -1,0 +1,4 @@
+.accordionListRoot {
+  outline: none;
+  overflow: auto;
+}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.stories.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.stories.tsx
@@ -1,4 +1,4 @@
-import AccordionList from "./AccordionList";
+import { AccordionList } from "./AccordionList";
 
 const SECTIONS = [
   {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.styled.tsx
@@ -1,7 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-import styled from "@emotion/styled";
-
-export const AccordionListRoot = styled.div`
-  outline: none;
-  overflow: auto;
-`;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -231,7 +231,7 @@ export class AccordionList<
     for (let i = 0; i < sections.length; i++) {
       if (
         _.some(sections[i]?.items ?? [], (item) =>
-          Boolean(this.props.itemIsSelected?.(item)),
+          Boolean(this.props.itemIsSelected?.(item, i)),
         )
       ) {
         selectedSection = i;
@@ -285,7 +285,7 @@ export class AccordionList<
         itemIndex++
       ) {
         const item = section.items?.[itemIndex];
-        if (item && itemIsSelected(item)) {
+        if (item && itemIsSelected(item, itemIndex)) {
           return {
             sectionIndex,
             itemIndex,
@@ -398,7 +398,7 @@ export class AccordionList<
     alwaysTogglable: boolean,
     alwaysExpanded: boolean,
     hideSingleSectionTitle: boolean,
-    itemIsSelected: (item: TItem) => boolean | undefined,
+    itemIsSelected: (item: TItem, index: number) => boolean | undefined,
     hideEmptySectionsInSearch: boolean,
     openSection: number | null,
     _globalSearch: boolean,
@@ -475,7 +475,7 @@ export class AccordionList<
         for (const [itemIndex, item] of section.items.entries()) {
           if (searchFilter(item)) {
             const isLastItem = itemIndex === section.items.length - 1;
-            if (itemIsSelected(item)) {
+            if (itemIsSelected(item, itemIndex)) {
               this._initialSelectedRowIndex = rows.length;
             }
             rows.push({

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -20,7 +20,7 @@ import { Icon, type IconName, type TextInputProps } from "metabase/ui";
 import { AccordionListRoot } from "./AccordionList.styled";
 import { AccordionListCell } from "./AccordionListCell";
 import type { Item, Row, Section } from "./types";
-import { type Cursor, getNextCursor, getPrevCursor } from "./utils";
+import { type Cursor, get, getNextCursor, getPrevCursor } from "./utils";
 
 type Props<
   TItem extends Item,
@@ -650,23 +650,21 @@ export class AccordionList<
       itemIsSelected = () => false,
       renderSectionIcon = (section: TSection) =>
         section.icon && <Icon name={section.icon as IconName} />,
-      renderItemName = (item: TItem) =>
-        "name" in item ? (item.name as string) : undefined,
+      renderItemName = (item: TItem) => get<string>(item, "name"),
       renderItemLabel,
-      renderItemDescription = (item: TItem) =>
-        "description" in item ? (item.description as string) : "",
-      renderItemIcon = (item: TItem) =>
-        "icon" in item && item.icon ? (
-          <Icon name={item.icon as IconName} />
-        ) : null,
+      renderItemDescription = (item: TItem) => get<string>(item, "description"),
+      renderItemIcon = (item: TItem) => {
+        const icon = get<IconName>(item, "icon");
+        return icon ? <Icon name={icon} /> : null;
+      },
       renderItemExtra = () => null,
       renderItemWrapper = (content: ReactNode) => content,
       showSpinner = () => false,
 
-      getItemClassName = (item: TItem) =>
-        "className" in item && typeof item.className === "string"
-          ? item.className
-          : undefined,
+      getItemClassName = (item: TItem) => {
+        const className = get(item, "className");
+        return typeof className === "string" ? className : undefined;
+      },
       getItemStyles = () => ({}),
       alwaysExpanded = false,
     } = this.props;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -42,7 +42,6 @@ type Props<
   onChangeSection?: (section: TSection, sectionIndex: number) => boolean | void;
   openSection?: number;
   role?: string;
-  searchCaseInsensitive?: boolean;
   searchProp?: string | string[];
   searchable?: boolean | ((section: Section) => boolean | undefined);
   sections: TSection[];
@@ -251,18 +250,12 @@ export class AccordionList<
   };
 
   searchPredicate = (item: TItem, searchPropMember: string) => {
-    const { searchCaseInsensitive = true } = this.props;
     const path = searchPropMember.split(".");
 
-    let { searchText } = this.state;
-    let itemText = String(getIn(item, path) || "");
+    const { searchText } = this.state;
+    const itemText = String(getIn(item, path) || "");
 
-    if (searchCaseInsensitive) {
-      itemText = itemText.toLowerCase();
-      searchText = searchText.toLowerCase();
-    }
-
-    return itemText.indexOf(searchText) >= 0;
+    return itemText.toLowerCase().indexOf(searchText.toLowerCase()) >= 0;
   };
 
   checkSectionHasItemsMatchingSearch = (

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -15,12 +15,12 @@ import {
 } from "react-virtualized";
 import _ from "underscore";
 
-import { Icon, type IconName, type TextInputProps } from "metabase/ui";
+import type { TextInputProps } from "metabase/ui";
 
 import { AccordionListRoot } from "./AccordionList.styled";
 import { AccordionListCell } from "./AccordionListCell";
 import type { Item, Row, Section } from "./types";
-import { type Cursor, get, getNextCursor, getPrevCursor } from "./utils";
+import { type Cursor, getNextCursor, getPrevCursor } from "./utils";
 
 type Props<
   TItem extends Item,
@@ -647,26 +647,6 @@ export class AccordionList<
       "data-testid": testId,
       maxHeight = Infinity,
 
-      itemIsClickable = () => true,
-      itemIsSelected = () => false,
-      renderSectionIcon = (section: TSection) =>
-        section.icon && <Icon name={section.icon as IconName} />,
-      renderItemName = (item: TItem) => get<string>(item, "name"),
-      renderItemLabel,
-      renderItemDescription = (item: TItem) => get<string>(item, "description"),
-      renderItemIcon = (item: TItem) => {
-        const icon = get<IconName>(item, "icon");
-        return icon ? <Icon name={icon} /> : null;
-      },
-      renderItemExtra = () => null,
-      renderItemWrapper = (content: ReactNode) => content,
-      showSpinner = () => false,
-
-      getItemClassName = (item: TItem) => {
-        const className = get(item, "className");
-        return typeof className === "string" ? className : undefined;
-      },
-      getItemStyles = () => ({}),
       alwaysExpanded = false,
     } = this.props;
     const { cursor, scrollToAlignment } = this.state;
@@ -677,23 +657,6 @@ export class AccordionList<
       cursor != null ? rows.findIndex(this.isRowSelected) : undefined;
 
     const searchRowIndex = rows.findIndex((row) => row.type === "search");
-
-    const itemProps = {
-      ...this.props,
-      itemIsClickable,
-      itemIsSelected,
-      renderSectionIcon,
-      renderItemLabel,
-      renderItemName,
-      renderItemDescription,
-      renderItemIcon,
-      renderItemExtra,
-      renderItemWrapper,
-      showSpinner,
-      getItemClassName,
-      getItemStyles,
-      style,
-    };
 
     if (!this.isVirtualized()) {
       return (
@@ -712,7 +675,7 @@ export class AccordionList<
           {rows.map((row, index) => (
             <AccordionListCell<TItem, TSection>
               key={index}
-              {...itemProps}
+              {...this.props}
               row={row}
               sections={sections}
               onChange={this.handleChange}
@@ -785,7 +748,7 @@ export class AccordionList<
               {() => (
                 <AccordionListCell<TItem, TSection>
                   hasCursor={this.isRowSelected(rows[index])}
-                  {...itemProps}
+                  {...this.props}
                   style={style}
                   row={rows[index]}
                   sections={sections}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -252,7 +252,7 @@ export class AccordionList<
   };
 
   searchPredicate = (item: TItem, searchPropMember: string) => {
-    const { searchCaseInsensitive = true, searchFuzzy } = this.props;
+    const { searchCaseInsensitive = true, searchFuzzy = true } = this.props;
     let { searchText } = this.state;
     const path = searchPropMember.split(".");
     let itemText = String(getIn(item, path) || "");

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -651,9 +651,9 @@ export class AccordionList<
       itemIsSelected = () => false,
       renderSectionIcon = (section: TSection) =>
         section.icon && <Icon name={section.icon as IconName} />,
-      renderItemLabel = () => undefined,
       renderItemName = (item: TItem) =>
-        ("name" in item ? item.name : "") as string,
+        "name" in item ? (item.name as string) : undefined,
+      renderItemLabel,
       renderItemDescription = (item: TItem) =>
         "description" in item ? (item.description as string) : "",
       renderItemIcon = (item: TItem) =>

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -43,7 +43,6 @@ type Props<
   openSection?: number;
   role?: string;
   searchCaseInsensitive?: boolean;
-  searchFuzzy?: boolean;
   searchProp?: string | string[];
   searchable?: boolean | ((section: Section) => boolean | undefined);
   sections: TSection[];
@@ -252,19 +251,18 @@ export class AccordionList<
   };
 
   searchPredicate = (item: TItem, searchPropMember: string) => {
-    const { searchCaseInsensitive = true, searchFuzzy = true } = this.props;
-    let { searchText } = this.state;
+    const { searchCaseInsensitive = true } = this.props;
     const path = searchPropMember.split(".");
+
+    let { searchText } = this.state;
     let itemText = String(getIn(item, path) || "");
+
     if (searchCaseInsensitive) {
       itemText = itemText.toLowerCase();
       searchText = searchText.toLowerCase();
     }
-    if (searchFuzzy) {
-      return itemText.indexOf(searchText) >= 0;
-    } else {
-      return itemText.startsWith(searchText);
-    }
+
+    return itemText.indexOf(searchText) >= 0;
   };
 
   checkSectionHasItemsMatchingSearch = (

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -26,30 +26,30 @@ type Props<
   TItem extends Item,
   TSection extends Section<TItem> = Section<TItem>,
 > = SharedAccordionProps<TItem, TSection> & {
-  style?: CSSProperties;
+  "data-testid"?: string | null;
+  alwaysTogglable?: boolean;
   className?: string;
+  globalSearch?: boolean;
+  hasInitialFocus?: boolean;
+  hideEmptySectionsInSearch?: boolean;
+  hideSingleSectionTitle?: boolean;
+  initiallyOpenSection?: number;
   id?: string;
+  onChange?: (item: TItem) => void;
+  onChangeSection?: (section: TSection, sectionIndex: number) => boolean | void;
+  openSection?: number;
+  role?: string;
+  searchCaseInsensitive?: boolean;
+  searchFuzzy?: boolean;
+  searchProp?: string | string[];
+  searchable?: boolean | ((section: Section) => boolean | undefined);
+  sections: TSection[];
+  style?: CSSProperties;
 
   // TODO: pass width to this component as solely number or string if possible
   // currently prop is number on initialization, then string afterwards
   width?: string | number;
   maxHeight?: number;
-  role?: string;
-  sections: TSection[];
-  initiallyOpenSection?: number;
-  globalSearch?: boolean;
-  openSection?: number;
-  onChange?: (item: TItem) => void;
-  onChangeSection?: (section: TSection, sectionIndex: number) => boolean | void;
-  alwaysTogglable?: boolean;
-  hideSingleSectionTitle?: boolean;
-  searchable?: boolean | ((section: Section) => boolean | undefined);
-  searchProp?: string | string[];
-  searchCaseInsensitive?: boolean;
-  searchFuzzy?: boolean;
-  hideEmptySectionsInSearch?: boolean;
-  hasInitialFocus?: boolean;
-  "data-testid"?: string | null;
 };
 
 type State = {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -34,7 +34,6 @@ type Props<
   className?: string;
   globalSearch?: boolean;
   hasInitialFocus?: boolean;
-  hideEmptySectionsInSearch?: boolean;
   hideSingleSectionTitle?: boolean;
   initiallyOpenSection?: number;
   id?: string;
@@ -390,7 +389,6 @@ export class AccordionList<
     alwaysExpanded: boolean,
     hideSingleSectionTitle: boolean,
     itemIsSelected: (item: TItem, index: number) => boolean | undefined,
-    hideEmptySectionsInSearch: boolean,
     openSection: number | null,
     _globalSearch: boolean,
     searchText: string,
@@ -417,7 +415,7 @@ export class AccordionList<
       ) {
         if (
           !searchable ||
-          !(hideEmptySectionsInSearch || globalSearch) ||
+          !globalSearch ||
           this.checkSectionHasItemsMatchingSearch(section, searchFilter) ||
           section.type === "action"
         ) {
@@ -524,7 +522,6 @@ export class AccordionList<
       alwaysExpanded = false,
       hideSingleSectionTitle = false,
       itemIsSelected = () => false,
-      hideEmptySectionsInSearch = false,
       globalSearch = false,
     } = this.props;
 
@@ -540,7 +537,6 @@ export class AccordionList<
       alwaysExpanded,
       hideSingleSectionTitle,
       itemIsSelected,
-      hideEmptySectionsInSearch,
       openSection,
       globalSearch,
       searchText,

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -24,9 +24,7 @@ import type { Item, Row, Section } from "./types";
 import { type Cursor, getNextCursor, getPrevCursor } from "./utils";
 
 type Props<T extends Item> = {
-  style?: CSSProperties & {
-    "--accordion-list-width"?: string;
-  };
+  style?: CSSProperties;
   className?: string;
   id?: string;
 

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -68,7 +68,7 @@ export class AccordionList<
 > extends Component<Props<TItem, TSection>, State> {
   _cache: CellMeasurerCache;
 
-  _list: RefObject<List>;
+  listRef: RefObject<List>;
   listRootRef: RefObject<HTMLDivElement>;
 
   _initialSelectedRowIndex?: number;
@@ -111,7 +111,7 @@ export class AccordionList<
     });
 
     this.listRootRef = createRef();
-    this._list = createRef();
+    this.listRef = createRef();
   }
 
   componentDidMount() {
@@ -132,13 +132,13 @@ export class AccordionList<
       const index = this._initialSelectedRowIndex;
 
       if (
-        this._list &&
+        this.listRef.current &&
         index != null &&
         this._startIndex != null &&
         this._stopIndex != null &&
         !(index >= this._startIndex && index <= this._stopIndex)
       ) {
-        this._list.current?.scrollToRow(index);
+        this.listRef.current?.scrollToRow(index);
       }
     }, 0);
   }
@@ -164,7 +164,7 @@ export class AccordionList<
   _getListContainerElement() {
     const element = this.isVirtualized()
       ? // @ts-expect-error: TODO remove reliance on internals here
-        this._list.current?.Grid?._scrollingContainer
+        this.listRef.current?.Grid?._scrollingContainer
       : this.listRootRef.current;
 
     return element ?? null;
@@ -181,13 +181,13 @@ export class AccordionList<
   }
 
   _forceUpdateList() {
-    if (this._list) {
+    if (this.listRef.current) {
       // NOTE: unclear why this particular set of functions works, but it does
-      this._list.current?.invalidateCellSizeAfterRender({
+      this.listRef.current.invalidateCellSizeAfterRender({
         columnIndex: 0,
         rowIndex: 0,
       });
-      this._list.current?.forceUpdateGrid();
+      this.listRef.current.forceUpdateGrid();
       this.forceUpdate();
     }
   }
@@ -368,7 +368,7 @@ export class AccordionList<
     const searchRow = this.getRows().findIndex((row) => row.type === "search");
 
     if (searchRow >= 0 && this.isVirtualized()) {
-      this._list.current?.scrollToRow(searchRow);
+      this.listRef.current?.scrollToRow(searchRow);
     }
   };
 
@@ -683,7 +683,7 @@ export class AccordionList<
     return (
       <List
         id={id}
-        ref={this._list}
+        ref={this.listRef}
         className={className}
         style={{
           // HACK - Ensure the component can scroll

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -709,34 +709,32 @@ export class AccordionList<
           onKeyDown: this.handleKeyDown,
           "data-testid": testId,
         }}
-        rowRenderer={({ key, index, parent, style }) => {
-          return (
-            <CellMeasurer
-              cache={this._cache}
-              columnIndex={0}
-              key={key}
-              rowIndex={index}
-              parent={parent}
-            >
-              {() => (
-                <AccordionListCell<TItem, TSection>
-                  hasCursor={this.isRowSelected(rows[index])}
-                  {...this.props}
-                  style={style}
-                  row={rows[index]}
-                  sections={sections}
-                  onChange={this.handleChange}
-                  searchText={this.state.searchText}
-                  onChangeSearchText={this.handleChangeSearchText}
-                  sectionIsExpanded={this.isSectionExpanded}
-                  canToggleSections={this.canToggleSections()}
-                  toggleSection={this.toggleSection}
-                  withBorders={withBorders}
-                />
-              )}
-            </CellMeasurer>
-          );
-        }}
+        rowRenderer={({ key, index, parent, style }) => (
+          <CellMeasurer
+            cache={this._cache}
+            columnIndex={0}
+            key={key}
+            rowIndex={index}
+            parent={parent}
+          >
+            {() => (
+              <AccordionListCell<TItem, TSection>
+                hasCursor={this.isRowSelected(rows[index])}
+                {...this.props}
+                style={style}
+                row={rows[index]}
+                sections={sections}
+                onChange={this.handleChange}
+                searchText={this.state.searchText}
+                onChangeSearchText={this.handleChangeSearchText}
+                sectionIsExpanded={this.isSectionExpanded}
+                canToggleSections={this.canToggleSections()}
+                toggleSection={this.toggleSection}
+                withBorders={withBorders}
+              />
+            )}
+          </CellMeasurer>
+        )}
         onRowsRendered={({ startIndex, stopIndex }) => {
           this._startIndex = startIndex;
           this._stopIndex = stopIndex;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -3,7 +3,6 @@ import {
   type CSSProperties,
   Component,
   type KeyboardEvent,
-  type ReactNode,
   type RefObject,
   createRef,
 } from "react";
@@ -15,17 +14,18 @@ import {
 } from "react-virtualized";
 import _ from "underscore";
 
-import type { TextInputProps } from "metabase/ui";
-
 import { AccordionListRoot } from "./AccordionList.styled";
-import { AccordionListCell } from "./AccordionListCell";
+import {
+  AccordionListCell,
+  type SharedAccordionProps,
+} from "./AccordionListCell";
 import type { Item, Row, Section } from "./types";
 import { type Cursor, getNextCursor, getPrevCursor } from "./utils";
 
 type Props<
   TItem extends Item,
   TSection extends Section<TItem> = Section<TItem>,
-> = {
+> = SharedAccordionProps<TItem, TSection> & {
   style?: CSSProperties;
   className?: string;
   id?: string;
@@ -34,52 +34,22 @@ type Props<
   // currently prop is number on initialization, then string afterwards
   width?: string | number;
   maxHeight?: number;
-
   role?: string;
-
   sections: TSection[];
-
   initiallyOpenSection?: number;
   globalSearch?: boolean;
   openSection?: number;
   onChange?: (item: TItem) => void;
   onChangeSection?: (section: TSection, sectionIndex: number) => boolean | void;
-
-  // section getters/render props
-  renderSectionIcon?: (section: TSection) => ReactNode;
-  renderSearchSection?: (section: TSection) => ReactNode;
-
-  // item getters/render props
-  itemIsSelected?: (item: TItem) => boolean | undefined;
-  itemIsClickable?: (item: TItem) => boolean;
-  renderItemName?: (item: TItem) => string | undefined;
-  renderItemLabel?: (item: TItem) => string | undefined;
-  renderItemDescription?: (item: TItem) => ReactNode;
-  renderItemIcon?: (item: TItem) => ReactNode;
-  renderItemExtra?: (item: TItem, isSelected: boolean) => ReactNode;
-  renderItemWrapper?: (content: ReactNode, item: TItem) => ReactNode;
-  getItemClassName?: (item: TItem) => string | undefined;
-  getItemStyles?: (item: TItem) => CSSProperties | undefined;
-
   alwaysTogglable?: boolean;
-  alwaysExpanded?: boolean;
   hideSingleSectionTitle?: boolean;
-  showSpinner?: (itemOrSection: TItem | TSection) => boolean;
-  showItemArrows?: boolean;
-
   searchable?: boolean | ((section: Section) => boolean | undefined);
   searchProp?: string | string[];
   searchCaseInsensitive?: boolean;
   searchFuzzy?: boolean;
-  searchPlaceholder?: string;
-  searchInputProps?: TextInputProps;
   hideEmptySectionsInSearch?: boolean;
   hasInitialFocus?: boolean;
-
-  itemTestId?: string;
   "data-testid"?: string | null;
-
-  withBorders?: boolean;
 };
 
 type State = {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { getIn } from "icepick";
 import {
   type CSSProperties,
@@ -14,7 +15,9 @@ import {
 } from "react-virtualized";
 import _ from "underscore";
 
-import { AccordionListRoot } from "./AccordionList.styled";
+import { Box } from "metabase/ui";
+
+import S from "./AccordionList.module.css";
 import {
   AccordionListCell,
   type SharedAccordionProps,
@@ -630,12 +633,12 @@ export class AccordionList<
 
     if (!this.isVirtualized()) {
       return (
-        <AccordionListRoot
+        <Box
+          className={cx(S.accordionListRoot, className)}
           ref={this.listRootRef}
           role="tree"
           onKeyDown={this.handleKeyDown}
           tabIndex={-1}
-          className={className}
           style={{
             width,
             ...style,
@@ -662,7 +665,7 @@ export class AccordionList<
               withBorders={withBorders}
             />
           ))}
-        </AccordionListRoot>
+        </Box>
       );
     }
 

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -23,7 +23,7 @@ import { AccordionListCell } from "./AccordionListCell";
 import type { Item, Row, Section } from "./types";
 import { type Cursor, getNextCursor, getPrevCursor } from "./utils";
 
-type Props<T extends Item> = {
+type Props<TItem extends Item> = {
   style?: CSSProperties;
   className?: string;
   id?: string;
@@ -35,37 +35,37 @@ type Props<T extends Item> = {
 
   role?: string;
 
-  sections: Section<T>[];
+  sections: Section<TItem>[];
 
   initiallyOpenSection?: number;
   globalSearch?: boolean;
   openSection?: number;
-  onChange?: (item: T) => void;
+  onChange?: (item: TItem) => void;
   onChangeSection?: (
-    section: Section<T>,
+    section: Section<TItem>,
     sectionIndex: number,
   ) => boolean | void;
 
   // section getters/render props
-  renderSectionIcon?: (section: Section<T>) => ReactNode;
-  renderSearchSection?: (section: Section<T>) => ReactNode;
+  renderSectionIcon?: (section: Section<TItem>) => ReactNode;
+  renderSearchSection?: (section: Section<TItem>) => ReactNode;
 
   // item getters/render props
-  itemIsSelected?: (item: T) => boolean | undefined;
-  itemIsClickable?: (item: T) => boolean;
-  renderItemName?: (item: T) => string | undefined;
-  renderItemLabel?: (item: T) => string | undefined;
-  renderItemDescription?: (item: T) => ReactNode;
-  renderItemIcon?: (item: T) => ReactNode;
-  renderItemExtra?: (item: T, isSelected: boolean) => ReactNode;
-  renderItemWrapper?: (content: ReactNode, item: T) => ReactNode;
-  getItemClassName?: (item: T) => string | undefined;
-  getItemStyles?: (item: T) => CSSProperties | undefined;
+  itemIsSelected?: (item: TItem) => boolean | undefined;
+  itemIsClickable?: (item: TItem) => boolean;
+  renderItemName?: (item: TItem) => string | undefined;
+  renderItemLabel?: (item: TItem) => string | undefined;
+  renderItemDescription?: (item: TItem) => ReactNode;
+  renderItemIcon?: (item: TItem) => ReactNode;
+  renderItemExtra?: (item: TItem, isSelected: boolean) => ReactNode;
+  renderItemWrapper?: (content: ReactNode, item: TItem) => ReactNode;
+  getItemClassName?: (item: TItem) => string | undefined;
+  getItemStyles?: (item: TItem) => CSSProperties | undefined;
 
   alwaysTogglable?: boolean;
   alwaysExpanded?: boolean;
   hideSingleSectionTitle?: boolean;
-  showSpinner?: (itemOrSection: T | Section<T>) => boolean;
+  showSpinner?: (itemOrSection: TItem | Section<TItem>) => boolean;
   showItemArrows?: boolean;
 
   searchable?: boolean | ((section: Section) => boolean | undefined);
@@ -90,7 +90,10 @@ type State = {
   scrollToAlignment: Alignment;
 };
 
-export class AccordionList<T extends Item> extends Component<Props<T>, State> {
+export class AccordionList<TItem extends Item> extends Component<
+  Props<TItem>,
+  State
+> {
   _cache: CellMeasurerCache;
 
   _list: RefObject<List>;
@@ -101,7 +104,7 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
   _stopIndex?: number;
   _forceUpdateTimeout?: NodeJS.Timeout | null;
 
-  constructor(props: Props<T>, context: unknown) {
+  constructor(props: Props<TItem>, context: unknown) {
     super(props, context);
 
     let openSection;
@@ -168,7 +171,7 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
     }, 0);
   }
 
-  componentDidUpdate(_prevProps: Props<T>, prevState: State) {
+  componentDidUpdate(_prevProps: Props<TItem>, prevState: State) {
     // if anything changes that affects the selected rows we need to clear the row height cache
     if (
       this.state.openSection !== prevState.openSection ||
@@ -266,7 +269,7 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
     return selectedSection === sectionIndex;
   }
 
-  handleChange = (item: T) => {
+  handleChange = (item: TItem) => {
     if (this.props.onChange) {
       this.props.onChange(item);
     }
@@ -276,7 +279,7 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
     this.setState({ searchText, cursor: null });
   };
 
-  searchPredicate = (item: T, searchPropMember: string) => {
+  searchPredicate = (item: TItem, searchPropMember: string) => {
     const { searchCaseInsensitive = true, searchFuzzy } = this.props;
     let { searchText } = this.state;
     const path = searchPropMember.split(".");
@@ -293,8 +296,8 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
   };
 
   checkSectionHasItemsMatchingSearch = (
-    section: Section<T>,
-    searchFilter: (item: T) => boolean,
+    section: Section<TItem>,
+    searchFilter: (item: TItem) => boolean,
   ) => {
     return (section.items?.filter(searchFilter).length ?? 0) > 0;
   };
@@ -397,7 +400,7 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
     }
   };
 
-  searchFilter = (item: T) => {
+  searchFilter = (item: TItem) => {
     const { searchProp = ["name", "displayName"] } = this.props;
     const { searchText } = this.state;
 
@@ -414,21 +417,21 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
   };
 
   getRowsCached = (
-    searchFilter: (item: T) => boolean,
+    searchFilter: (item: TItem) => boolean,
     searchable:
       | boolean
-      | ((section: Section<T>) => boolean | undefined)
+      | ((section: Section<TItem>) => boolean | undefined)
       | undefined,
-    sections: Section<T>[],
+    sections: Section<TItem>[],
     alwaysTogglable: boolean,
     alwaysExpanded: boolean,
     hideSingleSectionTitle: boolean,
-    itemIsSelected: (item: T) => boolean | undefined,
+    itemIsSelected: (item: TItem) => boolean | undefined,
     hideEmptySectionsInSearch: boolean,
     openSection: number | null,
     _globalSearch: boolean,
     searchText: string,
-  ): Row<T>[] => {
+  ): Row<TItem>[] => {
     // if any section is searchable just enable a global search
     let globalSearch = _globalSearch;
 
@@ -442,7 +445,7 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
         ? searchable(sections[sectionIndex])
         : searchable;
 
-    const rows: Row<T>[] = [];
+    const rows: Row<TItem>[] = [];
     for (const [sectionIndex, section] of sections.entries()) {
       const isLastSection = sectionIndex === sections.length - 1;
       if (
@@ -549,10 +552,10 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
     return rows;
   };
 
-  getRows(): Row<T>[] {
+  getRows(): Row<TItem>[] {
     const {
       sections,
-      searchable = (section: Section<T>) =>
+      searchable = (section: Section<TItem>) =>
         section?.items && section.items.length > 10,
       alwaysTogglable = false,
       alwaysExpanded = false,
@@ -588,7 +591,7 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
     return alwaysTogglable || sections.length > 1;
   };
 
-  isRowSelected = (row: Row<T>) => {
+  isRowSelected = (row: Row<TItem>) => {
     if (!this.state.cursor) {
       return false;
     }
@@ -646,13 +649,14 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
 
       itemIsClickable = () => true,
       itemIsSelected = () => false,
-      renderSectionIcon = (section: Section<T>) =>
+      renderSectionIcon = (section: Section<TItem>) =>
         section.icon && <Icon name={section.icon as IconName} />,
       renderItemLabel = () => undefined,
-      renderItemName = (item: T) => ("name" in item ? item.name : "") as string,
-      renderItemDescription = (item: T) =>
+      renderItemName = (item: TItem) =>
+        ("name" in item ? item.name : "") as string,
+      renderItemDescription = (item: TItem) =>
         "description" in item ? (item.description as string) : "",
-      renderItemIcon = (item: T) =>
+      renderItemIcon = (item: TItem) =>
         "icon" in item && item.icon ? (
           <Icon name={item.icon as IconName} />
         ) : null,
@@ -660,7 +664,7 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
       renderItemWrapper = (content: ReactNode) => content,
       showSpinner = () => false,
 
-      getItemClassName = (item: T) =>
+      getItemClassName = (item: TItem) =>
         "className" in item && typeof item.className === "string"
           ? item.className
           : undefined,
@@ -707,7 +711,7 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
           data-testid={testId}
         >
           {rows.map((row, index) => (
-            <AccordionListCell<T>
+            <AccordionListCell<TItem>
               key={index}
               {...itemProps}
               row={row}
@@ -781,7 +785,7 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
               parent={parent}
             >
               {() => (
-                <AccordionListCell<T>
+                <AccordionListCell<TItem>
                   hasCursor={this.isRowSelected(rows[index])}
                   {...itemProps}
                   style={style}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -35,7 +35,7 @@ type Props<
   globalSearch?: boolean;
   hasInitialFocus?: boolean;
   hideSingleSectionTitle?: boolean;
-  initiallyOpenSection?: number;
+  initiallyOpenSection?: number | null;
   id?: string;
   onChange?: (item: TItem) => void;
   onChangeSection?: (section: TSection, sectionIndex: number) => boolean | void;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -20,59 +20,8 @@ import { Icon, type IconName } from "metabase/ui";
 
 import { AccordionListRoot } from "./AccordionList.styled";
 import { AccordionListCell } from "./AccordionListCell";
+import type { Item, Row, Section } from "./types";
 import { type Cursor, getNextCursor, getPrevCursor } from "./utils";
-
-export type Section<T extends Item = Item> = {
-  key?: string;
-  name?: ReactNode;
-  displayName?: ReactNode;
-  type?:
-    | "action"
-    | "header"
-    | "search"
-    | "loading"
-    | "no-results"
-    | "item"
-    | "back";
-  icon?: IconName | null;
-  loading?: boolean;
-  items?: T[];
-  active?: boolean;
-  className?: string | null;
-};
-
-export type Item = object;
-
-export type Row<T extends object> = {
-  section: Section<T>;
-  sectionIndex: number;
-  isLastSection: boolean;
-} & (
-  | {
-      type: "action";
-    }
-  | {
-      type: "header";
-    }
-  | {
-      type: "search";
-    }
-  | {
-      type: "loading";
-    }
-  | {
-      type: "no-results";
-    }
-  | {
-      type: "back";
-    }
-  | {
-      type: "item";
-      item: T;
-      itemIndex: number;
-      isLastItem: boolean;
-    }
-);
 
 type Props<T extends Item> = {
   style?: CSSProperties & {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -645,6 +645,7 @@ export class AccordionList<
       role = "grid",
       withBorders,
       "data-testid": testId,
+      maxHeight = Infinity,
 
       itemIsClickable = () => true,
       itemIsSelected = () => false,
@@ -732,30 +733,29 @@ export class AccordionList<
       );
     }
 
-    const mh = this.props.maxHeight ?? Infinity;
-    const maxHeight = mh > 0 && mh < Infinity ? mh : window.innerHeight;
+    const max =
+      maxHeight > 0 && maxHeight < Infinity ? maxHeight : window.innerHeight;
 
     const height = Math.min(
-      maxHeight,
+      max,
       rows.reduce(
         (height, _row, index) => height + this._cache.rowHeight({ index }),
         0,
       ),
     );
 
-    const defaultListStyle = {
-      // HACK - Ensure the component can scroll
-      // This is a temporary fix to handle cases where the parent component doesn’t pass in the correct `maxHeight`
-      overflowY: "auto" as const,
-      outline: "none" as const,
-    };
-
     return (
       <List
         id={id}
         ref={this._list}
         className={className}
-        style={{ ...defaultListStyle, ...style }}
+        style={{
+          // HACK - Ensure the component can scroll
+          // This is a temporary fix to handle cases where the parent component doesn’t pass in the correct `maxHeight`
+          overflowY: "auto",
+          outline: "none",
+          ...style,
+        }}
         containerStyle={{ pointerEvents: "auto" }}
         // @ts-expect-error: TODO
         width={width}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -2,7 +2,6 @@ import { getIn } from "icepick";
 import {
   type CSSProperties,
   Component,
-  type HTMLProps,
   type KeyboardEvent,
   type ReactNode,
   type RefObject,
@@ -16,7 +15,7 @@ import {
 } from "react-virtualized";
 import _ from "underscore";
 
-import { Icon, type IconName } from "metabase/ui";
+import { Icon, type IconName, type TextInputProps } from "metabase/ui";
 
 import { AccordionListRoot } from "./AccordionList.styled";
 import { AccordionListCell } from "./AccordionListCell";
@@ -73,7 +72,7 @@ type Props<
   searchCaseInsensitive?: boolean;
   searchFuzzy?: boolean;
   searchPlaceholder?: string;
-  searchInputProps?: HTMLProps<HTMLInputElement>;
+  searchInputProps?: TextInputProps;
   hideEmptySectionsInSearch?: boolean;
   hasInitialFocus?: boolean;
 
@@ -681,6 +680,7 @@ export class AccordionList<
     const searchRowIndex = rows.findIndex((row) => row.type === "search");
 
     const itemProps = {
+      ...this.props,
       itemIsClickable,
       itemIsSelected,
       renderSectionIcon,

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -206,13 +206,14 @@ export class AccordionList<
   };
 
   getOpenSection() {
-    if (this.props.sections.length === 1) {
+    const { sections } = this.props;
+    if (sections.length === 1) {
       return 0;
     }
 
     let { openSection } = this.state;
     if (openSection === undefined) {
-      for (const [index, section] of this.props.sections.entries()) {
+      for (const [index, section] of sections.entries()) {
         if (this.sectionIsSelected(section, index)) {
           openSection = index;
           break;
@@ -223,12 +224,12 @@ export class AccordionList<
   }
 
   sectionIsSelected(_section: Section, sectionIndex: number) {
-    const { sections } = this.props;
+    const { sections, itemIsSelected } = this.props;
     let selectedSection = null;
     for (let i = 0; i < sections.length; i++) {
       if (
         _.some(sections[i]?.items ?? [], (item) =>
-          Boolean(this.props.itemIsSelected?.(item, i)),
+          Boolean(itemIsSelected?.(item, i)),
         )
       ) {
         selectedSection = i;
@@ -239,9 +240,7 @@ export class AccordionList<
   }
 
   handleChange = (item: TItem) => {
-    if (this.props.onChange) {
-      this.props.onChange(item);
-    }
+    this.props.onChange?.(item);
   };
 
   handleChangeSearchText = (searchText: string) => {
@@ -563,17 +562,19 @@ export class AccordionList<
   };
 
   isSectionExpanded = (sectionIndex: number) => {
+    const { globalSearch, alwaysExpanded } = this.props;
     const openSection = this.getOpenSection();
 
     return Boolean(
-      this.props.alwaysExpanded ||
+      alwaysExpanded ||
         openSection === sectionIndex ||
-        (this.props.globalSearch && this.state.searchText.length > 0),
+        (globalSearch && this.state.searchText.length > 0),
     );
   };
 
   canSelectSection = (sectionIndex: number) => {
-    const section = this.props.sections[sectionIndex];
+    const { globalSearch, alwaysExpanded, sections } = this.props;
+    const section = sections[sectionIndex];
     if (!section) {
       return false;
     }
@@ -583,8 +584,7 @@ export class AccordionList<
     }
 
     return (
-      !this.props.alwaysExpanded &&
-      !(this.props.globalSearch && this.state.searchText.length > 0)
+      !alwaysExpanded && !(globalSearch && this.state.searchText.length > 0)
     );
   };
 

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.tsx
@@ -400,21 +400,19 @@ export class AccordionList<T extends Item> extends Component<Props<T>, State> {
   };
 
   searchFilter = (item: T) => {
-    const { searchProp } = this.props;
+    const { searchProp = ["name", "displayName"] } = this.props;
     const { searchText } = this.state;
 
     if (!searchText || searchText.length === 0) {
       return true;
     }
 
-    if (typeof searchProp === "string") {
-      return this.searchPredicate(item, searchProp);
-    } else if (Array.isArray(searchProp)) {
-      const searchResults = searchProp.map((member) =>
-        this.searchPredicate(item, member),
-      );
-      return Boolean(searchResults.reduce((acc, curr) => acc || curr));
-    }
+    const searchProps = Array.isArray(searchProp) ? searchProp : [searchProp];
+
+    const searchResults = searchProps.map((member) =>
+      this.searchPredicate(item, member),
+    );
+    return searchResults.reduce((acc, curr) => acc || curr);
   };
 
   getRowsCached = (

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.js
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.js
@@ -2,7 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import { fireEvent, render, screen } from "__support__/ui";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
-import AccordionList from "metabase/core/components/AccordionList";
+import { AccordionList } from "metabase/core/components/AccordionList";
 
 const SECTIONS = [
   {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 
 import { fireEvent, render, screen } from "__support__/ui";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
@@ -88,7 +89,7 @@ describe("AccordionList", () => {
     const sections = ["Widgets", "Doohickeys"];
 
     sections.forEach((name) => {
-      const SECTION = screen.queryByText(name);
+      const SECTION = screen.getByText(name);
       expect(SEARCH_FIELD.compareDocumentPosition(SECTION)).toBe(
         Node.DOCUMENT_POSITION_FOLLOWING,
       );
@@ -126,10 +127,10 @@ describe("AccordionList", () => {
 
   describe("with the `renderItemWrapper` prop", () => {
     it("should be able to wrap the list items in components like popovers", async () => {
-      const renderItemWrapper = (itemContent, item) => {
+      const renderItemWrapper = (itemContent: ReactNode) => {
         return (
           <TippyPopover content={<div>popover</div>}>
-            {itemContent}
+            <div>{itemContent}</div>
           </TippyPopover>
         );
       };
@@ -147,13 +148,13 @@ describe("AccordionList", () => {
   });
 });
 
-function assertAbsence(array) {
+function assertAbsence(array: string[]) {
   array.forEach((item) => {
     expect(screen.queryByText(item)).not.toBeInTheDocument();
   });
 }
 
-function assertPresence(array) {
+function assertPresence(array: string[]) {
   array.forEach((item) => {
     expect(screen.getByText(item)).toBeInTheDocument();
   });

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -10,7 +10,7 @@ import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
 import type { IconName, TextInputProps } from "metabase/ui";
-import { Box, Icon, Text } from "metabase/ui";
+import { Box, Icon, Text, isValidIconName } from "metabase/ui";
 
 import styles from "./AccordionListCell.module.css";
 import {
@@ -20,7 +20,7 @@ import {
   ListCellItem,
 } from "./AccordionListCell.styled";
 import type { Item, Row, Section } from "./types";
-import { get } from "./utils";
+import { isReactNode } from "./utils";
 
 export type SharedAccordionProps<
   TItem extends Item,
@@ -71,8 +71,9 @@ export function AccordionListCell<
   canToggleSections,
   color: colorProp = "brand",
   getItemClassName = (item: TItem) => {
-    const className = get(item, "className");
-    return typeof className === "string" ? className : undefined;
+    if ("className" in item && typeof item.className === "string") {
+      return item.className;
+    }
   },
   getItemStyles = () => ({}),
   hasCursor,
@@ -84,12 +85,22 @@ export function AccordionListCell<
   renderSectionIcon = (section: TSection) =>
     section.icon && <Icon name={section.icon as IconName} />,
   renderItemLabel,
-  renderItemName = (item: TItem) => get<string>(item, "name"),
-  renderItemDescription = (item: TItem) => get<string>(item, "description"),
+  renderItemName = (item: TItem) => {
+    if ("name" in item && typeof item.name === "string") {
+      return item.name;
+    }
+  },
+  renderItemDescription = (item: TItem) => {
+    if ("description" in item && isReactNode(item.description)) {
+      return item.description;
+    }
+  },
   renderItemExtra = () => null,
   renderItemIcon = (item: TItem) => {
-    const icon = get<IconName>(item, "icon");
-    return icon ? <Icon name={icon} /> : null;
+    if ("icon" in item && isValidIconName(item.icon)) {
+      return <Icon name={item.icon} />;
+    }
+    return null;
   },
   renderItemWrapper = (content: ReactNode) => content,
   row,

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -9,7 +9,7 @@ import ListS from "metabase/css/components/list.module.css";
 import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
-import type { IconName, TextInputProps } from "metabase/ui";
+import type { TextInputProps } from "metabase/ui";
 import { Box, Icon, Text, isValidIconName } from "metabase/ui";
 
 import styles from "./AccordionListCell.module.css";
@@ -83,7 +83,7 @@ export function AccordionListCell<
   onChange,
   onChangeSearchText,
   renderSectionIcon = (section: TSection) =>
-    section.icon && <Icon name={section.icon as IconName} />,
+    section.icon && <Icon name={section.icon} />,
   renderItemLabel,
   renderItemName = (item: TItem) => {
     if ("name" in item && typeof item.name === "string") {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -71,7 +71,11 @@ export function AccordionListCell<
   canToggleSections,
   color: colorProp = "brand",
   getItemClassName = (item: TItem) => {
-    if ("className" in item && typeof item.className === "string") {
+    if (
+      typeof item === "object" &&
+      "className" in item &&
+      typeof item.className === "string"
+    ) {
       return item.className;
     }
   },
@@ -86,18 +90,30 @@ export function AccordionListCell<
     section.icon && <Icon name={section.icon} />,
   renderItemLabel,
   renderItemName = (item: TItem) => {
-    if ("name" in item && typeof item.name === "string") {
+    if (
+      typeof item === "object" &&
+      "name" in item &&
+      typeof item.name === "string"
+    ) {
       return item.name;
     }
   },
   renderItemDescription = (item: TItem) => {
-    if ("description" in item && isReactNode(item.description)) {
+    if (
+      typeof item === "object" &&
+      "description" in item &&
+      isReactNode(item.description)
+    ) {
       return item.description;
     }
   },
   renderItemExtra = () => null,
   renderItemIcon = (item: TItem) => {
-    if ("icon" in item && isValidIconName(item.icon)) {
+    if (
+      typeof item === "object" &&
+      "icon" in item &&
+      isValidIconName(item.icon)
+    ) {
       return <Icon name={item.icon} />;
     }
     return null;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -375,7 +375,6 @@ export function AccordionListCell<
   return (
     <div
       style={style}
-      aria-expanded={sectionIsExpanded(sectionIndex)}
       data-element-id="list-section"
       className={cx(section.className, {
         [ListS.ListSectionExpanded]: sectionIsExpanded(sectionIndex),

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -38,7 +38,7 @@ type AccordionListCellProps<
 
   renderSectionIcon: (section: TSection) => ReactNode;
 
-  renderItemLabel: (item: TItem) => string | undefined;
+  renderItemLabel?: (item: TItem) => string | undefined;
   renderItemName: (item: TItem) => string | undefined;
   renderItemDescription: (item: TItem) => ReactNode;
   renderItemIcon: (item: TItem) => ReactNode;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -285,12 +285,12 @@ export function AccordionListCell<
     );
   } else if (type === "item") {
     const { item, itemIndex, isLastItem } = row;
-    const isSelected = itemIsSelected(item, itemIndex) ?? false;
+    const isSelected = itemIsSelected(item, itemIndex);
     const isClickable = itemIsClickable(item, itemIndex) ?? false;
     const icon = renderItemIcon(item);
     const name = renderItemName(item);
     const description = renderItemDescription(item);
-    const extra = renderItemExtra(item, isSelected);
+    const extra = renderItemExtra(item, isSelected ?? false);
     const label = renderItemLabel ? renderItemLabel(item) : name;
 
     content = (

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -22,20 +22,12 @@ import {
 import type { Item, Row, Section } from "./types";
 import { get } from "./utils";
 
-type AccordionListCellProps<
+export type SharedAccordionProps<
   TItem extends Item,
   TSection extends Section<TItem>,
 > = {
-  style?: CSSProperties;
-  sections: TSection[];
-  row: Row<TItem, TSection>;
-  onChange: (item: TItem) => void;
   itemIsSelected?: (item: TItem, index: number) => boolean | undefined;
   itemIsClickable?: (item: TItem, index: number) => boolean | undefined;
-  sectionIsExpanded: (sectionIndex: number) => boolean | undefined;
-  canToggleSections?: boolean;
-  alwaysExpanded?: boolean;
-  toggleSection: (sectionIndex: number) => void;
   renderSectionIcon?: (section: TSection) => ReactNode;
   renderItemLabel?: (item: TItem) => string | undefined;
   renderItemName?: (item: TItem) => string | undefined;
@@ -44,17 +36,31 @@ type AccordionListCellProps<
   renderItemExtra?: (item: TItem, isSelected: boolean) => ReactNode;
   renderItemWrapper?: (content: ReactNode, item: TItem) => ReactNode;
   showSpinner?: (itemOrSection: TItem | TSection) => boolean;
-  searchText: string;
-  onChangeSearchText: (searchText: string) => void;
-  searchPlaceholder?: string;
-  showItemArrows?: boolean;
-  itemTestId?: string;
   getItemClassName?: (item: TItem, index: number) => string | undefined;
   getItemStyles?: (item: TItem, index: number) => CSSProperties | undefined;
   searchInputProps?: TextInputProps;
-  hasCursor?: boolean;
+  searchPlaceholder?: string;
+  itemTestId?: string;
+  showItemArrows?: boolean;
+  alwaysExpanded?: boolean;
   withBorders?: boolean;
   color?: ColorName;
+};
+
+type AccordionListCellProps<
+  TItem extends Item,
+  TSection extends Section<TItem>,
+> = SharedAccordionProps<TItem, TSection> & {
+  style?: CSSProperties;
+  sections: TSection[];
+  row: Row<TItem, TSection>;
+  onChange: (item: TItem) => void;
+  sectionIsExpanded: (sectionIndex: number) => boolean | undefined;
+  canToggleSections: boolean;
+  toggleSection: (sectionIndex: number) => void;
+  searchText: string;
+  onChangeSearchText: (searchText: string) => void;
+  hasCursor: boolean;
 };
 
 export function AccordionListCell<

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -19,43 +19,43 @@ import {
   IconWrapper,
   ListCellItem,
 } from "./AccordionListCell.styled";
-import type { Row, Section } from "./types";
+import type { Item, Row, Section } from "./types";
 
-type AccordionListCellProps<T extends object> = {
+type AccordionListCellProps<TItem extends Item> = {
   style: CSSProperties;
-  sections: Section<T>[];
-  row: Row<T>;
-  onChange: (item: T) => void;
-  itemIsSelected: (item: T, index: number) => boolean | undefined;
-  itemIsClickable: (item: T, index: number) => boolean | undefined;
+  sections: Section<TItem>[];
+  row: Row<TItem>;
+  onChange: (item: TItem) => void;
+  itemIsSelected: (item: TItem, index: number) => boolean | undefined;
+  itemIsClickable: (item: TItem, index: number) => boolean | undefined;
   sectionIsExpanded: (sectionIndex: number) => boolean | undefined;
   canToggleSections?: boolean;
   alwaysExpanded?: boolean;
   toggleSection: (sectionIndex: number) => void;
 
-  renderSectionIcon: (section: Section<T>) => ReactNode;
+  renderSectionIcon: (section: Section<TItem>) => ReactNode;
 
-  renderItemLabel: (item: T) => string | undefined;
-  renderItemName: (item: T) => string | undefined;
-  renderItemDescription: (item: T) => ReactNode;
-  renderItemIcon: (item: T) => ReactNode;
-  renderItemExtra: (item: T, isSelected: boolean) => ReactNode;
-  renderItemWrapper: (content: ReactNode, item: T) => ReactNode;
-  showSpinner: (itemOrSection: T | Section<T>) => boolean;
+  renderItemLabel: (item: TItem) => string | undefined;
+  renderItemName: (item: TItem) => string | undefined;
+  renderItemDescription: (item: TItem) => ReactNode;
+  renderItemIcon: (item: TItem) => ReactNode;
+  renderItemExtra: (item: TItem, isSelected: boolean) => ReactNode;
+  renderItemWrapper: (content: ReactNode, item: TItem) => ReactNode;
+  showSpinner: (itemOrSection: TItem | Section<TItem>) => boolean;
   searchText: string;
   onChangeSearchText: (searchText: string) => void;
   searchPlaceholder?: string;
   showItemArrows?: boolean;
   itemTestId?: string;
-  getItemClassName: (item: T, index: number) => string | undefined;
-  getItemStyles: (item: T, index: number) => CSSProperties | undefined;
+  getItemClassName: (item: TItem, index: number) => string | undefined;
+  getItemStyles: (item: TItem, index: number) => CSSProperties | undefined;
   searchInputProps?: TextInputProps;
   hasCursor?: boolean;
   withBorders?: boolean;
   color?: ColorName;
 };
 
-export function AccordionListCell<T extends object>({
+export function AccordionListCell<TItem extends Item>({
   style,
   sections,
   row,
@@ -85,7 +85,7 @@ export function AccordionListCell<T extends object>({
   hasCursor,
   withBorders,
   color: colorProp = "brand",
-}: AccordionListCellProps<T>) {
+}: AccordionListCellProps<TItem>) {
   const { type, section, sectionIndex, isLastSection } = row;
   let content;
   let borderTop;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -21,10 +21,13 @@ import {
 } from "./AccordionListCell.styled";
 import type { Item, Row, Section } from "./types";
 
-type AccordionListCellProps<TItem extends Item> = {
+type AccordionListCellProps<
+  TItem extends Item,
+  TSection extends Section<TItem>,
+> = {
   style: CSSProperties;
-  sections: Section<TItem>[];
-  row: Row<TItem>;
+  sections: TSection[];
+  row: Row<TItem, TSection>;
   onChange: (item: TItem) => void;
   itemIsSelected: (item: TItem, index: number) => boolean | undefined;
   itemIsClickable: (item: TItem, index: number) => boolean | undefined;
@@ -33,7 +36,7 @@ type AccordionListCellProps<TItem extends Item> = {
   alwaysExpanded?: boolean;
   toggleSection: (sectionIndex: number) => void;
 
-  renderSectionIcon: (section: Section<TItem>) => ReactNode;
+  renderSectionIcon: (section: TSection) => ReactNode;
 
   renderItemLabel: (item: TItem) => string | undefined;
   renderItemName: (item: TItem) => string | undefined;
@@ -41,7 +44,7 @@ type AccordionListCellProps<TItem extends Item> = {
   renderItemIcon: (item: TItem) => ReactNode;
   renderItemExtra: (item: TItem, isSelected: boolean) => ReactNode;
   renderItemWrapper: (content: ReactNode, item: TItem) => ReactNode;
-  showSpinner: (itemOrSection: TItem | Section<TItem>) => boolean;
+  showSpinner: (itemOrSection: TItem | TSection) => boolean;
   searchText: string;
   onChangeSearchText: (searchText: string) => void;
   searchPlaceholder?: string;
@@ -55,7 +58,10 @@ type AccordionListCellProps<TItem extends Item> = {
   color?: ColorName;
 };
 
-export function AccordionListCell<TItem extends Item>({
+export function AccordionListCell<
+  TItem extends Item,
+  TSection extends Section<TItem>,
+>({
   style,
   sections,
   row,
@@ -85,7 +91,7 @@ export function AccordionListCell<TItem extends Item>({
   hasCursor,
   withBorders,
   color: colorProp = "brand",
-}: AccordionListCellProps<TItem>) {
+}: AccordionListCellProps<TItem, TSection>) {
   const { type, section, sectionIndex, isLastSection } = row;
   let content;
   let borderTop;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -12,7 +12,6 @@ import type { ColorName } from "metabase/lib/colors/types";
 import type { TextInputProps } from "metabase/ui";
 import { Box, Icon, Text } from "metabase/ui";
 
-import type { Row, Section } from "./AccordionList";
 import styles from "./AccordionListCell.module.css";
 import {
   Content,
@@ -20,6 +19,7 @@ import {
   IconWrapper,
   ListCellItem,
 } from "./AccordionListCell.styled";
+import type { Row, Section } from "./types";
 
 type AccordionListCellProps<T extends object> = {
   style: CSSProperties;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -26,85 +26,83 @@ export type SharedAccordionProps<
   TItem extends Item,
   TSection extends Section<TItem>,
 > = {
-  itemIsSelected?: (item: TItem, index: number) => boolean | undefined;
-  itemIsClickable?: (item: TItem, index: number) => boolean | undefined;
-  renderSectionIcon?: (section: TSection) => ReactNode;
-  renderItemLabel?: (item: TItem) => string | undefined;
-  renderItemName?: (item: TItem) => string | undefined;
-  renderItemDescription?: (item: TItem) => ReactNode;
-  renderItemIcon?: (item: TItem) => ReactNode;
-  renderItemExtra?: (item: TItem, isSelected: boolean) => ReactNode;
-  renderItemWrapper?: (content: ReactNode, item: TItem) => ReactNode;
-  showSpinner?: (itemOrSection: TItem | TSection) => boolean;
+  alwaysExpanded?: boolean;
+  color?: ColorName;
   getItemClassName?: (item: TItem, index: number) => string | undefined;
   getItemStyles?: (item: TItem, index: number) => CSSProperties | undefined;
+  itemIsClickable?: (item: TItem, index: number) => boolean | undefined;
+  itemIsSelected?: (item: TItem, index: number) => boolean | undefined;
+  itemTestId?: string;
+  renderItemDescription?: (item: TItem) => ReactNode;
+  renderItemExtra?: (item: TItem, isSelected: boolean) => ReactNode;
+  renderItemIcon?: (item: TItem) => ReactNode;
+  renderItemLabel?: (item: TItem) => string | undefined;
+  renderItemName?: (item: TItem) => string | undefined;
+  renderItemWrapper?: (content: ReactNode, item: TItem) => ReactNode;
+  renderSectionIcon?: (section: TSection) => ReactNode;
   searchInputProps?: TextInputProps;
   searchPlaceholder?: string;
-  itemTestId?: string;
   showItemArrows?: boolean;
-  alwaysExpanded?: boolean;
+  showSpinner?: (itemOrSection: TItem | TSection) => boolean;
   withBorders?: boolean;
-  color?: ColorName;
 };
 
 type AccordionListCellProps<
   TItem extends Item,
   TSection extends Section<TItem>,
 > = SharedAccordionProps<TItem, TSection> & {
-  style?: CSSProperties;
-  sections: TSection[];
-  row: Row<TItem, TSection>;
-  onChange: (item: TItem) => void;
-  sectionIsExpanded: (sectionIndex: number) => boolean | undefined;
   canToggleSections: boolean;
-  toggleSection: (sectionIndex: number) => void;
-  searchText: string;
-  onChangeSearchText: (searchText: string) => void;
   hasCursor: boolean;
+  onChange: (item: TItem) => void;
+  onChangeSearchText: (searchText: string) => void;
+  row: Row<TItem, TSection>;
+  searchText: string;
+  sectionIsExpanded: (sectionIndex: number) => boolean | undefined;
+  sections: TSection[];
+  style?: CSSProperties;
+  toggleSection: (sectionIndex: number) => void;
 };
 
 export function AccordionListCell<
   TItem extends Item,
   TSection extends Section<TItem>,
 >({
-  style,
-  sections,
-  row,
-  onChange,
-  itemIsClickable = () => true,
-  itemIsSelected = () => false,
-  sectionIsExpanded,
-  canToggleSections,
   alwaysExpanded,
-  toggleSection,
-  renderSectionIcon = (section: TSection) =>
-    section.icon && <Icon name={section.icon as IconName} />,
-  renderItemLabel,
-  renderItemName = (item: TItem) => get<string>(item, "name"),
-  renderItemDescription = (item: TItem) => get<string>(item, "description"),
-  renderItemIcon = (item: TItem) => {
-    const icon = get<IconName>(item, "icon");
-    return icon ? <Icon name={icon} /> : null;
-  },
-
-  renderItemExtra = () => null,
-  renderItemWrapper = (content: ReactNode) => content,
-  showSpinner = () => false,
-
-  searchText,
-  onChangeSearchText,
-  searchPlaceholder = t`Find...`,
-  showItemArrows,
-  itemTestId,
+  canToggleSections,
+  color: colorProp = "brand",
   getItemClassName = (item: TItem) => {
     const className = get(item, "className");
     return typeof className === "string" ? className : undefined;
   },
   getItemStyles = () => ({}),
-  searchInputProps,
   hasCursor,
+  itemIsClickable = () => true,
+  itemIsSelected = () => false,
+  itemTestId,
+  onChange,
+  onChangeSearchText,
+  renderSectionIcon = (section: TSection) =>
+    section.icon && <Icon name={section.icon as IconName} />,
+  renderItemLabel,
+  renderItemName = (item: TItem) => get<string>(item, "name"),
+  renderItemDescription = (item: TItem) => get<string>(item, "description"),
+  renderItemExtra = () => null,
+  renderItemIcon = (item: TItem) => {
+    const icon = get<IconName>(item, "icon");
+    return icon ? <Icon name={icon} /> : null;
+  },
+  renderItemWrapper = (content: ReactNode) => content,
+  row,
+  searchInputProps,
+  searchPlaceholder = t`Find...`,
+  searchText,
+  sectionIsExpanded,
+  sections,
+  showItemArrows,
+  showSpinner = () => false,
+  style,
+  toggleSection,
   withBorders,
-  color: colorProp = "brand",
 }: AccordionListCellProps<TItem, TSection>) {
   const { type, section, sectionIndex, isLastSection } = row;
   let content;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -9,7 +9,7 @@ import ListS from "metabase/css/components/list.module.css";
 import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
-import type { TextInputProps } from "metabase/ui";
+import type { IconName, TextInputProps } from "metabase/ui";
 import { Box, Icon, Text } from "metabase/ui";
 
 import styles from "./AccordionListCell.module.css";
@@ -20,38 +20,37 @@ import {
   ListCellItem,
 } from "./AccordionListCell.styled";
 import type { Item, Row, Section } from "./types";
+import { get } from "./utils";
 
 type AccordionListCellProps<
   TItem extends Item,
   TSection extends Section<TItem>,
 > = {
-  style: CSSProperties;
+  style?: CSSProperties;
   sections: TSection[];
   row: Row<TItem, TSection>;
   onChange: (item: TItem) => void;
-  itemIsSelected: (item: TItem, index: number) => boolean | undefined;
-  itemIsClickable: (item: TItem, index: number) => boolean | undefined;
+  itemIsSelected?: (item: TItem, index: number) => boolean | undefined;
+  itemIsClickable?: (item: TItem, index: number) => boolean | undefined;
   sectionIsExpanded: (sectionIndex: number) => boolean | undefined;
   canToggleSections?: boolean;
   alwaysExpanded?: boolean;
   toggleSection: (sectionIndex: number) => void;
-
-  renderSectionIcon: (section: TSection) => ReactNode;
-
+  renderSectionIcon?: (section: TSection) => ReactNode;
   renderItemLabel?: (item: TItem) => string | undefined;
-  renderItemName: (item: TItem) => string | undefined;
-  renderItemDescription: (item: TItem) => ReactNode;
-  renderItemIcon: (item: TItem) => ReactNode;
-  renderItemExtra: (item: TItem, isSelected: boolean) => ReactNode;
-  renderItemWrapper: (content: ReactNode, item: TItem) => ReactNode;
-  showSpinner: (itemOrSection: TItem | TSection) => boolean;
+  renderItemName?: (item: TItem) => string | undefined;
+  renderItemDescription?: (item: TItem) => ReactNode;
+  renderItemIcon?: (item: TItem) => ReactNode;
+  renderItemExtra?: (item: TItem, isSelected: boolean) => ReactNode;
+  renderItemWrapper?: (content: ReactNode, item: TItem) => ReactNode;
+  showSpinner?: (itemOrSection: TItem | TSection) => boolean;
   searchText: string;
   onChangeSearchText: (searchText: string) => void;
   searchPlaceholder?: string;
   showItemArrows?: boolean;
   itemTestId?: string;
-  getItemClassName: (item: TItem, index: number) => string | undefined;
-  getItemStyles: (item: TItem, index: number) => CSSProperties | undefined;
+  getItemClassName?: (item: TItem, index: number) => string | undefined;
+  getItemStyles?: (item: TItem, index: number) => CSSProperties | undefined;
   searchInputProps?: TextInputProps;
   hasCursor?: boolean;
   withBorders?: boolean;
@@ -66,27 +65,36 @@ export function AccordionListCell<
   sections,
   row,
   onChange,
-  itemIsSelected,
-  itemIsClickable,
+  itemIsClickable = () => true,
+  itemIsSelected = () => false,
   sectionIsExpanded,
   canToggleSections,
   alwaysExpanded,
   toggleSection,
-  renderSectionIcon,
+  renderSectionIcon = (section: TSection) =>
+    section.icon && <Icon name={section.icon as IconName} />,
   renderItemLabel,
-  renderItemName,
-  renderItemDescription,
-  renderItemIcon,
-  renderItemExtra,
-  renderItemWrapper,
-  showSpinner,
+  renderItemName = (item: TItem) => get<string>(item, "name"),
+  renderItemDescription = (item: TItem) => get<string>(item, "description"),
+  renderItemIcon = (item: TItem) => {
+    const icon = get<IconName>(item, "icon");
+    return icon ? <Icon name={icon} /> : null;
+  },
+
+  renderItemExtra = () => null,
+  renderItemWrapper = (content: ReactNode) => content,
+  showSpinner = () => false,
+
   searchText,
   onChangeSearchText,
   searchPlaceholder = t`Find...`,
   showItemArrows,
   itemTestId,
-  getItemClassName,
-  getItemStyles,
+  getItemClassName = (item: TItem) => {
+    const className = get(item, "className");
+    return typeof className === "string" ? className : undefined;
+  },
+  getItemStyles = () => ({}),
   searchInputProps,
   hasCursor,
   withBorders,

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable react/prop-types */
-
 import cx from "classnames";
+import type { CSSProperties, ReactNode } from "react";
 import { t } from "ttag";
 
 import EmptyState from "metabase/components/EmptyState";
@@ -9,8 +8,11 @@ import LoadingSpinner from "metabase/components/LoadingSpinner";
 import ListS from "metabase/css/components/list.module.css";
 import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
+import type { ColorName } from "metabase/lib/colors/types";
+import type { TextInputProps } from "metabase/ui";
 import { Box, Icon, Text } from "metabase/ui";
 
+import type { Row, Section } from "./AccordionList";
 import styles from "./AccordionListCell.module.css";
 import {
   Content,
@@ -19,7 +21,41 @@ import {
   ListCellItem,
 } from "./AccordionListCell.styled";
 
-export const AccordionListCell = ({
+type AccordionListCellProps<T extends object> = {
+  style: CSSProperties;
+  sections: Section<T>[];
+  row: Row<T>;
+  onChange: (item: T) => void;
+  itemIsSelected: (item: T, index: number) => boolean | undefined;
+  itemIsClickable: (item: T, index: number) => boolean | undefined;
+  sectionIsExpanded: (sectionIndex: number) => boolean | undefined;
+  canToggleSections?: boolean;
+  alwaysExpanded?: boolean;
+  toggleSection: (sectionIndex: number) => void;
+
+  renderSectionIcon: (section: Section<T>) => ReactNode;
+
+  renderItemLabel: (item: T) => string | undefined;
+  renderItemName: (item: T) => string | undefined;
+  renderItemDescription: (item: T) => ReactNode;
+  renderItemIcon: (item: T) => ReactNode;
+  renderItemExtra: (item: T, isSelected: boolean) => ReactNode;
+  renderItemWrapper: (content: ReactNode, item: T) => ReactNode;
+  showSpinner: (itemOrSection: T | Section<T>) => boolean;
+  searchText: string;
+  onChangeSearchText: (searchText: string) => void;
+  searchPlaceholder?: string;
+  showItemArrows?: boolean;
+  itemTestId?: string;
+  getItemClassName: (item: T, index: number) => string | undefined;
+  getItemStyles: (item: T, index: number) => CSSProperties | undefined;
+  searchInputProps?: TextInputProps;
+  hasCursor?: boolean;
+  withBorders?: boolean;
+  color?: ColorName;
+};
+
+export function AccordionListCell<T extends object>({
   style,
   sections,
   row,
@@ -48,16 +84,9 @@ export const AccordionListCell = ({
   searchInputProps,
   hasCursor,
   withBorders,
-}) => {
-  const {
-    type,
-    section,
-    sectionIndex,
-    item,
-    itemIndex,
-    isLastItem,
-    isLastSection,
-  } = row;
+  color: colorProp = "brand",
+}: AccordionListCellProps<T>) {
+  const { type, section, sectionIndex, isLastSection } = row;
   let content;
   let borderTop;
   let borderBottom;
@@ -74,7 +103,7 @@ export const AccordionListCell = ({
             CS.textUppercase,
             CS.textBold,
           )}
-          style={{ color: color }}
+          style={{ color: color(colorProp) }}
         >
           {section.name}
         </div>
@@ -86,7 +115,7 @@ export const AccordionListCell = ({
       borderTop =
         section.type === "back" ||
         section.type === "action" ||
-        section.items?.length > 0;
+        (section.items?.length ?? 0) > 0;
       borderBottom = section.type === "back";
 
       content = (
@@ -237,8 +266,9 @@ export const AccordionListCell = ({
       />
     );
   } else if (type === "item") {
-    const isSelected = itemIsSelected(item, itemIndex);
-    const isClickable = itemIsClickable(item, itemIndex);
+    const { item, itemIndex, isLastItem } = row;
+    const isSelected = itemIsSelected(item, itemIndex) ?? false;
+    const isClickable = itemIsClickable(item, itemIndex) ?? false;
     const icon = renderItemIcon(item);
     const name = renderItemName(item);
     const description = renderItemDescription(item);
@@ -266,7 +296,7 @@ export const AccordionListCell = ({
           },
           getItemClassName(item, itemIndex),
         )}
-        style={getItemStyles(item, itemIndex)}
+        style={getItemStyles(item, itemIndex) ?? {}}
       >
         <Content
           isClickable={isClickable}
@@ -327,7 +357,7 @@ export const AccordionListCell = ({
   return (
     <div
       style={style}
-      aria-expanded={sectionIsExpanded}
+      aria-expanded={sectionIsExpanded(sectionIndex)}
       data-element-id="list-section"
       className={cx(section.className, {
         [ListS.ListSectionExpanded]: sectionIsExpanded(sectionIndex),
@@ -339,4 +369,4 @@ export const AccordionListCell = ({
       {content}
     </div>
   );
-};
+}

--- a/frontend/src/metabase/core/components/AccordionList/index.js
+++ b/frontend/src/metabase/core/components/AccordionList/index.js
@@ -1,1 +1,5 @@
-export { default } from "./AccordionList";
+export {
+  AccordionList,
+  AccordionList as default,
+  Section,
+} from "./AccordionList";

--- a/frontend/src/metabase/core/components/AccordionList/index.js
+++ b/frontend/src/metabase/core/components/AccordionList/index.js
@@ -1,5 +1,1 @@
-export {
-  AccordionList,
-  AccordionList as default,
-  Section,
-} from "./AccordionList";
+export { AccordionList, Section } from "./AccordionList";

--- a/frontend/src/metabase/core/components/AccordionList/types.ts
+++ b/frontend/src/metabase/core/components/AccordionList/types.ts
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import type { IconName } from "metabase/ui";
 
-export type Item = object;
+export type Item = object | string;
 
 export type Section<TItem extends Item = Item> = {
   name?: ReactNode;

--- a/frontend/src/metabase/core/components/AccordionList/types.ts
+++ b/frontend/src/metabase/core/components/AccordionList/types.ts
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+
+import type { IconName } from "metabase/ui";
+
+export type Section<T extends Item = Item> = {
+  key?: string;
+  name?: ReactNode;
+  displayName?: ReactNode;
+  type?:
+    | "action"
+    | "header"
+    | "search"
+    | "loading"
+    | "no-results"
+    | "item"
+    | "back";
+  icon?: IconName | null;
+  loading?: boolean;
+  items?: T[];
+  active?: boolean;
+  className?: string | null;
+};
+
+export type Item = object;
+
+export type Row<T extends object> = {
+  section: Section<T>;
+  sectionIndex: number;
+  isLastSection: boolean;
+} & (
+  | {
+      type: "action";
+    }
+  | {
+      type: "header";
+    }
+  | {
+      type: "search";
+    }
+  | {
+      type: "loading";
+    }
+  | {
+      type: "no-results";
+    }
+  | {
+      type: "back";
+    }
+  | {
+      type: "item";
+      item: T;
+      itemIndex: number;
+      isLastItem: boolean;
+    }
+);

--- a/frontend/src/metabase/core/components/AccordionList/types.ts
+++ b/frontend/src/metabase/core/components/AccordionList/types.ts
@@ -2,7 +2,9 @@ import type { ReactNode } from "react";
 
 import type { IconName } from "metabase/ui";
 
-export type Section<T extends Item = Item> = {
+export type Item = object;
+
+export type Section<TItem extends Item = Item> = {
   key?: string;
   name?: ReactNode;
   displayName?: ReactNode;
@@ -16,15 +18,13 @@ export type Section<T extends Item = Item> = {
     | "back";
   icon?: IconName | null;
   loading?: boolean;
-  items?: T[];
+  items?: TItem[];
   active?: boolean;
   className?: string | null;
 };
 
-export type Item = object;
-
-export type Row<T extends object> = {
-  section: Section<T>;
+export type Row<TItem extends Item> = {
+  section: Section<TItem>;
   sectionIndex: number;
   isLastSection: boolean;
 } & (
@@ -48,7 +48,7 @@ export type Row<T extends object> = {
     }
   | {
       type: "item";
-      item: T;
+      item: TItem;
       itemIndex: number;
       isLastItem: boolean;
     }

--- a/frontend/src/metabase/core/components/AccordionList/types.ts
+++ b/frontend/src/metabase/core/components/AccordionList/types.ts
@@ -5,9 +5,7 @@ import type { IconName } from "metabase/ui";
 export type Item = object;
 
 export type Section<TItem extends Item = Item> = {
-  key?: string;
   name?: ReactNode;
-  displayName?: ReactNode;
   type?:
     | "action"
     | "header"
@@ -18,13 +16,12 @@ export type Section<TItem extends Item = Item> = {
     | "back";
   icon?: IconName | null;
   loading?: boolean;
+  className?: string;
   items?: TItem[];
-  active?: boolean;
-  className?: string | null;
 };
 
-export type Row<TItem extends Item> = {
-  section: Section<TItem>;
+export type Row<TItem extends Item, TSection extends Section<TItem>> = {
+  section: TSection;
   sectionIndex: number;
   isLastSection: boolean;
 } & (

--- a/frontend/src/metabase/core/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/core/components/AccordionList/utils.ts
@@ -1,4 +1,5 @@
-import { getIn } from "icepick";
+import { type ReactNode, isValidElement } from "react";
+import { isFragment } from "react-is";
 
 import type { Section } from "./types";
 
@@ -163,6 +164,13 @@ export const getPrevCursor = (
   return cursor;
 };
 
-export function get<T = unknown>(object: unknown, path: string): T | undefined {
-  return getIn(object, path.split("."));
+export function isReactNode(x: unknown): x is ReactNode {
+  return (
+    isValidElement(x) ||
+    isFragment(x) ||
+    typeof x === "string" ||
+    typeof x === "number" ||
+    x === null ||
+    x === undefined
+  );
 }

--- a/frontend/src/metabase/core/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/core/components/AccordionList/utils.ts
@@ -1,4 +1,4 @@
-import type { Section } from "./AccordionList";
+import type { Section } from "./types";
 
 export type Cursor = {
   sectionIndex: number;

--- a/frontend/src/metabase/core/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/core/components/AccordionList/utils.ts
@@ -1,3 +1,5 @@
+import { getIn } from "icepick";
+
 import type { Section } from "./types";
 
 export type Cursor = {
@@ -160,3 +162,7 @@ export const getPrevCursor = (
 
   return cursor;
 };
+
+export function get<T = unknown>(object: unknown, path: string): T | undefined {
+  return getIn(object, path.split("."));
+}

--- a/frontend/src/metabase/core/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/core/components/AccordionList/utils.ts
@@ -1,10 +1,8 @@
-type Cursor = {
+import type { Section } from "./AccordionList";
+
+export type Cursor = {
   sectionIndex: number;
   itemIndex: number | null;
-};
-
-type Section = {
-  items: any;
 };
 
 type SectionPredicate = (sectionIndex: number) => boolean;
@@ -66,10 +64,10 @@ export const getNextCursor = (
     for (
       let itemIndex =
         sectionIndex === cursor.sectionIndex ? (cursor.itemIndex ?? 0) : 0;
-      itemIndex < section.items.length;
+      itemIndex < (section.items?.length ?? 0);
       itemIndex++
     ) {
-      const item = section.items[itemIndex];
+      const item = section.items?.[itemIndex];
       const itemCursor = {
         sectionIndex,
         itemIndex,
@@ -122,11 +120,11 @@ export const getPrevCursor = (
         let itemIndex =
           sectionIndex === cursor.sectionIndex
             ? (cursor.itemIndex ?? 0)
-            : section.items.length - 1;
+            : (section.items?.length ?? 0) - 1;
         itemIndex >= 0;
         itemIndex--
       ) {
-        const item = section.items[itemIndex];
+        const item = section.items?.[itemIndex];
         const itemCursor = {
           sectionIndex,
           itemIndex,

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
@@ -11,8 +11,10 @@ import type {
 import Select from "metabase/core/components/Select";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 
-export interface FormSelectProps<TValue, TOption = SelectOption<TValue>>
-  extends Omit<SelectProps<TValue, TOption>, "value"> {
+export interface FormSelectProps<
+  TValue,
+  TOption extends object = SelectOption<TValue>,
+> extends Omit<SelectProps<TValue, TOption>, "value"> {
   name: string;
   title?: string;
   actions?: ReactNode;
@@ -25,7 +27,7 @@ export interface FormSelectProps<TValue, TOption = SelectOption<TValue>>
  */
 const FormSelect = forwardRef(function FormSelect<
   TValue,
-  TOption = SelectOption<TValue>,
+  TOption extends object = SelectOption<TValue>,
 >(
   {
     name,

--- a/frontend/src/metabase/core/components/Select/Select.styled.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.styled.tsx
@@ -1,9 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-import styled from "@emotion/styled";
-
-import AccordionList from "metabase/core/components/AccordionList";
-
-export const SelectAccordionList = styled(AccordionList)`
-  color: var(--mb-color-brand);
-  outline: none;
-`;

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -11,7 +11,7 @@ import { Children, Component, createRef } from "react";
 import _ from "underscore";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
-import AccordionList from "metabase/core/components/AccordionList";
+import { AccordionList } from "metabase/core/components/AccordionList";
 import type { SelectButtonProps } from "metabase/core/components/SelectButton";
 import SelectButton from "metabase/core/components/SelectButton";
 import CS from "metabase/css/core/index.css";

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -56,7 +56,6 @@ export interface SelectProps<
   searchProp?: string;
   searchCaseInsensitive?: boolean;
   searchPlaceholder?: string;
-  searchFuzzy?: boolean;
   globalSearch?: boolean;
   hideEmptySectionsInSearch?: boolean;
   width?: number;
@@ -245,7 +244,6 @@ class BaseSelect<
       searchProp,
       searchCaseInsensitive,
       searchPlaceholder,
-      searchFuzzy,
       hideEmptySectionsInSearch,
       isInitiallyOpen,
       onClose,
@@ -319,7 +317,6 @@ class BaseSelect<
           searchable={!!searchProp}
           searchProp={searchProp}
           searchCaseInsensitive={searchCaseInsensitive}
-          searchFuzzy={searchFuzzy}
           searchPlaceholder={searchPlaceholder}
           globalSearch={this.props.globalSearch}
           hideEmptySectionsInSearch={hideEmptySectionsInSearch}

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -54,7 +54,6 @@ export interface SelectProps<
 
   // AccordionList props
   searchProp?: string;
-  searchCaseInsensitive?: boolean;
   searchPlaceholder?: string;
   globalSearch?: boolean;
   hideEmptySectionsInSearch?: boolean;
@@ -242,7 +241,6 @@ class BaseSelect<
       containerClassName,
       placeholder,
       searchProp,
-      searchCaseInsensitive,
       searchPlaceholder,
       hideEmptySectionsInSearch,
       isInitiallyOpen,
@@ -316,7 +314,6 @@ class BaseSelect<
           onChange={this.handleChange}
           searchable={!!searchProp}
           searchProp={searchProp}
-          searchCaseInsensitive={searchCaseInsensitive}
           searchPlaceholder={searchPlaceholder}
           globalSearch={this.props.globalSearch}
           hideEmptySectionsInSearch={hideEmptySectionsInSearch}

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -11,6 +11,7 @@ import { Children, Component, createRef } from "react";
 import _ from "underscore";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+import AccordionList from "metabase/core/components/AccordionList";
 import type { SelectButtonProps } from "metabase/core/components/SelectButton";
 import SelectButton from "metabase/core/components/SelectButton";
 import CS from "metabase/css/core/index.css";
@@ -20,11 +21,12 @@ import { composeEventHandlers } from "metabase/lib/compose-event-handlers";
 import type { IconName } from "metabase/ui";
 import { Icon } from "metabase/ui";
 
-import { SelectAccordionList } from "./Select.styled";
-
 const MIN_ICON_WIDTH = 20;
 
-export interface SelectProps<TValue, TOption = SelectOption<TValue>> {
+export interface SelectProps<
+  TValue,
+  TOption extends object = SelectOption<TValue>,
+> {
   className?: string;
   containerClassName?: string;
 
@@ -98,9 +100,10 @@ export interface SelectChangeTarget<TValue> {
   value: TValue;
 }
 
-class BaseSelect<TValue, TOption = SelectOption<TValue>> extends Component<
-  SelectProps<TValue, TOption>
-> {
+class BaseSelect<
+  TValue,
+  TOption extends object = SelectOption<TValue>,
+> extends Component<SelectProps<TValue, TOption>> {
   _popover?: any;
   selectButtonRef: RefObject<any>;
   _getValues: () => TValue[];
@@ -298,7 +301,7 @@ class BaseSelect<TValue, TOption = SelectOption<TValue>> extends Component<
         // this can happen when filtering items via search
         pinInitialAttachment
       >
-        <SelectAccordionList
+        <AccordionList<TOption>
           hasInitialFocus
           sections={sections}
           className="MB-Select"
@@ -321,6 +324,10 @@ class BaseSelect<TValue, TOption = SelectOption<TValue>> extends Component<
           globalSearch={this.props.globalSearch}
           hideEmptySectionsInSearch={hideEmptySectionsInSearch}
           data-testid={testId ? `${testId}-list` : null}
+          style={{
+            color: "var(--mb-color-brand)",
+            outline: "none",
+          }}
         />
         {footer}
       </PopoverWithTrigger>

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -56,7 +56,6 @@ export interface SelectProps<
   searchProp?: string;
   searchPlaceholder?: string;
   globalSearch?: boolean;
-  hideEmptySectionsInSearch?: boolean;
   width?: number;
 
   optionNameFn?: (option: TOption) => string | undefined;
@@ -242,7 +241,6 @@ class BaseSelect<
       placeholder,
       searchProp,
       searchPlaceholder,
-      hideEmptySectionsInSearch,
       isInitiallyOpen,
       onClose,
       disabled,
@@ -316,7 +314,6 @@ class BaseSelect<
           searchProp={searchProp}
           searchPlaceholder={searchPlaceholder}
           globalSearch={this.props.globalSearch}
-          hideEmptySectionsInSearch={hideEmptySectionsInSearch}
           data-testid={testId ? `${testId}-list` : null}
           style={{
             color: "var(--mb-color-brand)",

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/ValuesYouCanReference.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/ValuesYouCanReference.jsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
-import AccordionList from "metabase/core/components/AccordionList";
+import { AccordionList } from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import {
   isMappableColumn,

--- a/frontend/src/metabase/parameters/components/ParameterTargetList.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterTargetList.jsx
@@ -2,7 +2,7 @@
 import { Component } from "react";
 import _ from "underscore";
 
-import AccordionList from "metabase/core/components/AccordionList";
+import { AccordionList } from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import { Icon } from "metabase/ui";
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
@@ -1,7 +1,8 @@
 import cx from "classnames";
 import { useCallback, useMemo } from "react";
 
-import AccordionList, {
+import {
+  AccordionList,
   type Section,
 } from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
@@ -1,7 +1,9 @@
 import cx from "classnames";
 import { useCallback, useMemo } from "react";
 
-import AccordionList from "metabase/core/components/AccordionList";
+import AccordionList, {
+  type Section,
+} from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import { Icon } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
@@ -30,11 +32,6 @@ type Item = {
   database: Database;
 };
 
-type Section = {
-  name?: JSX.Element;
-  items?: Item[];
-};
-
 const DataSelectorDatabasePicker = ({
   databases,
   selectedDatabase,
@@ -44,7 +41,7 @@ const DataSelectorDatabasePicker = ({
   hasInitialFocus,
 }: DataSelectorDatabasePickerProps) => {
   const sections = useMemo(() => {
-    const sections: Section[] = [];
+    const sections: Section<Item>[] = [];
 
     if (onBack) {
       sections.push({ name: <RawDataBackButton /> });
@@ -62,7 +59,7 @@ const DataSelectorDatabasePicker = ({
   }, [databases, onBack]);
 
   const handleChangeSection = useCallback(
-    (section: Section, sectionIndex: number) => {
+    (_section: Section<Item>, sectionIndex: number) => {
       const isNavigationSection = onBack && sectionIndex === 0;
       if (isNavigationSection) {
         onBack();
@@ -77,7 +74,7 @@ const DataSelectorDatabasePicker = ({
   }
 
   return (
-    <AccordionList
+    <AccordionList<Item>
       id="DatabasePicker"
       key="databasePicker"
       className={CS.textBrand}

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -123,7 +123,9 @@ const DataSelectorDatabaseSchemaPicker = ({
       renderItemIcon={() => <Icon name="folder" size={16} />}
       initiallyOpenSection={openSection}
       alwaysTogglable={true}
-      showSpinner={(x) => "active" in x && !x.active}
+      showSpinner={(itemOrSection) =>
+        "active" in itemOrSection && !itemOrSection.active
+      }
       showItemArrows={hasNextStep}
       maxHeight={Infinity}
     />

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -1,7 +1,8 @@
 import cx from "classnames";
 import { t } from "ttag";
 
-import AccordionList, {
+import {
+  AccordionList,
   type Section,
 } from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -123,7 +123,7 @@ const DataSelectorDatabaseSchemaPicker = ({
       renderItemIcon={() => <Icon name="folder" size={16} />}
       initiallyOpenSection={openSection}
       alwaysTogglable={true}
-      showSpinner={(x) => "active" in x && Boolean(x.active)}
+      showSpinner={(x) => "active" in x && !x.active}
       showItemArrows={hasNextStep}
       maxHeight={Infinity}
     />

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -25,7 +25,7 @@ type DataSelectorDatabaseSchemaPicker = {
   selectedSchema: Schema;
   onBack: () => void;
   onChangeDatabase: (database: Database) => void;
-  onChangeSchema: (item: { schema?: Schema }) => void;
+  onChangeSchema: (schema?: Schema) => void;
 };
 
 type Item = {
@@ -116,7 +116,7 @@ const DataSelectorDatabaseSchemaPicker = ({
       className={CS.textBrand}
       hasInitialFocus={hasInitialFocus}
       sections={sections}
-      onChange={onChangeSchema}
+      onChange={({ schema }) => onChangeSchema(schema)}
       onChangeSection={handleChangeSection}
       itemIsSelected={({ schema }) => schema === selectedSchema}
       renderSectionIcon={renderSectionIcon}

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -1,11 +1,11 @@
 import cx from "classnames";
-import type * as React from "react";
 import { t } from "ttag";
 
-import AccordionList from "metabase/core/components/AccordionList";
+import AccordionList, {
+  type Section,
+} from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import { isSyncCompleted } from "metabase/lib/syncing";
-import type { IconName } from "metabase/ui";
 import { Icon } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type Schema from "metabase-lib/v1/metadata/Schema";
@@ -27,20 +27,10 @@ type DataSelectorDatabaseSchemaPicker = {
   onChangeSchema: (item: { schema?: Schema }) => void;
 };
 
-type Section = {
-  name: string | React.ReactElement;
-  items?: {
-    schema: Schema;
-    name: string;
-  }[];
-  className?: string | null;
-  icon?: IconName;
-  loading?: boolean;
-  active: boolean;
-  type?: string;
+type Item = {
+  schema: Schema;
+  name: string;
 };
-
-type Sections = Section[];
 
 const DataSelectorDatabaseSchemaPicker = ({
   databases,
@@ -58,7 +48,7 @@ const DataSelectorDatabaseSchemaPicker = ({
     return <DataSelectorLoading />;
   }
 
-  const sections: Sections = databases.map((database) => ({
+  const sections: Section<Item>[] = databases.map((database) => ({
     name: database.is_saved_questions ? t`Saved Questions` : database.name,
     items:
       !database.is_saved_questions && database.getSchemas().length > 1
@@ -67,7 +57,7 @@ const DataSelectorDatabaseSchemaPicker = ({
             name: schema.displayName() ?? "",
           }))
         : [],
-    className: database.is_saved_questions ? CS.bgLight : null,
+    className: database.is_saved_questions ? CS.bgLight : undefined,
     icon: database.is_saved_questions ? "collection" : "database",
     loading:
       selectedDatabase?.id === database.id &&
@@ -95,9 +85,7 @@ const DataSelectorDatabaseSchemaPicker = ({
     return true;
   };
 
-  const showSpinner = ({ active }: { active?: boolean }) => active === false;
-
-  const renderSectionIcon = ({ icon }: { icon?: IconName }) =>
+  const renderSectionIcon = ({ icon }: Section<Item>) =>
     icon && (
       <Icon className={cx("Icon", CS.textDefault)} name={icon} size={18} />
     );
@@ -121,20 +109,20 @@ const DataSelectorDatabaseSchemaPicker = ({
   }
 
   return (
-    <AccordionList
+    <AccordionList<Item>
       id="DatabaseSchemaPicker"
       key="databaseSchemaPicker"
       className={CS.textBrand}
       hasInitialFocus={hasInitialFocus}
       sections={sections}
-      onChange={({ schema }: any) => onChangeSchema(schema)}
+      onChange={onChangeSchema}
       onChangeSection={handleChangeSection}
-      itemIsSelected={(schema: Schema) => schema === selectedSchema}
+      itemIsSelected={({ schema }) => schema === selectedSchema}
       renderSectionIcon={renderSectionIcon}
       renderItemIcon={() => <Icon name="folder" size={16} />}
       initiallyOpenSection={openSection}
       alwaysTogglable={true}
-      showSpinner={showSpinner}
+      showSpinner={(x) => "active" in x && Boolean(x.active)}
       showItemArrows={hasNextStep}
       maxHeight={Infinity}
     />

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
@@ -5,7 +5,7 @@ import {
   HoverParent,
   TableColumnInfoIcon,
 } from "metabase/components/MetadataInfo/ColumnInfoIcon";
-import AccordionList from "metabase/core/components/AccordionList";
+import { AccordionList } from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import type { IconName } from "metabase/ui";
 import { Box, DelayGroup, Icon } from "metabase/ui";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
@@ -91,7 +91,7 @@ const DataSelectorFieldPicker = ({
           searchable={hasFiltering}
           onChange={(item: { field: Field }) => onChangeField(item.field)}
           itemIsSelected={checkIfItemIsSelected}
-          itemIsClickable={(item: FieldWithName) => item.field}
+          itemIsClickable={(item: FieldWithName) => Boolean(item.field)}
           renderItemWrapper={renderItemWrapper}
           renderItemIcon={renderItemIcon}
         />

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSchemaPicker/DataSelectorSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSchemaPicker/DataSelectorSchemaPicker.tsx
@@ -1,4 +1,4 @@
-import AccordionList from "metabase/core/components/AccordionList";
+import { AccordionList } from "metabase/core/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import { Box, Icon } from "metabase/ui";
 import type Schema from "metabase-lib/v1/metadata/Schema";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -110,8 +110,8 @@ const DataSelectorTablePicker = ({
       <HoverParent>{content}</HoverParent>
     );
 
-    const showSpinner = (x: Item | Section<Item>) =>
-      "table" in x && !isSyncCompleted(x.table);
+    const showSpinner = (itemOrSection: Item | Section<Item>) =>
+      "table" in itemOrSection && !isSyncCompleted(itemOrSection.table);
 
     const handleChange = ({ table }: { table: Table }) => onChangeTable(table);
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -7,7 +7,9 @@ import {
   HoverParent,
   TableInfoIcon,
 } from "metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
-import AccordionList from "metabase/core/components/AccordionList";
+import AccordionList, {
+  type Section,
+} from "metabase/core/components/AccordionList";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
@@ -40,6 +42,12 @@ type HeaderProps = Pick<
   DataSelectorTablePickerProps,
   "schemas" | "selectedSchema" | "selectedDatabase" | "onBack"
 >;
+
+type Item = {
+  name: string;
+  table: Table;
+  database: Database;
+};
 
 const DataSelectorTablePicker = ({
   schemas,
@@ -75,7 +83,7 @@ const DataSelectorTablePicker = ({
   );
 
   if (tables.length > 0 || isLoading) {
-    const sections = [
+    const sections: Section<Item>[] = [
       {
         name: header,
         items: tables.filter(isNotNull).map((table) => ({
@@ -101,8 +109,8 @@ const DataSelectorTablePicker = ({
       <HoverParent>{content}</HoverParent>
     );
 
-    const showSpinner = ({ table }: { table: Table }) =>
-      Boolean(table && !isSyncCompleted(table));
+    const showSpinner = (x: Item | Section<Item>) =>
+      "table" in x && !isSyncCompleted(x.table);
 
     const handleChange = ({ table }: { table: Table }) => onChangeTable(table);
 
@@ -111,7 +119,7 @@ const DataSelectorTablePicker = ({
     return (
       <DelayGroup>
         <Box w={rem(300)} style={{ overflowY: "auto" }}>
-          <AccordionList
+          <AccordionList<Item>
             id="TablePicker"
             key="tablePicker"
             className={CS.textBrand}

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -7,7 +7,8 @@ import {
   HoverParent,
   TableInfoIcon,
 } from "metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon";
-import AccordionList, {
+import {
+  AccordionList,
   type Section,
 } from "metabase/core/components/AccordionList";
 import ExternalLink from "metabase/core/components/ExternalLink";

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.module.css
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.module.css
@@ -1,4 +1,3 @@
 .StyledAccordionList {
   color: var(--mb-color-filter);
-  width: var(--accordion-list-width);
 }

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -20,11 +20,13 @@ import type { ColumnListItem, SegmentListItem } from "../types";
 
 import S from "./FilterColumnPicker.module.css";
 
+type Item = ColumnListItem | SegmentListItem;
+
 export interface FilterColumnPickerProps {
   className?: string;
   query: Lib.Query;
   stageIndexes: number[];
-  checkItemIsSelected?: (item: ColumnListItem | SegmentListItem) => boolean;
+  checkItemIsSelected?: (item: Item) => boolean;
   onColumnSelect: (item: ColumnListItem) => void;
   onSegmentSelect: (item: SegmentListItem) => void;
   onExpressionSelect?: () => void;
@@ -34,7 +36,7 @@ export interface FilterColumnPickerProps {
   withColumnItemIcon?: boolean;
 }
 
-const CUSTOM_EXPRESSION_SECTION: Section<ColumnListItem | SegmentListItem> = {
+const CUSTOM_EXPRESSION_SECTION: Section<Item> = {
   key: "custom-expression",
   type: "action",
   get name() {
@@ -44,9 +46,7 @@ const CUSTOM_EXPRESSION_SECTION: Section<ColumnListItem | SegmentListItem> = {
   icon: "filter",
 };
 
-export const isSegmentListItem = (
-  item: ColumnListItem | SegmentListItem,
-): item is SegmentListItem => {
+export const isSegmentListItem = (item: Item): item is SegmentListItem => {
   return (item as SegmentListItem).segment != null;
 };
 
@@ -83,7 +83,7 @@ export function FilterColumnPicker({
     }
   };
 
-  const handleSelect = (item: ColumnListItem | SegmentListItem) => {
+  const handleSelect = (item: Item) => {
     if (isSegmentListItem(item)) {
       onSegmentSelect(item);
     } else {
@@ -93,7 +93,7 @@ export function FilterColumnPicker({
 
   return (
     <DelayGroup>
-      <AccordionList<ColumnListItem | SegmentListItem>
+      <AccordionList<Item>
         className={cx(S.StyledAccordionList, className)}
         sections={sections}
         onChange={handleSelect}
@@ -102,7 +102,7 @@ export function FilterColumnPicker({
         renderItemWrapper={renderItemWrapper}
         renderItemName={renderItemName}
         renderItemDescription={omitDescription}
-        renderItemIcon={(item: ColumnListItem | SegmentListItem) =>
+        renderItemIcon={(item) =>
           withColumnItemIcon ? renderItemIcon(query, item) : null
         }
         // disable scrollbars inside the list
@@ -127,7 +127,7 @@ function getSections(
   stageIndexes: number[],
   withColumnGroupIcon: boolean,
   withCustomExpression: boolean,
-): Section<ColumnListItem | SegmentListItem>[] {
+): Section<Item>[] {
   const withMultipleStages = stageIndexes.length > 1;
   const columnSections = stageIndexes.flatMap((stageIndex) => {
     const columns = Lib.filterableColumns(query, stageIndex);
@@ -174,14 +174,11 @@ function getSections(
   ];
 }
 
-function renderItemName(item: ColumnListItem | SegmentListItem) {
+function renderItemName(item: Item) {
   return item.displayName;
 }
 
-function renderItemIcon(
-  query: Lib.Query,
-  item: ColumnListItem | SegmentListItem,
-) {
+function renderItemIcon(query: Lib.Query, item: Item) {
   if (isSegmentListItem(item)) {
     return <Icon name="star" size={18} />;
   }

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -7,7 +7,8 @@ import {
   HoverParent,
   QueryColumnInfoIcon,
 } from "metabase/components/MetadataInfo/ColumnInfoIcon";
-import AccordionList, {
+import {
+  AccordionList,
   type Section,
 } from "metabase/core/components/AccordionList";
 import { getGroupName } from "metabase/querying/filters/utils/groups";

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -7,9 +7,10 @@ import {
   HoverParent,
   QueryColumnInfoIcon,
 } from "metabase/components/MetadataInfo/ColumnInfoIcon";
-import AccordionList from "metabase/core/components/AccordionList";
+import AccordionList, {
+  type Section,
+} from "metabase/core/components/AccordionList";
 import { getGroupName } from "metabase/querying/filters/utils/groups";
-import type { IconName } from "metabase/ui";
 import { DelayGroup, Icon } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
@@ -32,15 +33,7 @@ export interface FilterColumnPickerProps {
   withColumnItemIcon?: boolean;
 }
 
-type Section = {
-  key?: string;
-  type: string;
-  name: string;
-  items: (Lib.ColumnMetadata | Lib.SegmentMetadata)[];
-  icon?: IconName;
-};
-
-const CUSTOM_EXPRESSION_SECTION: Section = {
+const CUSTOM_EXPRESSION_SECTION: Section<ColumnListItem | SegmentListItem> = {
   key: "custom-expression",
   type: "action",
   get name() {
@@ -99,7 +92,7 @@ export function FilterColumnPicker({
 
   return (
     <DelayGroup>
-      <AccordionList
+      <AccordionList<ColumnListItem | SegmentListItem>
         className={cx(S.StyledAccordionList, className)}
         sections={sections}
         onChange={handleSelect}
@@ -111,7 +104,10 @@ export function FilterColumnPicker({
           withColumnItemIcon ? renderItemIcon(query, item) : null
         }
         // disable scrollbars inside the list
-        style={{ overflow: "visible", "--accordion-list-width": `${WIDTH}px` }}
+        style={{
+          overflow: "visible",
+          width: WIDTH,
+        }}
         maxHeight={Infinity}
         // Compat with E2E tests around MLv1-based components
         // Prefer using a11y role selectors
@@ -129,7 +125,7 @@ function getSections(
   stageIndexes: number[],
   withColumnGroupIcon: boolean,
   withCustomExpression: boolean,
-) {
+): Section<ColumnListItem | SegmentListItem>[] {
   const withMultipleStages = stageIndexes.length > 1;
   const columnSections = stageIndexes.flatMap((stageIndex) => {
     const columns = Lib.filterableColumns(query, stageIndex);
@@ -154,9 +150,7 @@ function getSections(
       const segmentItems = segments.map((segment) => {
         const segmentInfo = Lib.displayInfo(query, stageIndex, segment);
         return {
-          name: segmentInfo.name,
-          displayName: segmentInfo.displayName,
-          filterPositions: segmentInfo.filterPositions,
+          ...segmentInfo,
           segment,
           stageIndex,
         };
@@ -178,7 +172,7 @@ function getSections(
   ];
 }
 
-function renderItemName(item: ColumnListItem) {
+function renderItemName(item: ColumnListItem | SegmentListItem) {
   return item.displayName;
 }
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -101,6 +101,7 @@ export function FilterColumnPicker({
         itemIsSelected={checkItemIsSelected}
         renderItemWrapper={renderItemWrapper}
         renderItemName={renderItemName}
+        renderItemDescription={omitDescription}
         renderItemIcon={(item: ColumnListItem | SegmentListItem) =>
           withColumnItemIcon ? renderItemIcon(query, item) : null
         }
@@ -201,4 +202,8 @@ function renderItemIcon(
 
 function renderItemWrapper(content: ReactNode) {
   return <HoverParent>{content}</HoverParent>;
+}
+
+function omitDescription() {
+  return undefined;
 }


### PR DESCRIPTION
Closes [QUE-1370](https://linear.app/metabase/issue/QUE-1370/convert-accordionlist-to-typecript)

- Converts the `AccordionList` component to TypeScript and fixes up components that use it.
- Removes unused props

There should be no functionality changes so I added no tests as the component is pretty well-covered. Note that this PR is going into an integration branch which will get more tests later on.
