### PR TITLE
Reduce setting label size to reduce accidental clicks

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingHeader/SettingHeader.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingHeader/SettingHeader.tsx
@@ -30,7 +30,13 @@ export const SettingTitle = ({
   id?: string;
   children: React.ReactNode;
 }) => (
-  <Text htmlFor={id} component="label" c="text-dark" fw="bold" display="block">
+  <Text
+    htmlFor={id}
+    component="label"
+    c="text-dark"
+    fw="bold"
+    display="inline-block"
+  >
     {children}
   </Text>
 );


### PR DESCRIPTION
Closes ADM-871

### Description

Since our setting header is a label input, clicking it activates whatever input it labels. This has real consequences with switch elements.  Since the header was a block element it expanded well beyond the text and could cause you to toggle settings accidentally. This reduces the click target size to the size of the actual text, which feels right to me.

Before | After
---|---
![oldClick](https://github.com/user-attachments/assets/f91a8896-551e-4336-b6d5-0b54be49d8aa) | ![newclick](https://github.com/user-attachments/assets/8870f170-f705-4a5c-b185-bdd752b39675)


