### PR TITLE
[Metabot] Do not allow root collection to be selectable as a metabot entity

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
@@ -214,6 +214,8 @@ function MetabotConfigurationPane({
       {isOpen && (
         <CollectionPickerModal
           title={t`Select a collection`}
+          shouldDisableItem={(item) => item.id === "root"}
+          canSelectItem={(item) => item && item.id !== "root"}
           value={{
             id: collection?.id ?? null,
             model: "collection",

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAdminPage.unit.spec.tsx
@@ -5,6 +5,8 @@ import { Route } from "react-router";
 import {
   findRequests,
   setupCollectionByIdEndpoint,
+  setupCollectionItemsEndpoint,
+  setupCollectionsEndpoints,
   setupRecentViewsAndSelectionsEndpoints,
 } from "__support__/server-mocks";
 import {
@@ -14,13 +16,14 @@ import {
   setupMetabotPromptSuggestionsEndpoint,
   setupMetabotsEndpoint,
 } from "__support__/server-mocks/metabot";
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import type {
   MetabotApiEntity,
   MetabotEntity,
   MetabotId,
   RecentItem,
 } from "metabase-types/api";
+import { createMockCollection } from "metabase-types/api/mocks";
 
 import { MetabotAdminPage } from "./MetabotAdminPage";
 import * as hooks from "./utils";
@@ -193,6 +196,40 @@ describe("MetabotAdminPage", () => {
       fetchMock.calls(`path:/api/ee/metabot-v3/metabot/1/prompt-suggestions`)
         .length,
     ).toEqual(3); // +1 refetch for DELETE, +1 for PUT
+  });
+
+  it("should not allow selecting the root collection", async () => {
+    // setup entity picker endpoints
+    const rootCollection = createMockCollection({ id: "root" });
+    setupCollectionsEndpoints({ collections: [rootCollection] });
+    setupCollectionItemsEndpoint({
+      collection: rootCollection,
+      collectionItems: [],
+      models: [],
+    });
+    setupCollectionItemsEndpoint({
+      collection: createMockCollection({ id: 1 }),
+      collectionItems: [],
+      models: [],
+    });
+
+    // default to no entities for default metabot - this will default the
+    // entity picker's initial value to be the root collection
+    await setup(1, { ...entities, 1: [] });
+
+    await userEvent.click(screen.getByText("Pick a collection"));
+
+    const entityPicker = await screen.findByTestId("entity-picker-modal");
+    const entityPickerTabs =
+      await within(entityPicker).findByTestId("tabs-view");
+    await userEvent.click(
+      await within(entityPickerTabs).findByText(/Collections/),
+    );
+
+    // should not be able to select the default Our analytics option
+    expect(
+      await screen.findByRole("button", { name: /Select/ }),
+    ).toBeDisabled();
   });
 
   it("should delete the selected collection", async () => {

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -31,9 +31,10 @@ export interface CollectionPickerModalProps {
   searchResultFilter?: (searchResults: SearchResult[]) => SearchResult[];
   recentFilter?: (recentItems: RecentItem[]) => RecentItem[];
   models?: CollectionPickerModel[];
+  canSelectItem: (item: CollectionPickerItem) => boolean;
 }
 
-const canSelectItem = (
+const baseCanSelectItem = (
   item: Pick<CollectionPickerItem, "can_write" | "model"> | null,
 ): item is CollectionPickerValueItem => {
   return (
@@ -59,10 +60,20 @@ export const CollectionPickerModal = ({
   searchResultFilter,
   recentFilter,
   models = ["collection"],
+  canSelectItem: _canSelectItem,
 }: CollectionPickerModalProps) => {
   options = { ...defaultOptions, ...options };
+
   const [selectedItem, setSelectedItem] = useState<CollectionPickerItem | null>(
     null,
+  );
+  const canSelectItem = useCallback(
+    (
+      item: Pick<CollectionPickerItem, "id" | "can_write" | "model"> | null,
+    ): item is CollectionPickerValueItem => {
+      return baseCanSelectItem(item) && (_canSelectItem?.(item) ?? true);
+    },
+    [_canSelectItem],
   );
 
   const { tryLogRecentItem } = useLogRecentItem();
@@ -105,7 +116,7 @@ export const CollectionPickerModal = ({
         await handleChange(item);
       }
     },
-    [handleChange, options],
+    [handleChange, options, canSelectItem],
   );
 
   const handleConfirm = async () => {
@@ -199,7 +210,7 @@ export const CollectionPickerModal = ({
     } else {
       return "root";
     }
-  }, [selectedItem, value]);
+  }, [selectedItem, value, canSelectItem]);
 
   return (
     <>

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -31,7 +31,7 @@ export interface CollectionPickerModalProps {
   searchResultFilter?: (searchResults: SearchResult[]) => SearchResult[];
   recentFilter?: (recentItems: RecentItem[]) => RecentItem[];
   models?: CollectionPickerModel[];
-  canSelectItem: (item: CollectionPickerItem) => boolean;
+  canSelectItem?: (item: CollectionPickerItem) => boolean;
 }
 
 const baseCanSelectItem = (


### PR DESCRIPTION
Closes [BOT-198](https://linear.app/metabase/issue/BOT-198/root-collection-cant-be-selected-as-metabots-source)

### Description

Prevents the root collection from being selected as an entity for a metabot.

### How to verify

- Visit AI admin settings page + select a metabot
- Pick / change a collection for metabot
- See that you can't choose Our analytics

### Demo
![CleanShot 2025-06-17 at 13 07 54@2x](https://github.com/user-attachments/assets/17e9cff1-14f8-480a-a9d6-0270a3ead250)
![CleanShot 2025-06-17 at 13 07 59@2x](https://github.com/user-attachments/assets/53ddb874-2378-4831-bce1-25fad8d80d72)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
