### PR TITLE
Fix sample app dev bundle tests

### DIFF
--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -196,6 +196,7 @@ jobs:
     strategy:
       matrix:
         test_suite: ${{ fromJSON(needs.get-sample-apps-data.outputs.matrix) }}
+        environment: ["production", "development"]
     if: |
       !cancelled() && needs.build.result == 'success'
     runs-on: ubuntu-22.04
@@ -212,6 +213,7 @@ jobs:
       TZ: US/Pacific # to make node match the instance tz
       CYPRESS_CI: true
       SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-apps-data.outputs.branch_name }}
+      SAMPLE_APP_ENVIRONMENT: ${{ matrix.environment }}
     permissions:
       id-token: write
 


### PR DESCRIPTION
Fix sample app dev bundle tests by restoring back the `environment` matrix.

How to verify:
- CI should be green