### PR TITLE
make database widget keyboard friendly

### DIFF
--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.styled.tsx
@@ -26,7 +26,7 @@ interface EngineCardRootProps {
   isActive: boolean;
 }
 
-export const EngineCardRoot = styled.li<EngineCardRootProps>`
+export const EngineCardRoot = styled.button<EngineCardRootProps>`
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.tsx
@@ -218,7 +218,7 @@ const EngineCard = ({
 
   return (
     <EngineCardRoot
-      role="listitem"
+      role="option"
       id={getListOptionId(rootId, option)}
       isActive={isActive}
       onClick={handleClick}

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.tsx
@@ -218,7 +218,7 @@ const EngineCard = ({
 
   return (
     <EngineCardRoot
-      role="option"
+      role="listitem"
       id={getListOptionId(rootId, option)}
       isActive={isActive}
       onClick={handleClick}

--- a/frontend/src/metabase/databases/components/DatabaseForm/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/tests/common.unit.spec.tsx
@@ -92,6 +92,18 @@ describe("DatabaseForm", () => {
       screen.queryByText("Choose when syncs and scans happen"),
     ).not.toBeInTheDocument();
   });
+
+  it("should allow tab navigation through form fields", async () => {
+    setup();
+
+    // tabs ou tof the search
+    await userEvent.tab();
+    // select the first option (H2)
+    await userEvent.tab();
+    await userEvent.keyboard("{Enter}");
+
+    expect(screen.getByPlaceholderText("Our H2")).toBeInTheDocument();
+  });
 });
 
 const EXPECTED_DEFAULT_SCHEMA = {


### PR DESCRIPTION
This component wasn't usable without the mouse, and the cards didn't show up when I was using the `f` key of [vimium](https://chromewebstore.google.com/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb?hl=en) and similar


How to verify:
On the a brand new instance, during the "Connect your data" step of the setup, just try to use tab

Before:

https://github.com/user-attachments/assets/d7365ce5-8778-4bc9-8f93-952e50572ca7



After:

https://github.com/user-attachments/assets/f6e8f260-19fb-4e9c-ade4-487e4428bf0f

