### PR TITLE
Remove duplicate findRequests test helper

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
@@ -2,12 +2,12 @@ import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
 import {
+  findRequests,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingsEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, within } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import { createMockGroup, createMockSettings } from "metabase-types/api/mocks";
 
 import { type JWTFormValues, SettingsJWTForm } from "./SettingsJWTForm";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.unit.spec.tsx
@@ -1,12 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import type { EnterpriseSettings } from "metabase-types/api";
 import { createMockSettings } from "metabase-types/api/mocks";
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkSettings.unit.spec.tsx
@@ -1,12 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { fireEvent, renderWithProviders, screen } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import type { EnterpriseSettings } from "metabase-types/api";
 import { createMockSettings } from "metabase-types/api/mocks";
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/IllustrationWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/IllustrationWidget.unit.spec.tsx
@@ -1,12 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import type {
   EnterpriseSettingKey,
   EnterpriseSettings,

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/ImageUploadWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/IllustrationWidget/ImageUploadWidget.unit.spec.tsx
@@ -1,12 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import type {
   EnterpriseSettingKey,
   EnterpriseSettings,

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.unit.spec.tsx
@@ -1,12 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import { createMockSettings } from "metabase-types/api/mocks";
 
 import { MetabotToggleWidget } from "./MetabotToggleWidget";

--- a/frontend/src/metabase/admin/settings/components/Email/SMTPConnectionForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/Email/SMTPConnectionForm.unit.spec.tsx
@@ -1,12 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupEmailEndpoints,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import type {
   EnterpriseSettingKey,
   SettingDefinition,

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/EmbeddingSdkOptionCard/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/EmbeddingSdkOptionCard/tests/common.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
+import { findRequests } from "__support__/server-mocks";
 import { screen } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 
 import { type SetupOpts, setup as baseSetup } from "./setup";
 

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkLegaleseModal/EmbeddingSdkLegaleseModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkLegaleseModal/EmbeddingSdkLegaleseModal.unit.spec.tsx
@@ -1,12 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingsEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import { createMockSettings } from "metabase-types/api/mocks";
 
 import { EmbeddingSdkLegaleseModal } from "./EmbeddingSdkLegaleseModal";

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/common.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
+import { findRequests } from "__support__/server-mocks";
 import { screen, within } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 
 import { setup } from "./setup";
 

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle/EmbeddingToggle.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle/EmbeddingToggle.unit.spec.tsx
@@ -1,12 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import type { SettingDefinition } from "metabase-types/api";
 import {
   createMockSettingDefinition,

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/EmbeddingSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/EmbeddingSettingsPage.unit.spec.tsx
@@ -1,12 +1,12 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import { createMockSettings } from "metabase-types/api/mocks";
 
 import { EmbeddingSettingsPage } from "./EmbeddingSettingsPage";

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettingsForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettingsForm.unit.spec.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupDatabaseListEndpoint,
   setupPropertiesEndpoints,
   setupSchemaEndpoints,
@@ -16,7 +17,6 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import { UndoListing } from "metabase/containers/UndoListing";
 import type { Database } from "metabase-types/api";
 import {

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.unit.spec.tsx
@@ -1,13 +1,13 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  findRequests,
   setupGeoJSONEndpoint,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import { UndoListing } from "metabase/containers/UndoListing";
 import type { CustomGeoJSONMap } from "metabase-types/api";
 import {

--- a/frontend/src/metabase/api/utils/use-token-refresh.unit.spec.tsx
+++ b/frontend/src/metabase/api/utils/use-token-refresh.unit.spec.tsx
@@ -1,6 +1,8 @@
-import { setupPropertiesEndpoints } from "__support__/server-mocks";
+import {
+  findRequests,
+  setupPropertiesEndpoints,
+} from "__support__/server-mocks";
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
-import { findRequests } from "__support__/utils";
 import { createMockSettings } from "metabase-types/api/mocks";
 
 import { useGetSettingsQuery } from "../session";

--- a/frontend/test/__support__/utils.ts
+++ b/frontend/test/__support__/utils.ts
@@ -1,4 +1,4 @@
-import fetchMock from "fetch-mock";
+import type fetchMock from "fetch-mock";
 
 import { act, waitFor } from "./ui";
 
@@ -40,16 +40,3 @@ export const waitForRequest = async (
     throw error;
   }
 };
-
-export async function findRequests(method: "PUT" | "POST" | "DELETE" | "GET") {
-  const calls = fetchMock.calls();
-  const data = calls.filter((call) => call[1]?.method === method) ?? [];
-
-  const reqs = data.map(async ([url, details]) => {
-    const body = ((await details?.body) as string) ?? "{}";
-
-    return { url: url, body: JSON.parse(body ?? "{}") };
-  });
-
-  return Promise.all(reqs);
-}


### PR DESCRIPTION
closes adm-873

### Description

I wrote this cute little 	`findRequests` testing helper ... and it was so great I wrote it again in another place... this removes the duplication. This removes the one in the `utils` file in favor of the one in the `server-mocks` file.

