### PR TITLE
Multi dimensional breakout for series color in bar charts

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model/dataset.ts
@@ -3,7 +3,7 @@ import {
   X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
-import type { RawSeries } from "metabase-types/api";
+import type { RawSeries, RowValue } from "metabase-types/api";
 
 import { getDatasetKey } from "../../model/dataset";
 import type { ChartDataset, Datum } from "../../model/types";
@@ -30,10 +30,26 @@ export function getScatterPlotDataset(
         if (columnIndex === columnDescs.dimension.index) {
           datum[X_AXIS_DATA_KEY] = value;
         }
+
+        let breakoutIndexes: number[] | undefined = undefined;
+        if (
+          "breakout" in columnDescs &&
+          columnDescs.breakout.breakoutDimensions.length > 0
+        ) {
+          breakoutIndexes = columnDescs.breakout.breakoutDimensions.map(
+            (b) => b.index,
+          );
+        }
+
+        let breakoutValue: RowValue | undefined = undefined;
+        if (breakoutIndexes && breakoutIndexes.length > 0) {
+          breakoutValue = breakoutIndexes.map((idx) => row[idx]).join(" - ");
+        }
+
         const seriesKey =
-          "breakout" in columnDescs
-            ? getDatasetKey(column, card.id, row[columnDescs.breakout.index])
-            : getDatasetKey(column, card.id);
+          !breakoutIndexes || breakoutIndexes.length === 0
+            ? getDatasetKey(column, card.id)
+            : getDatasetKey(column, card.id, breakoutValue);
 
         datum[seriesKey] = value;
       });

--- a/frontend/src/metabase/visualizations/lib/graph/columns.ts
+++ b/frontend/src/metabase/visualizations/lib/graph/columns.ts
@@ -13,6 +13,22 @@ export type ColumnDescriptor = {
   column: RemappingHydratedDatasetColumn;
 };
 
