### PR TITLE
Use composedPath to detect a click target for useSequencedContentCloseHandler

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -86,6 +86,26 @@ describe("scenarios > embedding-sdk > popovers", () => {
     H.popover().findByText("ID").should("be.visible");
   });
 
+  it("should prevent closing the ChartNestedSettingsSeriesSingle popover when clicking it", () => {
+    mountSdkContent(
+      <InteractiveQuestion questionId={ORDERS_BY_YEAR_QUESTION_ID} />,
+    );
+
+    openVizSettingsSidebar();
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("settings-count").click();
+
+      // Clicking at the edge of popover to be sure that the click does not close it
+      cy.findByTestId("series-settings").click(1, 1);
+      cy.findByTestId("series-settings").should("be.visible");
+
+      // Clicking outside of the popover to be sure that the click closes it
+      cy.findByTestId("chartsettings-list-container").click(1, 1);
+      cy.findByTestId("series-settings").should("not.exist");
+    });
+  });
+
   it("should prevent closing the ChartSettingMultiSelect when clicking it", () => {
     cy.get<string>("@questionId").then((questionId) => {
       mountSdkContent(<InteractiveQuestion questionId={questionId} />);

--- a/frontend/src/metabase/common/hooks/use-sequenced-content-close-handler.ts
+++ b/frontend/src/metabase/common/hooks/use-sequenced-content-close-handler.ts
@@ -13,7 +13,8 @@ type PopoverData = {
 export const RENDERED_POPOVERS: PopoverData[] = [];
 
 function isEventInsideElement(e: Event, el: Element) {
-  return isElement(e.target) && el.contains(e.target);
+  const target = e.composedPath()[0];
+  return isElement(target) && el.contains(target);
 }
 
 export function removePopoverData(popoverData: PopoverData) {


### PR DESCRIPTION
This change is the preparation for SDK as Web Components

The previous behavior does not support Shadow Root, so the `composedPath` is used, that respects elements inside a Shadow Root

Regular behavior should not be changed.

How to verify:
- find a question
- change its viz type to combo
- via summarize add 4-5 summarize functions or metrics
- open chart settings (next to viz type button in left bottom corner), for any Y-axis item, click the three dots icon to open the nested Tippy popover.
- play with it, it should not be closed when clicking inside it or its items, should be closed when clicking anywhere outside of it.