### PR TITLE
Possible fix & tests for 48543

### DIFF
--- a/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+++ b/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
@@ -16,6 +16,23 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- floating-point-type?
+  "Check if the effective type is a floating point type that might have precision issues."
+  [effective-type]
+  (and effective-type
+       (or (isa? effective-type :type/Float)
+           (isa? effective-type :type/Decimal))))
+
+(defn- calculate-ulp-tolerance
+  "Calculate ULP-based tolerance for robust floating point comparison.
+  ULP automatically scales with value magnitude and doesn't break down near zero.
+
+  Uses 4 ULPs by default."
+  [value]
+  (let [ulp-count 4 ; Allow up to 4 representable numbers between values
+        ulp-value (Math/ulp (double value))]
+    (* ulp-count ulp-value)))
+
 (mu/defn- parse-value-for-base-type
   [v              :- :string
    effective-type :- ::lib.schema.common/base-type]
@@ -47,7 +64,79 @@
      (v :guard string?)]
     [:value info (parse-value-for-base-type v (:effective-type info))]))
 
+(defn- is-filtering-aggregated-results?
+  "Check if we're in a stage that filters results from a previous aggregation stage."
+  [query stage-index]
+  (and (number? stage-index)
+       (> stage-index 0)
+       (let [previous-stage (get-in query [:stages (dec stage-index)])]
+         ;; Previous stage has aggregations:
+         (seq (:aggregation previous-stage)))))
+
+(defn- should-apply-ulp-filter?
+  "Check if ULP-based filtering should be applied to this floating point value.
+  Apply ULP filtering when filtering floating point results from aggregations."
+  [effective-type value field-ref query stage-index]
+  (and (floating-point-type? effective-type)
+       (number? value)
+       (or
+         ;; Pattern 1: Multi-stage queries filtering aggregated results (real UI workflow)
+        (is-filtering-aggregated-results? query stage-index)
+         ;; Pattern 2: Direct aggregation references (programmatic/test usage)
+        (and (vector? field-ref)
+             (= :aggregation (first field-ref))))))
+
+(defn- apply-floating-point-ulp-this-stage-or-join
+  "Transform floating point equality filters to ULP-based range filters to handle
+  precision issues."
+  [query _path-type path stage-or-join]
+  (let [stage-index (when (and (vector? path) (>= (count path) 2))
+                      (second path))] ; Extract stage index from path
+    (lib.util.match/replace stage-or-join
+      ;; Transform:
+      ;;   [:= opts field [:value {:effective-type :type/Float} value]]
+      ;; to
+      ;;   [:between opts field (value - ulp-tolerance) (value + ulp-tolerance)]
+      [:= opts field-ref [:value info value]]
+      (if (and (floating-point-type? (:effective-type info))
+               (should-apply-ulp-filter? (:effective-type info) value field-ref query stage-index))
+        (let [ulp-tolerance (calculate-ulp-tolerance value)
+              lower-info (assoc info :lib/uuid (str (random-uuid)))
+              upper-info (assoc info :lib/uuid (str (random-uuid)))]
+          [:between opts field-ref
+           [:value lower-info (- value ulp-tolerance)]
+           [:value upper-info (+ value ulp-tolerance)]])
+        [:= opts field-ref [:value info value]])
+
+      ;; Transform:
+      ;;   [:!= opts field [:value {:effective-type :type/Float} value]]
+      ;; to
+      ;;   [:or opts [:< field (value - ulp-tolerance)] [:> field (value + ulp-tolerance)]]
+      [:!= opts field-ref [:value info value]]
+      (if (and (floating-point-type? (:effective-type info))
+               (should-apply-ulp-filter? (:effective-type info) value field-ref query stage-index))
+        (let [ulp-tolerance (calculate-ulp-tolerance value)
+              lower-info (assoc info :lib/uuid (str (random-uuid)))
+              upper-info (assoc info :lib/uuid (str (random-uuid)))
+              ;; Create new field references with unique UUIDs to avoid duplication
+              field-ref-1 (if (map? (second field-ref))
+                            (update field-ref 1 assoc :lib/uuid (str (random-uuid)))
+                            field-ref)
+              field-ref-2 (if (map? (second field-ref))
+                            (update field-ref 1 assoc :lib/uuid (str (random-uuid)))
+                            field-ref)
+              ;; Create opts with UUIDs for sub-clauses
+              less-opts {:lib/uuid (str (random-uuid))}
+              greater-opts {:lib/uuid (str (random-uuid))}]
+          [:or opts
+           [:< less-opts field-ref-1 [:value lower-info (- value ulp-tolerance)]]
+           [:> greater-opts field-ref-2 [:value upper-info (+ value ulp-tolerance)]]])
+        [:!= opts field-ref [:value info value]]))))
+
 (mu/defn auto-parse-filter-values :- ::lib.schema/query
-  "Automatically parse String filter clause values to the appropriate type."
+  "Automatically parse String filter clause values to the appropriate type and apply
+  ULP-based tolerance for floating point comparisons to handle precision issues."
   [query :- ::lib.schema/query]
-  (lib.walk/walk query auto-parse-filter-values-this-stage-or-join))
+  (-> query
+      (lib.walk/walk auto-parse-filter-values-this-stage-or-join)
+      (lib.walk/walk apply-floating-point-ulp-this-stage-or-join)))

