### PR TITLE
Remove API keys from new iframe embedding

### DIFF
--- a/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
@@ -1,6 +1,5 @@
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme/MetabaseTheme";
 
-import { createApiKey } from "./api";
 import { setTokenFeatures } from "./e2e-enterprise-helpers";
 import { enableJwtAuth } from "./e2e-jwt-helpers";
 import { restore } from "./e2e-setup-helpers";
@@ -154,7 +153,7 @@ export function prepareSdkIframeEmbedTest({
   setupMockAuthProviders(enabledAuthMethods);
 }
 
-type EnabledAuthMethods = "jwt" | "saml" | "api-key";
+type EnabledAuthMethods = "jwt" | "saml";
 
 function setupMockAuthProviders(enabledAuthMethods: EnabledAuthMethods[]) {
   if (enabledAuthMethods.includes("jwt")) {
@@ -166,15 +165,5 @@ function setupMockAuthProviders(enabledAuthMethods: EnabledAuthMethods[]) {
   // Metabase into thinking that SAML is enabled and configured.
   if (enabledAuthMethods.includes("saml")) {
     enableSamlAuth();
-  }
-
-  if (enabledAuthMethods.includes("api-key")) {
-    const ADMIN_GROUP_ID = 2;
-
-    createApiKey("test iframe sdk embedding", ADMIN_GROUP_ID).then(
-      ({ body }) => {
-        cy.wrap(body.unmasked_key).as("apiKey");
-      },
-    );
   }
 }

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -96,29 +96,6 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     });
   });
 
