### PR TITLE
update inline filters ui

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -20,7 +20,14 @@ import { isJWT } from "metabase/lib/utils";
 import { isUuid } from "metabase/lib/uuid";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import type { EmbedResourceDownloadOptions } from "metabase/public/lib/types";
-import { Flex, type IconName, type IconProps, Menu, Title } from "metabase/ui";
+import {
+  Box,
+  Flex,
+  type IconName,
+  type IconProps,
+  Menu,
+  Title,
+} from "metabase/ui";
 import { getVisualizationRaw, isCartesianChart } from "metabase/visualizations";
 import Visualization from "metabase/visualizations/components/Visualization";
 import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
@@ -400,6 +407,7 @@ export function DashCardVisualization({
         <Flex align="center" justify="flex-end">
           {inlineParameters.length > 0 && (
             <DashboardParameterList
+              widgetsVariant="subtle"
               parameters={inlineParameters}
               isSortable={false}
               isFullscreen={isFullscreen}
@@ -425,13 +433,16 @@ export function DashCardVisualization({
 
     return (
       <Flex align="center" justify="flex-end">
-        {inlineParameters.length > 0 && (
-          <DashboardParameterList
-            parameters={inlineParameters}
-            isSortable={false}
-            isFullscreen={isFullscreen}
-          />
-        )}
+        <Box mr="sm">
+          {inlineParameters.length > 0 && (
+            <DashboardParameterList
+              widgetsVariant="subtle"
+              parameters={inlineParameters}
+              isSortable={false}
+              isFullscreen={isFullscreen}
+            />
+          )}
+        </Box>
         {!isEditing && (
           <DashCardMenu
             downloadsEnabled={downloadsEnabled}


### PR DESCRIPTION
Closes [VIZ-1168](https://linear.app/metabase/issue/VIZ-1168/add-dark-mode-support-for-inline-question-filters)

### Description

Uses `subtle` parameters widgets variant.

### Demo

<img width="798" alt="Screenshot 2025-06-18 at 7 21 02 PM" src="https://github.com/user-attachments/assets/6b32f037-0a33-4d18-80db-590633aec24c" />

<img width="797" alt="Screenshot 2025-06-18 at 8 18 26 PM" src="https://github.com/user-attachments/assets/bb8d0390-6a9f-46c5-9847-fdb057d075c2" />

