### PR TITLE
Init question action ids properly

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -1157,6 +1157,24 @@
                                               (assoc-in [:params :cc] "optional")))
                                      (select-keys [:status :body])))))))))))))))))
 
+(deftest unified-execute-unsaved-action-id
+  (let [url "action/v2/execute"
+        req #(-> (mt/user-http-request-full-response
+                  (:user % :crowberto) :post url
+                  (merge {:scope {:unknown :legacy-action} :input {}} %))
+                 (dissoc :headers))]
+    (mt/with-premium-features #{:table-data-editing}
+      (data-editing.tu/with-data-editing-enabled! true
+        (mt/with-actions-enabled
+          (mt/with-non-admin-groups-no-root-collection-perms
+            (testing "Cannot execute a temporary action id"
+              (is (=? {:status 400
+                       :body   {:message "Cannot execute an unsaved action given only its temporary id"}}
+                      (req {:action_id (str (random-uuid))
+                            :scope     {:table-id (mt/id :venues)}
+                            :input     {:id 1}
+                            :params    {:status "approved"}}))))))))))
+
 (deftest list-and-add-to-dashcard-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}


### PR DESCRIPTION
1. Init actions for dashcard questions the same way we do it for dashcard editables.
2. Improve the error message when called with a temporary id.