### PR TITLE
Migrate new menu to Mantine

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -571,7 +571,7 @@ describe("scenarios > home > custom homepage", () => {
   });
 });
 
-H.describeWithSnowplow("scenarios > setup", () => {
+H.describeWithSnowplow.only("scenarios > setup", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();
@@ -621,7 +621,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
 
     cy.log("From the app bar");
     H.newButton().should("be.visible").click();
-    cy.findByRole("dialog").should("be.visible");
+    cy.findByRole("menu", { name: /new/i }).should("be.visible");
     H.expectUnstructuredSnowplowEvent({
       event: "new_button_clicked",
       triggered_from: "app-bar",
@@ -629,7 +629,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
 
     cy.log("Track closing the button as well");
     H.newButton().should("be.visible").click();
-    cy.findByRole("dialog").should("not.exist");
+    cy.findByRole("menu", { name: /new/i }).should("not.exist");
     H.expectUnstructuredSnowplowEvent(
       {
         event: "new_button_clicked",
@@ -645,7 +645,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
       cy.findByText("New").click();
     });
 
-    cy.findByRole("dialog").should("be.visible");
+    cy.findByRole("menu", { name: /new/i }).should("be.visible");
     H.expectUnstructuredSnowplowEvent({
       event: "new_button_clicked",
       triggered_from: "empty-collection",
@@ -660,7 +660,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
     cy.visit("/");
 
     H.newButton().should("be.visible").click();
-    cy.findByRole("dialog").findByText("Dashboard").click();
+    cy.findByRole("menu", { name: /new/i }).findByText("Dashboard").click();
     cy.findByTestId("new-dashboard-modal").should("be.visible");
     H.expectUnstructuredSnowplowEvent({
       event: "new_button_item_clicked",
@@ -675,7 +675,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
       cy.findByText("This collection is empty").should("be.visible");
       cy.findByText("New").click();
     });
-    cy.findByRole("dialog").findByText("Dashboard").click();
+    cy.findByRole("menu", { name: /new/i }).findByText("Dashboard").click();
     cy.findByTestId("new-dashboard-modal").should("be.visible");
     H.expectUnstructuredSnowplowEvent(
       {

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -54,9 +54,32 @@ describe("NewItemMenu", () => {
     expect(screen.queryByText("Action")).not.toBeInTheDocument();
   });
 
+  it("should support keyboard navigation", async () => {
+    await setup();
+
+    await userEvent.keyboard("{ArrowDown}");
+
+    expect(
+      await screen.findByRole("menuitem", { name: /Question/ }),
+    ).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{ArrowDown}");
+
+    expect(
+      await screen.findByRole("menuitem", { name: /Dashboard/ }),
+    ).toHaveFocus();
+
+    await userEvent.keyboard("{Enter}");
+
+    expect(
+      await screen.findByRole("dialog", { name: /New dashboard/ }),
+    ).toBeInTheDocument();
+  });
+
   describe("New Dashboard", () => {
     it("should open new dashboard modal on click", async () => {
-      setup();
+      await setup();
       await userEvent.click(await screen.findByText("Dashboard"));
       const modal = await screen.findByRole("dialog");
       expect(modal).toHaveTextContent("New dashboard");

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.beforeunload-events.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.beforeunload-events.unit.spec.tsx
@@ -126,7 +126,7 @@ describe("QueryBuilder - beforeunload events", () => {
 
       await userEvent.click(screen.getByText("New"));
       await userEvent.click(
-        within(await screen.findByRole("dialog")).getByText("SQL query"),
+        within(await screen.findByRole("menu")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 
@@ -146,7 +146,7 @@ describe("QueryBuilder - beforeunload events", () => {
 
       await userEvent.click(screen.getByText("New"));
       await userEvent.click(
-        within(await screen.findByRole("dialog")).getByText("SQL query"),
+        within(await screen.findByRole("menu")).getByText("SQL query"),
       );
 
       await waitForLoaderToBeRemoved();

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
@@ -472,7 +472,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       await userEvent.click(screen.getByText("New"));
       await userEvent.click(
-        within(await screen.findByRole("dialog")).getByText("SQL query"),
+        within(await screen.findByRole("menu")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 
@@ -494,7 +494,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       await userEvent.click(screen.getByText("New"));
       await userEvent.click(
-        within(await screen.findByRole("dialog")).getByText("SQL query"),
+        within(await screen.findByRole("menu")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 
@@ -515,7 +515,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       await userEvent.click(screen.getByText("New"));
       await userEvent.click(
-        within(await screen.findByRole("dialog")).getByText("SQL query"),
+        within(await screen.findByRole("menu")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 
@@ -545,7 +545,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       await userEvent.click(screen.getByText("New"));
       await userEvent.click(
-        within(await screen.findByRole("dialog")).getByText("SQL query"),
+        within(await screen.findByRole("menu")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56304

### Description
Updates the New Item Menu to use the Mantine `<Menu/>` component and support keyboard navigation. Also removes some unused props 

### How to verify

1. Use the keyboard to focus the New Item button and press enter.
2. Use the keyboard to navigate up and down the menu, and use enter to select.

### Demo
https://github.com/user-attachments/assets/701e3029-1e67-4b4a-9940-c4ca568ee368

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
