### PR TITLE
Initialize actions directly within questions too

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -879,7 +879,8 @@
            metabase.queries.init
            metabase.queries.models.query ; TODO FIXME
            metabase.queries.schema}      ; TODO FIXME
-   :uses #{analytics
+   :uses #{actions
+           analytics
            analyze
            api
            app-db

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -55,6 +55,7 @@
  [metabase.actions.models
   enabled-table-actions
   dashcard->action
+  save-grid-action
   select-action
   select-actions
   table-primitive-action

--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -4,7 +4,6 @@
    [clojure.core.cache :as cache]
    [clojure.core.memoize :as memoize]
    [clojure.set :as set]
-   [clojure.string :as str]
    [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.actions.core :as actions]

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1045,7 +1045,11 @@
                                                 (cond-> (nil? type)
                                                   (assoc :type :question))
                                                 maybe-normalize-query
-                                                (ensure-clause-idents ::before-insert))
+                                                (ensure-clause-idents ::before-insert)
+                                                (u/update-in-if-exists
+                                                 [:visualization_settings :table.enabled_actions]
+                                                 (let [save-grid-action @(requiring-resolve 'metabase.actions.core/save-grid-action)]
+                                                   (partial map (partial save-grid-action "card" (:id input-card-data))))))
          {:keys [metadata metadata-future]} (card.metadata/maybe-async-result-metadata
                                              {:query     (:dataset_query card-data)
                                               :metadata  result_metadata

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5345,28 +5345,6 @@
                 (:param_fields (mt/with-test-user :crowberto
                                  (#'api.dashboard/get-dashboard (:id dashboard))))))))))
 
-(deftest create-or-fix-action-id-test
-  (let [f       #'api.dashboard/create-or-fix-action-id
-        unsaved {:id -1}
-        saved   {:id 1337}]
-    (mt/with-dynamic-fn-redefs [u/generate-nano-id (fn [] "rAnDoM")]
-      (testing "leaves valid ids alone"
-        (is (= "dashcard:7331:unique"
-               (f saved "dashcard:7331:unique"))))
-      (testing "replaces temporary FE ids"
-        (is (= "dashcard:1337:rAnDoM"
-               (f saved (str (random-uuid))))))
-      (testing "creates useful and unique ids"
-        (is (= "dashcard:1337:rAnDoM"
-               (f saved nil))))
-      (testing "does its best without a parent"
-        (is (= "dashcard:unknown:rAnDoM"
-               (f unsaved nil)
-               (f nil nil))))
-      (testing "accepts its new parent"
-        (is (= "dashcard:1337:SAVE_ME"
-               (f saved "dashcard:unknown:SAVE_ME")))))))
-
 (deftest post-update-test
   (mt/with-temp [:model/Collection    {collection-id-1 :id} {}
                  :model/Collection    {collection-id-2 :id} {}

--- a/test/metabase/queries/api/card_test.clj
+++ b/test/metabase/queries/api/card_test.clj
@@ -919,6 +919,24 @@
                 (is (=? {:id pos-int?}
                         (mt/user-http-request :crowberto :post 200 "card" card)))))))))))
 
+(deftest save-row-action
+  (testing "POST /api/card"
+    (testing "Should be able to save a card with a row action"
+      (mt/with-model-cleanup [:model/Card]
+        (testing "without result metadata"
+          (let [temp-id (str (random-uuid))]
+            (is (=? {:id pos-int?
+                     :visualization_settings {:table.enabled_actions
+                                              [{:id         (str "card:unknown:" temp-id),
+                                                :action-id  1
+                                                :actionType "data-grid/row-action"
+                                                :enabled    true}]}}
+                    (mt/user-http-request :crowberto :post 200 "card"
+                                          (merge (mt/with-temp-defaults :model/Card)
+                                                 {:dataset_query          (mt/mbql-query venues {:filter [:= $id 0]})
+                                                  :visualization_settings {:table.enabled_actions
+                                                                           [{:id temp-id, :action-id 1}]}}))))))))))
+
 (deftest save-card-with-empty-result-metadata-test
   (testing "we should be able to save a Card if the `result_metadata` is *empty* (but not nil) (#9286)"
     (mt/with-model-cleanup [:model/Card]


### PR DESCRIPTION
We can save actions directly in questions as well.

Not sure if we're going to keep this behavior, but this hooks things up so we at least save them correctly.