### PR TITLE
WRK-482: Preview for Slack templates in notifications

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/alerts/TableNotificationsModals/CreateOrEditTableNotificationModal/CreateOrEditTableNotificationModal.tsx
@@ -314,24 +314,17 @@ const useNotificationTemplatePreview = (
     (channelType: NotificationChannelType) => {
       if (previewOpen) {
         setPreviewOpen(false);
+        setChannelType(null);
         return;
       }
 
       setChannelType(channelType);
 
       if (channelType === "channel/email") {
-        const handler = requestBody?.handlers.find(
-          (h) => h.channel_type === channelType && h.template,
-        );
-        const currentTemplate =
-          handler?.template || defaultTemplates?.[channelType];
-
-        if (currentTemplate) {
-          setPreviewOpen(true);
-        }
+        setPreviewOpen(true);
       }
     },
-    [requestBody, defaultTemplates, previewOpen],
+    [previewOpen],
   );
 
   /*

--- a/frontend/src/metabase-types/api/notification.ts
+++ b/frontend/src/metabase-types/api/notification.ts
@@ -250,6 +250,7 @@ type RenderedEmailPayload = {
 export type PreviewNotificationTemplateResponse = {
   context: unknown;
   rendered: RenderedEmailPayload;
+  preview_url?: string;
 };
 
 // Initial schema for conditional expression.

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -781,6 +781,17 @@ export const NotificationChannelsPicker = ({
                   <TemplateInfoTooltip
                     context={templateContext["channel/slack"]}
                   />
+                  {onPreviewClick && (
+                    <TemplateToolbarButton
+                      icon="external"
+                      label={
+                        isPreviewOpen ? t`Close preview` : t`Open Slack preview`
+                      }
+                      onClick={() =>
+                        onPreviewClick(templateStateKeyMap["slack"])
+                      }
+                    />
+                  )}
                 </Flex>
               </Flex>
               <Stack gap="xs">

--- a/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
+++ b/frontend/src/metabase/notifications/modals/shared/components/NotificationChannels/NotificationChannelsPicker/NotificationChannelsPicker.tsx
@@ -784,9 +784,7 @@ export const NotificationChannelsPicker = ({
                   {onPreviewClick && (
                     <TemplateToolbarButton
                       icon="external"
-                      label={
-                        isPreviewOpen ? t`Close preview` : t`Open Slack preview`
-                      }
+                      label={t`Open message preview`}
                       onClick={() =>
                         onPreviewClick(templateStateKeyMap["slack"])
                       }


### PR DESCRIPTION
Closes [WRK-482](https://linear.app/metabase/issue/WRK-482/preview-for-slack-templates-in-notifications)

### Description
We've introduced ability to generate previews for custom Slack templates through Slack's own service which properly displays generated Build Kit (Slack's message-formatting framework) message, instead of trying to render mrkdwn by ourselves. Unlike email templates, we're not using generated HTML but rather generate an external URL which is returned from `/preview_template` request and then user is redirected to the Build Kit renderer page.

### Demo
<img width="602" alt="image" src="https://github.com/user-attachments/assets/0b8a7243-43ba-4152-9b28-b2406125db01" />

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/29e431ee-bf47-49ab-9c54-4bf2b9c70afc" />
