### PR TITLE
Resolve a circular dependency in collections

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.tsx
@@ -14,6 +14,7 @@ import {
 import PinnedItemOverview from "metabase/collections/components/PinnedItemOverview";
 import Header from "metabase/collections/containers/CollectionHeader";
 import type {
+  CollectionOrTableIdProps,
   CreateBookmark,
   DeleteBookmark,
   OnFileUpload,
@@ -42,7 +43,6 @@ import type {
 import { SortDirection } from "metabase-types/api/sorting";
 import type { State } from "metabase-types/store";
 
-import type { CollectionOrTableIdProps } from "../ModelUploadModal";
 import { ModelUploadModal } from "../ModelUploadModal";
 import UploadOverlay from "../UploadOverlay";
 

--- a/frontend/src/metabase/collections/components/ModelUploadModal.tsx
+++ b/frontend/src/metabase/collections/components/ModelUploadModal.tsx
@@ -12,25 +12,12 @@ import {
   Stack,
   Text,
 } from "metabase/ui";
-import type { CardId, CollectionId, TableId } from "metabase-types/api";
+import type { CollectionId, TableId } from "metabase-types/api";
 import { UploadMode } from "metabase-types/store/upload";
 
 import type { OnFileUpload } from "../types";
 
 import { findLastEditedCollectionItem } from "./utils";
-
-export type CollectionOrTableIdProps =
-  | {
-      uploadMode: UploadMode.create;
-      collectionId: CollectionId;
-      tableId?: never;
-    }
-  | {
-      uploadMode: UploadMode.append | UploadMode.replace;
-      collectionId?: never;
-      tableId: TableId;
-      modelId?: CardId;
-    };
 
 export function ModelUploadModal({
   opened,

--- a/frontend/src/metabase/collections/types.ts
+++ b/frontend/src/metabase/collections/types.ts
@@ -1,13 +1,27 @@
 import type {
   BookmarkId,
   BookmarkType,
+  CardId,
   Collection,
   CollectionId,
   CollectionItem,
   Dashboard,
+  TableId,
 } from "metabase-types/api";
+import type { UploadMode } from "metabase-types/store/upload";
 
-import type { CollectionOrTableIdProps } from "./components/ModelUploadModal";
+export type CollectionOrTableIdProps =
+  | {
+      uploadMode: UploadMode.create;
+      collectionId: CollectionId;
+      tableId?: never;
+    }
+  | {
+      uploadMode: UploadMode.append | UploadMode.replace;
+      collectionId?: never;
+      tableId: TableId;
+      modelId?: CardId;
+    };
 
 export type MoveCollectionDestination = Pick<Collection, "id"> & {
   model: "collection";

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DwhUpload/DwhUpload.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DwhUpload/DwhUpload.tsx
@@ -1,11 +1,11 @@
 import { type ChangeEvent, useCallback, useRef, useState } from "react";
 import { c, t } from "ttag";
 
-import {
-  type CollectionOrTableIdProps,
-  ModelUploadModal,
-} from "metabase/collections/components/ModelUploadModal";
-import type { OnFileUpload } from "metabase/collections/types";
+import { ModelUploadModal } from "metabase/collections/components/ModelUploadModal";
+import type {
+  CollectionOrTableIdProps,
+  OnFileUpload,
+} from "metabase/collections/types";
 import { UploadInput } from "metabase/components/upload";
 import { useToggle } from "metabase/hooks/use-toggle";
 import { useDispatch } from "metabase/lib/redux";


### PR DESCRIPTION
AFAICT, this was the only circular dependency in collections. It was easy to resolve so... why not? :)

<img width="1404" alt="image" src="https://github.com/user-attachments/assets/591b0501-517b-4936-a3c9-9d09c2321ca3" />
