### PR TITLE
fix: fetch initial value for remapped category select

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputSearchableSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputSearchableSelect.tsx
@@ -51,6 +51,7 @@ export const ActionInputSearchableSelect = ({
   });
 
   const { options, isLoading, isFetching } = useActionInputSearchableOptions({
+    initialValue,
     search,
     fieldId: fieldId,
     searchFieldId: searchFieldId,


### PR DESCRIPTION
Related to [WRK-354](https://linear.app/metabase/issue/WRK-354/fk-is-displayed-instead-of-a-value-per-table-metadatafield-display)

Migration to described action forms re-introduced this issue again, so there's a fix for it.