### PR TITLE
[Metabot] Add streaming support

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1665,6 +1665,7 @@
            query-processor
            request
            settings
+           server
            system
            users
            util

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1664,8 +1664,8 @@
            pulse
            query-processor
            request
-           settings
            server
+           settings
            system
            users
            util

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -77,17 +77,16 @@
   "Send a chat message to the LLM via the AI Proxy."
   [_route-params
    _query-params
-   ; TODO: conversation_id is unused, should we should send it back as a header?
-   {:keys [conversation_id] :as body} :- [:map
-                                          [:metabot_id {:optional true} :string]
-                                          [:message ms/NonBlankString]
-                                          [:context ::metabot-v3.context/context]
-                                          [:conversation_id ms/UUIDString]
-                                          [:history [:maybe ::metabot-v3.client.schema/messages]]
-                                          [:state :map]]]
+
+   body :- [:map
+            [:metabot_id {:optional true} :string]
+            [:message ms/NonBlankString]
+            [:context ::metabot-v3.context/context]
+            [:conversation_id ms/UUIDString]
+            [:history [:maybe ::metabot-v3.client.schema/messages]]
+            [:state :map]]]
   (metabot-v3.context/log body :llm.log/fe->be)
-  (let [res (streaming-request body)]
-    res))
+  (streaming-request body))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/metabot-v3` routes."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -77,6 +77,7 @@
   "Send a chat message to the LLM via the AI Proxy."
   [_route-params
    _query-params
+   ; TODO: conversation_id is unused, should we should send it back as a header?
    {:keys [conversation_id] :as body} :- [:map
                                           [:metabot_id {:optional true} :string]
                                           [:message ms/NonBlankString]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -59,6 +59,35 @@
          :conversation_id conversation_id)
     (metabot-v3.context/log :llm.log/be->fe)))
 
+(defn streaming-request
+  "Handles an incoming request, making all required tool invocation, LLM call loops, etc."
+  [{:keys [metabot_id message context history conversation_id state]
+    :or {metabot_id metabot-v3.config/internal-metabot-id}}]
+  (let [initial-message (metabot-v3.envelope/user-message message)
+        history         (conj (vec history) initial-message)]
+    (metabot-v3.tools.api/streaming-handle-envelope
+     {:context         (metabot-v3.context/create-context context)
+      :metabot-id      metabot_id
+      :profile-id      (get-in metabot-v3.config/metabot-config [metabot_id :profile-id])
+      :conversation-id conversation_id
+      :messages        history
+      :state           state})))
+
+(api.macros/defendpoint :post "/v2/agent-streaming"
+  "Send a chat message to the LLM via the AI Proxy."
+  [_route-params
+   _query-params
+   {:keys [conversation_id] :as body} :- [:map
+                                          [:metabot_id {:optional true} :string]
+                                          [:message ms/NonBlankString]
+                                          [:context ::metabot-v3.context/context]
+                                          [:conversation_id ms/UUIDString]
+                                          [:history [:maybe ::metabot-v3.client.schema/messages]]
+                                          [:state :map]]]
+  (metabot-v3.context/log body :llm.log/fe->be)
+  (let [res (streaming-request body)]
+    res))
+
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/metabot-v3` routes."
   (handlers/routes

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -13,8 +13,8 @@
    [metabase-enterprise.metabot-v3.util :as metabot-v3.u]
    [metabase.api.common :as api]
    [metabase.premium-features.core :as premium-features]
-   [metabase.system.core :as system]
    [metabase.server.streaming-response :as sr]
+   [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -173,16 +173,16 @@
       (log/debugf "Response from AI Proxy:\n%s" (u/pprint-to-str (select-keys response #{:body :status :headers})))
       (if (= (:status response) 200)
         (sr/streaming-response {:content-type "text/event-stream; charset=utf-8"} [os canceled-chan]
-                               (loop []
-                                 (when-let [line (.readLine response-lines)]
-                                   (println "LINE" line)
-                                   (.write os (.getBytes (str line "\n") "UTF-8"))
-                                   (.flush os)
-                                   (Thread/sleep 10)
-                                   (recur))))
+          (loop []
+            (when-let [line (.readLine response-lines)]
+              (println "LINE" line)
+              (.write os (.getBytes (str line "\n") "UTF-8"))
+              (.flush os)
+              (Thread/sleep 10)
+              (recur))))
         (throw (ex-info (format "Error: unexpected status code: %d %s" (:status response) (:reason-phrase response))
                         {:request (assoc options :body body)
-                          :response response}))))
+                         :response response}))))
     (catch Throwable e
       (throw (ex-info (format "Error in request to AI Proxy: %s" (ex-message e)) {} e)))))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -67,7 +67,7 @@
 (defn- agent-v2-endpoint-url []
   (str (metabot-v3.settings/ai-proxy-base-url) "/v2/agent"))
 
-defn- agent-v2-streaming-endpoint-url []
+(defn- agent-v2-streaming-endpoint-url []
   (str (metabot-v3.settings/ai-proxy-base-url) "/v2/agent/stream"))
 
 (defn- metric-selection-endpoint-url []
@@ -170,7 +170,7 @@ defn- agent-v2-streaming-endpoint-url []
           _ (log/info response)
           response-lines (-> response :body io/reader)]
       (metabot-v3.context/log (:body response) :llm.log/llm->be)
