### PR TITLE
[MBQL lib] When removing clauses, match downstream refs correctly

### DIFF
--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -17,6 +17,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.util :as u]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
 
@@ -76,21 +77,25 @@
     query))
 
 (defn- update-stale-references-in-stage
-  "Fix stale references in `stage-number` stage of `query-modfied`. `stage-number` should not be 0."
+  "Fix stale references in `stage-number` stage of `query-modfied`.
+
+  `stage-number` should not be 0; [[update-stale-references]] is about fixing subsequent stages."
   [query-modified stage-number query-original]
-  (let [old-previous-stage-columns (lib.metadata.calculation/returned-columns query-original (dec stage-number))
-        new-previous-stage-columns (lib.metadata.calculation/returned-columns query-modified (dec stage-number))
-        source-uuid->new-column (m/index-by :lib/source-uuid new-previous-stage-columns)]
+  (let [old-columns (lib.metadata.calculation/visible-columns query-original stage-number)
+        new-columns (lib.metadata.calculation/visible-columns query-modified stage-number)
+        source-uuid->new-column (m/index-by :lib/source-uuid new-columns)]
     (lib.util/update-query-stage
      query-modified stage-number
      #(lib.util.match/replace
         %
         #{:field}
-        (let [old-matching-column (lib.equality/find-matching-column &match old-previous-stage-columns)
-              source-uuid (:lib/source-uuid old-matching-column)
-              new-column  (source-uuid->new-column source-uuid)
-              new-name    ((some-fn :lib/desired-column-alias :name) new-column)]
-          (assoc &match 2 new-name))))))
+        (let [old-matching-column (lib.equality/find-matching-column &match old-columns)]
+          (if-let [new-column (some-> old-matching-column :lib/source-uuid source-uuid->new-column)]
+            (assoc &match 2 ((some-fn :lib/desired-column-alias :name) new-column))
+            (do
+              (log/warnf "Failed to match downstream ref %s against visible columns, ref is on stage %d at %s"
+                         &match stage-number &parents)
+              &match)))))))
 
 (defn update-stale-references
   "Update stale refs in query after clause removal.

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -1702,3 +1702,58 @@
         (testing description
           (is (= ["Products" "Products_II"]
                  (map :alias (lib/joins new-query)))))))))
+
+(deftest ^:parallel stale-clauses-test-unrelated-refs-are-stable
+  (testing "deleting eg. an aggregation should not break a downstream ref to a breakout (#59441)"
+    (let [base1  (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                     (lib/join (meta/table-metadata :products))
+                     (lib/aggregate (lib/count))
+                     (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal))))
+          cols   (m/index-by :lib/desired-column-alias (lib/breakoutable-columns base1))
+          base2  (-> base1
+                     (lib/breakout (get cols "Products__CATEGORY"))             ; Explicitly joined
+                     (lib/breakout (get cols "PEOPLE__via__USER_ID__SOURCE"))   ; Implicitly joined
+                     lib/append-stage)
+          [category] (lib/visible-columns base2)
+          ;; Adding an expression based on one of the breakouts.
+          query      (lib/expression base2 "WidgetOrNah" (lib/case [[(lib/= category "Widget") "Widget!"]] "Nah"))
+          [cnt sum]  (lib/aggregations query 0)]
+      (is (=? [:count {}]
+              cnt))
+      (is (=? [:sum {} [:field {} (meta/id :orders :subtotal)]]
+              sum))
+      (is (=? (update-in query [:stages 0 :aggregation] (comp vector first))
+              (lib/remove-clause query 0 sum)))
+      (is (=? (update-in query [:stages 0 :aggregation] (comp vec rest))
+              (lib/remove-clause query 0 cnt))))))
+
+(deftest ^:parallel stale-clauses-test-no-capture-of-later-aggregations
+  (testing "deleting an aggregation in stage 0 should not delete refs to a similar aggregation in stage 1"
+    (let [base1                     (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                                        (lib/join (meta/table-metadata :products))
+                                        (lib/aggregate (lib/count))
+                                        (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal))))
+          cols                      (m/index-by :lib/desired-column-alias (lib/breakoutable-columns base1))
+          base2                     (-> base1
+                                        (lib/breakout (get cols "Products__CATEGORY"))             ; Explicitly joined
+                                        (lib/breakout (get cols "PEOPLE__via__USER_ID__SOURCE"))   ; Implicitly joined
+                                        lib/append-stage)
+          [category _source count0] (lib/visible-columns base2)
+          ;; Adding a second stage with: a filter on stage 0's count, its own count aggregation, and order-by
+          ;; (stage 1's) count, descending.
+          base3                     (-> base2
+                                        (lib/filter (lib/> count0 100))
+                                        (lib/aggregate (lib/count))
+                                        (lib/breakout category))
+          [_cat1 cnt1]              (lib/orderable-columns base3)
+          query                     (lib/order-by base3 cnt1 :desc)
+          [cnt0]                    (lib/aggregations query 0)]
+      (is (=? [:count {}]
+              cnt0))
+      ;; Deleting the :count aggregation from stage 0 should:
+      ;; - Removing the filter on stage 1, which references the :count from stage 0.
+      ;; - Preserve the order-by on stage 1, which references the :count from stage 1.
+      (is (=? (-> query
+                  (update-in [:stages 0 :aggregation] (comp vec rest))
+                  (update-in [:stages 1] dissoc :filters))
+              (lib/remove-clause query 0 cnt0))))))


### PR DESCRIPTION
Closes #59441.

### Description

Previously this was matching against the `returned-columns` of the
previous stage, but that's incorrect. Since we're trying to match stage
`k` refs we must match against stage `k` columns, not stage `k-1`.

### How to verify

Follow the repro in #59441 and see that it works now.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
