### PR TITLE
Clear checksums when rolling back from 55

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11888,7 +11888,7 @@ databaseChangeLog:
       rollback:
         - sql:
             sql: >-
-              update databasechangelog
+              update ${databasechangelog.name}
               set md5sum=null
               where id in (
                            'v46.00-080',

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -11876,6 +11876,56 @@ databaseChangeLog:
             constraintName: fk_metabot_prompt_card_id
             onDelete: CASCADE
 
+
+  - changeSet:
+      id: v55.2025-06-16T17:36:06
+      author: nvoxland
+      comment: |
+        In v55 we renamed the `metabase.app_db` namespace which changed checksums.
+        The validCheckSum=ANY allows forward migration, but a rollback doesn't reset the checksums to the value old versions expect
+      changes:
+        - empty: #no-op on forward migration
+      rollback:
+        - sql:
+            sql: >-
+              update databasechangelog
+              set md5sum=null
+              where id in (
+                           'v46.00-080',
+                           'v46.00-086',
+                           'v47.00-016',
+                           'v47.00-027',
+                           'v47.00-028',
+                           'v47.00-029',
+                           'v47.00-033',
+                           'v47.00-034',
+                           'v47.00-043',
+                           'v47.00-044',
+                           'v47.00-045',
+                           'v47.00-046',
+                           'v48.00-001',
+                           'v48.00-022',
+                           'v48.00-023',
+                           'v49.00-059',
+                           'v49.2024-01-22T11:52:00',
+                           'v49.2024-04-09T10:00:03',
+                           'v50.2024-03-28T16:30:35',
+                           'v50.2024-04-25T01:04:05',
+                           'v50.2024-04-25T01:04:06',
+                           'v50.2024-04-25T01:04:07',
+                           'v50.2024-05-15T13:13:13',
+                           'v50.2024-05-17T19:54:26',
+                           'v50.2024-05-27T15:55:22',
+                           'v50.2024-06-12T12:33:07',
+                           'v51.2024-05-13T16:00:00',
+                           'v51.2024-08-07T10:00:00',
+                           'v51.2024-08-07T11:00:00',
+                           'v52.2024-10-26T18:42:42',
+                           'v52.2024-11-12T15:13:18',
+                           'v52.2024-12-03T15:55:22',
+                           'v54.2025-02-14T08:05:00'
+                  );
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59566
### Description

In v55 we renamed a namespace used in migrations in #58200. The checksum: ANY we added in that PR works for upgrades, but if you downgrade from 55 to 54, when you try to start 54 the old verisons of the changesets which are back have a different checksum which flags liquibase to not trust that the database is in an expected state and so not safe to update.

Rather than backporting the `checksum: ANY` flag back to 54, 53, or any versions we want to support downgrading to, I added a no-op migration with a rollback that clears the checksums from the databasechangelog table in the problem changesets. This allows us to downgrade to any previous version, not just to patch versions that would have had the `checksum: ANY` flag added to them.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Install or upgrade an instance to v55
2. Downgrade the database to v54
3. Restart the instance with v54
4. See that it correctly comes up 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
