### PR TITLE
fix: css layout of time grouping errors

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.module.css
@@ -34,6 +34,7 @@
     display: flex;
     /* A large value for animation */
     max-height: 1000px;
+    flex-direction: column;
   }
 
   &.collapsing {


### PR DESCRIPTION
CSS glitch after resolving conflicts

### Before
<img width="1087" alt="Screenshot 2025-06-17 at 23 10 01" src="https://github.com/user-attachments/assets/f2158a23-2a00-4cc2-9621-7ea7bddc28ba" />


### After

<img width="1101" alt="Screenshot 2025-06-17 at 23 10 06" src="https://github.com/user-attachments/assets/432494bb-2015-4eff-a1a3-5ccaee08fa05" />
