### PR TITLE
upgrade liquibase and postgres

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -170,7 +170,7 @@
   org.graalvm.polyglot/js-community         {:mvn/version "24.2.1" :extension "pom"} ; JavaScript engine
   org.graalvm.polyglot/polyglot             {:mvn/version "24.2.1"}             ; GraalVM platform, required by JS engine
   org.jsoup/jsoup                           {:mvn/version "1.21.1"}             ; required by hickory
-  org.liquibase/liquibase-core              {:mvn/version "4.32.0"              ; migration management (Java lib)
+  org.liquibase/liquibase-core              {:mvn/version "4.33.0"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
   org.mariadb.jdbc/mariadb-java-client      ^:antq/exclude                      ; 3.x only support jdbc:mariadb, so using 2.x for now
   {:mvn/version "2.7.10"}             ; MySQL/MariaDB driver

--- a/deps.edn
+++ b/deps.edn
@@ -170,13 +170,11 @@
   org.graalvm.polyglot/js-community         {:mvn/version "24.2.1" :extension "pom"} ; JavaScript engine
   org.graalvm.polyglot/polyglot             {:mvn/version "24.2.1"}             ; GraalVM platform, required by JS engine
   org.jsoup/jsoup                           {:mvn/version "1.21.1"}             ; required by hickory
-  org.liquibase/liquibase-core              ^:antq/exclude                      ; FIXME: no idea why it fails
-  {:mvn/version "4.26.0"              ; migration management (Java lib)
-   :exclusions  [ch.qos.logback/logback-classic]}
+  org.liquibase/liquibase-core              {:mvn/version "4.32.0"              ; migration management (Java lib)
+                                             :exclusions  [ch.qos.logback/logback-classic]}
   org.mariadb.jdbc/mariadb-java-client      ^:antq/exclude                      ; 3.x only support jdbc:mariadb, so using 2.x for now
   {:mvn/version "2.7.10"}             ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
-  ; NOTE: Postgres fix in 42.7.5 breaks liquibase on case-sensitive databases until https://github.com/liquibase/liquibase/pull/6755 is released
   org.postgresql/postgresql                 {:mvn/version "42.7.7"}             ; Postgres driver
   org.slf4j/slf4j-api                       {:mvn/version "2.0.17"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -8264,10 +8264,10 @@ databaseChangeLog:
   - changeSet:
       id: v50.2024-05-29T18:42:13
       author: johnswanson
+      dbms: h2
       comment: Populate `archived_directly` and `archive_operation_id` (H2)
       changes:
         - sqlFile:
-            dbms: h2
             path: trash/h2.sql
             relativeToChangelogFile: true
       rollback: # not needed, columns will be deleted

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6458,10 +6458,10 @@ databaseChangeLog:
   - changeSet:
       id: v49.2024-06-27T00:00:00
       author: calherries
+      dbms: mysql,mariadb
       comment: Make metabase_field.name use case-sensitive collation for MySQL
       changes:
         - sql:
-            dbms: mysql,mariadb
             sql: >-
               ALTER TABLE metabase_field MODIFY
               name VARCHAR(254)
@@ -6469,7 +6469,6 @@ databaseChangeLog:
               COLLATE utf8mb4_bin;
       rollback:
         - sql:
-            dbms: mysql,mariadb
             sql: >-
               ALTER TABLE metabase_field MODIFY
               name VARCHAR(254)
@@ -6602,10 +6601,10 @@ databaseChangeLog:
   - changeSet:
       id: v49.2024-06-27T00:00:06
       author: calherries
+      dbms: postgresql
       comment: Remove the idx_uniq_field_table_id_parent_id_name_2col unique index because it blocks load-from-h2
       changes:
         - sql:
-            dbms: postgresql
             sql: DROP INDEX IF EXISTS idx_uniq_field_table_id_parent_id_name_2col;
       rollback: # We deliberately don't restore this constraint because otherwise it can block downgrading to 48 after load-from-h2
 
@@ -8254,10 +8253,10 @@ databaseChangeLog:
   - changeSet:
       id: v50.2024-05-29T14:05:03
       author: johnswanson
+      dbms: postgresql
       comment: Populate `archived_directly` and `archive_operation_id` (Postgres)
       changes:
         - sqlFile:
-            dbms: postgresql
             path: trash/postgres.sql
             relativeToChangelogFile: true
       rollback: # not needed, columns will be deleted
@@ -8276,11 +8275,11 @@ databaseChangeLog:
   - changeSet:
       id: v50.2024-05-29T18:42:14
       author: johnswanson
+      dbms: mysql
       comment: Populate `archived_directly` and `archive_operation_id` (MySQL)
       validCheckSum: ANY
       changes:
         - sqlFile:
-            dbms: mysql
             path: trash/mysql.sql
             relativeToChangelogFile: true
       rollback: # not needed, columns will be deleted
@@ -8288,10 +8287,10 @@ databaseChangeLog:
   - changeSet:
       id: v50.2024-05-29T18:42:15
       author: johnswanson
+      dbms: mariadb
       comment: Populate `archived_directly` and `archive_operation_id` (MariaDB)
       changes:
         - sqlFile:
-            dbms: mariadb
             path: trash/mariadb.sql
             relativeToChangelogFile: true
       rollback: # not needed, columns will be deleted
@@ -11361,10 +11360,10 @@ databaseChangeLog:
       id: v55.2025-05-19T01:00:00
       validCheckSum: ANY
       author: ranquild
+      dbms: mysql,mariadb
       comment: Make metabase_table.name and schema use case-sensitive collation for MySQL
       changes:
         - sql:
-            dbms: mysql,mariadb
             sql: >-
               ALTER TABLE metabase_table MODIFY
               `name` varchar(254)
@@ -11377,7 +11376,6 @@ databaseChangeLog:
               COLLATE utf8mb4_bin;
       rollback:
         - sql:
-            dbms: mysql,mariadb
             sql: >-
               ALTER TABLE metabase_table MODIFY
               `name` VARCHAR(254)

--- a/src/metabase/app_db/liquibase/h2.clj
+++ b/src/metabase/app_db/liquibase/h2.clj
@@ -18,7 +18,11 @@
         (proxy-super quoteObject (upcase object-name) object-type)))
 
     (mustQuoteObjectName [_object-name _object-type]
-      true)))
+      true)
+
+    (correctObjectName [object-name object-type]
+      (let [^H2Database this this]
+        (proxy-super correctObjectName (upcase object-name) object-type)))))
 
 ;; HACK! Create a [[java.lang.Package]] for the proxy class if one does not already exist. This is needed because:
 ;;

