### PR TITLE
Set PK still on upsert, for now

### DIFF
--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -936,9 +936,7 @@
                                             ;; HACK to avoid the fact that FE don't provide row-key for now
                                             (if (empty? row-key)
                                               (let [pk-cols (keys (table-id->pk-field-name->id database table-id))]
-                                                (-> input
-                                                    (assoc :row-key (select-keys row pk-cols))
-                                                    (update :row (fn [row] (apply dissoc row pk-cols)))))
+                                                (assoc input :row-key (select-keys row pk-cols)))
                                               input)))})]
     (when (seq errors)
       (throw (ex-info (tru "Error(s) creating or updating rows.")


### PR DESCRIPTION
This gives me the heebie jeebies, but I think it's correct.

This is needed for the cases where the PK in not auto incrementing, e.g. it takes a logical value like `customer_id`.