### PR TITLE
fix(SDK): Apply proper SDK styling to the SortableList drag overlay

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -264,9 +264,9 @@ export const moveColumnDown = (column, distance) => {
 
 export const moveDnDKitElement = (
   element,
-  { horizontal = 0, vertical = 0 } = {},
+  { horizontal = 0, vertical = 0, onBeforeDragEnd } = {},
 ) => {
-  element
+  const chainable = element
     .trigger("pointerdown", 0, 0, {
       force: true,
       isPrimary: true,
@@ -286,7 +286,11 @@ export const moveDnDKitElement = (
       isPrimary: true,
       button: 0,
     })
-    .wait(200)
+    .wait(200);
+
+  onBeforeDragEnd?.();
+
+  chainable
     .trigger("pointerup", horizontal, vertical, {
       force: true,
       isPrimary: true,

--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -16,6 +16,8 @@ import {
   createQuestion,
   getDashboardCard,
   modal,
+  moveDnDKitElement,
+  openVizSettingsSidebar,
   tooltip,
   updateSetting,
 } from "e2e/support/helpers";
@@ -369,7 +371,7 @@ describe("scenarios > embedding-sdk > styles", () => {
       // TODO: good place for a visual regression test
     });
 
-    describe("tooltips styles", () => {
+    describe("tooltips/overlays styles", () => {
       beforeEach(() => {
         signInAsAdminAndEnableEmbeddingSdk();
 
@@ -426,14 +428,7 @@ describe("scenarios > embedding-sdk > styles", () => {
 
         tooltip()
           .findByText("Back to Test Dashboard")
-          .then(($tooltip) => {
-            const tooltipElement = $tooltip[0];
-
-            const tooltipContainerStyle =
-              window.getComputedStyle(tooltipElement);
-
-            expect(tooltipContainerStyle.fontFamily).to.equal("Impact");
-          });
+          .should("have.css", "font-family", "Impact");
       });
 
       it("should render echarts tooltip with our styles", () => {
@@ -454,21 +449,36 @@ describe("scenarios > embedding-sdk > styles", () => {
         cy.findAllByTestId("echarts-tooltip")
           .eq(0)
           .should("exist")
-          .then(($tooltip) => {
-            const tooltipElement = $tooltip[0];
+          .get(".echarts-tooltip-container")
+          .should("have.css", "font-family", "Impact");
+      });
 
-            const tooltipContainer = tooltipElement.closest(
-              ".echarts-tooltip-container",
-            );
+      it("should render DragOverlay of SortableList with our styles", () => {
+        mountSdkContent(
+          <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />,
+          {
+            sdkProviderProps: {
+              theme: {
+                fontFamily: "Impact",
+              },
+            },
+          },
+        );
 
-            expect(tooltipContainer).to.exist;
+        openVizSettingsSidebar();
 
-            const tooltipContainerStyle = window.getComputedStyle(
-              tooltipContainer!,
-            );
-
-            expect(tooltipContainerStyle.fontFamily).to.equal("Impact");
-          });
+        moveDnDKitElement(cy.findByTestId("draggable-item-ID"), {
+          vertical: -100,
+          onBeforeDragEnd: () => {
+            cy.get(".drag-overlay").within(() => {
+              cy.findByTestId("draggable-item-ID").should(
+                "have.css",
+                "font-family",
+                "Impact",
+              );
+            });
+          },
+        });
       });
     });
   });

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/QuestionSettings/QuestionSettingsDropdown/QuestionSettingsDropdown.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/QuestionSettings/QuestionSettingsDropdown/QuestionSettingsDropdown.tsx
@@ -42,6 +42,7 @@ export const QuestionSettingsDropdown = ({
           </Center>
         }
         className={ToolbarButtonS.PrimaryToolbarButton}
+        data-testid="viz-settings-button"
       />
     </Popover.Target>
     <Popover.Dropdown miw="20rem" mah={height ?? FLEXIBLE_SIZE_DEFAULT_HEIGHT}>

--- a/frontend/src/metabase/core/components/Sortable/SortableList.tsx
+++ b/frontend/src/metabase/core/components/Sortable/SortableList.tsx
@@ -11,6 +11,7 @@ import { createPortal } from "react-dom";
 import _ from "underscore";
 
 import GrabberS from "metabase/css/components/grabber.module.css";
+import { getPortalRootElement } from "metabase/css/core/overlays/utils";
 import { isNotNull } from "metabase/lib/types";
 
 export type SortableDivider = {
@@ -141,7 +142,10 @@ export const SortableList = <T,>({
         // we need to render the DragOverlay in a separate portal
         // (https://docs.dndkit.com/api-documentation/draggable/drag-overlay#portals)
         createPortal(
-          <DragOverlay>
+          <DragOverlay
+            // Used in e2e, because can't pass data-testid
+            className="drag-overlay"
+          >
             {activeItem
               ? renderItem({
                   item: activeItem,
@@ -150,7 +154,7 @@ export const SortableList = <T,>({
                 })
               : null}
           </DragOverlay>,
-          document.body,
+          getPortalRootElement(),
         )}
     </DndContext>
   );


### PR DESCRIPTION
We have to render SortableList DragOverlay portal inside the SDK container to properly apply SDK styles.
Context: https://metaboat.slack.com/team/U08894X1SS0

The bug:
![image](https://github.com/user-attachments/assets/9f5ec22b-9c59-4c05-8a5e-50e896a57a66)


How to verify:
- ci should pass