### PR TITLE
Implement notification badge for updates

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -10,6 +10,8 @@ import {
   AdminNavWrapper,
 } from "../AdminNav";
 
+import { UpdatesNavItem } from "./UpdatesNavItem";
+
 const NavDivider = () => <Divider my="sm" />;
 
 export function SettingsNav() {
@@ -48,9 +50,7 @@ export function SettingsNav() {
         label={t`Notification channels`}
         icon="bell"
       />
-      {!hasHosting && (
-        <SettingsNavItem path="updates" label={t`Updates`} icon="sparkles" />
-      )}
+      {!hasHosting && <UpdatesNavItem />}
       <NavDivider />
       <SettingsNavItem
         path="localization"
@@ -125,7 +125,7 @@ export function SettingsNav() {
   );
 }
 
-function SettingsNavItem({ path, ...navItemProps }: AdminNavItemProps) {
+export function SettingsNavItem({ path, ...navItemProps }: AdminNavItemProps) {
   return (
     <AdminNavItem
       data-testid={`settings-sidebar-link`}

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
@@ -1,0 +1,44 @@
+import { t } from "ttag";
+
+import { useGetVersionInfoQuery } from "metabase/api";
+import { useSetting } from "metabase/common/hooks";
+import { useSelector } from "metabase/lib/redux";
+import { newVersionAvailable } from "metabase/lib/utils";
+import { Badge } from "metabase/ui";
+
+import { getCurrentVersion } from "../../selectors";
+
+import { SettingsNavItem } from "./SettingsNav";
+
+export function UpdatesNavItem() {
+  const { data: versionInfo } = useGetVersionInfoQuery();
+  const currentVersion = useSelector(getCurrentVersion);
+  const updateChannel = useSetting("update-channel") ?? "latest";
+  const latestVersion = versionInfo?.[updateChannel]?.version;
+
+  const isNewVersionAvailable =
+    latestVersion && newVersionAvailable({ currentVersion, latestVersion });
+
+  return (
+    <SettingsNavItem
+      path="updates"
+      label={<div>{t`Updates`}</div>}
+      icon="sparkles"
+      rightSection={
+        isNewVersionAvailable ? (
+          <Badge
+            data-testid="updates-nav-badge"
+            styles={{
+              root: {
+                color: "var(--mb-color-text-white)",
+                backgroundColor: "var(--mb-color-error)",
+              },
+            }}
+          >
+            {t`1`}
+          </Badge>
+        ) : null
+      }
+    />
+  );
+}

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
@@ -35,7 +35,7 @@ export function UpdatesNavItem() {
               },
             }}
           >
-            {t`1`}
+            1
           </Badge>
         ) : null
       }

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.unit.spec.tsx
@@ -1,0 +1,79 @@
+import {
+  setupPropertiesEndpoints,
+  setupSettingEndpoint,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { SettingKey, UpdateChannel } from "metabase-types/api";
+import {
+  createMockSettingDefinition,
+  createMockSettings,
+} from "metabase-types/api/mocks";
+import { createMockSettingsState } from "metabase-types/store/mocks";
+
+import { UpdatesNavItem } from "./UpdatesNavItem";
+
+const setup = async (props: {
+  updateChannel: UpdateChannel;
+  versionTag: string;
+}) => {
+  const versionNoticeSettings = {
+    version: {
+      date: "2025-03-19",
+      src_hash: "4df5cf3e5e86b0cc7421d80e2a8835e2ce3afa7d",
+      tag: props.versionTag,
+      hash: "4742ea1",
+    },
+    "update-channel": props.updateChannel,
+  };
+
+  const settings = createMockSettings(versionNoticeSettings);
+  setupPropertiesEndpoints(settings);
+  setupSettingEndpoint({
+    settingKey: "version-info",
+    settingValue: {
+      beta: {
+        version: "v1.54.0-beta",
+        released: "2025-03-24",
+        highlights: [],
+      },
+      latest: {
+        version: "v1.53.8",
+        released: "2025-03-25",
+        patch: true,
+        highlights: [],
+      },
+      nightly: {
+        version: "v1.52.3",
+        released: "2024-12-16",
+        highlights: [],
+      },
+    },
+  });
+
+  setupSettingsEndpoints(
+    Object.entries(settings).map(([key, value]) =>
+      createMockSettingDefinition({ key: key as SettingKey, value }),
+    ),
+  );
+
+  renderWithProviders(<UpdatesNavItem />, {
+    storeInitialState: {
+      settings: createMockSettingsState(settings),
+    },
+  });
+
+  await screen.findByText("Updates");
+};
+
+describe("UpdatesNavItem", () => {
+  it("should not show badge if there are no updates available", async () => {
+    await setup({ versionTag: "v1.53.8", updateChannel: "latest" });
+    expect(screen.queryByTestId("updates-nav-badge")).not.toBeInTheDocument();
+  });
+
+  it("should show badge updates are available", async () => {
+    await setup({ versionTag: "v1.53.8", updateChannel: "beta" });
+    expect(screen.getByTestId("updates-nav-badge")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.unit.spec.tsx
@@ -74,6 +74,6 @@ describe("UpdatesNavItem", () => {
 
   it("should show badge updates are available", async () => {
     await setup({ versionTag: "v1.53.8", updateChannel: "beta" });
-    expect(screen.getByTestId("updates-nav-badge")).toBeInTheDocument();
+    expect(await screen.findByTestId("updates-nav-badge")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<img width="515" alt="Screenshot 2025-06-19 at 12 34 45 PM" src="https://github.com/user-attachments/assets/00bf33ad-88ab-449d-bb48-43bc75b9c44f" />

I'm using the current designs for now, but I'll change if I get feedback that we can use `New` or another non-numeric indicator

https://metaboat.slack.com/archives/C02H619CJ8K/p1750282804596389