### PR TITLE
feat: an api for debugging permissions issues

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1678,6 +1678,16 @@
            util
            warehouse-schema}}
 
+  enterprise/permission-debug
+  {:team "Admin Webapp"
+   :api #{metabase-enterprise.permission-debug.api}
+   :uses #{api
+           lib
+           models
+           permissions
+           query-processor
+           util}}
+
   enterprise/premium-features
   {:team "Admin Webapp"
    :api  #{}

--- a/enterprise/backend/src/metabase_enterprise/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes.clj
@@ -20,6 +20,7 @@
    [metabase-enterprise.llm.api]
    [metabase-enterprise.metabot-v3.api]
    [metabase-enterprise.metabot-v3.tools.api]
+   [metabase-enterprise.permission-debug.api]
    [metabase-enterprise.sandbox.api.routes]
    [metabase-enterprise.scim.routes]
    [metabase-enterprise.serialization.api]
@@ -83,6 +84,7 @@
    "/logs"                         (premium-handler 'metabase-enterprise.advanced-config.api.logs :audit-app)
    "/metabot-tools"                metabase-enterprise.metabot-v3.tools.api/routes
    "/metabot-v3"                   (premium-handler metabase-enterprise.metabot-v3.api/routes :metabot-v3)
+   "/permission_debug"             (premium-handler metabase-enterprise.permission-debug.api/routes :advanced-permissions)
    "/scim"                         (premium-handler metabase-enterprise.scim.routes/routes :scim)
    "/serialization"                (premium-handler metabase-enterprise.serialization.api/routes :serialization)
    "/stale"                        (premium-handler metabase-enterprise.stale.api/routes :collection-cleanup)

--- a/enterprise/backend/src/metabase_enterprise/permission_debug/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/permission_debug/api.clj
@@ -6,9 +6,9 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]))
 
-(api.macros/defendpoint :get "/" :- ::permission-debug.impl/DebuggerSchema
-  "This endpoint expects a `user_id`, a `model_id` to debug permissions against, and `permission_type`.
-  The type of model we are debugging against is inferred by the `permission_type`.
+(api.macros/defendpoint :get "/" :- permission-debug.impl/DebuggerSchema
+  "This endpoint expects a `user_id`, a `model_id` to debug permissions against, and `action_type`.
+  The type of model we are debugging against is inferred by the `action_type`.
 
   It will return:
   - `decision`: The overall permission decision (\"allow\", \"denied\", or \"limited\")
@@ -20,9 +20,9 @@
   - `suggestions`: A map of group IDs to group names that could provide access
 
   Example requests:
-  - Check if user can read a card: `GET /api/ee/permission_debug?user_id=123&model_id=456&permission_type=card/read`
-  - Check if user can query a card: `GET /api/ee/permission_debug?user_id=123&model_id=456&permission_type=card/query`
-  - Check if user can download data: `GET /api/ee/permission_debug?user_id=123&model_id=456&permission_type=card/download-data`
+  - Check if user can read a card: `GET /api/ee/permission_debug?user_id=123&model_id=456&action_type=card/read`
+  - Check if user can query a card: `GET /api/ee/permission_debug?user_id=123&model_id=456&action_type=card/query`
+  - Check if user can download data: `GET /api/ee/permission_debug?user_id=123&model_id=456&action_type=card/download-data`
 
   Example responses:
   - Allowed access:
@@ -62,16 +62,16 @@
     }
     ```"
   [_route-params
-   {:keys [user_id model_id permission_type]
+   {:keys [user_id model_id action_type]
     :or {}} :- [:map
                 [:user_id pos-int?]
                 [:model_id :string]
-                [:permission_type ::permission-debug.impl/PermissionType]]
+                [:action_type permission-debug.impl/ActionType]]
    _body]
   (permission-debug.impl/debug-permissions
    {:user-id user_id
     :model-id model_id
-    :permission-type permission_type}))
+    :action-type action_type}))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/permission_debug` routes."

--- a/enterprise/backend/src/metabase_enterprise/permission_debug/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/permission_debug/api.clj
@@ -1,0 +1,78 @@
+(ns metabase-enterprise.permission-debug.api
+  "`/api/ee/permission_debug/` routes"
+  (:require
+   [metabase-enterprise.permission-debug.impl :as permission-debug.impl]
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]))
+
+(api.macros/defendpoint :get "/" :- ::permission-debug.impl/DebuggerSchema
+  "This endpoint expects a `user_id`, a `model_id` to debug permissions against, and `permission_type`.
+  The type of model we are debugging against is inferred by the `permission_type`.
+
+  It will return:
+  - `decision`: The overall permission decision (\"allow\", \"denied\", or \"limited\")
+  - `model-type`: The type of model being checked (e.g., \"question\")
+  - `model-id`: The ID of the model being checked
+  - `segment`: A set of segmentation types applied (e.g., \"sandboxed\", \"impersonated\", \"routed\")
+  - `message`: A sequence of strings explaining the decision
+  - `data`: A map containing details about permissions (table or collection names to group names)
+  - `suggestions`: A map of group IDs to group names that could provide access
+
+  Example requests:
+  - Check if user can read a card: `GET /api/ee/permission_debug?user_id=123&model_id=456&permission_type=card/read`
+  - Check if user can query a card: `GET /api/ee/permission_debug?user_id=123&model_id=456&permission_type=card/query`
+  - Check if user can download data: `GET /api/ee/permission_debug?user_id=123&model_id=456&permission_type=card/download-data`
+
+  Example responses:
+  - Allowed access:
+    ```json
+    {
+      \"decision\": \"allow\",
+      \"model-type\": \"question\",
+      \"model-id\": \"456\",
+      \"segment\": [],
+      \"message\": [\"User has permission to read this card\"],
+      \"data\": {},
+      \"suggestions\": {}
+    }
+    ```
+  - Denied access with blocked table:
+    ```json
+    {
+      \"decision\": \"denied\",
+      \"model-type\": \"question\",
+      \"model-id\": \"456\",
+      \"segment\": [],
+      \"message\": [\"User does not have permission to query this card\"],
+      \"data\": {\"sample-db.PUBLIC.ORDERS\": [\"All Users\"]},
+      \"suggestions\": {}
+    }
+    ```
+  - Limited access:
+    ```json
+    {
+      \"decision\": \"limited\",
+      \"model-type\": \"question\",
+      \"model-id\": \"456\",
+      \"segment\": [],
+      \"message\": [\"User has permission to download some data from this card\"],
+      \"data\": {},
+      \"suggestions\": {}
+    }
+    ```"
+  [_route-params
+   {:keys [user_id model_id permission_type]
+    :or {}} :- [:map
+                [:user_id pos-int?]
+                [:model_id :string]
+                [:permission_type ::permission-debug.impl/PermissionType]]
+   _body]
+  (permission-debug.impl/debug-permissions
+   {:user-id user_id
+    :model-id model_id
+    :permission-type permission_type}))
+
+(def ^{:arglists '([request respond raise])} routes
+  "`/api/ee/permission_debug` routes."
+  (api.macros/ns-handler *ns* api/+check-superuser +auth))

--- a/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
@@ -163,15 +163,15 @@
 
 (defn- check-table-permissions
   "Check table-level permissions for a card's query tables.
-   
-   Arguments:
+
+  Arguments:
    - user-id: The ID of the user to check permissions for
    - card: The card model containing the dataset_query to analyze
    - permissions-blocking: Map specifying which permission types to check for blocking
                            (e.g., {:perms/view-data :blocked} or {:perms/download-results :no})
    - permissions-granting: Map specifying which permission types should be considered as granting access
                             (e.g., {:perms/view-data :legacy-no-self-service} or {:perms/download-results :ten-thousand-rows})
-   
+
    Returns a map of blocked tables by group in the format:
    {[db-name schema table-name] #{group-name-1 group-name-2}}"
   [user-id card permissions-blocking permissions-granting]

--- a/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
@@ -225,7 +225,8 @@
       :message     [(if (seq blocked-by-group)
                       (tru "User does not have permission to query this card")
                       (tru "User has permission to query this card"))]
-      :data        (if blocked-by-group (format-blocked blocked-by-group) {})
+      :data        (cond-> {}
+                     (not-empty blocked-by-group) (assoc :blocked-tables (format-blocked blocked-by-group)))
       :suggestions {}})))
 
 (mu/defmethod debug-permissions :card/download-data :- DebuggerSchema
@@ -251,5 +252,7 @@
                       (seq blocked-by-group) (tru "User does not have permission to download data from this card")
                       (seq limited-by-group) (tru "User has permission to download some data from this card")
                       :else (tru "User has permission to download data from this card"))]
-      :data        (if blocked-by-group (format-blocked blocked-by-group) {})
+      :data        (cond-> {}
+                     (not-empty limited-by-group) (assoc :download-limited-tables (format-blocked limited-by-group))
+                     (not-empty blocked-by-group) (assoc :download-no-tables (format-blocked blocked-by-group)))
       :suggestions {}})))