+export type ColumnDescriptors = {
+  breakoutDimensions: ColumnDescriptor[];
+};
+
+export const getBreakoutDimensionsIndexes = (
+  descriptors: ColumnDescriptors,
+) => {
+  return descriptors.breakoutDimensions.map((d) => d.index);
+};
+
+export const getBreakoutDimensionsColumns = (
+  descriptors: ColumnDescriptors,
+) => {
+  return descriptors.breakoutDimensions.map((d) => d.column);
+};
+
 export const getColumnDescriptors = <TColumn extends DatasetColumn>(
   columnNames: string[],
   columns: TColumn[],
@@ -48,7 +64,7 @@ export const hasValidColumnsSelected = (
 
 export type BreakoutChartColumns = {
   dimension: ColumnDescriptor;
-  breakout: ColumnDescriptor;
+  breakout: ColumnDescriptors;
   metric: ColumnDescriptor;
 };
 
@@ -86,10 +102,14 @@ export const getCartesianChartColumns = (
     "graph.dimensions" | "graph.metrics" | "scatter.bubble"
   >,
 ): CartesianChartColumns => {
-  const [dimension, breakout] = getColumnDescriptors(
+  const dimensions = getColumnDescriptors(
     (settings["graph.dimensions"] ?? []).filter(isNotNull),
     columns,
   );
+  const dimension = dimensions[0];
+  const breakout: ColumnDescriptors = {
+    breakoutDimensions: dimensions.slice(1),
+  };
 
   const metrics = getColumnDescriptors(
     _.uniq((settings["graph.metrics"] ?? []).filter(isNotNull)),
@@ -101,7 +121,7 @@ export const getCartesianChartColumns = (
     columns,
   )[0];
 
-  if (breakout) {
+  if (breakout.breakoutDimensions.length > 0) {
     return {
       dimension,
       breakout,

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -8,6 +8,7 @@ import {
 } from "metabase/visualizations";
 import { getCardsColumns } from "metabase/visualizations/echarts/cartesian/model";
 import { getCardsSeriesModels } from "metabase/visualizations/echarts/cartesian/model/series";
+import { getBreakoutDimensionsColumns } from "metabase/visualizations/lib/graph/columns";
 import { dimensionIsNumeric } from "metabase/visualizations/lib/numeric";
 import { dimensionIsTimeseries } from "metabase/visualizations/lib/timeseries";
 import {
@@ -405,7 +406,11 @@ export function getAvailableAdditionalColumns(
   getCardsColumns(rawSeries, settings).forEach((cardColumns) => {
     alreadyIncludedColumns.add(cardColumns.dimension.column);
     if ("breakout" in cardColumns) {
-      alreadyIncludedColumns.add(cardColumns.breakout.column);
+      for (const breakoutColumn of getBreakoutDimensionsColumns(
+        cardColumns.breakout,
+      )) {
+        alreadyIncludedColumns.add(breakoutColumn);
+      }
       alreadyIncludedColumns.add(cardColumns.metric.column);
     } else {
       cardColumns.metrics.forEach((columnDescriptor) =>

--- a/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.tsx
@@ -21,6 +21,7 @@ Object.assign(
     getUiName: () => t`Bar`,
     identifier: "bar",
     iconName: "bar",
+    maxDimensionsSupported: 3,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     noun: t`bar chart`,
     minSize: getMinSize("bar"),

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition-legacy.js
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition-legacy.js
@@ -74,6 +74,7 @@ function transformSingleSeries(s, series, seriesIndex) {
         breakoutValues.push(seriesValue);
         groupParts.push(stackedKeys);
       }
+
       const newRow = rowColumnIndexes.map((columnIndex) => row[columnIndex]);
       newRow._origin = { seriesIndex, rowIndex, row, cols };
       seriesRows.push(newRow);

--- a/frontend/src/metabase/visualizations/visualizations/LineChart/LineChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LineChart/LineChart.tsx
@@ -21,6 +21,7 @@ Object.assign(
     getUiName: () => t`Line`,
     identifier: "line",
     iconName: "line",
+    maxDimensionsSupported: 3,
     // eslint-disable-next-line ttag/no-module-declaration
     noun: t`line chart`,
     minSize: getMinSize("line"),

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -335,6 +335,7 @@ RowChartVisualization.identifier = "row";
 RowChartVisualization.iconName = "horizontal_bar";
 // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
 RowChartVisualization.noun = t`row chart`;
+RowChartVisualization.maxDimensionsSupported = 3;
 
 RowChartVisualization.noHeader = true;
 RowChartVisualization.minSize = getMinSize("row");

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
@@ -102,12 +102,21 @@ const getColumnsData = (
 
   let metricDatum: MetricDatum;
 
-  // For now, this only accepts 1 dimension breakouts.
   if ("breakout" in chartColumns && datum.breakout) {
-    data.push({
-      key: chartColumns.breakout.breakoutDimensions[0].column.display_name,
-      value: series.seriesKey,
-      col: chartColumns.breakout.breakoutDimensions[0].column,
+    const breakoutDims = chartColumns.breakout.breakoutDimensions;
+    const breakoutValues =
+      typeof series.seriesKey === "string"
+        ? series.seriesKey.split(" - ")
+        : Array.isArray(series.seriesKey)
+          ? series.seriesKey
+          : [series.seriesKey];
+
+    breakoutDims.forEach((dim, i) => {
+      data.push({
+        key: dim.column.display_name,
+        value: breakoutValues[i],
+        col: dim.column,
+      });
     });
 
     metricDatum = datum.breakout[series.seriesKey].metrics;

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
@@ -102,11 +102,12 @@ const getColumnsData = (
 
   let metricDatum: MetricDatum;
 
+  // For now, this only accepts 1 dimension breakouts.
   if ("breakout" in chartColumns && datum.breakout) {
     data.push({
-      key: chartColumns.breakout.column.display_name,
+      key: chartColumns.breakout.breakoutDimensions[0].column.display_name,
       value: series.seriesKey,
-      col: chartColumns.breakout.column,
+      col: chartColumns.breakout.breakoutDimensions[0].column,
     });
 
     metricDatum = datum.breakout[series.seriesKey].metrics;
@@ -157,7 +158,7 @@ export const getClickData = (
 
   if ("breakout" in chartColumns) {
     dimensions.push({
-      column: chartColumns.breakout.column,
+      column: chartColumns.breakout.breakoutDimensions[0].column,
       value: series.seriesInfo?.breakoutValue ?? null,
     });
   }
@@ -183,7 +184,7 @@ export const getLegendClickData = (
     "breakout" in chartColumns
       ? [
           {
-            column: chartColumns.breakout.column,
+            column: chartColumns.breakout.breakoutDimensions[0].column,
             value: currentSeries.seriesInfo?.breakoutValue ?? null,
           },
         ]

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/warnings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/warnings.ts
@@ -10,7 +10,7 @@ export const getChartWarnings = (
     rows.map((row) => {
       const dimensionValue = row[chartColumns.dimension.index];
       return "breakout" in chartColumns
-        ? `${row[chartColumns.breakout.index]}:${dimensionValue}`
+        ? `${row[chartColumns.breakout.breakoutDimensions[0].index]}:${dimensionValue}`
         : String(dimensionValue);
     }),
   );

--- a/frontend/src/metabase/visualizations/visualizations/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/ScatterPlot/ScatterPlot.tsx
@@ -27,6 +27,7 @@ Object.assign(
     getUiName: () => t`Scatter`,
     identifier: "scatter",
     iconName: "bubble",
+    maxDimensionsSupported: 3,
     // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
     noun: t`scatter plot`,
     minSize: getMinSize("scatter"),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/57705

### Description

This update enhances the charting UI by allowing users to apply multiple categorical dimensions to the series color breakout in bar, row, line and scatter charts.
Previously, users needed to manually create a combined field in SQL to visualize metrics broken down by combinations of rows. With this enhancement, users can now directly select two or more categorical fields in the UI to generate composite breakouts for the series color without any SQL required. For now, we have capped the number of dimensions to 3, but this is easily expandable just by modifying the maxDimensionsSupported declared in each chart.

### How to verify 

(Using the sample database)
1. New question -> Question -> Products -> Join data -> Reviews -> Visualize
2. Visualization -> Bar -> Options
3. When adding a new series breakout, you are now able to click it one again and select more metrics.

### Demo

https://youtu.be/lAFk_X-B5YA

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
