### PR TITLE
Fix padding in Heading visualization component

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -7,7 +7,6 @@ import { useToggle } from "metabase/hooks/use-toggle";
 import { useTranslateContent } from "metabase/i18n/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { isEmpty } from "metabase/lib/validate";
-import { TextInput } from "metabase/ui";
 import { fillParametersInText } from "metabase/visualizations/shared/utils/parameter-substitution";
 import type {
   Dashboard,
@@ -19,6 +18,7 @@ import {
   HeadingContainer,
   HeadingContent,
   InputContainer,
+  TextInput,
 } from "./Heading.styled";
 
 interface HeadingProps {


### PR DESCRIPTION
This fixes a bug where the padding on a Heading would disappear when it was edited.

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/b3cd934b-320b-4202-9619-1e1cad7b046d.png)

After:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/utGnP2ljFMMNOgi82vVn/cc35902e-309a-4b02-8f6b-5d14295015e9.png)

