### PR TITLE
QUE-1359: Add highlight when item has cursor

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1645,7 +1645,10 @@ describe("issue QUE-1359", () => {
       .findByText("Custom Expression")
       .parent()
       .then((el) => {
-        cy.wrap(el[0].className).should("contain", "ListSectionHeaderCursor");
+        cy.wrap(window.getComputedStyle(el[0]).outline).should(
+          "contain",
+          "solid",
+        );
       });
   });
 });

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1,4 +1,6 @@
 const { H } = cy;
+import _ from "underscore";
+
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,
@@ -1637,16 +1639,7 @@ describe("issue QUE-1359", () => {
     H.openReviewsTable({ mode: "notebook" });
     H.filter({ mode: "notebook" });
 
-    cy.realPress("ArrowDown");
-    cy.realPress("ArrowDown");
-    cy.realPress("ArrowDown");
-    cy.realPress("ArrowDown");
-    cy.realPress("ArrowDown");
-    cy.realPress("ArrowDown");
-    cy.realPress("ArrowDown");
-    cy.realPress("ArrowDown");
-    cy.realPress("ArrowDown");
-    cy.realPress("ArrowDown");
+    _.times(10, () => cy.realPress("ArrowDown"));
 
     H.popover()
       .findByText("Custom Expression")

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1,5 +1,4 @@
 const { H } = cy;
-import _ from "underscore";
 
 import {
   SAMPLE_DB_ID,
@@ -1639,7 +1638,7 @@ describe("issue QUE-1359", () => {
     H.openReviewsTable({ mode: "notebook" });
     H.filter({ mode: "notebook" });
 
-    _.times(10, () => cy.realPress("ArrowDown"));
+    Cypress._.times(10, () => cy.realPress("ArrowDown"));
 
     H.popover()
       .findByText("Custom Expression")

--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1626,3 +1626,33 @@ describe("issue 58923", () => {
       });
   });
 });
+
+describe("issue QUE-1359", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should render an outline on the custom expression item in the filter popover (QUE-1359)", () => {
+    H.openReviewsTable({ mode: "notebook" });
+    H.filter({ mode: "notebook" });
+
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+    cy.realPress("ArrowDown");
+
+    H.popover()
+      .findByText("Custom Expression")
+      .parent()
+      .then((el) => {
+        cy.wrap(el[0].className).should("contain", "ListSectionHeaderCursor");
+      });
+  });
+});

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.tsx
@@ -242,7 +242,7 @@ export function AccordionListCell<
           CS.hoverParent,
           styles.action,
           {
-            "List-section-header--cursor": hasCursor,
+            [ListS.ListSectionHeaderCursor]: hasCursor,
             [CS.cursorPointer]: canToggleSections,
             [CS.textBrand]: sectionIsExpanded(sectionIndex),
           },


### PR DESCRIPTION
Closes [QUE-1359](https://linear.app/metabase/issue/QUE-1359/focus-on-the-custom-expression-link-with-arrow-keys)

Adds missing highlighting to the Custom Expression action when selecting it via cursor keys.

It was already possible to select it, but we were not displaying the outline on it correctly.

### To verify

1. New -> Question -> Orders
2. Filter
3. Use cursor keys to navigate to the `Custom expression` item, it should be highlighted
4. Press enter to select it and verify you are now editing a custom expression