-      (log/debugf "Response from AI Proxy:\n%s" (u/pprint-to-str (select-keys response #{:body :status :headers}))) keys response #{:body :status :headers})))
+      (log/debugf "Response from AI Proxy:\n%s" (u/pprint-to-str (select-keys response #{:body :status :headers})))
       (if (= (:status response) 200)
         (sr/streaming-response {:content-type "text/event-stream; charset=utf-8"} [os canceled-chan]
                                (loop []

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -1,6 +1,8 @@
 (ns metabase-enterprise.metabot-v3.client
   (:require
    [clj-http.client :as http]
+   [clojure.core.async :as a]
+   [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
    [malli.core :as mc]
@@ -12,6 +14,7 @@
    [metabase.api.common :as api]
    [metabase.premium-features.core :as premium-features]
    [metabase.system.core :as system]
+   [metabase.server.streaming-response :as sr]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -63,6 +66,9 @@
 
 (defn- agent-v2-endpoint-url []
   (str (metabot-v3.settings/ai-proxy-base-url) "/v2/agent"))
+
+defn- agent-v2-streaming-endpoint-url []
+  (str (metabot-v3.settings/ai-proxy-base-url) "/v2/agent/stream"))
 
 (defn- metric-selection-endpoint-url []
   (str (metabot-v3.settings/ai-proxy-base-url) "/v1/select-metric"))
@@ -126,6 +132,57 @@
         (throw (ex-info (format "Error: unexpected status code: %d %s" (:status response) (:reason-phrase response))
                         {:request (assoc options :body body)
                          :response response}))))
+    (catch Throwable e
+      (throw (ex-info (format "Error in request to AI Proxy: %s" (ex-message e)) {} e)))))
+
+(mu/defn streaming-request :- :any
+  "Make a V2 request to the AI Proxy."
+  [{:keys [context messages profile-id conversation-id session-id state]}
+   :- [:map
+       [:context :map]
+       [:messages ::metabot-v3.client.schema/messages]
+       [:profile-id :string]
+       [:conversation-id :string]
+       [:session-id :string]
+       [:state :map]]]
+  (premium-features/assert-has-feature :metabot-v3 "MetaBot")
+  (try
+    (let [url      (agent-v2-streaming-endpoint-url)
+          body     (-> {:messages        messages
+                        :context         context
+                        :conversation_id conversation-id
+                        :profile_id      profile-id
+                        :state           state
+                        :user_id         api/*current-user-id*}
+                       (metabot-v3.u/recursive-update-keys metabot-v3.u/safe->snake_case_en))
+          _        (metabot-v3.context/log body :llm.log/be->llm)
+          _        (log/debugf "V2 request to AI Proxy:\n%s" (u/pprint-to-str body))
+          options  (cond-> {:headers          {"Accept"                    "text/event-stream"
+                                               "Content-Type"              "application/json;charset=UTF-8"
+                                               "x-metabase-instance-token" (premium-features/premium-embedding-token)
+                                               "x-metabase-session-token"  session-id
+                                               "x-metabase-url"            (system/site-url)}
+                            :body             (->json-bytes body)
+                            :throw-exceptions false
+                            :as :stream}
+                     *debug* (assoc :debug true))
+          response (post! url options)
+          _ (log/info response)
+          response-lines (-> response :body io/reader)]
+      (metabot-v3.context/log (:body response) :llm.log/llm->be)
+      (log/debugf "Response from AI Proxy:\n%s" (u/pprint-to-str (select-keys response #{:body :status :headers}))) keys response #{:body :status :headers})))
+      (if (= (:status response) 200)
+        (sr/streaming-response {:content-type "text/event-stream; charset=utf-8"} [os canceled-chan]
+                               (loop []
+                                 (when-let [line (.readLine response-lines)]
+                                   (println "LINE" line)
+                                   (.write os (.getBytes (str line "\n") "UTF-8"))
+                                   (.flush os)
+                                   (Thread/sleep 10)
+                                   (recur))))
+        (throw (ex-info (format "Error: unexpected status code: %d %s" (:status response) (:reason-phrase response))
+                        {:request (assoc options :body body)
+                          :response response}))))
     (catch Throwable e
       (throw (ex-info (format "Error in request to AI Proxy: %s" (ex-message e)) {} e)))))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -136,7 +136,21 @@
       (throw (ex-info (format "Error in request to AI Proxy: %s" (ex-message e)) {} e)))))
 
 (mu/defn streaming-request :- :any
-  "Make a V2 request to the AI Proxy."
+  "Make a streaming V2 request to the AI Service
+
+   This implements the streaming support for Metabot
+
+   Clojure backend makes the request to the AI Service which respond immediately with a response and starts
+   streaming the response chunks back. We want to ship these to the frontend as soon as possible to give
+   the user the ability to consume the response before it's done.
+
+   Since we want to send the chunks to the frontend as soon as possible, we manually write to the output stream
+   and flush after every chunk. If we've just returned the `response` object, ring would handle it correctly
+   but would also buffer the response.
+
+   Response chunks are encoded in the format understood by the frontend and AI Service, Clojure backend doesn't
+   know anything about it and just shuttles them over.
+   "
   [{:keys [context messages profile-id conversation-id session-id state]}
    :- [:map
        [:context :map]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -19,7 +19,8 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.o11y :refer [with-span]]))
+   [metabase.util.o11y :refer [with-span]])
+  (:import (java.io BufferedReader)))
 
 (set! *warn-on-reflection* true)
 
@@ -171,7 +172,7 @@
       (if (= (:status response) 200)
         (sr/streaming-response {:content-type "text/event-stream; charset=utf-8"} [os canceled-chan]
                                ;; Response from the AI Service will send response parts separated by newline
-          (with-open [response-lines (-> response :body io/reader)]
+          (with-open [response-lines ^BufferedReader (io/reader (:body response))]
             (loop []
                                    ;; Grab the next line and write it to the output stream with appended newline (frontend depends on it)
                                    ;; Immediately flush so it get's sent to the frontend as soon as possible

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -66,6 +66,12 @@
                                    :content assistant-message})
             (throw ex)))))))
 
+(defn streaming-handle-envelope
+  "Executes the AI loop in the context of a new session. Returns the response of the AI service."
+  [{:keys [metabot-id] :as e}]
+  (let [session-id (get-ai-service-token api/*current-user-id* metabot-id)]
+    (metabot-v3.client/streaming-request (assoc e :session-id session-id))))
+
 (mr/def ::bucket
   (into [:enum {:error/message "Valid bucket"
                 :encode/tool-api-request keyword}]

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -9,7 +9,7 @@ import {
 } from "embedding-sdk/components/private/PublicComponentWrapper";
 import { useLocale } from "metabase/common/hooks/use-locale";
 import { Flex, Icon, Paper, Stack, Text } from "metabase/ui";
-import { getErrorMessage } from "metabase-enterprise/metabot/constants";
+import { getAgentOfflineError } from "metabase-enterprise/metabot/constants";
 
 import { MetabotChatEmbedding } from "./MetabotChatEmbedding";
 import { QuestionDetails } from "./QuestionDetails";
@@ -60,7 +60,7 @@ interface MessageProps {
   message: string;
 }
 function Message({ message }: MessageProps) {
-  const isErrorMessage = message === getErrorMessage();
+  const isErrorMessage = message === getAgentOfflineError();
   if (isErrorMessage) {
     return (
       <Paper shadow="sm" p="lg" w="100%" maw="41.5rem" radius="lg" ta="center">

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/__snapshots__/process-stream.unit.spec.ts.snap
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/__snapshots__/process-stream.unit.spec.ts.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`processChatResponse should be able to process a valid stream 1`] = `
+{
+  "data": [
+    {
+      "type": "state",
+      "value": {
+        "queries": {},
+      },
+      "version": 1,
+    },
+  ],
+  "history": [
+    {
+      "content": "You, but don't tell anyone.",
+      "role": "assistant",
+    },
+    {
+      "role": "assistant",
+      "tool-calls": [
+        {
+          "arguments": "",
+          "id": "x",
+          "name": "x",
+        },
+      ],
+    },
+    {
+      "content": "",
+      "role": "tool",
+      "tool-call-id": "x",
+    },
+  ],
+  "parts": [
+    {
+      "code": "0",
+      "name": "text",
+      "value": "You, but don't tell anyone.",
+    },
+    {
+      "code": "2",
+      "name": "data",
+      "value": {
+        "type": "state",
+        "value": {
+          "queries": {},
+        },
+        "version": 1,
+      },
+    },
+    {
+      "code": "9",
+      "name": "tool_call",
+      "value": {
+        "args": "",
+        "toolCallId": "x",
+        "toolName": "x",
+      },
+    },
+    {
+      "code": "a",
+      "name": "tool_result",
+      "value": {
+        "result": "",
+        "toolCallId": "x",
+      },
+    },
+    {
+      "code": "d",
+      "name": "finish_message",
+      "value": {
+        "finishReason": "stop",
+        "usage": {
+          "completionTokens": 8,
+          "promptTokens": 4916,
+        },
+      },
+    },
+  ],
+  "text": "You, but don't tell anyone.",
+  "toolCalls": [
+    {
+      "args": "",
+      "state": "result",
+      "toolCallId": "x",
+      "toolName": "x",
+      "value": "",
+    },
+  ],
+}
+`;

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/__snapshots__/requests.unit.spec.ts.snap
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/__snapshots__/requests.unit.spec.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ai requests aiStreamingQuery should return full result of a successful request 1`] = `
+{
+  "data": [
+    {
+      "type": "state",
+      "value": {
+        "queries": {},
+      },
+      "version": 1,
+    },
+  ],
+  "history": [
+    {
+      "content": "You, but don't tell anyone.",
+      "role": "assistant",
+    },
+  ],
+  "parts": [
+    {
+      "code": "0",
+      "name": "text",
+      "value": "You, but don't tell anyone.",
+    },
+    {
+      "code": "2",
+      "name": "data",
+      "value": {
+        "type": "state",
+        "value": {
+          "queries": {},
+        },
+        "version": 1,
+      },
+    },
+    {
+      "code": "d",
+      "name": "finish_message",
+      "value": {
+        "finishReason": "stop",
+        "usage": {
+          "completionTokens": 8,
+          "promptTokens": 4916,
+        },
+      },
+    },
+  ],
+  "text": "You, but don't tell anyone.",
+  "toolCalls": [],
+}
+`;

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/index.ts
@@ -1,0 +1,2 @@
+export { aiStreamingQuery, getInflightRequestsForUrl } from "./requests";
+export type { JSONValue } from "./types";

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/process-stream.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/process-stream.ts
@@ -1,0 +1,245 @@
+import { match } from "ts-pattern";
+import _ from "underscore";
+
+import type { MetabotHistory } from "metabase-types/api";
+
+import {
+  dataPartSchema,
+  finishPartSchema,
+  toolCallPartSchema,
+  toolResultPartSchema,
+} from "./schemas";
+import type { JSONValue } from "./types";
+
+const StreamingPartTypeRegistry = {
+  TEXT: "0",
+  DATA: "2",
+  ERROR: "3",
+  FINISH_MESSAGE: "d",
+  TOOL_CALL: "9",
+  TOOL_RESULT: "a",
+} as const;
+
+const StreamingPartTypes = Object.values(StreamingPartTypeRegistry);
+
+type StreamingPartType = (typeof StreamingPartTypes)[number];
+
+/**
+ * Concatenates all the chunks into a single Uint8Array
+ */
+function concatChunks(chunks: Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const concatenatedChunks = new Uint8Array(totalLength);
+
+  let offset = 0;
+  for (const chunk of chunks) {
+    concatenatedChunks.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return concatenatedChunks;
+}
+
+function parseDataStreamPart(line: string) {
+  const firstSeparatorIndex = line.indexOf(":");
+  if (firstSeparatorIndex === -1) {
+    throw new Error("Failed to parse stream string. No separator found.");
+  }
+
+  const prefix = line.slice(0, firstSeparatorIndex);
+  if (!StreamingPartTypes.includes(prefix as StreamingPartType)) {
+    console.warn(`Recieved invalid message code: ${prefix}`);
+    return;
+  }
+
+  const code = prefix as StreamingPartType;
+  const textValue = line.slice(firstSeparatorIndex + 1);
+  const jsonValue: JSONValue = JSON.parse(textValue);
+
+  return match(code)
+    .with(StreamingPartTypeRegistry.TEXT, (code) => ({
+      code,
+      name: "text" as const,
+      value: jsonValue,
+    }))
+    .with(StreamingPartTypeRegistry.DATA, (code) => ({
+      code,
+      name: "data" as const,
+      value: dataPartSchema.validateSync(jsonValue, { strict: true }),
+    }))
+    .with(StreamingPartTypeRegistry.TOOL_CALL, (code) => ({
+      code,
+      name: "tool_call" as const,
+      value: toolCallPartSchema.validateSync(jsonValue, { strict: true }),
+    }))
+    .with(StreamingPartTypeRegistry.TOOL_RESULT, (code) => ({
+      code,
+      name: "tool_result" as const,
+      value: toolResultPartSchema.validateSync(jsonValue, { strict: true }),
+    }))
+    .with(StreamingPartTypeRegistry.ERROR, (code) => ({
+      code,
+      name: "error" as const,
+      value: jsonValue,
+    }))
+    .with(StreamingPartTypeRegistry.FINISH_MESSAGE, (code) => ({
+      code,
+      name: "finish_message" as const,
+      value: finishPartSchema.validateSync(jsonValue, { strict: true }),
+    }))
+    .exhaustive();
+}
+
+type ParsedStreamPart = Exclude<ReturnType<typeof parseDataStreamPart>, void>;
+type ParsedStreamPartName = ParsedStreamPart["name"];
+
+type AccumulatedStreamParts = {
+  toolCalls: (
+    | { toolCallId: string; toolName: string; state: "call" }
+    | { toolCallId: string; toolName: string; state: "result"; value: unknown }
+  )[];
+  text: null | string;
+  data: unknown[];
+  parts: ParsedStreamPart[];
+  history: MetabotHistory;
+};
+
+function accumulateStreamParts(streamParts: ParsedStreamPart[]) {
+  const acc: AccumulatedStreamParts = {
+    toolCalls: [],
+    data: [],
+    text: null,
+    parts: streamParts,
+    history: [],
+  };
+
+  return streamParts.reduce((acc, streamPart) => {
+    if (streamPart.name === "text") {
+      acc.text = `${acc.text ?? ""}${streamPart.value}`;
+      // NOTE: "navigate-to" omitted... not sure how much it matters
+      acc.history.push({ role: "assistant", content: streamPart.value });
+    }
+    if (streamPart.name === "data") {
+      acc.data = acc.data.concat(streamPart.value);
+    }
+    if (streamPart.name === "tool_call") {
+      acc.toolCalls.push({ ...streamPart.value, state: "call" });
+      acc.history.push({
+        role: "assistant",
+        "tool-calls": [
+          {
+            id: streamPart.value.toolCallId,
+            name: streamPart.value.toolName,
+            arguments: streamPart.value.args,
+          },
+        ],
+      });
+    }
+    if (streamPart.name === "tool_result") {
+      const toolCallId = streamPart.value.toolCallId;
+      const index = acc.toolCalls.findIndex((v) => v.toolCallId === toolCallId);
+
+      if (index === -1) {
+        throw new Error(
+          "Tool Results must be preceded by the tool call with the same toolCallId",
+        );
+      }
+
+      acc.toolCalls[index] = {
+        ...acc.toolCalls[index],
+        state: "result",
+        value: streamPart.value.result,
+      };
+      acc.history.push({
+        role: "tool",
+        content: streamPart.value.result,
+        "tool-call-id": streamPart.value.toolCallId,
+      });
+    }
+
+    return acc;
+  }, acc);
+}
+
+type StreamPartValue<name extends ParsedStreamPartName> = Extract<
+  ParsedStreamPart,
+  { name: name }
+>["value"];
+
+export type AIStreamingConfig = {
+  onTextPart?: (part: StreamPartValue<"text">) => void;
+  onDataPart?: (part: StreamPartValue<"data">) => void;
+  onToolCallPart?: (part: StreamPartValue<"tool_call">) => void;
+  onToolResultPart?: (part: StreamPartValue<"tool_result">) => void;
+  onStreamStateUpdate?: (
+    state: ReturnType<typeof accumulateStreamParts>,
+  ) => void;
+  onError?: (error: Error) => void;
+};
+
+export async function processChatResponse(
+  stream: ReadableStream<Uint8Array>,
+  config: AIStreamingConfig,
+) {
+  const parsedStreamParts: ParsedStreamPart[] = [];
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let chunks: Uint8Array[] = [];
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { value: chunk } = await reader.read();
+
+    if (chunk) {
+      chunks.push(chunk);
+      if (chunk[chunk.length - 1] !== "\n".charCodeAt(0)) {
+        // if the last character is not a newline, we have not read the whole JSON value
+        continue;
+      }
+    }
+
+    if (chunks.length === 0) {
+      break; // we have reached the end of the stream
+    }
+
+    const concatenatedChunks = concatChunks(chunks);
+    chunks = [];
+
+    const streamParts = _.compact(
+      decoder
+        .decode(concatenatedChunks, { stream: true })
+        .split("\n")
+        .filter((line) => line !== "") // splitting leaves an empty string at the end
+        .map(parseDataStreamPart),
+    );
+
+    for (const streamPart of streamParts) {
+      parsedStreamParts.push(streamPart);
+
+      if (streamPart.name === "text") {
+        config.onTextPart?.(streamPart.value);
+      }
+      if (streamPart.name === "data") {
+        config.onDataPart?.(streamPart.value);
+      }
+      if (streamPart.name === "tool_call") {
+        config.onToolCallPart?.(streamPart.value);
+      }
+      if (streamPart.name === "tool_result") {
+        config.onToolResultPart?.(streamPart.value);
+      }
+      if (streamPart.name === "error") {
+        config.onError?.(
+          new Error(streamPart.value ? `${streamPart.value}` : "Unknown error"),
+        );
+      }
+    }
+
+    const accumulated = accumulateStreamParts(parsedStreamParts);
+    config.onStreamStateUpdate?.(accumulated);
+  }
+
+  reader.releaseLock();
+
+  return accumulateStreamParts(parsedStreamParts);
+}

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/process-stream.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/process-stream.ts
@@ -258,7 +258,5 @@ export async function processChatResponse(
     config.onStreamStateUpdate?.(accumulated);
   }
 
-  reader.releaseLock();
-
   return accumulateStreamParts(parsedStreamParts);
 }

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/process-stream.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/process-stream.unit.spec.ts
@@ -1,0 +1,80 @@
+import { processChatResponse } from "./process-stream";
+import { createMockReadableStream } from "./test-utils";
+
+const getMockedCallbacks = () => ({
+  onTextPart: jest.fn(),
+  onDataPart: jest.fn(),
+  onToolCallPart: jest.fn(),
+  onToolResultPart: jest.fn(),
+  onError: jest.fn(),
+});
+
+const expectNoStreamedError = {
+  onError: (error: unknown) => {
+    expect(error).toBeUndefined();
+  },
+};
+
+const mockSuccessStreamData = [
+  `0:"You, but don't tell anyone."`,
+  `2:{"type":"state","version":1,"value":{"queries":{}}}`,
+  `9:{"toolCallId":"x","toolName":"x","args":""}`,
+  `a:{"toolCallId":"x","result":""}`,
+  `d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
+];
+const getMockSuccessStream = () =>
+  createMockReadableStream(mockSuccessStreamData);
+
+const getMockErrorStream = () => createMockReadableStream([`3:{}`]);
+
+// TODO: check code coverage
+
+describe("processChatResponse", () => {
+  it("should be able to process a valid stream", async () => {
+    const mockStream = getMockSuccessStream();
+    const result = await processChatResponse(mockStream, expectNoStreamedError);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("should call callbacks for relevant chunk types", async () => {
+    const mockSuccessStream = getMockSuccessStream();
+    const config = getMockedCallbacks();
+
+    await processChatResponse(mockSuccessStream, config);
+    expect(config.onTextPart).toHaveBeenCalled();
+    expect(config.onDataPart).toHaveBeenCalled();
+    expect(config.onToolCallPart).toHaveBeenCalled();
+    expect(config.onToolResultPart).toHaveBeenCalled();
+    expect(config.onError).not.toHaveBeenCalled();
+
+    const mockErrorStream = getMockErrorStream();
+    try {
+      await processChatResponse(mockErrorStream, config);
+    } catch (_) {}
+    expect(config.onError).toHaveBeenCalled();
+  });
+
+  it("should not error when seeing data parts it does not recognize", async () => {
+    const mockStream = createMockReadableStream([
+      `2:{"type":"__invalid__","version":1,"value":"hi"}`,
+      `d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
+    ]);
+    const config = getMockedCallbacks();
+    await expect(processChatResponse(mockStream, config)).resolves.toBeTruthy();
+    expect(config.onError).not.toHaveBeenCalled();
+  });
+
+  it("should ignore unknown part types", async () => {
+    const mockStream = createMockReadableStream([`x:"UNKNOWN PART TYPE"`]);
+    const config = getMockedCallbacks();
+    await expect(processChatResponse(mockStream, config)).resolves.toBeTruthy();
+    expect(config.onError).not.toHaveBeenCalled();
+  });
+
+  it("should error if there is no part type", async () => {
+    const mockStream = createMockReadableStream([`data-without-part-type`]);
+    await expect(
+      processChatResponse(mockStream, expectNoStreamedError),
+    ).rejects.toBeTruthy();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
@@ -1,0 +1,69 @@
+import { nanoid } from "@reduxjs/toolkit";
+
+import api from "metabase/lib/api";
+
+import { type AIStreamingConfig, processChatResponse } from "./process-stream";
+import type { JSONValue } from "./types";
+
+// keep track of inflight requests so that can be cancelled programmitcally from other
+// places in the app w/o passing references to the abort controller directly
+export const inflightAiStreamingRequests = new Map<
+  string,
+  { abortController: AbortController }
+>();
+
+export const getInflightRequestsForUrl = (url: string) => {
+  return [...inflightAiStreamingRequests.entries()]
+    .filter(([reqId]) => reqId.startsWith(`${url}-`))
+    .map(([_reqId, reqInfo]) => reqInfo);
+};
+
+/**
+ * Performs a streaming AI query by sending a POST request and processing the server-sent events response.
+ * @returns A promise that resolves to the processed chat response stream
+ */
+export async function aiStreamingQuery(
+  req: {
+    url: string;
+    signal?: AbortSignal | null | undefined;
+    body: JSONValue;
+  },
+  config: AIStreamingConfig = {},
+) {
+  const reqId = `${req.url}-${nanoid()}`;
+
+  try {
+    const abortController = new AbortController();
+
+    if (req.signal) {
+      req.signal.addEventListener("abort", () => {
+        abortController.abort(req.signal?.reason);
+        inflightAiStreamingRequests.delete(reqId);
+      });
+    }
+    inflightAiStreamingRequests.set(reqId, { abortController });
+
+    const response = await fetch(req.url, {
+      method: "POST",
+      headers: {
+        ...api.getClientHeaders(),
+        Accept: "text/event-stream",
+        "Content-Type": "application/json",
+      },
+      signal: abortController.signal,
+      body: JSON.stringify(req.body),
+    });
+
+    if (response && !response.ok) {
+      throw response;
+    }
+
+    if (!response || !response.body) {
+      throw new Error("No Response");
+    }
+
+    return processChatResponse(response.body, config);
+  } finally {
+    inflightAiStreamingRequests.delete(reqId);
+  }
+}

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
@@ -54,12 +54,12 @@ export async function aiStreamingQuery(
       body: JSON.stringify(req.body),
     });
 
-    if (response && !response.ok) {
-      throw response;
+    if (!response.ok) {
+      throw new Error(response.statusText);
     }
 
-    if (!response || !response.body) {
-      throw new Error("No Response");
+    if (!response.body) {
+      throw new Error("No response");
     }
 
     return processChatResponse(response.body, config);

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
@@ -62,7 +62,11 @@ export async function aiStreamingQuery(
       throw new Error("No response");
     }
 
-    return processChatResponse(response.body, config);
+    // without the await here the finally clause will run before
+    // processChatResponse has resolved causing the chat response
+    // to continue to be processed even if the provided abort
+    // signal has been aborted
+    return await processChatResponse(response.body, config);
   } finally {
     inflightAiStreamingRequests.delete(reqId);
   }

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.unit.spec.ts
@@ -1,0 +1,142 @@
+import fetchMock from "fetch-mock";
+
+import { aiStreamingQuery, getInflightRequestsForUrl } from "./requests";
+import { mockStreamedEndpoint } from "./test-utils";
+
+const ENDPOINT = "/some-streamed-endpoint";
+
+describe("ai requests", () => {
+  describe("aiStreamingQuery", () => {
+    it("should return full result of a successful request", async () => {
+      mockStreamedEndpoint({
+        url: ENDPOINT,
+        textChunks: whoIsYourFavoriteResponse,
+      });
+      const result = await aiStreamingQuery({ url: ENDPOINT, body: {} });
+
+      // TODO: make a snapshot test
+      expect(result).toEqual({
+        data: [{ type: "state", value: { queries: {} }, version: 1 }],
+        history: [
+          { content: "You, but don't tell anyone.", role: "assistant" },
+        ],
+        parts: [
+          { code: "0", name: "text", value: "You, but don't tell anyone." },
+          {
+            code: "2",
+            name: "data",
+            value: { type: "state", value: { queries: {} }, version: 1 },
+          },
+          {
+            code: "d",
+            name: "finish_message",
+            value: {
+              finishReason: "stop",
+              usage: { completionTokens: 8, promptTokens: 4916 },
+            },
+          },
+        ],
+        text: "You, but don't tell anyone.",
+        toolCalls: [],
+      });
+    });
+
+    it("should call callbacks for relevant chunk types", async () => {
+      mockStreamedEndpoint({
+        url: ENDPOINT,
+        textChunks: [
+          `0:"Testing"`,
+          `2:{"type":"state","version":1,"value":{}}`,
+          `9:{"toolCallId":"x","toolName":"x","args":""}`,
+          `a:{"toolCallId":"x","result":""}`,
+          `d:{"finishReason":"stop","usage":{"promptTokens":1,"completionTokens":1}}`,
+        ],
+      });
+
+      const successCbs = {
+        onTextPart: jest.fn(),
+        onDataPart: jest.fn(),
+        onToolCallPart: jest.fn(),
+        onToolResultPart: jest.fn(),
+        onError: jest.fn(),
+      };
+
+      await aiStreamingQuery({ url: ENDPOINT, body: {} }, successCbs);
+      expect(successCbs.onTextPart).toHaveBeenCalled();
+      expect(successCbs.onDataPart).toHaveBeenCalled();
+      expect(successCbs.onToolCallPart).toHaveBeenCalled();
+      expect(successCbs.onToolResultPart).toHaveBeenCalled();
+      expect(successCbs.onError).not.toHaveBeenCalled();
+
+      mockStreamedEndpoint({
+        url: ENDPOINT,
+        textChunks: [
+          `3:{}`, // error after finish to trigger all callbacks
+        ],
+      });
+
+      const failureCbs = {
+        onError: jest.fn(),
+      };
+      try {
+        await aiStreamingQuery({ url: ENDPOINT, body: {} }, failureCbs);
+      } catch (_) {}
+      expect(failureCbs.onError).toHaveBeenCalled();
+    });
+
+    it.todo("should be able abort request via a passed in signal");
+
+    describe("in-flight request tracking", () => {
+      it("should register/unregister with inflight requests on a successful request", async () => {
+        mockStreamedEndpoint({
+          url: ENDPOINT,
+          textChunks: whoIsYourFavoriteResponse,
+        });
+        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(0);
+        const promise = aiStreamingQuery({ url: ENDPOINT, body: {} });
+        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(1);
+        await promise;
+        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(0);
+      });
+
+      it("should properly unregister with inflight requests on error", async () => {
+        mockStreamedEndpoint({
+          url: ENDPOINT,
+          textChunks: [`3:{}`], // error message
+        });
+        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(0);
+        const promise = aiStreamingQuery({ url: ENDPOINT, body: {} });
+        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(1);
+
+        await expect(promise).rejects.not.toBeFalsy();
+
+        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(0);
+      });
+
+      it("should properly unregister with inflight requests on abort", async () => {
+        const controller = new AbortController();
+
+        fetchMock.post(`path:${ENDPOINT}`, { delay: 100, status: 200 });
+        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(0);
+        const promise = aiStreamingQuery({
+          url: ENDPOINT,
+          body: {},
+          signal: controller.signal,
+        });
+        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(1);
+        controller.abort();
+        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(0);
+        try {
+          await promise;
+        } catch (err) {}
+      });
+    });
+  });
+});
+
+// TODO: find a common place for fixtures
+const whoIsYourFavoriteResponse = [
+  `0:"You, but don't tell anyone."`,
+  `2:{"type":"state","version":1,"value":{"queries":{}}}`,
+  `d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
+];

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/schemas.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/schemas.ts
@@ -1,0 +1,36 @@
+import * as Yup from "yup";
+
+export const dataPartSchema = Yup.object({
+  type: Yup.string().required(),
+  version: Yup.number().required(),
+  value: Yup.mixed(),
+});
+
+export const toolCallPartSchema = Yup.object({
+  toolCallId: Yup.string().required(),
+  toolName: Yup.string().required(),
+  args: Yup.string(),
+});
+
+export const toolResultPartSchema = Yup.object({
+  toolCallId: Yup.string().required(),
+  result: Yup.mixed(),
+});
+
+export const finishPartSchema = Yup.object({
+  finishReason: Yup.string()
+    .oneOf([
+      "stop",
+      "length",
+      "content-filter",
+      "tool-calls",
+      "error",
+      "other",
+      "unknown",
+    ])
+    .required(),
+  usage: Yup.object({
+    promptTokens: Yup.number().required(),
+    completionTokens: Yup.number().required(),
+  }),
+});

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/schemas.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/schemas.ts
@@ -6,6 +6,8 @@ export const dataPartSchema = Yup.object({
   value: Yup.mixed(),
 });
 
+export const knownDataPartTypes = ["state", "navigate_to"];
+
 export const toolCallPartSchema = Yup.object({
   toolCallId: Yup.string().required(),
   toolName: Yup.string().required(),

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/schemas.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/schemas.ts
@@ -8,6 +8,10 @@ export const dataPartSchema = Yup.object({
 
 export const knownDataPartTypes = ["state", "navigate_to"];
 
+export type KnownDataPart =
+  | { type: "state"; version: 1; value: Record<string, any> }
+  | { type: "navigate_to"; version: 1; value: string };
+
 export const toolCallPartSchema = Yup.object({
   toolCallId: Yup.string().required(),
   toolName: Yup.string().required(),

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/test-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/test-utils.ts
@@ -1,0 +1,49 @@
+export function createMockReadableStream(textChunks: string[]) {
+  return new ReadableStream({
+    async start(controller) {
+      const textEncoder = new TextEncoder();
+      try {
+        for (const textChunk of textChunks) {
+          controller.enqueue(textEncoder.encode(`${textChunk}\n`));
+        }
+      } finally {
+        controller.close();
+      }
+    },
+  });
+}
+
+export function mockStreamedEndpoint({
+  url,
+  textChunks,
+  initialDelay = 0,
+}: {
+  url: string;
+  textChunks: string[];
+  initialDelay?: number;
+}) {
+  const originalFetch = global.fetch;
+
+  // fetch-mock is supposed to work with ReadableStreams, but when passed one
+  // the getReader methods ends up as undefined
+  return jest
+    .spyOn(global, "fetch")
+    .mockImplementation((fetchedUrl, ...args) => {
+      const isRequestedUrl =
+        typeof fetchedUrl === "string" && fetchedUrl.includes(url);
+
+      if (isRequestedUrl) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              status: 202,
+              ok: true,
+              body: createMockReadableStream(textChunks),
+            } as any);
+          }, initialDelay);
+        });
+      } else {
+        return originalFetch(fetchedUrl, ...args);
+      }
+    });
+}

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/types.ts
@@ -1,0 +1,11 @@
+/**
+A JSON value can be a string, number, boolean, object, array, or null.
+JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods.
+ */
+export type JSONValue =
+  | null
+  | string
+  | number
+  | boolean
+  | { [value: string]: JSONValue }
+  | Array<JSONValue>;

--- a/enterprise/frontend/src/metabase-enterprise/api/tags.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/tags.ts
@@ -1,10 +1,8 @@
 import type { TagDescription } from "@reduxjs/toolkit/query";
 
-export const METABOT_TAG = "metabot";
-
 export const ENTERPRISE_TAG_TYPES = [
   "scim",
-  METABOT_TAG,
+  "metabot",
   "metabot-entities-list",
   "metabot-prompt-suggestions",
   "gsheets-status",

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -314,6 +314,7 @@ const Thinking = ({
     ],
     construct_notebook_query: [t`Creating a query`, t`Contructing a question`],
     analyze_data: [t`Analyzing the data`, t`Exploring your data`],
+    analyze_chart: [t`Inspecting the visualization`, t`Looking at the data`],
     list_available_fields: undefined, // tool executes near instantly
   } as Record<string, string[] | undefined>;
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -1,7 +1,8 @@
-import { useClipboard } from "@mantine/hooks";
+import { useClipboard, useTimeout } from "@mantine/hooks";
 import cx from "classnames";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { c, jt, t } from "ttag";
+import _ from "underscore";
 
 import EmptyDashboardBot from "assets/img/dashboard-empty.svg?component";
 import { Sidebar } from "metabase/nav/containers/MainNavbar/MainNavbar.styled";
@@ -168,11 +169,9 @@ export const MetabotChat = () => {
 
               {/* loading */}
               {metabot.isDoingScience && (
-                <Loader
-                  color="brand"
-                  type="dots"
-                  size="lg"
-                  data-testid="metabot-response-loader"
+                <Thinking
+                  activeToolCallName={metabot.activeToolCall?.name}
+                  useStreaming={metabot.useStreaming}
                 />
               )}
 
@@ -207,8 +206,15 @@ export const MetabotChat = () => {
               data-testid="metabot-chat-input"
               w="100%"
               leftSection={
-                <Box h="100%" pt="11px">
-                  <Icon name="metabot" c="brand" />
+                <Box
+                  h="100%"
+                  pt="11px"
+                  onDoubleClick={() => metabot.toggleStreaming()}
+                >
+                  <Icon
+                    name="metabot"
+                    c={metabot.useStreaming ? "warning" : "brand"}
+                  />
                 </Box>
               }
               autosize
@@ -279,6 +285,51 @@ const Message = ({
           <Icon name="copy" size="1rem" />
         </ActionIcon>
       </Flex>
+    </Flex>
+  );
+};
+
+const Thinking = ({
+  activeToolCallName,
+  useStreaming,
+}: {
+  activeToolCallName: string | undefined;
+  useStreaming: boolean;
+}) => {
+  const [defaultMessageKey, setDefaultMessageKey] = useState<string>("");
+  useTimeout(() => setDefaultMessageKey("__SLOW_RESPONSE__"), 3000, {
+    autoInvoke: true,
+  });
+  useTimeout(() => setDefaultMessageKey("__VERY_SLOW_RESPONSE__"), 10000, {
+    autoInvoke: true,
+  });
+
+  const messagesKey = activeToolCallName ?? defaultMessageKey;
+
+  const messages = {
+    __SLOW_RESPONSE__: [t`Thinking...`, t`Working on your request`],
+    __VERY_SLOW_RESPONSE__: [
+      t`Lot's to consider`,
+      t`Working through the details...`,
+    ],
+    construct_notebook_query: [t`Creating a query`, t`Contructing a question`],
+    analyze_data: [t`Analyzing the data`, t`Exploring your data`],
+    list_available_fields: undefined, // tool executes near instantly
+  } as Record<string, string[] | undefined>;
+
+  const message = _.sample(
+    messages[messagesKey] ?? messages[defaultMessageKey] ?? [],
+  );
+
+  return (
+    <Flex gap="md" align="center">
+      <Loader
+        color="brand"
+        type="dots"
+        size="lg"
+        data-testid="metabot-response-loader"
+      />
+      {useStreaming && message && <Text c="text-light">{message}</Text>}
     </Flex>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
@@ -8,7 +8,7 @@ export const FIXED_METABOT_IDS = {
   EMBEDDED: 2 as const,
 };
 
-export function getErrorMessage() {
+export function getAgentOfflineError() {
   return t`I'm currently offline, try again later.`;
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -2,18 +2,20 @@ import { useCallback } from "react";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { useMetabotContext } from "metabase/metabot";
-import { METABOT_TAG, useMetabotAgentMutation } from "metabase-enterprise/api";
 
 import {
+  getActiveToolCall,
   getIsLongMetabotConversation,
   getIsProcessing,
   getLastAgentMessagesByType,
   getMessages,
   getMetabotId,
   getMetabotVisible,
+  getUseStreaming,
   resetConversation as resetConversationAction,
   setVisible as setVisibleAction,
   submitInput as submitInputAction,
+  toggleStreaming,
 } from "./state";
 
 export const useMetabotAgent = () => {
@@ -27,10 +29,6 @@ export const useMetabotAgent = () => {
   const isProcessing = useSelector(getIsProcessing as any) as ReturnType<
     typeof getIsProcessing
   >;
-
-  const [, sendMessageReq] = useMetabotAgentMutation({
-    fixedCacheKey: METABOT_TAG,
-  });
 
   const setVisible = useCallback(
     (isVisible: boolean) => dispatch(setVisibleAction(isVisible)),
@@ -92,6 +90,13 @@ export const useMetabotAgent = () => {
     setVisible,
     startNewConversation,
     submitInput,
-    isDoingScience: sendMessageReq.isLoading || isProcessing,
+    isDoingScience: isProcessing,
+    activeToolCall: useSelector(getActiveToolCall as any) as ReturnType<
+      typeof getActiveToolCall
+    >,
+    useStreaming: useSelector(getUseStreaming as any) as ReturnType<
+      typeof getUseStreaming
+    >,
+    toggleStreaming: () => dispatch(toggleStreaming()),
   };
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -56,8 +56,8 @@ export const useMetabotAgent = () => {
   );
 
   const startNewConversation = useCallback(
-    (message: string, metabotId?: string) => {
-      resetConversation();
+    async (message: string, metabotId?: string) => {
+      await resetConversation();
       setVisible(true);
       if (message) {
         submitInput(message, metabotId);

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot-streaming.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot-streaming.unit.spec.tsx
@@ -1,0 +1,214 @@
+// NOTE: these tests can replace their counterparts in the metabot.unit.spec.tsx once streaming becomes the default
+
+import { combineReducers } from "@reduxjs/toolkit";
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import { P, isMatching } from "ts-pattern";
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { uuid } from "metabase/lib/uuid";
+import { mockStreamedEndpoint } from "metabase-enterprise/api/ai-streaming/test-utils";
+import type { User } from "metabase-types/api";
+import {
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { Metabot } from "./components/Metabot";
+import { FIXED_METABOT_IDS } from "./constants";
+import { MetabotProvider } from "./context";
+import {
+  type MetabotState,
+  metabotInitialState,
+  metabotReducer,
+} from "./state";
+
+const mockAgentEndpoint = (
+  params: Omit<Parameters<typeof mockStreamedEndpoint>[0], "url">,
+) =>
+  mockStreamedEndpoint({
+    url: "/api/ee/metabot-v3/v2/agent-streaming",
+    ...params,
+  });
+
+function setup(
+  options: {
+    ui?: React.ReactElement;
+    metabotPluginInitialState?: MetabotState;
+    currentUser?: User | null | undefined;
+    promptSuggestions?: { prompt: string }[];
+  } | void,
+) {
+  const settings = mockSettings({
+    "token-features": createMockTokenFeatures({
+      metabot_v3: true,
+    }),
+  });
+
+  setupEnterprisePlugins();
+
+  const {
+    ui = <Metabot />,
+    currentUser = createMockUser(),
+    metabotPluginInitialState = {
+      ...metabotInitialState,
+      conversationId: uuid(),
+      visible: true,
+      useStreaming: true,
+    },
+    promptSuggestions = [],
+  } = options || {};
+
+  fetchMock.get(
+    `path:/api/ee/metabot-v3/metabot/${FIXED_METABOT_IDS.DEFAULT}/prompt-suggestions`,
+    { prompts: promptSuggestions, offset: 0, limit: 3, total: 3 },
+  );
+
+  return renderWithProviders(<MetabotProvider>{ui}</MetabotProvider>, {
+    storeInitialState: createMockState({
+      settings,
+      currentUser: currentUser ? currentUser : undefined,
+      plugins: {
+        metabotPlugin: metabotPluginInitialState,
+      },
+    } as any),
+    customReducers: {
+      plugins: combineReducers({
+        metabotPlugin: metabotReducer,
+      }),
+    },
+  });
+}
+
+const input = () => screen.findByTestId("metabot-chat-input");
+const enterChatMessage = async (message: string, send = true) =>
+  userEvent.type(await input(), `${message}${send ? "{Enter}" : ""}`);
+const responseLoader = () => screen.findByTestId("metabot-response-loader");
+
+const assertVisible = async () =>
+  expect(await screen.findByTestId("metabot-chat")).toBeInTheDocument();
+
+const lastReqBody = async (agentSpy: ReturnType<typeof mockAgentEndpoint>) => {
+  await waitFor(() => expect(agentSpy).toHaveBeenCalled());
+  return JSON.parse(agentSpy.mock.lastCall?.[1]?.body as string);
+};
+
+describe("metabot-streaming", () => {
+  describe("ui", () => {
+    it("should be able to render metabot", async () => {
+      setup();
+      await assertVisible();
+    });
+
+    it("should show empty state ui if conversation is empty", async () => {
+      setup();
+      mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
+
+      expect(
+        await screen.findByTestId("metabot-empty-chat-info"),
+      ).toBeInTheDocument();
+
+      await enterChatMessage("Who is your favorite?");
+      expect(
+        await screen.findByText("Who is your favorite?"),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByTestId("metabot-empty-chat-info"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should render markdown for metabot's replies", async () => {
+      setup();
+      mockAgentEndpoint({
+        textChunks: [
+          `0:"# You, but don't tell anyone."`,
+          `2:{"type":"state","version":1,"value":{"queries":{}}}`,
+          `d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
+        ],
+      });
+      await enterChatMessage("Who is your favorite?");
+
+      const heading = await screen.findByRole("heading", { level: 1 });
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveTextContent(`You, but don't tell anyone.`);
+    });
+  });
+
+  describe("message", () => {
+    it("should properly send chat messages", async () => {
+      setup();
+
+      mockAgentEndpoint(
+        { textChunks: whoIsYourFavoriteResponse, initialDelay: 50 }, // small delay to cause loading state
+      );
+
+      await enterChatMessage("Who is your favorite?", false);
+      expect(await input()).toHaveValue("Who is your favorite?");
+
+      await enterChatMessage("Who is your favorite?");
+      expect(await responseLoader()).toBeInTheDocument();
+      expect(
+        await screen.findByText("You, but don't tell anyone."),
+      ).toBeInTheDocument();
+
+      // should auto-clear input + refocus
+      expect(await input()).toHaveValue("");
+      expect(await input()).toHaveFocus();
+    });
+  });
+
+  describe("context", () => {
+    it("should send along default context", async () => {
+      setup();
+      const agentSpy = mockAgentEndpoint({
+        textChunks: whoIsYourFavoriteResponse,
+      });
+
+      await enterChatMessage("Who is your favorite?");
+
+      expect(
+        isMatching(
+          { current_time_with_timezone: P.string },
+          (await lastReqBody(agentSpy))?.context,
+        ),
+      ).toEqual(true);
+    });
+  });
+
+  describe("history", () => {
+    it("should send conversation history along with future messages", async () => {
+      setup();
+
+      // create some chat history + wait for a response
+      mockAgentEndpoint({
+        textChunks: whoIsYourFavoriteResponse,
+        initialDelay: 500,
+      });
+      await enterChatMessage("Who is your favorite?");
+      expect(
+        await screen.findByText("You, but don't tell anyone."),
+      ).toBeInTheDocument();
+
+      // send another message and check that the proper history is being sent along
+      const agentSpy2 = mockAgentEndpoint({
+        textChunks: [], // next response doesn't matter
+      });
+      await enterChatMessage("Hi!");
+      const reqBody = await lastReqBody(agentSpy2);
+      expect(reqBody?.history).toEqual([
+        { content: "Who is your favorite?", role: "user" },
+        { content: "You, but don't tell anyone.", role: "assistant" },
+      ]);
+    });
+  });
+});
+
+const whoIsYourFavoriteResponse = [
+  `0:"You, but don't tell anyone."`,
+  `2:{"type":"state","version":1,"value":{"queries":{}}}`,
+  `d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
+];

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -227,7 +227,7 @@ export const cancelInflightAgentRequests = createAsyncThunk(
 
     // cancel streamed requests
     getInflightRequestsForUrl("/api/ee/metabot-v3/v2/agent-streaming").forEach(
-      (req) => req.abortController.abort("User manaully cancelled the request"),
+      (req) => req.abortController.abort(),
     );
   },
 );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -1,25 +1,36 @@
-import { isMatching } from "ts-pattern";
+import type { UnknownAction } from "@reduxjs/toolkit";
+import { push } from "react-router-redux";
+import { P, isMatching, match } from "ts-pattern";
 import { t } from "ttag";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { createAsyncThunk } from "metabase/lib/redux";
+import { getUser } from "metabase/selectors/user";
 import {
   EnterpriseApi,
-  METABOT_TAG,
   metabotAgent,
   metabotApi,
 } from "metabase-enterprise/api";
-import type { MetabotChatContext, MetabotReaction } from "metabase-types/api";
+import {
+  type JSONValue,
+  aiStreamingQuery,
+  getInflightRequestsForUrl,
+} from "metabase-enterprise/api/ai-streaming";
+import type {
+  MetabotAgentRequest,
+  MetabotChatContext,
+  MetabotReaction,
+} from "metabase-types/api";
 import type { Dispatch } from "metabase-types/store";
 
-import { getErrorMessage } from "../constants";
+import { getAgentOfflineError } from "../constants";
 import { notifyUnknownReaction, reactionHandlers } from "../reactions";
 
 import { metabot } from "./reducer";
 import {
+  getAgentRequestMeta,
   getIsProcessing,
   getMetabotConversationId,
-  getPrevAgentRequestMeta,
+  getUseStreaming,
 } from "./selectors";
 
 const isAbortError = isMatching({ name: "AbortError" });
@@ -27,14 +38,20 @@ const isAbortError = isMatching({ name: "AbortError" });
 export const {
   addAgentMessage,
   addUserMessage,
-  clearMessages,
   resetConversationId,
   setIsProcessing,
+  toolCallStart,
+  toolCallEnd,
 } = metabot.actions;
+
+export const toggleStreaming = () => (dispatch: Dispatch) => {
+  dispatch(resetConversation());
+  dispatch(metabot.actions.toggleStreaming());
+};
 
 export const setVisible =
   (isVisible: boolean) => (dispatch: Dispatch, getState: any) => {
-    const currentUser = getCurrentUser(getState());
+    const currentUser = getUser(getState());
     if (!currentUser) {
       console.error(
         "Metabot can not be opened while there is no signed in user",
@@ -55,16 +72,21 @@ export const submitInput = createAsyncThunk(
     },
     { dispatch, getState, signal },
   ) => {
-    const isProcessing = getIsProcessing(getState() as any);
+    const state = getState() as any;
+    const isProcessing = getIsProcessing(state);
     if (isProcessing) {
       return console.error("Metabot is actively serving a request");
     }
 
     dispatch(addUserMessage(data.message));
 
-    const meta = getPrevAgentRequestMeta(getState() as any);
+    const useStreaming = getUseStreaming(getState() as any);
+    const sendRequest = useStreaming
+      ? sendStreamedAgentRequest
+      : sendAgentRequest;
+    const meta = getAgentRequestMeta(getState() as any);
     const sendMessageRequestPromise = dispatch(
-      sendMessageRequest({ ...data, ...meta }),
+      sendRequest({ ...data, ...meta }),
     );
     signal.addEventListener("abort", () => {
       sendMessageRequestPromise.abort();
@@ -73,16 +95,10 @@ export const submitInput = createAsyncThunk(
   },
 );
 
-export const sendMessageRequest = createAsyncThunk(
-  "metabase-enterprise/metabot/sendMessageRequest",
+export const sendAgentRequest = createAsyncThunk(
+  "metabase-enterprise/metabot/sendAgentRequest",
   async (
-    data: {
-      message: string;
-      context: MetabotChatContext;
-      history: any[];
-      state: any;
-      metabot_id?: string;
-    },
+    data: Omit<MetabotAgentRequest, "conversation_id">,
     { dispatch, getState },
   ) => {
     // TODO: make enterprise store
@@ -98,10 +114,7 @@ export const sendMessageRequest = createAsyncThunk(
     }
 
     const metabotRequestPromise = dispatch(
-      metabotAgent.initiate(
-        { ...data, conversation_id: sessionId },
-        { fixedCacheKey: METABOT_TAG },
-      ),
+      metabotAgent.initiate({ ...data, conversation_id: sessionId }),
     );
 
     const result = await metabotRequestPromise;
@@ -113,7 +126,9 @@ export const sendMessageRequest = createAsyncThunk(
       } else {
         console.error("Metabot request returned error: ", result.error);
         const message =
-          (result.error as any).status >= 500 ? getErrorMessage() : undefined;
+          (result.error as any).status >= 500
+            ? getAgentOfflineError()
+            : undefined;
         dispatch(stopProcessingAndNotify(message));
       }
     }
@@ -124,14 +139,97 @@ export const sendMessageRequest = createAsyncThunk(
   },
 );
 
+export const sendStreamedAgentRequest = createAsyncThunk(
+  "metabase-enterprise/metabot/sendStreamedAgentRequest",
+  async (
+    req: Omit<MetabotAgentRequest, "conversation_id">,
+    { dispatch, getState, signal },
+  ) => {
+    // TODO: make enterprise store
+    let sessionId = getMetabotConversationId(getState() as any);
+
+    // should not be needed, but just in case the value got unset
+    if (!sessionId) {
+      console.warn(
+        "Metabot has no session id while open, this should never happen",
+      );
+      dispatch(resetConversationId());
+      sessionId = getMetabotConversationId(getState() as any) as string;
+    }
+
+    try {
+      const body = { ...req, conversation_id: sessionId };
+      const state = { ...body.state };
+
+      const response = await aiStreamingQuery(
+        {
+          url: "/api/ee/metabot-v3/v2/agent-streaming",
+          // NOTE: StructuredDatasetQuery as part of the EntityInfo in MetabotChatContext
+          // is upsetting the types, casting for now
+          body: body as JSONValue,
+          signal,
+        },
+        {
+          // TODO: onDataPart should only log on known values, we should drop unknown
+          onDataPart: (part) => {
+            // TODO: did we add a new reaction w/ Thomas' new work?
+            match(part)
+              .with({ type: "state" }, (part) =>
+                Object.assign(state, part.value),
+              )
+              .with({ type: "navigate_to" }, (part) => {
+                dispatch(push(part.value) as UnknownAction);
+              })
+              // TODO: change to exhaustive
+              .otherwise(() => {});
+          },
+          onTextPart: (part) => {
+            dispatch(addAgentMessage({ type: "reply", message: String(part) }));
+          },
+          onToolCallPart: (part) => dispatch(toolCallStart(part)),
+          onToolResultPart: () => dispatch(toolCallEnd()),
+        },
+      );
+
+      return {
+        data: {
+          conversation_id: body.conversation_id,
+          history: [...body.history, ...response.history],
+          state,
+        },
+        error: undefined,
+      } as const;
+    } catch (error) {
+      console.error("Metabot request error: ", error);
+
+      const notification = match(error)
+        .with({ name: "AbortError" }, () => false as const)
+        .with({ status: P.number.gte(500) }, getAgentOfflineError)
+        .otherwise(() => t`I can’t do that, unfortunately.`);
+
+      if (notification !== false) {
+        dispatch(addAgentMessage({ type: "error", message: notification }));
+      }
+
+      return { data: undefined, error };
+    }
+  },
+);
+
 export const cancelInflightAgentRequests = createAsyncThunk(
   "metabase-enterprise/metabot/cancelInflightAgentRequests",
   (_args, { dispatch }) => {
+    // cancel rtkquery managed requests
     const requests = dispatch(EnterpriseApi.util.getRunningMutationsThunk());
     const agentRequests = requests.filter(
       (req) => req.arg.endpointName === metabotApi.endpoints.metabotAgent.name,
     );
     agentRequests.forEach((req) => req.abort());
+
+    // cancel streamed requests
+    getInflightRequestsForUrl("/api/ee/metabot-v3/v2/agent-streaming").forEach(
+      (req) => req.abortController.abort("User manaully cancelled the request"),
+    );
   },
 );
 
@@ -139,17 +237,11 @@ export const resetConversation = createAsyncThunk(
   "metabase-enterprise/metabot/resetConversation",
   (_args, { dispatch }) => {
     dispatch(cancelInflightAgentRequests());
-    // clear previous agent request state so history value is empty for future requests
-    dispatch(
-      EnterpriseApi.internalActions.removeMutationResult({
-        fixedCacheKey: METABOT_TAG,
-      }),
-    );
+
     // clear out suggested prompts so the user is shown something fresh
     dispatch(EnterpriseApi.util.invalidateTags(["metabot-prompt-suggestions"]));
 
-    dispatch(clearMessages());
-    dispatch(resetConversationId());
+    dispatch(metabot.actions.resetConversation());
   },
 );
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -101,7 +101,10 @@ export const metabot = createSlice({
         state.isProcessing = true;
       })
       .addCase(sendStreamedAgentRequest.fulfilled, (state, action) => {
-        state.history = action.payload?.data?.history?.slice() ?? [];
+        state.history = [
+          ...state.history,
+          ...(action.payload?.data?.history?.slice() ?? []),
+        ];
         state.state = { ...(action.payload?.data?.state ?? {}) };
         state.activeToolCall = undefined;
         state.isProcessing = false;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -2,9 +2,9 @@ import { type PayloadAction, createSlice } from "@reduxjs/toolkit";
 
 import { logout } from "metabase/auth/actions";
 import { uuid } from "metabase/lib/uuid";
-import type { MetabotChatContext } from "metabase-types/api";
+import type { MetabotHistory, MetabotStateContext } from "metabase-types/api";
 
-import { sendMessageRequest } from "./actions";
+import { sendAgentRequest, sendStreamedAgentRequest } from "./actions";
 
 export type MetabotAgentChatMessage =
   | { actor: "agent"; message: string; type: "reply" }
@@ -17,29 +17,40 @@ export type MetabotChatMessage =
   | MetabotUserChatMessage;
 
 export interface MetabotState {
+  useStreaming: boolean;
   isProcessing: boolean;
-  lastSentContext: MetabotChatContext | undefined;
   conversationId: string | undefined;
   messages: MetabotChatMessage[];
   visible: boolean;
+  history: MetabotHistory;
   state: any;
+  activeToolCall: { id: string; name: string } | undefined;
 }
 
 export const metabotInitialState: MetabotState = {
+  useStreaming: false,
   isProcessing: false,
-  lastSentContext: undefined,
   conversationId: undefined,
   messages: [],
   visible: false,
+  history: [],
   state: {},
+  activeToolCall: undefined,
 };
 
 export const metabot = createSlice({
   name: "metabase-enterprise/metabot",
   initialState: metabotInitialState,
   reducers: {
+    toggleStreaming: (state) => {
+      state.useStreaming = !state.useStreaming;
+    },
     addUserMessage: (state, action: PayloadAction<string>) => {
       state.messages.push({ actor: "user", message: action.payload });
+
+      if (state.useStreaming) {
+        state.history.push({ role: "user", content: action.payload });
+      }
     },
     addAgentMessage: (
       state,
@@ -51,8 +62,26 @@ export const metabot = createSlice({
         type: action.payload.type,
       });
     },
-    clearMessages: (state) => {
+    setStateContext: (state, action: PayloadAction<MetabotStateContext>) => {
+      state.state = action.payload;
+    },
+    toolCallStart: (
+      state,
+      action: PayloadAction<{ toolCallId: string; toolName: string }>,
+    ) => {
+      const { toolCallId, toolName } = action.payload;
+      state.activeToolCall = { id: toolCallId, name: toolName };
+    },
+    toolCallEnd: (state) => {
+      state.activeToolCall = undefined;
+    },
+    resetConversation: (state) => {
       state.messages = [];
+      state.history = [];
+      state.state = {};
+      state.isProcessing = false;
+      state.activeToolCall = undefined;
+      state.conversationId = uuid();
     },
     resetConversationId: (state) => {
       state.conversationId = uuid();
@@ -66,10 +95,33 @@ export const metabot = createSlice({
   },
   extraReducers: (builder) => {
     builder
-      .addCase(sendMessageRequest.pending, (state, action) => {
-        state.lastSentContext = action.meta.arg.context;
+      .addCase(logout.pending, () => metabotInitialState)
+      // streamed response handlers
+      .addCase(sendStreamedAgentRequest.pending, (state) => {
+        state.isProcessing = true;
       })
-      .addCase(logout.pending, () => metabotInitialState);
+      .addCase(sendStreamedAgentRequest.fulfilled, (state, action) => {
+        state.history = action.payload?.data?.history?.slice() ?? [];
+        state.state = { ...(action.payload?.data?.state ?? {}) };
+        state.activeToolCall = undefined;
+        state.isProcessing = false;
+      })
+      .addCase(sendStreamedAgentRequest.rejected, (state) => {
+        state.activeToolCall = undefined;
+        state.isProcessing = false;
+      })
+      // non-streamed response handlers
+      .addCase(sendAgentRequest.pending, (state) => {
+        state.isProcessing = true;
+      })
+      .addCase(sendAgentRequest.fulfilled, (state, action) => {
+        state.history = action.payload?.data?.history?.slice() ?? [];
+        state.state = { ...(action.payload?.data?.state ?? {}) };
+        state.isProcessing = false;
+      })
+      .addCase(sendAgentRequest.rejected, (state) => {
+        state.isProcessing = false;
+      });
   },
 });
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -83,7 +83,7 @@ export const getMetabotId = createSelector(getIsEmbedding, (isEmbedding) =>
   isEmbedding ? FIXED_METABOT_IDS.EMBEDDED : FIXED_METABOT_IDS.DEFAULT,
 );
 
-export const getAgentRequestMeta = createSelector(
+export const getAgentRequestMetadata = createSelector(
   getHistory,
   getMetabotState,
   (history, state) => ({

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -2,7 +2,6 @@ import { createSelector } from "@reduxjs/toolkit";
 import _ from "underscore";
 
 import { getIsEmbedding } from "metabase/selectors/embed";
-import { METABOT_TAG, metabotApi } from "metabase-enterprise/api";
 
 import {
   FIXED_METABOT_IDS,
@@ -13,6 +12,11 @@ import type { MetabotStoreState } from "./types";
 
 export const getMetabot = (state: MetabotStoreState) =>
   state.plugins.metabotPlugin;
+
+export const getUseStreaming = createSelector(
+  getMetabot,
+  (metabot) => metabot.useStreaming,
+);
 
 export const getMetabotVisible = createSelector(
   getMetabot,
@@ -40,14 +44,19 @@ export const getLastAgentMessagesByType = createSelector(
   },
 );
 
+export const getActiveToolCall = createSelector(
+  getMetabot,
+  (metabot) => metabot.activeToolCall,
+);
+
 export const getIsProcessing = createSelector(
   getMetabot,
   (metabot) => metabot.isProcessing,
 );
 
-export const getLastSentContext = createSelector(
+export const getHistory = createSelector(
   getMetabot,
-  (metabot) => metabot.lastSentContext,
+  (metabot) => metabot.history,
 );
 
 export const getMetabotConversationId = createSelector(
@@ -74,21 +83,11 @@ export const getMetabotId = createSelector(getIsEmbedding, (isEmbedding) =>
   isEmbedding ? FIXED_METABOT_IDS.EMBEDDED : FIXED_METABOT_IDS.DEFAULT,
 );
 
-export const getPrevAgentResponse = metabotApi.endpoints.metabotAgent.select({
-  requestId: undefined,
-  fixedCacheKey: METABOT_TAG,
-});
-
-/**
- * Used to access values like history + state from the previous request
- * which are meant to be repeated back on future requests
- */
-export const getPrevAgentRequestMeta = createSelector(
-  getPrevAgentResponse,
-  (res) => {
-    return {
-      state: res.data?.state ?? {},
-      history: res.data?.history ?? [],
-    };
-  },
+export const getAgentRequestMeta = createSelector(
+  getHistory,
+  getMetabotState,
+  (history, state) => ({
+    state,
+    history,
+  }),
 );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.unit.spec.ts
@@ -13,12 +13,14 @@ describe("metabot selectors", () => {
       // NOTE: importing default initial state from ./reducer
       // breaks the tests for some reason
       const metabotPlugin: MetabotState = {
+        useStreaming: false,
         isProcessing: false,
-        lastSentContext: undefined,
         messages,
         state: {},
+        history: [],
         visible: true,
         conversationId: uuid(),
+        activeToolCall: undefined,
       };
 
       return createMockState({ plugins: { metabotPlugin } } as any);

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -51,7 +51,9 @@ export type MetabotHistoryEntry =
   | MetabotHistoryToolEntry
   | MetabotHistoryMessageEntry;
 
-export type MetabotHistory = any;
+export type MetabotHistory = any[];
+
+export type MetabotStateContext = Record<string, any>;
 
 export type MetabotMessageReaction = {
   type: "metabot.reaction/message";
@@ -134,9 +136,10 @@ export type MetabotEntityInfo =
 export type MetabotAgentRequest = {
   message: string;
   context: MetabotChatContext;
-  history: MetabotHistory[];
+  history: MetabotHistory;
+  state: MetabotStateContext;
   conversation_id: string; // uuid
-  state: any;
+  metabot_id?: string;
 };
 
 export type MetabotAgentResponse = {
@@ -184,36 +187,7 @@ export type DeleteSuggestedMetabotPromptRequest = {
   prompt_id: SuggestedMetabotPrompt["id"];
 };
 
-/* Metabot v3 - Type Guards */
-
-export const isMetabotMessageReaction = (
-  reaction: MetabotReaction,
-): reaction is MetabotMessageReaction => {
-  return reaction.type === "metabot.reaction/message";
-};
-
-export const isMetabotToolMessage = (
-  message: MetabotHistoryEntry,
-): message is MetabotHistoryToolEntry => {
-  return (
-    message.role === "assistant" && message.assistant_response_type === "tools"
-  );
-};
-
-export const isMetabotHistoryMessage = (
-  message: MetabotHistoryEntry,
-): message is MetabotHistoryMessageEntry => {
-  return (
-    message.role === "assistant" &&
-    message.assistant_response_type === "message"
-  );
-};
-
-export const isMetabotMessage = (
-  message: MetabotHistoryEntry,
-): message is MetabotHistoryMessageEntry => {
-  return message.role === "assistant";
-};
+/* Metabot v3 - Entity Types */
 
 export type MetabotId = number;
 export type MetabotName = string;

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 import { Crypto, CryptoKey } from "@peculiar/webcrypto";
 import { TextDecoder, TextEncoder } from "util";
+import { ReadableStream } from "web-streams-polyfill";
 import "cross-fetch/polyfill";
 import "raf/polyfill";
 import "jest-localstorage-mock";

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -47,6 +47,9 @@ globalThis.CryptoKey = CryptoKey;
 global.TextEncoder = JSDOMTextEncoder;
 global.TextDecoder = TextDecoder;
 
+// replace node's ReadableStream what one that matches what is in the browser
+global.ReadableStream = ReadableStream;
+
 // https://github.com/jsdom/jsdom/issues/3002
 Range.prototype.getBoundingClientRect = () => ({
   bottom: 0,

--- a/package.json
+++ b/package.json
@@ -344,6 +344,7 @@
     "typedoc-plugin-merge-modules": "^7.0.0",
     "typedoc-plugin-redirect": "^1.2.0",
     "typescript-plugin-css-modules": "^5.1.0",
+    "web-streams-polyfill": "^4.1.0",
     "webpack": "5.94.0",
     "webpack-bundle-analyzer": "^4.10.1",
     "webpack-cli": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21388,6 +21388,11 @@ web-namespaces@^2.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
+web-streams-polyfill@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.1.0.tgz#3ba095d0eb3ef6377cd126e8354b2cdba286e0d3"
+  integrity sha512-A7Jxrg7+eV+eZR/CIdESDnRGFb6/bcKukGvJBB5snI6cw3is1c2qamkYstC1bY1p08TyMRlN9eTMkxmnKJBPBw==
+
 webcrypto-core@^1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.8.1.tgz#09d5bd8a9c48e9fbcaf412e06b1ff1a57514ce86"


### PR DESCRIPTION
Part of [BOT-115](https://linear.app/metabase/issue/BOT-115/frontend-ai-sdk-streaming-implementation)

### Description

This PR adds streaming support to the frontend of metabot. Currently it has to be enabled by double-clicking the icon next to the prompt input like so:
https://github.com/user-attachments/assets/30fd40fd-18fa-4bde-a840-3d97eed93698
You conversation state will be cleared and once metabot is yellow streaming support is on.


### How to verify

There's no specific script to encourage folks to go down, but here's a broad few ideas to explore in making sure it's working:
- conversation state + history builds up over time like you'd expect
- normal chat conversation behave how they did before
- you're able to see metabot's in progress work
- failed requests work like you'd expect

### Demo

https://www.loom.com/share/b837bd234bae432a9d4b0cd99d00cfe6?sid=a02edad6-ac40-41fa-8a96-9293058b47f2

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
