### PR TITLE
Add blue dot attention notice to events icon links

### DIFF
--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -154,6 +154,11 @@ export type EmbeddingSetupStepSeenEvent = ValidateEvent<{
     | "done";
 }>;
 
+export type EventsClickedEvent = ValidateEvent<{
+  event: "events_clicked";
+  triggered_from: "chart" | "collection";
+}>;
+
 export type SimpleEvent =
   | CSVUploadClickedEvent
   | DatabaseAddClickedEvent
@@ -173,4 +178,5 @@ export type SimpleEvent =
   | NewButtonItemClickedEvent
   | VisualizeAnotherWayClickedEvent
   | VisualizerModalEvent
-  | EmbeddingSetupStepSeenEvent;
+  | EmbeddingSetupStepSeenEvent
+  | EventsClickedEvent;

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionTimeline.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionTimeline.tsx
@@ -20,23 +20,21 @@ function CollectionTimelineAcknowledgement({
 }) {
   return (
     <UserHasSeen id="events-menu">
-      {({ hasSeen, ack }) => {
-        return (
-          <Indicator disabled={hasSeen} size={6}>
-            {children({
-              ack: () => {
-                trackSimpleEvent({
-                  event: "events_clicked",
-                  triggered_from: "collection",
-                });
-                if (!hasSeen) {
-                  ack();
-                }
-              },
-            })}
-          </Indicator>
-        );
-      }}
+      {({ hasSeen, ack }) => (
+        <Indicator disabled={hasSeen} size={6} offset={6}>
+          {children({
+            ack: () => {
+              trackSimpleEvent({
+                event: "events_clicked",
+                triggered_from: "collection",
+              });
+              if (!hasSeen) {
+                ack();
+              }
+            },
+          })}
+        </Indicator>
+      )}
     </UserHasSeen>
   );
 }