-  it("shows an error if we are using an API key in production", () => {
-    H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["api-key"] });
-    cy.signOut();
-
-    cy.log("restore the current page's domain");
-    cy.visit("http://localhost:4000");
-
-    cy.log("visit a test page with an origin of example.com using api keys");
-    cy.get<string>("@apiKey").then((apiKey) => {
-      const frame = H.loadSdkIframeEmbedTestPage({
-        origin: "http://example.com",
-        dashboardId: ORDERS_DASHBOARD_ID,
-        apiKey,
-      });
-
-      frame
-        .findByText("Using an API key in production is not allowed.")
-        .should("exist");
-
-      cy.findByText("Orders in a dashboard").should("not.exist");
-    });
-  });
-
   it("shows an error if we are using the existing user session in production", () => {
     H.prepareSdkIframeEmbedTest({ enabledAuthMethods: [] });
     cy.signOut();
@@ -142,24 +119,6 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
       .should("exist");
 
     frame.findByText("Orders in a dashboard").should("not.exist");
-  });
-
-  it("does not show an error if we are using an API key in development", () => {
-    H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["api-key"] });
-    cy.signOut();
-
-    cy.get<string>("@apiKey").then((apiKey) => {
-      const frame = H.loadSdkIframeEmbedTestPage({
-        dashboardId: ORDERS_DASHBOARD_ID,
-        apiKey,
-      });
-
-      assertDashboardLoaded(frame);
-
-      frame
-        .findByText("Using an API key in production is not allowed.")
-        .should("not.exist");
-    });
   });
 
   it("uses JWT when authMethod is set to 'jwt' and both SAML and JWT are enabled", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/missing-tokens.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/missing-tokens.cy.spec.ts
@@ -4,40 +4,32 @@ describe("scenarios > embedding > sdk iframe embedding > without token features"
   beforeEach(() => {
     H.prepareSdkIframeEmbedTest({
       withTokenFeatures: false,
-
-      // JWT requires a valid license to use, so we expect customers to use API keys when testing.
-      enabledAuthMethods: ["api-key"],
+      enabledAuthMethods: [],
     });
-
-    cy.signOut();
   });
 
   it("shows an error if the token features are missing and the parent page is not localhost", () => {
     cy.visit("http://localhost:4000");
 
-    cy.get("@apiKey").then((apiKey) => {
-      const frame = H.loadSdkIframeEmbedTestPage({
-        origin: "http://example.com",
-        template: "exploration",
-        apiKey,
-      });
-
-      frame
-        .findByText("A valid license is required for embedding.")
-        .should("be.visible");
+    const frame = H.loadSdkIframeEmbedTestPage({
+      origin: "http://example.com",
+      template: "exploration",
+      useExistingUserSession: true,
     });
+
+    frame
+      .findByText("A valid license is required for embedding.")
+      .should("be.visible");
   });
 
   it("does not show an error if the token features are missing and the parent page is localhost", () => {
-    cy.get("@apiKey").then((apiKey) => {
-      const frame = H.loadSdkIframeEmbedTestPage({
-        template: "exploration",
-        apiKey,
-      });
-
-      frame
-        .findByText("A valid license is required for embedding.")
-        .should("not.exist");
+    const frame = H.loadSdkIframeEmbedTestPage({
+      template: "exploration",
+      useExistingUserSession: true,
     });
+
+    frame
+      .findByText("A valid license is required for embedding.")
+      .should("not.exist");
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -17,7 +17,6 @@ import { useSdkIframeEmbedEventBus } from "../hooks/use-sdk-iframe-embed-event-b
 import type { SdkIframeEmbedSettings } from "../types/embed";
 
 import {
-  SdkIframeApiKeyInProductionError,
   SdkIframeExistingUserSessionInProductionError,
   SdkIframeInvalidLicenseError,
 } from "./SdkIframeError";
@@ -47,11 +46,6 @@ export const SdkIframeEmbedRoute = () => {
     return <SdkIframeInvalidLicenseError />;
   }
 
-  // Using API keys in production is not allowed. SSO is required.
-  if (isProduction && embedSettings.apiKey) {
-    return <SdkIframeApiKeyInProductionError />;
-  }
-
   // Using the existing user's session in production is not allowed. SSO is required.
   if (isProduction && embedSettings.useExistingUserSession) {
     return <SdkIframeExistingUserSessionInProductionError />;
@@ -61,7 +55,6 @@ export const SdkIframeEmbedRoute = () => {
 
   const authConfig = defineMetabaseAuthConfig({
     metabaseInstanceUrl: embedSettings.instanceUrl,
-    apiKey: embedSettings.apiKey,
   });
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeError.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeError.tsx
@@ -20,11 +20,6 @@ export const SdkIframeInvalidLicenseError = () => (
   <SdkIframeError message="A valid license is required for embedding." />
 );
 
-// Only shown when the app is running on production yet they are using an API key.
-export const SdkIframeApiKeyInProductionError = () => (
-  <SdkIframeError message="Using an API key in production is not allowed." />
-);
-
 // Only shown when the app is running on production yet they are using an existing user session.
 export const SdkIframeExistingUserSessionInProductionError = () => (
   <SdkIframeError message="Using the existing user's session in production is not allowed." />

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -18,7 +18,6 @@ const EMBEDDING_ROUTE = "embed/sdk/v1";
 type EmbedSettingKey = keyof SdkIframeEmbedSettings;
 
 const ALLOWED_EMBED_SETTING_KEYS = [
-  "apiKey",
   "instanceUrl",
   "dashboardId",
   "questionId",
@@ -207,11 +206,6 @@ class MetabaseEmbed {
   }
 
   private async _authenticate() {
-    // If we are using an API key, we don't need to authenticate via SSO.
-    if (this._settings.apiKey) {
-      return;
-    }
-
     try {
       const { method, sessionToken } = await this._getMetabaseSessionToken();
       validateSessionToken(sessionToken);

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
@@ -2,7 +2,6 @@ import { MetabaseEmbed } from "./embed";
 
 describe("embed.js script tag for sdk iframe embedding", () => {
   const defaultSettings = {
-    apiKey: "test-api-key",
     instanceUrl: "http://localhost:3000",
 
     // this will fail due to the target being missing,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -106,7 +106,6 @@ type CollectionBrowserEntityTypes =
   | "model";
 
 type SdkIframeEmbedBaseSettings = {
-  apiKey: string;
   instanceUrl: string;
   theme?: MetabaseTheme;
   locale?: string;


### PR DESCRIPTION
Closes EMB-519

We don't need API keys in new iframe embedding anymore, thanks to https://github.com/metabase/metabase/pull/59701. As embedders can now use their admin user session cookie for local development via `useExistingUserSession: true`, there is no use having API keys around. This PR removes it.

# How to test

We just need to ensure that tests are passing, as this PR only removes the `apiKey` field and API keys will no longer work in new iframe embedding.