### PR TITLE
fix(sdk): Fix flickered "Question new not found error"

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -83,11 +83,14 @@ export const InteractiveQuestionDefaultView = ({
   const isQueryResultLoading =
     question && shouldRunCardQuery(question) && !queryResults;
 
-  if (isLocaleLoading || isQuestionLoading || isQueryResultLoading) {
+  if (
+    !isEditorOpen &&
+    (isLocaleLoading || isQuestionLoading || isQueryResultLoading)
+  ) {
     return <SdkLoader />;
   }
 
-  if (!question) {
+  if (!isEditorOpen && !question) {
     if (originalId) {
       return <QuestionNotFoundError id={originalId} />;
     } else {

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -83,10 +83,7 @@ export const InteractiveQuestionDefaultView = ({
   const isQueryResultLoading =
     question && shouldRunCardQuery(question) && !queryResults;
 
-  if (
-    !isEditorOpen &&
-    (isLocaleLoading || isQuestionLoading || isQueryResultLoading)
-  ) {
+  if (isLocaleLoading || isQuestionLoading || isQueryResultLoading) {
     return <SdkLoader />;
   }
 


### PR DESCRIPTION
Closes EMB-432

### Description
> [!note]
> Not that I didn't want to add tests, but it's almost impossible to add one.
> Testing the 1 frame of error appearance is impossible on Cypress, it couldn't see the 1 frame error flash. We can't mock the component either, since we import from `@metabase/embedding-sdk-react` since we want to test the npm package on CI as well.

Fix the flashing error not found for `new` ID. It's kinda stupid to keep adding more boolean flag, I think eventually maybe it'd make sense to have a different component or a different branch entirely, but this will do for now.

### How to verify

The easier way to verify is to modify `ResourceNotFoundError` (`enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx`) add a log or something.
1. Add a `console.log` in `ResourceNotFoundError`
1. Run your backend e.g. `clj -M:dev:ee:dev-start`
1. `yarn storybook-embedding-sdk`
1. visit http://localhost:6006/?path=/story/embeddingsdk-interactivequestion--create-question, there should be no log
1. Revert the code removing `!isEditorOpen &&` and revisit the storybook, you should now see the log from the error component.


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ I spent probably about an hour or two trying to test the 1 frame of error showing, but nothing works. I can't even mock the SDK because I wanted to mock a private component which isn't exposed by the library.
