### PR TITLE
Content translation: design tweaks

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/helpers/e2e-content-translation-helpers.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/helpers/e2e-content-translation-helpers.ts
@@ -15,11 +15,15 @@ export const uploadTranslationDictionary = (rows: DictionaryArray) => {
   cy.intercept("POST", "/api/ee/content-translation/upload-dictionary").as(
     "uploadDictionary",
   );
+  cy.intercept("GET", "/api/setting").as("getSettings");
   cy.signInAsAdmin();
   cy.visit("/admin/settings/localization");
+  cy.wait("@getSettings");
+
   cy.findByTestId("content-localization-setting").findByText(
     /Upload translation dictionary/,
   );
+
   cy.get("#content-translation-dictionary-upload-input").selectFile(
     {
       contents: Cypress.Buffer.from(getCSVWithHeaderRow(rows)),
@@ -34,6 +38,10 @@ export const uploadTranslationDictionary = (rows: DictionaryArray) => {
     .click();
 
   cy.wait("@uploadDictionary");
+
+  cy.findByRole("heading", {
+    name: "Localizing user-generated content",
+  }).scrollIntoView();
 };
 
 export const uploadTranslationDictionaryViaAPI = (rows: DictionaryArray) => {

--- a/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/upload-and-download.cy.spec.ts
@@ -68,6 +68,7 @@ describe("scenarios > admin > localization > content translation", () => {
     describe("The translation upload form", () => {
       it("accepts a CSV upload with ASCII characters", () => {
         uploadTranslationDictionary(germanFieldNames);
+        cy.findByRole("status").findByText("Dictionary uploaded");
         cy.findByTestId("content-localization-setting").findByText(
           "Dictionary uploaded",
         );
@@ -128,24 +129,24 @@ describe("scenarios > admin > localization > content translation", () => {
         uploadTranslationDictionary(stringTranslatedTwice);
         cy.findAllByRole("alert")
           .contains(/couldn.*t upload the file/)
-          .should("be.visible");
+          .should("exist");
         cy.findAllByRole("alert")
           .contains(
             new RegExp(
               `Row ${stringTranslatedTwice.length + 1}.*earlier in the file`,
             ),
           )
-          .should("be.visible");
+          .should("exist");
       });
 
       it("rejects a CSV upload with invalid locale in one row", () => {
         uploadTranslationDictionary(invalidLocaleXX);
         cy.findAllByRole("alert")
           .contains(/couldn.*t upload the file/)
-          .should("be.visible");
+          .should("exist");
         cy.findAllByRole("alert")
           .contains(/Row 2: Invalid locale: xx/)
-          .should("be.visible");
+          .should("exist");
       });
 
       it(
@@ -176,15 +177,14 @@ describe("scenarios > admin > localization > content translation", () => {
         uploadTranslationDictionary(multipleInvalidLocales);
         cy.findAllByRole("alert")
           .contains(/couldn.*t upload the file/)
-          .should("be.visible");
+          .should("exist");
         cy.log("The first error is in row 2 (the first row is the header)");
         cy.findAllByRole("alert")
           .contains(/Row 2: Invalid locale/)
-          .should("be.visible");
+          .should("exist");
         cy.findAllByRole("alert")
           .contains(/Row 5: Invalid locale/)
-          .scrollIntoView()
-          .should("be.visible");
+          .should("exist");
       });
 
       it("rejects, in the frontend, a CSV upload that is too big", () => {
@@ -206,7 +206,7 @@ describe("scenarios > admin > localization > content translation", () => {
 
         cy.findAllByRole("alert")
           .contains(/The file is larger than 1.5 MB/)
-          .should("be.visible");
+          .should("exist");
         cy.log(
           "The frontend should prevent the upload attempt; the endpoint should not be called",
         );
@@ -232,8 +232,9 @@ describe("scenarios > admin > localization > content translation", () => {
           .click();
         cy.findAllByRole("alert")
           .contains(/CSV error/)
-          .should("be.visible");
+          .should("exist");
         cy.wait("@uploadDictionary");
+        cy.findByRole("status").findByText("Could not upload dictionary");
       });
     });
   });

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration/ContentTranslationConfiguration.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration/ContentTranslationConfiguration.tsx
@@ -12,10 +12,11 @@ import {
 import { c, msgid, ngettext, t } from "ttag";
 
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
+import { SettingsSection } from "metabase/admin/settings/components/SettingsSection";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import Markdown from "metabase/common/components/Markdown";
 import { UploadInput } from "metabase/common/components/upload";
-import { useConfirmation, useDocsUrl } from "metabase/common/hooks";
+import { useConfirmation, useDocsUrl, useToast } from "metabase/common/hooks";
 import {
   Form,
   FormProvider,
@@ -60,7 +61,7 @@ export const ContentTranslationConfiguration = () => {
     string | null
   >();
   const [isDownloadInProgress, setIsDownloadInProgress] = useState(false);
-  const [errorMessages, setErrorMessages] = useState<string[]>([]);
+  const [uploadErrorMessages, setUploadErrorMessages] = useState<string[]>([]);
   const [showDownloadingIndicator, setShowDownloadingIndicator] =
     useState(false);
 
@@ -68,6 +69,8 @@ export const ContentTranslationConfiguration = () => {
     setDownloadErrorMessage(errorMessage);
     setIsDownloadInProgress(false);
   }, []);
+
+  const [sendToast] = useToast();
 
   const triggerDownload = async () => {
     setDownloadErrorMessage(null);
@@ -86,6 +89,7 @@ export const ContentTranslationConfiguration = () => {
       const filename = "metabase-content-translations.csv";
       openSaveDialog(filename, blob);
       setIsDownloadInProgress(false);
+      await sendToast({ message: t`Dictionary downloaded`, icon: "download" });
     } catch {
       showDownloadError(t`An error occurred`);
     }
@@ -111,92 +115,95 @@ export const ContentTranslationConfiguration = () => {
   );
 
   return (
-    <Stack
-      gap="sm"
-      maw="38rem"
-      aria-labelledby="content-translation-header"
-      data-testid="content-translation-configuration"
-    >
-      <SettingHeader
-        id="content-translation-header"
-        title={t`Upload a dictionary to translate user-generated content`}
-        description={
-          <>
-            <Stack gap="sm">
-              <DescriptionText>{t`You can upload a translation dictionary to handle user-generated strings, like dashboard names.`}</DescriptionText>
-              <DescriptionText>{t`The dictionary must be a CSV with these columns:`}</DescriptionText>
-              <List ms="sm" c="text-medium">
-                <List.Item c="inherit">{t`Locale Code`}</List.Item>
-                <List.Item c="inherit">{t`String`}</List.Item>
-                <List.Item c="inherit">{t`Translation`}</List.Item>
-              </List>
-              <DescriptionText>{t`Don't put any sensitive data in the dictionary, since anyone can see the dictionary—including viewers of public links.`}</DescriptionText>
-              <DescriptionText>{t`Uploading a new dictionary will replace the existing dictionary.`}</DescriptionText>
-              <Markdown
-                components={{
-                  em: ({ children }: { children: ReactNode }) => (
-                    <ExternalLink href={availableLocalesDocsUrl}>
-                      {children}
-                    </ExternalLink>
-                  ),
-                }}
-              >
-                {t`See a list of *supported locales*.`}
-              </Markdown>
-            </Stack>
-          </>
-        }
-      />
-      <Group>
-        <Button
-          onClick={triggerDownload}
-          leftSection={
-            showDownloadingIndicator ? null : <Icon name="download" c="brand" />
+    <SettingsSection title={t`Localizing user-generated content`}>
+      <Stack
+        gap="sm"
+        maw="38rem"
+        aria-labelledby="content-translation-header"
+        data-testid="content-translation-configuration"
+      >
+        <SettingHeader
+          id="content-translation-header"
+          description={
+            <>
+              <Stack gap="sm">
+                <DescriptionText>{t`You can upload a translation dictionary to handle user-generated strings, like dashboard names.`}</DescriptionText>
+                <DescriptionText>{t`The dictionary must be a CSV with these columns:`}</DescriptionText>
+                <List ms="sm" c="text-medium">
+                  <List.Item c="inherit">{t`Locale Code`}</List.Item>
+                  <List.Item c="inherit">{t`String`}</List.Item>
+                  <List.Item c="inherit">{t`Translation`}</List.Item>
+                </List>
+                <DescriptionText>{t`Don't put any sensitive data in the dictionary, since anyone can see the dictionary—including viewers of public links.`}</DescriptionText>
+                <DescriptionText>{t`Uploading a new dictionary will replace the existing dictionary.`}</DescriptionText>
+                <Markdown
+                  components={{
+                    em: ({ children }: { children: ReactNode }) => (
+                      <ExternalLink href={availableLocalesDocsUrl}>
+                        {children}
+                      </ExternalLink>
+                    ),
+                  }}
+                >
+                  {t`See a list of *supported locales*.`}
+                </Markdown>
+              </Stack>
+            </>
           }
-          miw="calc(50% - 0.5rem)"
-          style={{ flexGrow: 1 }}
-          disabled={isDownloadInProgress}
-        >
-          {showDownloadingIndicator ? (
-            <Loader size="sm" />
-          ) : (
-            t`Download translation dictionary`
-          )}
-        </Button>
-        <FormProvider
-          // We're only using Formik to make the appearance of the submit button
-          // depend on the form's status. We're not using Formik's other features
-          // here.
-          initialValues={{}}
-          onSubmit={() => {}}
-        >
-          <UploadForm setErrorMessages={setErrorMessages} />
-        </FormProvider>
-      </Group>
-      {downloadErrorMessage && (
-        <Text role="alert" c="danger">
-          {downloadErrorMessage}
-        </Text>
-      )}
-      {!!errorMessages.length && (
-        <Stack gap="xs">
-          <Text role="alert" c="error">
-            {ngettext(
-              msgid`We couldn't upload the file due to this error:`,
-              `We couldn't upload the file due to these errors:`,
-              errorMessages.length,
+        />
+        <Group>
+          <Button
+            onClick={triggerDownload}
+            leftSection={
+              showDownloadingIndicator ? null : (
+                <Icon name="download" c="brand" />
+              )
+            }
+            miw="calc(50% - 0.5rem)"
+            style={{ flexGrow: 1 }}
+            disabled={isDownloadInProgress}
+          >
+            {showDownloadingIndicator ? (
+              <Loader size="sm" />
+            ) : (
+              t`Download translation dictionary`
             )}
+          </Button>
+          <FormProvider
+            // We're only using Formik to make the appearance of the submit button
+            // depend on the form's status. We're not using Formik's other features
+            // here.
+            initialValues={{}}
+            onSubmit={() => {}}
+          >
+            <UploadForm setErrorMessages={setUploadErrorMessages} />
+          </FormProvider>
+        </Group>
+        {downloadErrorMessage && (
+          <Text role="alert" c="danger">
+            {downloadErrorMessage}
           </Text>
-          <List withPadding>
-            {errorMessages.map((errorMessage) => (
-              <List.Item key={errorMessage} role="alert" c="danger">
-                {errorMessage}
-              </List.Item>
-            ))}
-          </List>
-        </Stack>
-      )}
-    </Stack>
+        )}
+        {!!uploadErrorMessages.length && (
+          <Stack gap="xs">
+            <Text role="alert" c="error">
+              {ngettext(
+                msgid`We couldn't upload the file due to this error:`,
+                `We couldn't upload the file due to these errors:`,
+                uploadErrorMessages.length,
+              )}
+            </Text>
+            <List withPadding>
+              {uploadErrorMessages.map((errorMessage) => (
+                <List.Item key={errorMessage} role="alert" c="danger">
+                  {errorMessage}
+                </List.Item>
+              ))}
+            </List>
+          </Stack>
+        )}
+      </Stack>
+    </SettingsSection>
   );
 };
 
@@ -213,11 +220,12 @@ const UploadForm = ({
       const file = event.target.files[0];
 
       if (file.size > maxContentDictionarySizeInBytes) {
-        setErrorMessages([
+        setStatus("rejected");
+        updateUploadErrorMessages([
           c("{0} is a number")
             .t`The file is larger than ${approxMaxContentDictionarySizeInMB} MB`,
         ]);
-        setStatus("rejected");
+        resetInput();
         return;
       }
 
@@ -253,25 +261,48 @@ const UploadForm = ({
 
   const { status, setStatus } = useFormContext();
 
+  const [sendToast] = useToast();
+
+  const updateUploadErrorMessages = useCallback(
+    (errorMessages: string[]) => {
+      setErrorMessages(errorMessages);
+      if (errorMessages.length) {
+        return sendToast({
+          message: t`Could not upload dictionary`,
+          icon: "warning",
+        });
+      }
+    },
+    [setErrorMessages, sendToast],
+  );
+
   const uploadFile = useCallback(
     async (file: File) => {
       if (!file) {
         console.error("No file selected");
         return;
       }
-      setErrorMessages([]);
+      updateUploadErrorMessages([]);
       setStatus("pending");
       await uploadContentTranslationDictionary({ file })
         .unwrap()
-        .then(() => {
+        .then(async () => {
           setStatus("fulfilled");
+          await sendToast({ message: t`Dictionary uploaded` });
         })
-        .catch((e) => {
-          setErrorMessages(e.data.errors ?? [t`Unknown error encountered`]);
+        .catch(async (e) => {
+          await updateUploadErrorMessages(
+            e.data?.errors ?? [t`Unknown error encountered`],
+          );
           setStatus("rejected");
         });
     },
-    [uploadContentTranslationDictionary, setErrorMessages, setStatus],
+    [
+      uploadContentTranslationDictionary,
+      updateUploadErrorMessages,
+      setStatus,
+      sendToast,
+    ],
   );
 
   const { show: askConfirmation, modalContent: confirmationModal } =

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration/tests/common.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/components/ContentTranslationConfiguration/tests/common.unit.spec.tsx
@@ -15,9 +15,7 @@ describe("ContentTranslationConfiguration", () => {
         screen.getByTestId("content-translation-configuration"),
       ).toBeInTheDocument();
       expect(
-        screen.getByText(
-          "Upload a dictionary to translate user-generated content",
-        ),
+        screen.getByText("Localizing user-generated content"),
       ).toBeInTheDocument();
     });
 

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/LocalizationSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/LocalizationSettingsPage.tsx
@@ -35,9 +35,6 @@ export function LocalizationSettingsPage() {
             </Stack>
           }
         />
-        <ErrorBoundary>
-          <PLUGIN_CONTENT_TRANSLATION.ContentTranslationConfiguration />
-        </ErrorBoundary>
         <AdminSettingInput
           name="report-timezone"
           searchable
@@ -72,6 +69,9 @@ export function LocalizationSettingsPage() {
           inputType="select"
         />
       </SettingsSection>
+      <ErrorBoundary>
+        <PLUGIN_CONTENT_TRANSLATION.ContentTranslationConfiguration />
+      </ErrorBoundary>
       <FormattingWidget />
     </SettingsPageWrapper>
   );


### PR DESCRIPTION
This PR improves the design of the content translation admin settings UI, in two ways:
* We now show toasts on dictionary upload/download success and failure
* The content translation configuration UI is now in its own section within Admin / Settings / Localization
