### PR TITLE
Add regression test for #40676

### DIFF
--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -1703,6 +1703,34 @@
           (is (= ["Products" "Products_II"]
                  (map :alias (lib/joins new-query)))))))))
 
+(deftest ^:parallel replaced-join-gets-updated-alias-even-with-fks-to-same-field-test
+  (testing "replaced join gets replaced alias even if the replaced fk points to the same field (#40676)"
+    (let [orig-query (-> (lib/query meta/metadata-provider (meta/table-metadata :ic/reports))
+                         (lib/join (lib/join-clause (meta/table-metadata :ic/accounts)
+                                                    [(lib/= (meta/field-metadata :ic/reports :created-by)
+                                                            (meta/field-metadata :ic/accounts :id))])))
+          [orig-join] (lib/joins orig-query)
+          ;; This simulates how the FE updates the join via lib/with-join-conditions and lib/replace-clause.
+          new-query  (lib/replace-clause orig-query orig-join (lib/with-join-conditions
+                                                               orig-join
+                                                               [(lib/= (meta/field-metadata :ic/reports :updated-by)
+                                                                       (meta/field-metadata :ic/accounts :id))]))
+          [new-join] (lib/joins new-query)
+          id->breakout-name (fn [query id]
+                              (->> query
+                                   lib/breakoutable-columns
+                                   (m/find-first #(= id (:id %)))
+                                   (lib/display-info query)
+                                   :long-display-name))
+          orig-name  (id->breakout-name orig-query (meta/id :ic/accounts :name))
+          new-name   (id->breakout-name new-query (meta/id :ic/accounts :name))]
+      (testing "join gets correct join alias"
+        (is (= "IC Accounts - Created By" (:alias orig-join)))
+        (is (= "IC Accounts - Updated By" (:alias new-join))))
+      (testing "breakoutable columns have correct long display name"
+        (is (= "IC Accounts - Created By → Name" orig-name))
+        (is (= "IC Accounts - Updated By → Name" new-name))))))
+
 (deftest ^:parallel stale-clauses-test-unrelated-refs-are-stable
   (testing "deleting eg. an aggregation should not break a downstream ref to a breakout (#59441)"
     (let [base1  (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
@@ -1711,8 +1739,8 @@
                      (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal))))
           cols   (m/index-by :lib/desired-column-alias (lib/breakoutable-columns base1))
           base2  (-> base1
-                     (lib/breakout (get cols "Products__CATEGORY"))             ; Explicitly joined
-                     (lib/breakout (get cols "PEOPLE__via__USER_ID__SOURCE"))   ; Implicitly joined
+                     (lib/breakout (get cols "Products__CATEGORY"))           ; Explicitly joined
+                     (lib/breakout (get cols "PEOPLE__via__USER_ID__SOURCE")) ; Implicitly joined
                      lib/append-stage)
           [category] (lib/visible-columns base2)
           ;; Adding an expression based on one of the breakouts.

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -2403,7 +2403,7 @@
    :position                   2
    :visibility-type            :normal
    :preview-display            true
-   :display-name               "Created By"
+   :display-name               "Updated By"
    :database-position          2
    :database-required          false
    :fingerprint                {:global {:distinct-count 2, :nil% 0.0}}


### PR DESCRIPTION
Closes #40676
Closes QUE-327

### Description

Add a regression test for #40676. I backported this test to the release-x.49.x branch and verified it fails there.

Also: fix a copy/paste error in the `:display-name` for the `field-metadata-method [:ic/reports :updated-by]`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
