### PR TITLE
Render Mantine and Echarts tooltips in a proper portal container for SDK

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -1,18 +1,33 @@
 import { Button, MantineProvider } from "@mantine/core";
 import {
   CreateDashboardModal,
+  InteractiveDashboard,
   InteractiveQuestion,
   MetabaseProvider,
   StaticQuestion,
   defineMetabaseTheme,
 } from "@metabase/embedding-sdk-react";
 
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import { modal, updateSetting } from "e2e/support/helpers";
+import {
+  chartPathWithFillColor,
+  createDashboard,
+  createQuestion,
+  getDashboardCard,
+  modal,
+  tooltip,
+  updateSetting,
+} from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
-import { DEFAULT_SDK_AUTH_PROVIDER_CONFIG } from "e2e/support/helpers/embedding-sdk-component-testing";
+import {
+  DEFAULT_SDK_AUTH_PROVIDER_CONFIG,
+  mountSdkContent,
+} from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > embedding-sdk > styles", () => {
   beforeEach(() => {
@@ -352,6 +367,109 @@ describe("scenarios > embedding-sdk > styles", () => {
         .and("have.css", "font-family", "Lato");
 
       // TODO: good place for a visual regression test
+    });
+
+    describe("tooltips styles", () => {
+      beforeEach(() => {
+        signInAsAdminAndEnableEmbeddingSdk();
+
+        createQuestion({
+          name: "Tooltip test",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            ],
+          },
+          display: "bar",
+        })
+          .then(({ body: { id: ordersQuestionId } }) =>
+            createDashboard({
+              dashcards: [
+                {
+                  id: 1,
+                  size_x: 10,
+                  size_y: 20,
+                  row: 0,
+                  col: 0,
+                  card_id: ordersQuestionId,
+                },
+              ],
+            }),
+          )
+          .then((dashboard) => {
+            cy.wrap(dashboard.body.id).as("dashboardId");
+          });
+
+        cy.signOut();
+
+        cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
+        cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+          "dashcardQuery",
+        );
+      });
+
+      it("should render Mantine tooltip with our styles", () => {
+        cy.get("@dashboardId").then((dashboardId) => {
+          mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />, {
+            sdkProviderProps: {
+              theme: {
+                fontFamily: "Impact",
+              },
+            },
+          });
+        });
+
+        getSdkRoot().findByText("Tooltip test").click();
+        getSdkRoot().findByLabelText("Back to Test Dashboard").realHover();
+
+        tooltip()
+          .findByText("Back to Test Dashboard")
+          .then(($tooltip) => {
+            const tooltipElement = $tooltip[0];
+
+            const tooltipContainerStyle =
+              window.getComputedStyle(tooltipElement);
+
+            expect(tooltipContainerStyle.fontFamily).to.equal("Impact");
+          });
+      });
+
+      it("should render echarts tooltip with our styles", () => {
+        cy.get("@dashboardId").then((dashboardId) => {
+          mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />, {
+            sdkProviderProps: {
+              theme: {
+                fontFamily: "Impact",
+              },
+            },
+          });
+        });
+
+        getDashboardCard(0).within(() => {
+          chartPathWithFillColor("#509EE3").eq(0).realHover();
+        });
+
+        cy.findAllByTestId("echarts-tooltip")
+          .eq(0)
+          .should("exist")
+          .then(($tooltip) => {
+            const tooltipElement = $tooltip[0];
+
+            const tooltipContainer = tooltipElement.closest(
+              ".echarts-tooltip-container",
+            );
+
+            expect(tooltipContainer).to.exist;
+
+            const tooltipContainerStyle = window.getComputedStyle(
+              tooltipContainer!,
+            );
+
+            expect(tooltipContainerStyle.fontFamily).to.equal("Impact");
+          });
+      });
     });
   });
 

--- a/frontend/src/metabase/embedding-sdk/theme/default-component-theme.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/default-component-theme.ts
@@ -170,5 +170,13 @@ export function getEmbeddingComponentOverrides(): MantineThemeOverride["componen
         },
       }, // satisfies Partial<PopoverProps>,
     },
+    Tooltip: {
+      defaultProps: {
+        withinPortal: true,
+        portalProps: {
+          target: `#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}`,
+        },
+      }, // satisfies Partial<TooltipProps>,
+    },
   };
 }

--- a/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
+++ b/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
@@ -3,6 +3,8 @@ import type React from "react";
 import { useEffect, useMemo } from "react";
 import _ from "underscore";
 
+import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/config";
+import { isEmbeddingSdk } from "metabase/env";
 import { getObjectValues } from "metabase/lib/objects";
 import { isNotNull } from "metabase/lib/types";
 import TooltipStyles from "metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.module.css";
@@ -68,8 +70,13 @@ export const getTooltipBaseOption = (
     enterable: true,
     className: TooltipStyles.ChartTooltipRoot,
     appendTo: () => {
+      const echartsTooltipContainerSelector = ".echarts-tooltip-container";
+      const containerSelector = !isEmbeddingSdk
+        ? echartsTooltipContainerSelector
+        : `#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID} ${echartsTooltipContainerSelector}`;
+
       let container = document.querySelector(
-        ".echarts-tooltip-container",
+        containerSelector,
       ) as HTMLDivElement;
 
       if (!container) {
@@ -85,7 +92,13 @@ export const getTooltipBaseOption = (
           "calc(var(--mb-overlay-z-index) + 1)",
         );
 
-        document.body.append(container);
+        if (!isEmbeddingSdk) {
+          document.body.append(container);
+        } else {
+          document
+            .getElementById(EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID)
+            ?.append(container);
+        }
       }
 
       return container;


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-495/properly-provide-sdk-styles-to-mantine-and-echart-tooltips

Currently we render some Mantine components for SDK in a special container that is wapped within SDK styles: popovers/modals/etc. But the Tooltip component is not overriden in `frontend/src/metabase/embedding-sdk/theme/default-component-theme.ts`.
We should override it and render inside `EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID`.


Also for echarts tooltip for SDK we should append the `.echarts-tooltip-container` container inside the `EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID` container as well.

Before:
![image](https://github.com/user-attachments/assets/4fbf800e-bc8f-406f-ba8f-84076567bc64)

After:
![image](https://github.com/user-attachments/assets/523482ea-36e4-40bb-a0da-e48ecebc8d58)


How to verify:
- i added e2e to cover it.