### PR TITLE
Add e2e reproduction for #35067

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
@@ -157,6 +157,26 @@ const multiStageQuestion = {
   },
 };
 
+const multiStageQuestionWithImplicitJoinBreakoutAndCustomColumn = {
+  query: {
+    "source-query": {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        [
+          "field",
+          PRODUCTS.ID,
+          { "base-type": "type/Integer", "source-field": ORDERS.PRODUCT_ID },
+        ],
+      ],
+    },
+    expressions: {
+      CC: ["*", 2, ["field", "count", { "base-type": "type/Integer" }]],
+    },
+    limit: 5,
+  },
+};
+
 const nativeQuestion = {
   display: "table",
   native: {
@@ -585,6 +605,49 @@ describe("scenarios > visualizations > table column settings", () => {
       _showColumn(testData);
       _hideColumn(testData2);
       _showColumn(testData2);
+    });
+
+    it("should be able to show and hide columns in a multi-stage query with custom columns (metabase#35067)", () => {
+      H.createQuestion(
+        multiStageQuestionWithImplicitJoinBreakoutAndCustomColumn,
+        { visitQuestion: true },
+      );
+      openSettings();
+
+      const countColumn = {
+        column: "Count",
+        columnName: "Count",
+        table: "summaries",
+        sanityCheck: "CC",
+        needsScroll: false,
+      };
+
+      const productIdColumn = {
+        column: "ID",
+        columnName: "Product → ID",
+        table: "summaries",
+        sanityCheck: "Count",
+        needsScroll: false,
+      };
+
+      const customColumn = {
+        column: "CC",
+        columnName: "CC",
+        table: "summaries",
+        sanityCheck: "Count",
+        needsScroll: false,
+      };
+
+      _hideColumn(countColumn);
+      _showColumn(countColumn);
+      _removeColumn(countColumn);
+      _addColumn(countColumn);
+      _hideColumn(productIdColumn);
+      _showColumn(productIdColumn);
+      _removeColumn(productIdColumn);
+      _addColumn(productIdColumn);
+      _hideColumn(customColumn);
+      _showColumn(customColumn);
     });
   });
 

--- a/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
@@ -157,26 +157,6 @@ const multiStageQuestion = {
   },
 };
 
-const multiStageQuestionWithImplicitJoinBreakoutAndCustomColumn = {
-  query: {
-    "source-query": {
-      "source-table": ORDERS_ID,
-      aggregation: [["count"]],
-      breakout: [
-        [
-          "field",
-          PRODUCTS.ID,
-          { "base-type": "type/Integer", "source-field": ORDERS.PRODUCT_ID },
-        ],
-      ],
-    },
-    expressions: {
-      CC: ["*", 2, ["field", "count", { "base-type": "type/Integer" }]],
-    },
-    limit: 5,
-  },
-};
-
 const nativeQuestion = {
   display: "table",
   native: {
@@ -609,7 +589,28 @@ describe("scenarios > visualizations > table column settings", () => {
 
     it("should be able to show and hide columns in a multi-stage query with custom columns (metabase#35067)", () => {
       H.createQuestion(
-        multiStageQuestionWithImplicitJoinBreakoutAndCustomColumn,
+        {
+          query: {
+            "source-query": {
+              "source-table": ORDERS_ID,
+              aggregation: [["count"]],
+              breakout: [
+                [
+                  "field",
+                  PRODUCTS.ID,
+                  {
+                    "base-type": "type/Integer",
+                    "source-field": ORDERS.PRODUCT_ID,
+                  },
+                ],
+              ],
+            },
+            expressions: {
+              CC: ["*", 2, ["field", "count", { "base-type": "type/Integer" }]],
+            },
+            limit: 5,
+          },
+        },
         { visitQuestion: true },
       );
       openSettings();


### PR DESCRIPTION
Closes #35067
Closes QUE-222

### Description

Add an e2e regression test for the bug in #35067.

This test fails when backported to v49 and should pass in master.

Stress test run ✅ : https://github.com/metabase/metabase/actions/runs/15693221576

The test:

1. creates a multi-stage query with a breakout on an implicitly-joined column and a custom column in the second stage
2. opens the settings for the table viz
3. verifies it can hide/show and remove/add the the given columns in the query

### How to verify

See new e2e test

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
