### PR TITLE
WRK-538: Fix examples in storybook docs

### DIFF
--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.mdx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.mdx
@@ -10,6 +10,4 @@ import * as UpsellBannerStories from "./UpsellBanner.stories";
 
 ## Examples
 
-<Canvas>
-  <Story of={UpsellBannerStories.Default} />
-</Canvas>
+<Canvas of={UpsellBannerStories.Default} />

--- a/frontend/src/metabase/admin/upsells/components/UpsellBigCard.mdx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBigCard.mdx
@@ -9,6 +9,4 @@ import * as UpsellBigCardStories from "./UpsellBigCard.stories";
 
 ## Examples
 
-<Canvas>
-  <Story of={UpsellBigCardStories.Default} />
-</Canvas>
+<Canvas of={UpsellBigCardStories.Default} />

--- a/frontend/src/metabase/admin/upsells/components/UpsellCard.mdx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCard.mdx
@@ -11,10 +11,6 @@ import * as UpsellCardStories from "./UpsellCard.stories";
 
 ## Examples
 
-<Canvas>
-  <Story of={UpsellCardStories.WithImage} />
-</Canvas>
+<Canvas of={UpsellCardStories.WithImage} />
 
-<Canvas>
-  <Story of={UpsellCardStories.WithoutImage} />
-</Canvas>
+<Canvas of={UpsellCardStories.WithoutImage} />

--- a/frontend/src/metabase/admin/upsells/components/UpsellPill.mdx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellPill.mdx
@@ -10,10 +10,6 @@ import * as UpsellPillStories from "./UpsellPill.stories";
 
 ## Examples
 
-<Canvas>
-  <Story of={UpsellPillStories.Default} />
-</Canvas>
+<Canvas of={UpsellPillStories.Default} />
 
-<Canvas>
-  <Story of={UpsellPillStories.Multiline} />
-</Canvas>
+<Canvas of={UpsellPillStories.Multiline} />

--- a/frontend/src/metabase/common/components/Sidesheet/Sidesheet.mdx
+++ b/frontend/src/metabase/common/components/Sidesheet/Sidesheet.mdx
@@ -25,36 +25,24 @@ import { TestTabbedSidesheet, TestPagedSidesheet } from "./Sidesheet.samples";
 
 // TODO: figure out how to get CSS modules working with storybook 🔥
 
-<Canvas>
-  <Story of={SidesheetStories.Default} />
-</Canvas>
+<Canvas of={SidesheetStories.Default} />
 
 ### With cards
 
-<Canvas>
-  <Story of={SidesheetStories.WithCards} />
-</Canvas>
+<Canvas of={SidesheetStories.WithCards} />
 
 ### With sectioned cards
 
-<Canvas>
-  <Story of={SidesheetStories.WithSectionedCards} />
-</Canvas>
+<Canvas of={SidesheetStories.WithSectionedCards} />
 
 ### With pages
 
-<Canvas>
-  <Story of={SidesheetStories.WithSubPages} />
-</Canvas>
+<Canvas of={SidesheetStories.WithSubPages} />
 
 ### With tabs
 
-<Canvas>
-  <Story of={SidesheetStories.WithTabs} />
-</Canvas>
+<Canvas of={SidesheetStories.WithTabs} />
 
 ### Sidesheet Buttons
 
-<Canvas>
-  <Story of={SidesheetStories.SidesheetButtons} />
-</Canvas>
+<Canvas of={SidesheetStories.SidesheetButtons} />

--- a/frontend/src/metabase/ui/components/buttons/Button/Button.mdx
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.mdx
@@ -44,96 +44,64 @@ Not to use:
 
 ## Examples
 
-<Canvas>
-  <Story of={ButtonStories.Default} />
-</Canvas>
+<Canvas of={ButtonStories.Default} />
 
 ### Button.Group
 
-<Canvas>
-  <Story of={ButtonStories.ButtonGroup} />
-</Canvas>
+<Canvas of={ButtonStories.ButtonGroup} />
 
 ### Default size
 
-<Canvas>
-  <Story of={ButtonStories.DefaultSize} />
-</Canvas>
+<Canvas of={ButtonStories.DefaultSize} />
 
 #### Custom color
 
-<Canvas>
-  <Story of={ButtonStories.DefaultSizeCustomColor} />
-</Canvas>
+<Canvas of={ButtonStories.DefaultSizeCustomColor} />
 
 #### Disabled state
 
-<Canvas>
-  <Story of={ButtonStories.DefaultSizeDisabled} />
-</Canvas>
+<Canvas of={ButtonStories.DefaultSizeDisabled} />
 
 #### Loading state
 
-<Canvas>
-  <Story of={ButtonStories.DefaultSizeLoading} />
-</Canvas>
+<Canvas of={ButtonStories.DefaultSizeLoading} />
 
 ### Default size & full width
 
-<Canvas>
-  <Story of={ButtonStories.DefaultSizeFullWidth} />
-</Canvas>
+<Canvas of={ButtonStories.DefaultSizeFullWidth} />
 
 #### Disabled state
 
-<Canvas>
-  <Story of={ButtonStories.DefaultSizeFullWidthDisabled} />
-</Canvas>
+<Canvas of={ButtonStories.DefaultSizeFullWidthDisabled} />
 
 #### Loading state
 
-<Canvas>
-  <Story of={ButtonStories.DefaultSizeFullWidthLoading} />
-</Canvas>
+<Canvas of={ButtonStories.DefaultSizeFullWidthLoading} />
 
 ### Compact size
 
-<Canvas>
-  <Story of={ButtonStories.CompactSize} />
-</Canvas>
+<Canvas of={ButtonStories.CompactSize} />
 
 #### Custom color
 
-<Canvas>
-  <Story of={ButtonStories.CompactSizeCustomColor} />
-</Canvas>
+<Canvas of={ButtonStories.CompactSizeCustomColor} />
 
 #### Disabled state
 
-<Canvas>
-  <Story of={ButtonStories.CompactSizeDisabled} />
-</Canvas>
+<Canvas of={ButtonStories.CompactSizeDisabled} />
 
 #### Loading state
 
-<Canvas>
-  <Story of={ButtonStories.CompactSizeLoading} />
-</Canvas>
+<Canvas of={ButtonStories.CompactSizeLoading} />
 
 ### Compact size & full width
 
-<Canvas>
-  <Story of={ButtonStories.CompactSizeFullWidth} />
-</Canvas>
+<Canvas of={ButtonStories.CompactSizeFullWidth} />
 
 #### Disabled state
 
-<Canvas>
-  <Story of={ButtonStories.CompactSizeFullWidthDisabled} />
-</Canvas>
+<Canvas of={ButtonStories.CompactSizeFullWidthDisabled} />
 
 #### Loading state
 
-<Canvas>
-  <Story of={ButtonStories.CompactSizeFullWidthLoading} />
-</Canvas>
+<Canvas of={ButtonStories.CompactSizeFullWidthLoading} />

--- a/frontend/src/metabase/ui/components/buttons/PopoverBackButton/PopoverBackButton.mdx
+++ b/frontend/src/metabase/ui/components/buttons/PopoverBackButton/PopoverBackButton.mdx
@@ -9,6 +9,4 @@ import * as PopoverBackButtonStories from "./PopoverBackButton.stories";
 
 ## Examples
 
-<Canvas>
-  <Story of={PopoverBackButtonStories.Default} />
-</Canvas>
+<Canvas of={PopoverBackButtonStories.Default} />

