### PR TITLE
Fix inline filters legend when exporting dashboard PDF

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
@@ -4,6 +4,7 @@ import {
   setParameterValue,
   setParameterValueToDefault,
 } from "metabase/dashboard/actions";
+import { DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME } from "metabase/dashboard/constants";
 import {
   getDashboardComplete,
   getEditingParameter,
@@ -37,6 +38,7 @@ export function DashboardParameterList({
 
   return (
     <ParametersList
+      className={DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME}
       parameters={parameters}
       editingParameter={editingParameter}
       hideParameters={hiddenParameterSlugs}

--- a/frontend/src/metabase/dashboard/components/DashboardParameterPanel/DashboardParameterPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardParameterPanel/DashboardParameterPanel.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import { useRef } from "react";
 
 import TransitionS from "metabase/css/core/transitions.module.css";
-import { DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
+import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 import { useIsParameterPanelSticky } from "metabase/dashboard/hooks/use-is-parameter-panel-sticky";
 import {
   getDashboardComplete,
@@ -101,7 +101,7 @@ export function DashboardParameterPanel({
       >
         <FixedWidthContainer
           className={DashboardS.ParametersFixedWidthContainer}
-          id={DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID}
+          id={DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID}
           isFixedWidth={dashboard?.width === "fixed"}
           data-testid="fixed-width-filters"
         >

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -56,6 +56,8 @@ export const DASHBOARD_PDF_EXPORT_ROOT_ID =
   "Dashboard-Parameters-And-Cards-Container";
 export const DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID =
   "Dashboard-Parameters-Content";
+export const DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME =
+  "Dashboard-Parameters-List";
 
 export const DEFAULT_DASHBOARD_DISPLAY_OPTIONS: EmbedDisplayParams = {
   background: true,

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -54,7 +54,7 @@ export const DASHBOARD_SLOW_TIMEOUT = 15 * 1000;
 
 export const DASHBOARD_PDF_EXPORT_ROOT_ID =
   "Dashboard-Parameters-And-Cards-Container";
-export const DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID =
+export const DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID =
   "Dashboard-Parameters-Content";
 
 export const DEFAULT_DASHBOARD_DISPLAY_OPTIONS: EmbedDisplayParams = {

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
@@ -17,7 +17,7 @@ import CS from "metabase/css/core/index.css";
 import DashboardS from "metabase/css/dashboard.module.css";
 import { DashboardGridConnected } from "metabase/dashboard/components/DashboardGrid";
 import { DashboardTabs } from "metabase/dashboard/components/DashboardTabs";
-import { DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
+import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 import {
   DashboardData,
   type DashboardDataReturnedProps,
@@ -191,7 +191,7 @@ const AutomaticDashboardAppInner = ({
           {parameters && parameters.length > 0 && (
             <div className={cx(CS.px1, CS.pt1)}>
               <FixedWidthContainer
-                id={DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID}
+                id={DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID}
                 data-testid="fixed-width-filters"
                 isFixedWidth={dashboard?.width === "fixed"}
               >

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -10,7 +10,7 @@ import DashboardS from "metabase/dashboard/components/Dashboard/Dashboard.module
 import { FixedWidthContainer } from "metabase/dashboard/components/Dashboard/DashboardComponents";
 import { ExportAsPdfButton } from "metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton";
 import {
-  DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID,
+  DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID,
   DASHBOARD_PDF_EXPORT_ROOT_ID,
 } from "metabase/dashboard/constants";
 import { useIsParameterPanelSticky } from "metabase/dashboard/hooks/use-is-parameter-panel-sticky";
@@ -243,7 +243,7 @@ export const EmbedFrame = ({
           >
             <FixedWidthContainer
               className={DashboardS.ParametersFixedWidthContainer}
-              id={DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID}
+              id={DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID}
               data-testid="fixed-width-filters"
               isFixedWidth={dashboard?.width === "fixed"}
             >

--- a/frontend/src/metabase/visualizations/lib/get-dashboard-image.ts
+++ b/frontend/src/metabase/visualizations/lib/get-dashboard-image.ts
@@ -1,4 +1,4 @@
-import { DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
+import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 
 import { SAVING_DOM_IMAGE_CLASS } from "./image-exports";
 const PARAMETERS_MARGIN_BOTTOM = 12;
@@ -40,7 +40,7 @@ export const getDashboardImage = async (
   }
 
   const parametersNode = dashboardRoot
-    ?.querySelector(`#${DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID}`)
+    ?.querySelector(`#${DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID}`)
     ?.cloneNode(true);
 
   let parametersHeight = 0;

--- a/frontend/src/metabase/visualizations/lib/image-exports.ts
+++ b/frontend/src/metabase/visualizations/lib/image-exports.ts
@@ -4,7 +4,7 @@ import { css } from "@emotion/react";
 import GlobalDashboardS from "metabase/css/dashboard.module.css";
 import DashboardS from "metabase/dashboard/components/Dashboard/Dashboard.module.css";
 import DashboardGridS from "metabase/dashboard/components/DashboardGrid.module.css";
-import { DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
+import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 import { isEmbeddingSdk, isStorybookActive } from "metabase/env";
 import { openImageBlobOnStorybook } from "metabase/lib/loki-utils";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
@@ -109,7 +109,7 @@ export const setupDashboardForRendering = (
   }
 
   const parametersNode = dashboardRoot
-    ?.querySelector(`#${DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID}`)
+    ?.querySelector(`#${DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID}`)
     ?.cloneNode(true);
 
   let parametersHeight = 0;

--- a/frontend/src/metabase/visualizations/lib/image-exports.ts
+++ b/frontend/src/metabase/visualizations/lib/image-exports.ts
@@ -2,9 +2,11 @@
 import { css } from "@emotion/react";
 
 import GlobalDashboardS from "metabase/css/dashboard.module.css";
-import DashboardS from "metabase/dashboard/components/Dashboard/Dashboard.module.css";
 import DashboardGridS from "metabase/dashboard/components/DashboardGrid.module.css";
-import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
+import {
+  DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID,
+  DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME,
+} from "metabase/dashboard/constants";
 import { isEmbeddingSdk, isStorybookActive } from "metabase/env";
 import { openImageBlobOnStorybook } from "metabase/lib/loki-utils";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
@@ -26,7 +28,7 @@ export const saveDomImageStyles = css`
       display: none;
     }
 
-    .${DashboardS.FixedWidthContainer} {
+    .${DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME} {
       legend {
         top: -9px;
       }

--- a/frontend/src/metabase/visualizations/lib/image-exports.ts
+++ b/frontend/src/metabase/visualizations/lib/image-exports.ts
@@ -108,17 +108,18 @@ export const setupDashboardForRendering = (
     return undefined;
   }
 
-  const parametersNode = dashboardRoot
+  const pageHeaderParametersNode = dashboardRoot
     ?.querySelector(`#${DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID}`)
     ?.cloneNode(true);
 
   let parametersHeight = 0;
-  if (parametersNode instanceof HTMLElement) {
-    gridNode.append(parametersNode);
-    parametersNode.style.cssText = `margin-bottom: ${PARAMETERS_MARGIN_BOTTOM}px`;
+  if (pageHeaderParametersNode instanceof HTMLElement) {
+    gridNode.append(pageHeaderParametersNode);
+    pageHeaderParametersNode.style.cssText = `margin-bottom: ${PARAMETERS_MARGIN_BOTTOM}px`;
     parametersHeight =
-      parametersNode.getBoundingClientRect().height + PARAMETERS_MARGIN_BOTTOM;
-    gridNode.removeChild(parametersNode);
+      pageHeaderParametersNode.getBoundingClientRect().height +
+      PARAMETERS_MARGIN_BOTTOM;
+    gridNode.removeChild(pageHeaderParametersNode);
   }
 
   const contentWidth = gridNode.offsetWidth;
@@ -133,7 +134,9 @@ export const setupDashboardForRendering = (
     contentWidth,
     contentHeight,
     parametersNode:
-      parametersNode instanceof HTMLElement ? parametersNode : null,
+      pageHeaderParametersNode instanceof HTMLElement
+        ? pageHeaderParametersNode
+        : null,
     parametersHeight,
     backgroundColor,
   };

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -2,8 +2,8 @@
 import { css } from "@emotion/react";
 
 import GlobalDashboardS from "metabase/css/dashboard.module.css";
-import DashboardS from "metabase/dashboard/components/Dashboard/Dashboard.module.css";
 import DashboardGridS from "metabase/dashboard/components/DashboardGrid.module.css";
+import { DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME } from "metabase/dashboard/constants";
 import { isEmbeddingSdk, isStorybookActive } from "metabase/env";
 import { openImageBlobOnStorybook } from "metabase/lib/loki-utils";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
@@ -28,7 +28,7 @@ export const saveDomImageStyles = css`
       display: none;
     }
 
-    .${DashboardS.FixedWidthContainer} {
+    .${DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME} {
       legend {
         top: -9px;
       }

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
+import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 import type { Dashboard } from "metabase-types/api";
 
 import {
@@ -178,7 +178,7 @@ export const saveDashboardPdf = async ({
 
   const pdfHeader = createHeaderElement(dashboardName, HEADER_MARGIN_BOTTOM);
   const parametersNode = dashboardRoot
-    ?.querySelector(`#${DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID}`)
+    ?.querySelector(`#${DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID}`)
     ?.cloneNode(true);
 
   let parametersHeight = 0;


### PR DESCRIPTION
Fixes inline filters appearance when exporting a dashboard as PDF

### Demo

**Before**

![before](https://github.com/user-attachments/assets/a07ca869-1770-46ba-ae97-fdf06c8af6bb)

**After**

![after](https://github.com/user-attachments/assets/d462082b-aed3-4c33-a40d-db140cd15d49)
