### PR TITLE
disable metadata popovers when column header clicked

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1487,3 +1487,24 @@ describe("issue 55673", { tags: "@flaky" }, () => {
     cy.findByTestId("click-actions-view").should("not.exist");
   });
 });
+
+describe("issue 55637", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not show column metadata popovers when header cell is clicked (metabase#55637)", () => {
+    H.openOrdersTable();
+    H.tableHeaderColumn("ID").realHover();
+    cy.findByTestId("column-info").should("exist");
+
+    H.tableHeaderColumn("ID").click();
+
+    H.tableHeaderColumn("ID").realHover();
+    cy.findByTestId("column-info").should("not.exist");
+
+    H.tableHeaderColumn("Tax").realHover();
+    cy.findByTestId("column-info").should("not.exist");
+  });
+});

--- a/frontend/src/metabase/components/MetadataInfo/ColumnInfo/ColumnInfo.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnInfo/ColumnInfo.tsx
@@ -72,7 +72,7 @@ export function QueryColumnInfo({
     : {};
 
   return (
-    <InfoContainer className={className}>
+    <InfoContainer className={className} data-testid="column-info">
       <ColumnDescription description={description} />
       <Small>
         <SemanticTypeLabel semanticType={semanticType} />

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -14,6 +14,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useLatest } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -164,6 +165,9 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
   }: TableProps,
   ref: Ref<HTMLDivElement>,
 ) {
+  const getInfoPopoversDisabledRef = useLatest(() => {
+    return clicked !== null || !hasMetadataPopovers || isDashboard;
+  });
   const tableTheme = theme?.other?.table;
   const dispatch = useDispatch();
   const isClientSideSortingEnabled = isDashboard;
@@ -493,7 +497,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
               className={cx({
                 [S.pivotedFirstColumn]: columnIndex === 0 && isPivoted,
               })}
-              infoPopoversDisabled={!hasMetadataPopovers || isDashboard}
+              getInfoPopoversDisabled={getInfoPopoversDisabledRef.current}
               timezone={data.results_timezone}
               question={question}
               column={col}
@@ -544,7 +548,6 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
     });
   }, [
     theme,
-    hasMetadataPopovers,
     data,
     question,
     mode,
@@ -559,6 +562,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
     tableTheme,
     isDashboard,
     tc,
+    getInfoPopoversDisabledRef,
   ]);
 
   const handleColumnResize = useCallback(
@@ -736,7 +740,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
           <ErrorMessage
             type="noRows"
             title={t`No results!`}
-            message={t`This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific.`}
+            message={t`This may be the answer you're looking for. If not, try removing or changing your filters to make them less specific.`}
             action={undefined}
           />
         </Flex>

--- a/frontend/src/metabase/visualizations/components/TableInteractive/cells/HeaderCellWithColumnInfo.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/cells/HeaderCellWithColumnInfo.tsx
@@ -16,7 +16,7 @@ import type { DatasetColumn } from "metabase-types/api";
 import S from "./HeaderCellWithColumnInfo.module.css";
 
 export interface HeaderCellWithColumnInfoProps extends HeaderCellProps {
-  infoPopoversDisabled: boolean;
+  getInfoPopoversDisabled: () => boolean;
   timezone?: string;
   question: Question;
   column: DatasetColumn;
@@ -36,7 +36,7 @@ export const HeaderCellWithColumnInfo = memo(
     align,
     sort,
     variant = "light",
-    infoPopoversDisabled,
+    getInfoPopoversDisabled,
     question,
     timezone,
     column,
@@ -67,7 +67,7 @@ export const HeaderCellWithColumnInfo = memo(
 
     return (
       <HeaderCellWrapper className={className} variant={variant} align={align}>
-        {infoPopoversDisabled ? (
+        {getInfoPopoversDisabled() ? (
           cellContent
         ) : (
           <QueryColumnInfoPopover


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #55637
Closes [VIZ-586](https://linear.app/metabase/issue/VIZ-586/column-info-popover-appears-behind-the-column-settings-popover)

### Description

Column metadata popovers appear when hovering over column headers. However, when a column header’s click menu is visible, the column metadata popovers should not be shown.

### How to verify

- Open Orders table
- Hover over a column header -> ensure it shows the metadata popover
- Click on the column header
- Ensure hovers do not trigger metadata popovers anymore

### Demo

<video src="https://github.com/user-attachments/assets/72ae942c-a6cf-43a9-8208-06d8ecd35b6f" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
