### PR TITLE
Fix error in `/api/activity/popular_items` when tables have been deleted

### DIFF
--- a/src/metabase/activity_feed/api.clj
+++ b/src/metabase/activity_feed/api.clj
@@ -78,7 +78,9 @@
                                              {:group-by  [:model :model_id]
                                               :where     [:and
                                                           [:= :context "view"]
-                                                          [:in :model #{"dashboard" "table"}]]
+                                                          [:in :model #{"dashboard" "table"}]
+                                                          [:or [:= :active true] [:= :active nil]]
+                                                          [:or [:= :archived false] [:= :archived nil]]]
                                               :order-by  [[:max_ts :desc] [:model :desc]]
                                               :limit     views-limit
                                               :left-join [[:report_dashboard :d]

--- a/test/metabase/activity_feed/api_test.clj
+++ b/test/metabase/activity_feed/api_test.clj
@@ -319,9 +319,16 @@
                                          :description "just another dashboard"
                                          :creator_id  (mt/user->id :crowberto)
                                          :view_count  5}
+                 :model/Dashboard archived-dash {:name        "archived-dashboard"
+                                                 :description "archived dashboard"
+                                                 :creator_id  (mt/user->id :crowberto)
+                                                 :view_count  5
+                                                 :archived true}
                  :model/Table     table1 {:name "rand-name"}
                  :model/Table     hidden-table {:name            "hidden table"
                                                 :visibility_type "hidden"}
+                 :model/Table     inactive-table {:name            "inactive table"
+                                                  :active false}
                  :model/Card      dataset {:name                   "rand-name"
                                            :type                   :model
                                            :creator_id             (mt/user->id :crowberto)
@@ -332,7 +339,7 @@
                                            :creator_id             (mt/user->id :crowberto)
                                            :display                "table"
                                            :visualization_settings {}}]
-    (let [test-ids (set (map :id [card1 archived dash1 dash2 table1 hidden-table dataset metric]))]
+    (let [test-ids (set (map :id [card1 archived dash1 dash2 table1 hidden-table dataset metric inactive-table archived-dash]))]
       (testing "Items viewed by multiple users are never duplicated in the popular items list."
         (mt/with-model-cleanup [:model/RecentViews :model/QueryExecution]
           (create-views! [[(mt/user->id :rasta)     "dashboard" (:id dash1)]
@@ -351,7 +358,9 @@
           (create-views! [[(mt/user->id :rasta) "dashboard" (:id dash1)]
                           [(mt/user->id :rasta) "card"      (:id card1)]
                           [(mt/user->id :rasta) "table"     (:id table1)]
-                          [(mt/user->id :rasta) "card"      (:id metric)]])
+                          [(mt/user->id :rasta) "card"      (:id metric)]
+                          [(mt/user->id :rasta) "table"      (:id inactive-table)]
+                          [(mt/user->id :rasta) "dashboard"      (:id archived-dash)]])
           (is (= [["dashboard" (:id dash1)]
                   ["card" (:id card1)]
                   ["metric" (:id metric)]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59477
### Description

If a warehouse table gets deleted, it breaks the popular-items API by coming through as a nil value in the returned list.

This PR updates the select query to exclude active=false values. While I was in there, I also updated the query to also exclude archived=true dashboards

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Add a table to your warehouse database and resync the schema
2. Visit the table in metabase and go back to the home page to see it show up on the list of items to explore
3. Drop the table in your warehouse database and resync the schema
4. Reload the home page and see that it loads correctly and doesn't include the dropped table anymore

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