@@ -48,20 +46,18 @@ const CollectionTimeline = ({
 
   return (
     <CollectionTimelineAcknowledgement>
-      {({ ack }) => {
-        return (
-          <Tooltip label={t`Events`} position="bottom">
-            <div>
-              <CollectionHeaderButton
-                as={Link}
-                to={url}
-                icon="calendar"
-                onClick={ack}
-              />
-            </div>
-          </Tooltip>
-        );
-      }}
+      {({ ack }) => (
+        <Tooltip label={t`Events`} position="bottom">
+          <div>
+            <CollectionHeaderButton
+              as={Link}
+              to={url}
+              icon="calendar"
+              onClick={ack}
+            />
+          </div>
+        </Tooltip>
+      )}
     </CollectionTimelineAcknowledgement>
   );
 };

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionTimeline.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionTimeline.tsx
@@ -1,8 +1,10 @@
 import { t } from "ttag";
 
 import Link from "metabase/common/components/Link/Link";
+import { UserHasSeen } from "metabase/common/components/UserHasSeen/UserHasSeen";
+import { trackSimpleEvent } from "metabase/lib/analytics";
 import * as Urls from "metabase/lib/urls";
-import { Tooltip } from "metabase/ui";
+import { Indicator, Tooltip } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
 
 import { CollectionHeaderButton } from "./CollectionHeader.styled";
@@ -11,17 +13,56 @@ interface CollectionTimelineProps {
   collection: Collection;
 }
 
+function CollectionTimelineAcknowledgement({
+  children,
+}: {
+  children: (props: { ack: () => void }) => React.ReactNode;
+}) {
+  return (
+    <UserHasSeen id="events-menu">
+      {({ hasSeen, ack }) => {
+        return (
+          <Indicator disabled={hasSeen} size={6}>
+            {children({
+              ack: () => {
+                trackSimpleEvent({
+                  event: "events_clicked",
+                  triggered_from: "collection",
+                });
+                if (!hasSeen) {
+                  ack();
+                }
+              },
+            })}
+          </Indicator>
+        );
+      }}
+    </UserHasSeen>
+  );
+}
+
 const CollectionTimeline = ({
   collection,
 }: CollectionTimelineProps): JSX.Element => {
   const url = Urls.timelinesInCollection(collection);
 
   return (
-    <Tooltip label={t`Events`} position="bottom">
-      <div>
-        <CollectionHeaderButton as={Link} to={url} icon="calendar" />
-      </div>
-    </Tooltip>
+    <CollectionTimelineAcknowledgement>
+      {({ ack }) => {
+        return (
+          <Tooltip label={t`Events`} position="bottom">
+            <div>
+              <CollectionHeaderButton
+                as={Link}
+                to={url}
+                icon="calendar"
+                onClick={ack}
+              />
+            </div>
+          </Tooltip>
+        );
+      }}
+    </CollectionTimelineAcknowledgement>
   );
 };
 

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/common.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
-import fetchMock from "fetch-mock";
 
+import { findRequests } from "__support__/server-mocks";
 import { screen, waitFor, within } from "__support__/ui";
 import type { CollectionId } from "metabase-types/api";
 
@@ -148,14 +148,15 @@ describe("CollectionHeader", () => {
 
       userEvent.click(button);
 
-      await waitFor(() => {
-        expect(
-          fetchMock.calls(
-            "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/events-menu",
-            { method: "PUT" },
-          ),
-        ).toHaveLength(1);
+      const puts = await waitFor(async () => {
+        const puts = await findRequests("PUT");
+        expect(puts).toHaveLength(1);
+        return puts;
       });
+
+      expect(puts[0].url).toBe(
+        "http://localhost/api/user-key-value/namespace/user_acknowledgement/key/events-menu",
+      );
     });
   });
 

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/setup.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/setup.tsx
@@ -1,3 +1,5 @@
+import { Route } from "react-router";
+
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
   setupDashboardQuestionCandidatesEndpoint,
@@ -51,6 +53,11 @@ export const setup = ({
     namespace: "user_acknowledgement",
     value: true,
   });
+  setupUserKeyValueEndpoints({
+    key: "events-menu",
+    namespace: "user_acknowledgement",
+    value: false,
+  });
 
   const props = getProps({
     collection: createMockCollection(collection),
@@ -66,9 +73,14 @@ export const setup = ({
     setupEnterprisePlugins();
   }
 
-  renderWithProviders(<CollectionHeader {...props} />, {
-    storeInitialState: state,
-  });
+  renderWithProviders(
+    <Route path="/" component={() => <CollectionHeader {...props} />} />,
+    {
+      storeInitialState: state,
+      initialRoute: "/",
+      withRouter: true,
+    },
+  );
 
   return props;
 };

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -146,6 +146,7 @@ export const CollectionMenu = ({
               <Indicator
                 disabled={hasSeenAll}
                 size={6}
+                offset={6}
                 data-testid="menu-indicator-root"
               >
                 <ActionIcon size={32} variant="viewHeader">

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
@@ -22,23 +22,21 @@ function QuestionTimelineAcknowledgement({
 }) {
   return (
     <UserHasSeen id="events-menu">
-      {({ hasSeen, ack }) => {
-        return (
-          <Indicator disabled={hasSeen} size={6}>
-            {children({
-              ack: () => {
-                trackSimpleEvent({
-                  event: "events_clicked",
-                  triggered_from: "chart",
-                });
-                if (!hasSeen) {
-                  ack();
-                }
-              },
-            })}
-          </Indicator>
-        );
-      }}
+      {({ hasSeen, ack }) => (
+        <Indicator disabled={hasSeen} size={6} offset={4}>
+          {children({
+            ack: () => {
+              trackSimpleEvent({
+                event: "events_clicked",
+                triggered_from: "chart",
+              });
+              if (!hasSeen) {
+                ack();
+              }
+            },
+          })}
+        </Indicator>
+      )}
     </UserHasSeen>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
@@ -1,15 +1,46 @@
 import { t } from "ttag";
 
+import { UserHasSeen } from "metabase/common/components/UserHasSeen/UserHasSeen";
 import { ViewFooterButton } from "metabase/common/components/ViewFooterButton";
+import { trackSimpleEvent } from "metabase/lib/analytics";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
   onCloseTimelines,
   onOpenTimelines,
 } from "metabase/query_builder/actions";
 import { getUiControls } from "metabase/query_builder/selectors";
+import { Indicator } from "metabase/ui";
 
 export interface QuestionTimelineWidgetProps {
   className?: string;
+}
+
+function QuestionTimelineAcknowledgement({
+  children,
+}: {
+  children: (props: { ack: () => void }) => React.ReactNode;
+}) {
+  return (
+    <UserHasSeen id="events-menu">
+      {({ hasSeen, ack }) => {
+        return (
+          <Indicator disabled={hasSeen} size={6}>
+            {children({
+              ack: () => {
+                trackSimpleEvent({
+                  event: "events_clicked",
+                  triggered_from: "chart",
+                });
+                if (!hasSeen) {
+                  ack();
+                }
+              },
+            })}
+          </Indicator>
+        );
+      }}
+    </UserHasSeen>
+  );
 }
 
 const QuestionTimelineWidget = ({
@@ -21,15 +52,22 @@ const QuestionTimelineWidget = ({
   const handleOpenTimelines = () => dispatch(onOpenTimelines());
   const handleCloseTimelines = () => dispatch(onCloseTimelines());
 
+  function handleClick(isShowingTimelineSidebar: boolean, ack: () => void) {
+    isShowingTimelineSidebar ? handleCloseTimelines() : handleOpenTimelines();
+    ack();
+  }
+
   return (
-    <ViewFooterButton
-      icon="calendar"
-      tooltipLabel={t`Events`}
-      onClick={
-        isShowingTimelineSidebar ? handleCloseTimelines : handleOpenTimelines
-      }
-      className={className}
-    />
+    <QuestionTimelineAcknowledgement>
+      {({ ack }) => (
+        <ViewFooterButton
+          icon="calendar"
+          tooltipLabel={t`Events`}
+          onClick={() => handleClick(isShowingTimelineSidebar, ack)}
+          className={className}
+        />
+      )}
+    </QuestionTimelineAcknowledgement>
   );
 };
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-36/add-blue-dot-to-events-icon-snowplow-event

### Description

I'm adding blue dot indicator to event menu item which are present in two places - Collections Header and Timeline view.
I'm using ready [UserHasSeen](https://storybook.metabase.com/?path=/docs/patterns-product-callouts-userhasseen--docs) API and  Mantine [Indicator](https://v7.mantine.dev/core/indicator/) component.

### How to verify

Users should see blue dot next Event's icon. The blue dot should disappear after interacting with those items.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
