### PR TITLE
hide add filter button for users without query edit permission

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1762,6 +1762,26 @@ describe("scenarios > dashboard > parameters", () => {
         .should("not.exist");
       H.undoToast().should("not.exist");
     });
+
+    it("should not show add filter button for users with no data editing permissions", () => {
+      H.createQuestionAndDashboard({
+        questionDetails: ordersCountByCategory,
+      }).then(({ body: { dashboard_id } }) => {
+        cy.signIn("nodata");
+        H.visitDashboard(dashboard_id);
+        H.editDashboard();
+
+        H.getDashboardCard(0)
+          .realHover()
+          .findByTestId("dashboardcard-actions-panel")
+          .should("be.visible");
+
+        // Ensure the "Add a filter" button is not present
+        H.getDashboardCard(0)
+          .findByLabelText("Add a filter")
+          .should("not.exist");
+      });
+    });
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -14,6 +14,7 @@ import { getDashcardData, getDashcardHref } from "metabase/dashboard/selectors";
 import {
   getDashcardResultsError,
   isDashcardLoading,
+  isQuestionCard,
   isQuestionDashCard,
 } from "metabase/dashboard/utils";
 import { isEmbeddingSdk } from "metabase/env";
@@ -23,6 +24,7 @@ import type { NewParameterOpts } from "metabase/parameters/utils/dashboards";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import type { EmbedResourceDownloadOptions } from "metabase/public/lib/types";
+import { getMetadata } from "metabase/selectors/metadata";
 import { Box } from "metabase/ui";
 import { getVisualizationRaw } from "metabase/visualizations";
 import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
@@ -34,6 +36,7 @@ import {
   isVisualizerDashboardCard,
   isVisualizerSupportedVisualization,
 } from "metabase/visualizer/utils";
+import Question from "metabase-lib/v1/Question";
 import type {
   Card,
   CardId,
@@ -350,6 +353,13 @@ function DashCardInner({
     onEditVisualization(dashcard, initialState);
   }, [dashcard, series, onEditVisualization, datasets]);
 
+  const metadata = useSelector(getMetadata);
+  const question = useMemo(() => {
+    return isQuestionCard(dashcard.card)
+      ? new Question(dashcard.card, metadata)
+      : null;
+  }, [dashcard.card, metadata]);
+
   return (
     <ErrorBoundary>
       <Box
@@ -394,6 +404,7 @@ function DashCardInner({
             series={series}
             dashboard={dashboard}
             dashcard={dashcard}
+            question={question}
             isLoading={isLoading}
             isPreviewing={isPreviewingCard}
             hasError={hasError}
@@ -414,6 +425,8 @@ function DashCardInner({
         <DashCardVisualization
           dashboard={dashboard}
           dashcard={dashcard}
+          question={question}
+          metadata={metadata}
           series={series}
           getClickActionMode={getClickActionMode}
           gridSize={gridSize}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -12,7 +12,6 @@ import {
 } from "metabase/dashboard/selectors";
 import {
   getVirtualCardType,
-  isQuestionCard,
   isVirtualDashCard,
   supportsInlineParameters,
 } from "metabase/dashboard/utils";
@@ -21,7 +20,6 @@ import { isJWT } from "metabase/lib/utils";
 import { isUuid } from "metabase/lib/uuid";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import type { EmbedResourceDownloadOptions } from "metabase/public/lib/types";
-import { getMetadata } from "metabase/selectors/metadata";
 import { Flex, type IconName, type IconProps, Menu, Title } from "metabase/ui";
 import { getVisualizationRaw, isCartesianChart } from "metabase/visualizations";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -39,7 +37,8 @@ import {
   splitVisualizerSeries,
 } from "metabase/visualizer/utils";
 import { getVisualizationColumns } from "metabase/visualizer/utils/get-visualization-columns";
-import Question from "metabase-lib/v1/Question";
+import type Question from "metabase-lib/v1/Question";
+import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Card,
   CardId,
@@ -72,6 +71,8 @@ interface DashCardVisualizationProps {
   dashboard: Dashboard;
   dashcard: DashboardCard;
   series: Series;
+  question: Question | null;
+  metadata: Metadata;
   getClickActionMode?: ClickActionModeGetter;
   getHref?: () => string | undefined;
 
@@ -124,6 +125,8 @@ export function DashCardVisualization({
   dashcard,
   dashboard,
   series: untranslatedRawSeries,
+  question,
+  metadata,
   getClickActionMode,
   getHref,
   gridSize,
@@ -155,13 +158,6 @@ export function DashCardVisualization({
   onEditVisualization,
 }: DashCardVisualizationProps) {
   const datasets = useSelector((state) => getDashcardData(state, dashcard.id));
-
-  const metadata = useSelector(getMetadata);
-  const question = useMemo(() => {
-    return isQuestionCard(dashcard.card)
-      ? new Question(dashcard.card, metadata)
-      : null;
-  }, [dashcard.card, metadata]);
 
   const inlineParameters = useSelector((state) =>
     getDashCardInlineValuePopulatedParameters(state, dashcard.id),


### PR DESCRIPTION
Closes [VIZ-1140](https://linear.app/metabase/issue/VIZ-1140/dont-show-add-filter-button-for-question-dashcards-with-lacking)

### Description

Hides `Add a filter` button that adds inline dashcard filters when users don't have query editing permissions.

### How to verify

- Create a user that do not have query editing permission but can edit collection items such as dashboards
- Login as this user
- Open any dashboard with a card
- Try adding an inline filter — ensure there is no such button

### Demo

<img width="1085" alt="Screenshot 2025-06-16 at 9 39 05 PM" src="https://github.com/user-attachments/assets/e4e4d9f4-e12c-47fd-b86b-00b2b7bdf8dd" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
