### PR TITLE
Improve Admin Nav Spacing + Active Behavior

### DIFF
--- a/frontend/src/metabase/admin/settings/components/AdminNav/AdminNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/AdminNav/AdminNav.tsx
@@ -21,7 +21,7 @@ export const AdminNavWrapper = ({
   return (
     <Stack
       w="16rem"
-      gap="xs"
+      gap={0}
       bg="white"
       p="md"
       h="100%"
@@ -55,6 +55,7 @@ export function AdminNavItem({
       active={path === subpath}
       variant="admin-nav"
       label={label}
+      mb="xs"
       {...(icon ? { leftSection: <Icon name={icon} /> } : undefined)}
       {...navLinkProps}
     />

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -2,7 +2,7 @@ import { t } from "ttag";
 
 import { UpsellGem } from "metabase/admin/upsells/components/UpsellGem";
 import { useHasTokenFeature } from "metabase/common/hooks";
-import { Divider, Flex, Text } from "metabase/ui";
+import { Divider, Flex } from "metabase/ui";
 
 import {
   AdminNavItem,
@@ -25,11 +25,7 @@ export function SettingsNav() {
   return (
     <AdminNavWrapper>
       <SettingsNavItem path="general" label={t`General`} icon="gear" />
-      <SettingsNavItem
-        path="authentication"
-        label={t`Authentication`}
-        icon="lock"
-      >
+      <SettingsNavItem label={t`Authentication`} path="auth" icon="lock">
         <SettingsNavItem path="authentication" label={t`Overview`} />
         {hasScim && (
           <SettingsNavItem
@@ -62,7 +58,7 @@ export function SettingsNav() {
         path="whitelabel"
         label={
           <Flex gap="sm" align="center">
-            <Text>{t`Appearance`}</Text>
+            <span>{t`Appearance`}</span>
             {!hasWhitelabel && <UpsellGem />}
           </Flex>
         }
@@ -115,7 +111,7 @@ export function SettingsNav() {
         path="cloud"
         label={
           <Flex gap="sm" align="center">
-            <Text>{t`Cloud`}</Text>
+            <span>{t`Cloud`}</span>
             {!hasHosting && <UpsellGem />}
           </Flex>
         }

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -131,7 +131,7 @@ const hasActiveChild = (children: ReactElement[], pathname: string) =>
     (child) => child?.props?.path && pathname.includes(child.props.path),
   );
 
-function SettingsNavItem({ path, ...navItemProps }: AdminNavItemProps) {
+export function SettingsNavItem({ path, ...navItemProps }: AdminNavItemProps) {
   const children = React.Children.toArray(
     navItemProps.children,
   ) as ReactElement[];

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.unit.spec.tsx
@@ -1,0 +1,94 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockLocation,
+  createMockRoutingState,
+} from "metabase-types/store/mocks";
+
+import { SettingsNav } from "./SettingsNav";
+
+const setup = async ({ initialRoute }: { initialRoute: string }) => {
+  renderWithProviders(<Route path="*" component={SettingsNav} />, {
+    withRouter: true,
+    initialRoute,
+    storeInitialState: {
+      routing: createMockRoutingState({
+        locationBeforeTransitions: createMockLocation({
+          pathname: initialRoute,
+        }),
+      }),
+    },
+  });
+};
+
+describe("SettingsNav", () => {
+  it("should render the settings nav", async () => {
+    await setup({ initialRoute: "/admin/settings/general" });
+
+    expect(await screen.findByText("General")).toBeInTheDocument();
+    expect(await screen.findByText("Authentication")).toBeInTheDocument();
+  });
+
+  it("should highlight the active nav item", async () => {
+    await setup({ initialRoute: "/admin/settings/general" });
+
+    const generalNavItem = await screen.findByRole("link", { name: /General/ });
+    expect(generalNavItem).toHaveAttribute("data-active", "true");
+
+    const authNavItem = screen.getByText("Authentication");
+    expect(authNavItem).not.toHaveAttribute("data-active");
+  });
+
+  it("should collapse sections by default", async () => {
+    await setup({ initialRoute: "/admin/settings/general" });
+    const authNavItem = screen.getByRole("link", { name: /Authentication/ });
+    expect(authNavItem).not.toHaveAttribute("data-expanded");
+  });
+
+  it("should open a section by default if the page loads on a child route", async () => {
+    await setup({ initialRoute: "/admin/settings/authentication/google" });
+
+    const authNavItem = await screen.findByRole("link", {
+      name: /Authentication/,
+    });
+    expect(authNavItem).toHaveAttribute("data-expanded", "true");
+    const googleAuthItem = await screen.findByRole("link", {
+      name: /Google auth/,
+    });
+    expect(googleAuthItem).toHaveAttribute("data-active", "true");
+  });
+
+  it("should expand and collapse a section", async () => {
+    await setup({ initialRoute: "/admin/settings/general" });
+
+    const authNavItem = await screen.findByRole("link", {
+      name: /Authentication/,
+    });
+
+    expect(authNavItem).not.toHaveAttribute("data-expanded");
+    await userEvent.click(authNavItem); // expand
+    expect(authNavItem).toHaveAttribute("data-expanded", "true");
+    await userEvent.click(authNavItem); // collapse
+    expect(authNavItem).not.toHaveAttribute("data-expanded");
+  });
+
+  it("should highlight a collapsed parent when a child is active", async () => {
+    await setup({ initialRoute: "/admin/settings/authentication/google" });
+
+    const authNavItem = await screen.findByRole("link", {
+      name: /Authentication/,
+    });
+    const googleAuthItem = await screen.findByRole("link", {
+      name: /Google auth/,
+    });
+    expect(authNavItem).toHaveAttribute("data-expanded", "true");
+    expect(authNavItem).not.toHaveAttribute("data-active");
+    expect(googleAuthItem).toHaveAttribute("data-active", "true");
+
+    await userEvent.click(authNavItem);
+    expect(authNavItem).not.toHaveAttribute("data-expanded");
+    expect(authNavItem).toHaveAttribute("data-active", "true");
+  });
+});

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.unit.spec.tsx
@@ -1,7 +1,9 @@
 import userEvent from "@testing-library/user-event";
 import { Route } from "react-router";
 
+import { setupSettingEndpoint } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
+import { createMockVersionInfo } from "metabase-types/api/mocks";
 import {
   createMockLocation,
   createMockRoutingState,
@@ -10,6 +12,11 @@ import {
 import { SettingsNav } from "./SettingsNav";
 
 const setup = async ({ initialRoute }: { initialRoute: string }) => {
+  setupSettingEndpoint({
+    settingKey: "version-info",
+    settingValue: createMockVersionInfo(),
+  });
+
   renderWithProviders(<Route path="*" component={SettingsNav} />, {
     withRouter: true,
     initialRoute,

--- a/frontend/src/metabase/common/components/LeftNavPane/LeftNavPane.jsx
+++ b/frontend/src/metabase/common/components/LeftNavPane/LeftNavPane.jsx
@@ -1,11 +1,13 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
 import { IndexLink, Link } from "react-router";
-import { t } from "ttag";
 
 import AdminS from "metabase/css/admin.module.css";
 import CS from "metabase/css/core/index.css";
 
+/**
+ * @deprecated use frontend/src/metabase/admin/settings/components/AdminNav instead
+ */
 export function LeftNavPaneItem({ name, path, index = false }) {
   const isSelected = path === window.location.pathname;
   return (
@@ -45,26 +47,9 @@ export function LeftNavPaneItem({ name, path, index = false }) {
   );
 }
 
-export function LeftNavPaneItemBack({ path }) {
-  return (
-    <li>
-      <Link
-        to={path}
-        className={cx(
-          AdminS.AdminListItem,
-          CS.flex,
-          CS.alignCenter,
-          CS.textBold,
-          CS.justifyBetween,
-          CS.link,
-        )}
-      >
-        &lt; {t`Back`}
-      </Link>
-    </li>
-  );
-}
-
+/**
+ * @deprecated use frontend/src/metabase/admin/settings/components/AdminNav instead
+ */
 export function LeftNavPane({ children }) {
   return (
     <aside


### PR DESCRIPTION
closes ADM-967 (spacing)
closes ADM-904 (active behavior)

### Description

Consistent spacing between nav elements

Before | After
---|---
 ![Screenshot 2025-06-19 at 2 07 14 PM](https://github.com/user-attachments/assets/84f2fd0c-10e9-4d7b-9950-c4a02776f34c) | ![Screenshot 2025-06-19 at 2 10 00 PM](https://github.com/user-attachments/assets/870bc794-10ff-41af-bbe8-c8e2acea9238)

Consistent Nav Element Sizing

Before | After
---|---
![Screenshot 2025-06-19 at 2 11 25 PM](https://github.com/user-attachments/assets/8c3d732d-5b19-4e37-b597-bdbe4b3c05c9) | ![Screenshot 2025-06-19 at 2 10 48 PM](https://github.com/user-attachments/assets/4316aac5-b9de-42bd-8862-88464350e607)

Parents are now highlighted when a collapsed child is active

Before | After
---|---
![old-collapse](https://github.com/user-attachments/assets/34ac211d-c276-4f62-9478-cb1d602dac4c) | ![new-collapse](https://github.com/user-attachments/assets/f3190136-c759-49d1-a030-bb02e2650309) 


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
