### PR TITLE
fix(sdk): Render ChartSettingColorPicker color picker without a portal

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -4,6 +4,7 @@ import {
 } from "@metabase/embedding-sdk-react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import * as H from "e2e/support/helpers";
 import { openVizSettingsSidebar } from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
@@ -107,6 +108,36 @@ describe("scenarios > embedding-sdk > popovers", () => {
           cy.get('[data-element-id="mantine-popover"]').should("be.hidden");
         },
       );
+    });
+  });
+
+  it("should prevent closing the ChartSettingColorPicker when clicking it", () => {
+    mountSdkContent(
+      <InteractiveQuestion questionId={ORDERS_BY_YEAR_QUESTION_ID} />,
+    );
+
+    openVizSettingsSidebar();
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("color-selector-button").click();
+
+      // Clicking at the edge of the color picker popover to be sure that the click does not close it
+      cy.findByTestId("color-selector-popover").click(1, 1);
+      cy.findByTestId("color-selector-popover").should("be.visible");
+
+      // Clicking outside the color picker to be sure that the click closes it
+      cy.findByTestId("chartsettings-sidebar").click(1, 1);
+      cy.findByTestId("color-selector-popover").should("not.exist");
+
+      cy.findByTestId("settings-count").click();
+
+      cy.findByTestId("series-settings").within(() => {
+        cy.findByTestId("color-selector-button").click();
+
+        // Clicking at the edge of the color picker popover to be sure that the click does not close it
+        cy.findByTestId("color-selector-popover").click(1, 1);
+        cy.findByTestId("color-selector-popover").should("be.visible");
+      });
     });
   });
 });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker/ChartSettingColorPicker.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker/ChartSettingColorPicker.tsx
@@ -3,6 +3,7 @@ import cx from "classnames";
 import type { PillSize } from "metabase/common/components/ColorPill";
 import { ColorSelector } from "metabase/common/components/ColorSelector";
 import CS from "metabase/css/core/index.css";
+import { isEmbeddingSdk } from "metabase/env";
 import { getAccentColors } from "metabase/lib/colors/groups";
 import type { AccentColorOptions } from "metabase/lib/colors/types";
 import { Box, type BoxProps } from "metabase/ui";
@@ -31,11 +32,16 @@ export const ChartSettingColorPicker = ({
   },
   ...boxProps
 }: ChartSettingColorPickerProps) => {
+  // For the SDK the ColorSelector is rendered inside a parent Mantine popover,
+  // so as a nested popover it should not be rendered within a portal
+  const withinPortal = !isEmbeddingSdk;
+
   return (
     <Box className={cx(CS.flex, CS.alignCenter, className)} {...boxProps}>
       <ColorSelector
         value={value}
         colors={getAccentColors(accentColorOptions)}
+        withinPortal={withinPortal}
         onChange={onChange}
         pillSize={pillSize}
       />

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -167,6 +167,7 @@ export const ChartSettingFieldPicker = ({
           },
           section: {
             backgroundColor: "unset",
+            zIndex: "initial",
           },
           input: {
             marginLeft: theme.spacing.xs,


### PR DESCRIPTION
In the SDK, we render the ChartSettingColorPicker as a child of a parent Mantine popover. Since the ColorPicker is also a Mantine popover, both popovers are closing when clicked inside the ColorPicker.

The PR prevents rendering the ColorPicker in a portal for `sdk` only.

The issue:

https://github.com/user-attachments/assets/de229de3-03ee-46dd-b8bb-e775b46b33de

How to verify: 
- find a question
- change its viz type to combo
- via summarize add 4-5 summarize functions or metrics
- open chart settings (next to viz type button in left bottom corner), for any Y-axis item open its color picker
- click inside the color picker, but not on the color item, the click should NOT close the picek
- click outside of the color picker - it should be closed
