### PR TITLE
Disable database routing for clickhouse

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1593,6 +1593,7 @@
    :uses #{api
            config
            database-routing
+           driver
            events
            lib
            models

--- a/enterprise/backend/src/metabase_enterprise/database_routing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/api.clj
@@ -3,6 +3,7 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
+   [metabase.driver.util :as driver.u]
    [metabase.events.core :as events]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
@@ -72,6 +73,9 @@
 (defn- create-or-update-router!
   [db-id user-attribute]
   (let [db (t2/select-one :model/Database db-id)]
+    (when-not (driver.u/supports? (:engine db) :database-routing db)
+      (throw (ex-info "This database does not support DB routing" {:status-code 400})))
+
     (events/publish-event! :event/database-update {:object db
                                                    :previous-object db
                                                    :user-id api/*current-user-id*

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -53,7 +53,8 @@
                               :left-join                       (not driver-api/is-test?)
                               :describe-fks                    false
                               :actions                         false
-                              :metadata/key-constraints        (not driver-api/is-test?)}]
+                              :metadata/key-constraints        (not driver-api/is-test?)
+                              :database-routing                false}]
   (defmethod driver/database-supports? [:clickhouse feature] [_driver _feature _db] supported?))
 
 (def ^:private default-connection-details

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -49,7 +49,8 @@
                               :multi-level-schema              true
                               :set-timezone                    true
                               :standard-deviation-aggregations true
-                              :test/jvm-timezone-setting       false}]
+                              :test/jvm-timezone-setting       false
+                              :database-routing                true}]
   (defmethod driver/database-supports? [:databricks feature] [_driver _feature _db] supported?))
 
 (defmethod sql-jdbc.sync/database-type->base-type :databricks

--- a/modules/drivers/druid/src/metabase/driver/druid.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid.clj
@@ -18,7 +18,8 @@
                               :expression-literals            true
                               :schemas                        false
                               :set-timezone                   true
-                              :temporal/requires-default-unit true}]
+                              :temporal/requires-default-unit true
+                              :database-routing               true}]
   (defmethod driver/database-supports? [:druid feature] [_driver _feature _db] supported?))
 
 (defmethod driver/can-connect? :druid

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -419,7 +419,8 @@
                               :expressions/text                true
                               :expressions/datetime            true
                               ;; Index sync is turned off across the application as it is not used ATM.
-                              :index-info                      false}]
+                              :index-info                      false
+                              :database-routing                true}]
   (defmethod driver/database-supports? [:mongo feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:mongo :schemas] [_driver _feat _db] false)

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -43,7 +43,8 @@
                               ;; we have this 'feature' so the frontend doesn't try to present the option to you.
                               :case-sensitivity-string-filter-options false
                               ;; Index sync is turned off across the application as it is not used ATM.
-                              :index-info                             false}]
+                              :index-info                             false
+                              :database-routing                       true}]
   (defmethod driver/database-supports? [:sqlite feature] [_driver _feature _db] supported?))
 
 ;; Every SQLite3 file starts with "SQLite Format 3"

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -705,7 +705,10 @@
     :test/cannot-destroy-db
 
     ;; There are drivers that support uuids in queries, but not in create table as eg. Athena.
-    :test/uuids-in-create-table-statements})
+    :test/uuids-in-create-table-statements
+
+    ;; Does this driver support Metabase's database routing feature?
+    :database-routing})
 
 (defmulti database-supports?
   "Does this driver and specific instance of a database support a certain `feature`?

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -68,7 +68,8 @@
                               :regex                     true
                               :test/jvm-timezone-setting false
                               :uuid-type                 true
-                              :uploads                   true}]
+                              :uploads                   true
+                              :database-routing          true}]
   (defmethod driver/database-supports? [:h2 feature]
     [_driver _feature _database]
     supported?))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -86,7 +86,8 @@
                               ;; fully support `offset` we need to do some kooky query transformations just for MySQL
                               ;; and make this work.
                               :window-functions/offset                false
-                              :expression-literals                    true}]
+                              :expression-literals                    true
+                              :database-routing                       true}]
   (defmethod driver/database-supports? [:mysql feature] [_driver _feature _db] supported?))
 
 ;; This is a bit of a lie since the JSON type was introduced for MySQL since 5.7.8.

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -75,7 +75,8 @@
                               :expressions/text         true
                               :expressions/integer      true
                               :expressions/float        true
-                              :expressions/date         true}]
+                              :expressions/date         true
+                              :database-routing         true}]
   (defmethod driver/database-supports? [:postgres feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:postgres :nested-field-columns]

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -39,7 +39,8 @@
                  :expressions/datetime
                  :expressions/date
                  :expressions/text
-                 :distinct-where]]
+                 :distinct-where
+                 :database-routing]]
   (defmethod driver/database-supports? [:sql feature] [_driver _feature _db] true))
 
 (defmethod driver/database-supports? [:sql :persist-models-enabled]


### PR DESCRIPTION
Clickhouse's databases are more like schemas, and Database Routing is not working correctly.

For now, let's disable Database Routing for Clickhouse. In a followup PR I'll write tests for other drivers to make sure DB routing is working for them, if not we can disable them as well.

Fixes [ADM-1006: Block creation of DB routers for clickhouse](https://linear.app/metabase/issue/ADM-1006/block-creation-of-db-routers-for-clickhouse)