### PR TITLE
Ensure inline filters connect only to a single dashcard

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -160,9 +160,11 @@ describe("scenarios > dashboard > filters > date", () => {
     });
 
     H.visitDashboard(ORDERS_DASHBOARD_ID);
-    // we can't use helpers as they use english words
-    cy.icon("pencil").click();
-    cy.icon("filter").click();
+    H.dashboardHeader().within(() => {
+      // we can't use helpers as they use english words
+      cy.icon("pencil").click();
+      cy.icon("filter").click();
+    });
 
     H.popover().icon("calendar").click(); // "Time" -> "All Options"
 

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1762,6 +1762,37 @@ describe("scenarios > dashboard > parameters", () => {
         .should("not.exist");
       H.undoToast().should("not.exist");
     });
+
+    it("should allow connecting inline parameters only to their own card", () => {
+      H.createQuestionAndDashboard({
+        questionDetails: ordersCountByCategory,
+      }).then(({ body: dashcard }) => {
+        H.visitDashboard(dashcard.dashboard_id);
+        H.editDashboard();
+
+        // Add a second card
+        H.openQuestionsSidebar();
+        H.sidebar().findByText("Orders, Count").click();
+        H.getDashboardCard(1).findByText("Count").should("exist");
+
+        // Add a filter to the first card
+        H.setDashCardFilter(0, "Text or Category", null, "Category");
+        H.selectDashboardFilter(H.getDashboardCard(0), "Category");
+
+        // Ensure the filter can't be connected to the second card
+        H.getDashboardCard(1)
+          .findByText("This filter can only connect to its own card.")
+          .should("be.visible");
+
+        // Disconnect the filter from the first card
+        H.sidebar().findByText("Disconnect from card").click();
+
+        // Ensure it still can't be connected to the second card
+        H.getDashboardCard(1)
+          .findByText("This filter can only connect to its own card.")
+          .should("be.visible");
+      });
+    });
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
@@ -4,6 +4,7 @@ import { isActionDashCard } from "metabase/actions/utils";
 import {
   getDashcardParameterMappingOptions,
   getEditingParameter,
+  getEditingParameterInlineDashcard,
   getParameterTarget,
   getQuestionByCard,
 } from "metabase/dashboard/selectors";
