### PR TITLE
Use Side Nav for Performance Pages

### DIFF
--- a/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
@@ -540,9 +540,7 @@ function assertDbRoutingDisabled() {
 
 function setupModelPersistence() {
   interceptPerformanceRoutes();
-  cy.visit("/admin");
-  cy.findByRole("link", { name: "Performance" }).click();
-  cy.findByRole("tab", { name: "Model persistence" }).click();
-  cy.findByRole("switch", { name: "Disabled" }).click({ force: true });
+  cy.visit("/admin/performance/models");
+  cy.findByTestId("admin-layout-content").findByText("Disabled").click();
   cy.wait("@enablePersistence");
 }

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-performance-helpers.ts
@@ -36,16 +36,13 @@ export const log = (message: string) => {
   console.log(message);
 };
 
-export const databaseCachingPage = () =>
-  cy.findByRole("tabpanel", { name: "Database caching" });
-
-export const visitDashboardAndQuestionCachingTab = () => {
-  cy.visit("/admin/performance");
-  cy.findByRole("tablist")
-    .get("[aria-selected]")
-    .contains("Database caching")
-    .should("be.visible");
-  cy.findByRole("tab", { name: "Dashboard and question caching" }).click();
+export const goToPerformancePage = (
+  name:
+    | "Database caching"
+    | "Dashboard and question caching"
+    | "Model persistence",
+) => {
+  cy.findByTestId("admin-layout-sidebar").findByText(name).click();
 };
 
 export const setupQuestionTest = (

--- a/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
+++ b/e2e/test/scenarios/admin/performance/helpers/e2e-strategy-form-helpers.ts
@@ -1,6 +1,6 @@
 import { match } from "ts-pattern";
 
-import { modal, popover } from "e2e/support/helpers";
+import { popover } from "e2e/support/helpers";
 import {
   type ScheduleComponentType,
   getScheduleComponentLabel,
@@ -12,7 +12,7 @@ import type {
   InheritStrategy,
 } from "metabase-types/api";
 
-import { databaseCachingPage, log } from "./e2e-performance-helpers";
+import { log } from "./e2e-performance-helpers";
 import type { SelectCacheStrategyOptions, StrategyBearer } from "./types";
 
 /** Save the cache strategy form and wait for a response from the relevant endpoint */
@@ -74,11 +74,6 @@ export const checkPreemptiveCachingDisabled = () =>
     cy.findByRole("switch").should("not.be.checked");
   });
 
-export const dashboardAndQuestionsTable = () =>
-  cy.findByRole("table", {
-    name: /Here are the dashboards and questions/,
-  });
-
 export const formLauncher = (
   itemName: string,
   preface:
@@ -89,7 +84,9 @@ export const formLauncher = (
 ) => {
   const regExp = new RegExp(`Edit.*${itemName}.*${preface}.*${strategyLabel}`);
   cy.log(`Finding strategy for launcher for regular expression: ${regExp}`);
-  const launcher = databaseCachingPage().findByLabelText(regExp);
+  const launcher = cy
+    .findByTestId("admin-layout-content")
+    .findByLabelText(regExp);
   launcher.should("exist");
   return launcher;
 };
@@ -101,7 +98,6 @@ export const openStrategyFormForDatabaseOrDefaultPolicy = (
   currentStrategyLabel?: string,
 ) => {
   cy.visit("/admin/performance");
-  cy.findByRole("tablist").get("[aria-selected]").contains("Database caching");
   cy.log(`Open strategy form for ${databaseNameOrDefaultPolicy}`);
   formLauncher(
     databaseNameOrDefaultPolicy,
@@ -145,13 +141,6 @@ export const cacheStrategySidesheet = () =>
 
 export const questionSettingsSidesheet = () =>
   cy.findByRole("dialog", { name: /Question settings/ }).should("be.visible");
-
-export const cancelConfirmationModal = () => {
-  modal().within(() => {
-    cy.findByText("Discard your changes?");
-    cy.button("Cancel").click();
-  });
-};
 
 export const getRadioButtonForStrategyType = (
   strategyType: CacheStrategyType,

--- a/e2e/test/scenarios/admin/performance/strategyForm.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/strategyForm.cy.spec.ts
@@ -5,16 +5,14 @@ import {
 } from "e2e/support/cypress_sample_instance_data";
 
 import {
+  goToPerformancePage,
   interceptPerformanceRoutes,
-  visitDashboardAndQuestionCachingTab,
 } from "./helpers/e2e-performance-helpers";
 import {
   adaptiveRadioButton,
   cacheStrategyForm,
-  cancelConfirmationModal,
   checkPreemptiveCachingDisabled,
   checkPreemptiveCachingEnabled,
-  dashboardAndQuestionsTable,
   disablePreemptiveCaching,
   dontCacheResultsRadioButton,
   durationRadioButton,
@@ -39,7 +37,7 @@ describe("scenarios > admin > performance > strategy form", () => {
     });
 
     it("can enable and disable model persistence", () => {
-      cy.findByRole("tab", { name: "Model persistence" }).click();
+      goToPerformancePage("Model persistence");
       cy.findByRole("switch", { name: "Disabled" }).click({ force: true });
       cy.wait("@enablePersistence");
       cy.findByTestId("toast-undo").contains("Saved");
@@ -53,7 +51,7 @@ describe("scenarios > admin > performance > strategy form", () => {
     });
 
     it("can change when models are refreshed", () => {
-      cy.findByRole("tab", { name: "Model persistence" }).click();
+      goToPerformancePage("Model persistence");
       cy.findByRole("switch", { name: "Disabled" }).click({ force: true });
       cy.wait("@enablePersistence");
       cy.findByTestId("toast-undo").contains("Saved");
@@ -83,16 +81,13 @@ describe("scenarios > admin > performance > strategy form", () => {
       dontCacheResultsRadioButton().should("be.checked");
     });
 
-    it("has the right tabs", () => {
-      cy.findByRole("main")
-        .findByRole("tablist")
-        .findAllByRole("tab")
-        .should("have.length", 2);
-      cy.findByRole("tab", { name: "Database caching" }).should("be.visible");
-      cy.findByRole("tab", { name: "Model persistence" }).should("be.visible");
-      cy.findByRole("tab", { name: "Dashboard and question caching" }).should(
-        "not.exist",
-      );
+    it("has the correct nav items", () => {
+      cy.findByTestId("admin-layout-sidebar").within(() => {
+        cy.findAllByRole("link").should("have.length", 2);
+        cy.findByText("Database caching").should("be.visible");
+        cy.findByText("Model persistence").should("be.visible");
+        cy.findByText("Dashboard and question caching").should("not.exist");
+      });
     });
 
     describe("adaptive strategy", () => {
@@ -125,18 +120,15 @@ describe("scenarios > admin > performance > strategy form", () => {
       H.setTokenFeatures("all");
     });
 
-    it("has the right tabs", () => {
+    it("has the correct nav items", () => {
       cy.visit("/admin");
       cy.findByRole("link", { name: "Performance" }).click();
-      cy.findByRole("main")
-        .findByRole("tablist")
-        .findAllByRole("tab")
-        .should("have.length", 3);
-      cy.findByRole("tab", { name: "Database caching" }).should("be.visible");
-      cy.findByRole("tab", { name: "Dashboard and question caching" }).should(
-        "be.visible",
-      );
-      cy.findByRole("tab", { name: "Model persistence" }).should("be.visible");
+      cy.findByTestId("admin-layout-sidebar").within(() => {
+        cy.findAllByRole("link").should("have.length", 3);
+        cy.findByText("Database caching").should("be.visible");
+        cy.findByText("Dashboard and question caching").should("be.visible");
+        cy.findByText("Model persistence").should("be.visible");
+      });
     });
 
     it("can call cache invalidation endpoint for Sample Database", () => {
@@ -357,8 +349,8 @@ describe("scenarios > admin > performance > strategy form", () => {
     describe("Dashboard and question caching tab", () => {
       it("can configure Sample Database on the 'Dashboard and question caching' tab", () => {
         interceptPerformanceRoutes();
-        visitDashboardAndQuestionCachingTab();
-        dashboardAndQuestionsTable()
+        cy.visit("/admin/performance/dashboards-and-questions");
+        cy.findByTestId("cache-config-table")
           .should("be.visible")
           .contains(
             "No dashboards or questions have their own caching policies yet.",
@@ -368,8 +360,8 @@ describe("scenarios > admin > performance > strategy form", () => {
         durationRadioButton().click();
         cy.findByLabelText(/Cache results for this many hours/).type("99");
         saveCacheStrategyForm({ strategyType: "duration", model: "database" });
-        visitDashboardAndQuestionCachingTab();
-        dashboardAndQuestionsTable()
+        cy.visit("/admin/performance/dashboards-and-questions");
+        cy.findByTestId("cache-config-table")
           .contains("Duration: 99h")
           .within(() => {
             cy.findByText("Duration: 99h").click();
@@ -380,8 +372,8 @@ describe("scenarios > admin > performance > strategy form", () => {
 
       it("confirmation modal appears before dirty form is abandoned", () => {
         interceptPerformanceRoutes();
-        visitDashboardAndQuestionCachingTab();
-        dashboardAndQuestionsTable()
+        cy.visit("/admin/performance/dashboards-and-questions");
+        cy.findByTestId("cache-config-table")
           .should("be.visible")
           .contains(
             "No dashboards or questions have their own caching policies yet.",
@@ -391,8 +383,8 @@ describe("scenarios > admin > performance > strategy form", () => {
         durationRadioButton().click();
         cy.findByLabelText(/Cache results for this many hours/).type("99");
         saveCacheStrategyForm({ strategyType: "duration", model: "database" });
-        visitDashboardAndQuestionCachingTab();
-        dashboardAndQuestionsTable()
+        cy.visit("/admin/performance/dashboards-and-questions");
+        cy.findByTestId("cache-config-table")
           .contains("Duration: 99h")
           .within(() => {
             cy.findByText("Duration: 99h").click();
@@ -405,9 +397,9 @@ describe("scenarios > admin > performance > strategy form", () => {
         durationRadioButton().click();
         cy.findByLabelText(/Cache results for this many hours/).type("24");
         saveCacheStrategyForm({ strategyType: "duration", model: "database" });
-        visitDashboardAndQuestionCachingTab();
-        dashboardAndQuestionsTable().contains("Adaptive");
-        dashboardAndQuestionsTable()
+        cy.visit("/admin/performance/dashboards-and-questions");
+        cy.findByTestId("cache-config-table").contains("Adaptive");
+        cy.findByTestId("cache-config-table")
           .contains("Duration: 24h")
           .within(() => {
             cy.findByText("Duration: 24h").click();
@@ -416,23 +408,13 @@ describe("scenarios > admin > performance > strategy form", () => {
         cy.log("Make form dirty");
         scheduleRadioButton().click();
 
-        cy.log("Modal appears when another row's form launcher is clicked");
-        dashboardAndQuestionsTable()
-          .contains("Adaptive")
-          .within(() => {
-            cy.findByText("Adaptive").click();
-          });
-        cancelConfirmationModal();
+        cy.log("Modal appears when the user tries to close the sidesheet");
+        cy.findByTestId("modal-overlay").click();
 
-        cy.log("Modal appears when another admin nav item is clicked");
-        cy.findByLabelText("Navigation bar").within(() => {
-          cy.findByText("Settings").click();
-        });
-        cancelConfirmationModal();
-
-        cy.log("Modal appears when another Performance tab is clicked");
-        cy.findByRole("tab", { name: "Database caching" }).click();
-        cancelConfirmationModal();
+        H.modal()
+          .should("have.length", 2) // sidesheet and confirm modal are both modals
+          .last()
+          .findByText("Discard your changes?");
       });
     });
 
@@ -448,8 +430,8 @@ describe("scenarios > admin > performance > strategy form", () => {
         checkPreemptiveCachingEnabled();
 
         // Check that it's also enabled on the "Dashboard and question caching" admin page
-        visitDashboardAndQuestionCachingTab();
-        dashboardAndQuestionsTable()
+        cy.visit("/admin/performance/dashboards-and-questions");
+        cy.findByTestId("cache-config-table")
           .contains("Duration: 24h")
           .within(() => {
             cy.findByText("Duration: 24h").click();
@@ -478,8 +460,8 @@ describe("scenarios > admin > performance > strategy form", () => {
         checkPreemptiveCachingEnabled();
 
         // Check that it's also enabled on the "Dashboard and question caching" admin page
-        visitDashboardAndQuestionCachingTab();
-        dashboardAndQuestionsTable()
+        cy.visit("/admin/performance/dashboards-and-questions");
+        cy.findByTestId("cache-config-table")
           .contains("Scheduled: hourly")
           .within(() => {
             cy.findByText("Scheduled: hourly").click();

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -261,6 +261,7 @@ const _StrategyEditorForQuestionsAndDashboards = ({
               <ClientSortableTable<CacheableItem>
                 className={Styles.CacheableItemTable}
                 columns={tableColumns}
+                data-testid="cache-config-table"
                 rows={cacheableItems}
                 rowRenderer={rowRenderer}
                 defaultSortColumn="name"

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -23,6 +23,7 @@ import {
   Skeleton,
   Stack,
   Text,
+  Title,
 } from "metabase/ui";
 import { Repeat } from "metabase/ui/components/feedback/Skeleton/Repeat";
 import type { CacheableModel } from "metabase-types/api";
@@ -261,21 +262,20 @@ const _StrategyEditorForQuestionsAndDashboards = ({
       }}
     >
       <Stack
-        gap="sm"
-        lh="1.5rem"
-        pt="md"
-        pb="md"
-        px="2.5rem"
+        gap="xl"
         style={{
           flex: 1,
           overflowY: "auto",
         }}
       >
-        <Box component="aside" maw="32rem" id={explanatoryAsideId}>
-          {t`Here are the dashboards and questions that have their own caching policies, which override any default or database policies you’ve set.`}
+        <Box component="aside" id={explanatoryAsideId}>
+          <Title order={1}>{t`Caching for dashboards and questions`}</Title>
+          <Text>
+            {t`Here are the dashboards and questions that have their own caching policies, which override any default or database policies you’ve set.`}
+          </Text>
         </Box>
         {confirmationModal}
-        <Flex maw="60rem">
+        <Flex>
           <DelayedLoadingAndErrorWrapper
             error={error}
             loading={loading}

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards.tsx
@@ -4,27 +4,17 @@ import { withRouter } from "react-router";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { Panel } from "metabase/admin/performance/components/StrategyEditorForDatabases.styled";
 import { StrategyForm } from "metabase/admin/performance/components/StrategyForm";
-import { rootId } from "metabase/admin/performance/constants/simple";
 import { useCacheConfigs } from "metabase/admin/performance/hooks/useCacheConfigs";
 import { useConfirmIfFormIsDirty } from "metabase/admin/performance/hooks/useConfirmIfFormIsDirty";
 import { useSaveStrategy } from "metabase/admin/performance/hooks/useSaveStrategy";
+import { SettingsPageWrapper } from "metabase/admin/settings/components/SettingsSection";
 import { skipToken, useSearchQuery } from "metabase/api";
+import { Sidesheet } from "metabase/common/components/Sidesheet";
 import { ClientSortableTable } from "metabase/common/components/Table/ClientSortableTable";
 import type { ColumnItem } from "metabase/common/components/Table/types";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
-import {
-  Box,
-  Button,
-  Center,
-  Flex,
-  Icon,
-  Skeleton,
-  Stack,
-  Text,
-  Title,
-} from "metabase/ui";
+import { Center, Flex, Skeleton, Stack } from "metabase/ui";
 import { Repeat } from "metabase/ui/components/feedback/Skeleton/Repeat";
 import type { CacheableModel } from "metabase-types/api";
 import { CacheDurationUnit } from "metabase-types/api";
@@ -249,17 +239,9 @@ const _StrategyEditorForQuestionsAndDashboards = ({
   }, [updateTarget, isStrategyFormDirty]);
 
   return (
-    <Flex
-      role="region"
-      aria-label={t`Dashboard and question caching`}
-      w="100%"
-      direction="row"
-      justify="space-between"
-      onKeyDown={(e) => {
-        if (e.key === "Escape" && !e.ctrlKey && !e.metaKey) {
-          closeForm();
-        }
-      }}
+    <SettingsPageWrapper
+      title={t`Caching for dashboards and questions`}
+      description={t`Here are the dashboards and questions that have their own caching policies, which override any default or database policies you’ve set.`}
     >
       <Stack
         gap="xl"
@@ -268,12 +250,6 @@ const _StrategyEditorForQuestionsAndDashboards = ({
           overflowY: "auto",
         }}
       >
-        <Box component="aside" id={explanatoryAsideId}>
-          <Title order={1}>{t`Caching for dashboards and questions`}</Title>
-          <Text>
-            {t`Here are the dashboards and questions that have their own caching policies, which override any default or database policies you’ve set.`}
-          </Text>
-        </Box>
         {confirmationModal}
         <Flex>
           <DelayedLoadingAndErrorWrapper
@@ -305,35 +281,26 @@ const _StrategyEditorForQuestionsAndDashboards = ({
         </Flex>
       </Stack>
 
-      {targetId !== null && targetModel !== null && (
-        <Panel className={Styles.StrategyFormPanel}>
-          <Button
-            variant="subtle"
-            pos="absolute"
-            p="1rem"
-            top="1rem"
-            style={{ insetInlineEnd: "1rem" }}
-            onClick={() => {
-              closeForm();
-            }}
-          >
-            <Text color="var(--mb-color-text-dark)">
-              <Icon name="close" />
-            </Text>
-          </Button>
+      <Sidesheet
+        isOpen={targetId !== null && targetModel !== null}
+        onClose={closeForm}
+        title={targetName ?? `Untitled ${targetModel}`}
+      >
+        {targetModel && (
           <StrategyForm
             targetId={targetId}
             targetModel={targetModel}
-            targetName={targetName ?? `Untitled ${targetModel}`}
+            targetName=""
             setIsDirty={setIsStrategyFormDirty}
             saveStrategy={saveStrategy}
             savedStrategy={savedStrategy}
             shouldAllowInvalidation={true}
-            shouldShowName={targetId !== rootId}
+            shouldShowName={false}
+            isInSidebar
           />
-        </Panel>
-      )}
-    </Flex>
+        )}
+      </Sidesheet>
+    </SettingsPageWrapper>
   );
 };
 

--- a/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
+++ b/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
@@ -3,6 +3,10 @@ import type { ChangeEvent } from "react";
 import { useEffect, useState } from "react";
 import { c, msgid, ngettext, t } from "ttag";
 
+import {
+  SettingsPageWrapper,
+  SettingsSection,
+} from "metabase/admin/settings/components/SettingsSection";
 import { ModelCachingScheduleWidget } from "metabase/admin/settings/components/widgets/ModelCachingScheduleWidget/ModelCachingScheduleWidget";
 import { useDocsUrl, useSetting, useToast } from "metabase/common/hooks";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
@@ -14,7 +18,7 @@ import {
   getShowMetabaseLinks,
 } from "metabase/selectors/whitelabel";
 import { PersistedModelsApi } from "metabase/services";
-import { Box, Stack, Switch, Text, Title } from "metabase/ui";
+import { Switch, Text } from "metabase/ui";
 
 import ModelPersistenceConfigurationS from "./ModelPersistenceConfiguration.module.css";
 
@@ -110,17 +114,15 @@ export const ModelPersistenceConfiguration = () => {
   const { url: docsUrl } = useDocsUrl("data-modeling/model-persistence");
 
   return (
-    <Stack gap="xl">
-      <Box
-        mb="sm"
-        lh="1.5rem"
+    <SettingsPageWrapper
+      title={t`Model persistence`}
+      description={t`Enable model persistence to make your models (and the queries that use them) load faster.`}
+    >
+      <SettingsSection
         className={ModelPersistenceConfigurationS.Explanation}
+        maw="40rem"
       >
-        <Title order={1}>{t`Model persistence`}</Title>
         <Text>
-          {t`Enable model persistence to make your models (and the queries that use them) load faster.`}
-        </Text>
-        <p>
           {c(
             '{0} is either "Metabase" or the customized name of the application.',
           )
@@ -134,13 +136,12 @@ export const ModelPersistenceConfiguration = () => {
               >{t`Learn more`}</ExternalLink>
             </>
           )}
-        </p>
+        </Text>
         <DelayedLoadingAndErrorWrapper
           error={null}
           loading={modelPersistenceEnabled === undefined}
         >
           <Switch
-            mt="sm"
             label={
               <Text fw="bold">
                 {modelPersistenceEnabled ? t`Enabled` : t`Disabled`}
@@ -150,22 +151,23 @@ export const ModelPersistenceConfiguration = () => {
             checked={modelPersistenceEnabled}
           />
         </DelayedLoadingAndErrorWrapper>
-      </Box>
-      {/* modelCachingSchedule is sometimes undefined but TS thinks it is always a string */}
-      {modelPersistenceEnabled && modelCachingSchedule && (
-        <div>
-          <ModelCachingScheduleWidget
-            value={modelCachingSchedule}
-            options={modelCachingOptions}
-            onChange={async (value: unknown) => {
-              await resolveWithToasts([
-                PersistedModelsApi.setRefreshSchedule({ cron: value }),
-                dispatch(refreshSiteSettings()),
-              ]);
-            }}
-          />
-        </div>
-      )}
-    </Stack>
+
+        {/* modelCachingSchedule is sometimes undefined but TS thinks it is always a string */}
+        {modelPersistenceEnabled && modelCachingSchedule && (
+          <div>
+            <ModelCachingScheduleWidget
+              value={modelCachingSchedule}
+              options={modelCachingOptions}
+              onChange={async (value: unknown) => {
+                await resolveWithToasts([
+                  PersistedModelsApi.setRefreshSchedule({ cron: value }),
+                  dispatch(refreshSiteSettings()),
+                ]);
+              }}
+            />
+          </div>
+        )}
+      </SettingsSection>
+    </SettingsPageWrapper>
   );
 };

--- a/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
+++ b/frontend/src/metabase/admin/performance/components/ModelPersistenceConfiguration.tsx
@@ -14,7 +14,7 @@ import {
   getShowMetabaseLinks,
 } from "metabase/selectors/whitelabel";
 import { PersistedModelsApi } from "metabase/services";
-import { Box, Stack, Switch, Text } from "metabase/ui";
+import { Box, Stack, Switch, Text, Title } from "metabase/ui";
 
 import ModelPersistenceConfigurationS from "./ModelPersistenceConfiguration.module.css";
 
@@ -110,15 +110,16 @@ export const ModelPersistenceConfiguration = () => {
   const { url: docsUrl } = useDocsUrl("data-modeling/model-persistence");
 
   return (
-    <Stack gap="xl" maw="40rem">
+    <Stack gap="xl">
       <Box
         mb="sm"
         lh="1.5rem"
         className={ModelPersistenceConfigurationS.Explanation}
       >
-        <p>
+        <Title order={1}>{t`Model persistence`}</Title>
+        <Text>
           {t`Enable model persistence to make your models (and the queries that use them) load faster.`}
-        </p>
+        </Text>
         <p>
           {c(
             '{0} is either "Metabase" or the customized name of the application.',

--- a/frontend/src/metabase/admin/performance/components/PerformanceApp.tsx
+++ b/frontend/src/metabase/admin/performance/components/PerformanceApp.tsx
@@ -10,6 +10,7 @@ import { getPerformanceTabName } from "../utils";
 
 export const PerformanceApp = ({ children }: { children: React.ReactNode }) => (
   <AdminSettingsLayout
+    maw="60rem"
     sidebar={
       <AdminNavWrapper>
         <AdminNavItem

--- a/frontend/src/metabase/admin/performance/components/PerformanceApp.tsx
+++ b/frontend/src/metabase/admin/performance/components/PerformanceApp.tsx
@@ -1,122 +1,37 @@
-import classNames from "classnames";
-import { useLayoutEffect, useRef, useState } from "react";
-import type { Route } from "react-router";
-import { push } from "react-router-redux";
-
-import { useDispatch } from "metabase/lib/redux";
+import {
+  AdminNavItem,
+  AdminNavWrapper,
+} from "metabase/admin/settings/components/AdminNav";
+import { AdminSettingsLayout } from "metabase/components/AdminLayout/AdminSettingsLayout";
 import { PLUGIN_CACHING } from "metabase/plugins";
-import { Flex, Tabs } from "metabase/ui";
 
 import { PerformanceTabId } from "../types";
 import { getPerformanceTabName } from "../utils";
 
-import { ModelPersistenceConfiguration } from "./ModelPersistenceConfiguration";
-import P from "./PerformanceApp.module.css";
-import { StrategyEditorForDatabases } from "./StrategyEditorForDatabases";
-
-const validTabIds = new Set(Object.values(PerformanceTabId).map(String));
-const isValidTabId = (tab: string | null): tab is PerformanceTabId =>
-  !!tab && validTabIds.has(tab);
-
-export const PerformanceApp = ({
-  tabId = PerformanceTabId.Databases,
-  route,
-}: {
-  tabId: PerformanceTabId;
-  route: Route;
-}) => {
-  const [tabsHeight, setTabsHeight] = useState<number>(300);
-  const tabsRef = useRef<HTMLDivElement>(null);
-
-  useLayoutEffect(() => {
-    const handleResize = () => {
-      const tabs = tabsRef?.current;
-      if (!tabs) {
-        return;
-      }
-      const tabsElementTop = tabs.getBoundingClientRect().top;
-      const newHeight = window.innerHeight - tabsElementTop - tabs.clientTop;
-      setTabsHeight(newHeight);
-    };
-    window.addEventListener("resize", handleResize);
-    handleResize();
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, [tabsRef, setTabsHeight]);
-
-  const dispatch = useDispatch();
-
-  return (
-    <Tabs
-      value={tabId}
-      onChange={(value) => {
-        if (isValidTabId(value)) {
-          dispatch(
-            push(
-              `/admin/performance/${
-                value === PerformanceTabId.Databases ? "" : value
-              }`,
-            ),
-          );
-        } else {
-          console.error("Invalid tab value", value);
-        }
-      }}
-      style={{ height: tabsHeight, display: "flex", flexDirection: "column" }}
-      ref={tabsRef}
-      bg="var(--mb-color-bg-light)"
-    >
-      <Tabs.List className={P.TabsList}>
-        <Tabs.Tab
-          className={P.Tab}
-          key={PerformanceTabId.Databases}
-          value={PerformanceTabId.Databases}
-        >
-          {getPerformanceTabName(PerformanceTabId.Databases)}
-        </Tabs.Tab>
-        <PLUGIN_CACHING.DashboardAndQuestionCachingTab />
-        <Tabs.Tab
-          className={P.Tab}
-          key={PerformanceTabId.Models}
-          value={PerformanceTabId.Models}
-        >
-          {getPerformanceTabName(PerformanceTabId.Models)}
-        </Tabs.Tab>
-      </Tabs.List>
-      <Tabs.Panel
-        key={tabId}
-        value={tabId}
-        className={classNames(P.TabsPanel, {
-          [P.hideOverflow]: [
-            PerformanceTabId.Databases,
-            PerformanceTabId.DashboardsAndQuestions,
-          ].includes(tabId),
-        })}
-      >
-        {tabId === PerformanceTabId.Databases && (
-          <Flex className={classNames(P.TabBody, P.DatabasesTabBody)}>
-            <StrategyEditorForDatabases route={route} />
-          </Flex>
+export const PerformanceApp = ({ children }: { children: React.ReactNode }) => (
+  <AdminSettingsLayout
+    sidebar={
+      <AdminNavWrapper>
+        <AdminNavItem
+          label={getPerformanceTabName(PerformanceTabId.Databases)}
+          path="/admin/performance/databases"
+          icon="database"
+        />
+        <AdminNavItem
+          label={getPerformanceTabName(PerformanceTabId.DashboardsAndQuestions)}
+          path="/admin/performance/dashboards-and-questions"
+          icon="dashboard"
+        />
+        {PLUGIN_CACHING && (
+          <AdminNavItem
+            label={getPerformanceTabName(PerformanceTabId.Models)}
+            path="/admin/performance/models"
+            icon="model"
+          />
         )}
-        {tabId === PerformanceTabId.DashboardsAndQuestions && (
-          <Flex className={classNames(P.TabBody, P.hideOverflow)}>
-            <PLUGIN_CACHING.StrategyEditorForQuestionsAndDashboards
-              route={route}
-            />
-          </Flex>
-        )}
-        {tabId === PerformanceTabId.Models && (
-          <Flex
-            className={classNames(
-              P.TabBody,
-              P.ModelPersistenceConfigurationTabBody,
-            )}
-          >
-            <ModelPersistenceConfiguration />
-          </Flex>
-        )}
-      </Tabs.Panel>
-    </Tabs>
-  );
-};
+      </AdminNavWrapper>
+    }
+  >
+    {children}
+  </AdminSettingsLayout>
+);

--- a/frontend/src/metabase/admin/performance/components/PerformanceApp.tsx
+++ b/frontend/src/metabase/admin/performance/components/PerformanceApp.tsx
@@ -18,18 +18,20 @@ export const PerformanceApp = ({ children }: { children: React.ReactNode }) => (
           path="/admin/performance/databases"
           icon="database"
         />
-        <AdminNavItem
-          label={getPerformanceTabName(PerformanceTabId.DashboardsAndQuestions)}
-          path="/admin/performance/dashboards-and-questions"
-          icon="dashboard"
-        />
-        {PLUGIN_CACHING && (
+        {PLUGIN_CACHING.isGranularCachingEnabled() && (
           <AdminNavItem
-            label={getPerformanceTabName(PerformanceTabId.Models)}
-            path="/admin/performance/models"
-            icon="model"
+            label={getPerformanceTabName(
+              PerformanceTabId.DashboardsAndQuestions,
+            )}
+            path="/admin/performance/dashboards-and-questions"
+            icon="dashboard"
           />
         )}
+        <AdminNavItem
+          label={getPerformanceTabName(PerformanceTabId.Models)}
+          path="/admin/performance/models"
+          icon="model"
+        />
       </AdminNavWrapper>
     }
   >

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -4,11 +4,12 @@ import { withRouter } from "react-router";
 import { t } from "ttag";
 import { findWhere } from "underscore";
 
+import { SettingsPageWrapper } from "metabase/admin/settings/components/SettingsSection";
 import { UpsellCacheConfig } from "metabase/admin/upsells";
 import { useListDatabasesQuery } from "metabase/api";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { PLUGIN_CACHING } from "metabase/plugins";
-import { Box, Flex, Stack, Text, Title } from "metabase/ui";
+import { Flex } from "metabase/ui";
 import type { CacheableModel } from "metabase-types/api";
 import { CacheDurationUnit } from "metabase-types/api";
 
@@ -123,15 +124,17 @@ const StrategyEditorForDatabases_Base = ({
   }
 
   return (
-    <Stack gap="xl" aria-label={t`Data caching settings`}>
-      <Box>
-        <Title order={1}>{t`Database caching`}</Title>
-        <Text>
+    <SettingsPageWrapper
+      title={t`Database caching`}
+      aria-label={t`Data caching settings`}
+      description={
+        <>
           {t`Speed up queries by caching their results.`}
           <PLUGIN_CACHING.GranularControlsExplanation />
-        </Text>
-      </Box>
-      <Stack gap="xl" aria-label={t`Data caching settings`}></Stack>
+        </>
+      }
+      h="calc(100vh - 7rem)"
+    >
       {confirmationModal}
       <Flex gap="xl" style={{ overflow: "hidden" }}>
         <RoundedBox twoColumns={canOverrideRootStrategy}>
@@ -163,7 +166,7 @@ const StrategyEditorForDatabases_Base = ({
         </RoundedBox>
         <UpsellCacheConfig source="performance-data_cache" />
       </Flex>
-    </Stack>
+    </SettingsPageWrapper>
   );
 };
 

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -8,7 +8,7 @@ import { UpsellCacheConfig } from "metabase/admin/upsells";
 import { useListDatabasesQuery } from "metabase/api";
 import { DelayedLoadingAndErrorWrapper } from "metabase/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
 import { PLUGIN_CACHING } from "metabase/plugins";
-import { Flex, Stack } from "metabase/ui";
+import { Box, Flex, Stack, Text, Title } from "metabase/ui";
 import type { CacheableModel } from "metabase-types/api";
 import { CacheDurationUnit } from "metabase-types/api";
 
@@ -18,11 +18,7 @@ import { useConfirmIfFormIsDirty } from "../hooks/useConfirmIfFormIsDirty";
 import { useSaveStrategy } from "../hooks/useSaveStrategy";
 import type { UpdateTargetId } from "../types";
 
-import {
-  Panel,
-  RoundedBox,
-  TabWrapper,
-} from "./StrategyEditorForDatabases.styled";
+import { Panel, RoundedBox } from "./StrategyEditorForDatabases.styled";
 import { StrategyForm } from "./StrategyForm";
 
 const StrategyEditorForDatabases_Base = ({
@@ -127,13 +123,15 @@ const StrategyEditorForDatabases_Base = ({
   }
 
   return (
-    <TabWrapper role="region" aria-label={t`Data caching settings`}>
-      <Stack gap="xl" lh="1.5rem" maw="32rem" mb="1.5rem">
-        <aside>
+    <Stack gap="xl" aria-label={t`Data caching settings`}>
+      <Box>
+        <Title order={1}>{t`Database caching`}</Title>
+        <Text>
           {t`Speed up queries by caching their results.`}
           <PLUGIN_CACHING.GranularControlsExplanation />
-        </aside>
-      </Stack>
+        </Text>
+      </Box>
+      <Stack gap="xl" aria-label={t`Data caching settings`}></Stack>
       {confirmationModal}
       <Flex gap="xl" style={{ overflow: "hidden" }}>
         <RoundedBox twoColumns={canOverrideRootStrategy}>
@@ -165,7 +163,7 @@ const StrategyEditorForDatabases_Base = ({
         </RoundedBox>
         <UpsellCacheConfig source="performance-data_cache" />
       </Flex>
-    </TabWrapper>
+    </Stack>
   );
 };
 

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -47,6 +47,8 @@ import {
   PLUGIN_METABOT,
 } from "metabase/plugins";
 
+import { ModelPersistenceConfiguration } from "./performance/components/ModelPersistenceConfiguration";
+import { StrategyEditorForDatabases } from "./performance/components/StrategyEditorForDatabases";
 import { PerformanceTabId } from "./performance/types";
 import RedirectToAllowedSettings from "./settings/containers/RedirectToAllowedSettings";
 import { getSettingsRoutes } from "./settingsRoutes";
@@ -160,18 +162,23 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
         path="performance"
         component={createAdminRouteGuard("performance")}
       >
-        <Route title={t`Performance`}>
+        <Route title={t`Performance`} component={PerformanceApp}>
           <IndexRedirect to={PerformanceTabId.Databases} />
-          {PLUGIN_CACHING.getTabMetadata().map(({ name, key, tabId }) => (
-            <Route
-              component={(routeProps) => (
-                <PerformanceApp {...routeProps} tabId={tabId} />
-              )}
-              title={name}
-              path={tabId}
-              key={key}
-            />
-          ))}
+          <Route
+            path="databases"
+            title={t`Databases`}
+            component={StrategyEditorForDatabases}
+          />
+          <Route
+            path="models"
+            title={t`Models`}
+            component={ModelPersistenceConfiguration}
+          />
+          <Route
+            path="dashboards-and-questions"
+            title={t`Dashboards and questions`}
+            component={PLUGIN_CACHING.StrategyEditorForQuestionsAndDashboards}
+          />
         </Route>
       </Route>
       {PLUGIN_METABOT.AdminRoute}

--- a/frontend/src/metabase/admin/settings/components/SettingsSection.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSection.tsx
@@ -20,8 +20,7 @@ export function SettingsSection({
   title?: React.ReactNode;
   description?: React.ReactNode;
   children?: React.ReactNode;
-  boxProps?: BoxProps;
-}) {
+} & BoxProps) {
   return (
     <Box {...boxProps}>
       {children && (

--- a/frontend/src/metabase/components/AdminLayout/AdminSettingsLayout.tsx
+++ b/frontend/src/metabase/components/AdminLayout/AdminSettingsLayout.tsx
@@ -10,9 +10,11 @@ import S from "./AdminSettingsLayout.module.css";
 export const AdminSettingsLayout = ({
   sidebar,
   children,
+  maw = "50rem",
 }: {
   sidebar: React.ReactNode;
   children?: React.ReactNode;
+  maw?: string;
 }) => {
   return (
     <Box className={S.Wrapper}>
@@ -21,7 +23,7 @@ export const AdminSettingsLayout = ({
           {sidebar}
         </Box>
         <Box className={S.Content} data-testid="admin-layout-content">
-          <Box maw="50rem" w="100%">
+          <Box maw={maw} w="100%">
             <Box pb="2rem">
               <ErrorBoundary>{children ?? <NotFound />}</ErrorBoundary>
             </Box>


### PR DESCRIPTION
Closes ADM-920

### Description

![performance-pages-side-nav](https://github.com/user-attachments/assets/0654c526-241e-48ed-81e9-46d4c8f8ba6b)

- use side nav instead of top tabs for performance pages
- move cache config form for dashboards and questions to sidesheet


