### PR TITLE
Content translation: Add sample translations if dictionary is blank

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -21,11 +21,19 @@
 (def ^:private max-content-translation-dictionary-size-mib 1.5)
 (def ^:private max-content-translation-dictionary-size-bytes (* max-content-translation-dictionary-size-mib 1024 1024))
 
+(def ^:private sample-translations [{:locale "de" :msgid "Sample translation" :msgstr "Musterübersetzung"}
+                                    {:locale "pt_BR" :msgid "Sample translation" :msgstr "Tradução de exemplo"}
+                                    {:locale "ja" :msgid "Sample translation" :msgstr "サンプル翻訳"}
+                                    {:locale "ko" :msgid "Sample translation" :msgstr "샘플 번역"}])
+
 (api.macros/defendpoint :get "/csv"
   "Provides content translation dictionary in CSV"
   []
   (api/check-superuser)
   (let [translations (ct/get-translations)
+        translations (if (empty? translations)
+                       sample-translations
+                       translations)
         csv-data (cons ["Language" "String" "Translation"]
                        (map (fn [{:keys [locale msgid msgstr]}]
                               [locale msgid msgstr])

--- a/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
@@ -67,7 +67,17 @@
                                         (= (nth % 1) "Hello")
                                         (= (nth % 2) "Bonjour"))
                                   data)]
-              (is (seq matches))))))))
+              (is (seq matches)))))))
+    (testing "returns sample translations when content-translation table is empty"
+      (ct-utils/with-clean-translations!
+        (mt/with-premium-features #{:content-translation}
+          (let [body (mt/user-http-request :crowberto :get 200 "ee/content-translation/csv" {})
+                data (with-open [reader (java.io.StringReader. body)]
+                       (doall (csv/read-csv reader)))
+                matches (filter #(and (= (nth % 0) "de")
+                                      (= (nth % 1) "Sample translation"))
+                                data)]
+            (is (seq matches)))))))
   (testing "POST /api/ee/content-translation/upload-dictionary"
     (testing "nonadmin cannot use"
       (ct-utils/with-clean-translations!


### PR DESCRIPTION
On master, admins can download a CSV containing the dictionary of content translations. We use this dictionary to translate user-generated content. With this PR, when they download the CSV and there are no translations stored, some sample translations are included in the CSV.

<img width="473" alt="image" src="https://github.com/user-attachments/assets/baac1c32-767d-4370-b32b-8773d6d2b7c3" />

---

- [x] A test has been added

---

Closes https://linear.app/metabase/issue/ADM-617/content-translation-add-examples-to-blank-content-translation