### PR TITLE
log analytics event even if tracking is disabled

### DIFF
--- a/frontend/src/metabase/lib/analytics.ts
+++ b/frontend/src/metabase/lib/analytics.ts
@@ -41,19 +41,22 @@ export function trackSimpleEvent(event: SimpleEvent) {
 }
 
 export function trackSchemaEvent(schema: SchemaType, event: SchemaEvent): void {
-  if (Settings.trackingEnabled() && Settings.snowplowEnabled()) {
-    if (shouldLogAnalytics) {
-      const { event: type, ...other } = event;
-      // eslint-disable-next-line no-console
-      console.log(
-        `%c[SNOWPLOW EVENT]%c, ${type}`,
-        // eslint-disable-next-line no-color-literals
-        "background: #222; color: #bada55",
-        "color: ",
-        other,
-      );
-    }
+  const shouldSendEvent =
+    Settings.trackingEnabled() && Settings.snowplowEnabled();
 
+  if (shouldLogAnalytics) {
+    const { event: type, ...other } = event;
+    // eslint-disable-next-line no-console
+    console.log(
+      `%c[SNOWPLOW EVENT | event sent:${shouldSendEvent}]%c, ${type}`,
+      // eslint-disable-next-line no-color-literals
+      "background: #222; color: #bada55",
+      "color: ",
+      other,
+    );
+  }
+
+  if (shouldSendEvent) {
     Snowplow.trackSelfDescribingEvent({
       event: {
         schema: `iglu:com.metabase/${schema}/jsonschema/${VERSIONS[schema]}`,


### PR DESCRIPTION
The logic was changed in a pr to only log the analytics event when they're really sent, thi makes it less useful locally as we don't send the events.
`snowplow-available` is always false locally as the default value is `config/is-prod?` 
https://github.com/metabase/metabase/blob/cd36e96b15e557634488dd7f134c0c7a5b177f68/src/metabase/analytics/settings.clj#L43-L51

This PR restores the original log logic and also logs if the analytics event is really sent or not.

<img width="867" alt="image" src="https://github.com/user-attachments/assets/fc733ee7-2eef-4d44-b7e0-14b1c5e243b8" />


## How to verify

Set `MB_LOG_ANALYTICS=true` and open the browser console while doing something that should trigger analytics events