### PR TITLE
Closes VIZ-1115 - Clean up x-rays sidebar visual bug

### DIFF
--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
@@ -124,11 +124,11 @@ const AutomaticDashboardAppInner = () => {
           <div className={CS.wrapper}>
             <div className={cx(CS.pl1, { [CS.pr1]: !hasSidebar })}>
               <FixedWidthContainer
-                data-testid="fixed-width-dashboard-header"
                 isFixedWidth={dashboard?.width === "fixed" && !hasSidebar}
               >
                 <div className={cx(CS.flex, CS.alignCenter, CS.py2)}>
                   <FixedWidthContainer
+                    data-testid="fixed-width-dashboard-header"
                     className={cx(CS.flex, CS.alignCenter)}
                     isFixedWidth={dashboard?.width === "fixed"}
                   >

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
@@ -122,53 +122,48 @@ const AutomaticDashboardAppInner = () => {
           data-testid="automatic-dashboard-header"
         >
           <div className={CS.wrapper}>
-            <FixedWidthContainer
-              data-testid="fixed-width-dashboard-header"
-              isFixedWidth={dashboard?.width === "fixed" && !hasSidebar}
-            >
-              <div
-                className={cx(
-                  CS.flex,
-                  CS.alignCenter,
-                  CS.py2,
-                  hasSidebar && CS.pl1,
-                )}
+            <div className={cx(CS.pl1, { [CS.pr1]: !hasSidebar })}>
+              <FixedWidthContainer
+                data-testid="fixed-width-dashboard-header"
+                isFixedWidth={dashboard?.width === "fixed" && !hasSidebar}
               >
-                <FixedWidthContainer
-                  className={cx(CS.flex, CS.alignCenter)}
-                  isFixedWidth={dashboard?.width === "fixed"}
-                >
-                  <XrayIcon />
-                  <div>
-                    <h2 className={cx(CS.textWrap, CS.mr2)}>
-                      {dashboard && <TransientTitle dashboard={dashboard} />}
-                    </h2>
+                <div className={cx(CS.flex, CS.alignCenter, CS.py2)}>
+                  <FixedWidthContainer
+                    className={cx(CS.flex, CS.alignCenter)}
+                    isFixedWidth={dashboard?.width === "fixed"}
+                  >
+                    <XrayIcon />
+                    <div>
+                      <h2 className={cx(CS.textWrap, CS.mr2)}>
+                        {dashboard && <TransientTitle dashboard={dashboard} />}
+                      </h2>
+                    </div>
+                  </FixedWidthContainer>
+                  <div
+                    className={cx(CS.flex, CS.flexGrow1)}
+                    style={{ maxWidth: SIDEBAR_W }}
+                  >
+                    {savedDashboardId != null ? (
+                      <Button className={CS.mlAuto} disabled>{t`Saved`}</Button>
+                    ) : (
+                      <ActionButton
+                        className={cx(CS.mlAuto, CS.textNoWrap)}
+                        success
+                        borderless
+                        actionFn={save}
+                      >
+                        {t`Save this`}
+                      </ActionButton>
+                    )}
                   </div>
-                </FixedWidthContainer>
-                <div
-                  className={cx(CS.flex, CS.flexGrow1)}
-                  style={{ maxWidth: SIDEBAR_W }}
-                >
-                  {savedDashboardId != null ? (
-                    <Button className={CS.mlAuto} disabled>{t`Saved`}</Button>
-                  ) : (
-                    <ActionButton
-                      className={cx(CS.mlAuto, CS.textNoWrap)}
-                      success
-                      borderless
-                      actionFn={save}
-                    >
-                      {t`Save this`}
-                    </ActionButton>
-                  )}
                 </div>
-              </div>
-              {dashboard && tabs.length > 1 && (
-                <div className={cx(CS.wrapper, CS.flex, CS.alignCenter)}>
-                  <DashboardTabs dashboardId={dashboard.id} />
-                </div>
-              )}
-            </FixedWidthContainer>
+                {dashboard && tabs.length > 1 && (
+                  <div className={cx(CS.wrapper, CS.flex, CS.alignCenter)}>
+                    <DashboardTabs dashboardId={dashboard.id} />
+                  </div>
+                )}
+              </FixedWidthContainer>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
@@ -113,47 +113,51 @@ const AutomaticDashboardAppInner = () => {
       })}
     >
       {dashboard && <SetTitle title={dashboard.name} />}