--- a/test/metabase/app_db/liquibase_test.clj
+++ b/test/metabase/app_db/liquibase_test.clj
@@ -63,17 +63,17 @@
             (liquibase/consolidate-liquibase-changesets! conn liquibase)
 
             (testing "makes sure the change log filename are correctly set"
-              (is (= (set (mdb.test-util/liquibase-file->included-ids "migrations/000_legacy_migrations.yaml" driver/*driver* conn))
+              (is (= (set (mdb.test-util/liquibase-file->included-ids "migrations/000_legacy_migrations.yaml" driver/*driver*))
                      (t2/select-fn-set :id table-name :filename "migrations/000_legacy_migrations.yaml")))
 
-              (is (= (set (mdb.test-util/liquibase-file->included-ids "migrations/001_update_migrations.yaml" driver/*driver* conn))
+              (is (= (set (mdb.test-util/liquibase-file->included-ids "migrations/001_update_migrations.yaml" driver/*driver*))
                      (t2/select-fn-set :id table-name :filename "migrations/001_update_migrations.yaml")))
 
               (is (= []
                      (remove #(str/starts-with? % "v56.") (t2/select-fn-set :id table-name :filename "migrations/056_update_migrations.yaml"))))
 
               (is (= (t2/select-fn-set :id table-name)
-                     (set (mdb.test-util/all-liquibase-ids true driver/*driver* conn)))))))))))
+                     (set (mdb.test-util/all-liquibase-ids true driver/*driver*)))))))))))
 
 (deftest wait-for-all-locks-test
   (mt/test-drivers #{:h2 :mysql :postgres}

--- a/test/metabase/app_db/liquibase_test.clj
+++ b/test/metabase/app_db/liquibase_test.clj
@@ -63,17 +63,17 @@
             (liquibase/consolidate-liquibase-changesets! conn liquibase)
 
             (testing "makes sure the change log filename are correctly set"
-              (is (= (set (mdb.test-util/liquibase-file->included-ids "migrations/000_legacy_migrations.yaml" driver/*driver*))
+              (is (= (set (mdb.test-util/liquibase-file->included-ids "migrations/000_legacy_migrations.yaml" driver/*driver* conn))
                      (t2/select-fn-set :id table-name :filename "migrations/000_legacy_migrations.yaml")))
 
-              (is (= (set (mdb.test-util/liquibase-file->included-ids "migrations/001_update_migrations.yaml" driver/*driver*))
+              (is (= (set (mdb.test-util/liquibase-file->included-ids "migrations/001_update_migrations.yaml" driver/*driver* conn))
                      (t2/select-fn-set :id table-name :filename "migrations/001_update_migrations.yaml")))
 
               (is (= []
                      (remove #(str/starts-with? % "v56.") (t2/select-fn-set :id table-name :filename "migrations/056_update_migrations.yaml"))))
 
               (is (= (t2/select-fn-set :id table-name)
-                     (set (mdb.test-util/all-liquibase-ids true driver/*driver*)))))))))))
+                     (set (mdb.test-util/all-liquibase-ids true driver/*driver* conn)))))))))))
 
 (deftest wait-for-all-locks-test
   (mt/test-drivers #{:h2 :mysql :postgres}

--- a/test/metabase/app_db/setup_test.clj
+++ b/test/metabase/app_db/setup_test.clj
@@ -61,7 +61,7 @@
         (is (= :done
                (mdb.setup/setup-db! driver/*driver* (mdb.connection/data-source) true true)))
         (testing "migrations are executed in the order they are defined"
-          (is (= (mdb.test-util/all-liquibase-ids false driver/*driver*)
+          (is (= (mdb.test-util/all-liquibase-ids false driver/*driver* conn)
                  (t2/select-pks-vec (liquibase/changelog-table-name conn) {:order-by [[:orderexecuted :asc]]}))))))))
 
 (deftest setup-db-no-auto-migrate-test

--- a/test/metabase/app_db/setup_test.clj
+++ b/test/metabase/app_db/setup_test.clj
@@ -61,7 +61,7 @@
         (is (= :done
                (mdb.setup/setup-db! driver/*driver* (mdb.connection/data-source) true true)))
         (testing "migrations are executed in the order they are defined"
-          (is (= (mdb.test-util/all-liquibase-ids false driver/*driver* conn)
+          (is (= (mdb.test-util/all-liquibase-ids false driver/*driver*)
                  (t2/select-pks-vec (liquibase/changelog-table-name conn) {:order-by [[:orderexecuted :asc]]}))))))))
 
 (deftest setup-db-no-auto-migrate-test

--- a/test/metabase/app_db/test_util.clj
+++ b/test/metabase/app_db/test_util.clj
@@ -80,6 +80,22 @@
       ;; if the changelog has filter by dbms, remove the ones that doens't apply for the current db-type
          (remove (fn [{{:keys [dbms]} :changeSet}] (and (not (str/blank? dbms))
                                                         (not (str/includes? dbms (name db-type))))))
+        ;if the changelog has filter by dbms on sql/sqlFile tags, remove the ones that doesn't apply for the current db-type.
+        ; BUT: if the changeSet has a preCondition with onFail "MARK_RAN", we keep it because that marks it as ran anyway
+        ; BUT: if there is more than one change, even if they all don't get ran it gets marked as ran (https://github.com/liquibase/liquibase/issues/7153)
+         (filter (fn [{{:keys [changes id preConditions]} :changeSet}]
+                   (cond
+                     (some #(= {:onFail "MARK_RAN"} %) preConditions)
+                     true
+
+                     (= 1 (count changes))
+                     (let [change (first changes)]
+                       (cond
+                         (:sql change) (str/includes? (get-in change [:sql :dbms] (name db-type)) (name db-type))
+                         (:sqlFile change) (str/includes? (get-in change [:sqlFile :dbms] (name db-type)) (name db-type))
+                         :else true))
+
+                     :else true)))
       ;; remove ignored changeSets
          (remove #(get-in % [:changeSet :ignore]))
          (map #(str (get-in % [:changeSet :id])))

--- a/test/metabase/app_db/test_util.clj
+++ b/test/metabase/app_db/test_util.clj
@@ -83,7 +83,7 @@
         ;if the changelog has filter by dbms on sql/sqlFile tags, remove the ones that doesn't apply for the current db-type.
         ; BUT: if the changeSet has a preCondition with onFail "MARK_RAN", we keep it because that marks it as ran anyway
         ; BUT: if there is more than one change, even if they all don't get ran it gets marked as ran (https://github.com/liquibase/liquibase/issues/7153)
-         (filter (fn [{{:keys [changes id preConditions]} :changeSet}]
+         (filter (fn [{{:keys [changes preConditions]} :changeSet}]
                    (cond
                      (some #(= {:onFail "MARK_RAN"} %) preConditions)
                      true

--- a/test/metabase/app_db/test_util.clj
+++ b/test/metabase/app_db/test_util.clj
@@ -74,13 +74,16 @@
 (defn liquibase-file->included-ids
   "Read a liquibase migration file and returns all the migration id that is applied to `db-type`.
   Ids are orderer in the order it's defined in migration file."
-  [file-path db-type]
-  (let [content (u.yaml/from-file (io/resource file-path))]
+  [file-path db-type conn]
+  (let [content (u.yaml/from-file (io/resource file-path))
+        lb-type (if (= "MariaDB" (.getDatabaseProductName (.getMetaData ^java.sql.Connection conn)))
+                  :mariadb
+                  db-type)]
     (->> (:databaseChangeLog content)
-      ;; if the changelog has filter by dbms, remove the ones that doens't apply for the current db-type
+      ;; if the changelog has filter by dbms, remove the ones that doens't apply for the current lb-type
          (remove (fn [{{:keys [dbms]} :changeSet}] (and (not (str/blank? dbms))
-                                                        (not (str/includes? dbms (name db-type))))))
-        ;if the changelog has filter by dbms on sql/sqlFile tags, remove the ones that doesn't apply for the current db-type.
+                                                        (not (str/includes? dbms (name lb-type))))))
+        ;if the changelog has filter by dbms on sql/sqlFile tags, remove the ones that doesn't apply for the current lb-type.
         ; BUT: if the changeSet has a preCondition with onFail "MARK_RAN", we keep it because that marks it as ran anyway
         ; BUT: if there is more than one change, even if they all don't get ran it gets marked as ran (https://github.com/liquibase/liquibase/issues/7153)
          (filter (fn [{{:keys [changes preConditions]} :changeSet}]
@@ -91,8 +94,8 @@
                      (= 1 (count changes))
                      (let [change (first changes)]
                        (cond
-                         (:sql change) (str/includes? (get-in change [:sql :dbms] (name db-type)) (name db-type))
-                         (:sqlFile change) (str/includes? (get-in change [:sqlFile :dbms] (name db-type)) (name db-type))
+                         (:sql change) (str/includes? (get-in change [:sql :dbms] (name lb-type)) (name lb-type))
+                         (:sqlFile change) (str/includes? (get-in change [:sqlFile :dbms] (name lb-type)) (name lb-type))
                          :else true))
 
                      :else true)))
@@ -112,5 +115,5 @@
 
 (defn all-liquibase-ids
   "Returns a set of all changeset IDs from all migration files."
-  [include-legacy? driver]
-  (apply concat (map #(liquibase-file->included-ids % driver) (all-migration-files include-legacy?))))
+  [include-legacy? driver conn]
+  (apply concat (map #(liquibase-file->included-ids % driver conn) (all-migration-files include-legacy?))))

--- a/test/metabase/test/initialize/db.clj
+++ b/test/metabase/test/initialize/db.clj
@@ -1,7 +1,6 @@
 (ns metabase.test.initialize.db
   (:require
    [metabase.app-db.core :as mdb]
-   [metabase.app-db.env :as mdb.env]
    [metabase.task.bootstrap :as task.bootstrap]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -10,7 +9,6 @@
 (set! *warn-on-reflection* true)
 
 (defn init! []
-  (println "Appdb: " mdb.env/env)
   (log/info (u/format-color 'blue "Setting up %s test DB and running migrations..." (mdb/db-type)))
   (task.bootstrap/set-jdbc-backend-properties! (mdb/db-type))
   (mdb/setup-db! :create-sample-content? false) ; skip sample content for speedy tests. this doesn't reflect production

--- a/test/metabase/test/initialize/db.clj
+++ b/test/metabase/test/initialize/db.clj
@@ -1,6 +1,7 @@
 (ns metabase.test.initialize.db
   (:require
    [metabase.app-db.core :as mdb]
+   [metabase.app-db.env :as mdb.env]
    [metabase.task.bootstrap :as task.bootstrap]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -9,6 +10,7 @@
 (set! *warn-on-reflection* true)
 
 (defn init! []
+  (println "Appdb: " mdb.env/env)
   (log/info (u/format-color 'blue "Setting up %s test DB and running migrations..." (mdb/db-type)))
   (task.bootstrap/set-jdbc-backend-properties! (mdb/db-type))
   (mdb/setup-db! :create-sample-content? false) ; skip sample content for speedy tests. this doesn't reflect production


### PR DESCRIPTION
Newest version of postgresql driver wasn't working with our existing liquibase version.

There were issues we hit with a couple of the in-between ones, but 4.33 is working with a few tweaks:
- The behavior around when changesets with sql/sqlFile changes that are not ran due to a dbms tag is overall counted as ran or not. It's a liquibase bug that should get fixed up at some point
- Rather than fighting with those differences, I moved the dbms filtering to the changeset level rather than in the sql/sqlFile tag. That is probably the better spot for it anyway when the changeset it targetted at a particular database type
- Had to fix up the handling of mysql vs. mariadb since liquibase calls them something different but metabase does not
