### PR TITLE
Improve custom dashboard error state for settings admins

### DIFF
--- a/frontend/src/metabase/common/components/DashboardSelector/DashboardSelector.tsx
+++ b/frontend/src/metabase/common/components/DashboardSelector/DashboardSelector.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { t } from "ttag";
 
+import { skipToken, useGetDashboardQuery } from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
 import type { DashboardPickerValueItem } from "metabase/common/components/DashboardPicker";
 import { DashboardPickerModal } from "metabase/common/components/DashboardPicker";
-import { useDashboardQuery } from "metabase/common/hooks";
-import { Flex } from "metabase/ui";
+import { Flex, Group, Icon } from "metabase/ui";
 import type { DashboardId } from "metabase-types/api";
 
 import { DashboardPickerButton } from "./DashboardSelector.styled";
@@ -19,16 +20,38 @@ export const DashboardSelector = ({
   value,
 }: DashboardSelectorProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { data: dashboard, isLoading } = useDashboardQuery({ id: value });
+  const {
+    data: dashboard,
+    isLoading,
+    error,
+  } = useGetDashboardQuery(
+    value
+      ? {
+          id: value,
+          ignore_error: true, // don't throw up an error page if the user can't access the dashboard
+        }
+      : skipToken,
+  );
 
   if (isLoading) {
     return (
       <Flex>
-        <DashboardPickerButton>{t`Loading...`}</DashboardPickerButton>
+        <DashboardPickerButton disabled>{t`Loading...`}</DashboardPickerButton>
       </Flex>
     );
   }
 
+  if (error) {
+    return (
+      <Group bg="bg-light" p="1rem">
+        <Icon name="warning" />
+        {t`Error loading dashboard.`}
+        {"  "}
+        {getErrorMessage(error)}
+      </Group>
+    );
+  }
+  ``;
   return (
     <Flex>
       <DashboardPickerButton onClick={() => setIsOpen(true)}>


### PR DESCRIPTION
Closes ADM-926

### Description

If you were a settings admin on an instance that had a custom dashboard homepage set, and you didn't have permission to access that dashboard, and you tried to visit the settings page, the whole page would get blocked. This contains the error to just the part of the UI that would show the dashboard.

Before | After
---|---
![Screenshot 2025-06-19 at 3 16 09 PM](https://github.com/user-attachments/assets/3431b378-55b0-49b4-bbe7-81b5958ea0c8) | ![Screenshot 2025-06-19 at 3 15 38 PM](https://github.com/user-attachments/assets/e4c66204-213d-4a3e-b151-ce50aafabb52)
