### PR TITLE
QUE-1360: scroll selected item into view

### DIFF
--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -1052,6 +1052,29 @@ describe("scenarios > question > filter", () => {
       cy.findByLabelText("Filter value").should("be.visible");
     });
   });
+
+  it("should render the selected item in view", () => {
+    cy.viewport(1280, 320);
+    H.openReviewsTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
+
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+
+    H.popover()
+      .findByRole("tree")
+      .parent()
+      .then((el) => {
+        cy.wrap(el[0].scrollTop).should("be.greaterThan", 0);
+      });
+
+    H.popover().findByText("Created At").should("be.visible");
+  });
 });
 
 function openExpressionEditorFromFreshlyLoadedPage() {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import type { CSSProperties, ReactNode } from "react";
+import { type CSSProperties, type ReactNode, useEffect, useRef } from "react";
 import { t } from "ttag";
 
 import EmptyState from "metabase/components/EmptyState";
@@ -135,6 +135,13 @@ export function AccordionListCell<
   let content;
   let borderTop;
   let borderBottom;
+
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (hasCursor) {
+      ref.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [hasCursor]);
 
   if (type === "header") {
     if (alwaysExpanded) {
@@ -401,6 +408,7 @@ export function AccordionListCell<
 
   return (
     <div
+      ref={ref}
       style={style}
       data-element-id="list-section"
       className={cx(section.className, {


### PR DESCRIPTION
Closes [QUE-1360](https://linear.app/metabase/issue/QUE-1360/scroll-highlighted-item-into-view-when-navigating-the-accordionlist)


### To verify
1. New Question -> Filter 
2. Resize window to cause the popover to overflow
3. use arrow keys (up/down) to select items 
4. Make sure selected items are always scrolled into view