### PR TITLE
shorten filename to not overflow byte limit in some filesystems

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -175,7 +175,7 @@
                     (when-not continue-on-error
                       (throw e))
                     ;; eschew big and scary stacktrace
-                    (log/warnf "Skipping deserialization error: %s %s" (ex-message e) (ex-data e))
+                    (log/warnf (u/strip-error e "Skipping deserialization error"))
                     (update ctx :errors conj e))))
               ctx
               contents))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1258,7 +1258,7 @@
                 (is (= 1 (count (:errors report))))
                 (is (= 3 (count (:seen report)))))
               (is (= [["Failed to read file for Collection does-not-exist"]]
-                     (logs-extract #"Skipping deserialization error: (.*) \{.*\}$"
+                     (logs-extract #"Skipping deserialization error: (.*) \{.*\}\n"
                                    (messages)))))))))))
 
 (deftest with-dbs-works-as-expected-test

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -69,10 +69,10 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
+   [metabase.util.string :as u.str]
    [toucan2.core :as t2]
    [toucan2.model :as t2.model]
-   [toucan2.realize :as t2.realize])
-  (:import [com.google.common.base Utf8]))
+   [toucan2.realize :as t2.realize]))
 
 (set! *warn-on-reflection* true)
 
@@ -847,13 +847,9 @@
 (def ^:private max-label-bytes 200) ;; 255 is a limit in ext4
 
 (defn- truncate-label [^String s]
-  (let [char-count (count s)
-        byte-count (Utf8/encodedLength s)]
-    (cond
-      (> byte-count max-label-bytes)  (let [target-count (int (* char-count (/ max-label-bytes byte-count)))]
-                                        (subs s 0 target-count))
-      (> char-count max-label-length) (subs s 0 max-label-length)
-      :else                           s)))
+  (-> s
+      (u.str/limit-bytes max-label-bytes)
+      (u.str/limit-chars max-label-length)))
 
 (defn- lower-plural [s]
   (-> s u/lower-case-en (str "s")))

--- a/test/metabase/util/string_test.clj
+++ b/test/metabase/util/string_test.clj
@@ -33,7 +33,9 @@
 
 (deftest ^:parallel elide-test
   (is (= "short" (u.str/elide "short" 5)))
-  (is (= "lo..." (u.str/elide "longer string" 5))))
+  (is (= "lo..." (u.str/elide "longer string" 5)))
+  (is (= "short" (u.str/limit-chars "short" 5)))
+  (is (= "longe" (u.str/limit-chars "longer string" 5))))
 
 (deftest ^:parallel random-string
   (is 10 (count (u.str/random-string 10)))


### PR DESCRIPTION
in particular ext4 limits file name by 255 *bytes*, not chars, which is doable by using 3-byte chars

fixes #59233

as for `limit-bytes`:

```
;; old one
Evaluation count : 69444 in 6 samples of 11574 calls.
             Execution time mean : 9.385244 µs
    Execution time std-deviation : 993.904052 ns
   Execution time lower quantile : 8.635478 µs ( 2.5%)
   Execution time upper quantile : 10.583322 µs (97.5%)
                   Overhead used : 1.693418 ns

;; new one
Evaluation count : 1005306 in 6 samples of 167551 calls.
             Execution time mean : 604.163079 ns
    Execution time std-deviation : 14.545828 ns
   Execution time lower quantile : 594.599907 ns ( 2.5%)
   Execution time upper quantile : 622.892874 ns (97.5%)
                   Overhead used : 1.693418 ns
```