### PR TITLE
[manual backport] modify trigger to send source + target branches (#59575)

### DIFF
--- a/.github/workflows/docs_bump_detected.yml
+++ b/.github/workflows/docs_bump_detected.yml
@@ -15,15 +15,13 @@ on:
 jobs:
   push_workflow_to_docs_metabase_github_io_job:
     runs-on: ubuntu-latest
+    env:
+      SOURCE_BRANCH: ${{ github.head_ref || github.ref  }}
+      TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
     steps:
       - name: Report changed docs files exist
         run: |
           echo "A change in the docs directory was detected."
-
-      - name: Put source and target branches into env
-        env:
-          SOURCE_BRANCH: ${{ github.head_ref || github.ref  }}
-          TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
 
       - name: Trigger repo dispatch
         uses: actions/github-script@v7

--- a/.github/workflows/docs_bump_detected.yml
+++ b/.github/workflows/docs_bump_detected.yml
@@ -1,7 +1,14 @@
 name: Docs Bump Detected
 
 on:
-  pull_request:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - 'master'
+      - 'release-x.[0-9]+.x'
     paths:
       - 'docs/**'
 
@@ -13,22 +20,20 @@ jobs:
         run: |
           echo "A change in the docs directory was detected."
 
+      - name: Put source and target branches into env
+        env:
+          SOURCE_BRANCH: ${{ github.head_ref || github.ref  }}
+          TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
+
       - name: Trigger repo dispatch
         uses: actions/github-script@v7
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref  }}
         with:
           github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           script: | #js
-            if (process.env.BRANCH_NAME === "master" ||
-                /^release-x\.\d+\.x$/.test(process.env.BRANCH_NAME)) {
               github.rest.repos.createDispatchEvent({
                 owner: "${{ github.repository_owner }}",
                 repo: "docs.metabase.github.io",
                 event_type: "docs_update",
-                client_payload: { branch_name: process.env.BRANCH_NAME
-                }
-              });
-            } else {
-              console.log("Branch name is not to be published: ", process.env.BRANCH_NAME);
-            }
+                client_payload: {
+                  source_branch: process.env.SOURCE_BRANCH,
+                  target_branch: process.env.TARGET_BRANCH}});

--- a/.github/workflows/docs_merge_detected.yml
+++ b/.github/workflows/docs_merge_detected.yml
@@ -1,35 +1,38 @@
 name: Docs Merge Detected
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
-      - master
+      - 'master'
+      - 'release-x.[0-9]+.x'
     paths:
       - 'docs/**'
 
 jobs:
-  push_workflow_to_docs_metabase_github_io_job_merge:
+  push_and_merge_workflow_to_docs_metabase_github_io_job:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Report changed docs files exist
         run: |
-          echo "A change in the docs directory was detected on merge."
+          echo "A PR with changes to the docs directory was merged."
+
+      - name: Put source and target branches into env
+        env:
+          SOURCE_BRANCH: ${{ github.head_ref || github.ref  }}
+          TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
 
       - name: Trigger repo dispatch
         uses: actions/github-script@v7
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref  }}
         with:
           github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           script: | #js
-            if (process.env.BRANCH_NAME === "master" ||
-                /^release-x\.\d+\.x$/.test(process.env.BRANCH_NAME)) {
-              github.rest.repos.createDispatchEvent({
+            github.rest.repos.createDispatchEvent({
                 owner: "${{ github.repository_owner }}",
                 repo: "docs.metabase.github.io",
                 event_type: "docs_merge",
-                client_payload: { branch_name: process.env.BRANCH_NAME }
-              });
-            } else {
-              console.log("Branch name is not to be published: ", process.env.BRANCH_NAME);
-            }
+                client_payload: {
+                  source_branch: process.env.SOURCE_BRANCH,
+                  target_branch: process.env.TARGET_BRANCH}});

--- a/.github/workflows/docs_merge_detected.yml
+++ b/.github/workflows/docs_merge_detected.yml
@@ -14,15 +14,13 @@ jobs:
   push_and_merge_workflow_to_docs_metabase_github_io_job:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    env:
+      SOURCE_BRANCH: ${{ github.head_ref || github.ref  }}
+      TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
     steps:
       - name: Report changed docs files exist
         run: |
           echo "A PR with changes to the docs directory was merged."
-
-      - name: Put source and target branches into env
-        env:
-          SOURCE_BRANCH: ${{ github.head_ref || github.ref  }}
-          TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
 
       - name: Trigger repo dispatch
         uses: actions/github-script@v7


### PR DESCRIPTION
I am backporting this to check the case for a doc change like `55-docs-hotfix` -> `release-x.55.x`