--- a/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
@@ -1,0 +1,235 @@
+(ns metabase-enterprise.permission-debug.impl
+  "Implementation of permission debugging functionality.
+
+  Maps actions to it's own definition of a permission type since the permission types used in our
+  modeling don't necessarily match 1:1 with actions a user may perform in the ui.
+
+  | Permission Type | Action | Target Model | Permissions |
+  | --------------- | ------ | ------------ | ----------- |
+  | `:card/read` | get a card model via API | card | perms/collection-access |
+  | `:card/query` | run the query associated with the card | card → tables used in query | perms/view-data perms/collection-access |
+  | `:card/download-data` | download data from the card query | card → tables used in query | perms/download-results perms/collection-access |
+  "
+  (:require
+   [clojure.set :as set]
+   [metabase.api.common :as api]
+   [metabase.lib.util :as lib.util]
+   [metabase.lib.util.match :as lib.util.match]
+   [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
+   [metabase.query-processor.preprocess :as qp.preprocess]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(mr/def ::DebuggerSchema [:schema {:registry
+                                   {::group-id :int
+                                    ::perm-debug-info [:map
+                                                       [:model-type  [:enum "question" "invalid"]]
+                                                       [:model-id    :string]
+                                                       [:decision    [:enum "allow" "denied" "limited"]]
+                                                       [:segment     [:set [:enum "sandboxed" "impersonated" "routed"]]]
+                                                       [:message     [:sequential :string]]
+                                                       [:data        [:map]]
+                                                       [:suggestions [:map-of ::group-id :string]]]}}
+                          ::perm-debug-info])
+
+(mr/def ::PermissionType [:enum :card/read :card/query :card/download-data])
+
+(mr/def ::DebuggerArguments [:map
+                             [:user-id pos-int?]
+                             [:model-id :string]
+                             [:permission-type ::PermissionType]])
+
+(defmulti debug-permissions
+  "Debug permissions for a given entity and user.
+
+   Dispatches on the `:permission_type` key in the input map.
+
+   Expected input map keys:
+   - `:user-id` - The ID of the user to check permissions for
+   - `:model-id` - The ID of the model to check permissions against
+   - `:permission-type` - The type of permission to check (e.g., 'view', 'write')
+
+   Returns a map conforming to the DebuggerSchema defined in the API."
+  {:arglists '([debug-info-map])}
+  (fn [{:keys [permission-type]}]
+    permission-type))
+
+(mu/defmethod debug-permissions :default :- ::DebuggerSchema
+  [_debug-info-map :- ::DebuggerArguments]
+  {:decision    "denied"
+   :model-type  "invalid"
+   :model-id    ""
+   :segment     #{}
+   :message     [(tru "Unknown permission type")]
+   :suggestions {}})
+
+(defn- user-can-read?
+  "Reset the bound permissions to run a can read check for a specific user"
+  [model pk user-id]
+  (binding [api/*current-user-id* user-id
+            api/*current-user-permissions-set* (delay (perms/user-permissions-set user-id))]
+    (mi/can-read? model pk)))
+
+(mu/defn- merge-permission-check :- ::DebuggerSchema
+  "Merges n permissions responses with right most wins semantics. model-type and model-id must match across
+  permissions respones. If the decision is denied that should that precendence over limited which should be
+  prefered over allowed when merging."
+  [& responses :- [:sequential ::DebuggerSchema]]
+  (when (seq responses)
+    (let [first-response (first responses)
+          decision-precedence {"denied" 3 "limited" 2 "allow" 1}
+          get-highest-precedence-decision (fn [decisions]
+                                            (->> decisions
+                                                 (map #(vector (decision-precedence %) %))
+                                                 (sort-by first >)
+                                                 first
+                                                 second))]
+      (reduce (fn [acc response]
+                ;; Verify model-type and model-id match
+                (when (or (not= (:model-type acc) (:model-type response))
+                          (not= (:model-id acc) (:model-id response)))
+                  (throw (ex-info "model-type and model-id must match across permission responses"
+                                  {:acc acc :response response})))
+
+                ;; Determine the winning decision
+                (let [winning-decision (get-highest-precedence-decision [(:decision acc) (:decision response)])
+                      acc-precedence (decision-precedence (:decision acc))
+                      response-precedence (decision-precedence (:decision response))
+                      ;; Only include fields from responses that have the winning decision precedence
+                      acc-contributes? (= acc-precedence (decision-precedence winning-decision))
+                      response-contributes? (= response-precedence (decision-precedence winning-decision))]
+
+                  {:decision    winning-decision
+                   :model-type  (:model-type response)
+                   :model-id    (:model-id response)
+                   :segment     (set/union (if acc-contributes? (:segment acc) #{})
+                                           (if response-contributes? (:segment response) #{}))
+                   :message     (into (if acc-contributes? (:message acc) [])
+                                      (if response-contributes? (:message response) []))
+                   :data        (merge (if acc-contributes? (:data acc) {})
+                                       (if response-contributes? (:data response) {}))
+                   :suggestions (merge (if acc-contributes? (:suggestions acc) {})
+                                       (if response-contributes? (:suggestions response) {}))}))
+              first-response
+              (rest responses)))))
+
+(mu/defmethod debug-permissions :card/read :- ::DebuggerSchema
+  [{:keys [user-id model-id] :as _debug-info} :- ::DebuggerArguments]
+  (let [can-read? (user-can-read? :model/Card (Integer/parseInt model-id) user-id)]
+    {:decision    (if can-read? "allow" "denied")
+     :model-type  "question"
+     :model-id    model-id
+     :segment     #{}
+     :message     [(if can-read?
+                     (tru "User has permission to read this card")
+                     (tru "User does not have permission to read this card"))]
+     :data        {}
+     :suggestions {}}))
+
+(defn- format-blocked
+  "Formats a map of [:db_name :schema :table_name] -> #{:group_name} into a translatable string like:
+  db_name.schema.table_name by group_name_1 and group_name 2."
+  [blocked-by-group]
+  (update-keys blocked-by-group (fn [[db-name schema table-name]]
+                                  (if schema
+                                    (str db-name "." schema "." table-name)
+                                    (str db-name "." table-name)))))
+
+(defn- check-table-permissions
+  "Check table-level permissions for a card's query tables.
+   Returns a map of blocked tables by group."
+  [user-id card permission-filter visible-filter]
+  (let [user-is-superuser? (t2/select-one-fn :is_superuser :model/User :id user-id)
+        query (-> card :dataset_query qp.preprocess/preprocess)
+        query-tables (-> query :query lib.util/collect-source-tables)
+        native? (boolean (lib.util.match/match-one query (m :guard (every-pred map? :native))))]
+    (->>
+     (cond
+       native?
+       ;; native queries are blocked if _any_ table in the database is blocked (or limited for download perms)
+       (t2/query {:select [[:db.name :db_name] :blocked.schema [:blocked.name :table_name] [:pg.name :group_name]]
+                  :from [[:metabase_table :blocked]]
+                  :join [[(perms/select-tables-and-groups-granting-perm
+                           {:user-id user-id
+                            :is-superuser? user-is-superuser?}
+                           permission-filter) :perm_grant] [:= :blocked.id :perm_grant.id]
+                         [:metabase_database :db] [:= :blocked.db_id :db.id]
+                         [:permissions_group :pg] [:= :perm_grant.group_id :pg.id]]
+                  :where [:and [:= :blocked.db_id (:database_id card)]
+                          [:not
+                           [:in :blocked.id (perms/visible-table-filter-select
+                                             :db_id
+                                             {:user-id user-id
+                                              :is-superuser? user-is-superuser?}
+                                             visible-filter)]]]})
+
+       (seq query-tables)
+       (t2/query {:select [[:db.name :db_name] :blocked.schema [:blocked.name :table_name] [:pg.name :group_name]]
+                  :from [[:metabase_table :blocked]]
+                  :join [[(perms/select-tables-and-groups-granting-perm
+                           {:user-id user-id
+                            :is-superuser? user-is-superuser?}
+                           permission-filter) :perm_grant] [:= :blocked.id :perm_grant.id]
+                         [:metabase_database :db] [:= :blocked.db_id :db.id]
+                         [:permissions_group :pg] [:= :perm_grant.group_id :pg.id]]
+                  :where [:and [:in :blocked.id query-tables]
+                          [:not
+                           [:in :blocked.id (perms/visible-table-filter-select
+                                             :id
+                                             {:user-id user-id
+                                              :is-superuser? user-is-superuser?}
+                                             visible-filter)]]]})
+       :else
+       nil)
+     (map (juxt (juxt :db_name :schema :table_name) :group_name))
+     (reduce #(update %1 (first %2) set/union (set [(second %2)])) {}))))
+
+(mu/defmethod debug-permissions :card/query :- ::DebuggerSchema
+  [{:keys [user-id model-id] :as debug-info} :- ::DebuggerArguments]
+  (merge-permission-check
+   (debug-permissions (assoc debug-info :permission-type :card/read))
+   (let [card-id (Integer/parseInt model-id)
+         card (t2/select-one :model/Card :id card-id)
+         blocked-by-group (check-table-permissions user-id card
+                                                   {:perms/view-data [:blocked :most]}
+                                                   {:perms/view-data :legacy-no-self-service})]
+     {:decision    (if (seq blocked-by-group) "denied" "allow")
+      :segment     #{}
+      :model-type  "question"
+      :model-id    model-id
+      :message     [(if (seq blocked-by-group)
+                      (tru "User does not have permission to query this card")
+                      (tru "User has permission to query this card"))]
+      :data        (if blocked-by-group (format-blocked blocked-by-group) {})
+      :suggestions {}})))
+
+(mu/defmethod debug-permissions :card/download-data :- ::DebuggerSchema
+  [{:keys [user-id model-id] :as debug-info} :- ::DebuggerArguments]
+  (merge-permission-check
+   (debug-permissions (assoc debug-info :permission-type :card/query))
+   (let [card-id (Integer/parseInt model-id)
+         card (t2/select-one :model/Card :id card-id)
+         limited-by-group (check-table-permissions user-id card
+                                                   {:perms/download-results [:ten-thousand-rows :least]}
+                                                   {:perms/download-results :one-million-rows})
+         blocked-by-group (check-table-permissions user-id card
+                                                   {:perms/download-results [:no :most]}
+                                                   {:perms/download-results :ten-thousand-rows})]
+     {:decision    (cond
+                     (seq blocked-by-group) "denied"
+                     (seq limited-by-group) "limited"
+                     :else "allow")
+      :model-type  "question"
+      :model-id    model-id
+      :segment     #{}
+      :message     [(cond
+                      (seq blocked-by-group) (tru "User does not have permission to download data from this card")
+                      (seq limited-by-group) (tru "User has permission to download some data from this card")
+                      :else (tru "User has permission to download data from this card"))]
+      :data        (if blocked-by-group (format-blocked blocked-by-group) {})
+      :suggestions {}})))

--- a/enterprise/backend/test/metabase_enterprise/permission_debug/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/permission_debug/api_test.clj
@@ -1,0 +1,150 @@
+(ns metabase-enterprise.permission-debug.api-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(defn with-advanced-permissions-fixture [f]
+  (mt/with-premium-features #{:advanced-permissions}
+    (f)))
+
+(use-fixtures :once (fixtures/initialize :db))
+(use-fixtures :each with-advanced-permissions-fixture)
+
+(deftest permission-debug-test
+  (testing "GET /api/ee/permission_debug"
+    (testing "should require superuser permissions"
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :get 403 "ee/permission_debug"))))))
+
+(deftest permission-debug-card-read-scenarios-test
+  (testing "GET /api/ee/permission_debug for card/read scenarios"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)}]
+      (testing "should return allow when user has read permission"
+        (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
+                                             :user_id (str (mt/user->id :rasta))
+                                             :model_id (str (:id card))
+                                             :permission_type "card/read")]
+          (is (= "allow" (:decision response)))
+          (is (= "question" (:model-type response)))
+          (is (= (str (:id card)) (:model-id response)))
+          (is (= '() (:segment response)))
+          (is (seq (:message response)))
+          (is (= {} (:data response)))
+          (is (= {} (:suggestions response)))))
+
+      (testing "should return denied when user lacks read permission"
+        (mt/with-temp [:model/Collection private-collection {}
+                       :model/Card private-card {:collection_id (:id private-collection)}]
+          (perms/revoke-collection-permissions! (perms/all-users-group) private-collection)
+          (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
+                                               :user_id (str (mt/user->id :rasta))
+                                               :model_id (str (:id private-card))
+                                               :permission_type "card/read")]
+            (is (= "denied" (:decision response)))
+            (is (= "question" (:model-type response)))
+            (is (seq (:message response))))
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) private-collection))))))
+
+(deftest permission-debug-card-query-scenarios-test
+  (testing "GET /api/ee/permission_debug for card/query scenarios"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (testing "should return allow when user has query permission"
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :unrestricted)
+        (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
+                                             :user_id (str (mt/user->id :rasta))
+                                             :model_id (str (:id card))
+                                             :permission_type "card/query")]
+          (is (= "allow" (:decision response)))
+          (is (= "question" (:model-type response)))
+          (is (= '() (:segment response)))
+          (is (= {} (:data response)))))
+
+      (testing "should return denied when table access is blocked"
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :blocked)
+        (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
+                                             :user_id (str (mt/user->id :rasta))
+                                             :model_id (str (:id card))
+                                             :permission_type "card/query")]
+          (is (= "denied" (:decision response)))
+          (is (seq (:data response))))))))
+
+(deftest permission-debug-card-download-scenarios-test
+  (testing "GET /api/ee/permission_debug for card/download-data scenarios"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (testing "should return allow when user has download permission"
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :unrestricted)
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/download-results :one-million-rows)
+        (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
+                                             :user_id (str (mt/user->id :crowberto))
+                                             :model_id (str (:id card))
+                                             :permission_type "card/download-data")]
+          (is (= "allow" (:decision response)))
+          (is (= "question" (:model-type response)))
+          (is (= '() (:segment response)))
+          (is (seq (:message response)))))
+
+      (testing "should return limited when user has limited download permission"
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :unrestricted)
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/download-results :ten-thousand-rows)
+        (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
+                                             :user_id (str (mt/user->id :rasta))
+                                             :model_id (str (:id card))
+                                             :permission_type "card/download-data")]
+          (is (contains? #{"allow" "limited" "denied"} (:decision response)))
+          (is (= "question" (:model-type response))))))))
+
+(deftest permission-debug-invalid-scenarios-test
+  (testing "GET /api/ee/permission_debug for invalid scenarios"
+    (testing "should handle unknown permission types"
+      (is (= {:specific-errors
+              {:permission_type ["should be either :card/read, :card/query or :card/download-data, received: :unknown/permission"]},
+              :errors {:permission_type "enum of :card/read, :card/query, :card/download-data"}}
+             (mt/user-http-request :crowberto :get 400 "ee/permission_debug"
+                                   :user_id "1"
+                                   :model_id "999"
+                                   :permission_type "unknown/permission"))))
+
+    (testing "should require valid parameters"
+      (is (= {:errors {:user_id "integer greater than 0"},
+              :specific-errors {:user_id ["should be a positive int, received: \"invalid\""]}}
+             (mt/user-http-request :crowberto :get "ee/permission_debug"
+                                   :user_id "invalid"
+                                   :model_id "999"
+                                   :permission_type "card/read"))))))
+
+(deftest permission-debug-response-schema-test
+  (testing "GET /api/ee/permission_debug response schema validation"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)}]
+      (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
+                                           :user_id (str (mt/user->id :rasta))
+                                           :model_id (str (:id card))
+                                           :permission_type "card/read")]
+        (testing "response should have all required fields"
+          (is (contains? response :decision))
+          (is (contains? response :model-type))
+          (is (contains? response :model-id))
+          (is (contains? response :segment))
+          (is (contains? response :message))
+          (is (contains? response :data))
+          (is (contains? response :suggestions)))
+
+        (testing "decision should be valid enum value"
+          (is (contains? #{"allow" "denied" "limited"} (:decision response))))
+
+        (testing "segment should be a sequence"
+          (is (sequential? (:segment response))))
+
+        (testing "message should be a sequence"
+          (is (sequential? (:message response))))
+
+        (testing "data and suggestions should be maps"
+          (is (map? (:data response)))
+          (is (map? (:suggestions response))))))))

--- a/enterprise/backend/test/metabase_enterprise/permission_debug/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/permission_debug/api_test.clj
@@ -28,7 +28,7 @@
                                              :model_id (str (:id card))
                                              :action_type "card/read")]
           (is (= "allow" (:decision response)))
-          (is (= "question" (:model-type response)))
+          (is (= "card" (:model-type response)))
           (is (= (str (:id card)) (:model-id response)))
           (is (= '() (:segment response)))
           (is (seq (:message response)))
@@ -44,7 +44,7 @@
                                                :model_id (str (:id private-card))
                                                :action_type "card/read")]
             (is (= "denied" (:decision response)))
-            (is (= "question" (:model-type response)))
+            (is (= "card" (:model-type response)))
             (is (seq (:message response))))
           (perms/grant-collection-readwrite-permissions! (perms/all-users-group) private-collection))))))
 
@@ -60,7 +60,7 @@
                                              :model_id (str (:id card))
                                              :action_type "card/query")]
           (is (= "allow" (:decision response)))
-          (is (= "question" (:model-type response)))
+          (is (= "card" (:model-type response)))
           (is (= '() (:segment response)))
           (is (= {} (:data response)))))
 
@@ -86,7 +86,7 @@
                                              :model_id (str (:id card))
                                              :action_type "card/download-data")]
           (is (= "allow" (:decision response)))
-          (is (= "question" (:model-type response)))
+          (is (= "card" (:model-type response)))
           (is (= '() (:segment response)))
           (is (seq (:message response)))))
 
@@ -98,7 +98,7 @@
                                              :model_id (str (:id card))
                                              :action_type "card/download-data")]
           (is (contains? #{"allow" "limited" "denied"} (:decision response)))
-          (is (= "question" (:model-type response))))))))
+          (is (= "card" (:model-type response))))))))
 
 (deftest permission-debug-invalid-scenarios-test
   (testing "GET /api/ee/permission_debug for invalid scenarios"

--- a/enterprise/backend/test/metabase_enterprise/permission_debug/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/permission_debug/api_test.clj
@@ -26,7 +26,7 @@
         (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
                                              :user_id (str (mt/user->id :rasta))
                                              :model_id (str (:id card))
-                                             :permission_type "card/read")]
+                                             :action_type "card/read")]
           (is (= "allow" (:decision response)))
           (is (= "question" (:model-type response)))
           (is (= (str (:id card)) (:model-id response)))
@@ -42,7 +42,7 @@
           (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
                                                :user_id (str (mt/user->id :rasta))
                                                :model_id (str (:id private-card))
-                                               :permission_type "card/read")]
+                                               :action_type "card/read")]
             (is (= "denied" (:decision response)))
             (is (= "question" (:model-type response)))
             (is (seq (:message response))))
@@ -58,7 +58,7 @@
         (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
                                              :user_id (str (mt/user->id :rasta))
                                              :model_id (str (:id card))
-                                             :permission_type "card/query")]
+                                             :action_type "card/query")]
           (is (= "allow" (:decision response)))
           (is (= "question" (:model-type response)))
           (is (= '() (:segment response)))
@@ -69,7 +69,7 @@
         (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
                                              :user_id (str (mt/user->id :rasta))
                                              :model_id (str (:id card))
-                                             :permission_type "card/query")]
+                                             :action_type "card/query")]
           (is (= "denied" (:decision response)))
           (is (seq (:data response))))))))
 
@@ -84,7 +84,7 @@
         (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
                                              :user_id (str (mt/user->id :crowberto))
                                              :model_id (str (:id card))
-                                             :permission_type "card/download-data")]
+                                             :action_type "card/download-data")]
           (is (= "allow" (:decision response)))
           (is (= "question" (:model-type response)))
           (is (= '() (:segment response)))
@@ -96,7 +96,7 @@
         (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
                                              :user_id (str (mt/user->id :rasta))
                                              :model_id (str (:id card))
-                                             :permission_type "card/download-data")]
+                                             :action_type "card/download-data")]
           (is (contains? #{"allow" "limited" "denied"} (:decision response)))
           (is (= "question" (:model-type response))))))))
 
@@ -104,12 +104,12 @@
   (testing "GET /api/ee/permission_debug for invalid scenarios"
     (testing "should handle unknown permission types"
       (is (= {:specific-errors
-              {:permission_type ["should be either :card/read, :card/query or :card/download-data, received: :unknown/permission"]},
-              :errors {:permission_type "enum of :card/read, :card/query, :card/download-data"}}
+              {:action_type ["should be either :card/read, :card/query or :card/download-data, received: :unknown/permission"]},
+              :errors {:action_type "enum of :card/read, :card/query, :card/download-data"}}
              (mt/user-http-request :crowberto :get 400 "ee/permission_debug"
                                    :user_id "1"
                                    :model_id "999"
-                                   :permission_type "unknown/permission"))))
+                                   :action_type "unknown/permission"))))
 
     (testing "should require valid parameters"
       (is (= {:errors {:user_id "integer greater than 0"},
@@ -117,7 +117,7 @@
              (mt/user-http-request :crowberto :get "ee/permission_debug"
                                    :user_id "invalid"
                                    :model_id "999"
-                                   :permission_type "card/read"))))))
+                                   :action_type "card/read"))))))
 
 (deftest permission-debug-response-schema-test
   (testing "GET /api/ee/permission_debug response schema validation"
@@ -126,7 +126,7 @@
       (let [response (mt/user-http-request :crowberto :get 200 "ee/permission_debug"
                                            :user_id (str (mt/user->id :rasta))
                                            :model_id (str (:id card))
-                                           :permission_type "card/read")]
+                                           :action_type "card/read")]
         (testing "response should have all required fields"
           (is (contains? response :decision))
           (is (contains? response :model-type))

--- a/enterprise/backend/test/metabase_enterprise/permission_debug/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/permission_debug/impl_test.clj
@@ -105,7 +105,7 @@
           (is (= #{} (:segment result)))
           (is (= #{(tru "User does not have permission to query this card")}
                  (into #{} (:message result))))
-          (is (= {"test-data (h2).PUBLIC.CHECKINS" #{"All Users"}} (:data result)))
+          (is (= {:blocked-tables {"test-data (h2).PUBLIC.CHECKINS" #{"All Users"}}} (:data result)))
           (is (= {} (:suggestions result))))))))
 
 (deftest debug-permissions-card-query-mixed-permissions-test
@@ -197,7 +197,7 @@
           (is (= #{} (:segment result)))
           (is (= [(tru "User does not have permission to query this card")]
                  (:message result)))
-          (is (= {"test-data (h2).PUBLIC.VENUES" #{"All Users"}}
+          (is (= {:blocked-tables {"test-data (h2).PUBLIC.VENUES" #{"All Users"}}}
                  (:data result)))
           (is (= {} (:suggestions result))))))))
 
@@ -216,14 +216,14 @@
           (is (= #{} (:segment result)))
           (is (= [(tru "User does not have permission to query this card")]
                  (:message result)))
-          (is (= {"test-data (h2).PUBLIC.CATEGORIES" #{"All Users"}
-                  "test-data (h2).PUBLIC.CHECKINS" #{"All Users"}
-                  "test-data (h2).PUBLIC.ORDERS" #{"All Users"}
-                  "test-data (h2).PUBLIC.PEOPLE" #{"All Users"}
-                  "test-data (h2).PUBLIC.PRODUCTS" #{"All Users"}
-                  "test-data (h2).PUBLIC.REVIEWS" #{"All Users"}
-                  "test-data (h2).PUBLIC.USERS" #{"All Users"}
-                  "test-data (h2).PUBLIC.VENUES" #{"All Users"}}
+          (is (= {:blocked-tables {"test-data (h2).PUBLIC.CATEGORIES" #{"All Users"}
+                                   "test-data (h2).PUBLIC.CHECKINS" #{"All Users"}
+                                   "test-data (h2).PUBLIC.ORDERS" #{"All Users"}
+                                   "test-data (h2).PUBLIC.PEOPLE" #{"All Users"}
+                                   "test-data (h2).PUBLIC.PRODUCTS" #{"All Users"}
+                                   "test-data (h2).PUBLIC.REVIEWS" #{"All Users"}
+                                   "test-data (h2).PUBLIC.USERS" #{"All Users"}
+                                   "test-data (h2).PUBLIC.VENUES" #{"All Users"}}}
                  (:data result)))
           (is (= {} (:suggestions result))))))))
 
@@ -254,7 +254,7 @@
           (is (= #{} (:segment result)))
           (is (= #{(tru "User does not have permission to query this card")}
                  (into #{} (:message result))))
-          (is (= {"test-data (h2).PUBLIC.CHECKINS" #{"All Users"}} (:data result)))
+          (is (= {:blocked-tables {"test-data (h2).PUBLIC.CHECKINS" #{"All Users"}}} (:data result)))
           (is (= {} (:suggestions result))))))))
 
 (deftest debug-permissions-card-download-results-with-permission-test
@@ -308,7 +308,7 @@
           (is (= "denied" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= [(tru "User does not have permission to download data from this card")] (:message result)))
-          (is (= {"test-data (h2).PUBLIC.CHECKINS" #{"All Users"}} (:data result)))
+          (is (= {:download-no-tables {"test-data (h2).PUBLIC.CHECKINS" #{"All Users"}}} (:data result)))
           (is (= {} (:suggestions result))))))))
 
 (deftest debug-permissions-card-download-results-mixed-permissions-test
@@ -332,7 +332,8 @@
                     (tru "User has permission to query this card")
                     (tru "User has permission to download data from this card")]
                    (:message result)))
-            (is (= {} (:data result)))
+            (is (= {}
+                   (:data result)))
             (is (= {} (:suggestions result)))))))))
 
 (deftest debug-permissions-card-download-results-admin-test
@@ -362,7 +363,8 @@
           (is (= "limited" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= [(tru "User has permission to download some data from this card")] (:message result)))
-          (is (= {} (:data result)))
+          (is (= {:download-limited-tables {"test-data (h2).PUBLIC.CHECKINS" #{"All Users"}}}
+                 (:data result)))
           (is (= {} (:suggestions result))))))))
 
 (deftest debug-permissions-card-download-results-mixed-limited-permissions-test
@@ -371,7 +373,7 @@
                    :model/Card card {:collection_id (:id collection)
                                      :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
       (let [regular-user-id (mt/user->id :rasta)]
-        (mt/with-temp [:model/PermissionsGroup {pg-id :id} {}
+        (mt/with-temp [:model/PermissionsGroup {pg-id :id} {:name "test other group"}
                        :model/PermissionsGroupMembership _ {:group_id pg-id :user_id regular-user-id}]
           (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :unrestricted)
           (perms/set-table-permission! pg-id (mt/id :checkins) :perms/download-results :ten-thousand-rows)
@@ -384,5 +386,6 @@
             (is (= #{} (:segment result)))
             (is (= [(tru "User has permission to download some data from this card")]
                    (:message result)))
-            (is (= {} (:data result)))
+            (is (= {:download-limited-tables {"test-data (h2).PUBLIC.CHECKINS" #{"test other group"}}}
+                   (:data result)))
             (is (= {} (:suggestions result)))))))))

--- a/enterprise/backend/test/metabase_enterprise/permission_debug/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/permission_debug/impl_test.clj
@@ -1,0 +1,388 @@
+(ns metabase-enterprise.permission-debug.impl-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.permission-debug.impl :as permission-debug.impl]
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util.i18n :refer [tru]]))
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(defmacro with-temp-revoke-collection-perms!
+  [group-or-id collection-or-id & body]
+  `(do (perms/revoke-collection-permissions! ~group-or-id ~collection-or-id)
+       ~@body
+       (perms/grant-collection-readwrite-permissions! ~group-or-id ~collection-or-id)))
+
+(deftest debug-permissions-card-read-with-permission-test
+  (testing "debug-permissions for :card/read when user has permission to read the card"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)}]
+      (let [regular-user-id (mt/user->id :rasta)
+            result (permission-debug.impl/debug-permissions
+                    {:user-id regular-user-id
+                     :model-id (str (:id card))
+                     :permission-type :card/read})]
+        (is (= "allow" (:decision result)))
+        (is (= #{} (:segment result)))
+        (is (= [(tru "User has permission to read this card")] (:message result)))
+        (is (= {} (:suggestions result)))))))
+
+(deftest debug-permissions-card-read-without-permission-test
+  (testing "debug-permissions for :card/read when user does not have permission to read the card"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (with-temp-revoke-collection-perms! (perms/all-users-group) collection
+          (let [result (permission-debug.impl/debug-permissions
+                        {:user-id regular-user-id
+                         :model-id (str (:id card))
+                         :permission-type :card/read})]
+            (is (= "denied" (:decision result)))
+            (is (= #{} (:segment result)))
+            (is (= [(tru "User does not have permission to read this card")] (:message result)))
+            (is (= {} (:suggestions result)))))))))
+
+(deftest debug-permissions-card-read-admin-test
+  (testing "debug-permissions for :card/read when user is admin"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)}]
+      (let [admin-user-id (mt/user->id :crowberto)
+            result (permission-debug.impl/debug-permissions
+                    {:user-id admin-user-id
+                     :model-id (str (:id card))
+                     :permission-type :card/read})]
+        (is (= "allow" (:decision result)))))))
+
+(deftest debug-permissions-card-query-with-permission-test
+  (testing "debug-permissions for :card/query when user has permission to read the card and query all tables"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :unrestricted)
+        (let [result (permission-debug.impl/debug-permissions
+                      {:user-id regular-user-id
+                       :model-id (str (:id card))
+                       :permission-type :card/query})]
+          (is (= "allow" (:decision result)))
+          (is (= #{} (:segment result)))
+          (is (= [(tru "User has permission to read this card")
+                  (tru "User has permission to query this card")]
+                 (:message result)))
+          (is (= {} (:suggestions result))))))))
+
+(deftest debug-permissions-card-query-without-card-permission-test
+  (testing "debug-permissions for :card/query when user does not have permission to read the card"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (with-temp-revoke-collection-perms! (perms/all-users-group) collection
+          (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :unrestricted)
+          (let [result (permission-debug.impl/debug-permissions
+                        {:user-id regular-user-id
+                         :model-id (str (:id card))
+                         :permission-type :card/query})]
+            (is (= "denied" (:decision result)))
+            (is (= #{} (:segment result)))
+            (is (= [(tru "User does not have permission to read this card")] (:message result)))
+            (is (= {} (:suggestions result)))))))))
+
+(deftest debug-permissions-card-query-with-blocked-tables-test
+  (testing "debug-permissions for :card/query when user has permission to read the card but tables are blocked"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :blocked)
+        (let [result (permission-debug.impl/debug-permissions
+                      {:user-id regular-user-id
+                       :model-id (str (:id card))
+                       :permission-type :card/query})]
+          (is (= "denied" (:decision result)))
+          (is (= #{} (:segment result)))
+          (is (= #{(tru "User does not have permission to query this card")}
+                 (into #{} (:message result))))
+          (is (= {"test-data (h2).PUBLIC.CHECKINS" #{"All Users"}} (:data result)))
+          (is (= {} (:suggestions result))))))))
+
+(deftest debug-permissions-card-query-mixed-permissions-test
+  (testing "debug-permissions for :card/query when one group grants permissions and another blocks them"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (mt/with-temp [:model/PermissionsGroup {pg-id :id} {}
+                       :model/PermissionsGroupMembership _ {:group_id pg-id :user_id regular-user-id}]
+          (perms/set-table-permission! pg-id (mt/id :checkins) :perms/view-data :unrestricted)
+          (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :blocked)
+          (let [result (permission-debug.impl/debug-permissions
+                        {:user-id regular-user-id
+                         :model-id (str (:id card))
+                         :permission-type :card/query})]
+            (is (= "allow" (:decision result)))
+            (is (= #{} (:segment result)))
+            (is (= [(tru "User has permission to read this card")
+                    (tru "User has permission to query this card")]
+                   (:message result)))
+            (is (= {} (:suggestions result)))))))))
+
+(deftest debug-permissions-card-query-admin-test
+  (testing "debug-permissions for :card/query when user is admin"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [admin-user-id (mt/user->id :crowberto)
+            result (permission-debug.impl/debug-permissions
+                    {:user-id admin-user-id
+                     :model-id (str (:id card))
+                     :permission-type :card/query})]
+        (is (= "allow" (:decision result)))))))
+
+(deftest debug-permissions-card-query-native-query-test
+  (testing "debug-permissions for :card/query when user has permission to read the card with native query"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query {:database (mt/id)
+                                                     :type :native
+                                                     :native {:query "SELECT * FROM checkins WHERE date > '2014-01-01'"}}}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :unrestricted)
+        (let [result (permission-debug.impl/debug-permissions
+                      {:user-id regular-user-id
+                       :model-id (str (:id card))
+                       :permission-type :card/query})]
+          (is (= "allow" (:decision result)))
+          (is (= #{} (:segment result)))
+          (is (= [(tru "User has permission to read this card")
+                  (tru "User has permission to query this card")]
+                 (:message result)))
+          (is (= {} (:data result)))
+          (is (= {} (:suggestions result))))))))
+
+(deftest debug-permissions-card-query-native-query-allowed-test
+  (testing "debug-permissions for :card/query when user has permission to read the card with native query"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/native-query {:query "SELECT * FROM checkins WHERE date > '2014-01-01'"})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :unrestricted)
+        (let [result (permission-debug.impl/debug-permissions
+                      {:user-id regular-user-id
+                       :model-id (str (:id card))
+                       :permission-type :card/query})]
+          (is (= "allow" (:decision result)))
+          (is (= #{} (:segment result)))
+          (is (= [(tru "User has permission to read this card")
+                  (tru "User has permission to query this card")]
+                 (:message result)))
+          (is (= {} (:data result)))
+          (is (= {} (:suggestions result))))))))
+
+(deftest debug-permissions-card-query-native-query-blocked-table-test
+  (testing "debug-permissions for :card/query when user does not have permission to read one table in the database"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/native-query {:query "SELECT * FROM checkins WHERE date > '2014-01-01'"})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :unrestricted)
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/view-data :blocked)
+        (let [result (permission-debug.impl/debug-permissions
+                      {:user-id regular-user-id
+                       :model-id (str (:id card))
+                       :permission-type :card/query})]
+          (is (= "denied" (:decision result)))
+          (is (= #{} (:segment result)))
+          (is (= [(tru "User does not have permission to query this card")]
+                 (:message result)))
+          (is (= {"test-data (h2).PUBLIC.VENUES" #{"All Users"}}
+                 (:data result)))
+          (is (= {} (:suggestions result))))))))
+
+(deftest debug-permissions-card-query-native-query-blocked-test
+  (testing "debug-permissions for :card/query when user has permission to read the card with native query"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/native-query {:query "SELECT * FROM checkins WHERE date > '2014-01-01'"})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :blocked)
+        (let [result (permission-debug.impl/debug-permissions
+                      {:user-id regular-user-id
+                       :model-id (str (:id card))
+                       :permission-type :card/query})]
+          (is (= "denied" (:decision result)))
+          (is (= #{} (:segment result)))
+          (is (= [(tru "User does not have permission to query this card")]
+                 (:message result)))
+          (is (= {"test-data (h2).PUBLIC.CATEGORIES" #{"All Users"}
+                  "test-data (h2).PUBLIC.CHECKINS" #{"All Users"}
+                  "test-data (h2).PUBLIC.ORDERS" #{"All Users"}
+                  "test-data (h2).PUBLIC.PEOPLE" #{"All Users"}
+                  "test-data (h2).PUBLIC.PRODUCTS" #{"All Users"}
+                  "test-data (h2).PUBLIC.REVIEWS" #{"All Users"}
+                  "test-data (h2).PUBLIC.USERS" #{"All Users"}
+                  "test-data (h2).PUBLIC.VENUES" #{"All Users"}}
+                 (:data result)))
+          (is (= {} (:suggestions result))))))))
+
+(deftest debug-permissions-card-query-with-joined-card-blocked-test
+  (testing "debug-permissions for :card/query when card joins data from another card with blocked source table"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card source-card {:collection_id (:id collection)
+                                            :dataset_query (mt/mbql-query venues {:fields [$id $name]})}
+                   :model/Card joined-card {:collection_id (:id collection)
+                                            :dataset_query {:database (mt/id)
+                                                            :type :query
+                                                            :query {:source-table (str "card__" (:id source-card))
+                                                                    :joins [{:fields :all
+                                                                             :source-table (mt/id :checkins)
+                                                                             :condition [:=
+                                                                                         [:field (mt/id :venues :id) nil]
+                                                                                         [:field (mt/id :checkins :venue_id) {:join-alias "CHECKINS"}]]
+                                                                             :alias "CHECKINS"}]}}}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        ;; Grant access to venues table but block checkins table
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/view-data :unrestricted)
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :blocked)
+        (let [result (permission-debug.impl/debug-permissions
+                      {:user-id regular-user-id
+                       :model-id (str (:id joined-card))
+                       :permission-type :card/query})]
+          (is (= "denied" (:decision result)))
+          (is (= #{} (:segment result)))
+          (is (= #{(tru "User does not have permission to query this card")}
+                 (into #{} (:message result))))
+          (is (= {"test-data (h2).PUBLIC.CHECKINS" #{"All Users"}} (:data result)))
+          (is (= {} (:suggestions result))))))))
+
+(deftest debug-permissions-card-download-results-with-permission-test
+  (testing "debug-permissions for :card/download-data when user has permission to read the card and download data"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/download-results :one-million-rows)
+        (let [result (permission-debug.impl/debug-permissions
+                      {:user-id regular-user-id
+                       :model-id (str (:id card))
+                       :permission-type :card/download-data})]
+          (is (= "allow" (:decision result)))
+          (is (= #{} (:segment result)))
+          (is (= [(tru "User has permission to read this card")
+                  (tru "User has permission to query this card")
+                  (tru "User has permission to download data from this card")] (:message result)))
+          (is (= {} (:data result)))
+          (is (= {} (:suggestions result))))))))
+
+(deftest debug-permissions-card-download-results-without-card-permission-test
+  (testing "debug-permissions for :card/download-data when user does not have permission to read the card"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (with-temp-revoke-collection-perms! (perms/all-users-group) collection
+          (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/download-results :one-million-rows)
+          (let [result (permission-debug.impl/debug-permissions
+                        {:user-id regular-user-id
+                         :model-id (str (:id card))
+                         :permission-type :card/download-data})]
+            (is (= "denied" (:decision result)))
+            (is (= #{} (:segment result)))
+            (is (= [(tru "User does not have permission to read this card")] (:message result)))
+            (is (= {} (:suggestions result)))))))))
+
+(deftest debug-permissions-card-download-results-blocked-download-test
+  (testing "debug-permissions for :card/download-data when user has permission to read the card but download is blocked"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :unrestricted)
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/download-results :no)
+        (let [result (permission-debug.impl/debug-permissions
+                      {:user-id regular-user-id
+                       :model-id (str (:id card))
+                       :permission-type :card/download-data})]
+          (is (= "denied" (:decision result)))
+          (is (= #{} (:segment result)))
+          (is (= [(tru "User does not have permission to download data from this card")] (:message result)))
+          (is (= {"test-data (h2).PUBLIC.CHECKINS" #{"All Users"}} (:data result)))
+          (is (= {} (:suggestions result))))))))
+
+(deftest debug-permissions-card-download-results-mixed-permissions-test
+  (testing "debug-permissions for :card/download-data when one group grants download permissions and another blocks them"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (mt/with-temp [:model/PermissionsGroup {pg-id :id} {}
+                       :model/PermissionsGroupMembership _ {:group_id pg-id :user_id regular-user-id}]
+          (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :unrestricted)
+          (perms/set-table-permission! pg-id (mt/id :checkins) :perms/download-results :one-million-rows)
+          (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/download-results :no)
+          (let [result (permission-debug.impl/debug-permissions
+                        {:user-id regular-user-id
+                         :model-id (str (:id card))
+                         :permission-type :card/download-data})]
+            (is (= "allow" (:decision result)))
+            (is (= #{} (:segment result)))
+            (is (= [(tru "User has permission to read this card")
+                    (tru "User has permission to query this card")
+                    (tru "User has permission to download data from this card")]
+                   (:message result)))
+            (is (= {} (:data result)))
+            (is (= {} (:suggestions result)))))))))
+
+(deftest debug-permissions-card-download-results-admin-test
+  (testing "debug-permissions for :card/download-data when user is admin"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [admin-user-id (mt/user->id :crowberto)
+            result (permission-debug.impl/debug-permissions
+                    {:user-id admin-user-id
+                     :model-id (str (:id card))
+                     :permission-type :card/download-data})]
+        (is (= "allow" (:decision result)))))))
+
+(deftest debug-permissions-card-download-results-ten-thousand-rows-test
+  (testing "debug-permissions for :card/download-data when user has permission to read the card and download up to ten thousand rows"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :unrestricted)
+        (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/download-results :ten-thousand-rows)
+        (let [result (permission-debug.impl/debug-permissions
+                      {:user-id regular-user-id
+                       :model-id (str (:id card))
+                       :permission-type :card/download-data})]
+          (is (= "limited" (:decision result)))
+          (is (= #{} (:segment result)))
+          (is (= [(tru "User has permission to download some data from this card")] (:message result)))
+          (is (= {} (:data result)))
+          (is (= {} (:suggestions result))))))))
+
+(deftest debug-permissions-card-download-results-mixed-limited-permissions-test
+  (testing "debug-permissions for :card/download-data when one group grants download permissions and another blocks them"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card card {:collection_id (:id collection)
+                                     :dataset_query (mt/mbql-query checkins {:filter [:> $date "2014-01-01"]})}]
+      (let [regular-user-id (mt/user->id :rasta)]
+        (mt/with-temp [:model/PermissionsGroup {pg-id :id} {}
+                       :model/PermissionsGroupMembership _ {:group_id pg-id :user_id regular-user-id}]
+          (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :unrestricted)
+          (perms/set-table-permission! pg-id (mt/id :checkins) :perms/download-results :ten-thousand-rows)
+          (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/download-results :no)
+          (let [result (permission-debug.impl/debug-permissions
+                        {:user-id regular-user-id
+                         :model-id (str (:id card))
+                         :permission-type :card/download-data})]
+            (is (= "limited" (:decision result)))
+            (is (= #{} (:segment result)))
+            (is (= [(tru "User has permission to download some data from this card")]
+                   (:message result)))
+            (is (= {} (:data result)))
+            (is (= {} (:suggestions result)))))))))

--- a/enterprise/backend/test/metabase_enterprise/permission_debug/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/permission_debug/impl_test.clj
@@ -23,7 +23,7 @@
             result (permission-debug.impl/debug-permissions
                     {:user-id regular-user-id
                      :model-id (str (:id card))
-                     :permission-type :card/read})]
+                     :action-type :card/read})]
         (is (= "allow" (:decision result)))
         (is (= #{} (:segment result)))
         (is (= [(tru "User has permission to read this card")] (:message result)))
@@ -38,7 +38,7 @@
           (let [result (permission-debug.impl/debug-permissions
                         {:user-id regular-user-id
                          :model-id (str (:id card))
-                         :permission-type :card/read})]
+                         :action-type :card/read})]
             (is (= "denied" (:decision result)))
             (is (= #{} (:segment result)))
             (is (= [(tru "User does not have permission to read this card")] (:message result)))
@@ -52,7 +52,7 @@
             result (permission-debug.impl/debug-permissions
                     {:user-id admin-user-id
                      :model-id (str (:id card))
-                     :permission-type :card/read})]
+                     :action-type :card/read})]
         (is (= "allow" (:decision result)))))))
 
 (deftest debug-permissions-card-query-with-permission-test
@@ -65,7 +65,7 @@
         (let [result (permission-debug.impl/debug-permissions
                       {:user-id regular-user-id
                        :model-id (str (:id card))
-                       :permission-type :card/query})]
+                       :action-type :card/query})]
           (is (= "allow" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= [(tru "User has permission to read this card")
@@ -84,7 +84,7 @@
           (let [result (permission-debug.impl/debug-permissions
                         {:user-id regular-user-id
                          :model-id (str (:id card))
-                         :permission-type :card/query})]
+                         :action-type :card/query})]
             (is (= "denied" (:decision result)))
             (is (= #{} (:segment result)))
             (is (= [(tru "User does not have permission to read this card")] (:message result)))
@@ -100,7 +100,7 @@
         (let [result (permission-debug.impl/debug-permissions
                       {:user-id regular-user-id
                        :model-id (str (:id card))
-                       :permission-type :card/query})]
+                       :action-type :card/query})]
           (is (= "denied" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= #{(tru "User does not have permission to query this card")}
@@ -121,7 +121,7 @@
           (let [result (permission-debug.impl/debug-permissions
                         {:user-id regular-user-id
                          :model-id (str (:id card))
-                         :permission-type :card/query})]
+                         :action-type :card/query})]
             (is (= "allow" (:decision result)))
             (is (= #{} (:segment result)))
             (is (= [(tru "User has permission to read this card")
@@ -138,7 +138,7 @@
             result (permission-debug.impl/debug-permissions
                     {:user-id admin-user-id
                      :model-id (str (:id card))
-                     :permission-type :card/query})]
+                     :action-type :card/query})]
         (is (= "allow" (:decision result)))))))
 
 (deftest debug-permissions-card-query-native-query-test
@@ -153,7 +153,7 @@
         (let [result (permission-debug.impl/debug-permissions
                       {:user-id regular-user-id
                        :model-id (str (:id card))
-                       :permission-type :card/query})]
+                       :action-type :card/query})]
           (is (= "allow" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= [(tru "User has permission to read this card")
@@ -172,7 +172,7 @@
         (let [result (permission-debug.impl/debug-permissions
                       {:user-id regular-user-id
                        :model-id (str (:id card))
-                       :permission-type :card/query})]
+                       :action-type :card/query})]
           (is (= "allow" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= [(tru "User has permission to read this card")
@@ -192,7 +192,7 @@
         (let [result (permission-debug.impl/debug-permissions
                       {:user-id regular-user-id
                        :model-id (str (:id card))
-                       :permission-type :card/query})]
+                       :action-type :card/query})]
           (is (= "denied" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= [(tru "User does not have permission to query this card")]
@@ -211,7 +211,7 @@
         (let [result (permission-debug.impl/debug-permissions
                       {:user-id regular-user-id
                        :model-id (str (:id card))
-                       :permission-type :card/query})]
+                       :action-type :card/query})]
           (is (= "denied" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= [(tru "User does not have permission to query this card")]
@@ -249,7 +249,7 @@
         (let [result (permission-debug.impl/debug-permissions
                       {:user-id regular-user-id
                        :model-id (str (:id joined-card))
-                       :permission-type :card/query})]
+                       :action-type :card/query})]
           (is (= "denied" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= #{(tru "User does not have permission to query this card")}
@@ -267,7 +267,7 @@
         (let [result (permission-debug.impl/debug-permissions
                       {:user-id regular-user-id
                        :model-id (str (:id card))
-                       :permission-type :card/download-data})]
+                       :action-type :card/download-data})]
           (is (= "allow" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= [(tru "User has permission to read this card")
@@ -287,7 +287,7 @@
           (let [result (permission-debug.impl/debug-permissions
                         {:user-id regular-user-id
                          :model-id (str (:id card))
-                         :permission-type :card/download-data})]
+                         :action-type :card/download-data})]
             (is (= "denied" (:decision result)))
             (is (= #{} (:segment result)))
             (is (= [(tru "User does not have permission to read this card")] (:message result)))
@@ -304,7 +304,7 @@
         (let [result (permission-debug.impl/debug-permissions
                       {:user-id regular-user-id
                        :model-id (str (:id card))
-                       :permission-type :card/download-data})]
+                       :action-type :card/download-data})]
           (is (= "denied" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= [(tru "User does not have permission to download data from this card")] (:message result)))
@@ -325,7 +325,7 @@
           (let [result (permission-debug.impl/debug-permissions
                         {:user-id regular-user-id
                          :model-id (str (:id card))
-                         :permission-type :card/download-data})]
+                         :action-type :card/download-data})]
             (is (= "allow" (:decision result)))
             (is (= #{} (:segment result)))
             (is (= [(tru "User has permission to read this card")
@@ -344,7 +344,7 @@
             result (permission-debug.impl/debug-permissions
                     {:user-id admin-user-id
                      :model-id (str (:id card))
-                     :permission-type :card/download-data})]
+                     :action-type :card/download-data})]
         (is (= "allow" (:decision result)))))))
 
 (deftest debug-permissions-card-download-results-ten-thousand-rows-test
@@ -358,7 +358,7 @@
         (let [result (permission-debug.impl/debug-permissions
                       {:user-id regular-user-id
                        :model-id (str (:id card))
-                       :permission-type :card/download-data})]
+                       :action-type :card/download-data})]
           (is (= "limited" (:decision result)))
           (is (= #{} (:segment result)))
           (is (= [(tru "User has permission to download some data from this card")] (:message result)))
@@ -379,7 +379,7 @@
           (let [result (permission-debug.impl/debug-permissions
                         {:user-id regular-user-id
                          :model-id (str (:id card))
-                         :permission-type :card/download-data})]
+                         :action-type :card/download-data})]
             (is (= "limited" (:decision result)))
             (is (= #{} (:segment result)))
             (is (= [(tru "User has permission to download some data from this card")]

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -42,7 +42,8 @@
  [metabase.permissions.models.data-permissions.sql
   UserInfo
   PermissionMapping
-  visible-table-filter-select]
+  visible-table-filter-select
+  select-tables-and-groups-granting-perm]
  [metabase.permissions.models.permissions
   audit-namespace-clause
   can-read-audit-helper

--- a/test/metabase/permissions/models/data_permissions/sql_test.clj
+++ b/test/metabase/permissions/models/data_permissions/sql_test.clj
@@ -1,0 +1,179 @@
+(ns metabase.permissions.models.data-permissions.sql-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.permissions.core :as perms]
+   [metabase.permissions.models.data-permissions.sql :as sql]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(deftest superuser-returns-all-tables-test
+  (testing "superuser returns all tables regardless of permissions"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table _ {:db_id (:id db)}
+                   :model/Table _ {:db_id (:id db)}
+                   :model/PermissionsGroup _ {}
+                   :model/User user {}]
+      (let [user-info {:user-id (:id user) :is-superuser? true}
+            permission-mapping {:perms/view-data :unrestricted}
+            query (sql/select-tables-and-groups-granting-perm user-info permission-mapping)
+            results (t2/query query)]
+        (is (seq results) "Superuser should get results")
+        (is (every? #(contains? % :id) results) "Results should contain table IDs")
+        (is (every? #(contains? % :group_id) results) "Results should contain group IDs")))))
+
+(deftest non-superuser-with-table-level-permissions-test
+  (testing "non-superuser with table-level permissions"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table table1 {:db_id (:id db)}
+                   :model/Table _ {:db_id (:id db)}
+                   :model/PermissionsGroup group {}
+                   :model/User user {}
+                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}
+                   :model/DataPermissions _ {:db_id (:id db)
+                                             :table_id (:id table1)
+                                             :group_id (:id group)
+                                             :perm_type :perms/view-data
+                                             :perm_value :unrestricted}]
+      (let [user-info {:user-id (:id user) :is-superuser? false}
+            permission-mapping {:perms/view-data :unrestricted}
+            query (sql/select-tables-and-groups-granting-perm user-info permission-mapping)
+            results (t2/query query)]
+        (is (seq results) "User with permissions should get results")
+        (is (some #(= (:id %) (:id table1)) results) "Should include table with permissions")
+        (is (every? #(contains? #{(:id group) (u/the-id (perms/all-users-group))}  (:group_id %)) results) "Should include user's group")))))
+
+(deftest non-superuser-with-database-level-permissions-test
+  (testing "non-superuser with database-level permissions"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table table1 {:db_id (:id db)}
+                   :model/Table table2 {:db_id (:id db)}
+                   :model/PermissionsGroup group {}
+                   :model/User user {}
+                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}
+                   :model/DataPermissions _ {:db_id (:id db)
+                                             :table_id nil
+                                             :group_id (:id group)
+                                             :perm_type :perms/view-data
+                                             :perm_value :unrestricted}]
+      (let [user-info {:user-id (:id user) :is-superuser? false}
+            permission-mapping {:perms/view-data :unrestricted}
+            query (sql/select-tables-and-groups-granting-perm user-info permission-mapping)
+            results (t2/query query)]
+        (is (seq results) "User with database-level permissions should get results")
+        (is (some #(= (:id %) (:id table1)) results) "Should include table1 from database permission")
+        (is (some #(= (:id %) (:id table2)) results) "Should include table2 from database permission")
+        (is (every? #(contains? #{(:id group) (u/the-id (perms/all-users-group))}  (:group_id %)) results) "Should include user's group")))))
+
+(deftest multiple-permission-types-in-mapping-test
+  (testing "multiple permission types in mapping"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table table1 {:db_id (:id db)}
+                   :model/PermissionsGroup group {}
+                   :model/User user {}
+                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}]
+      (perms/set-table-permission! group table1 :perms/view-data :blocked)
+      (perms/set-table-permission! group table1 :perms/create-queries :no)
+      (let [user-info {:user-id (:id user) :is-superuser? false}
+            permission-mapping {:perms/view-data [:blocked :most]
+                                :perms/create-queries [:no :most]}
+            query (sql/select-tables-and-groups-granting-perm user-info permission-mapping)
+            results (t2/query query)]
+        (is (seq results) "User with multiple permissions should get results")
+        (is (some #(= (:id %) (:id table1)) results) "Should include both permissions")
+        (is (every? #(contains? #{"perms/view-data" "perms/create-queries"}  (:perm_type %)) results) "Should include the requested permission types")
+        (is (every? #(contains? #{(:id group) (u/the-id (perms/all-users-group))}  (:group_id %)) results) "Should include user's group")))))
+
+(deftest permission-level-with-most-least-directive-test
+  (testing "permission level with most/least directive"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table table1 {:db_id (:id db)}
+                   :model/PermissionsGroup group {}
+                   :model/User user {}
+                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}
+                   :model/DataPermissions _ {:db_id (:id db)
+                                             :table_id (:id table1)
+                                             :group_id (:id group)
+                                             :perm_type :perms/view-data
+                                             :perm_value :unrestricted}]
+      (let [user-info {:user-id (:id user) :is-superuser? false}
+            permission-mapping {:perms/view-data [:unrestricted :most]}
+            query (sql/select-tables-and-groups-granting-perm user-info permission-mapping)
+            results (t2/query query)]
+        (is (seq results) "User with most/least directive should get results")
+        (is (some #(= (:id %) (:id table1)) results) "Should include table with permissions")))))
+
+(deftest user-with-no-group-membership-test
+  (testing "user with no group membership"
+    (mt/with-restored-data-perms!
+      (mt/with-temp [:model/Database db {}
+                     :model/Table _ {:db_id (:id db)}
+                     :model/PermissionsGroup _ {}
+                     :model/User user {}]
+        ;; need to remove permissions belong to the all users group since a user is always part
+        ;; of that group
+        (t2/delete! :model/DataPermissions :group_id (u/the-id (perms/all-users-group)))
+        (let [user-info {:user-id (:id user) :is-superuser? false}
+              permission-mapping {:perms/view-data :unrestricted}
+              query (sql/select-tables-and-groups-granting-perm user-info permission-mapping)
+              results (t2/query query)]
+          (is (empty? results) "User with no group membership should get no results"))))))
+
+(deftest user-with-no-matching-permissions-test
+  (testing "user with no matching permissions"
+    (mt/with-restored-data-perms!
+      (mt/with-temp [:model/Database db {}
+                     :model/Table table1 {:db_id (:id db)}
+                     :model/PermissionsGroup group {}
+                     :model/User user {}
+                     :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}]
+        (t2/delete! :model/DataPermissions :group_id (u/the-id (perms/all-users-group)))
+        (perms/set-table-permission! group table1 :perms/view-data :blocked)
+        (let [user-info {:user-id (:id user) :is-superuser? false}
+              permission-mapping {:perms/view-data :unrestricted}
+              query (sql/select-tables-and-groups-granting-perm user-info permission-mapping)
+              results (t2/debug (t2/query query))]
+          (is (not (some #(= (:id table1) (:id %)) results)) "User with non-matching permissions should get no results"))))))
+
+(deftest empty-permission-mapping-test
+  (testing "empty permission mapping"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table _ {:db_id (:id db)}
+                   :model/PermissionsGroup group {}
+                   :model/User user {}
+                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group)}]
+      (let [user-info {:user-id (:id user) :is-superuser? false}
+            permission-mapping {}
+            query (sql/select-tables-and-groups-granting-perm user-info permission-mapping)
+            results (t2/query query)]
+        (is (empty? results) "Empty permission mapping should not return results")))))
+
+(deftest multiple-groups-with-different-permissions-test
+  (testing "multiple groups with different permissions"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table table1 {:db_id (:id db)}
+                   :model/Table table2 {:db_id (:id db)}
+                   :model/PermissionsGroup group1 {}
+                   :model/PermissionsGroup group2 {}
+                   :model/User user {}
+                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group1)}
+                   :model/PermissionsGroupMembership _ {:user_id (:id user) :group_id (:id group2)}
+                   :model/DataPermissions _ {:db_id (:id db)
+                                             :table_id (:id table1)
+                                             :group_id (:id group1)
+                                             :perm_type :perms/view-data
+                                             :perm_value :unrestricted}
+                   :model/DataPermissions _ {:db_id (:id db)
+                                             :table_id (:id table2)
+                                             :group_id (:id group2)
+                                             :perm_type :perms/view-data
+                                             :perm_value :unrestricted}]
+      (let [user-info {:user-id (:id user) :is-superuser? false}
+            permission-mapping {:perms/view-data :unrestricted}
+            query (sql/select-tables-and-groups-granting-perm user-info permission-mapping)
+            results (t2/query query)]
+        (is (seq results) "User in multiple groups should get results")
+        (is (some #(and (= (:id %) (:id table1)) (= (:group_id %) (:id group1))) results)
+            "Should include table1 from group1")
+        (is (some #(and (= (:id %) (:id table2)) (= (:group_id %) (:id group2))) results)
+            "Should include table2 from group2")))))


### PR DESCRIPTION
### Description

This adds a first version of an API for returning debugging information to Admins for solving card access permissions issues for users. It allows a superuser to make a request to the permission_debug endpoint with a user_id, model_id (just for cards right now) and one of `card/read`, `card/query`, or `card/download-data` permissions and it will respond with a message indicating if the user is allowed to take that action and what groups memberships they may have that prevent that action. 

The API looks like:

```
 - Check if user can read a card: `GET /api/ee/permission_debug?user_id=123&model_id=456&action_type=card/read`
  - Check if user can query a card: `GET /api/ee/permission_debug?user_id=123&model_id=456&action_type=card/query`
  - Check if user can download data: `GET /api/ee/permission_debug?user_id=123&model_id=456&action_type=card/download-data`
  Example responses:
  - Allowed access:
    ```json
    {
      \"decision\": \"allow\",
      \"model-type\": \"question\",
      \"model-id\": \"456\",
      \"segment\": [],
      \"message\": [\"User has permission to read this card\"],
      \"data\": {},
      \"suggestions\": {}
    }
    ```
  - Denied access with blocked table:
    ```json
    {
      \"decision\": \"denied\",
      \"model-type\": \"question\",
      \"model-id\": \"456\",
      \"segment\": [],
      \"message\": [\"User does not have permission to query this card\"],
      \"data\": {\"sample-db.PUBLIC.ORDERS\": [\"All Users\"]},
      \"suggestions\": {}
    }
    ```
  - Limited access:
    ```json
    {
      \"decision\": \"limited\",
      \"model-type\": \"question\",
      \"model-id\": \"456\",
      \"segment\": [],
      \"message\": [\"User has permission to download some data from this card\"],
      \"data\": {},
      \"suggestions\": {}
    }
```

Right now suggestions and segment are not filled in and data is not provided for positive group membership yet (what groups allowed you access) all are planned future work. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