@@ -41,6 +42,7 @@ const mapStateToProps = (
     target: getParameterTarget(state, props),
     question: getQuestionByCard(state, props),
     mappingOptions: getDashcardParameterMappingOptions(state, props),
+    editingParameterInlineDashcard: getEditingParameterInlineDashcard(state),
     isRecentlyAutoConnected: getIsRecentlyAutoConnectedDashcard(
       state,
       props,
@@ -59,6 +61,7 @@ interface DashcardCardParameterMapperProps {
   question?: Question;
   mappingOptions: ParameterMappingOption[];
   isRecentlyAutoConnected: boolean;
+  editingParameterInlineDashcard?: DashboardCard;
 }
 
 export function DashCardCardParameterMapper({
@@ -70,6 +73,7 @@ export function DashCardCardParameterMapper({
   question,
   mappingOptions,
   isRecentlyAutoConnected,
+  editingParameterInlineDashcard,
 }: DashcardCardParameterMapperProps) {
   const isQuestion = isQuestionDashCard(dashcard);
   const hasSeries = isQuestion && dashcard.series && dashcard.series.length > 0;
@@ -114,6 +118,7 @@ export function DashCardCardParameterMapper({
         editingParameter={editingParameter}
         mappingOptions={mappingOptions}
         isQuestion={isQuestion}
+        editingParameterInlineDashcard={editingParameterInlineDashcard}
         card={card}
         selectedMappingOption={selectedMappingOption}
         target={target}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
@@ -7,6 +7,7 @@ import CS from "metabase/css/core/index.css";
 import { setParameterMapping } from "metabase/dashboard/actions/parameters";
 import {
   getVirtualCardType,
+  isQuestionDashCard,
   isVirtualDashCard,
   showVirtualDashCardInfoText,
 } from "metabase/dashboard/utils";
@@ -40,6 +41,7 @@ interface DashCardCardParameterMapperContentProps {
   selectedMappingOption: ParameterMappingOption | undefined;
   target: ParameterTarget | null | undefined;
   layoutHeight: number;
+  editingParameterInlineDashcard?: DashboardCard;
 }
 
 export const DashCardCardParameterMapperContent = ({
@@ -56,6 +58,7 @@ export const DashCardCardParameterMapperContent = ({
   card,
   target,
   shouldShowAutoConnectHint,
+  editingParameterInlineDashcard,
 }: DashCardCardParameterMapperContentProps) => {
   const isVirtual = isVirtualDashCard(dashcard);
   const virtualCardType = getVirtualCardType(dashcard);
@@ -63,6 +66,14 @@ export const DashCardCardParameterMapperContent = ({
     editingParameter != null && isTemporalUnitParameter(editingParameter);
 
   const dispatch = useDispatch();
+
+  const isInlineParameterOfAnotherQuestionCard = useMemo(() => {
+    return (
+      editingParameterInlineDashcard != null &&
+      isQuestionDashCard(editingParameterInlineDashcard) &&
+      editingParameterInlineDashcard.id !== dashcard.id
+    );
+  }, [editingParameterInlineDashcard, dashcard.id]);
 
   const headerContent = useMemo(() => {
     if (layoutHeight <= 2) {
@@ -132,6 +143,15 @@ export const DashCardCardParameterMapperContent = ({
         question={question}
         parameter={editingParameter}
       />
+    );
+  }
+
+  if (isInlineParameterOfAnotherQuestionCard) {
+    return (
+      <Flex className={S.TextCardDefault} ta="center">
+        <Icon name="info" size={12} className={CS.pr1} />
+        {t`This filter can only connect to its own card.`}
+      </Flex>
     );
   }
 

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.tsx
@@ -5,6 +5,7 @@ import { useSetDashboardAttributeHandler } from "metabase/dashboard/components/D
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 import {
   getEditingParameter,
+  getEditingParameterInlineDashcard,
   getParameters,
 } from "metabase/dashboard/selectors";
 import { useSelector } from "metabase/lib/redux";
@@ -117,6 +118,9 @@ export function DashboardSidebars({
 }: DashboardSidebarsProps) {
   const parameters = useSelector(getParameters);
   const editingParameter = useSelector(getEditingParameter);
+  const editingParameterInlineDashcard = useSelector(
+    getEditingParameterInlineDashcard,
+  );
 
   const handleAddCard = useCallback(
     (cardId: CardId) => {
@@ -186,9 +190,11 @@ export function DashboardSidebars({
         parameters,
         (p) => p.id === editingParameterId,
       );
+
       return (
         <ParameterSidebar
           parameter={parameter}
+          editingParameterInlineDashcard={editingParameterInlineDashcard}
           otherParameters={otherParameters}
           onChangeName={setParameterName}
           onChangeType={setParameterType}

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -49,6 +49,7 @@ import type {
 import { getNewCardUrl } from "./actions/getNewCardUrl";
 import {
   canResetFilter,
+  findDashCardForInlineParameter,
   getMappedParametersIds,
   hasDatabaseActionsEnabled,
   hasInlineParameters,
@@ -361,6 +362,22 @@ export const getEditingParameter = createSelector(
     return editingParameterId != null
       ? _.findWhere(parameters, { id: editingParameterId })
       : null;
+  },
+);
+
+/**
+ * Returns the dashcard id of the dashcard that contains the parameter.
+ * If the parameter is dashboard header parameter, it returns undefined.
+ */
+export const getEditingParameterInlineDashcard = createSelector(
+  [getEditingParameterId, getDashcards],
+  (editingParameterId, dashcards) => {
+    return editingParameterId
+      ? findDashCardForInlineParameter(
+          editingParameterId,
+          Object.values(dashcards),
+        )
+      : undefined;
   },
 );
 

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -137,13 +137,16 @@ export function supportsInlineParameters(
   return isQuestionDashCard(dashcard) || isHeadingDashCard(dashcard);
 }
 
-type VirtualDashboardCardWithInlineFilters = VirtualDashboardCard & {
+type DashboardCardWithInlineFilters = (
+  | VirtualDashboardCard
+  | QuestionDashboardCard
+) & {
   inline_parameters: ParameterId[];
 };
 
 export function hasInlineParameters(
   dashcard: BaseDashboardCard,
-): dashcard is VirtualDashboardCardWithInlineFilters {
+): dashcard is DashboardCardWithInlineFilters {
   return (
     supportsInlineParameters(dashcard) &&
     Array.isArray(dashcard.inline_parameters) &&
@@ -154,12 +157,12 @@ export function hasInlineParameters(
 export function findDashCardForInlineParameter(
   parameterId: ParameterId,
   dashcards: BaseDashboardCard[],
-): VirtualDashboardCardWithInlineFilters | undefined {
+): DashboardCardWithInlineFilters | undefined {
   return dashcards.find((dashcard) => {
     if (hasInlineParameters(dashcard)) {
       return dashcard.inline_parameters.some((id) => id === parameterId);
     }
-  }) as VirtualDashboardCardWithInlineFilters | undefined;
+  }) as DashboardCardWithInlineFilters | undefined;
 }
 
 export function isDashcardInlineParameter(

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -8,6 +8,7 @@ import {
 import { t } from "ttag";
 
 import { resetParameterMapping } from "metabase/dashboard/actions";
+import { isQuestionDashCard } from "metabase/dashboard/utils";
 import { useDispatch } from "metabase/lib/redux";
 import {
   getDashboardParameterSections,
@@ -32,6 +33,7 @@ import {
   parameterHasNoDisplayValue,
 } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {
+  DashboardCard,
   Parameter,
   TemporalUnit,
   ValuesQueryType,
@@ -61,6 +63,7 @@ export interface ParameterSettingsProps {
   onChangeRequired: (value: boolean) => void;
   onChangeTemporalUnits: (temporalUnits: TemporalUnit[]) => void;
   embeddedParameterVisibility: EmbeddingParameterVisibility | null;
+  editingParameterInlineDashcard?: DashboardCard;
 }
 
 const parameterSections = getDashboardParameterSections();
@@ -72,6 +75,7 @@ const defaultOptionForSection = getDefaultOptionForParameterSectionMap();
 
 export const ParameterSettings = ({
   parameter,
+  editingParameterInlineDashcard,
   isParameterSlugUsed,
   onChangeName,
   onChangeType,
@@ -293,7 +297,12 @@ export const ParameterSettings = ({
             onClick={() => {
               dispatch(resetParameterMapping(parameter.id));
             }}
-          >{t`Disconnect from cards`}</Button>
+          >
+            {editingParameterInlineDashcard != null &&
+            isQuestionDashCard(editingParameterInlineDashcard)
+              ? t`Disconnect from card`
+              : t`Disconnect from cards`}
+          </Button>
         </Box>
       )}
     </Box>

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -11,6 +11,7 @@ import { Tabs, Text } from "metabase/ui";
 import { isFilterParameter } from "metabase-lib/v1/parameters/utils/parameter-type";
 import { parameterHasNoDisplayValue } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {
+  DashboardCard,
   Parameter,
   ParameterId,
   TemporalUnit,
@@ -61,6 +62,7 @@ export interface ParameterSidebarProps {
   ) => void;
   onRemoveParameter: (parameterId: ParameterId) => void;
   onClose: () => void;
+  editingParameterInlineDashcard?: DashboardCard;
 }
 
 export const ParameterSidebar = ({
@@ -79,6 +81,7 @@ export const ParameterSidebar = ({
   onRemoveParameter,
   onClose,
   hasMapping,
+  editingParameterInlineDashcard,
 }: ParameterSidebarProps): JSX.Element => {
   const parameterId = parameter.id;
   const tabs = useMemo(() => getTabs(parameter), [parameter]);
@@ -225,6 +228,7 @@ export const ParameterSidebar = ({
 
         <Tabs.Panel pr="md" pl="md" value="settings" key="settings">
           <ParameterSettings
+            editingParameterInlineDashcard={editingParameterInlineDashcard}
             parameter={parameter}
             embeddedParameterVisibility={embeddedParameterVisibility}
             isParameterSlugUsed={isParameterSlugUsed}


### PR DESCRIPTION
Closes [VIZ-1138](https://linear.app/metabase/issue/VIZ-1138/prevent-question-card-filters-usage-by-other-dashcards)
Closes [VIZ-1141](https://linear.app/metabase/issue/VIZ-1141/update-disconnect-from-cards-button-for-question-card-filters)

### Description

This PR restricts connecting an inline dashcard filter to other cards [VIZ-1138](https://linear.app/metabase/issue/VIZ-1138/prevent-question-card-filters-usage-by-other-dashcards) and updates copy to align with this restiction [VIZ-1141](https://linear.app/metabase/issue/VIZ-1141/update-disconnect-from-cards-button-for-question-card-filters)

### How to verify

- Create a dashboard with two questions
- Add an inline filter to the first question
- Try connecting it to the second question — ensure it is not possible

### Demo

<img width="1078" alt="Screenshot 2025-06-16 at 8 55 51 PM" src="https://github.com/user-attachments/assets/36186e1f-05d5-4f3c-8d81-b9f749cf173e" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
