### PR TITLE
Viz 1103 flaky test e2e tests warn before leave scenarios dashboard

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -219,6 +219,7 @@ export function addHeadingWhileEditing(
 }
 
 export function openQuestionsSidebar() {
+  dashboardHeader().findByLabelText("Add questions").should("not.be.disabled");
   dashboardHeader().findByLabelText("Add questions").click();
 }
 

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1215,6 +1215,7 @@ describe("scenarios > dashboard", () => {
   describe("warn before leave", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/card/*/query_metadata").as("queryMetadata");
+      cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     });
 
     it("should warn a user before leaving after adding, editing, or removing a card on a dashboard", () => {
@@ -1232,6 +1233,7 @@ describe("scenarios > dashboard", () => {
       cy.wait("@queryMetadata");
       assertPreventLeave({ openSidebar: false });
       H.saveDashboard();
+      cy.reload();
 
       // edit
       H.editDashboard();
@@ -1241,6 +1243,7 @@ describe("scenarios > dashboard", () => {
       dragOnXAxis(card, 100);
       assertPreventLeave();
       H.saveDashboard();
+      cy.reload();
 
       // remove
       H.editDashboard();
@@ -1257,6 +1260,8 @@ describe("scenarios > dashboard", () => {
       assertPreventLeave();
       H.saveDashboard();
 
+      cy.reload();
+
       // move tab
       H.editDashboard();
       dragOnXAxis(cy.findByRole("tab", { name: "Tab 2" }), -200);
@@ -1267,6 +1272,8 @@ describe("scenarios > dashboard", () => {
       cy.wait(1000);
       assertPreventLeave();
       H.saveDashboard();
+
+      cy.reload();
 
       // duplicate tab
       H.editDashboard();
@@ -1280,6 +1287,8 @@ describe("scenarios > dashboard", () => {
         "true",
       );
 
+      cy.reload();
+
       // remove tab
       H.editDashboard();
       H.deleteTab("Copy of Tab 1");
@@ -1288,6 +1297,8 @@ describe("scenarios > dashboard", () => {
       cy.url().should("include", "tab-1");
       assertPreventLeave();
       H.saveDashboard({ waitMs: 100 });
+
+      cy.reload();
 
       // rename tab
       H.editDashboard();

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1309,8 +1309,10 @@ describe("scenarios > dashboard", () => {
     function createNewDashboard() {
       H.newButton("Dashboard").click();
       H.modal().within(() => {
-        cy.findByLabelText("Name").type("Test");
-        cy.findByRole("button", { name: "Create" }).click();
+        cy.findByLabelText("Name").should("be.focused");
+        cy.findByLabelText("Name").realType("Test");
+        cy.findByRole("button", { name: "Create" }).should("not.be.disabled");
+        cy.findByRole("button", { name: "Create" }).realClick({ force: true });
       });
     }
 

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1215,7 +1215,6 @@ describe("scenarios > dashboard", () => {
   describe("warn before leave", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/card/*/query_metadata").as("queryMetadata");
-      cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     });
 
     it("should warn a user before leaving after adding, editing, or removing a card on a dashboard", () => {


### PR DESCRIPTION
Closes [VIZ-1103: \[Flaky Test\] \[e2e-tests\] warn before leave scenarios > dashboard warn before leave should warn a user before leaving after adding, removed, moving, or duplicating a tab](https://linear.app/metabase/issue/VIZ-1103/flaky-test-e2e-tests-warn-before-leave-scenarios-dashboard-warn-before)

### Description

Reloads the page between main actions to avoid exiting the edit mode for no apparent reason.

Stress test: https://github.com/metabase/metabase/actions/runs/15636865218