-      <div style={{ marginRight: hasSidebar ? 346 : undefined }}>
-        {isHeaderVisible && (
-          <div
-            className={cx(CS.bgWhite, CS.borderBottom)}
-            data-testid="automatic-dashboard-header"
-          >
-            <div className={CS.wrapper}>
-              <FixedWidthContainer
-                data-testid="fixed-width-dashboard-header"
-                isFixedWidth={dashboard?.width === "fixed"}
-              >
-                <div className={cx(CS.flex, CS.alignCenter, CS.py2)}>
-                  <XrayIcon />
-                  <div>
-                    <h2 className={cx(CS.textWrap, CS.mr2)}>
-                      {dashboard && <TransientTitle dashboard={dashboard} />}
-                    </h2>
-                  </div>
-                  {savedDashboardId != null ? (
-                    <Button className={CS.mlAuto} disabled>{t`Saved`}</Button>
-                  ) : (
-                    <ActionButton
-                      className={cx(CS.mlAuto, CS.textNoWrap)}
-                      success
-                      borderless
-                      actionFn={save}
-                    >
-                      {t`Save this`}
-                    </ActionButton>
-                  )}
-                </div>
-                {dashboard && tabs.length > 1 && (
-                  <div className={cx(CS.wrapper, CS.flex, CS.alignCenter)}>
-                    <DashboardTabs dashboardId={dashboard.id} />
-                  </div>
-                )}
-              </FixedWidthContainer>
-            </div>
-          </div>
-        )}
 
