### PR TITLE
fix chart crash when dimension aggregation is removed

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -80,9 +80,11 @@ export function useModelsAndOption(
       showWarning,
     );
 
-    model.dimensionModel.column.display_name = tc(
-      model.dimensionModel.column.display_name,
-    );
+    if (model.dimensionModel.column) {
+      model.dimensionModel.column.display_name = tc(
+        model.dimensionModel.column.display_name,
+      );
+    }
     return model;
   }, [
     card.display,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/59671

### Description

When removing an aggregation dimension on a saved MBQL cartesian chart and trying to visualize it the chart crashes. 

### How to verify

- Create and save a line chart Orders: Count by Created At [Month]
- Open the notebook editor
- Remove the Created At aggregation
- Click visualize -> ensure it does not crash

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
