### PR TITLE
chore: remove dead with-allowed-... macro in card

### DIFF
--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -905,20 +905,17 @@
                                            :embedding_params :archived :auto_apply_filters}))]
              (when (api/column-will-change? :archived current-dash dash-updates)
                (if (:archived dash-updates)
-                 (queries/with-allowed-changes-to-internal-dashboard-card
-                   (t2/update! :model/Card
-                               :dashboard_id id
-                               :archived false
-                               {:archived true :archived_directly false}))
-                 (queries/with-allowed-changes-to-internal-dashboard-card
-                   (t2/update! :model/Card
-                               :dashboard_id id
-                               :archived true
-                               :archived_directly false
-                               {:archived false}))))
+                 (t2/update! :model/Card
+                             :dashboard_id id
+                             :archived false
+                             {:archived true :archived_directly false})
+                 (t2/update! :model/Card
+                             :dashboard_id id
+                             :archived true
+                             :archived_directly false
+                             {:archived false})))
              (when (api/column-will-change? :collection_id current-dash dash-updates)
-               (queries/with-allowed-changes-to-internal-dashboard-card
-                 (t2/update! :model/Card :dashboard_id id {:collection_id (:collection_id dash-updates)})))
+               (t2/update! :model/Card :dashboard_id id {:collection_id (:collection_id dash-updates)}))
              (t2/update! :model/Dashboard id updates)
              (when (contains? updates :collection_id)
                (events/publish-event! :event/collection-touch {:collection-id id :user-id api/*current-user-id*}))

--- a/src/metabase/queries/core.clj
+++ b/src/metabase/queries/core.clj
@@ -30,8 +30,6 @@
   model?
   sole-dashboard-id
   update-card!
-   ;; TODO -- 95% sure this should go in the `dashboards` module rather than here.
-  with-allowed-changes-to-internal-dashboard-card
    ;; TODO -- not convinced whether this belongs here or in `permissions`
   with-can-run-adhoc-query]
  [metabase.queries.models.card.metadata

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -460,14 +460,6 @@
 (defn- dashboard-internal-card? [card]
   (boolean (:dashboard_id card)))
 
-(def ^:dynamic ^:private *updating-dashboard* false)
-
-(defmacro with-allowed-changes-to-internal-dashboard-card
-  "Allow making changes to dashboard-internal cards that would not normally be allowed."
-  [& body]
-  `(binding [*updating-dashboard* true]
-     ~@body))
-
 (defn- invalid-dashboard-internal-card-update-reason?
   "Returns the reason, if any, why this card is an invalid Dashboard Question"
   [card changes]
@@ -478,10 +470,7 @@
                              (:dashboard_id changes)))]
     (when will-be-dq?
       (cond
-        (not (or *updating-dashboard*
-                 ;; if the `dashboard_id` is changing, allow specifying a `collection_id`. Note that if it's different
-                 ;; than the actual `collection_id` of the new dashboard we're moving to, it will be ignored.
-                 dq-will-change?
+        (not (or dq-will-change?
                  (not (api/column-will-change? :collection_id card changes))))
         (tru "Invalid Dashboard Question: Cannot manually set `collection_id` on a Dashboard Question")
         (api/column-will-change? :collection_position card changes)


### PR DESCRIPTION
### Description

This macro does not do anything any longer the dynamic var it set is only readed through the `update-card!` path and it was only used in a path that called `t2/update!` instead.

### Checklist

- [N/A] Tests have been added/updated to cover changes in this PR
