### PR TITLE
QUE-1398: Fix flake in header popover

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1478,6 +1478,11 @@ describe("issue 55673", () => {
     H.tableHeaderClick("Product ID");
     cy.findByTestId("click-actions-view").should("be.visible");
 
+    cy.focused().should(
+      "have.attr",
+      "data-testid",
+      "click-actions-sort-control-sort.ascending",
+    );
     cy.realPress(["Escape"]);
     cy.findByTestId("click-actions-view").should("not.exist");
   });


### PR DESCRIPTION
Closes QUE-1398

[Stress test](https://github.com/metabase/metabase/actions/runs/15757595714)

The flake rate is about 12% on Trunk.io, so 100 runs should turn up 12 flakes but the stress test found none.