### PR TITLE
Closes VIZ-917 two data points for one series (second try)

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -598,7 +598,6 @@ const buildEChartsLineAreaSeries = (
       },
     },
     blur: {
-      // label: getBlurLabelStyle(settings, hasMultipleSeries),
       itemStyle: {
         opacity: isSymbolVisible ? blurOpacity : 0,
       },

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -598,7 +598,7 @@ const buildEChartsLineAreaSeries = (
       },
     },
     blur: {
-      label: getBlurLabelStyle(settings, hasMultipleSeries),
+      // label: getBlurLabelStyle(settings, hasMultipleSeries),
       itemStyle: {
         opacity: isSymbolVisible ? blurOpacity : 0,
       },


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57370
Closes [VIZ-917: Area chart shows data point values twice when graphing only one series](https://linear.app/metabase/issue/VIZ-917/area-chart-shows-data-point-values-twice-when-graphing-only-one-series)

### Description
