### PR TITLE
Localize the trash name on memoized collection

### DIFF
--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -61,13 +61,13 @@
 (defn- trash-collection* []
   (t2/select-one :model/Collection :type trash-collection-type))
 
-(def ^{:arglists '([])} trash-collection
-  "Memoized copy of the Trash collection from the DB."
-  (mdb/memoize-for-application-db
-   (fn []
-     (u/prog1 (trash-collection*)
-       (when-not <>
-         (throw (ex-info "Fatal error: Trash collection is missing" {})))))))
+(let [get-trash (mdb/memoize-for-application-db
+                 (fn []
+                   (u/prog1 (trash-collection*)
+                     (when-not <>
+                       (throw (ex-info "Fatal error: Trash collection is missing" {}))))))]
+  (defn trash-collection []
+    (assoc (get-trash) :name (deferred-tru "Trash"))))
 
 (defn trash-collection-id
   "The ID representing the Trash collection."
@@ -110,7 +110,7 @@
   query without `:model/Collection`)."
   [collection]
   (cond-> collection
-    (is-trash? collection) (assoc :name (deferred-tru "Trash"))))
+    (is-trash? collection) (assoc :name (tru "Trash"))))
 
 (t2/define-after-select :model/Collection [collection]
   (maybe-localize-trash-name collection))

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -23,7 +23,7 @@
    [metabase.search.spec :as search.spec]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.i18n :refer [trs tru]]
+   [metabase.util.i18n :refer [trs tru deferred-tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -110,7 +110,7 @@
   query without `:model/Collection`)."
   [collection]
   (cond-> collection
-    (is-trash? collection) (assoc :name (tru "Trash"))))
+    (is-trash? collection) (assoc :name (deferred-tru "Trash"))))
 
 (t2/define-after-select :model/Collection [collection]
   (maybe-localize-trash-name collection))

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -66,7 +66,9 @@
                    (u/prog1 (trash-collection*)
                      (when-not <>
                        (throw (ex-info "Fatal error: Trash collection is missing" {}))))))]
-  (defn trash-collection []
+  (defn trash-collection
+    "Get the (memoized) trash collection"
+    []
     (assoc (get-trash) :name (deferred-tru "Trash"))))
 
 (defn trash-collection-id

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -14,6 +14,7 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.i18n :as i18n]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -54,6 +55,11 @@
   (is (= {(mt/user->id :rasta) "Rasta Toucan's Personal Collection"
           (mt/user->id :lucky) "Lucky Pigeon's Personal Collection"}
          (collection/user->personal-collection-names [(mt/user->id :lucky) (mt/user->id :rasta)] :site))))
+
+(deftest trash-collection-name-is-localized-test
+  (let [trash (collection/trash-collection)]
+    (is (-> trash :name i18n/localized-string?)
+        "Trash name must be a localized string")))
 
 (deftest personal-collection-with-ui-details-test
   (testing "With personal_owner"

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -56,7 +56,7 @@
           (mt/user->id :lucky) "Lucky Pigeon's Personal Collection"}
          (collection/user->personal-collection-names [(mt/user->id :lucky) (mt/user->id :rasta)] :site))))
 
-(deftest trash-collection-name-is-localized-test
+(deftest ^:parallel trash-collection-name-is-localized-test
   (let [trash (collection/trash-collection)]
     (is (-> trash :name i18n/localized-string?)
         "Trash name must be a localized string")))


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/59260

The memoized version of the Trash currently has whichever `name` first selected it because we were using `tru` instead of `deferred-tru`.