### PR TITLE
WRK-451: Implement 'Update records' default action functionality

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -34,10 +34,6 @@
   ([table-id]
    (filter #(= table-id (:table_id %)) (list-actions))))
 
-(defn- execute-action!
-  [body]
-  (mt/user-http-request :crowberto :post 200 "action/v2/tmp-modal" body))
-
 (defn- table-url [table-id]
   (format "ee/data-editing/table/%d" table-id))
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/actions/use-built-in-actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/actions/use-built-in-actions.ts
@@ -8,6 +8,7 @@ export const useBuiltInActions = (
   return useMemo(() => {
     let hasCreateAction = false;
     let hasDeleteAction = false;
+    let hasUpdateAction = true;
 
     actionsVizSettings?.forEach((action) => {
       if (action.actionId === "data-grid.row/create" && action.enabled) {
@@ -16,11 +17,15 @@ export const useBuiltInActions = (
       if (action.actionId === "data-grid.row/delete" && action.enabled) {
         hasDeleteAction = true;
       }
+      if (action.actionId === "data-grid.row/update" && !action.enabled) {
+        hasUpdateAction = false;
+      }
     });
 
     return {
       hasCreateAction,
       hasDeleteAction,
+      hasUpdateAction,
     };
   }, [actionsVizSettings]);
 };

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
@@ -179,9 +179,10 @@ export const EditTableDashcardVisualization = memo(
       visualizationSettings,
     );
 
-    const { hasCreateAction, hasDeleteAction } = useBuiltInActions(
-      visualizationSettings?.["editableTable.enabledActions"],
-    );
+    const { hasCreateAction, hasUpdateAction, hasDeleteAction } =
+      useBuiltInActions(
+        visualizationSettings?.["editableTable.enabledActions"],
+      );
 
     const hasEditableAndVisibleColumns = useMemo(() => {
       return data.cols.some(
@@ -285,7 +286,10 @@ export const EditTableDashcardVisualization = memo(
           justify="space-between"
           align="center"
         >
-          <Text fw="bold">{title}</Text>
+          <Group gap="sm" align="center">
+            <Text fw="bold">{title}</Text>
+            {!hasUpdateAction && <Icon name="lock" />}
+          </Group>
 
           {!isEditing && (
             <Group gap="sm" align="center">

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-editable-column-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-editable-column-config.ts
@@ -43,9 +43,9 @@ export function useEditableTableColumnConfigFromVisualizationSettings(
       columnOrder,
       columnVisibilityMap,
       isColumnHidden: (columnName: string) => hiddenColumnSet.has(columnName),
-      isColumnReadonly: (columnName: string) =>
-        // If there are no editable columns settings, all columns are editable
-        editableColumnSet.size > 0 && !editableColumnSet.has(columnName),
+      isColumnReadonly: (columnName: string) => {
+        return !editableColumnSet.has(columnName);
+      },
     };
   }, [visualizationSettings]);
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-column-row-select.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-column-row-select.tsx
@@ -32,7 +32,7 @@ export function getRowSelectColumn() {
       </Flex>
     ),
     cell: ({ row }: { row: Row<RowValues> }) => (
-      <Flex px=".5rem" h="100%" align="center">
+      <Flex p=".5rem" h="100%" align="start">
         <Checkbox
           checked={row.getIsSelected()}
           disabled={!row.getCanSelect()}

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { t } from "ttag";
 
 import { uuid } from "metabase/lib/uuid";
-import { Button, Modal, Stack } from "metabase/ui";
+import { Button, Modal, Stack, Text } from "metabase/ui";
 import type { BasicTableViewColumn } from "metabase/visualizations/types/table-actions";
 import type {
   RowActionFieldSettings,
@@ -51,6 +51,7 @@ export const ConfigureTableActions = ({
         actionId: action.id,
         actionType: "data-grid/row-action",
         parameterMappings,
+        enabled: true,
       };
 
       if (name && name !== action.name) {
@@ -58,6 +59,21 @@ export const ConfigureTableActions = ({
       }
 
       const newArray = tableActions ? [...tableActions, newItem] : [newItem];
+
+      onChange(newArray);
+    },
+    [onChange, tableActions],
+  );
+
+  const updateAction = useCallback(
+    (action: TableActionDisplaySettings) => {
+      if (!tableActions) {
+        return;
+      }
+
+      const newArray = tableActions.map((tableAction) => {
+        return tableAction.id !== action.id ? tableAction : action;
+      });
 
       onChange(newArray);
     },
@@ -82,19 +98,16 @@ export const ConfigureTableActions = ({
         actionId: action.id,
         actionType: "data-grid/row-action",
         parameterMappings,
+        enabled: editingAction?.enabled ?? true,
       };
 
       if (name && name !== action.name) {
         newItem.name = name;
       }
 
-      const newArray = (tableActions || []).map((action) => {
-        return action.actionId !== newItem.actionId ? action : newItem;
-      });
-
-      onChange(newArray);
+      updateAction(newItem);
     },
-    [onChange, tableActions],
+    [updateAction, editingAction],
   );
 
   const handleRemoveAction = useCallback(
@@ -109,25 +122,30 @@ export const ConfigureTableActions = ({
   );
 
   return (
-    <>
-      <Stack gap="xs">
-        {tableActions?.map((action) => {
-          return (
-            <RowActionItem
-              key={action.id}
-              action={action}
-              onRemove={handleRemoveAction}
-              onEdit={setEditingAction}
-            />
-          );
-        })}
+    <Stack gap="sm">
+      <Text fw={700}>{t`Connected actions`}</Text>
+      <Stack gap="sm" mb="lg">
+        {tableActions?.length ? (
+          tableActions?.map((action) => {
+            return (
+              <RowActionItem
+                key={action.id}
+                action={action}
+                onRemove={handleRemoveAction}
+                onEdit={setEditingAction}
+                onEnable={updateAction}
+              />
+            );
+          })
+        ) : (
+          <Text>{t`Create, connect, pass data around`}</Text>
+        )}
       </Stack>
 
       <Button
-        variant="subtle"
-        p={0}
+        variant="active"
         onClick={openEditingModal}
-      >{t`Add a new row action`}</Button>
+      >{t`Add new connected action`}</Button>
 
       {isEditingModalOpen && (
         <Modal.Root
@@ -148,6 +166,6 @@ export const ConfigureTableActions = ({
           />
         </Modal.Root>
       )}
-    </>
+    </Stack>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/RowActionItem.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/RowActionItem.module.css
@@ -1,0 +1,17 @@
+.iconGroup {
+  visibility: hidden;
+  opacity: 0;
+  transition:
+    opacity 0.2s ease-in-out,
+    visibility 0.2s ease-in-out;
+
+  .actionIcon {
+    height: 1rem;
+    min-height: 0;
+  }
+}
+
+.rowActionItem:hover .iconGroup {
+  visibility: visible;
+  opacity: 1;
+}

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/RowActionItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/RowActionItem.tsx
@@ -1,48 +1,57 @@
 import { t } from "ttag";
 
-import { ActionIcon, Group, Icon, Text, Tooltip } from "metabase/ui";
+import { ActionIcon, Checkbox, Group, Icon, Menu } from "metabase/ui";
 import type { TableActionDisplaySettings } from "metabase-types/api";
+
+import S from "./RowActionItem.module.css";
 
 type RowActionItemProps = {
   action: TableActionDisplaySettings;
   onRemove: (id: TableActionDisplaySettings["id"]) => void;
   onEdit: (action: TableActionDisplaySettings) => void;
+  onEnable: (action: TableActionDisplaySettings) => void;
 };
 
 export const RowActionItem = ({
   action,
   onRemove,
   onEdit,
+  onEnable,
 }: RowActionItemProps) => {
   const { id, name } = action;
 
   return (
-    <Group justify="space-between" align="center">
-      <Text>{name}</Text>
-      <Group>
-        <Tooltip label={t`Edit`}>
-          <ActionIcon
-            p={0}
-            c="text-medium"
-            size="sm"
-            radius="xl"
-            onClick={() => onEdit(action)}
-          >
-            <Icon size={16} name="gear" />
-          </ActionIcon>
-        </Tooltip>
-        <Tooltip label={t`Remove`}>
-          <ActionIcon
-            p={0}
-            c="text-medium"
-            size="sm"
-            radius="xl"
-            onClick={() => onRemove(id)}
-          >
-            <Icon size={16} name="close" />
-          </ActionIcon>
-        </Tooltip>
-      </Group>
+    <Group
+      p={0}
+      justify="space-between"
+      align="center"
+      className={S.rowActionItem}
+    >
+      <Checkbox
+        key={action.actionId}
+        label={name}
+        checked={action.enabled}
+        onChange={(e) => {
+          onEnable({ ...action, enabled: e.target.checked });
+        }}
+      />
+      <div className={S.iconGroup}>
+        <Menu>
+          <Menu.Target>
+            <ActionIcon variant="subtle" className={S.actionIcon}>
+              <Icon name="ellipsis" />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item onClick={() => onEdit(action)}>
+              {t`Edit custom action`}
+            </Menu.Item>
+            <Menu.Item onClick={() => onRemove(id)} color="error">
+              {t`Delete custom action`}
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </div>
     </Group>
   );
 };

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -179,11 +179,15 @@ export type TableRowActionDisplaySettings = {
   name: string;
   actionType: "data-grid/row-action";
   parameterMappings?: RowActionFieldSettings[];
+  enabled: boolean;
 };
 
 export type EditableTableBuiltInActionDisplaySettings = {
   id: string;
-  actionId: "data-grid.row/create" | "data-grid.row/delete";
+  actionId:
+    | "data-grid.row/create"
+    | "data-grid.row/delete"
+    | "data-grid.row/update";
   enabled: boolean;
   actionType: "data-grid/built-in";
 };

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -238,6 +238,12 @@ export const addEditableTableDashCardToDashboard =
               },
               {
                 id: uuid(),
+                actionId: "data-grid.row/update",
+                enabled: true,
+                actionType: "data-grid/built-in",
+              },
+              {
+                id: uuid(),
                 actionId: "data-grid.row/delete",
                 enabled: true,
                 actionType: "data-grid/built-in",
@@ -562,6 +568,9 @@ export const updateEditableTableCardQueryInEditMode = createThunkAction(
         newDashcardAttributes.visualization_settings = {
           ...dashcard.visualization_settings,
           initial_dataset_query: newCard.dataset_query,
+          "table.editableColumns": newCard.result_metadata.map(
+            (field) => field.name,
+          ),
         };
       }
 

--- a/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/ConfigureEditableTableColumns.tsx
+++ b/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/ConfigureEditableTableColumns.tsx
@@ -263,13 +263,7 @@ function useEditableTableColumnSettingItems(
       }
     }
 
-    // By default, all columns are editable if no settings are provided
-    // If settings are provided, we preserve them even if a new column is added
-    const editableColumnSet = new Set(
-      columnEditableSettings.length > 0
-        ? columnEditableSettings
-        : fields.map((it) => it.name),
-    );
+    const editableColumnSet = new Set(columnEditableSettings);
 
     return nameOrder.map((name) => {
       const setting = nameToDisplaySettingMap[name];

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -76,6 +76,7 @@ import type {
   DatasetError,
   DatasetErrorType,
   EditableTableActionsDisplaySettings,
+  EditableTableBuiltInActionDisplaySettings,
   Group,
   GroupPermissions,
   GroupsPermissions,
@@ -781,7 +782,7 @@ export const PLUGIN_TABLE_ACTIONS = {
   isEnabled: () => false,
   isBuiltInEditableTableAction: (
     _action: EditableTableActionsDisplaySettings,
-  ) => false,
+  ): _action is EditableTableBuiltInActionDisplaySettings => false,
   useTableActionsExecute: (_params: {
     actionsVizSettings: TableActionDisplaySettings[] | undefined;
     datasetData: DatasetData | null | undefined;


### PR DESCRIPTION
Closes [WRK-451](https://linear.app/metabase/issue/WRK-451/refactor-actions-tab-in-editables-and-questions)

### Description

Updating the layout of editables' Action tab and introducing "Update records" default action. Disabling this checkbox makes all columns uneditable and vice versa. By default, the checkbox is set. If it's unchecked, user is able to enable specific columns for editing.

Among important changes, `editableColumns` array is now treated as is. Meaning, if it's empty, all columns are read-only. It is populated with the list of all columns at the moment when an editable is created.

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/29da5691-e906-4aea-a2bc-f7f2bae0d5fb" />

Also, fixes a bug with row checkboxes disappearing when rows became too high.