### PR TITLE
fix: increment graph revision when parent permissions are copied

### DIFF
--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1191,7 +1191,11 @@
                  (for [dest     dest-collections-or-ids
                        :let     [readwrite-path (perms/collection-readwrite-path dest)]
                        group-id group-ids-with-write-perms]
-                   {:group_id group-id, :object readwrite-path})))))
+                   {:group_id group-id, :object readwrite-path})))
+    ;; update the perms graph revision number so that editors of the permissions graph are forced to be aware
+    ;; of the new permissions/collections.
+    (perms/increment-implicit-perms-revision! :model/CollectionPermissionGraphRevision
+                                              "Automatically updated permissions due to collection creation or move")))
 
 (defn- copy-parent-permissions!
   "When creating a new Collection, we shall copy the Permissions entries for its parent. That way, Groups who can see

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -99,6 +99,7 @@
   log-permissions-changes
   sandboxed-or-impersonated-user?
   sandboxed-user?
+  increment-implicit-perms-revision!
   save-perms-revision!]
  [metabase.permissions.validation
   check-group-manager

--- a/src/metabase/permissions/models/permissions.clj
+++ b/src/metabase/permissions/models/permissions.clj
@@ -366,23 +366,22 @@
       (clear-current-user-cached-permissions!))))
 
 (defn grant-permissions!
-  "Grant permissions for `group-or-id` and return the inserted permissions. Two-arity grants any arbitrary Permissions `path`.
-  With > 2 args, grants the data permissions from calling [[data-perms-path]]."
-  ([group-or-id path]
-   (try
-     (t2/insert! :model/Permissions
-                 (map (fn [path-object]
-                        {:group_id (u/the-id group-or-id) :object path-object})
-                      (distinct (conj (perms.u/->v2-path path) path))))
-     (clear-current-user-cached-permissions!)
-     ;; on some occasions through weirdness we might accidentally try to insert a key that's already been inserted
-     (catch Throwable e
-       (log/error e (u/format-color 'red "Failed to grant permissions"))
-       ;; if we're running tests, we're doing something wrong here if duplicate permissions are getting assigned,
-       ;; mostly likely because tests aren't properly cleaning up after themselves, and possibly causing other tests
-       ;; to pass when they shouldn't. Don't allow this during tests
-       (when config/is-test?
-         (throw e))))))
+  "Grant permissions for `group-or-id` and return the inserted permissions. Two-arity grants any arbitrary Permissions `path`."
+  [group-or-id path]
+  (try
+    (t2/insert! :model/Permissions
+                (map (fn [path-object]
+                       {:group_id (u/the-id group-or-id) :object path-object})
+                     (distinct (conj (perms.u/->v2-path path) path))))
+    (clear-current-user-cached-permissions!)
+    ;; on some occasions through weirdness we might accidentally try to insert a key that's already been inserted
+    (catch Throwable e
+      (log/error e (u/format-color 'red "Failed to grant permissions"))
+      ;; if we're running tests, we're doing something wrong here if duplicate permissions are getting assigned,
+      ;; mostly likely because tests aren't properly cleaning up after themselves, and possibly causing other tests
+      ;; to pass when they shouldn't. Don't allow this during tests
+      (when config/is-test?
+        (throw e)))))
 
 ;;;; Audit Permissions helper fns
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #41498
### Description

This fixes a bug where selecting update permissions on subcollections does not take into account new collections created between loading the collection permissions page and submitting changes. This updates the collection revision model to write a new revision when the collection permissions graph changes due to the insertion of a new collection which means we would respond 409 to the graph update. This makes sure the administrator double checks the set of collections they want to change to take into account the new collections. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
