### PR TITLE
disable dashcard pointer events when editing dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.module.css
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.module.css
@@ -6,6 +6,6 @@
   color: var(--mb-color-text-medium);
 }
 
-.InlineParametersContainer * {
+.InlineParametersList * {
   pointer-events: all;
 }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.module.css
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.module.css
@@ -5,3 +5,7 @@
 .VirtualDashCardOverlayText {
   color: var(--mb-color-text-medium);
 }
+
+.InlineParametersContainer * {
+  pointer-events: all;
+}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -435,6 +435,7 @@ export function DashCardVisualization({
         <Box mr="sm">
           {inlineParameters.length > 0 && (
             <DashboardParameterList
+              className={S.InlineParametersList}
               widgetsVariant="subtle"
               parameters={inlineParameters}
               isSortable={false}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -13,7 +13,6 @@ import {
 import {
   getVirtualCardType,
   isVirtualDashCard,
-  supportsInlineParameters,
 } from "metabase/dashboard/utils";
 import { useSelector } from "metabase/lib/redux";
 import { isJWT } from "metabase/lib/utils";
@@ -487,11 +486,7 @@ export function DashCardVisualization({
       className={cx(CS.flexFull, {
         [CS.overflowAuto]: visualizationOverlay,
         [CS.overflowHidden]: !visualizationOverlay,
-
-        // Heading dashcards configure pointer events on their own
-        // to make the inner input and inline filters interactive.
-        [CS.pointerEventsNone]:
-          isEditingDashboardLayout && !supportsInlineParameters(dashcard),
+        [CS.pointerEventsNone]: isEditingDashboardLayout,
       })}
       dashboard={dashboard}
       dashcard={dashcard}

--- a/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import type { ComponentProps } from "react";
 
 import {
@@ -24,12 +25,14 @@ interface DashboardParameterListProps
     ComponentProps<typeof ParametersList>,
     "widgetsVariant" | "widgetsWithinPortal" | "vertical"
   > {
+  className?: string;
   parameters: Array<Parameter & { value: unknown }>;
   isSortable?: boolean;
   isFullscreen: boolean;
 }
 
 export function DashboardParameterList({
+  className,
   parameters,
   isSortable = true,
   isFullscreen,
@@ -47,7 +50,7 @@ export function DashboardParameterList({
 
   return (
     <ParametersList
-      className={DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME}
+      className={cx(DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME, className)}
       parameters={parameters}
       editingParameter={editingParameter}
       hideParameters={hiddenParameterSlugs}


### PR DESCRIPTION
Closes [VIZ-1166](https://linear.app/metabase/issue/VIZ-1166/disable-chart-click-events-when-editing-a-dashcard-parameter)

### Description

Disables dashcards pointer events when editing a dashboard while enabling them only for inline filters.

### Demo

<video src="https://github.com/user-attachments/assets/ac049c51-9840-49d3-929f-1f6a2eb98741" />
