### PR TITLE
Update InputBlurChange styling to match prior implementation

### DIFF
--- a/frontend/src/metabase/components/InputBlurChange/InputBlurChange.tsx
+++ b/frontend/src/metabase/components/InputBlurChange/InputBlurChange.tsx
@@ -20,6 +20,7 @@ export interface InputBlurChangeProps
   normalize?: (value: Value) => Value;
 }
 
+/** see also: metabase/ui/components/inputs/TextInputBlurChange 🤦‍♀️ */
 const InputBlurChange = (props: InputBlurChangeProps) => {
   const {
     value,
@@ -77,7 +78,9 @@ const InputBlurChange = (props: InputBlurChangeProps) => {
       value={internalValue}
       onBlur={handleBlur}
       onChange={handleChange}
-      w="100%"
+      styles={{
+        input: { width: "100%" },
+      }}
     />
   );
 };


### PR DESCRIPTION
Closes ADM-1003
follow up to #58931 
### Description

Apply width: 100% to the inner input component rather than the container.

Before | After
---|---
![Screenshot 2025-06-19 at 10 21 25 AM](https://github.com/user-attachments/assets/e87dfe52-6c6a-4254-b904-57f2ded5dbec) | ![Screenshot 2025-06-19 at 10 21 10 AM](https://github.com/user-attachments/assets/1a1eaf85-169d-43bb-a239-6fd0cc785c10)

