### PR TITLE
Ensure new v2 table list only returns active tables

### DIFF
--- a/src/metabase/actions/api.clj
+++ b/src/metabase/actions/api.clj
@@ -261,6 +261,7 @@
                                              {:status-code 400})))
         tables             (t2/select [:model/Table :id :display_name :name :description :schema]
                                       :db_id database-id
+                                      :active true
                                       {:order-by :name})]
     {:tables tables}))
 

--- a/test/metabase/actions/api_test.clj
+++ b/test/metabase/actions/api_test.clj
@@ -723,7 +723,14 @@
                                                     :display_name "Leather Sofa Table"
                                                     :description  "Premium leather side table"
                                                     :schema       "public"
-                                                    :db_id        db-id-2}]
+                                                    :db_id        db-id-2}
+                     :model/Table _                {:name         "inactive_table"
+                                                    :display_name "Inactive Table"
+                                                    :description  "inactive"
+                                                    :schema       "public"
+                                                    :db_id        db-id-1
+                                                    :active       false}]
+
         (testing "Returns only tables from the specified database, in alphabetical order"
           (is (=? {:tables [{:id table-id-2 :name "mahogany_coffee_table" :display_name "Mahogany Coffee Table"
                              :description "Luxurious mahogany coffee table" :schema "public"}


### PR DESCRIPTION
The new V2 table list did not filter out inactive tables, this PR fixes that