### PR TITLE
fix: card before-update to not always force update

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -152,8 +152,8 @@
   "If a Card is updated, and its result metadata changes, check that these changes do not violate the constraints placed
   on sandboxes (the Card cannot add fields or change types vs. the original Table)."
   :feature :sandboxes
-  [{new-result-metadata :result_metadata, card-id :id}]
-  (when new-result-metadata
+  [{new-result-metadata :result_metadata, card-id :id} changes]
+  (when (contains? changes :result_metadata)
     (when-let [gtaps-using-this-card (not-empty (t2/select [:model/GroupTableAccessPolicy :id :table_id] :card_id card-id))]
       (let [original-result-metadata (t2/select-one-fn :result_metadata :model/Card :id card-id)]
         (when-not (= original-result-metadata new-result-metadata)

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -362,7 +362,7 @@
   "Check that a `card`, if it is using another Card as its source, does not have circular references between source
   Cards. (e.g. Card A cannot use itself as a source, or if A uses Card B as a source, Card B cannot use Card A, and so
   forth.)"
-  [{query :dataset_query, id :id}]      ; don't use `u/the-id` here so that we can use this with `pre-insert` too
+  [{query :dataset_query, id :id}] ; don't use `u/the-id` here so that we can use this with `pre-insert` too
   (loop [query query, ids-already-seen #{id}]
     (let [source-card-id (qp.util/query->source-card-id query)]
       (cond
@@ -548,7 +548,7 @@
 (defenterprise pre-update-check-sandbox-constraints
   "Checks additional sandboxing constraints for Metabase Enterprise Edition. The OSS implementation is a no-op."
   metabase-enterprise.sandbox.models.group-table-access-policy
-  [_])
+  [_ _])
 
 (defn- update-parameters-using-card-as-values-source
   "Update the config of parameter on any Dashboard/Card use this `card` as values source .
@@ -556,7 +556,7 @@
   Remove parameter.values_source_type and set parameter.values_source_type to nil ( the default type ) when:
   - card is archived
   - card.result_metadata changes and the parameter values source field can't be found anymore"
-  [{id :id, :as changes}]
+  [{:keys [id]} changes]
   (when (some #{:archived :result_metadata} (keys changes))
     (let [parameter-cards (t2/select :model/ParameterCard :card_id id)]
       (doseq [[[po-type po-id] param-cards]
@@ -612,10 +612,10 @@
                                                           :where  [:= :action.model_id model-id]})]
     (t2/delete! :model/Action :id [:in action-ids])))
 
-(defn- pre-update [{id :id, :as changes}]
+(defn- pre-update [{id :id :as card} changes]
   ;; TODO - don't we need to be doing the same permissions check we do in `pre-insert` if the query gets changed? Or
   ;; does that happen in the `PUT` endpoint? (#40013)
-  (u/prog1 changes
+  (u/prog1 card
     (let [;; Fetch old card data if necessary, and share the data between multiple checks.
           old-card-info (when (or (contains? changes :type)
                                   (:dataset_query changes)
@@ -637,7 +637,7 @@
               (field-values/update-field-values-for-on-demand-dbs! newly-added-param-field-ids)))))
       ;; make sure this Card doesn't have circular source query references if we're updating the query
       (when (:dataset_query changes)
-        (check-for-circular-source-query-references changes))
+        (check-for-circular-source-query-references card))
       ;; updating a model dataset query to not support implicit actions will disable implicit actions if they exist
       (when (and (:dataset_query changes)
                  (= (:type old-card-info) :model)
@@ -655,11 +655,11 @@
       (collection/check-collection-namespace :model/Card (:collection_id changes))
       (params/assert-valid-parameters changes)
       (params/assert-valid-parameter-mappings changes)
-      (update-parameters-using-card-as-values-source changes)
+      (update-parameters-using-card-as-values-source card changes)
       (when (:parameters changes)
         (parameter-card/upsert-or-delete-from-parameters! "card" id (:parameters changes)))
       ;; additional checks (Enterprise Edition only)
-      (pre-update-check-sandbox-constraints changes)
+      (pre-update-check-sandbox-constraints card changes)
       (card.metadata/assert-valid-idents! (merge old-card-info changes))
       (assert-valid-type (merge old-card-info changes)))))
 
@@ -715,10 +715,10 @@
                                     ensure-clause-idents-list (:aggregation query) "aggregation" stage-number ctx)
        (:expressions query) (update :expression-idents
                                     ensure-clause-idents-expressions (:expressions query) stage-number ctx)
-       (:breakout query)    (update :breakout-idents
-                                    ensure-clause-idents-list (:breakout query) "breakout" stage-number ctx)
-       (:joins query)       (update :joins
-                                    ensure-clause-idents-joins stage-number ctx)))
+       (:breakout query) (update :breakout-idents
+                                 ensure-clause-idents-list (:breakout query) "breakout" stage-number ctx)
+       (:joins query) (update :joins
+                              ensure-clause-idents-joins stage-number ctx)))
    inner-query))
 
 (defn- ensure-clause-idents-outer [{:keys [query type] :as outer-query} ctx]
@@ -834,10 +834,10 @@
       (field-values/update-field-values-for-on-demand-dbs! field-ids))
     (parameter-card/upsert-or-delete-from-parameters! "card" (:id card) (:parameters card))))
 
-(defn- apply-dashboard-question-updates [changes]
+(defn- apply-dashboard-question-updates [card changes]
   (if-let [dashboard-id (:dashboard_id changes)]
-    (assoc changes :collection_id (t2/select-one-fn :collection_id :model/Dashboard :id dashboard-id))
-    changes))
+    (assoc card :collection_id (t2/select-one-fn :collection_id :model/Dashboard :id dashboard-id))
+    card))
 
 (defn- strip-model-from-idents
   [result-metadata
@@ -847,41 +847,39 @@
 (defn- normalize-result-metadata-idents
   "If the `:type` is changing, the `:result_metadata` needs to change too, either adding or removing model details
   from the `:ident`s."
-  [card-updates card-entity changes]
-  (let [input-metadata   (or (:result_metadata card-updates)
-                             (:result_metadata card-entity))
+  [card]
+  (let [changes (t2/changes card)
+        input-metadata (:result_metadata card)
         updated-metadata (case (:type changes)
-                           :question (strip-model-from-idents input-metadata card-entity)
-                           :model    (card.metadata/fix-incoming-idents input-metadata card-entity)
+                           :question (strip-model-from-idents input-metadata card)
+                           :model (card.metadata/fix-incoming-idents input-metadata card)
                            nil)]
-    (cond-> card-updates
+    (cond-> card
       updated-metadata (assoc :result_metadata updated-metadata))))
+
+(defn- populate-result-metadata
+  "If we have fresh result_metadata, we don't have to populate it anew. When result_metadata doesn't
+  change for a native query, populate-result-metadata removes it (set to nil) unless prevented by the
+  verified-result-metadata? flag (see #37009)."
+  [card changes verified-result-metadata?]
+  (cond-> card
+    (or (empty? (:result_metadata card))
+        (not verified-result-metadata?)
+        (contains? (t2/changes card) :type))
+    (card.metadata/populate-result-metadata changes)))
 
 (t2/define-before-update :model/Card
   [{:keys [verified-result-metadata?] :as card}]
-  ;; remove all the unchanged keys from the map, except for `:id`, so the functions below can do the right thing since
-  ;; they were written pre-Toucan 2 and don't know about [[t2/changes]]...
-  ;;
-  ;; We have to convert this to a plain map rather than a Toucan 2 instance at this point to work around upstream bug
-  ;; https://github.com/camsaul/toucan2/issues/145 .
-  ;; TODO: ^ that's been fixed, this could be refactored
-  (let [changes (-> card
-                    (dissoc :verified-result-metadata?)
-                    (assoc :card_schema current-schema-version)
-                    t2/changes)]
-    (-> (into (select-keys card [:id :type :entity_id]) changes)
-        apply-dashboard-question-updates
+
+  (let [changes (t2/changes card)]
+    (-> card
+        (dissoc :verified-result-metadata?)
+        (assoc :card_schema current-schema-version)
+        (apply-dashboard-question-updates changes)
         maybe-normalize-query
-        (normalize-result-metadata-idents card changes)
-        ;; If we have fresh result_metadata, we don't have to populate it anew. When result_metadata doesn't
-        ;; change for a native query, populate-result-metadata removes it (set to nil) unless prevented by the
-        ;; verified-result-metadata? flag (see #37009).
-        (cond-> #_changes
-         (or (empty? (:result_metadata card))
-             (not verified-result-metadata?)
-             (contains? changes :type))
-          card.metadata/populate-result-metadata)
-        pre-update
+        normalize-result-metadata-idents
+        (populate-result-metadata changes verified-result-metadata?)
+        (pre-update changes)
         populate-query-fields
         maybe-populate-initially-published-at)))
 


### PR DESCRIPTION
### Description

As part of making sure we're not generating unintended updates to avoid database deadlocks, this fixes the `before-update` callback on the card model to not always associate in the card id, entity_id, and type into the map of values to update which results in us bypassing toucan2's no-op update check and causing an update to always run. 

This also adds some tests to cover uncovered behavior in the before-update callback. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
