### PR TITLE
allow connecting inline filters to other cards on the same tab

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1766,7 +1766,7 @@ describe("scenarios > dashboard > parameters", () => {
       H.undoToast().should("not.exist");
     });
 
-    it("should allow connecting inline parameters only to their own card", () => {
+    it("should allow connecting inline parameters only to cards on the same tab", () => {
       H.createQuestionAndDashboard({
         questionDetails: ordersCountByCategory,
       }).then(({ body: dashcard }) => {
@@ -1776,23 +1776,28 @@ describe("scenarios > dashboard > parameters", () => {
         // Add a second card
         H.openQuestionsSidebar();
         H.sidebar().findByText("Orders, Count").click();
-        H.getDashboardCard(1).findByText("Count").should("exist");
+
+        // Add a second tab
+        H.createNewTab();
+        H.goToTab("Tab 2");
+
+        // Add a question to the second tab
+        H.sidebar().findByText("Orders, Count").click();
+
+        H.goToTab("Tab 1");
 
         // Add a filter to the first card
         H.setDashCardFilter(0, "Text or Category", null, "Category");
         H.selectDashboardFilter(H.getDashboardCard(0), "Category");
 
+        // Connect it to the second card
+        H.selectDashboardFilter(H.getDashboardCard(1), "Category");
+
+        H.goToTab("Tab 2");
+
         // Ensure the filter can't be connected to the second card
-        H.getDashboardCard(1)
-          .findByText("This filter can only connect to its own card.")
-          .should("be.visible");
-
-        // Disconnect the filter from the first card
-        H.sidebar().findByText("Disconnect from card").click();
-
-        // Ensure it still can't be connected to the second card
-        H.getDashboardCard(1)
-          .findByText("This filter can only connect to its own card.")
+        H.getDashboardCard(0)
+          .findByText("The selected filter is on another tab.")
           .should("be.visible");
       });
     });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
@@ -7,7 +7,6 @@ import CS from "metabase/css/core/index.css";
 import { setParameterMapping } from "metabase/dashboard/actions/parameters";
 import {
   getVirtualCardType,
-  isQuestionDashCard,
   isVirtualDashCard,
   showVirtualDashCardInfoText,
 } from "metabase/dashboard/utils";
@@ -67,13 +66,13 @@ export const DashCardCardParameterMapperContent = ({
 
   const dispatch = useDispatch();
 
-  const isInlineParameterOfAnotherQuestionCard = useMemo(() => {
+  const isInlineParameterFromAnotherTab = useMemo(() => {
     return (
       editingParameterInlineDashcard != null &&
-      isQuestionDashCard(editingParameterInlineDashcard) &&
-      editingParameterInlineDashcard.id !== dashcard.id
+      editingParameterInlineDashcard.dashboard_tab_id !==
+        dashcard.dashboard_tab_id
     );
-  }, [editingParameterInlineDashcard, dashcard.id]);
+  }, [editingParameterInlineDashcard, dashcard.dashboard_tab_id]);
 
   const headerContent = useMemo(() => {
     if (layoutHeight <= 2) {
@@ -146,11 +145,11 @@ export const DashCardCardParameterMapperContent = ({
     );
   }
 
-  if (isInlineParameterOfAnotherQuestionCard) {
+  if (isInlineParameterFromAnotherTab) {
     return (
       <Flex className={S.TextCardDefault} ta="center">
         <Icon name="info" size={12} className={CS.pr1} />
-        {t`This filter can only connect to its own card.`}
+        {t`The selected filter is on another tab.`}
       </Flex>
     );
   }


### PR DESCRIPTION
Closes [VIZ-1171](https://linear.app/metabase/issue/VIZ-1171/remove-arbitrary-limit-on-card-filters-connecting-to-other-cards)

### Description

Allows connecting inline filters to all other cards on the same tab.

### Demo

<img width="558" alt="Screenshot 2025-06-18 at 8 13 53 PM" src="https://github.com/user-attachments/assets/e846e34c-3cc7-4e27-82dd-454ed29d7c6e" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
