### PR TITLE
set embedding-homepage visible as soon as we can

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
@@ -28,16 +28,14 @@ describe("scenarios > setup embedding (EMB-477)", () => {
     cy.location("pathname").should("eq", "/setup");
   });
 
-  it("should allow users to use existing setup flow", () => {
+  it("should show the embedding homepage if the user skips the flow after having created the user", () => {
     cy.visit("/setup/embedding");
     assertEmbeddingOnboardingPageLoaded();
 
-    cy.log("Go to user step");
     step().within(() => {
       cy.button("Start").should("be.visible").click();
     });
 
-    cy.log("Create user");
     step().within(() => {
       cy.findByRole("heading", { name: "What should we call you?" }).should(
         "be.visible",
@@ -46,7 +44,6 @@ describe("scenarios > setup embedding (EMB-477)", () => {
       fillOutUserForm();
 
       cy.intercept("POST", "/api/setup").as("setup");
-
       cy.intercept("PUT", "/api/setting").as("setting");
       cy.button("Next").should("be.enabled").click();
     });
@@ -56,8 +53,6 @@ describe("scenarios > setup embedding (EMB-477)", () => {
     // user, we need to make sure that request is done before navigating
     // otherwise it'll get cancelled by the browser
     cy.wait("@setting");
-
-    cy.log("Navigate to '/', it should show the embedding homepage");
     cy.visit("/");
 
     main()

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/UserCreationStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/UserCreationStep.tsx
@@ -23,10 +23,10 @@ export const UserCreationStep = () => {
 
   const handleSubmit = async (user: UserInfo) => {
     await dispatch(submitUser(user)).unwrap();
-    goToNextStep();
     // We want want to set the embedding homepage visible if the user skips the rest of the flow.
     // This is the first place where we can do this, as we need the initial setup to be done.
     await updateSettings({ "embedding-homepage": "visible" });
+    goToNextStep();
   };
 
   return (

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/UserCreationStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/UserCreationStep.tsx
@@ -23,7 +23,7 @@ export const UserCreationStep = () => {
 
   const handleSubmit = async (user: UserInfo) => {
     await dispatch(submitUser(user)).unwrap();
-    // We want want to set the embedding homepage visible if the user skips the rest of the flow.
+    // We want to set the embedding homepage visible if the user skips the rest of the flow.
     // This is the first place where we can do this, as we need the initial setup to be done.
     await updateSettings({ "embedding-homepage": "visible" });
     goToNextStep();

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/UserCreationStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/UserCreationStep.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { useUpdateSettingsMutation } from "metabase/api";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { Box, Text, Title } from "metabase/ui";
 import type { UserInfo } from "metabase-types/store";
@@ -18,10 +19,14 @@ export const UserCreationStep = () => {
   // const user = {}; // TODO: pre-fill from
   const isHosted = useSelector(getIsHosted);
   const dispatch = useDispatch();
+  const [updateSettings] = useUpdateSettingsMutation();
 
   const handleSubmit = async (user: UserInfo) => {
     await dispatch(submitUser(user)).unwrap();
     goToNextStep();
+    // We want want to set the embedding homepage visible if the user skips the rest of the flow.
+    // This is the first place where we can do this, as we need the initial setup to be done.
+    await updateSettings({ "embedding-homepage": "visible" });
   };
 
   return (


### PR DESCRIPTION
Closes [EMB-489: if skipping the flow right after the user step, the embedding homepage should still be visible](https://linear.app/metabase/issue/EMB-489/if-skipping-the-flow-right-after-the-user-step-the-embedding-homepage)