--- a/test/metabase/query_processor/middleware/auto_parse_filter_values_test.clj
+++ b/test/metabase/query_processor/middleware/auto_parse_filter_values_test.clj
@@ -57,3 +57,272 @@
                 (-> (auto-parse-filter-values query)
                     lib/filters
                     first)))))))
+
+(deftest ^:parallel floating-point-ulp-equality-test
+  (testing "Should convert floating point equality filters to ULP-based ranges for aggregated values"
+    (let [float-value 123.456
+          ;; Create a query with aggregation first, then add filter against that aggregation
+          base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                         (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
+          query (lib/filter base-query
+                            (lib/= (lib/aggregation-ref base-query 0)
+                                   [:value
+                                    {:base-type :type/Float, :effective-type :type/Float, :lib/uuid (str (random-uuid))}
+                                    float-value]))]
+      (testing "= filter becomes :between filter"
+        (let [result-filter (-> query
+                                auto-parse-filter-values
+                                lib/filters
+                                first)]
+          (is (= :between (first result-filter)))
+          (is (= 5 (count result-filter))) ; [:between opts field lower upper]
+          (let [[_ _ _ lower upper] result-filter
+                lower-val (nth lower 2)
+                upper-val (nth upper 2)]
+            (is (< lower-val float-value))
+            (is (> upper-val float-value))
+            ;; ULP-based tolerance should be extremely small relative to value
+            (is (< (- upper-val lower-val) (* float-value 1e-10)))))))))
+
+(deftest ^:parallel floating-point-ulp-inequality-test
+  (testing "Should convert floating point inequality filters to ULP-based ranges for aggregated values"
+    (let [decimal-value 987.654M
+          ;; Create a query with aggregation first, then add filter against that aggregation
+          base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                         (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
+          query (lib/filter base-query
+                            (lib/!= (lib/aggregation-ref base-query 0)
+                                    [:value
+                                     {:base-type :type/Decimal, :effective-type :type/Decimal, :lib/uuid (str (random-uuid))}
+                                     decimal-value]))]
+      (testing "!= filter becomes :or [:< ...] [:> ...] filter"
+        (let [result-filter (-> query
+                                auto-parse-filter-values
+                                lib/filters
+                                first)]
+          (is (= :or (first result-filter)))
+          (is (= 4 (count result-filter))) ; [:or opts condition1 condition2]
+          (let [[_ _ less-than greater-than] result-filter]
+            (is (= :< (first less-than)))
+            (is (= :> (first greater-than)))))))))
+
+(deftest ^:parallel simple-floating-point-test
+  (testing "Should NOT convert regular floating point fields to ULP filters"
+    (let [simple-float 42.0
+          ;; Use regular field reference - should NOT get ULP filtering
+          query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                    (lib/filter (lib/= (meta/field-metadata :venues :latitude)
+                                       [:value
+                                        {:base-type :type/Float, :effective-type :type/Float, :lib/uuid (str (random-uuid))}
+                                        simple-float])))]
+      (testing "Regular field float = filter remains unchanged"
+        (let [result-filter (-> query
+                                auto-parse-filter-values
+                                lib/filters
+                                first)]
+          (is (= := (first result-filter)))
+          (is (= 4 (count result-filter))))))))
+
+(deftest ^:parallel non-floating-point-equality-unchanged-test
+  (testing "Should not modify equality filters for non-floating point types"
+    (let [int-value 42
+          query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                    (lib/filter (lib/= (meta/field-metadata :venues :price)
+                                       [:value
+                                        {:base-type :type/Integer, :effective-type :type/Integer, :lib/uuid (str (random-uuid))}
+                                        int-value])))]
+      (testing "Integer equality filter remains unchanged"
+        (let [result-filter (-> query
+                                auto-parse-filter-values
+                                lib/filters
+                                first)]
+          (is (= := (first result-filter)))
+          (is (= int-value (nth (nth result-filter 3) 2))))))))
+
+(deftest ^:parallel real-world-aggregation-test
+  (testing "Should handle real aggregated values like those from the issue"
+    (let [aggregated-value 2185.8607904174387 ; Actual value stolen from issue 48543
+          ;; Create a query with aggregation first, then add filter against that aggregation
+          base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                         (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
+          query (lib/filter base-query
+                            (lib/= (lib/aggregation-ref base-query 0)
+                                   [:value
+                                    {:base-type :type/Float, :effective-type :type/Float, :lib/uuid (str (random-uuid))}
+                                    aggregated-value]))]
+      (testing "Aggregated value = filter becomes :between filter that contains the original value"
+        (let [result-filter (-> query
+                                auto-parse-filter-values
+                                lib/filters
+                                first)]
+          (is (= :between (first result-filter)))
+          (is (= 5 (count result-filter))) ; [:between opts field lower upper]
+          (let [[_ _ _ lower upper] result-filter
+                lower-val (nth lower 2)
+                upper-val (nth upper 2)]
+            ;; Critical: the range MUST contain the original value
+            (is (<= lower-val aggregated-value upper-val)
+                (format "Range [%s, %s] must contain original value %s"
+                        lower-val upper-val aggregated-value))
+            (is (< lower-val aggregated-value) "Lower bound should be less than original")
+            (is (> upper-val aggregated-value) "Upper bound should be greater than original")))))))
+
+(deftest ^:parallel ulp-no-breakdown-test
+  (testing "ULP approach does not break down near zero (unlike naive epsilon-based method)"
+    (testing "Consistent behavior across all value magnitudes for aggregated fields"
+      (let [tiny-value 1e-6
+            ;; Create a query with aggregation first, then add filter against that aggregation
+            base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                           (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
+            query (lib/filter base-query
+                              (lib/= (lib/aggregation-ref base-query 0)
+                                     [:value
+                                      {:base-type :type/Float, :effective-type :type/Float, :lib/uuid (str (random-uuid))}
+                                      tiny-value]))
+            result-filter (-> query auto-parse-filter-values lib/filters first)]
+
+        ;; Ensure we have a valid result before destructuring
+        (when (and result-filter (= 5 (count result-filter)))
+          (let [[_ _ _ lower upper] result-filter
+                lower-val (nth lower 2)
+                upper-val (nth upper 2)
+                ulp-tolerance (/ (- upper-val lower-val) 2)
+                percentage-of-value (* 100 (/ ulp-tolerance tiny-value))]
+
+            ;; Basic sanity checks
+            (is (= :between (first result-filter)) "Should transform to :between filter")
+            (is (= 5 (count result-filter)) "Should have 5 elements: [between opts field lower upper]")
+
+            ;; The range should contain the original value
+            (is (<= lower-val tiny-value upper-val)
+                (str "Range [" lower-val ", " upper-val "] must contain original value " tiny-value))
+
+            ;; ULP maintains tight precision even for tiny values (no breakdown!)
+            (is (< percentage-of-value 1e-10)
+                (str "ULP maintains precision for tiny value " tiny-value ", tolerance is only " percentage-of-value "% of value"))
+
+            #_(println (str "ULP tiny value test: value=" tiny-value ", tolerance=" ulp-tolerance ", percentage=" percentage-of-value "%"))))))))
+
+(deftest ^:parallel ulp-consistency-demonstration-test
+  (testing "Demonstrates ULP tolerance consistency across value magnitudes for aggregated fields"
+    (doseq [[value expected-behavior] [[1000.0 "excellent"]
+                                       [1.0 "excellent"]
+                                       [0.001 "excellent"]
+                                       [0.000001 "excellent"]
+                                       [0.0000000001 "excellent"]
+                                       [0.00000000000001 "excellent"]]] ; ULP works great for all values!
+      (let [;; Create the same multi-stage structure that the UI creates:
+            ;; Stage 0: Aggregation query
+            base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                           (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
+            ;; Stage 1: Filter the aggregated results (simulating "Filter by this value")
+            query (-> base-query
+                      ;; Add a new stage that filters the results
+                      lib/append-stage
+                      ;; Filter using a field reference that matches what the UI creates
+                      (lib/filter (lib/= [:field {:base-type :type/Float, :lib/uuid (str (random-uuid))} "sum"]
+                                         [:value
+                                          {:base-type :type/Float, :effective-type :type/Float, :lib/uuid (str (random-uuid))}
+                                          value])))
+            result-filter (-> query auto-parse-filter-values lib/filters first)]
+
+        ;; Add safety checks for the destructuring
+        (is (not (nil? result-filter)) (format "result-filter should not be nil for value %g" value))
+        (is (= 5 (count result-filter)) (format "result-filter should have 5 elements for value %g, got: %s" value result-filter))
+
+        (when (and result-filter (= 5 (count result-filter)))
+          (let [[_ _ _ lower upper] result-filter
+                lower-val (nth lower 2)
+                upper-val (nth upper 2)
+                ulp-tolerance (/ (- upper-val lower-val) 2)
+                percentage-of-value (* 100 (/ ulp-tolerance value))]
+
+            ;; All should transform to :between
+            (is (= :between (first result-filter)))
+
+            ;; All should contain the original value
+            (is (<= lower-val value upper-val))
+
+            ;; Show the scaling behavior
+            (println (format "Value: %g, ULP Tolerance: %g (%.2e%% of value) - %s"
+                             value ulp-tolerance percentage-of-value expected-behavior))
+
+            ;; ULP maintains excellent precision across all magnitudes
+            (is (< percentage-of-value 1e-10) "ULP should maintain extremely small relative tolerance for all values")))))))
+
+(deftest ^:parallel near-zero-practical-impact-test
+  (testing "ULP maintains distinct tolerance ranges for different values (no breakdown) for aggregated fields"
+    (let [tiny-value 1e-9
+          very-different-value 5e-6 ; 5000x larger but still tiny
+          ;; Create queries with aggregation first, then add filters against that aggregation
+          base-query1 (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                          (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
+          query1 (lib/filter base-query1
+                             (lib/= (lib/aggregation-ref base-query1 0)
+                                    [:value
+                                     {:base-type :type/Float, :effective-type :type/Float, :lib/uuid (str (random-uuid))}
+                                     tiny-value]))
+          base-query2 (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                          (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
+          query2 (lib/filter base-query2
+                             (lib/= (lib/aggregation-ref base-query2 0)
+                                    [:value
+                                     {:base-type :type/Float, :effective-type :type/Float, :lib/uuid (str (random-uuid))}
+                                     very-different-value]))
+          result1 (-> query1 auto-parse-filter-values lib/filters first)
+          result2 (-> query2 auto-parse-filter-values lib/filters first)]
+
+      (when (and result1 result2 (= 5 (count result1)) (= 5 (count result2)))
+        (let [[_ _ _ lower1 upper1] result1
+              [_ _ _ lower2 upper2] result2
+              range1 [(nth lower1 2) (nth upper1 2)]
+              range2 [(nth lower2 2) (nth upper2 2)]]
+
+          (testing "ULP maintains tight, non-overlapping ranges (unlike fixed absolute tolerance)"
+            ;; ULP should create distinct, tight ranges for different values
+            (let [[low1 high1] range1
+                  [low2 high2] range2]
+              ;; Each range should tightly contain its target value
+              (is (and (<= low1 tiny-value high1)
+                       (<= low2 very-different-value high2))
+                  "Both ranges should contain their respective target values")
+
+              ;; Ranges should be appropriately scaled and non-overlapping for different values
+              (is (not (and (<= low1 very-different-value) (<= very-different-value high1)))
+                  (format "ULP ranges should be distinct: [%g,%g] for %g vs [%g,%g] for %g"
+                          low1 high1 tiny-value low2 high2 very-different-value)))))))))
+
+(deftest ^:parallel aggregated-field-ulp-test
+  (testing "Should only apply ULP filtering to aggregated fields, not regular fields"
+    (let [test-value 123.456
+          ;; Test with regular field - should NOT get ULP filtering
+          regular-field-query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                                  (lib/filter (lib/= (meta/field-metadata :venues :latitude)
+                                                     [:value
+                                                      {:base-type :type/Float, :effective-type :type/Float, :lib/uuid (str (random-uuid))}
+                                                      test-value])))
+          ;; Test with aggregated field - should get ULP filtering
+          ;; This simulates a "Filter by this value" action on an aggregated result
+          base-query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                         (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
+          aggregated-field-query (lib/filter base-query
+                                             (lib/= (lib/aggregation-ref base-query 0)
+                                                    [:value
+                                                     {:base-type :type/Float, :effective-type :type/Float, :lib/uuid (str (random-uuid))}
+                                                     test-value]))]
+
+      (testing "Regular field equality should remain unchanged"
+        (let [result-filter (-> regular-field-query
+                                auto-parse-filter-values
+                                lib/filters
+                                first)]
+          (is (= := (first result-filter)) "Regular field should keep = filter")
+          (is (= 4 (count result-filter)) "Regular field filter should have 4 elements")))
+
+      (testing "Aggregated field equality should become :between filter"
+        (let [result-filter (-> aggregated-field-query
+                                auto-parse-filter-values
+                                lib/filters
+                                first)]
+          (is (= :between (first result-filter)) "Aggregated field should get :between filter")
+          (is (= 5 (count result-filter)) "Aggregated field filter should have 5 elements: [between opts field lower upper]"))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48543

### Description

This PR fixes a [bug](https://github.com/metabase/metabase/issues/48543) where the "Filter by this value" functionality was not working correctly for aggregated queries when using the equals (=) or not equals (≠) operators. Previously, when users clicked on a value in the results of an aggregated query and selected "=" or "≠" from the "Filter by this value" menu, the resulting query would produce no results instead of properly filtering the data.

The issue was a typical floating point bug. The fix is to use `Math.ulp` to provide fuzzy equivalence, but *only* to apply this in the context of filters over aggregated values.

### How to verify

To verify that the changes are working as expected:

1. New question -> Sample Dataset -> Products table
2. Summarize by "Count" and group by "Category" 
3. Run the query to see aggregated results
4. Click on any value in the "Count" column
5. Select "Filter by this value" -> "="
6. Verify that the query now returns results filtered by that specific count value (should show only categories with that exact count)
7. Repeat steps 4-6 but select "≠" instead
8. Verify that the query returns results excluding the selected count value
9. Test with other aggregation types (Sum, Average, etc.) to ensure the fix works across different aggregation functions

### Demo

After the fix:

<img width="388" alt="Screenshot 2025-06-13 at 8 08 51 PM" src="https://github.com/user-attachments/assets/fda383fb-05e5-46ba-825d-baade549e613" />

Before the fix, no results.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR