### PR TITLE
Support passing an environment file to jar-download

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -121,7 +121,7 @@
                 ["JARS=~/my-stuff ./bin/mage jar-download 1.45.2" "Download metabase_1.45.2.jar to ~/my-stuff"]]
    :requires   [[mage.jar-download :as jar-download]]
    :options    [["-r" "--run" "run the new jar after downloading it"]
-                ["-e" "--env FILE" "you can optionally provide a lein-env file to specify the environment to use when running the jar."]
+                ["-e" "--env-file FILE" "you can optionally provide a lein-env file to specify the environment to use when running the jar."]
                 ["-d" "--delete" "delete the old jar if found, by default does not re-download it"]
                 ["-p" "--port PORT" "you can optionally provide a port to run the jar on, if not, we use a sane port."]]
    :arg-schema [:or

--- a/bb.edn
+++ b/bb.edn
@@ -121,6 +121,7 @@
                 ["JARS=~/my-stuff ./bin/mage jar-download 1.45.2" "Download metabase_1.45.2.jar to ~/my-stuff"]]
    :requires   [[mage.jar-download :as jar-download]]
    :options    [["-r" "--run" "run the new jar after downloading it"]
+                ["-e" "--env FILE" "you can optionally provide a lein-env file to specify the environment to use when running the jar."]
                 ["-d" "--delete" "delete the old jar if found, by default does not re-download it"]
                 ["-p" "--port PORT" "you can optionally provide a port to run the jar on, if not, we use a sane port."]]
    :arg-schema [:or

--- a/mage/mage/jar_download.clj
+++ b/mage/mage/jar_download.clj
@@ -228,10 +228,7 @@
                      (remove #(re-matches #"^\s*;.*" %))
                      (clojure.string/join "\n"))
         edn-map (edn/read-string cleaned)]
-    (into {}
-          (map (fn [[k v]]
-                 [(-> k name (clojure.string/upper-case) (clojure.string/replace "-" "_")) v])
-               edn-map))))
+    (update-keys edn-map #(-> % name (clojure.string/upper-case) (clojure.string/replace "-" "_")))))
 
 (defn- parse-env [env-file]
   (when (and env-file (not (fs/exists? env-file)))
@@ -261,7 +258,7 @@
       (let [port        (try (parse-long (:port (:options parsed)))
                              (catch Exception _
                                (port-for-version latest-version)))
-            env-file (:env (:options parsed))
+            env-file (:env-file (:options parsed))
             socket-port (+ 3000 port)
             db-file (str u/project-root-directory "/metabase_" version ".db")
             extra-env (merge {"MB_DB_TYPE"          "h2"

--- a/mage/mage/jar_download.clj
+++ b/mage/mage/jar_download.clj
@@ -5,6 +5,7 @@
    [babashka.process :as p]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as json]
+   [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [mage.color :as c]
@@ -218,7 +219,28 @@
   (+ 3000
      (if-let [branch (:branch version)]
        (rem (Math/abs (hash branch)) 1000) ; Use hash of branch name for port
-       (major-version version)))) ; Use major version for port
+       (major-version version))))                           ; Use major version for port
+
+(defn- parse-lein-env [env-file]
+  (let [content (slurp env-file)
+        ;; Remove lines starting with ; (comments)
+        cleaned (->> (clojure.string/split-lines content)
+                     (remove #(re-matches #"^\s*;.*" %))
+                     (clojure.string/join "\n"))
+        edn-map (edn/read-string cleaned)]
+    (into {}
+          (map (fn [[k v]]
+                 [(-> k name (clojure.string/upper-case) (clojure.string/replace "-" "_")) v])
+               edn-map))))
+
+(defn- parse-env [env-file]
+  (when (and env-file (not (fs/exists? env-file)))
+    (throw (ex-info (str "Env file does not exist: " env-file)
+                    {:env-file      env-file
+                     :babashka/exit 1})))
+  (if env-file
+    (parse-lein-env env-file)
+    {}))
 
 (defn jar-download
   "Download a specific version of Metabase to a directory.
@@ -236,28 +258,33 @@
         ;; latest-version could be a version string like 1.50.35 or a map with :branch key
         {:keys [latest-version jar-path]} (download-jar! version dir delete?)]
     (when run?
-      ;; Check that the embedding token is set:
-      (u/env "MB_PREMIUM_EMBEDDING_TOKEN"
-             #(throw (ex-info (str "MB_PREMIUM_EMBEDDING_TOKEN is not set, please set it to run "
-                                   "your jar (it is in 1password. ask on slack if you need help).")
-                              {:parsed-args (dissoc parsed :summary)
-                               :latest-version latest-version
-                               :jar-path jar-path
-                               :babashka/exit 1})))
       (let [port        (try (parse-long (:port (:options parsed)))
                              (catch Exception _
                                (port-for-version latest-version)))
+            env-file (:env (:options parsed))
             socket-port (+ 3000 port)
-            db-file     (str u/project-root-directory "/metabase_" version ".db")
-            extra-env   {"MB_DB_TYPE"          "h2"
-                         "MB_DB_FILE"          db-file
-                         "MB_JETTY_PORT"       port
-                         "MB_CONFIG_FILE_PATH" (str u/project-root-directory "/mage/jar_download_config.yml")}
+            db-file (str u/project-root-directory "/metabase_" version ".db")
+            extra-env (merge {"MB_DB_TYPE"          "h2"
+                              "MB_DB_FILE"          db-file
+                              "MB_JETTY_PORT"       port
+                              "MB_CONFIG_FILE_PATH" (str u/project-root-directory "/mage/jar_download_config.yml")}
+                             (parse-env env-file))
             run-jar-cmd (str "java -Dclojure.server.repl=\"{:port " socket-port " :accept clojure.core.server/repl}\" -jar " jar-path)]
         (println (c/magenta "Running: " run-jar-cmd))
         (println "env:")
         (doseq [[k v] extra-env]
           (println (str "  " (c/yellow k) "=" (c/green v))))
+
+        (when (not (get extra-env "MB_PREMIUM_EMBEDDING_TOKEN"))
+          ;; Check that the embedding token is set:
+          (u/env "MB_PREMIUM_EMBEDDING_TOKEN"
+                 #(throw (ex-info (str "MB_PREMIUM_EMBEDDING_TOKEN is not set, please set it to run "
+                                       "your jar (it is in 1password. ask on slack if you need help).")
+                                  {:parsed-args    (dissoc parsed :summary)
+                                   :latest-version latest-version
+                                   :jar-path       jar-path
+                                   :babashka/exit  1}))))
+
         (println (str "Socket repl will open on " (c/green socket-port) ". "
                       "See: https://lambdaisland.com/guides/clojure-repls/clojure-repls#org259d775"))
         (println (str "\n\n   Open in browser: " (c/magenta "http://localhost:" port) "\n"))


### PR DESCRIPTION
### Description

It would be nice to use `mage jar-download` but with my regular development environment (database, users, API keys, etc) instead of h2.

This PR adds an --env flag that lets you specify an environment file whose values takes precedent over the default jar-download values.

Currently it just supports a lein-env file, but left it as an independent function so we could support other formats if/when we want.
 
### How to verify

Run `bin/mage jar-download 54 -r -e .lein-env` and have a v54 version running with my normal setup.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
