### PR TITLE
Scaffold new iframe embed setup flow

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -1,0 +1,3 @@
+export const SdkIframeEmbedPreview = () => {
+  return null;
+};

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.module.css
@@ -1,0 +1,49 @@
+.EmbedPreviewIframe {
+  width: 100%;
+  height: 100%;
+  min-height: 100vh;
+}
+
+.Container {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+.ResizeHandle {
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  background-color: var(--mb-color-border);
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.Sidebar {
+  height: 100%;
+  border-right: 1px solid var(--mb-color-border);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.SidebarContent {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  padding-bottom: 4rem;
+}
+
+.Navigation {
+  padding: 0.5rem 1rem;
+  background: var(--mb-color-bg-white);
+  border-top: 1px solid var(--mb-color-border);
+}
+
+.PreviewPanel {
+  flex: 1;
+  padding: 1rem;
+  overflow: hidden;
+}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -5,9 +5,9 @@ import { t } from "ttag";
 import "react-resizable/css/styles.css";
 
 import { Box, Button, Card, Group, Stack } from "metabase/ui";
-import { useSdkIframeEmbedNavigation } from "metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-navigation";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
+import { useSdkIframeEmbedNavigation } from "../hooks";
 
 import { SdkIframeEmbedPreview } from "./SdkIframeEmbedPreview";
 import S from "./SdkIframeEmbedSetup.module.css";

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -11,7 +11,7 @@ import { useSdkIframeEmbedSetupContext } from "../context";
 
 import { SdkIframeEmbedPreview } from "./SdkIframeEmbedPreview";
 import S from "./SdkIframeEmbedSetup.module.css";
-import { SdkIframeEmbedSetupProvider } from "./SdkIframeEmbedSetupContext";
+import { SdkIframeEmbedSetupProvider } from "./SdkIframeEmbedSetupProvider";
 
 const SdkIframeEmbedSetupContent = () => {
   const { currentStep } = useSdkIframeEmbedSetupContext();
@@ -48,7 +48,7 @@ const SdkIframeEmbedSetupContent = () => {
                 onClick={handleNext}
                 disabled={!canGoNext}
               >
-                {currentStep === "configure" ? t`Get Code` : t`Next`}
+                {currentStep === "select-embed-options" ? t`Get Code` : t`Next`}
               </Button>
             )}
           </Group>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -1,0 +1,124 @@
+import { useMemo, useState } from "react";
+import { ResizableBox } from "react-resizable";
+import { match } from "ts-pattern";
+import { t } from "ttag";
+
+import "react-resizable/css/styles.css";
+
+import { Box, Button, Card, Group, Stack } from "metabase/ui";
+
+import { SdkIframeEmbedPreview } from "./SdkIframeEmbedPreview";
+import S from "./SdkIframeEmbedSetup.module.css";
+import {
+  SdkIframeEmbedSetupProvider,
+  useSdkIframeEmbedSetupContext,
+} from "./SdkIframeEmbedSetupContext";
+import { SelectEmbedTypeStep } from "./SelectEmbedTypeStep";
+
+const SdkIframeEmbedSetupContent = () => {
+  const [sidebarWidth, setSidebarWidth] = useState(400);
+
+  const {
+    embedType: selectedType,
+    currentStep,
+    setCurrentStep,
+  } = useSdkIframeEmbedSetupContext();
+
+  const handleNext = () => {
+    if (currentStep === "select-embed-type") {
+      // Skip select-entity for exploration
+      if (selectedType === "exploration") {
+        setCurrentStep("configure");
+      } else {
+        setCurrentStep("select-entity");
+      }
+    } else if (currentStep === "select-entity") {
+      setCurrentStep("configure");
+    } else if (currentStep === "configure") {
+      setCurrentStep("get-code");
+    }
+  };
+
+  const handleBack = () => {
+    if (currentStep === "select-entity") {
+      setCurrentStep("select-embed-type");
+    } else if (currentStep === "configure") {
+      // Skip select-entity for exploration
+      if (selectedType === "exploration") {
+        setCurrentStep("select-embed-type");
+      } else {
+        setCurrentStep("select-entity");
+      }
+    } else if (currentStep === "get-code") {
+      setCurrentStep("configure");
+    }
+  };
+
+  const canGoNext = currentStep !== "get-code";
+  const canGoBack = currentStep !== "select-embed-type";
+
+  const StepContent = useMemo(() => {
+    return match(currentStep)
+      .with("select-embed-type", () => SelectEmbedTypeStep)
+      .with("select-entity", () => () => null)
+      .with("configure", () => () => null)
+      .with("get-code", () => () => null)
+      .exhaustive();
+  }, [currentStep]);
+
+  return (
+    <Box className={S.Container}>
+      <ResizableBox
+        width={sidebarWidth}
+        height={Infinity}
+        minConstraints={[300, Infinity]}
+        maxConstraints={[600, Infinity]}
+        onResizeStop={(_, data) => setSidebarWidth(data.size.width)}
+        axis="x"
+        handle={<Box className={S.ResizeHandle} />}
+      >
+        <Box className={S.Sidebar}>
+          <Box className={S.SidebarContent}>
+            <StepContent />
+          </Box>
+
+          <Group className={S.Navigation} justify="space-between">
+            <Button
+              variant="default"
+              onClick={handleBack}
+              disabled={!canGoBack}
+            >
+              {t`Back`}
+            </Button>
+
+            {currentStep !== "get-code" && (
+              <Button
+                variant="filled"
+                onClick={handleNext}
+                disabled={!canGoNext}
+              >
+                {currentStep === "configure" ? t`Get Code` : t`Next`}
+              </Button>
+            )}
+          </Group>
+        </Box>
+      </ResizableBox>
+
+      <Box className={S.PreviewPanel}>
+        <Card p="md" h="100%">
+          <Stack h="100%">
+            <SdkIframeEmbedPreview />
+          </Stack>
+        </Card>
+      </Box>
+    </Box>
+  );
+};
+
+export const SdkIframeEmbedSetup = () => {
+  return (
+    <SdkIframeEmbedSetupProvider>
+      <SdkIframeEmbedSetupContent />
+    </SdkIframeEmbedSetupProvider>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.unit.spec.tsx
@@ -1,0 +1,93 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { SdkIframeEmbedSetup } from "./SdkIframeEmbedSetup";
+
+const setup = () => renderWithProviders(<SdkIframeEmbedSetup />);
+
+describe("Embed flow > initial setup", () => {
+  it("shows the embed experience step as the first step", () => {
+    setup();
+
+    expect(
+      screen.getByText("Select your embed experience"),
+    ).toBeInTheDocument();
+  });
+
+  it("selects the dashboard experience by default", () => {
+    setup();
+
+    const dashboardRadio = screen.getByRole("radio", { name: /Dashboard/ });
+    expect(dashboardRadio).toBeChecked();
+  });
+});
+
+describe("Embed flow > forward and backward navigation", () => {
+  it("navigates forward through the embed flow", async () => {
+    setup();
+
+    expect(
+      screen.getByText("Select your embed experience"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("select entity placeholder")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back" })).toBeEnabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(
+      screen.getByText("select embed options placeholder"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Get Code" }),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Get Code" }));
+    expect(screen.getByText("get code placeholder")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Next" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Get Code" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("navigates backward to the previous step", async () => {
+    setup();
+
+    // Select embed type > select entity > select embed options
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(
+      screen.getByText("select embed options placeholder"),
+    ).toBeInTheDocument();
+
+    // Back to select entity
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByText("select entity placeholder")).toBeInTheDocument();
+
+    // Back to select embed type
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(
+      screen.getByText("Select your embed experience"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+  });
+
+  it("skips the 'select entity' step for exploration", async () => {
+    setup();
+
+    await userEvent.click(screen.getByRole("radio", { name: /Exploration/ }));
+
+    // Clicking next skips "select entity" and go directly to "select embed options"
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(
+      screen.getByText("select embed options placeholder"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText("select entity placeholder"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupContext.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupContext.tsx
@@ -1,0 +1,90 @@
+import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import { P, match } from "ts-pattern";
+
+import { useSetting } from "metabase/common/hooks";
+import type { SdkIframeEmbedSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
+
+import type {
+  SdkIframeEmbedSetupStep,
+  SdkIframeEmbedSetupType,
+} from "../types";
+
+interface SdkIframeEmbedSetupContextType {
+  currentStep: SdkIframeEmbedSetupStep;
+  setCurrentStep: (step: SdkIframeEmbedSetupStep) => void;
+
+  embedType: SdkIframeEmbedSetupType;
+  settings: SdkIframeEmbedSettings;
+  setSettings: (settings: SdkIframeEmbedSettings) => void;
+  updateSettings: (nextSettings: Partial<SdkIframeEmbedSettings>) => void;
+}
+
+const SdkIframeEmbedSetupContext =
+  createContext<SdkIframeEmbedSetupContextType | null>(null);
+
+interface SdkIframeEmbedSetupProviderProps {
+  children: ReactNode;
+}
+
+export const SdkIframeEmbedSetupProvider = ({
+  children,
+}: SdkIframeEmbedSetupProviderProps) => {
+  const [currentStep, setCurrentStep] =
+    useState<SdkIframeEmbedSetupStep>("select-embed-type");
+
+  const instanceUrl = useSetting("site-url");
+
+  const [settings, setSettings] = useState<SdkIframeEmbedSettings>({
+    apiKey: "",
+    dashboardId: 1,
+    instanceUrl,
+  });
+
+  const embedType = useMemo(
+    () =>
+      match<SdkIframeEmbedSettings, SdkIframeEmbedSetupType>(settings)
+        .with({ questionId: P.nonNullable }, () => "chart")
+        .with({ template: "exploration" }, () => "exploration")
+        .otherwise(() => "dashboard"),
+    [settings],
+  );
+
+  const updateSettings = (nextSettings: Partial<SdkIframeEmbedSettings>) =>
+    setSettings({
+      ...settings,
+      ...nextSettings,
+    } as SdkIframeEmbedSettings);
+
+  const value: SdkIframeEmbedSetupContextType = {
+    currentStep,
+    setCurrentStep,
+    embedType,
+    settings,
+    setSettings,
+    updateSettings,
+  };
+
+  return (
+    <SdkIframeEmbedSetupContext.Provider value={value}>
+      {children}
+    </SdkIframeEmbedSetupContext.Provider>
+  );
+};
+
+export const useSdkIframeEmbedSetupContext = () => {
+  const context = useContext(SdkIframeEmbedSetupContext);
+
+  if (!context) {
+    throw new Error(
+      "useSdkIframeEmbedSetupContext must be used within a SdkIframeEmbedSetupProvider",
+    );
+  }
+
+  return context;
+};

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupContext.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupContext.tsx
@@ -1,32 +1,17 @@
-import {
-  type ReactNode,
-  createContext,
-  useContext,
-  useMemo,
-  useState,
-} from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { P, match } from "ts-pattern";
 
 import { useSetting } from "metabase/common/hooks";
 import type { SdkIframeEmbedSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
 
+import {
+  SdkIframeEmbedSetupContext,
+  type SdkIframeEmbedSetupContextType,
+} from "../context";
 import type {
   SdkIframeEmbedSetupStep,
   SdkIframeEmbedSetupType,
 } from "../types";
-
-interface SdkIframeEmbedSetupContextType {
-  currentStep: SdkIframeEmbedSetupStep;
-  setCurrentStep: (step: SdkIframeEmbedSetupStep) => void;
-
-  embedType: SdkIframeEmbedSetupType;
-  settings: SdkIframeEmbedSettings;
-  setSettings: (settings: SdkIframeEmbedSettings) => void;
-  updateSettings: (nextSettings: Partial<SdkIframeEmbedSettings>) => void;
-}
-
-const SdkIframeEmbedSetupContext =
-  createContext<SdkIframeEmbedSetupContextType | null>(null);
 
 interface SdkIframeEmbedSetupProviderProps {
   children: ReactNode;
@@ -75,16 +60,4 @@ export const SdkIframeEmbedSetupProvider = ({
       {children}
     </SdkIframeEmbedSetupContext.Provider>
   );
-};
-
-export const useSdkIframeEmbedSetupContext = () => {
-  const context = useContext(SdkIframeEmbedSetupContext);
-
-  if (!context) {
-    throw new Error(
-      "useSdkIframeEmbedSetupContext must be used within a SdkIframeEmbedSetupProvider",
-    );
-  }
-
-  return context;
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -43,10 +43,13 @@ export const SdkIframeEmbedSetupProvider = ({
   );
 
   const updateSettings = (nextSettings: Partial<SdkIframeEmbedSettings>) =>
-    setSettings({
-      ...settings,
-      ...nextSettings,
-    } as SdkIframeEmbedSettings);
+    setSettings(
+      (prevSettings) =>
+        ({
+          ...prevSettings,
+          ...nextSettings,
+        }) as SdkIframeEmbedSettings,
+    );
 
   const value: SdkIframeEmbedSetupContextType = {
     currentStep,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -32,7 +32,8 @@ export const SdkIframeEmbedSetupProvider = ({
     dashboardId: 1,
   });
 
-  const embedType = useMemo(
+  // Which embed experience are we setting up?
+  const experience = useMemo(
     () =>
       match<SdkIframeEmbedSettings, SdkIframeEmbedSetupExperience>(settings)
         .with({ questionId: P.nonNullable }, () => "chart")
@@ -50,7 +51,7 @@ export const SdkIframeEmbedSetupProvider = ({
   const value: SdkIframeEmbedSetupContextType = {
     currentStep,
     setCurrentStep,
-    embedType,
+    experience,
     settings,
     setSettings,
     updateSettings,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -9,8 +9,8 @@ import {
   type SdkIframeEmbedSetupContextType,
 } from "../context";
 import type {
+  SdkIframeEmbedSetupExperience,
   SdkIframeEmbedSetupStep,
-  SdkIframeEmbedSetupType,
 } from "../types";
 
 interface SdkIframeEmbedSetupProviderProps {
@@ -20,20 +20,21 @@ interface SdkIframeEmbedSetupProviderProps {
 export const SdkIframeEmbedSetupProvider = ({
   children,
 }: SdkIframeEmbedSetupProviderProps) => {
-  const [currentStep, setCurrentStep] =
-    useState<SdkIframeEmbedSetupStep>("select-embed-type");
+  const [currentStep, setCurrentStep] = useState<SdkIframeEmbedSetupStep>(
+    "select-embed-experience",
+  );
 
   const instanceUrl = useSetting("site-url");
 
   const [settings, setSettings] = useState<SdkIframeEmbedSettings>({
     apiKey: "",
-    dashboardId: 1,
     instanceUrl,
+    dashboardId: 1,
   });
 
   const embedType = useMemo(
     () =>
-      match<SdkIframeEmbedSettings, SdkIframeEmbedSetupType>(settings)
+      match<SdkIframeEmbedSettings, SdkIframeEmbedSetupExperience>(settings)
         .with({ questionId: P.nonNullable }, () => "chart")
         .with({ template: "exploration" }, () => "exploration")
         .otherwise(() => "dashboard"),

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
@@ -23,11 +23,6 @@ export const SelectEmbedExperienceStep = () => {
     const defaultEntityId = 1;
 
     setSettings({
-      // clear other entity types
-      template: undefined,
-      questionId: undefined,
-      dashboardId: undefined,
-
       // these settings do not change when the embed type changes
       ...persistedSettings,
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
@@ -4,15 +4,15 @@ import _ from "underscore";
 import { Card, Radio, Stack, Text } from "metabase/ui";
 import type { SdkIframeEmbedSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
 
-import { EMBED_TYPES } from "../constants";
+import { EMBED_EXPERIENCES } from "../constants";
 import { useSdkIframeEmbedSetupContext } from "../context";
-import type { SdkIframeEmbedSetupType } from "../types";
+import type { SdkIframeEmbedSetupExperience } from "../types";
 import { getDefaultSdkIframeEmbedSettings } from "../utils/default-embed-setting";
 
-export const SelectEmbedTypeStep = () => {
+export const SelectEmbedExperienceStep = () => {
   const { embedType, settings, setSettings } = useSdkIframeEmbedSetupContext();
 
-  const handleEmbedTypeChange = (type: SdkIframeEmbedSetupType) => {
+  const handleEmbedExperienceChange = (type: SdkIframeEmbedSetupExperience) => {
     const persistedSettings = _.pick(settings, [
       "theme",
       "instanceUrl",
@@ -45,11 +45,11 @@ export const SelectEmbedTypeStep = () => {
       <Radio.Group
         value={embedType}
         onChange={(value) =>
-          handleEmbedTypeChange(value as SdkIframeEmbedSetupType)
+          handleEmbedExperienceChange(value as SdkIframeEmbedSetupExperience)
         }
       >
         <Stack gap="md">
-          {EMBED_TYPES.map((type) => (
+          {EMBED_EXPERIENCES.map((type) => (
             <Radio
               key={type.value}
               value={type.value}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
@@ -10,7 +10,7 @@ import type { SdkIframeEmbedSetupExperience } from "../types";
 import { getDefaultSdkIframeEmbedSettings } from "../utils/default-embed-setting";
 
 export const SelectEmbedExperienceStep = () => {
-  const { embedType, settings, setSettings } = useSdkIframeEmbedSetupContext();
+  const { experience, settings, setSettings } = useSdkIframeEmbedSetupContext();
 
   const handleEmbedExperienceChange = (type: SdkIframeEmbedSetupExperience) => {
     const persistedSettings = _.pick(settings, [
@@ -43,7 +43,7 @@ export const SelectEmbedExperienceStep = () => {
       </Text>
 
       <Radio.Group
-        value={embedType}
+        value={experience}
         onChange={(value) =>
           handleEmbedExperienceChange(value as SdkIframeEmbedSetupExperience)
         }

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
@@ -12,7 +12,9 @@ import { getDefaultSdkIframeEmbedSettings } from "../utils/default-embed-setting
 export const SelectEmbedExperienceStep = () => {
   const { experience, settings, setSettings } = useSdkIframeEmbedSetupContext();
 
-  const handleEmbedExperienceChange = (type: SdkIframeEmbedSetupExperience) => {
+  const handleEmbedExperienceChange = (
+    experience: SdkIframeEmbedSetupExperience,
+  ) => {
     const persistedSettings = _.pick(settings, [
       "theme",
       "instanceUrl",
@@ -27,7 +29,7 @@ export const SelectEmbedExperienceStep = () => {
       ...persistedSettings,
 
       // these settings are overridden when the embed type changes
-      ...getDefaultSdkIframeEmbedSettings(type, defaultEntityId),
+      ...getDefaultSdkIframeEmbedSettings(experience, defaultEntityId),
     } as SdkIframeEmbedSettings);
   };
 
@@ -39,17 +41,19 @@ export const SelectEmbedExperienceStep = () => {
 
       <Radio.Group
         value={experience}
-        onChange={(value) =>
-          handleEmbedExperienceChange(value as SdkIframeEmbedSetupExperience)
+        onChange={(experience) =>
+          handleEmbedExperienceChange(
+            experience as SdkIframeEmbedSetupExperience,
+          )
         }
       >
         <Stack gap="md">
-          {EMBED_EXPERIENCES.map((type) => (
+          {EMBED_EXPERIENCES.map((experience) => (
             <Radio
-              key={type.value}
-              value={type.value}
-              label={type.title}
-              description={type.description}
+              key={experience.value}
+              value={experience.value}
+              label={experience.title}
+              description={experience.description}
             />
           ))}
         </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedTypeStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedTypeStep.tsx
@@ -5,10 +5,9 @@ import { Card, Radio, Stack, Text } from "metabase/ui";
 import type { SdkIframeEmbedSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
 
 import { EMBED_TYPES } from "../constants";
+import { useSdkIframeEmbedSetupContext } from "../context";
 import type { SdkIframeEmbedSetupType } from "../types";
 import { getDefaultSdkIframeEmbedSettings } from "../utils/default-embed-setting";
-
-import { useSdkIframeEmbedSetupContext } from "./SdkIframeEmbedSetupContext";
 
 export const SelectEmbedTypeStep = () => {
   const { embedType, settings, setSettings } = useSdkIframeEmbedSetupContext();

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedTypeStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedTypeStep.tsx
@@ -1,0 +1,65 @@
+import { t } from "ttag";
+import _ from "underscore";
+
+import { Card, Radio, Stack, Text } from "metabase/ui";
+import type { SdkIframeEmbedSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
+
+import { EMBED_TYPES } from "../constants";
+import type { SdkIframeEmbedSetupType } from "../types";
+import { getDefaultSdkIframeEmbedSettings } from "../utils/default-embed-setting";
+
+import { useSdkIframeEmbedSetupContext } from "./SdkIframeEmbedSetupContext";
+
+export const SelectEmbedTypeStep = () => {
+  const { embedType, settings, setSettings } = useSdkIframeEmbedSetupContext();
+
+  const handleEmbedTypeChange = (type: SdkIframeEmbedSetupType) => {
+    const persistedSettings = _.pick(settings, [
+      "theme",
+      "instanceUrl",
+      "apiKey",
+    ]);
+
+    // TODO(EMB-508): use the most recent question or dashboard.
+    const defaultEntityId = 1;
+
+    setSettings({
+      // clear other entity types
+      template: undefined,
+      questionId: undefined,
+      dashboardId: undefined,
+
+      // these settings do not change when the embed type changes
+      ...persistedSettings,
+
+      // these settings are overridden when the embed type changes
+      ...getDefaultSdkIframeEmbedSettings(type, defaultEntityId),
+    } as SdkIframeEmbedSettings);
+  };
+
+  return (
+    <Card p="md" mb="md">
+      <Text size="lg" fw="bold" mb="md">
+        {t`Select your embed experience`}
+      </Text>
+
+      <Radio.Group
+        value={embedType}
+        onChange={(value) =>
+          handleEmbedTypeChange(value as SdkIframeEmbedSetupType)
+        }
+      >
+        <Stack gap="md">
+          {EMBED_TYPES.map((type) => (
+            <Radio
+              key={type.value}
+              value={type.value}
+              label={type.title}
+              description={type.description}
+            />
+          ))}
+        </Stack>
+      </Radio.Group>
+    </Card>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
@@ -1,4 +1,5 @@
-import type { SdkIframeEmbedSetupType } from "./types";
+import { SelectEmbedTypeStep } from "./components/SelectEmbedTypeStep";
+import type { SdkIframeEmbedSetupStep, SdkIframeEmbedSetupType } from "./types";
 
 export const EMBED_TYPES = [
   {
@@ -15,5 +16,29 @@ export const EMBED_TYPES = [
     value: "exploration" as SdkIframeEmbedSetupType,
     title: "Exploration",
     description: "Embed an interactive data exploration experience",
+  },
+];
+
+export const EMBED_STEPS: Array<{
+  id: SdkIframeEmbedSetupStep;
+  component: React.ComponentType;
+  skipFor?: SdkIframeEmbedSetupType[];
+}> = [
+  {
+    id: "select-embed-type",
+    component: SelectEmbedTypeStep,
+  },
+  {
+    id: "select-entity",
+    component: () => null,
+    skipFor: ["exploration"],
+  },
+  {
+    id: "configure",
+    component: () => null,
+  },
+  {
+    id: "get-code",
+    component: () => null,
   },
 ];

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
@@ -30,15 +30,15 @@ export const EMBED_STEPS: Array<{
   },
   {
     id: "select-entity",
-    component: () => null,
+    component: () => "select entity placeholder",
     skipFor: ["exploration"],
   },
   {
     id: "configure",
-    component: () => null,
+    component: () => "configure placeholder",
   },
   {
     id: "get-code",
-    component: () => null,
+    component: () => "get code placeholder",
   },
 ];

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
@@ -1,19 +1,22 @@
-import { SelectEmbedTypeStep } from "./components/SelectEmbedTypeStep";
-import type { SdkIframeEmbedSetupStep, SdkIframeEmbedSetupType } from "./types";
+import { SelectEmbedExperienceStep } from "./components/SelectEmbedExperienceStep";
+import type {
+  SdkIframeEmbedSetupExperience,
+  SdkIframeEmbedSetupStep,
+} from "./types";
 
-export const EMBED_TYPES = [
+export const EMBED_EXPERIENCES = [
   {
-    value: "dashboard" as SdkIframeEmbedSetupType,
+    value: "dashboard" as SdkIframeEmbedSetupExperience,
     title: "Dashboard",
     description: "Embed an entire dashboard with multiple charts and filters",
   },
   {
-    value: "chart" as SdkIframeEmbedSetupType,
+    value: "chart" as SdkIframeEmbedSetupExperience,
     title: "Chart",
     description: "Embed a single chart or visualization",
   },
   {
-    value: "exploration" as SdkIframeEmbedSetupType,
+    value: "exploration" as SdkIframeEmbedSetupExperience,
     title: "Exploration",
     description: "Embed an interactive data exploration experience",
   },
@@ -22,22 +25,22 @@ export const EMBED_TYPES = [
 type EmbedStepConfig = {
   id: SdkIframeEmbedSetupStep;
   component: React.ComponentType;
-  skipFor?: SdkIframeEmbedSetupType[];
+  skipFor?: SdkIframeEmbedSetupExperience[];
 };
 
 export const EMBED_STEPS: EmbedStepConfig[] = [
   {
-    id: "select-embed-type",
-    component: SelectEmbedTypeStep,
+    id: "select-embed-experience",
+    component: SelectEmbedExperienceStep,
   },
   {
-    id: "select-entity",
+    id: "select-embed-entity",
     component: () => "select entity placeholder",
     skipFor: ["exploration"],
   },
   {
-    id: "configure",
-    component: () => "configure placeholder",
+    id: "select-embed-options",
+    component: () => "select embed options placeholder",
   },
   {
     id: "get-code",

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
@@ -19,11 +19,13 @@ export const EMBED_TYPES = [
   },
 ];
 
-export const EMBED_STEPS: Array<{
+type EmbedStepConfig = {
   id: SdkIframeEmbedSetupStep;
   component: React.ComponentType;
   skipFor?: SdkIframeEmbedSetupType[];
-}> = [
+};
+
+export const EMBED_STEPS: EmbedStepConfig[] = [
   {
     id: "select-embed-type",
     component: SelectEmbedTypeStep,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
@@ -1,0 +1,19 @@
+import type { SdkIframeEmbedSetupType } from "./types";
+
+export const EMBED_TYPES = [
+  {
+    value: "dashboard" as SdkIframeEmbedSetupType,
+    title: "Dashboard",
+    description: "Embed an entire dashboard with multiple charts and filters",
+  },
+  {
+    value: "chart" as SdkIframeEmbedSetupType,
+    title: "Chart",
+    description: "Embed a single chart or visualization",
+  },
+  {
+    value: "exploration" as SdkIframeEmbedSetupType,
+    title: "Exploration",
+    description: "Embed an interactive data exploration experience",
+  },
+];

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/context.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/context.ts
@@ -2,13 +2,16 @@ import { createContext, useContext } from "react";
 
 import type { SdkIframeEmbedSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
 
-import type { SdkIframeEmbedSetupStep, SdkIframeEmbedSetupType } from "./types";
+import type {
+  SdkIframeEmbedSetupExperience,
+  SdkIframeEmbedSetupStep,
+} from "./types";
 
 export interface SdkIframeEmbedSetupContextType {
   currentStep: SdkIframeEmbedSetupStep;
   setCurrentStep: (step: SdkIframeEmbedSetupStep) => void;
 
-  embedType: SdkIframeEmbedSetupType;
+  embedType: SdkIframeEmbedSetupExperience;
   settings: SdkIframeEmbedSettings;
   setSettings: (settings: SdkIframeEmbedSettings) => void;
   updateSettings: (nextSettings: Partial<SdkIframeEmbedSettings>) => void;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/context.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/context.ts
@@ -11,7 +11,7 @@ export interface SdkIframeEmbedSetupContextType {
   currentStep: SdkIframeEmbedSetupStep;
   setCurrentStep: (step: SdkIframeEmbedSetupStep) => void;
 
-  embedType: SdkIframeEmbedSetupExperience;
+  experience: SdkIframeEmbedSetupExperience;
   settings: SdkIframeEmbedSettings;
   setSettings: (settings: SdkIframeEmbedSettings) => void;
   updateSettings: (nextSettings: Partial<SdkIframeEmbedSettings>) => void;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/context.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/context.ts
@@ -1,0 +1,30 @@
+import { createContext, useContext } from "react";
+
+import type { SdkIframeEmbedSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
+
+import type { SdkIframeEmbedSetupStep, SdkIframeEmbedSetupType } from "./types";
+
+export interface SdkIframeEmbedSetupContextType {
+  currentStep: SdkIframeEmbedSetupStep;
+  setCurrentStep: (step: SdkIframeEmbedSetupStep) => void;
+
+  embedType: SdkIframeEmbedSetupType;
+  settings: SdkIframeEmbedSettings;
+  setSettings: (settings: SdkIframeEmbedSettings) => void;
+  updateSettings: (nextSettings: Partial<SdkIframeEmbedSettings>) => void;
+}
+
+export const SdkIframeEmbedSetupContext =
+  createContext<SdkIframeEmbedSetupContextType | null>(null);
+
+export const useSdkIframeEmbedSetupContext = () => {
+  const context = useContext(SdkIframeEmbedSetupContext);
+
+  if (!context) {
+    throw new Error(
+      "useSdkIframeEmbedSetupContext must be used within a SdkIframeEmbedSetupProvider",
+    );
+  }
+
+  return context;
+};

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useSdkIframeEmbedNavigation } from "./use-sdk-iframe-embed-navigation";

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-navigation.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-navigation.ts
@@ -1,0 +1,66 @@
+import { useMemo } from "react";
+
+import { EMBED_STEPS } from "../constants";
+import { useSdkIframeEmbedSetupContext } from "../context";
+
+export function useSdkIframeEmbedNavigation() {
+  const { embedType, currentStep, setCurrentStep } =
+    useSdkIframeEmbedSetupContext();
+
+  const availableSteps = useMemo(() => {
+    // Exclude non-applicable steps for the current embed type
+    return EMBED_STEPS.filter((step) => !step.skipFor?.includes(embedType));
+  }, [embedType]);
+
+  const handleNext = () => {
+    const currentIndex = availableSteps.findIndex(
+      (step) => step.id === currentStep,
+    );
+
+    const nextStep = availableSteps[currentIndex + 1];
+
+    if (nextStep) {
+      setCurrentStep(nextStep.id);
+    }
+  };
+
+  const handleBack = () => {
+    const currentIndex = availableSteps.findIndex(
+      (step) => step.id === currentStep,
+    );
+
+    const prevStep = availableSteps[currentIndex - 1];
+
+    if (prevStep) {
+      setCurrentStep(prevStep.id);
+    }
+  };
+
+  const currentIndex = availableSteps.findIndex(
+    (step) => step.id === currentStep,
+  );
+
+  const canGoNext = currentIndex < availableSteps.length - 1;
+  const canGoBack = currentIndex > 0;
+
+  const isLastStep = currentIndex === availableSteps.length - 1;
+
+  const StepContent = useMemo(
+    () =>
+      EMBED_STEPS.find((step) => step.id === currentStep)?.component ?? noop,
+    [currentStep],
+  );
+
+  return {
+    handleNext,
+    handleBack,
+
+    canGoNext,
+    canGoBack,
+
+    isLastStep,
+    StepContent,
+  };
+}
+
+const noop = () => null;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-navigation.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-navigation.ts
@@ -4,13 +4,13 @@ import { EMBED_STEPS } from "../constants";
 import { useSdkIframeEmbedSetupContext } from "../context";
 
 export function useSdkIframeEmbedNavigation() {
-  const { embedType, currentStep, setCurrentStep } =
+  const { experience, currentStep, setCurrentStep } =
     useSdkIframeEmbedSetupContext();
 
   const availableSteps = useMemo(() => {
     // Exclude non-applicable steps for the current embed type
-    return EMBED_STEPS.filter((step) => !step.skipFor?.includes(embedType));
-  }, [embedType]);
+    return EMBED_STEPS.filter((step) => !step.skipFor?.includes(experience));
+  }, [experience]);
 
   const handleNext = () => {
     const currentIndex = availableSteps.findIndex(

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/index.ts
@@ -1,0 +1,7 @@
+import { PLUGIN_EMBEDDING_IFRAME_SDK_SETUP } from "metabase/plugins";
+
+import { SdkIframeEmbedSetup } from "./components/SdkIframeEmbedSetup";
+
+// Enable the embed setup functionality
+PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.shouldShowEmbedInNewItemMenu = () => true;
+PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.SdkIframeEmbedSetup = SdkIframeEmbedSetup;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/index.ts
@@ -1,7 +1,11 @@
 import { PLUGIN_EMBEDDING_IFRAME_SDK_SETUP } from "metabase/plugins";
+import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { SdkIframeEmbedSetup } from "./components/SdkIframeEmbedSetup";
 
-// Enable the embed setup functionality
-PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.shouldShowEmbedInNewItemMenu = () => true;
-PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.SdkIframeEmbedSetup = SdkIframeEmbedSetup;
+// Feature gate the embed setup for gradual rollouts.
+// In the future, we may drop this to enable users to try out new iframe embedding.
+if (hasPremiumFeature("embedding_iframe_sdk")) {
+  PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.shouldShowEmbedInNewItemMenu = () => true;
+  PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.SdkIframeEmbedSetup = SdkIframeEmbedSetup;
+}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
@@ -1,0 +1,7 @@
+export type SdkIframeEmbedSetupType = "dashboard" | "chart" | "exploration";
+
+export type SdkIframeEmbedSetupStep =
+  | "select-embed-type"
+  | "select-entity"
+  | "configure"
+  | "get-code";

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
@@ -1,7 +1,10 @@
-export type SdkIframeEmbedSetupType = "dashboard" | "chart" | "exploration";
+export type SdkIframeEmbedSetupExperience =
+  | "dashboard"
+  | "chart"
+  | "exploration";
 
 export type SdkIframeEmbedSetupStep =
-  | "select-embed-type"
-  | "select-entity"
-  | "configure"
+  | "select-embed-experience"
+  | "select-embed-entity"
+  | "select-embed-options"
   | "get-code";

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
@@ -1,0 +1,26 @@
+import { match } from "ts-pattern";
+
+import type { SdkIframeEmbedSetupType } from "../types";
+
+export const getDefaultSdkIframeEmbedSettings = (
+  type: SdkIframeEmbedSetupType,
+  defaultEntityId: string | number,
+) =>
+  match(type)
+    .with("dashboard", () => ({
+      dashboardId: defaultEntityId,
+      isDrillThroughEnabled: true,
+      withDownloads: false,
+      withTitle: true,
+    }))
+    .with("chart", () => ({
+      questionId: defaultEntityId,
+      isDrillThroughEnabled: true,
+      withDownloads: false,
+      withTitle: true,
+    }))
+    .with("exploration", () => ({
+      template: "exploration",
+      isSaveEnabled: true,
+    }))
+    .exhaustive();

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
@@ -1,9 +1,9 @@
 import { match } from "ts-pattern";
 
-import type { SdkIframeEmbedSetupType } from "../types";
+import type { SdkIframeEmbedSetupExperience } from "../types";
 
 export const getDefaultSdkIframeEmbedSettings = (
-  type: SdkIframeEmbedSetupType,
+  type: SdkIframeEmbedSetupExperience,
   defaultEntityId: string | number,
 ) =>
   match(type)

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -18,6 +18,7 @@ import "./database_routing";
 import "./whitelabel";
 import "./embedding";
 import "./embedding-sdk";
+import "./embedding_iframe_sdk_setup";
 import "./snippets";
 import "./sharing";
 import "./moderation";

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.enterprise.unit.spec.tsx
@@ -1,0 +1,39 @@
+import userEvent from "@testing-library/user-event";
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupDatabasesEndpoints } from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { Database } from "metabase-types/api";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import NewItemMenu from "./NewItemMenu";
+
+console.warn = jest.fn();
+console.error = jest.fn();
+
+type SetupOpts = {
+  databases?: Database[];
+  hasModels?: boolean;
+};
+
+const SAMPLE_DATABASE = createSampleDatabase();
+
+async function setup({ databases = [SAMPLE_DATABASE] }: SetupOpts = {}) {
+  setupDatabasesEndpoints(databases);
+  setupEnterprisePlugins();
+
+  renderWithProviders(<NewItemMenu trigger={<button>New</button>} />);
+
+  await userEvent.click(screen.getByText("New"));
+}
+
+describe("NewItemMenu (EE without token)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not show the Embed item when the feature token is missing", async () => {
+    setup();
+    await expect(screen.queryByText("Embed")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.enterprise.unit.spec.tsx
@@ -8,9 +8,6 @@ import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 import NewItemMenu from "./NewItemMenu";
 
-console.warn = jest.fn();
-console.error = jest.fn();
-
 type SetupOpts = {
   databases?: Database[];
   hasModels?: boolean;
@@ -28,6 +25,11 @@ async function setup({ databases = [SAMPLE_DATABASE] }: SetupOpts = {}) {
 }
 
 describe("NewItemMenu (EE without token)", () => {
+  beforeEach(() => {
+    console.warn = jest.fn();
+    console.error = jest.fn();
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
@@ -11,9 +11,6 @@ import { createMockState } from "metabase-types/store/mocks";
 
 import NewItemMenu from "./NewItemMenu";
 
-console.warn = jest.fn();
-console.error = jest.fn();
-
 type SetupOpts = {
   databases?: Database[];
   hasModels?: boolean;
@@ -41,6 +38,11 @@ async function setup({
 }
 
 describe("NewItemMenu (EE with token)", () => {
+  beforeEach(() => {
+    console.warn = jest.fn();
+    console.error = jest.fn();
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
@@ -1,0 +1,53 @@
+import userEvent from "@testing-library/user-event";
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupDatabasesEndpoints } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { Database, TokenFeatures } from "metabase-types/api";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import { createMockState } from "metabase-types/store/mocks";
+
+import NewItemMenu from "./NewItemMenu";
+
+console.warn = jest.fn();
+console.error = jest.fn();
+
+type SetupOpts = {
+  databases?: Database[];
+  hasModels?: boolean;
+  tokenFeatures?: Partial<TokenFeatures>;
+};
+
+const SAMPLE_DATABASE = createSampleDatabase();
+
+async function setup({
+  databases = [SAMPLE_DATABASE],
+  tokenFeatures,
+}: SetupOpts = {}) {
+  const settings = mockSettings({
+    "token-features": createMockTokenFeatures(tokenFeatures),
+  });
+
+  setupDatabasesEndpoints(databases);
+  setupEnterprisePlugins();
+
+  renderWithProviders(<NewItemMenu trigger={<button>New</button>} />, {
+    storeInitialState: createMockState({ settings }),
+  });
+
+  await userEvent.click(screen.getByText("New"));
+}
+
+describe("NewItemMenu (EE with token)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows the Embed item when embedding_iframe_sdk feature is enabled", async () => {
+    setup({ tokenFeatures: { embedding_iframe_sdk: true } });
+
+    expect(await screen.findByText("Embed")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
@@ -6,6 +6,7 @@ import { t } from "ttag";
 import EntityMenu from "metabase/common/components/EntityMenu";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { PLUGIN_EMBEDDING_IFRAME_SDK_SETUP } from "metabase/plugins";
 import { setOpenModal } from "metabase/redux/ui";
 import { getSetting } from "metabase/selectors/settings";
 import type { CollectionId } from "metabase-types/api";
@@ -93,6 +94,15 @@ const NewItemMenuView = ({
         dispatch(setOpenModal("dashboard"));
       },
     });
+
+    if (PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.shouldShowEmbedInNewItemMenu()) {
+      items.push({
+        title: t`Embed`,
+        icon: "embed",
+        link: "/embed/new",
+        onClose: onCloseNavbar,
+      });
+    }
 
     return items;
   }, [

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
@@ -95,6 +95,7 @@ const NewItemMenuView = ({
       },
     });
 
+    // This is a non-standard way of feature gating, akin to using hasPremiumFeature. Do not do this for more complex setups.
     if (PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.shouldShowEmbedInNewItemMenu()) {
       items.push({
         title: t`Embed`,

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -117,9 +117,9 @@ describe("nav > containers > Navbar > Core App", () => {
     expect(screen.queryByTestId("main-navbar-root")).not.toBeInTheDocument();
   });
 
-  ["question", "model", "dashboard"].forEach((pathname) => {
+  ["question/1", "model/1", "dashboard/1", "embed/new"].forEach((pathname) => {
     it(`should be hidden on initial load for a ${pathname}`, async () => {
-      await setup({ pathname: `/${pathname}/1` });
+      await setup({ pathname: `/${pathname}` });
       await expectNavbarClosed();
     });
   });

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -547,6 +547,11 @@ export const PLUGIN_EMBEDDING_IFRAME_SDK = {
   SdkIframeEmbedRoute: (): ReactNode => null,
 };
 
+export const PLUGIN_EMBEDDING_IFRAME_SDK_SETUP = {
+  shouldShowEmbedInNewItemMenu: () => false,
+  SdkIframeEmbedSetup: (): ReactNode => null,
+};
+
 export const PLUGIN_CONTENT_VERIFICATION = {
   contentVerificationEnabled: false,
   VerifiedFilter: {} as SearchFilterComponent<"verified">,

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -75,7 +75,8 @@ const errorPage = handleActions(
 
 // regexr.com/7r89i
 // A word boundary is added to /model so it doesn't match /browse/models
-const PATH_WITH_COLLAPSED_NAVBAR = /\/(model\b|question|dashboard|metabot).*/;
+const PATH_WITH_COLLAPSED_NAVBAR =
+  /\/(model\b|question|dashboard|metabot|embed).*/;
 
 export function isNavbarOpenForPathname(pathname: string, prevState: boolean) {
   return (

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -39,6 +39,7 @@ import NewModelOptions from "metabase/models/containers/NewModelOptions";
 import { getRoutes as getModelRoutes } from "metabase/models/routes";
 import {
   PLUGIN_COLLECTIONS,
+  PLUGIN_EMBEDDING_IFRAME_SDK_SETUP,
   PLUGIN_LANDING_PAGE,
   PLUGIN_METABOT,
 } from "metabase/plugins";
@@ -175,6 +176,11 @@ export const getRoutes = (store) => {
             path="trash"
             title={t`Trash`}
             component={TrashCollectionLanding}
+          />
+
+          <Route
+            path="embed/new"
+            component={PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.SdkIframeEmbedSetup}
           />
 
           <Route

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -93,6 +93,8 @@
      (route/not-found {:status 404, :body "Not found."}))
    ;; ^/public/ -> Public frontend and download routes
    (context "/public" [] public-routes)
+   ;; ^/embed/new -> Iframe embedding setup route
+   (GET "/embed/new" [] index/index)
    ;; ^/emebed/ -> Embed frontend and download routes
    (context "/embed" [] embed-routes)
    ;; Anything else (e.g. /user/edit_current) should serve up index.html; React app will handle the rest


### PR DESCRIPTION
Closes EMB-505

Scaffolds the foundation for the new iframe embedding's embed setup flow.

- Adds the new embed button on the "+ New" button. This is only shown when the feature token `embedding_iframe_sdk` is enabled.
- Adds the `/embed/new` page. This will show a blank page if the feature token is disabled, or if you are in OSS.
- Adds the first step to select the embed type (question, chart, exploration)
- Adds ability to navigate between steps (next and back), as well as to skip the embed options step when the "exploration" template is enabled.

See [the tech doc](https://www.notion.so/metabase/Tech-Embed-flow-for-new-iframe-embedding-1ff69354c90180049990fae0555a36a3?source=copy_link) for how this fits into the whole picture.

# How to test

- Make sure your current feature token has the `embedding_iframe_sdk` feature flag. If you are using the standard dev tokens, you should already have this feature on!
- Click on "+ New"
- You should now see a shiny new "Embed" button
- You should be able to navigate between embed steps, i.e. go back and go forward.

See the unit test section in [the testing plan in Notion](https://www.notion.so/metabase/Testing-Plan-Embed-flow-for-new-iframe-embedding-21569354c90180d18ca1f457b10de0ab?source=copy_link). These also also covered by unit tests, of course:

- You should be able to navigate between embed steps, i.e. go back and go forward.
- Clicking “Next” on the exploration template should go into the embed options step, and does not go into the select entity step.
- Step 1: Menu Item
    - It does not show the “Embed” menu item on the “+ New” button when in OSS
    - It does not show the “Embed” menu item on the “+ New” button when in EE without a valid token
    - It only shows the “Embed” menu item on the “+ New” button when in EE with a valid token
        - Clicking on “Embed” takes us to Step 1, select embed experience.

# Notes

I'll add an e2e test for showing a blank page when you visit `/embed/new` without feature token in the next PR. The reason is that I want this PR to be unit test only.

# Demo

![CleanShot 2568-06-19 at 23 42 50@2x](https://github.com/user-attachments/assets/3efc71f1-7fa8-40f0-b0dd-8f979d46139a)