+      {isHeaderVisible && (
+        <div
+          className={cx(CS.bgWhite, CS.borderBottom)}
+          data-testid="automatic-dashboard-header"
+        >
+          <div className={CS.wrapper}>
+            <FixedWidthContainer
+              data-testid="fixed-width-dashboard-header"
+              isFixedWidth={dashboard?.width === "fixed"}
+            >
+              <div className={cx(CS.flex, CS.alignCenter, CS.py2)}>
+                <XrayIcon />
+                <div>
+                  <h2 className={cx(CS.textWrap, CS.mr2)}>
+                    {dashboard && <TransientTitle dashboard={dashboard} />}
+                  </h2>
+                </div>
+                {savedDashboardId != null ? (
+                  <Button className={CS.mlAuto} disabled>{t`Saved`}</Button>
+                ) : (
+                  <ActionButton
+                    className={cx(CS.mlAuto, CS.textNoWrap)}
+                    success
+                    borderless
+                    actionFn={save}
+                  >
+                    {t`Save this`}
+                  </ActionButton>
+                )}
+              </div>
+              {dashboard && tabs.length > 1 && (
+                <div className={cx(CS.wrapper, CS.flex, CS.alignCenter)}>
+                  <DashboardTabs dashboardId={dashboard.id} />
+                </div>
+              )}
+            </FixedWidthContainer>
+          </div>
+        </div>
+      )}
+
+      <div
+        className={CS.relative}
+        style={{ paddingRight: hasSidebar ? 346 : undefined }}
+      >
         <div className={cx(CS.wrapper, CS.pb4)}>
           {parameters && parameters.length > 0 && (
             <div className={cx(CS.px1, CS.pt1)}>
@@ -204,21 +208,21 @@ const AutomaticDashboardAppInner = () => {
             </Link>
           </div>
         )}
-      </div>
 
-      {hasSidebar && (
-        <Box
-          className={cx(
-            CS.absolute,
-            CS.top,
-            CS.right,
-            CS.bottom,
-            S.SuggestionsSidebarWrapper,
-          )}
-        >
-          <SuggestionsSidebar related={related} />
-        </Box>
-      )}
+        {hasSidebar && (
+          <Box
+            className={cx(
+              CS.absolute,
+              CS.top,
+              CS.right,
+              CS.bottom,
+              S.SuggestionsSidebarWrapper,
+            )}
+          >
+            <SuggestionsSidebar related={related} />
+          </Box>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
@@ -37,6 +37,8 @@ import { XrayIcon } from "../XrayIcon";
 import S from "./AutomaticDashboardApp.module.css";
 import { SuggestionsSidebar } from "./SuggestionsSidebar";
 
+const SIDEBAR_W = 346;
+
 type AutomaticDashboardAppRouterProps = WithRouterProps<{ splat: string }>;
 
 const AutomaticDashboardAppInner = () => {
@@ -122,27 +124,44 @@ const AutomaticDashboardAppInner = () => {
           <div className={CS.wrapper}>
             <FixedWidthContainer
               data-testid="fixed-width-dashboard-header"
-              isFixedWidth={dashboard?.width === "fixed"}
+              isFixedWidth={dashboard?.width === "fixed" && !hasSidebar}
             >
-              <div className={cx(CS.flex, CS.alignCenter, CS.py2)}>
-                <XrayIcon />
-                <div>
-                  <h2 className={cx(CS.textWrap, CS.mr2)}>
-                    {dashboard && <TransientTitle dashboard={dashboard} />}
-                  </h2>
-                </div>
-                {savedDashboardId != null ? (
-                  <Button className={CS.mlAuto} disabled>{t`Saved`}</Button>
-                ) : (
-                  <ActionButton
-                    className={cx(CS.mlAuto, CS.textNoWrap)}
-                    success
-                    borderless
-                    actionFn={save}
-                  >
-                    {t`Save this`}
-                  </ActionButton>
+              <div
+                className={cx(
+                  CS.flex,
+                  CS.alignCenter,
+                  CS.py2,
+                  hasSidebar && CS.pl1,
                 )}
+              >
+                <FixedWidthContainer
+                  className={cx(CS.flex, CS.alignCenter)}
+                  isFixedWidth={dashboard?.width === "fixed"}
+                >
+                  <XrayIcon />
+                  <div>
+                    <h2 className={cx(CS.textWrap, CS.mr2)}>
+                      {dashboard && <TransientTitle dashboard={dashboard} />}
+                    </h2>
+                  </div>
+                </FixedWidthContainer>
+                <div
+                  className={cx(CS.flex, CS.flexGrow1)}
+                  style={{ maxWidth: SIDEBAR_W }}
+                >
+                  {savedDashboardId != null ? (
+                    <Button className={CS.mlAuto} disabled>{t`Saved`}</Button>
+                  ) : (
+                    <ActionButton
+                      className={cx(CS.mlAuto, CS.textNoWrap)}
+                      success
+                      borderless
+                      actionFn={save}
+                    >
+                      {t`Save this`}
+                    </ActionButton>
+                  )}
+                </div>
               </div>
               {dashboard && tabs.length > 1 && (
                 <div className={cx(CS.wrapper, CS.flex, CS.alignCenter)}>
@@ -156,7 +175,7 @@ const AutomaticDashboardAppInner = () => {
 
       <div
         className={CS.relative}
-        style={{ paddingRight: hasSidebar ? 346 : undefined }}
+        style={{ paddingRight: hasSidebar ? SIDEBAR_W : undefined }}
       >
         <div className={cx(CS.wrapper, CS.pb4)}>
           {parameters && parameters.length > 0 && (


### PR DESCRIPTION
Closes VIZ-1115

### Description

Updates `hasSidebar` version of automatic dashboard so the right sidebar doesn't look obviously broken. See [Slack thread](https://metaboat.slack.com/archives/C064QMXEV9N/p1747184202713489) for details.

### How to verify

1. Navigate to a page with an automatic dashboard, e.g. Sample Database -> Hover Orders ⚡-> X-ray this table
2. Verify the right sidebar shows up _under_ the header rather than next to it.

**A few variations to check:**
* w/ and w/o right sidebar
* fixed-width vs full-width dashboard
* w/ and w/o "more" link
* Wide and narrow screens (mobile not supported before or after this PR)

### Demo

| Width | Sidebar | No sidebar
| --- | --- | --- |
| Fixed | ![fixed-sb](https://github.com/user-attachments/assets/aa0446bb-f6a5-419a-b8be-1c6969f2fa1b) | ![fixed-no-sb](https://github.com/user-attachments/assets/ca68f112-0d9d-47f7-ab5c-70626737ee6e) |
| Full | ![full-sb](https://github.com/user-attachments/assets/16309689-d61a-4b1c-bf9e-860a3c0fb149) | ![full-no-sb](https://github.com/user-attachments/assets/357858a1-b724-4c59-83b1-7d1f444b4d44) |