### PR TITLE
parallelize requests and make them use rtk query

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
@@ -295,6 +295,17 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
 
     cy.log("5: Metabase");
     cy.button("New").should("be.visible");
+
+    cy.log(
+      "Only one 'Automatically Generated Dashboards' collection should be created",
+    );
+    sidebar().within(() => {
+      cy.findByText("Automatically Generated Dashboards").should("be.visible");
+      cy.findByText("Automatically Generated Dashboards").should(
+        "have.length",
+        1,
+      );
+    });
   });
 });
 

--- a/frontend/src/metabase/api/automagic-dashboards.ts
+++ b/frontend/src/metabase/api/automagic-dashboards.ts
@@ -1,4 +1,5 @@
 import type {
+  Dashboard,
   DashboardQueryMetadata,
   DatabaseId,
   DatabaseXray,
@@ -10,7 +11,6 @@ import {
   provideDashboardQueryMetadataTags,
   provideDatabaseCandidateListTags,
 } from "./tags";
-
 export const automagicDashboardsApi = Api.injectEndpoints({
   endpoints: (builder) => ({
     getXrayDashboardQueryMetadata: builder.query<
@@ -30,10 +30,24 @@ export const automagicDashboardsApi = Api.injectEndpoints({
       providesTags: (candidates = []) =>
         provideDatabaseCandidateListTags(candidates),
     }),
+    getXrayDashboardForModel: builder.query<
+      Dashboard,
+      { modelId: number; dashboard_load_id?: number }
+    >({
+      query: ({ modelId, dashboard_load_id }) => {
+        const params = dashboard_load_id ? { dashboard_load_id } : undefined;
+        return {
+          method: "GET",
+          url: `/api/automagic-dashboards/model/${modelId}`,
+          params,
+        };
+      },
+    }),
   }),
 });
 
 export const {
   useGetXrayDashboardQueryMetadataQuery,
   useListDatabaseXraysQuery,
+  useLazyGetXrayDashboardForModelQuery,
 } = automagicDashboardsApi;

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/EmbeddingSetupContext.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/EmbeddingSetupContext.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 
 import { trackSimpleEvent } from "metabase/lib/analytics";
-import type { DatabaseData, Table } from "metabase-types/api";
+import type { DashboardId, DatabaseData, Table } from "metabase-types/api";
 
 import { DataConnectionStep } from "./steps/DataConnectionStep";
 import { DoneStep } from "./steps/DoneStep";
@@ -42,8 +42,8 @@ type EmbeddingSetupContextType = {
   setError: (error: string) => void;
   selectedTables: Table[];
   setSelectedTables: (tables: Table[]) => void;
-  createdDashboardIds: number[];
-  setCreatedDashboardIds: (ids: number[]) => void;
+  createdDashboardIds: DashboardId[];
+  setCreatedDashboardIds: (ids: DashboardId[]) => void;
   stepKey: EmbeddingSetupStepKey;
   goToStep: (key: EmbeddingSetupStepKey) => void;
   steps: StepDefinition[];
@@ -79,7 +79,9 @@ export const EmbeddingSetupProvider = ({
   const [processingStatus, setProcessingStatus] = useState("");
   const [error, setError] = useState("");
   const [selectedTables, setSelectedTables] = useState<Table[]>([]);
-  const [createdDashboardIds, setCreatedDashboardIds] = useState<number[]>([]);
+  const [createdDashboardIds, setCreatedDashboardIds] = useState<DashboardId[]>(
+    [],
+  );
   const [stepKey, goToStep] = useState<EmbeddingSetupStepKey>(STEPS[0].key);
 
   const stepIndex = getStepIndexByKey(stepKey);


### PR DESCRIPTION
closes [EMB-493: \[tech\] parallelize the api requests](https://linear.app/metabase/issue/EMB-493/tech-parallelize-the-api-requests)

and addresses part (all?) of [EMB-487: \[tech\] refactor `fetch` calls to our api wrappers](https://linear.app/metabase/issue/EMB-487/tech-refactor-fetch-calls-to-our-api-wrappers)

As with everything in this project you'll need a fresh instance and go to `/setup/embedding` to test this out