### PR TITLE
QUE-1361: Allow using table in search and add fuzzy search

### DIFF
--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import {
   AccordionList,
-  type Section,
+  type Section as BaseSection,
 } from "metabase/common/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import { isSyncCompleted } from "metabase/lib/syncing";
@@ -33,6 +33,10 @@ type Item = {
   name: string;
 };
 
+type Section = BaseSection<Item> & {
+  active: boolean;
+};
+
 const DataSelectorDatabaseSchemaPicker = ({
   databases,
   selectedDatabase,
@@ -49,7 +53,7 @@ const DataSelectorDatabaseSchemaPicker = ({
     return <DataSelectorLoading />;
   }
 
-  const sections: Section<Item>[] = databases.map((database) => ({
+  const sections: Section[] = databases.map((database) => ({
     name: database.is_saved_questions ? t`Saved Questions` : database.name,
     items:
       !database.is_saved_questions && database.getSchemas().length > 1
@@ -58,7 +62,7 @@ const DataSelectorDatabaseSchemaPicker = ({
             name: schema.displayName() ?? "",
           }))
         : [],
-    className: database.is_saved_questions ? CS.bgLight : null,
+    className: database.is_saved_questions ? CS.bgLight : undefined,
     icon: database.is_saved_questions ? "collection" : "database",
     loading:
       selectedDatabase?.id === database.id &&
@@ -110,7 +114,7 @@ const DataSelectorDatabaseSchemaPicker = ({
   }
 
   return (
-    <AccordionList<Item>
+    <AccordionList<Item, Section>
       id="DatabaseSchemaPicker"
       key="databaseSchemaPicker"
       className={CS.textBrand}

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -107,7 +107,10 @@ export class AccordionList<
       searchText: "",
       cursor: null,
       scrollToAlignment: "start",
-      searchIndex: getSearchIndex(props),
+      searchIndex: getSearchIndex({
+        sections: props.sections,
+        searchProp: props.searchProp,
+      }),
     };
 
     this._cache = new CellMeasurerCache({
@@ -167,7 +170,10 @@ export class AccordionList<
   ) {
     return {
       ...state,
-      searchIndex: getSearchIndex(props),
+      searchIndex: getSearchIndex({
+        sections: props.sections,
+        searchProp: props.searchProp,
+      }),
     };
   }
 

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -401,7 +401,9 @@ export class AccordionList<
       const results = searchIndex.search(searchText, {
         limit: 50,
       });
-      return results.some((result) => result.item === item);
+      return results.some(
+        (result) => result.item === item && result.score && result.score < 0.6,
+      );
     }
 
     const searchProps = Array.isArray(searchProp) ? searchProp : [searchProp];

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -172,6 +172,7 @@ export class AccordionList<
     props: Props<TItem>,
     state: State<TItem>,
   ) {
+    const { searchText } = state;
     const searchIndex = getSearchIndex({
       sections: props.sections,
       searchProp: props.searchProp,
@@ -180,7 +181,7 @@ export class AccordionList<
     return {
       ...state,
       searchIndex,
-      searchResults: search(searchIndex, state.searchText),
+      searchResults: search({ searchIndex, searchText }),
     };
   }
 
@@ -281,7 +282,10 @@ export class AccordionList<
     this.setState({
       searchText,
       cursor: null,
-      searchResults: search(this.state.searchIndex, searchText),
+      searchResults: search({
+        searchIndex: this.state.searchIndex,
+        searchText,
+      }),
     });
   };
 

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -280,20 +280,21 @@ export class AccordionList<
   };
 
   getInitialCursor = () => {
-    const { cursor, searchText } = this.state;
+    const { searchText } = this.state;
+    if (searchText.length === 0) {
+      return this.getFirstSelectedItemCursor();
+    }
 
-    return (
-      cursor ??
-      (searchText.length === 0 ? this.getFirstSelectedItemCursor() : null)
-    );
+    return null;
   };
 
   handleKeyDown = (event: KeyboardEvent) => {
+    const { cursor } = this.state;
     if (event.key === "ArrowUp") {
       event.preventDefault();
 
       const prevCursor = getPrevCursor(
-        this.getInitialCursor(),
+        cursor ?? this.getInitialCursor(),
         this.props.sections,
         this.isSectionExpanded,
         this.canSelectSection,
@@ -310,7 +311,7 @@ export class AccordionList<
       event.preventDefault();
 
       const nextCursor = getNextCursor(
-        this.getInitialCursor(),
+        cursor ?? this.getInitialCursor(),
         this.props.sections,
         this.isSectionExpanded,
         this.canSelectSection,

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -49,6 +49,7 @@ type Props<
   role?: string;
   searchProp?: string | string[];
   searchable?: boolean | ((section: Section) => boolean | undefined);
+  fuzzySearch?: boolean;
   sections: TSection[];
   style?: CSSProperties;
 
@@ -386,11 +387,18 @@ export class AccordionList<
   };
 
   searchFilter = (item: TItem) => {
-    const { searchProp = ["name", "displayName"] } = this.props;
+    const { searchProp = ["name", "displayName"], fuzzySearch } = this.props;
     const { searchText } = this.state;
 
     if (!searchText || searchText.length === 0) {
       return true;
+    }
+
+    if (fuzzySearch) {
+      const results = this.state.searchIndex.search(searchText, {
+        limit: 50,
+      });
+      return results.some((result) => result.item === item);
     }
 
     const searchProps = Array.isArray(searchProp) ? searchProp : [searchProp];

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -23,7 +23,7 @@ import {
   AccordionListCell,
   type SharedAccordionProps,
 } from "./AccordionListCell";
-import type { Item, Row, SearchProps, Section } from "./types";
+import type { Item, Row, SearchProp, SearchProps, Section } from "./types";
 import {
   type Cursor,
   getNextCursor,
@@ -387,7 +387,10 @@ export class AccordionList<
   };
 
   searchFilter = (item: TItem) => {
-    const { searchProp = ["name", "displayName"], fuzzySearch } = this.props;
+    const {
+      searchProp = ["name", "displayName"] as SearchProp<TItem>[],
+      fuzzySearch,
+    } = this.props;
     const { searchText, searchIndex } = this.state;
 
     if (!searchText || searchText.length === 0) {

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -405,7 +405,10 @@ export class AccordionList<
   };
 
   itemScore = (item: TItem) => {
-    const { fuzzySearch, searchProp } = this.props;
+    const {
+      fuzzySearch,
+      searchProp = ["name", "displayName"] as unknown as SearchProps<TItem>,
+    } = this.props;
     const { searchText } = this.state;
 
     if (!searchText || searchText.length === 0) {

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -23,7 +23,7 @@ import {
   AccordionListCell,
   type SharedAccordionProps,
 } from "./AccordionListCell";
-import type { Item, Row, Section } from "./types";
+import type { Item, Row, SearchProps, Section } from "./types";
 import {
   type Cursor,
   getNextCursor,
@@ -47,7 +47,7 @@ type Props<
   onChangeSection?: (section: TSection, sectionIndex: number) => boolean | void;
   openSection?: number;
   role?: string;
-  searchProp?: string | string[];
+  searchProp?: SearchProps<TItem>;
   searchable?: boolean | ((section: Section) => boolean | undefined);
   fuzzySearch?: boolean;
   sections: TSection[];

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -295,10 +295,9 @@ export class AccordionList<
 
       const prevCursor = getPrevCursor(
         cursor ?? this.getInitialCursor(),
-        this.props.sections,
+        this.getRows(),
         this.isSectionExpanded,
         this.canSelectSection,
-        this.searchFilter,
       );
 
       return this.setState({
@@ -312,10 +311,9 @@ export class AccordionList<
 
       const nextCursor = getNextCursor(
         cursor ?? this.getInitialCursor(),
-        this.props.sections,
+        this.getRows(),
         this.isSectionExpanded,
         this.canSelectSection,
-        this.searchFilter,
       );
 
       return this.setState({

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -394,7 +394,10 @@ export class AccordionList<
         sectionScore: isSearching ? sectionScore(section, searchOptions) : 0,
         sectionIndex: index,
       }))
-      .filter(({ sectionScore }) => sectionScore < searchThreshold)
+      .filter(
+        ({ sectionScore, section }) =>
+          section.type || sectionScore < searchThreshold,
+      )
       .sort((a, b) => a.sectionScore - b.sectionScore);
 
     for (const { section, sectionIndex } of sortedSections) {

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -441,6 +441,7 @@ export class AccordionList<
     const { searchText } = this.state;
 
     const openSection = this.getOpenSection();
+    const isSearching = searchText.length > 0;
 
     // if any section is searchable just enable a global search
     let globalSearch = this.props.globalSearch ?? false;
@@ -448,7 +449,7 @@ export class AccordionList<
     const sectionIsExpanded = (sectionIndex: number) =>
       alwaysExpanded ||
       openSection === sectionIndex ||
-      (globalSearch && searchText.length > 0);
+      (globalSearch && isSearching);
 
     const sectionIsSearchable = (sectionIndex: number) =>
       typeof searchable === "function"
@@ -539,7 +540,6 @@ export class AccordionList<
     }
 
     if (globalSearch) {
-      const isSearching = searchText.length > 0;
       const isEmpty = rows.filter((row) => row.type === "item").length === 0;
 
       if (isSearching && isEmpty) {

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -684,8 +684,9 @@ export class AccordionList<
             rowIndex={index}
             parent={parent}
           >
-            {() => (
+            {({ registerChild }) => (
               <AccordionListCell<TItem, TSection>
+                ref={registerChild}
                 hasCursor={this.isRowSelected(rows[index])}
                 {...this.props}
                 style={style}

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -30,6 +30,11 @@ import {
   sectionScore,
 } from "./utils";
 
+// The threshold for the score of search results
+// when fuzzy searching. 0 is a perfect match, 1 is the
+// worst possible match.
+const SEARCH_SCORE_THRESHOLD = 0.4;
+
 type Props<
   TItem extends Item,
   TSection extends Section<TItem> = Section<TItem>,
@@ -380,7 +385,6 @@ export class AccordionList<
 
     const rows: Row<TItem, TSection>[] = [];
 
-    const searchThreshold = 0.4;
     const searchOptions = {
       searchText,
       sections,
@@ -396,7 +400,7 @@ export class AccordionList<
       }))
       .filter(
         ({ sectionScore, section }) =>
-          section.type || sectionScore < searchThreshold,
+          section.type || sectionScore < SEARCH_SCORE_THRESHOLD,
       )
       .sort((a, b) => a.sectionScore - b.sectionScore);
 
@@ -409,7 +413,7 @@ export class AccordionList<
           itemScore: isSearching ? itemScore(item, searchOptions) : 0,
           itemIndex: index,
         }))
-        .filter(({ itemScore }) => itemScore < searchThreshold)
+        .filter(({ itemScore }) => itemScore < SEARCH_SCORE_THRESHOLD)
         .sort((a, b) => a.itemScore - b.itemScore);
 
       if (

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -380,7 +380,7 @@ export class AccordionList<
 
     const rows: Row<TItem, TSection>[] = [];
 
-    const searchThreshold = 0.6;
+    const searchThreshold = 0.4;
     const searchOptions = {
       searchText,
       sections,

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -256,11 +256,8 @@ export class AccordionList<
     return itemText.toLowerCase().indexOf(searchText.toLowerCase()) >= 0;
   };
 
-  checkSectionHasItemsMatchingSearch = (
-    section: TSection,
-    searchFilter: (item: TItem) => boolean,
-  ) => {
-    return (section.items?.filter(searchFilter).length ?? 0) > 0;
+  checkSectionHasItemsMatchingSearch = (section: TSection) => {
+    return (section.items?.filter(this.searchFilter).length ?? 0) > 0;
   };
 
   getFirstSelectedItemCursor = () => {
@@ -414,7 +411,7 @@ export class AccordionList<
         if (
           !searchable ||
           !globalSearch ||
-          this.checkSectionHasItemsMatchingSearch(section, this.searchFilter) ||
+          this.checkSectionHasItemsMatchingSearch(section) ||
           section.type === "action"
         ) {
           if (section.type === "action") {

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -377,23 +377,22 @@ export class AccordionList<
     return searchResults.reduce((acc, curr) => acc || curr);
   };
 
-  getRowsCached = (
-    searchFilter: (item: TItem) => boolean,
-    searchable:
-      | boolean
-      | ((section: TSection) => boolean | undefined)
-      | undefined,
-    sections: TSection[],
-    alwaysTogglable: boolean,
-    alwaysExpanded: boolean,
-    hideSingleSectionTitle: boolean,
-    itemIsSelected: (item: TItem, index: number) => boolean | undefined,
-    openSection: number | null,
-    _globalSearch: boolean,
-    searchText: string,
-  ): Row<TItem, TSection>[] => {
+  getRows = (): Row<TItem, TSection>[] => {
+    const {
+      alwaysTogglable = false,
+      alwaysExpanded = false,
+      hideSingleSectionTitle = false,
+      itemIsSelected = () => false,
+      searchable = (section: TSection) =>
+        section?.items && section.items.length > 10,
+      sections,
+    } = this.props;
+    const { searchText } = this.state;
+
+    const openSection = this.getOpenSection();
+
     // if any section is searchable just enable a global search
-    let globalSearch = _globalSearch;
+    let globalSearch = this.props.globalSearch ?? false;
 
     const sectionIsExpanded = (sectionIndex: number) =>
       alwaysExpanded ||
@@ -415,7 +414,7 @@ export class AccordionList<
         if (
           !searchable ||
           !globalSearch ||
-          this.checkSectionHasItemsMatchingSearch(section, searchFilter) ||
+          this.checkSectionHasItemsMatchingSearch(section, this.searchFilter) ||
           section.type === "action"
         ) {
           if (section.type === "action") {
@@ -461,7 +460,7 @@ export class AccordionList<
         !section.loading
       ) {
         for (const [itemIndex, item] of section.items.entries()) {
-          if (searchFilter(item)) {
+          if (this.searchFilter(item)) {
             const isLastItem = itemIndex === section.items.length - 1;
             if (itemIsSelected(item, itemIndex)) {
               this._initialSelectedRowIndex = rows.length;
@@ -511,36 +510,6 @@ export class AccordionList<
 
     return rows;
   };
-
-  getRows(): Row<TItem, TSection>[] {
-    const {
-      sections,
-      searchable = (section: TSection) =>
-        section?.items && section.items.length > 10,
-      alwaysTogglable = false,
-      alwaysExpanded = false,
-      hideSingleSectionTitle = false,
-      itemIsSelected = () => false,
-      globalSearch = false,
-    } = this.props;
-
-    const { searchText } = this.state;
-
-    const openSection = this.getOpenSection();
-
-    return this.getRowsCached(
-      this.searchFilter,
-      searchable,
-      sections,
-      alwaysTogglable,
-      alwaysExpanded,
-      hideSingleSectionTitle,
-      itemIsSelected,
-      openSection,
-      globalSearch,
-      searchText,
-    );
-  }
 
   isVirtualized = () => this.props.maxHeight !== Infinity;
 

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -388,14 +388,14 @@ export class AccordionList<
 
   searchFilter = (item: TItem) => {
     const { searchProp = ["name", "displayName"], fuzzySearch } = this.props;
-    const { searchText } = this.state;
+    const { searchText, searchIndex } = this.state;
 
     if (!searchText || searchText.length === 0) {
       return true;
     }
 
     if (fuzzySearch) {
-      const results = this.state.searchIndex.search(searchText, {
+      const results = searchIndex.search(searchText, {
         limit: 50,
       });
       return results.some((result) => result.item === item);

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.unit.spec.tsx
@@ -84,6 +84,25 @@ describe("AccordionList", () => {
     assertAbsence(["Foo", "Bar", "Baz"]);
   });
 
+  it("should filter items when searched with fuzzySearch", () => {
+    render(
+      <AccordionList
+        sections={SECTIONS}
+        searchable
+        fuzzySearch
+        searchProp={["name", "displayName"]}
+      />,
+    );
+    const SEARCH_FIELD = screen.getByPlaceholderText("Find...");
+
+    fireEvent.change(SEARCH_FIELD, { target: { value: "Fob" } });
+    assertPresence(["Foo"]);
+    assertAbsence(["Bar", "Baz"]);
+
+    fireEvent.change(SEARCH_FIELD, { target: { value: "Something Else" } });
+    assertAbsence(["Foo", "Bar", "Baz"]);
+  });
+
   it("should render with the search bar on top if globalSearch is set", () => {
     render(<AccordionList sections={SECTIONS} globalSearch searchable />);
     const SEARCH_FIELD = screen.getByPlaceholderText("Find...");

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.unit.spec.tsx
@@ -6,6 +6,10 @@ import TippyPopover from "metabase/common/components/Popover/TippyPopover";
 
 import { AccordionList } from "./AccordionList";
 
+type Item = {
+  name: string;
+};
+
 const SECTIONS = [
   {
     name: "Widgets",
@@ -86,11 +90,11 @@ describe("AccordionList", () => {
 
   it("should filter items when searched with fuzzySearch", () => {
     render(
-      <AccordionList
+      <AccordionList<Item>
         sections={SECTIONS}
         searchable
         fuzzySearch
-        searchProp={["name", "displayName"]}
+        searchProp={["name"]}
       />,
     );
     const SEARCH_FIELD = screen.getByPlaceholderText("Find...");

--- a/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import type { CSSProperties, ReactNode } from "react";
+import { type CSSProperties, type ReactNode, forwardRef } from "react";
 import { t } from "ttag";
 
 import EmptyState from "metabase/common/components/EmptyState";
@@ -63,74 +63,77 @@ type AccordionListCellProps<
   toggleSection: (sectionIndex: number) => void;
 };
 
-export function AccordionListCell<
+export const AccordionListCell = forwardRef(function AccordionListCell<
   TItem extends Item,
   TSection extends Section<TItem>,
->({
-  alwaysExpanded,
-  canToggleSections,
-  color: colorProp = "brand",
-  getItemClassName = (item: TItem) => {
-    if (
-      typeof item === "object" &&
-      "className" in item &&
-      typeof item.className === "string"
-    ) {
-      return item.className;
-    }
-  },
-  getItemStyles = () => ({}),
-  hasCursor,
-  itemIsClickable = () => true,
-  itemIsSelected = () => false,
-  itemTestId,
-  onChange,
-  onChangeSearchText,
-  renderSectionIcon = (section: TSection) =>
-    section.icon && <Icon name={section.icon} />,
-  renderItemLabel,
-  renderItemName = (item: TItem) => {
-    if (
-      typeof item === "object" &&
-      "name" in item &&
-      typeof item.name === "string"
-    ) {
-      return item.name;
-    }
-  },
-  renderItemDescription = (item: TItem) => {
-    if (
-      typeof item === "object" &&
-      "description" in item &&
-      isReactNode(item.description)
-    ) {
-      return item.description;
-    }
-  },
-  renderItemExtra = () => null,
-  renderItemIcon = (item: TItem) => {
-    if (
-      typeof item === "object" &&
-      "icon" in item &&
-      isValidIconName(item.icon)
-    ) {
-      return <Icon name={item.icon} />;
-    }
-    return null;
-  },
-  renderItemWrapper = (content: ReactNode) => content,
-  row,
-  searchInputProps,
-  searchPlaceholder = t`Find...`,
-  searchText,
-  sectionIsExpanded,
-  sections,
-  showItemArrows,
-  showSpinner = () => false,
-  style,
-  toggleSection,
-  withBorders,
-}: AccordionListCellProps<TItem, TSection>) {
+>(
+  {
+    alwaysExpanded,
+    canToggleSections,
+    color: colorProp = "brand",
+    getItemClassName = (item: TItem) => {
+      if (
+        typeof item === "object" &&
+        "className" in item &&
+        typeof item.className === "string"
+      ) {
+        return item.className;
+      }
+    },
+    getItemStyles = () => ({}),
+    hasCursor,
+    itemIsClickable = () => true,
+    itemIsSelected = () => false,
+    itemTestId,
+    onChange,
+    onChangeSearchText,
+    renderSectionIcon = (section: TSection) =>
+      section.icon && <Icon name={section.icon} />,
+    renderItemLabel,
+    renderItemName = (item: TItem) => {
+      if (
+        typeof item === "object" &&
+        "name" in item &&
+        typeof item.name === "string"
+      ) {
+        return item.name;
+      }
+    },
+    renderItemDescription = (item: TItem) => {
+      if (
+        typeof item === "object" &&
+        "description" in item &&
+        isReactNode(item.description)
+      ) {
+        return item.description;
+      }
+    },
+    renderItemExtra = () => null,
+    renderItemIcon = (item: TItem) => {
+      if (
+        typeof item === "object" &&
+        "icon" in item &&
+        isValidIconName(item.icon)
+      ) {
+        return <Icon name={item.icon} />;
+      }
+      return null;
+    },
+    renderItemWrapper = (content: ReactNode) => content,
+    row,
+    searchInputProps,
+    searchPlaceholder = t`Find...`,
+    searchText,
+    sectionIsExpanded,
+    sections,
+    showItemArrows,
+    showSpinner = () => false,
+    style,
+    toggleSection,
+    withBorders,
+  }: AccordionListCellProps<TItem, TSection>,
+  ref,
+) {
   const { type, section, sectionIndex, isLastSection } = row;
   let content;
   let borderTop;
@@ -401,6 +404,7 @@ export function AccordionListCell<
 
   return (
     <div
+      ref={ref}
       style={style}
       data-element-id="list-section"
       className={cx(section.className, {
@@ -413,4 +417,4 @@ export function AccordionListCell<
       {content}
     </div>
   );
-}
+});

--- a/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
@@ -1,5 +1,13 @@
+import { useMergedRef } from "@mantine/hooks";
 import cx from "classnames";
-import { type CSSProperties, type ReactNode, forwardRef } from "react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  type Ref,
+  forwardRef,
+  useEffect,
+  useRef,
+} from "react";
 import { t } from "ttag";
 
 import EmptyState from "metabase/common/components/EmptyState";
@@ -132,12 +140,21 @@ export const AccordionListCell = forwardRef(function AccordionListCell<
     toggleSection,
     withBorders,
   }: AccordionListCellProps<TItem, TSection>,
-  ref,
+  ref: Ref<HTMLDivElement>,
 ) {
   const { type, section, sectionIndex, isLastSection } = row;
   let content;
   let borderTop;
   let borderBottom;
+
+  const innerRef = useRef<HTMLDivElement>(null);
+  const mergedRef = useMergedRef(ref, innerRef);
+
+  useEffect(() => {
+    if (hasCursor) {
+      innerRef.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [hasCursor]);
 
   if (type === "header") {
     if (alwaysExpanded) {
@@ -245,7 +262,7 @@ export const AccordionListCell = forwardRef(function AccordionListCell<
           CS.hoverParent,
           styles.action,
           {
-            "List-section-header--cursor": hasCursor,
+            [ListS.ListSectionHeaderCursor]: hasCursor,
             [CS.cursorPointer]: canToggleSections,
             [CS.textBrand]: sectionIsExpanded(sectionIndex),
           },
@@ -404,7 +421,7 @@ export const AccordionListCell = forwardRef(function AccordionListCell<
 
   return (
     <div
-      ref={ref}
+      ref={mergedRef}
       style={style}
       data-element-id="list-section"
       className={cx(section.className, {

--- a/frontend/src/metabase/common/components/AccordionList/index.js
+++ b/frontend/src/metabase/common/components/AccordionList/index.js
@@ -1,2 +1,0 @@
-export { AccordionList, Section } from "./AccordionList";
-export { SearchProp, SearchProps } from "./types";

--- a/frontend/src/metabase/common/components/AccordionList/index.js
+++ b/frontend/src/metabase/common/components/AccordionList/index.js
@@ -1,1 +1,2 @@
 export { AccordionList, Section } from "./AccordionList";
+export { SearchProp, SearchProps } from "./types";

--- a/frontend/src/metabase/common/components/AccordionList/index.ts
+++ b/frontend/src/metabase/common/components/AccordionList/index.ts
@@ -1,0 +1,2 @@
+export { AccordionList } from "./AccordionList";
+export type { Section, SearchProp, SearchProps } from "./types";

--- a/frontend/src/metabase/common/components/AccordionList/types.ts
+++ b/frontend/src/metabase/common/components/AccordionList/types.ts
@@ -51,7 +51,7 @@ export type Row<TItem extends Item, TSection extends Section<TItem>> = {
     }
 );
 
-type SearchProp<TItem extends Item> = TItem extends object
+export type SearchProp<TItem extends Item> = TItem extends object
   ? keyof TItem
   : string;
 

--- a/frontend/src/metabase/common/components/AccordionList/types.ts
+++ b/frontend/src/metabase/common/components/AccordionList/types.ts
@@ -50,3 +50,11 @@ export type Row<TItem extends Item, TSection extends Section<TItem>> = {
       isLastItem: boolean;
     }
 );
+
+type SearchProp<TItem extends Item> = TItem extends object
+  ? keyof TItem
+  : string;
+
+export type SearchProps<TItem extends Item> =
+  | Readonly<SearchProp<TItem>[]>
+  | SearchProp<TItem>;

--- a/frontend/src/metabase/common/components/AccordionList/types.ts
+++ b/frontend/src/metabase/common/components/AccordionList/types.ts
@@ -5,6 +5,7 @@ import type { IconName } from "metabase/ui";
 export type Item = object | string;
 
 export type Section<TItem extends Item = Item> = {
+  key?: string;
   name?: ReactNode;
   type?:
     | "action"

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -182,7 +182,7 @@ export const getSearchIndex = memoize(function <
   TSection extends Section<TItem>,
 >({
   sections,
-  searchProp = ["name", "displayName"],
+  searchProp = ["name", "displayName"] as unknown as SearchProps<TItem>,
 }: {
   sections: TSection[];
   searchProp?: SearchProps<TItem>;

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -1,4 +1,5 @@
 import Fuse from "fuse.js";
+import { getIn } from "icepick";
 import { type ReactNode, isValidElement } from "react";
 import { isFragment } from "react-is";
 import { memoize } from "underscore";
@@ -182,7 +183,7 @@ export const getSearchIndex = memoize(function <
   TSection extends Section<TItem>,
 >({
   sections,
-  searchProp = [],
+  searchProp = ["name", "displayName"],
 }: {
   sections: TSection[];
   searchProp?: string | string[];

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -228,5 +228,5 @@ export function search<T>(
     .search(searchText, {
       limit: 50,
     })
-    .filter((result) => result.score && result.score < 0.6);
+    .filter((result) => result.score && result.score < 0.4);
 }

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -1,5 +1,4 @@
 import Fuse from "fuse.js";
-import { getIn } from "icepick";
 import { type ReactNode, isValidElement } from "react";
 import { isFragment } from "react-is";
 import { memoize } from "underscore";

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -217,10 +217,13 @@ function memoize<T extends object, R>(fn: (t: T) => R): (t: T) => R {
   };
 }
 
-export function search<T>(
-  searchIndex: Fuse<T>,
-  searchText: string,
-): Fuse.FuseResult<T>[] | null {
+export const search = memoize(function <T>({
+  searchIndex,
+  searchText,
+}: {
+  searchIndex: Fuse<T>;
+  searchText: string;
+}): Fuse.FuseResult<T>[] | null {
   if (searchText === "") {
     return null;
   }
@@ -229,4 +232,4 @@ export function search<T>(
       limit: 50,
     })
     .filter((result) => result.score && result.score < 0.4);
-}
+});

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -216,3 +216,17 @@ function memoize<T extends object, R>(fn: (t: T) => R): (t: T) => R {
     return lastResult;
   };
 }
+
+export function search<T>(
+  searchIndex: Fuse<T>,
+  searchText: string,
+): Fuse.FuseResult<T>[] | null {
+  if (searchText === "") {
+    return null;
+  }
+  return searchIndex
+    .search(searchText, {
+      limit: 50,
+    })
+    .filter((result) => result.score && result.score < 0.6);
+}

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -35,7 +35,6 @@ export function getNextCursor<
 >(
   cursor: Cursor | null,
   rows: Row<TItem, TSection>[],
-  isSectionExpanded: SectionPredicate,
   canSelectSection: SectionPredicate,
   skipInitial: boolean = true,
 ): Cursor | null {
@@ -52,7 +51,6 @@ export function getNextCursor<
     return getNextCursor(
       getCursorForRow(firstRow),
       rows,
-      isSectionExpanded,
       canSelectSection,
       false,
     );
@@ -85,7 +83,6 @@ export function getPrevCursor<
 >(
   cursor: Cursor | null,
   rows: Row<TItem, TSection>[],
-  isSectionExpanded: SectionPredicate,
   canSelectSection: SectionPredicate,
 ): Cursor | null {
   if (!cursor) {
@@ -98,12 +95,7 @@ export function getPrevCursor<
     if (!firstRow) {
       return null;
     }
-    return getPrevCursor(
-      getCursorForRow(firstRow),
-      rows,
-      isSectionExpanded,
-      canSelectSection,
-    );
+    return getPrevCursor(getCursorForRow(firstRow), rows, canSelectSection);
   }
 
   const currentRowIndex = rows.findIndex((row) =>

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -234,7 +234,7 @@ export function sectionScore<
 function searchPredicate<TItem>(item: TItem, searchText: string, prop: string) {
   const path = prop.split(".");
   const itemText = String(getIn(item, path) || "");
-  return itemText.toLowerCase().indexOf(searchText.toLowerCase()) >= 0;
+  return itemText.toLowerCase().includes(searchText.toLowerCase());
 }
 
 /**

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -178,7 +178,7 @@ export function isReactNode(x: unknown): x is ReactNode {
   );
 }
 
-export const getSearchIndex = memoize(function <
+const getSearchIndex = memoize(function <
   TItem extends Item,
   TSection extends Section<TItem>,
 >({
@@ -218,7 +218,7 @@ function memoize<T extends object, R>(fn: (t: T) => R): (t: T) => R {
   };
 }
 
-export const search = memoize(function <T>({
+const search = memoize(function <T>({
   searchIndex,
   searchText,
 }: {
@@ -229,10 +229,8 @@ export const search = memoize(function <T>({
     return null;
   }
   const results = searchIndex
-    .search(searchText, {
-      limit: 50,
-    })
-    .filter((result) => result.score && result.score < 0.4);
+    .search(searchText, { limit: 50 })
+    .filter((result) => result.score && result.score < 0.6);
 
   const map = new Map<T, number>();
   for (const result of results) {

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -223,13 +223,19 @@ export const search = memoize(function <T>({
 }: {
   searchIndex: Fuse<T>;
   searchText: string;
-}): Fuse.FuseResult<T>[] | null {
+}): Map<T, number> | null {
   if (searchText === "") {
     return null;
   }
-  return searchIndex
+  const results = searchIndex
     .search(searchText, {
       limit: 50,
     })
     .filter((result) => result.score && result.score < 0.4);
+
+  const map = new Map<T, number>();
+  for (const result of results) {
+    map.set(result.item, result.score ?? 1);
+  }
+  return map;
 });

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -1,7 +1,7 @@
+import { shallowEqual } from "@mantine/hooks";
 import Fuse from "fuse.js";
 import { type ReactNode, isValidElement } from "react";
 import { isFragment } from "react-is";
-import { memoize } from "underscore";
 
 import type { Item, Section } from "./types";
 
@@ -196,3 +196,23 @@ export const getSearchIndex = memoize(function <
     isCaseSensitive: false,
   });
 });
+
+/**
+ * Memoizes a function based on shallow equality of its argument.
+ */
+function memoize<T extends object, R>(fn: (t: T) => R): (t: T) => R {
+  let lastArgs: T | null = null;
+  let lastResult: R | null = null;
+
+  return function (args: T): R {
+    if (
+      lastArgs == null ||
+      lastResult == null ||
+      !shallowEqual(lastArgs, args)
+    ) {
+      lastArgs = args;
+      lastResult = fn(args);
+    }
+    return lastResult;
+  };
+}

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -249,13 +249,14 @@ const searchSubstring = memoize(function <TItem extends Item>({
   return {
     threshold: SEARCH_SCORE_THRESHOLD,
     score(item: TItem) {
+      let score = 1;
       for (const prop of searchProps) {
         const path = prop.split(".");
         const itemText = String(getIn(item, path) || "");
         const match = itemText.toLowerCase().includes(searchText.toLowerCase());
-        return match ? 0 : 1;
+        score = Math.min(score, match ? 0 : 1);
       }
-      return 1;
+      return score;
     },
   };
 });

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -3,7 +3,7 @@ import Fuse from "fuse.js";
 import { type ReactNode, isValidElement } from "react";
 import { isFragment } from "react-is";
 
-import type { Item, Section } from "./types";
+import type { Item, SearchProps, Section } from "./types";
 
 export type Cursor = {
   sectionIndex: number;
@@ -185,7 +185,7 @@ export const getSearchIndex = memoize(function <
   searchProp = ["name", "displayName"],
 }: {
   sections: TSection[];
-  searchProp?: string | string[];
+  searchProp?: SearchProps<TItem>;
 }) {
   const items = sections.flatMap((section) => section.items ?? []);
   const keys = Array.isArray(searchProp) ? searchProp : [searchProp];

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -1,7 +1,8 @@
+import Fuse from "fuse.js";
 import { type ReactNode, isValidElement } from "react";
 import { isFragment } from "react-is";
 
-import type { Section } from "./types";
+import type { Item, Section } from "./types";
 
 export type Cursor = {
   sectionIndex: number;
@@ -173,4 +174,24 @@ export function isReactNode(x: unknown): x is ReactNode {
     x === null ||
     x === undefined
   );
+}
+
+export function getSearchIndex<
+  TItem extends Item,
+  TSection extends Section<TItem>,
+>({
+  sections,
+  searchProp = [],
+}: {
+  sections: TSection[];
+  searchProp?: string | string[];
+}) {
+  const items = sections.flatMap((section) => section.items ?? []);
+  const keys = Array.isArray(searchProp) ? searchProp : [searchProp];
+
+  return new Fuse<TItem>(items, {
+    keys,
+    includeScore: true,
+    isCaseSensitive: false,
+  });
 }

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -1,6 +1,7 @@
 import Fuse from "fuse.js";
 import { type ReactNode, isValidElement } from "react";
 import { isFragment } from "react-is";
+import { memoize } from "underscore";
 
 import type { Item, Section } from "./types";
 
@@ -176,7 +177,7 @@ export function isReactNode(x: unknown): x is ReactNode {
   );
 }
 
-export function getSearchIndex<
+export const getSearchIndex = memoize(function <
   TItem extends Item,
   TSection extends Section<TItem>,
 >({
@@ -194,4 +195,4 @@ export function getSearchIndex<
     includeScore: true,
     isCaseSensitive: false,
   });
-}
+});

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -200,26 +200,6 @@ const getSearchIndex = memoize(function <
   });
 });
 
-/**
- * Memoizes a function based on shallow equality of its argument.
- */
-function memoize<T extends object, R>(fn: (t: T) => R): (t: T) => R {
-  let lastArgs: T | null = null;
-  let lastResult: R | null = null;
-
-  return function (args: T): R {
-    if (
-      lastArgs == null ||
-      lastResult == null ||
-      !shallowEqual(lastArgs, args)
-    ) {
-      lastArgs = args;
-      lastResult = fn(args);
-    }
-    return lastResult;
-  };
-}
-
 const search = memoize(function <T>({
   searchIndex,
   searchText,
@@ -306,4 +286,29 @@ function searchPredicate<TItem>(item: TItem, searchText: string, prop: string) {
   const path = prop.split(".");
   const itemText = String(getIn(item, path) || "");
   return itemText.toLowerCase().indexOf(searchText.toLowerCase()) >= 0;
+}
+
+/**
+ * Memoizes a function based on shallow equality of its argument.
+ *
+ * This basically acts as a LRU cache with just one cache entry.
+ *
+ * We use this over _.memoize because we rely on object identiy to memoize
+ * the search index, and _.memoize use string hashing for equality.
+ */
+function memoize<T extends object, R>(fn: (t: T) => R): (t: T) => R {
+  let lastArgs: T | null = null;
+  let lastResult: R | null = null;
+
+  return function (args: T): R {
+    if (
+      lastArgs == null ||
+      lastResult == null ||
+      !shallowEqual(lastArgs, args)
+    ) {
+      lastArgs = args;
+      lastResult = fn(args);
+    }
+    return lastResult;
+  };
 }

--- a/frontend/src/metabase/common/components/AccordionList/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.unit.spec.ts
@@ -4,8 +4,6 @@ const sectionIsExpanded = () => true;
 const sectionIsNotExpanded = () => false;
 const canSelectSection = () => true;
 const cannotSelectSection = () => false;
-const filterAll = () => true;
-const filterEvenIds = (item: any) => item.id % 2 === 0;
 
 const sections = [
   {
@@ -32,28 +30,67 @@ const sections = [
   },
 ];
 
+const rows = [
+  {
+    type: "header" as const,
+    section: sections[0],
+    sectionIndex: 0,
+    isLastSection: false,
+  },
+  {
+    type: "item" as const,
+    section: sections[0],
+    sectionIndex: 0,
+    itemIndex: 0,
+    item: sections[0].items[0],
+    isLastSection: false,
+    isLastItem: false,
+  },
+  {
+    type: "item" as const,
+    section: sections[0],
+    sectionIndex: 0,
+    itemIndex: 1,
+    item: sections[0].items[1],
+    isLastSection: false,
+    isLastItem: true,
+  },
+  {
+    type: "header" as const,
+    section: sections[1],
+    sectionIndex: 1,
+    isLastSection: true,
+  },
+  {
+    type: "item" as const,
+    section: sections[1],
+    sectionIndex: 1,
+    itemIndex: 0,
+    item: sections[1].items[0],
+    isLastSection: true,
+    isLastItem: false,
+  },
+  {
+    type: "item" as const,
+    section: sections[1],
+    sectionIndex: 1,
+    itemIndex: 1,
+    item: sections[1].items[1],
+    isLastSection: true,
+    isLastItem: true,
+  },
+];
+
 describe("getNextCursor", () => {
   it("returns the first section selected when initial cursor is null and selecting sections allowed", () => {
     expect(
-      getNextCursor(
-        null,
-        sections,
-        sectionIsExpanded,
-        canSelectSection,
-        filterAll,
-      ),
+      getNextCursor(null, rows, sectionIsExpanded, canSelectSection),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
   });
 
   it("returns the first item of the first section selected when initial cursor is null and selecting sections is not allowed", () => {
     expect(
-      getNextCursor(
-        null,
-        sections,
-        sectionIsExpanded,
-        cannotSelectSection,
-        filterAll,
-      ),
+      getNextCursor(null, rows, sectionIsExpanded, cannotSelectSection),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
   });
 
@@ -61,10 +98,9 @@ describe("getNextCursor", () => {
     expect(
       getNextCursor(
         { sectionIndex: 0, itemIndex: null },
-        sections,
+        rows,
         sectionIsExpanded,
         cannotSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
   });
@@ -73,10 +109,9 @@ describe("getNextCursor", () => {
     expect(
       getNextCursor(
         { sectionIndex: 0, itemIndex: null },
-        sections,
+        rows,
         sectionIsNotExpanded,
         canSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: null });
   });
@@ -85,10 +120,9 @@ describe("getNextCursor", () => {
     expect(
       getNextCursor(
         { sectionIndex: 0, itemIndex: 0 },
-        sections,
+        rows,
         sectionIsExpanded,
         cannotSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 1 });
   });
@@ -97,10 +131,9 @@ describe("getNextCursor", () => {
     expect(
       getNextCursor(
         { sectionIndex: 0, itemIndex: 1 },
-        sections,
+        rows,
         sectionIsExpanded,
         canSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: null });
   });
@@ -109,10 +142,9 @@ describe("getNextCursor", () => {
     expect(
       getNextCursor(
         { sectionIndex: 0, itemIndex: 1 },
-        sections,
+        rows,
         sectionIsExpanded,
         cannotSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: 0 });
   });
@@ -121,10 +153,9 @@ describe("getNextCursor", () => {
     expect(
       getNextCursor(
         { sectionIndex: 1, itemIndex: 1 },
-        sections,
+        rows,
         sectionIsExpanded,
         cannotSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: 1 });
   });
@@ -133,25 +164,18 @@ describe("getNextCursor", () => {
     expect(
       getNextCursor(
         { sectionIndex: 0, itemIndex: 1 },
-        sections,
+        rows,
         sectionIsExpanded,
         cannotSelectSection,
-        filterEvenIds,
       ),
-    ).toStrictEqual({ sectionIndex: 1, itemIndex: 1 });
+    ).toStrictEqual({ sectionIndex: 1, itemIndex: 0 });
   });
 });
 
 describe("getPrevCursor", () => {
   it("returns the first section when initial cursor is null and selecting sections allowed", () => {
     expect(
-      getPrevCursor(
-        null,
-        sections,
-        sectionIsExpanded,
-        canSelectSection,
-        filterAll,
-      ),
+      getPrevCursor(null, rows, sectionIsExpanded, canSelectSection),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
   });
 
@@ -159,10 +183,9 @@ describe("getPrevCursor", () => {
     expect(
       getPrevCursor(
         { sectionIndex: 0, itemIndex: 0 },
-        sections,
+        rows,
         sectionIsExpanded,
         canSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
   });
@@ -171,10 +194,9 @@ describe("getPrevCursor", () => {
     expect(
       getPrevCursor(
         { sectionIndex: 0, itemIndex: 0 },
-        sections,
+        rows,
         sectionIsExpanded,
         cannotSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
   });
@@ -183,10 +205,9 @@ describe("getPrevCursor", () => {
     expect(
       getPrevCursor(
         { sectionIndex: 0, itemIndex: 1 },
-        sections,
+        rows,
         sectionIsExpanded,
         cannotSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
   });
@@ -195,10 +216,9 @@ describe("getPrevCursor", () => {
     expect(
       getPrevCursor(
         { sectionIndex: 1, itemIndex: null },
-        sections,
+        rows,
         sectionIsNotExpanded,
         canSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
   });
@@ -207,10 +227,9 @@ describe("getPrevCursor", () => {
     expect(
       getPrevCursor(
         { sectionIndex: 1, itemIndex: null },
-        sections,
+        rows,
         sectionIsExpanded,
         canSelectSection,
-        filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 1 });
   });
@@ -218,11 +237,10 @@ describe("getPrevCursor", () => {
   it("skips filtered out items", () => {
     expect(
       getPrevCursor(
-        { sectionIndex: 1, itemIndex: 1 },
-        sections,
+        { sectionIndex: 1, itemIndex: 0 },
+        rows,
         sectionIsExpanded,
         cannotSelectSection,
-        filterEvenIds,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 1 });
   });

--- a/frontend/src/metabase/common/components/AccordionList/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.unit.spec.ts
@@ -1,7 +1,5 @@
 import { getNextCursor, getPrevCursor } from "./utils";
 
-const sectionIsExpanded = () => true;
-const sectionIsNotExpanded = () => false;
 const canSelectSection = () => true;
 const cannotSelectSection = () => false;
 
@@ -83,15 +81,17 @@ const rows = [
 
 describe("getNextCursor", () => {
   it("returns the first section selected when initial cursor is null and selecting sections allowed", () => {
-    expect(
-      getNextCursor(null, rows, sectionIsExpanded, canSelectSection),
-    ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
+    expect(getNextCursor(null, rows, canSelectSection)).toStrictEqual({
+      sectionIndex: 0,
+      itemIndex: null,
+    });
   });
 
   it("returns the first item of the first section selected when initial cursor is null and selecting sections is not allowed", () => {
-    expect(
-      getNextCursor(null, rows, sectionIsExpanded, cannotSelectSection),
-    ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
+    expect(getNextCursor(null, rows, cannotSelectSection)).toStrictEqual({
+      sectionIndex: 0,
+      itemIndex: 0,
+    });
   });
 
   it("returns the first item of the first section selected when initial cursor is on the first section", () => {
@@ -99,18 +99,16 @@ describe("getNextCursor", () => {
       getNextCursor(
         { sectionIndex: 0, itemIndex: null },
         rows,
-        sectionIsExpanded,
         cannotSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
   });
 
-  it("returns the section section if first section is selected but not expanded", () => {
+  it("returns the next section if first section is selected but not expanded", () => {
     expect(
       getNextCursor(
         { sectionIndex: 0, itemIndex: null },
-        rows,
-        sectionIsNotExpanded,
+        rows.filter((item) => item.type !== "item"),
         canSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: null });
@@ -121,7 +119,6 @@ describe("getNextCursor", () => {
       getNextCursor(
         { sectionIndex: 0, itemIndex: 0 },
         rows,
-        sectionIsExpanded,
         cannotSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 1 });
@@ -129,12 +126,7 @@ describe("getNextCursor", () => {
 
   it("returns the second section when on the last item of the first section and selecting sections is allowed", () => {
     expect(
-      getNextCursor(
-        { sectionIndex: 0, itemIndex: 1 },
-        rows,
-        sectionIsExpanded,
-        canSelectSection,
-      ),
+      getNextCursor({ sectionIndex: 0, itemIndex: 1 }, rows, canSelectSection),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: null });
   });
 
@@ -143,7 +135,6 @@ describe("getNextCursor", () => {
       getNextCursor(
         { sectionIndex: 0, itemIndex: 1 },
         rows,
-        sectionIsExpanded,
         cannotSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: 0 });
@@ -154,7 +145,6 @@ describe("getNextCursor", () => {
       getNextCursor(
         { sectionIndex: 1, itemIndex: 1 },
         rows,
-        sectionIsExpanded,
         cannotSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: 1 });
@@ -165,7 +155,6 @@ describe("getNextCursor", () => {
       getNextCursor(
         { sectionIndex: 0, itemIndex: 1 },
         rows,
-        sectionIsExpanded,
         cannotSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: 0 });
@@ -174,19 +163,15 @@ describe("getNextCursor", () => {
 
 describe("getPrevCursor", () => {
   it("returns the first section when initial cursor is null and selecting sections allowed", () => {
-    expect(
-      getPrevCursor(null, rows, sectionIsExpanded, canSelectSection),
-    ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
+    expect(getPrevCursor(null, rows, canSelectSection)).toStrictEqual({
+      sectionIndex: 0,
+      itemIndex: null,
+    });
   });
 
   it("returns the first section when on the first item and selecting sections allowed", () => {
     expect(
-      getPrevCursor(
-        { sectionIndex: 0, itemIndex: 0 },
-        rows,
-        sectionIsExpanded,
-        canSelectSection,
-      ),
+      getPrevCursor({ sectionIndex: 0, itemIndex: 0 }, rows, canSelectSection),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
   });
 
@@ -195,7 +180,6 @@ describe("getPrevCursor", () => {
       getPrevCursor(
         { sectionIndex: 0, itemIndex: 0 },
         rows,
-        sectionIsExpanded,
         cannotSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
@@ -206,7 +190,6 @@ describe("getPrevCursor", () => {
       getPrevCursor(
         { sectionIndex: 0, itemIndex: 1 },
         rows,
-        sectionIsExpanded,
         cannotSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
@@ -216,8 +199,7 @@ describe("getPrevCursor", () => {
     expect(
       getPrevCursor(
         { sectionIndex: 1, itemIndex: null },
-        rows,
-        sectionIsNotExpanded,
+        rows.filter((item) => item.type !== "item"),
         canSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
@@ -228,7 +210,6 @@ describe("getPrevCursor", () => {
       getPrevCursor(
         { sectionIndex: 1, itemIndex: null },
         rows,
-        sectionIsExpanded,
         canSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 1 });
@@ -239,7 +220,6 @@ describe("getPrevCursor", () => {
       getPrevCursor(
         { sectionIndex: 1, itemIndex: 0 },
         rows,
-        sectionIsExpanded,
         cannotSelectSection,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 1 });

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -292,6 +292,7 @@ export function AggregationPicker({
         maxHeight={Infinity}
         withBorders
         globalSearch
+        fuzzySearch
       />
     </Box>
   );

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -206,7 +206,7 @@ export function QueryColumnPicker({
         }}
         maxHeight={Infinity}
         data-testid={dataTestId}
-        searchProp={["name", "displayName"]}
+        searchProp={["name", "displayName", "longDisplayName"]}
         // Compat with E2E tests around MLv1-based components
         // Prefer using a11y role selectors
         itemTestId="dimension-list-item"
@@ -215,6 +215,7 @@ export function QueryColumnPicker({
         width={width}
         globalSearch={!disableSearch}
         searchable={!disableSearch}
+        fuzzySearch
       />
     </DelayGroup>
   );

--- a/frontend/src/metabase/common/components/Select/Select.tsx
+++ b/frontend/src/metabase/common/components/Select/Select.tsx
@@ -10,7 +10,10 @@ import type {
 import { Children, Component, createRef } from "react";
 import _ from "underscore";
 
-import { AccordionList } from "metabase/common/components/AccordionList";
+import {
+  AccordionList,
+  type SearchProps,
+} from "metabase/common/components/AccordionList";
 import PopoverWithTrigger from "metabase/common/components/PopoverWithTrigger";
 import type { SelectButtonProps } from "metabase/common/components/SelectButton";
 import SelectButton from "metabase/common/components/SelectButton";
@@ -53,7 +56,7 @@ export interface SelectProps<
   buttonText?: string; // will override selected options text
 
   // AccordionList props
-  searchProp?: string;
+  searchProp?: SearchProps<TOption>;
   searchPlaceholder?: string;
   globalSearch?: boolean;
   width?: number;

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import {
   AccordionList,
-  type Section,
+  type Section as BaseSection,
 } from "metabase/common/components/AccordionList";
 import CS from "metabase/css/core/index.css";
 import { isSyncCompleted } from "metabase/lib/syncing";
@@ -33,6 +33,10 @@ type Item = {
   name: string;
 };
 
+type Section = BaseSection<Item> & {
+  active?: boolean;
+};
+
 const DataSelectorDatabaseSchemaPicker = ({
   databases,
   selectedDatabase,
@@ -49,7 +53,7 @@ const DataSelectorDatabaseSchemaPicker = ({
     return <DataSelectorLoading />;
   }
 
-  const sections: Section<Item>[] = databases.map((database) => ({
+  const sections: Section[] = databases.map((database) => ({
     name: database.is_saved_questions ? t`Saved Questions` : database.name,
     items:
       !database.is_saved_questions && database.getSchemas().length > 1
@@ -86,7 +90,7 @@ const DataSelectorDatabaseSchemaPicker = ({
     return true;
   };
 
-  const renderSectionIcon = ({ icon }: Section<Item>) =>
+  const renderSectionIcon = ({ icon }: Section) =>
     icon && (
       <Icon className={cx("Icon", CS.textDefault)} name={icon} size={18} />
     );
@@ -110,7 +114,7 @@ const DataSelectorDatabaseSchemaPicker = ({
   }
 
   return (
-    <AccordionList<Item>
+    <AccordionList<Item, Section>
       id="DatabaseSchemaPicker"
       key="databaseSchemaPicker"
       className={CS.textBrand}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -22,6 +22,13 @@ import S from "./FilterColumnPicker.module.css";
 
 type Item = ColumnListItem | SegmentListItem;
 
+const SEARCH_PROP = [
+  "name",
+  "displayName",
+  "tableName",
+  "tableDisplayName",
+] as const;
+
 export interface FilterColumnPickerProps {
   className?: string;
   query: Lib.Query;
@@ -114,7 +121,7 @@ export function FilterColumnPicker({
         // Compat with E2E tests around MLv1-based components
         // Prefer using a11y role selectors
         itemTestId="dimension-list-item"
-        searchProp={["name", "displayName"]}
+        searchProp={SEARCH_PROP}
         globalSearch
         fuzzySearch
         withBorders
@@ -145,6 +152,8 @@ function getSections(
           column,
           query,
           stageIndex,
+          tableName: columnInfo.table?.name,
+          tableDisplayName: columnInfo.table?.displayName,
         };
       });
       const segments = groupInfo.isSourceTable

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -20,14 +20,13 @@ import type { ColumnListItem, SegmentListItem } from "../types";
 
 import S from "./FilterColumnPicker.module.css";
 
-type Item = ColumnListItem | SegmentListItem;
+type Item =
+  | ColumnListItem
+  | (SegmentListItem & {
+      combinedDisplayName?: string;
+    });
 
-const SEARCH_PROP = [
-  "name",
-  "displayName",
-  "tableName",
-  "tableDisplayName",
-] as const;
+const SEARCH_PROP = ["name", "displayName", "combinedDisplayName"] as const;
 
 export interface FilterColumnPickerProps {
   className?: string;
@@ -152,8 +151,8 @@ function getSections(
           column,
           query,
           stageIndex,
-          tableName: columnInfo.table?.name,
-          tableDisplayName: columnInfo.table?.displayName,
+          combinedName: `${columnInfo.table?.name ?? ""} ${columnInfo.name}`,
+          combinedDisplayName: `${columnInfo.table?.displayName ?? ""} ${columnInfo.displayName}`,
         };
       });
       const segments = groupInfo.isSourceTable

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -116,6 +116,7 @@ export function FilterColumnPicker({
         itemTestId="dimension-list-item"
         searchProp={["name", "displayName"]}
         globalSearch
+        fuzzySearch
         withBorders
       />
     </DelayGroup>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
@@ -21,6 +21,8 @@ export type ColumnListItem = {
   column: Lib.ColumnMetadata;
   stageIndex: number;
   filterPositions?: number[];
+  tableName?: string;
+  tableDisplayName?: string;
 };
 
 export type SegmentListItem = Lib.SegmentDisplayInfo & {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
@@ -21,8 +21,6 @@ export type ColumnListItem = {
   column: Lib.ColumnMetadata;
   stageIndex: number;
   filterPositions?: number[];
-  tableName?: string;
-  tableDisplayName?: string;
 };
 
 export type SegmentListItem = Lib.SegmentDisplayInfo & {


### PR DESCRIPTION
Closes [QUE-1361](https://linear.app/metabase/issue/QUE-1361/it-should-be-possible-to-search-fields-by-table-name-in-the-column).
Closes [QUE-1362](https://linear.app/metabase/issue/QUE-1362/use-fuzzy-search-in-the-column-picker)

## To verify

1. New -> Question -> Orders
2. Filter
3. Type `Product`, you should now see all columns in the product table
4. Type `Product Price`, you should now see `Product -> Price` as a result (and some other results too).