--- a/frontend/src/metabase/ui/components/data-display/Card/Card.mdx
+++ b/frontend/src/metabase/ui/components/data-display/Card/Card.mdx
@@ -15,24 +15,16 @@ Our themed wrapper around [Mantine Card](https://v6.mantine.dev/core/card/).
 
 ## Examples
 
-<Canvas>
-  <Story of={CardStories.Default} />
-</Canvas>
+<Canvas of={CardStories.Default} />
 
 ### Card border
 
-<Canvas>
-  <Story of={CardStories.Border} />
-</Canvas>
+<Canvas of={CardStories.Border} />
 
 ### Card.Section
 
-<Canvas>
-  <Story of={CardStories.CardSection} />
-</Canvas>
+<Canvas of={CardStories.CardSection} />
 
 ### Card.Section border
 
-<Canvas>
-  <Story of={CardStories.CardSectionBorder} />
-</Canvas>
+<Canvas of={CardStories.CardSectionBorder} />

--- a/frontend/src/metabase/ui/components/data-display/Image/Image.mdx
+++ b/frontend/src/metabase/ui/components/data-display/Image/Image.mdx
@@ -16,12 +16,8 @@ Our themed wrapper around [Mantine Image](https://v6.mantine.dev/core/image/).
 
 ## Examples
 
-<Canvas>
-  <Story of={ImageStories.Default} />
-</Canvas>
+<Canvas of={ImageStories.Default} />
 
 ### Image position
 
-<Canvas>
-  <Story of={ImageStories.BackgroundPosition} />
-</Canvas>
+<Canvas of={ImageStories.BackgroundPosition} />

--- a/frontend/src/metabase/ui/components/feedback/Alert/Alert.mdx
+++ b/frontend/src/metabase/ui/components/feedback/Alert/Alert.mdx
@@ -11,6 +11,4 @@ Show helpful alerts when things go sideways (or maybe it's a happy alert. It hap
 
 ## Examples
 
-<Canvas>
-  <Story of={AlertStories.Default} />
-</Canvas>
+<Canvas of={AlertStories.Default} />

--- a/frontend/src/metabase/ui/components/feedback/Loader/Loader.mdx
+++ b/frontend/src/metabase/ui/components/feedback/Loader/Loader.mdx
@@ -22,12 +22,8 @@ Our themed wrapper around [Mantine Loader](https://v6.mantine.dev/core/loader/).
 
 ## Examples
 
-<Canvas>
-  <Story of={LoaderStories.Default} />
-</Canvas>
+<Canvas of={LoaderStories.Default} />
 
 ### Sizes
 
-<Canvas>
-  <Story of={LoaderStories.Sizes} />
-</Canvas>
+<Canvas of={LoaderStories.Sizes} />

--- a/frontend/src/metabase/ui/components/feedback/Progress/Progress.mdx
+++ b/frontend/src/metabase/ui/components/feedback/Progress/Progress.mdx
@@ -15,6 +15,4 @@ Our themed wrapper around [Mantine Progress](https://v6.mantine.dev/core/progres
 
 ## Examples
 
-<Canvas>
-  <Story of={ProgressStories.Default} />
-</Canvas>
+<Canvas of={ProgressStories.Default} />

--- a/frontend/src/metabase/ui/components/icons/Icon/Icon.mdx
+++ b/frontend/src/metabase/ui/components/icons/Icon/Icon.mdx
@@ -12,12 +12,8 @@ Our component wrapper around SVG icons.
 
 ## Examples
 
-<Canvas>
-  <Story of={IconStories.Default} />
-</Canvas>
+<Canvas of={IconStories.Default} />
 
 ### List
 
-<Canvas>
-  <Story of={IconStories.List} />
-</Canvas>
+<Canvas of={IconStories.List} />

--- a/frontend/src/metabase/ui/components/inputs/Autocomplete/Autocomplete.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Autocomplete/Autocomplete.mdx
@@ -14,114 +14,76 @@ Our themed wrapper around [Mantine Autocomplete](https://v6.mantine.dev/core/aut
 
 ## Examples
 
-<Canvas>
-  <Story of={AutocompleteStories.Default} />
-</Canvas>
+<Canvas of={AutocompleteStories.Default} />
 
 ### Size - md
 
-<Canvas>
-  <Story of={AutocompleteStories.EmptyMd} />
-</Canvas>
+<Canvas of={AutocompleteStories.EmptyMd} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={AutocompleteStories.AsteriskMd} />
-</Canvas>
+<Canvas of={AutocompleteStories.AsteriskMd} />
 
 #### Description
 
-<Canvas>
-  <Story of={AutocompleteStories.DescriptionMd} />
-</Canvas>
+<Canvas of={AutocompleteStories.DescriptionMd} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={AutocompleteStories.DisabledMd} />
-</Canvas>
+<Canvas of={AutocompleteStories.DisabledMd} />
 
 #### Error
 
-<Canvas>
-  <Story of={AutocompleteStories.ErrorMd} />
-</Canvas>
+<Canvas of={AutocompleteStories.ErrorMd} />
 
 #### Read only
 
-<Canvas>
-  <Story of={AutocompleteStories.ReadOnlyMd} />
-</Canvas>
+<Canvas of={AutocompleteStories.ReadOnlyMd} />
 
 #### Icons
 
-<Canvas>
-  <Story of={AutocompleteStories.IconsMd} />
-</Canvas>
+<Canvas of={AutocompleteStories.IconsMd} />
 
 #### Groups
 
-<Canvas>
-  <Story of={AutocompleteStories.GroupsMd} />
-</Canvas>
+<Canvas of={AutocompleteStories.GroupsMd} />
 
 #### Large sets
 
-<Canvas>
-  <Story of={AutocompleteStories.LargeSetsMd} />
-</Canvas>
+<Canvas of={AutocompleteStories.LargeSetsMd} />
 
 ### Size - xs
 
-<Canvas>
-  <Story of={AutocompleteStories.EmptyXs} />
-</Canvas>
+<Canvas of={AutocompleteStories.EmptyXs} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={AutocompleteStories.AsteriskXs} />
-</Canvas>
+<Canvas of={AutocompleteStories.AsteriskXs} />
 
 #### Description
 
-<Canvas>
-  <Story of={AutocompleteStories.DescriptionXs} />
-</Canvas>
+<Canvas of={AutocompleteStories.DescriptionXs} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={AutocompleteStories.DisabledXs} />
-</Canvas>
+<Canvas of={AutocompleteStories.DisabledXs} />
 
 #### Error
 
-<Canvas>
-  <Story of={AutocompleteStories.ErrorXs} />
-</Canvas>
+<Canvas of={AutocompleteStories.ErrorXs} />
 
 #### Read only
 
-<Canvas>
-  <Story of={AutocompleteStories.ReadOnlyXs} />
-</Canvas>
+<Canvas of={AutocompleteStories.ReadOnlyXs} />
 
 #### Icons
 
-<Canvas>
-  <Story of={AutocompleteStories.IconsXs} />
-</Canvas>
+<Canvas of={AutocompleteStories.IconsXs} />
 
 #### Groups
 
-<Canvas>
-  <Story of={AutocompleteStories.GroupsXs} />
-</Canvas>
+<Canvas of={AutocompleteStories.GroupsXs} />
 
 #### Large sets
 
-<Canvas>
-  <Story of={AutocompleteStories.LargeSetsXs} />
-</Canvas>
+<Canvas of={AutocompleteStories.LargeSetsXs} />

--- a/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.mdx
@@ -25,45 +25,31 @@ Checkbox buttons allow users to select a single option from a list of mutually e
 
 ## Examples
 
-<Canvas>
-  <Story of={CheckboxStories.Default} />
-</Canvas>
+<Canvas of={CheckboxStories.Default} />
 
 ### Checkbox.Group
 
-<Canvas>
-  <Story of={CheckboxStories.CheckboxGroup} />
-</Canvas>
+<Canvas of={CheckboxStories.CheckboxGroup} />
 
 ### Label
 
-<Canvas>
-  <Story of={CheckboxStories.Label} />
-</Canvas>
+<Canvas of={CheckboxStories.Label} />
 
 #### Left label position
 
-<Canvas>
-  <Story of={CheckboxStories.LabelLeftPosition} />
-</Canvas>
+<Canvas of={CheckboxStories.LabelLeftPosition} />
 
 ### Description
 
-<Canvas>
-  <Story of={CheckboxStories.Description} />
-</Canvas>
+<Canvas of={CheckboxStories.Description} />
 
 #### Left label position
 
-<Canvas>
-  <Story of={CheckboxStories.DescriptionLeftPosition} />
-</Canvas>
+<Canvas of={CheckboxStories.DescriptionLeftPosition} />
 
 #### Stacked Variant
 
-<Canvas>
-  <Story of={CheckboxStories.Stacked} />
-</Canvas>
+<Canvas of={CheckboxStories.Stacked} />
 
 ## Related components
 

--- a/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.mdx
+++ b/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.mdx
@@ -16,114 +16,76 @@ Our themed wrapper around [Mantine DateInput](https://v6.mantine.dev/dates/date-
 
 ## Examples
 
-<Canvas>
-  <Story of={DateInputStories.Default} />
-</Canvas>
+<Canvas of={DateInputStories.Default} />
 
 ### Size - md
 
-<Canvas>
-  <Story of={DateInputStories.EmptyMd} />
-</Canvas>
+<Canvas of={DateInputStories.EmptyMd} />
 
 #### Filled
 
-<Canvas>
-  <Story of={DateInputStories.FilledMd} />
-</Canvas>
+<Canvas of={DateInputStories.FilledMd} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={DateInputStories.AsteriskMd} />
-</Canvas>
+<Canvas of={DateInputStories.AsteriskMd} />
 
 #### Description
 
-<Canvas>
-  <Story of={DateInputStories.DescriptionMd} />
-</Canvas>
+<Canvas of={DateInputStories.DescriptionMd} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={DateInputStories.DisabledMd} />
-</Canvas>
+<Canvas of={DateInputStories.DisabledMd} />
 
 #### Error
 
-<Canvas>
-  <Story of={DateInputStories.ErrorMd} />
-</Canvas>
+<Canvas of={DateInputStories.ErrorMd} />
 
 #### Icon
 
-<Canvas>
-  <Story of={DateInputStories.IconMd} />
-</Canvas>
+<Canvas of={DateInputStories.IconMd} />
 
 #### Read only
 
-<Canvas>
-  <Story of={DateInputStories.ReadOnlyMd} />
-</Canvas>
+<Canvas of={DateInputStories.ReadOnlyMd} />
 
 #### No popover
 
-<Canvas>
-  <Story of={DateInputStories.NoPopoverMd} />
-</Canvas>
+<Canvas of={DateInputStories.NoPopoverMd} />
 
 ### Size - xs
 
-<Canvas>
-  <Story of={DateInputStories.EmptyXs} />
-</Canvas>
+<Canvas of={DateInputStories.EmptyXs} />
 
 #### Filled
 
-<Canvas>
-  <Story of={DateInputStories.FilledXs} />
-</Canvas>
+<Canvas of={DateInputStories.FilledXs} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={DateInputStories.AsteriskXs} />
-</Canvas>
+<Canvas of={DateInputStories.AsteriskXs} />
 
 #### Description
 
-<Canvas>
-  <Story of={DateInputStories.DescriptionXs} />
-</Canvas>
+<Canvas of={DateInputStories.DescriptionXs} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={DateInputStories.DisabledXs} />
-</Canvas>
+<Canvas of={DateInputStories.DisabledXs} />
 
 #### Error
 
-<Canvas>
-  <Story of={DateInputStories.ErrorXs} />
-</Canvas>
+<Canvas of={DateInputStories.ErrorXs} />
 
 #### Icon
 
-<Canvas>
-  <Story of={DateInputStories.IconXs} />
-</Canvas>
+<Canvas of={DateInputStories.IconXs} />
 
 #### Read only
 
-<Canvas>
-  <Story of={DateInputStories.ReadOnlyXs} />
-</Canvas>
+<Canvas of={DateInputStories.ReadOnlyXs} />
 
 #### No popover
 
-<Canvas>
-  <Story of={DateInputStories.NoPopoverXs} />
-</Canvas>
+<Canvas of={DateInputStories.NoPopoverXs} />

--- a/frontend/src/metabase/ui/components/inputs/DatePicker/DatePicker.mdx
+++ b/frontend/src/metabase/ui/components/inputs/DatePicker/DatePicker.mdx
@@ -17,42 +17,28 @@ Our themed wrapper around [Mantine DatePicker](https://v6.mantine.dev/dates/date
 
 ## Examples
 
-<Canvas>
-  <Story of={DatePickerStories.Default} />
-</Canvas>
+<Canvas of={DatePickerStories.Default} />
 
 ### Allow deselect
 
-<Canvas>
-  <Story of={DatePickerStories.AllowDeselect} />
-</Canvas>
+<Canvas of={DatePickerStories.AllowDeselect} />
 
 ### Multiple dates
 
-<Canvas>
-  <Story of={DatePickerStories.MultipleDates} />
-</Canvas>
+<Canvas of={DatePickerStories.MultipleDates} />
 
 ### Dates range
 
-<Canvas>
-  <Story of={DatePickerStories.DatesRange} />
-</Canvas>
+<Canvas of={DatePickerStories.DatesRange} />
 
 ### Dates range (SDK theme)
 
-<Canvas>
-  <Story of={DatePickerStories.DatesRangeSdk} />
-</Canvas>
+<Canvas of={DatePickerStories.DatesRangeSdk} />
 
 ### Single date in range
 
-<Canvas>
-  <Story of={DatePickerStories.SingleDateInRange} />
-</Canvas>
+<Canvas of={DatePickerStories.SingleDateInRange} />
 
 ### Number of columns
 
-<Canvas>
-  <Story of={DatePickerStories.NumberOfColumns} />
-</Canvas>
+<Canvas of={DatePickerStories.NumberOfColumns} />

--- a/frontend/src/metabase/ui/components/inputs/FileInput/FileInput.mdx
+++ b/frontend/src/metabase/ui/components/inputs/FileInput/FileInput.mdx
@@ -15,78 +15,52 @@ Our themed wrapper around [Mantine FileInput](https://v6.mantine.dev/core/file-i
 
 ## Examples
 
-<Canvas>
-  <Story of={FileInputStories.Default} />
-</Canvas>
+<Canvas of={FileInputStories.Default} />
 
 ### Size - md
 
-<Canvas>
-  <Story of={FileInputStories.EmptyMd} />
-</Canvas>
+<Canvas of={FileInputStories.EmptyMd} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={FileInputStories.AsteriskMd} />
-</Canvas>
+<Canvas of={FileInputStories.AsteriskMd} />
 
 #### Description
 
-<Canvas>
-  <Story of={FileInputStories.DescriptionMd} />
-</Canvas>
+<Canvas of={FileInputStories.DescriptionMd} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={FileInputStories.DisabledMd} />
-</Canvas>
+<Canvas of={FileInputStories.DisabledMd} />
 
 #### Error
 
-<Canvas>
-  <Story of={FileInputStories.ErrorMd} />
-</Canvas>
+<Canvas of={FileInputStories.ErrorMd} />
 
 #### Left Section
 
-<Canvas>
-  <Story of={FileInputStories.IconMd} />
-</Canvas>
+<Canvas of={FileInputStories.IconMd} />
 
 ### Size - xs
 
-<Canvas>
-  <Story of={FileInputStories.EmptyXs} />
-</Canvas>
+<Canvas of={FileInputStories.EmptyXs} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={FileInputStories.AsteriskXs} />
-</Canvas>
+<Canvas of={FileInputStories.AsteriskXs} />
 
 #### Description
 
-<Canvas>
-  <Story of={FileInputStories.DescriptionXs} />
-</Canvas>
+<Canvas of={FileInputStories.DescriptionXs} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={FileInputStories.DisabledXs} />
-</Canvas>
+<Canvas of={FileInputStories.DisabledXs} />
 
 #### Error
 
-<Canvas>
-  <Story of={FileInputStories.ErrorXs} />
-</Canvas>
+<Canvas of={FileInputStories.ErrorXs} />
 
 #### Icon
 
-<Canvas>
-  <Story of={FileInputStories.IconXs} />
-</Canvas>
+<Canvas of={FileInputStories.IconXs} />

--- a/frontend/src/metabase/ui/components/inputs/MonthPicker/MonthPicker.mdx
+++ b/frontend/src/metabase/ui/components/inputs/MonthPicker/MonthPicker.mdx
@@ -15,12 +15,8 @@ Our themed wrapper around [Mantine MonthPicker](https://v6.mantine.dev/dates/mon
 
 ## Examples
 
-<Canvas>
-  <Story of={MonthPickerStories.Default} />
-</Canvas>
+<Canvas of={MonthPickerStories.Default} />
 
 ### Allow deselect
 
-<Canvas>
-  <Story of={MonthPickerStories.AllowDeselect} />
-</Canvas>
+<Canvas of={MonthPickerStories.AllowDeselect} />

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.mdx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.mdx
@@ -15,150 +15,100 @@ Our themed wrapper around [Mantine MultiSelect](https://v6.mantine.dev/core/mult
 
 ## Examples
 
-<Canvas>
-  <Story of={MultiSelectStories.Default} />
-</Canvas>
+<Canvas of={MultiSelectStories.Default} />
 
 ### Size - md
 
-<Canvas>
-  <Story of={MultiSelectStories.EmptyMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.EmptyMd} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={MultiSelectStories.AsteriskMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.AsteriskMd} />
 
 #### Clearable
 
-<Canvas>
-  <Story of={MultiSelectStories.ClearableMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.ClearableMd} />
 
 #### Description
 
-<Canvas>
-  <Story of={MultiSelectStories.DescriptionMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.DescriptionMd} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={MultiSelectStories.DisabledMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.DisabledMd} />
 
 #### Error
 
-<Canvas>
-  <Story of={MultiSelectStories.ErrorMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.ErrorMd} />
 
 #### Read only
 
-<Canvas>
-  <Story of={MultiSelectStories.ReadOnlyMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.ReadOnlyMd} />
 
 #### Icons
 
-<Canvas>
-  <Story of={MultiSelectStories.IconsMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.IconsMd} />
 
 #### Groups
 
-<Canvas>
-  <Story of={MultiSelectStories.GroupsMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.GroupsMd} />
 
 #### Large sets
 
-<Canvas>
-  <Story of={MultiSelectStories.LargeSetsMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.LargeSetsMd} />
 
 #### Searchable
 
-<Canvas>
-  <Story of={MultiSelectStories.SearchableMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.SearchableMd} />
 
 #### Creatable
 
-<Canvas>
-  <Story of={MultiSelectStories.CreatableMd} />
-</Canvas>
+<Canvas of={MultiSelectStories.CreatableMd} />
 
 ### Size - xs
 
-<Canvas>
-  <Story of={MultiSelectStories.EmptyXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.EmptyXs} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={MultiSelectStories.AsteriskXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.AsteriskXs} />
 
 #### Clearable
 
-<Canvas>
-  <Story of={MultiSelectStories.ClearableXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.ClearableXs} />
 
 #### Description
 
-<Canvas>
-  <Story of={MultiSelectStories.DescriptionXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.DescriptionXs} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={MultiSelectStories.DisabledXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.DisabledXs} />
 
 #### Error
 
-<Canvas>
-  <Story of={MultiSelectStories.ErrorXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.ErrorXs} />
 
 #### Read only
 
-<Canvas>
-  <Story of={MultiSelectStories.ReadOnlyXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.ReadOnlyXs} />
 
 #### Icons
 
-<Canvas>
-  <Story of={MultiSelectStories.IconsXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.IconsXs} />
 
 #### Groups
 
-<Canvas>
-  <Story of={MultiSelectStories.GroupsXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.GroupsXs} />
 
 #### Large sets
 
-<Canvas>
-  <Story of={MultiSelectStories.LargeSetsXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.LargeSetsXs} />
 
 #### Searchable
 
-<Canvas>
-  <Story of={MultiSelectStories.SearchableXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.SearchableXs} />
 
 #### Creatable
 
-<Canvas>
-  <Story of={MultiSelectStories.CreatableXs} />
-</Canvas>
+<Canvas of={MultiSelectStories.CreatableXs} />

--- a/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.mdx
+++ b/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.mdx
@@ -17,102 +17,68 @@ Our themed wrapper around [Mantine NumberInput](https://v6.mantine.dev/core/numb
 
 ## Examples
 
-<Canvas>
-  <Story of={NumberInputStories.Default} />
-</Canvas>
+<Canvas of={NumberInputStories.Default} />
 
 ### Size - md
 
-<Canvas>
-  <Story of={NumberInputStories.EmptyMd} />
-</Canvas>
+<Canvas of={NumberInputStories.EmptyMd} />
 
 #### Filled
 
-<Canvas>
-  <Story of={NumberInputStories.FilledMd} />
-</Canvas>
+<Canvas of={NumberInputStories.FilledMd} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={NumberInputStories.AsteriskMd} />
-</Canvas>
+<Canvas of={NumberInputStories.AsteriskMd} />
 
 #### Description
 
-<Canvas>
-  <Story of={NumberInputStories.DescriptionMd} />
-</Canvas>
+<Canvas of={NumberInputStories.DescriptionMd} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={NumberInputStories.DisabledMd} />
-</Canvas>
+<Canvas of={NumberInputStories.DisabledMd} />
 
 #### Error
 
-<Canvas>
-  <Story of={NumberInputStories.ErrorMd} />
-</Canvas>
+<Canvas of={NumberInputStories.ErrorMd} />
 
 #### Icon
 
-<Canvas>
-  <Story of={NumberInputStories.IconMd} />
-</Canvas>
+<Canvas of={NumberInputStories.IconMd} />
 
 #### Read only
 
-<Canvas>
-  <Story of={NumberInputStories.ReadOnlyMd} />
-</Canvas>
+<Canvas of={NumberInputStories.ReadOnlyMd} />
 
 ### Size - xs
 
-<Canvas>
-  <Story of={NumberInputStories.EmptyXs} />
-</Canvas>
+<Canvas of={NumberInputStories.EmptyXs} />
 
 #### Filled
 
-<Canvas>
-  <Story of={NumberInputStories.FilledXs} />
-</Canvas>
+<Canvas of={NumberInputStories.FilledXs} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={NumberInputStories.AsteriskXs} />
-</Canvas>
+<Canvas of={NumberInputStories.AsteriskXs} />
 
 #### Description
 
-<Canvas>
-  <Story of={NumberInputStories.DescriptionXs} />
-</Canvas>
+<Canvas of={NumberInputStories.DescriptionXs} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={NumberInputStories.DisabledXs} />
-</Canvas>
+<Canvas of={NumberInputStories.DisabledXs} />
 
 #### Error
 
-<Canvas>
-  <Story of={NumberInputStories.ErrorXs} />
-</Canvas>
+<Canvas of={NumberInputStories.ErrorXs} />
 
 #### Icon
 
-<Canvas>
-  <Story of={NumberInputStories.IconXs} />
-</Canvas>
+<Canvas of={NumberInputStories.IconXs} />
 
 #### Read only
 
-<Canvas>
-  <Story of={NumberInputStories.ReadOnlyXs} />
-</Canvas>
+<Canvas of={NumberInputStories.ReadOnlyXs} />

--- a/frontend/src/metabase/ui/components/inputs/QuarterPicker/QuarterPicker.mdx
+++ b/frontend/src/metabase/ui/components/inputs/QuarterPicker/QuarterPicker.mdx
@@ -15,12 +15,8 @@ A version of [Mantine MonthPicker](https://v6.mantine.dev/dates/month-picker/) t
 
 ## Examples
 
-<Canvas>
-  <Story of={QuarterPickerStories.Default} />
-</Canvas>
+<Canvas of={QuarterPickerStories.Default} />
 
 ### Allow deselect
 
-<Canvas>
-  <Story of={QuarterPickerStories.AllowDeselect} />
-</Canvas>
+<Canvas of={QuarterPickerStories.AllowDeselect} />

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.mdx
@@ -25,39 +25,27 @@ Radio buttons allow users to select a single option from a list of mutually excl
 
 ## Examples
 
-<Canvas>
-  <Story of={RadioStories.Default} />
-</Canvas>
+<Canvas of={RadioStories.Default} />
 
 ### Radio.Group
 
-<Canvas>
-  <Story of={RadioStories.RadioGroup} />
-</Canvas>
+<Canvas of={RadioStories.RadioGroup} />
 
 ### Label
 
-<Canvas>
-  <Story of={RadioStories.Label} />
-</Canvas>
+<Canvas of={RadioStories.Label} />
 
 #### Left label position
 
-<Canvas>
-  <Story of={RadioStories.LabelLeftPosition} />
-</Canvas>
+<Canvas of={RadioStories.LabelLeftPosition} />
 
 ### Description
 
-<Canvas>
-  <Story of={RadioStories.Description} />
-</Canvas>
+<Canvas of={RadioStories.Description} />
 
 #### Left label position
 
-<Canvas>
-  <Story of={RadioStories.DescriptionLeftPosition} />
-</Canvas>
+<Canvas of={RadioStories.DescriptionLeftPosition} />
 
 ## Related components
 

--- a/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.mdx
+++ b/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.mdx
@@ -15,18 +15,12 @@ Our themed wrapper around [Mantine SegmentedControl](https://mantine.dev/core/se
 
 ## Examples
 
-<Canvas>
-  <Story of={SegmentedControlStories.Default} />
-</Canvas>
+<Canvas of={SegmentedControlStories.Default} />
 
 ### Full width
 
-<Canvas>
-  <Story of={SegmentedControlStories.FullWidth} />
-</Canvas>
+<Canvas of={SegmentedControlStories.FullWidth} />
 
 ## Colors
 
-<Canvas>
-  <Story of={SegmentedControlStories.Color} />
-</Canvas>
+<Canvas of={SegmentedControlStories.Color} />

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.mdx
@@ -15,138 +15,92 @@ Our themed wrapper around [Mantine Select](https://v6.mantine.dev/core/select/).
 
 ## Examples
 
-<Canvas>
-  <Story of={SelectStories.Default} />
-</Canvas>
+<Canvas of={SelectStories.Default} />
 
 ### Size - md
 
-<Canvas>
-  <Story of={SelectStories.EmptyMd} />
-</Canvas>
+<Canvas of={SelectStories.EmptyMd} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={SelectStories.AsteriskMd} />
-</Canvas>
+<Canvas of={SelectStories.AsteriskMd} />
 
 #### Clearable
 
-<Canvas>
-  <Story of={SelectStories.ClearableMd} />
-</Canvas>
+<Canvas of={SelectStories.ClearableMd} />
 
 #### Description
 
-<Canvas>
-  <Story of={SelectStories.DescriptionMd} />
-</Canvas>
+<Canvas of={SelectStories.DescriptionMd} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={SelectStories.DisabledMd} />
-</Canvas>
+<Canvas of={SelectStories.DisabledMd} />
 
 #### Error
 
-<Canvas>
-  <Story of={SelectStories.ErrorMd} />
-</Canvas>
+<Canvas of={SelectStories.ErrorMd} />
 
 #### Read only
 
-<Canvas>
-  <Story of={SelectStories.ReadOnlyMd} />
-</Canvas>
+<Canvas of={SelectStories.ReadOnlyMd} />
 
 #### Icons
 
-<Canvas>
-  <Story of={SelectStories.IconsMd} />
-</Canvas>
+<Canvas of={SelectStories.IconsMd} />
 
 #### Groups
 
-<Canvas>
-  <Story of={SelectStories.GroupsMd} />
-</Canvas>
+<Canvas of={SelectStories.GroupsMd} />
 
 #### Large sets
 
-<Canvas>
-  <Story of={SelectStories.LargeSetsMd} />
-</Canvas>
+<Canvas of={SelectStories.LargeSetsMd} />
 
 #### Searchable
 
-<Canvas>
-  <Story of={SelectStories.SearchableMd} />
-</Canvas>
+<Canvas of={SelectStories.SearchableMd} />
 
 ### Size - xs
 
-<Canvas>
-  <Story of={SelectStories.EmptyXs} />
-</Canvas>
+<Canvas of={SelectStories.EmptyXs} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={SelectStories.AsteriskXs} />
-</Canvas>
+<Canvas of={SelectStories.AsteriskXs} />
 
 #### Clearable
 
-<Canvas>
-  <Story of={SelectStories.ClearableXs} />
-</Canvas>
+<Canvas of={SelectStories.ClearableXs} />
 
 #### Description
 
-<Canvas>
-  <Story of={SelectStories.DescriptionXs} />
-</Canvas>
+<Canvas of={SelectStories.DescriptionXs} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={SelectStories.DisabledXs} />
-</Canvas>
+<Canvas of={SelectStories.DisabledXs} />
 
 #### Error
 
-<Canvas>
-  <Story of={SelectStories.ErrorXs} />
-</Canvas>
+<Canvas of={SelectStories.ErrorXs} />
 
 #### Read only
 
-<Canvas>
-  <Story of={SelectStories.ReadOnlyXs} />
-</Canvas>
+<Canvas of={SelectStories.ReadOnlyXs} />
 
 #### Icons
 
-<Canvas>
-  <Story of={SelectStories.IconsXs} />
-</Canvas>
+<Canvas of={SelectStories.IconsXs} />
 
 #### Groups
 
-<Canvas>
-  <Story of={SelectStories.GroupsXs} />
-</Canvas>
+<Canvas of={SelectStories.GroupsXs} />
 
 #### Large sets
 
-<Canvas>
-  <Story of={SelectStories.LargeSetsXs} />
-</Canvas>
+<Canvas of={SelectStories.LargeSetsXs} />
 
 #### Searchable
 
-<Canvas>
-  <Story of={SelectStories.SearchableXs} />
-</Canvas>
+<Canvas of={SelectStories.SearchableXs} />

--- a/frontend/src/metabase/ui/components/inputs/Switch/Switch.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Switch/Switch.mdx
@@ -24,30 +24,20 @@ In most situations you should use the `md` size variant, with the label on the l
 
 ## Examples
 
-<Canvas>
-  <Story of={SwitchStories.Default} />
-</Canvas>
+<Canvas of={SwitchStories.Default} />
 
 ### Label
 
-<Canvas>
-  <Story of={SwitchStories.Label} />
-</Canvas>
+<Canvas of={SwitchStories.Label} />
 
 ### Left label position
 
-<Canvas>
-  <Story of={SwitchStories.LabelLeftPosition} />
-</Canvas>
+<Canvas of={SwitchStories.LabelLeftPosition} />
 
 ### Description
 
-<Canvas>
-  <Story of={SwitchStories.Description} />
-</Canvas>
+<Canvas of={SwitchStories.Description} />
 
 ### Left description position
 
-<Canvas>
-  <Story of={SwitchStories.DescriptionLeftPosition} />
-</Canvas>
+<Canvas of={SwitchStories.DescriptionLeftPosition} />

--- a/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.mdx
+++ b/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.mdx
@@ -16,114 +16,76 @@ Our themed wrapper around [Mantine TextInput](https://v6.mantine.dev/core/text-i
 
 ## Examples
 
-<Canvas>
-  <Story of={TextInputStories.Default} />
-</Canvas>
+<Canvas of={TextInputStories.Default} />
 
 ### Size - md
 
-<Canvas>
-  <Story of={TextInputStories.EmptyMd} />
-</Canvas>
+<Canvas of={TextInputStories.EmptyMd} />
 
 #### Filled
 
-<Canvas>
-  <Story of={TextInputStories.FilledMd} />
-</Canvas>
+<Canvas of={TextInputStories.FilledMd} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={TextInputStories.AsteriskMd} />
-</Canvas>
+<Canvas of={TextInputStories.AsteriskMd} />
 
 #### Description
 
-<Canvas>
-  <Story of={TextInputStories.DescriptionMd} />
-</Canvas>
+<Canvas of={TextInputStories.DescriptionMd} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={TextInputStories.DisabledMd} />
-</Canvas>
+<Canvas of={TextInputStories.DisabledMd} />
 
 #### Error
 
-<Canvas>
-  <Story of={TextInputStories.ErrorMd} />
-</Canvas>
+<Canvas of={TextInputStories.ErrorMd} />
 
 #### Icon
 
-<Canvas>
-  <Story of={TextInputStories.IconMd} />
-</Canvas>
+<Canvas of={TextInputStories.IconMd} />
 
 #### Right section
 
-<Canvas>
-  <Story of={TextInputStories.RightSectionMd} />
-</Canvas>
+<Canvas of={TextInputStories.RightSectionMd} />
 
 #### Read only
 
-<Canvas>
-  <Story of={TextInputStories.ReadOnlyMd} />
-</Canvas>
+<Canvas of={TextInputStories.ReadOnlyMd} />
 
 ### Size - xs
 
-<Canvas>
-  <Story of={TextInputStories.EmptyXs} />
-</Canvas>
+<Canvas of={TextInputStories.EmptyXs} />
 
 #### Filled
 
-<Canvas>
-  <Story of={TextInputStories.FilledXs} />
-</Canvas>
+<Canvas of={TextInputStories.FilledXs} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={TextInputStories.AsteriskXs} />
-</Canvas>
+<Canvas of={TextInputStories.AsteriskXs} />
 
 #### Description
 
-<Canvas>
-  <Story of={TextInputStories.DescriptionXs} />
-</Canvas>
+<Canvas of={TextInputStories.DescriptionXs} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={TextInputStories.DisabledXs} />
-</Canvas>
+<Canvas of={TextInputStories.DisabledXs} />
 
 #### Error
 
-<Canvas>
-  <Story of={TextInputStories.ErrorXs} />
-</Canvas>
+<Canvas of={TextInputStories.ErrorXs} />
 
 #### Icon
 
-<Canvas>
-  <Story of={TextInputStories.IconXs} />
-</Canvas>
+<Canvas of={TextInputStories.IconXs} />
 
 #### Right section
 
-<Canvas>
-  <Story of={TextInputStories.RightSectionXs} />
-</Canvas>
+<Canvas of={TextInputStories.RightSectionXs} />
 
 #### Read only
 
-<Canvas>
-  <Story of={TextInputStories.ReadOnlyXs} />
-</Canvas>
+<Canvas of={TextInputStories.ReadOnlyXs} />

--- a/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.mdx
@@ -15,102 +15,68 @@ Our themed wrapper around [Mantine Textarea](https://v6.mantine.dev/core/textare
 
 ## Examples
 
-<Canvas>
-  <Story of={TextareaStories.Default} />
-</Canvas>
+<Canvas of={TextareaStories.Default} />
 
 ### Size - md
 
-<Canvas>
-  <Story of={TextareaStories.EmptyMd} />
-</Canvas>
+<Canvas of={TextareaStories.EmptyMd} />
 
 #### Filled
 
-<Canvas>
-  <Story of={TextareaStories.FilledMd} />
-</Canvas>
+<Canvas of={TextareaStories.FilledMd} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={TextareaStories.AsteriskMd} />
-</Canvas>
+<Canvas of={TextareaStories.AsteriskMd} />
 
 #### Description
 
-<Canvas>
-  <Story of={TextareaStories.DescriptionMd} />
-</Canvas>
+<Canvas of={TextareaStories.DescriptionMd} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={TextareaStories.DisabledMd} />
-</Canvas>
+<Canvas of={TextareaStories.DisabledMd} />
 
 #### Error
 
-<Canvas>
-  <Story of={TextareaStories.ErrorMd} />
-</Canvas>
+<Canvas of={TextareaStories.ErrorMd} />
 
 #### Read only
 
-<Canvas>
-  <Story of={TextareaStories.ReadOnlyMd} />
-</Canvas>
+<Canvas of={TextareaStories.ReadOnlyMd} />
 
 #### Autosize
 
-<Canvas>
-  <Story of={TextareaStories.AutosizeMd} />
-</Canvas>
+<Canvas of={TextareaStories.AutosizeMd} />
 
 ### Size - xs
 
-<Canvas>
-  <Story of={TextareaStories.EmptyXs} />
-</Canvas>
+<Canvas of={TextareaStories.EmptyXs} />
 
 #### Filled
 
-<Canvas>
-  <Story of={TextareaStories.FilledXs} />
-</Canvas>
+<Canvas of={TextareaStories.FilledXs} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={TextareaStories.AsteriskXs} />
-</Canvas>
+<Canvas of={TextareaStories.AsteriskXs} />
 
 #### Description
 
-<Canvas>
-  <Story of={TextareaStories.DescriptionXs} />
-</Canvas>
+<Canvas of={TextareaStories.DescriptionXs} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={TextareaStories.DisabledXs} />
-</Canvas>
+<Canvas of={TextareaStories.DisabledXs} />
 
 #### Error
 
-<Canvas>
-  <Story of={TextareaStories.ErrorXs} />
-</Canvas>
+<Canvas of={TextareaStories.ErrorXs} />
 
 #### Read only
 
-<Canvas>
-  <Story of={TextareaStories.ReadOnlyXs} />
-</Canvas>
+<Canvas of={TextareaStories.ReadOnlyXs} />
 
 #### Autosize
 
-<Canvas>
-  <Story of={TextareaStories.AutosizeXs} />
-</Canvas>
+<Canvas of={TextareaStories.AutosizeXs} />

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.mdx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.mdx
@@ -15,90 +15,60 @@ Our themed wrapper around [Mantine TimeInput](https://v6.mantine.dev/dates/time-
 
 # Examples
 
-<Canvas>
-  <Story of={TimeInputStories.Default} />
-</Canvas>
+<Canvas of={TimeInputStories.Default} />
 
 ### Size - md
 
-<Canvas>
-  <Story of={TimeInputStories.EmptyMd} />
-</Canvas>
+<Canvas of={TimeInputStories.EmptyMd} />
 
 #### Filled
 
-<Canvas>
-  <Story of={TimeInputStories.FilledMd} />
-</Canvas>
+<Canvas of={TimeInputStories.FilledMd} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={TimeInputStories.AsteriskMd} />
-</Canvas>
+<Canvas of={TimeInputStories.AsteriskMd} />
 
 #### Description
 
-<Canvas>
-  <Story of={TimeInputStories.DescriptionMd} />
-</Canvas>
+<Canvas of={TimeInputStories.DescriptionMd} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={TimeInputStories.DisabledMd} />
-</Canvas>
+<Canvas of={TimeInputStories.DisabledMd} />
 
 #### Error
 
-<Canvas>
-  <Story of={TimeInputStories.ErrorMd} />
-</Canvas>
+<Canvas of={TimeInputStories.ErrorMd} />
 
 #### Read only
 
-<Canvas>
-  <Story of={TimeInputStories.ReadOnlyMd} />
-</Canvas>
+<Canvas of={TimeInputStories.ReadOnlyMd} />
 
 ### Size - xs
 
-<Canvas>
-  <Story of={TimeInputStories.EmptyXs} />
-</Canvas>
+<Canvas of={TimeInputStories.EmptyXs} />
 
 #### Filled
 
-<Canvas>
-  <Story of={TimeInputStories.FilledXs} />
-</Canvas>
+<Canvas of={TimeInputStories.FilledXs} />
 
 #### Asterisk
 
-<Canvas>
-  <Story of={TimeInputStories.AsteriskXs} />
-</Canvas>
+<Canvas of={TimeInputStories.AsteriskXs} />
 
 #### Description
 
-<Canvas>
-  <Story of={TimeInputStories.DescriptionXs} />
-</Canvas>
+<Canvas of={TimeInputStories.DescriptionXs} />
 
 #### Disabled
 
-<Canvas>
-  <Story of={TimeInputStories.DisabledXs} />
-</Canvas>
+<Canvas of={TimeInputStories.DisabledXs} />
 
 #### Error
 
-<Canvas>
-  <Story of={TimeInputStories.ErrorXs} />
-</Canvas>
+<Canvas of={TimeInputStories.ErrorXs} />
 
 #### Read only
 
-<Canvas>
-  <Story of={TimeInputStories.ReadOnlyXs} />
-</Canvas>
+<Canvas of={TimeInputStories.ReadOnlyXs} />

--- a/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.mdx
+++ b/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.mdx
@@ -17,20 +17,12 @@ Our themed wrapper around [Mantine Tabs](https://v6.mantine.dev/core/tabs/).
 
 ## Examples
 
-<Canvas>
-  <Story of={TabsStories.Default} />
-</Canvas>
+<Canvas of={TabsStories.Default} />
 
-<Canvas>
-  <Story of={TabsStories.Icons} />
-</Canvas>
+<Canvas of={TabsStories.Icons} />
 
 ### Vertical orientation
 
-<Canvas>
-  <Story of={TabsStories.VerticalOrientation} />
-</Canvas>
+<Canvas of={TabsStories.VerticalOrientation} />
 
-<Canvas>
-  <Story of={TabsStories.VerticalOrientationIcons} />
-</Canvas>
+<Canvas of={TabsStories.VerticalOrientationIcons} />

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.mdx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.mdx
@@ -1,13 +1,13 @@
 import { Fragment } from "react";
 import { Canvas, Story, Meta } from "@storybook/blocks";
 import {
-  Box,
-  Button,
-  Flex,
-  HoverCard,
-  Text,
-  TextInput,
-  Stack,
+Box,
+Button,
+Flex,
+HoverCard,
+Text,
+TextInput,
+Stack,
 } from "metabase/ui";
 import * as HoverCardStories from "./HoverCard.stories";
 
@@ -23,7 +23,6 @@ Our themed wrapper around [Mantine HoverCard](https://v6.mantine.dev/core/hover-
 
 ## Examples
 
-<Canvas>
-  <Story of={HoverCardStories.Default} />
-  <Story of={HoverCardStories.InteractiveContent} />
-</Canvas>
+<Canvas of={HoverCardStories.Default} />
+
+<Canvas of={HoverCardStories.InteractiveContent} />

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.mdx
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.mdx
@@ -44,24 +44,16 @@ Not to use:
 
 ## Examples
 
-<Canvas>
-  <Story of={MenuStories.Default} />
-</Canvas>
+<Canvas of={MenuStories.Default} />
 
 ### Right section
 
-<Canvas>
-  <Story of={MenuStories.RightSection} />
-</Canvas>
+<Canvas of={MenuStories.RightSection} />
 
 ### Icons
 
-<Canvas>
-  <Story of={MenuStories.Icons} />
-</Canvas>
+<Canvas of={MenuStories.Icons} />
 
 ### Labels and dividers
 
-<Canvas>
-  <Story of={MenuStories.LabelsAndDividers} />
-</Canvas>
+<Canvas of={MenuStories.LabelsAndDividers} />

--- a/frontend/src/metabase/ui/components/overlays/Modal/Modal.mdx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/Modal.mdx
@@ -20,17 +20,13 @@ Our themed wrapper around [Mantine Modal](https://v6.mantine.dev/core/modal/).
 
 Sentence-case fits the friendly, casual personality of Metabase. This means it should be `Add to dashboard` instead of `Add To Dashboard` for example.
 
-<Canvas>
-  <Story of={ModalStories.SentenceCaseTitles} />
-</Canvas>
+<Canvas of={ModalStories.SentenceCaseTitles} />
 
 ### Headings for confirmation modals should always be a question, and the body text should elaborate on the consequences
 
 E.g.,`Delete this database?` with body copy that contains clarifying information about what will happen if this action is taken, e.g., `This can't be undone, and questions that rely on this data will no longer work.`
 
-<Canvas>
-  <Story of={ModalStories.Confirmation} />
-</Canvas>
+<Canvas of={ModalStories.Confirmation} />
 
 ### Buttons should be right-aligned, with the primary action on the far right
 
@@ -74,14 +70,10 @@ There are few legitimate cases where a modal should have more than two buttons. 
 
 It’s okay for a modal to have only a single button. Here’s an example:
 
-<Canvas>
-  <Story of={ModalStories.SingleButton} />
-</Canvas>
+<Canvas of={ModalStories.SingleButton} />
 
 ### It’s okay if a modal doesn’t have body text
 
 Sometimes it’s not necessary. Here's a modal with a heading, but no body text.
 
-<Canvas>
-  <Story of={ModalStories.NoBodyText} />
-</Canvas>
+<Canvas of={ModalStories.NoBodyText} />

--- a/frontend/src/metabase/ui/components/overlays/Popover/Popover.mdx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/Popover.mdx
@@ -1,13 +1,13 @@
 import { Fragment } from "react";
 import { Canvas, Story, Meta } from "@storybook/blocks";
 import {
-  Box,
-  Button,
-  Flex,
-  Popover,
-  Text,
-  TextInput,
-  Stack,
+Box,
+Button,
+Flex,
+Popover,
+Text,
+TextInput,
+Stack,
 } from "metabase/ui";
 import * as PopoverStories from "./Popover.stories";
 
@@ -23,7 +23,6 @@ Our themed wrapper around [Mantine Popover](https://v6.mantine.dev/core/popover/
 
 ## Examples
 
-<Canvas>
-  <Story of={PopoverStories.Default} />
-  <Story of={PopoverStories.InteractiveContent} />
-</Canvas>
+<Canvas of={PopoverStories.Default} />
+
+<Canvas of={PopoverStories.InteractiveContent} />

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.mdx
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.mdx
@@ -15,6 +15,4 @@ Our themed wrapper around [Mantine Tooltip](https://v6.mantine.dev/core/tooltip/
 
 ## Examples
 
-<Canvas>
-  <Story of={TooltipStories.Default} />
-</Canvas>
+<Canvas of={TooltipStories.Default} />

--- a/frontend/src/metabase/ui/components/typography/Anchor/Anchor.mdx
+++ b/frontend/src/metabase/ui/components/typography/Anchor/Anchor.mdx
@@ -20,15 +20,11 @@ The Anchor component allows users to display links with themed styles, and repla
 
 ## Examples
 
-<Canvas>
-  <Story of={AnchorStories.Default} />
-</Canvas>
+<Canvas of={AnchorStories.Default} />
 
 ### Sizes
 
-<Canvas>
-  <Story of={AnchorStories.Sizes} />
-</Canvas>
+<Canvas of={AnchorStories.Sizes} />
 
 ## Related components
 

--- a/frontend/src/metabase/ui/components/typography/List/List.mdx
+++ b/frontend/src/metabase/ui/components/typography/List/List.mdx
@@ -9,10 +9,6 @@ import * as ListStories from "./List.stories";
 
 Our themed wrapper around [Mantine List](https://v6.mantine.dev/core/list/).
 
-<Canvas>
-  <Story of={ListStories.Default} />
-</Canvas>
+<Canvas of={ListStories.Default} />
 
-<Canvas>
-  <Story of={ListStories.WithIcons} />
-</Canvas>
+<Canvas of={ListStories.WithIcons} />

--- a/frontend/src/metabase/ui/components/typography/Text/Text.mdx
+++ b/frontend/src/metabase/ui/components/typography/Text/Text.mdx
@@ -20,27 +20,19 @@ The Text component allows users to display text with themed styles, and replaces
 
 ## Examples
 
-<Canvas>
-  <Story of={TextStories.Default} />
-</Canvas>
+<Canvas of={TextStories.Default} />
 
 ### Sizes
 
-<Canvas>
-  <Story of={TextStories.Sizes} />
-</Canvas>
+<Canvas of={TextStories.Sizes} />
 
 ### Multiline
 
-<Canvas>
-  <Story of={TextStories.Multiline} />
-</Canvas>
+<Canvas of={TextStories.Multiline} />
 
 ### Truncated
 
-<Canvas>
-  <Story of={TextStories.Truncated} />
-</Canvas>
+<Canvas of={TextStories.Truncated} />
 
 ## Related components
 

--- a/frontend/src/metabase/ui/components/typography/Title/Title.mdx
+++ b/frontend/src/metabase/ui/components/typography/Title/Title.mdx
@@ -19,30 +19,8 @@ TBD
 
 ## Examples
 
-<Canvas>
-  <Story of={TitleStories.Default} />
-</Canvas>
+<Canvas of={TitleStories.Default} />
 
 ### Sizes
 
-<Canvas>
-  <Story of={TitleStories.Sizes} />
-</Canvas>
-
-### Underlined
-
-{/* <Canvas>
-  <Story of={TitleStories.Underlined} />
-</Canvas>
-
-### Truncated
-
-<Canvas>
-  <Story of={TitleStories.Truncated} />
-</Canvas>
-
-### Truncated and underlined
-
-<Canvas>
-  <Story of={TitleStories.TruncatedAndUnderlined} />
-</Canvas> */}
+<Canvas of={TitleStories.Sizes} />

--- a/frontend/src/metabase/ui/components/utils/Divider/Divider.mdx
+++ b/frontend/src/metabase/ui/components/utils/Divider/Divider.mdx
@@ -15,12 +15,8 @@ Our themed wrapper around [Mantine Divider](https://v6.mantine.dev/core/divider/
 
 ## Examples
 
-<Canvas>
-  <Story of={DividerStories.Default} />
-</Canvas>
+<Canvas of={DividerStories.Default} />
 
 ### Vertical orientation
 
-<Canvas>
-  <Story of={DividerStories.VerticalOrientation} />
-</Canvas>
+<Canvas of={DividerStories.VerticalOrientation} />

--- a/frontend/src/metabase/ui/components/utils/Paper/Paper.mdx
+++ b/frontend/src/metabase/ui/components/utils/Paper/Paper.mdx
@@ -16,18 +16,12 @@ Our themed wrapper around [Mantine Paper](https://v6.mantine.dev/core/paper/).
 
 ## Examples
 
-<Canvas>
-  <Story of={PaperStories.Default} />
-</Canvas>
+<Canvas of={PaperStories.Default} />
 
 ### No border
 
-<Canvas>
-  <Story of={PaperStories.NoBorder} />
-</Canvas>
+<Canvas of={PaperStories.NoBorder} />
 
 ### Border
 
-<Canvas>
-  <Story of={PaperStories.Border} />
-</Canvas>
+<Canvas of={PaperStories.Border} />


### PR DESCRIPTION
Closes [WRK-538](https://linear.app/metabase/issue/WRK-538/fix-examples-in-storybook-docs)

### Description

Fix incorrect rendering of examples in the "Docs" pages of Storybook.

### How to verify

1. Run `yarn storybook` script
2. Open "Docs" page for any component, check that it renders different examples instead of default one.

### Demo

**Before**

<img width="1418" alt="image" src="https://github.com/user-attachments/assets/5212e03c-8440-4740-9cd0-8e28938525db" />

**After**

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/0c4fc44f-937e-4618-9184-7ca5d3b6e31d" />
