### PR TITLE
Small UI Fixes

### DIFF
--- a/frontend/src/metabase/browse/components/BrowseTable.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseTable.styled.tsx
@@ -27,7 +27,6 @@ export const Cell = styled.td<ResponsiveProps>`
     padding: 0.25em 0.5rem 0.25em 0.5rem;
   }
 
-  &:focus-within,
   &:focus {
     outline: 2px solid var(--mb-color-focus);
 

--- a/frontend/src/metabase/search/components/DropdownSidebarFilter/DropdownSidebarFilter.styled.tsx
+++ b/frontend/src/metabase/search/components/DropdownSidebarFilter/DropdownSidebarFilter.styled.tsx
@@ -10,7 +10,6 @@ export const DropdownFieldSet = styled(FieldSet)<{
 }>`
   min-width: 0;
   text-overflow: ellipsis;
-  overflow: hidden;
   border: 2px solid
     ${({ fieldHasValueOrFocus }) =>
       fieldHasValueOrFocus

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
@@ -92,6 +92,7 @@
 .SelectItems_Options {
   padding: 0.75rem;
   max-height: rem(500px);
+  overflow-y: auto;
 }
 
 .SelectItems_Item {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54974
Closes https://github.com/metabase/metabase/issues/52013
Closes https://github.com/metabase/metabase/issues/51898


### Description
A collection of small UI fixes:
- Select options is now scrollable, rather than relying on the fact that popover dropdowns are scrollable
- Removes overflow hidden on the DropdownSidebarFilter component. This is only used on the search page, and it didn't appear to be needed but fixes the Safari issue
- Removes the focus-within rule on BrowseTables. This only really seems to impact Browse Metrics, and allows the outline to show on the button itself, rather than the `<td>`

### How to verify

1. Go to Admin -> Localization -> Unit of currency
2. Open the dropdown and scroll to the bottom. There should be padding after the last item
3. Go to Browse Metrics and tab through the table
4. The ellipsis menu should be outlined now, rather than the td
5. In Safari, open the search page and populate one of the search filters
6. The label should not be cut off vertically

### Demo
<img width="861" alt="image" src="https://github.com/user-attachments/assets/4cdc343f-b16f-4b34-8522-e7d1a6a9d81f" />
<img width="998" alt="image" src="https://github.com/user-attachments/assets/076973a8-c485-4ba6-a9c2-f54cb1aab9d6" />
<img width="420" alt="image" src="https://github.com/user-attachments/assets/76c5768b-1e34-4bd5-86b3-87c526172458" />

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
