### PR TITLE
sdk(test): Pass collection id to the CollectionBrowser stories

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.stories.tsx
@@ -12,6 +12,9 @@ export default {
     layout: "fullscreen",
   },
   decorators: [CommonSdkStoryWrapper],
+  argTypes: {
+    collectionId: collectionIdArgType,
+  },
 };
 
 const COLLECTION_ID = "root";
@@ -23,15 +26,8 @@ const Template: StoryFn<ComponentProps<typeof CollectionBrowser>> = (args) => {
 export const Default = {
   render: Template,
 
-  parameters: {
-    layout: "fullscreen",
-  },
-  decorators: [CommonSdkStoryWrapper],
   args: {
     collectionId: COLLECTION_ID,
-  },
-  argTypes: {
-    collectionId: collectionIdArgType,
   },
 };
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.stories.tsx
@@ -14,6 +14,8 @@ export default {
   decorators: [CommonSdkStoryWrapper],
 };
 
+const COLLECTION_ID = "root";
+
 const Template: StoryFn<ComponentProps<typeof CollectionBrowser>> = (args) => {
   return <CollectionBrowser {...args} />;
 };
@@ -25,6 +27,9 @@ export const Default = {
     layout: "fullscreen",
   },
   decorators: [CommonSdkStoryWrapper],
+  args: {
+    collectionId: COLLECTION_ID,
+  },
   argTypes: {
     collectionId: collectionIdArgType,
   },
@@ -34,6 +39,7 @@ export const WithTypeAndNameColumn = {
   render: Template,
 
   args: {
+    collectionId: COLLECTION_ID,
     visibleColumns: ["type", "name"],
   },
 };


### PR DESCRIPTION
Currently, it's not passed and we don't display the collection

Before:
![image](https://github.com/user-attachments/assets/a647c9e9-817a-4d22-8075-79f0f92c9f71)

After:
![image](https://github.com/user-attachments/assets/75d6b59b-4ea4-4ad0-baee-0d08148ef554)
