### PR TITLE
Scroll element into view before checking visibility

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
@@ -183,6 +183,7 @@ describe("scenarios > admin > localization > content translation", () => {
           .should("be.visible");
         cy.findAllByRole("alert")
           .contains(/Row 5: Invalid locale/)
+          .scrollIntoView()
           .should("be.visible");
       });
 


### PR DESCRIPTION
[CI is failing ](https://github.com/metabase/metabase/actions/runs/15667650699/job/44136531144) after merging [6d5393c](https://github.com/metabase/metabase/commit/6d5393cfeb68acee0c5ce57b99689c4f56ec7d43) 

The new Admin Settings layout adds more space to the pages, and this pushed one of the elements in this test below the fold. Scrolling it into view fixes the test