### PR TITLE
increment failed-fingerprints rather than the throwable object

### DIFF
--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -229,7 +229,7 @@
                                                (update :failed-fingerprints inc))
                                            ret)]
                                  (merge-with + acc ret))]
-                   (if (and (continue? ret) (not (sync-util/abandon-sync? ret)))
+                   (if (and (continue? new-acc) (not (sync-util/abandon-sync? ret)))
                      new-acc
                      (reduced new-acc))))
                (empty-stats-map 0)

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -222,8 +222,14 @@
                     (sync-util/reducible-sync-tables database))]
        (reduce (fn [acc table]
                  (log-progress-fn (if *refingerprint?* "refingerprint-fields" "fingerprint-fields") table)
-                 (let [new-acc (merge-with + acc (fingerprint-table! table))]
-                   (if (and (continue? new-acc) (not (sync-util/abandon-sync? new-acc)))
+                 (let [ret (fingerprint-table! table)
+                       new-acc (let [ret (if (:throwable ret)
+                                           (-> ret
+                                               (dissoc :throwable)
+                                               (update :failed-fingerprints inc))
+                                           ret)]
+                                 (merge-with + acc ret))]
+                   (if (and (continue? ret) (not (sync-util/abandon-sync? ret)))
                      new-acc
                      (reduced new-acc))))
                (empty-stats-map 0)

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -347,7 +347,7 @@
                                                              (swap! tables-fingerprinted inc)
                                                              (throw (CannotAcquireResourceException. "Unable to acquire resource")))
                       sync.fingerprint/*refingerprint?* true]
-          (is (=? (assoc (sync.fingerprint/empty-stats-map 0)
-                         :throwable #(instance? CannotAcquireResourceException %))
-                  (sync.fingerprint/fingerprint-fields-for-db! (mt/db) (constantly nil))))
+          (is (= (assoc (sync.fingerprint/empty-stats-map 0)
+                        :failed-fingerprints 1)
+                 (sync.fingerprint/fingerprint-fields-for-db! (mt/db) (constantly nil))))
           (is (= 1 @tables-fingerprinted)))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59560
Related to https://linear.app/metabase/issue/SEM-421/table-sync-fail-with-ambiguous-error-so-far-localised-to-1-user
# Description
This fixes a bug where a non-terminal exception thrown during fingerprinting caused fingerprinting to crash and swallow the original exception