### PR TITLE
disable inline filters sorting

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -833,6 +833,10 @@ describe("scenarios > dashboard > parameters", () => {
       H.addHeadingWhileEditing("Heading");
       H.setDashCardFilter(1, "Text or Category", null, "Category");
       H.selectDashboardFilter(H.getDashboardCard(0), "Category");
+      H.getDashboardCard(0).within(() => {
+        // Ensure filters are not draggable
+        cy.icon("grabber").should("not.exist");
+      });
       H.saveDashboard();
 
       // Verify the filter doesn't appear in the dashboard header

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -234,6 +234,12 @@ function ParametersList(props: ParametersListProps) {
     [rest.parameters],
   );
 
+  const parametersListCommonProps = {
+    ...rest,
+    widgetsVariant: "subtle" as const,
+    isSortable: false,
+  };
+
   if (isNarrow) {
     if (editingParameter) {
       const parameters = rest.parameters.filter(
@@ -242,9 +248,8 @@ function ParametersList(props: ParametersListProps) {
       // If a parameter is being edited, we don't show the dropdown
       return (
         <DashboardParameterList
-          {...rest}
+          {...parametersListCommonProps}
           parameters={parameters}
-          widgetsVariant="subtle"
         />
       );
     }
@@ -273,8 +278,7 @@ function ParametersList(props: ParametersListProps) {
           style={{ overflow: "visible" }}
         >
           <DashboardParameterList
-            {...rest}
-            widgetsVariant="subtle"
+            {...parametersListCommonProps}
             widgetsWithinPortal={false}
             vertical
           />
@@ -283,5 +287,5 @@ function ParametersList(props: ParametersListProps) {
     );
   }
 
-  return <DashboardParameterList {...rest} widgetsVariant="subtle" />;
+  return <DashboardParameterList {...parametersListCommonProps} />;
 }


### PR DESCRIPTION
Closes [VIZ-1179](https://linear.app/metabase/issue/VIZ-1179/filters-shouldnt-have-drag-handles-and-be-able-to-be-dragged)

### Description

Disables inline filters sorting in header dashboard cards.

### Demo

<img width="1124" alt="Screenshot 2025-06-18 at 4 57 13 PM" src="https://github.com/user-attachments/assets/2839186f-3611-4fae-a97c-d6235021321c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
