### PR TITLE
Add xrays drill thru repro for #23820

### DIFF
--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -426,7 +426,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
 
     H.cartesianChartCircle()
       .eq(3) // Wednesday
-      .click({ force: true });
+      .click();
 
     H.popover().within(() => {
       cy.findByText("Automatic insights…").click();

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -438,7 +438,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
     H.main().within(() => {
       cy.findByText(
         "A closer look at number of Orders where day of week of Created At is Wednesday",
-      ).should("exist");
+      ).should("be.visible");
     });
 
     getDashcardByTitle("A look at Created At fields").should("exist");

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -402,6 +402,49 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
       .findByText("Leaflet")
       .should("exist");
   });
+
+  it("should work on questions with breakout by day-of-week and null semantic type (metabase#23820)", () => {
+    cy.request("PUT", `/api/field/${ORDERS.CREATED_AT}`, {
+      semantic_type: null,
+    });
+    H.createQuestion(
+      {
+        name: "23820",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "day-of-week" }],
+          ],
+        },
+        display: "line",
+      },
+      { visitQuestion: true },
+    );
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    H.cartesianChartCircle()
+      .eq(3) // Wednesday
+      .click({ force: true });
+
+    H.popover().within(() => {
+      cy.findByText("Automatic insights…").click();
+      cy.findByText("X-ray").click();
+    });
+
+    cy.wait("@dataset");
+
+    H.main().within(() => {
+      cy.findByText(
+        "A closer look at number of Orders where day of week of Created At is Wednesday",
+      ).should("exist");
+    });
+
+    getDashcardByTitle("A look at Created At fields").should("exist");
+
+    getDashcardByTitle("A look at the number of Orders").should("exist");
+  });
 });
 
 function waitForSatisfyingResponse(


### PR DESCRIPTION
Closes #23820
Closes QUE-89

### Description

Add e2e and BE repro for x-rays drill thru in #23820

There are likely multiple changes that resolved this bug, most recently #58725. I backported this test to a version of v54 before that fix and verified that the tests fails there.

### How to verify

See repro steps in #23820
stats repro with Redshift DB: https://stats.metabase.com/question/26779-repro-for-23820
~~stress test flake run: https://github.com/metabase/metabase/actions/runs/15721616079~~
stress test flake run round 2: https://github.com/metabase/metabase/actions/runs/15739819759

### Demo

![Screenshot 2025-06-17 at 5 49 52 PM](https://github.com/user-attachments/assets/4447661e-7ae4-4b69-8076-72f392268d35)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
