### PR TITLE
Test overhaul

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -400,6 +400,7 @@
   clojure.test.check.clojure-test/defspec                                               clojure.test/deftest
   clojure.test.check.properties/for-all                                                 clojure.core/let
   clojurewerkz.quartzite.jobs/defjob                                                    clojure.core/defn
+  metabase-enterprise.data-editing.test-util/with-test-tables!                          clojure.core/let
   metabase-enterprise.serialization.test-util/with-dbs                                  clojure.core/fn
   metabase-enterprise.serialization.test-util/with-random-dump-dir                      clojure.core/let
   metabase.actions.test-util/with-actions                                               clojure.core/let

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -118,7 +118,7 @@
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
       (data-editing.tu/with-test-tables! [table-id data-editing.tu/default-test-table]
-        (let [url      "action/v2/execute-bulk"]
+        (let [url "action/v2/execute-bulk"]
           (testing "Initially the table is empty"
             (is (= [] (table-rows table-id))))
 
@@ -533,34 +533,34 @@
             {:name "a_b1 -"
              :columns [{:name "id", :type "int"}]
              :primary_key ["id"]}
-;; =>
+            ;; =>
             {:status 200
              :name "a_b1 -"
              :fields [{:name "id"
                        :base-type :type/BigInteger
                        :pk? true}]}
 
-;; if not admin, denied
+            ;; if not admin, denied
             #{:d}
             {:name        "a"
              :columns     [{:name "id", :type "int"}]
              :primary_key ["id"]}
             403
 
-;; data editing disabled, denied
+            ;; data editing disabled, denied
             #{:s}
             {:name        "a"
              :columns     [{:name "id", :type "int"}]
              :primary_key ["id"]}
             400
 
-;; compound pk
+            ;; compound pk
             #{:s :d}
             {:name "a"
              :columns [{:name "id_p1", :type "int"}
                        {:name "id_p2", :type "int"}]
              :primary_key ["id_p1" "id_p2"]}
-;; =>
+            ;; =>
             {:status 200
              :name "a"
              :fields [{:name "id_p1"
@@ -582,14 +582,13 @@
               req-body   {:name table-name
                           :columns [{:name "id", :type "auto_incrementing_int_pk"}
                                     {:name "n",  :type "int"}]
-                          :primary_key ["id"]}]
-
-          (let [_          (mt/user-http-request user :post 200 url req-body)
-                db         (t2/select-one :model/Database db-id)
-                table-id   (data-editing.tu/sync-new-table! db table-name)
-                create!    #(mt/user-http-request user :post 200 (table-url table-id) {:rows %})]
-            (create! [{:n 1} {:n 2}])
-            (is (= [[1 1] [2 2]] (table-rows table-id)))))))))
+                          :primary_key ["id"]}
+              _          (mt/user-http-request user :post 200 url req-body)
+              db         (t2/select-one :model/Database db-id)
+              table-id   (data-editing.tu/sync-new-table! db table-name)
+              create!    #(mt/user-http-request user :post 200 (table-url table-id) {:rows %})]
+          (create! [{:n 1} {:n 2}])
+          (is (= [[1 1] [2 2]] (table-rows table-id))))))))
 
 (deftest coercion-test
   (mt/with-premium-features #{:table-data-editing}

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -43,11 +43,7 @@
 (use-fixtures :each
   (fn [f]
     (mt/with-dynamic-fn-redefs [data-editing.api/require-authz? (constantly true)]
-      (f))
-    (when (->> (t2/select-one [:model/Database :settings] (mt/id)) :settings :database-enable-actions)
-      (throw (ex-info (format "the criminal! %s" f)
-                      {:thunk f}))))
-  #_#'data-editing.tu/restore-db-settings-fixture)
+      (f))))
 
 (deftest feature-flag-required-test
   (mt/with-premium-features #{}
@@ -59,10 +55,8 @@
 (deftest table-operations-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (with-open [table-ref (data-editing.tu/open-test-table!)]
-        (let [table-id @table-ref
-              url      (data-editing.tu/table-url table-id)]
-          (data-editing.tu/toggle-data-editing-enabled! true)
+      (data-editing.tu/with-test-tables! [table-id data-editing.tu/default-test-table]
+        (let [url (data-editing.tu/table-url table-id)]
           (testing "Initially the table is empty"
             (is (= [] (table-rows table-id))))
 
@@ -123,10 +117,8 @@
 (deftest table-operations-via-action-execute-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (with-open [table-ref (data-editing.tu/open-test-table!)]
-        (let [table-id @table-ref
-              url      "action/v2/execute-bulk"]
-          (data-editing.tu/toggle-data-editing-enabled! true)
+      (data-editing.tu/with-test-tables! [table-id data-editing.tu/default-test-table]
+        (let [url      "action/v2/execute-bulk"]
           (testing "Initially the table is empty"
             (is (= [] (table-rows table-id))))
 
@@ -197,15 +189,12 @@
 (deftest table-operations-via-action-execute-with-compound-pk-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (with-open [table-ref (data-editing.tu/open-test-table!
-                             {:id_1   'auto-inc-type
-                              :id_2   'auto-inc-type
-                              :name  [:text]
-                              :song  [:text]}
-                             {:primary-key [:id_1 :id_2]})]
-        (let [table-id @table-ref
-              url      "action/v2/execute-bulk"]
-          (data-editing.tu/toggle-data-editing-enabled! true)
+      (data-editing.tu/with-test-tables! [table-id [{:id_1   'auto-inc-type
+                                                     :id_2   'auto-inc-type
+                                                     :name  [:text]
+                                                     :song  [:text]}
+                                                    {:primary-key [:id_1 :id_2]}]]
+        (let [url "action/v2/execute-bulk"]
           (testing "Initially the table is empty"
             (is (= [] (table-rows table-id))))
 
@@ -324,8 +313,7 @@
 
 (deftest simple-delete-with-self-referential-children-test
   (mt/with-premium-features #{:table-data-editing}
-    (actions.tu/with-actions-temp-db self-referential-categories
-      (data-editing.tu/toggle-data-editing-enabled! true)
+    (data-editing.tu/with-actions-temp-db self-referential-categories
       (let [body {:action_id "data-grid.row/delete"
                   :scope     {:table-id (mt/id :category)}
                   :inputs    [{(mt/format-name :id) 1}]}
@@ -378,8 +366,7 @@
 (deftest mutual-recursion-delete-test
   (mt/test-drivers #{:h2 :postgres}
     (mt/with-premium-features #{:table-data-editing}
-      (actions.tu/with-actions-temp-db mutual-recursion-users-teams
-        (data-editing.tu/toggle-data-editing-enabled! true)
+      (data-editing.tu/with-actions-temp-db mutual-recursion-users-teams
         (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
                        (sql.tx/add-fk-sql driver/*driver*
                                           mutual-recursion-users-teams
@@ -416,285 +403,258 @@
                 (is (= 1 (count remaining-teams)))))))))))
 
 (deftest editing-allowed-test
-  #_(mt/with-premium-features #{:table-data-editing}
-      (mt/test-drivers #{:h2 :postgres}
-        (testing "40x returned if user/database not configured for editing"
-          (let [test-endpoints
-                (fn [flags]
-                  (with-open [table-ref (data-editing.tu/open-test-table!)]
-                    (let [actions-enabled (:a flags)
-                          editing-enabled (:d flags)
-                          superuser       (:s flags)
-                          url             (data-editing.tu/table-url @table-ref)
-                          settings        {:database-enable-table-editing (boolean editing-enabled)
-                                           :database-enable-actions       (boolean actions-enabled)}
-                          _               (data-editing.tu/alter-db-settings! merge settings)
-                          user            (if superuser :crowberto :rasta)
-                          req             mt/user-http-request-full-response
+  (mt/with-premium-features #{:table-data-editing}
+    (mt/test-drivers #{:h2 :postgres}
+      (testing "40x returned if user/database not configured for editing"
+        (let [test-endpoints (fn [flags]
+                               (data-editing.tu/with-test-tables! [table-id data-editing.tu/default-test-table]
+                                 (let [actions-enabled (:a flags)
+                                       editing-enabled (:d flags)
+                                       superuser       (:s flags)
+                                       url             (data-editing.tu/table-url table-id)
+                                       settings        {:database-enable-table-editing (boolean editing-enabled)
+                                                        :database-enable-actions       (boolean actions-enabled)}
+                                       user            (if superuser :crowberto :rasta)
+                                       req             mt/user-http-request-full-response]
+                                   (mt/with-temp-vals-in-db :model/Database (mt/id) {:settings settings}
+                                     {:settings settings
+                                      :user     user
+                                      :responses {:create (req user :post url {:rows [{:name "Pidgey" :song "Car alarms"}]})
+                                                  :update (req user :put url {:rows [{:id 1 :song "Join us now and share the software"}]})
+                                                  :delete (req user :post (str url "/delete") {:rows [{:id 1}]})}}))))
 
-                          post-response
-                          (req user :post url {:rows [{:name "Pidgey" :song "Car alarms"}]})
+              error-or-ok
+              (fn [{:keys [status body]}]
+                (if (<= 200 status 299)
+                  :ok
+                  [(:message body body) status]))
 
-                          put-response
-                          (req user :put url {:rows [{:id 1 :song "Join us now and share the software"}]})
-
-                          del-response
-                          (req user :post (str url "/delete") {:rows [{:id 1}]})]
-                      {:settings settings
-                       :user     user
-                       :responses {:create post-response
-                                   :update put-response
-                                   :delete del-response}})))
-
-                error-or-ok
-                (fn [{:keys [status body]}]
-                  (if (<= 200 status 299)
-                    :ok
-                    [(:message body body) status]))
-
-               ;; Shorthand config notation
-               ;; :a == action-editing should not affect result
-               ;; :d == data-editing   only allowed to edit if editing enabled
-               ;; :s == super-user     only allowed to edit if a superuser
-                tests
-                [#{:a}       ["You don't have permissions to do that." 403]
-                 #{:d}       ["You don't have permissions to do that." 403]
-                 #{:a :d}    ["You don't have permissions to do that." 403]
-                 #{:s}       ["Data editing is not enabled."           400]
-                 #{:s :a}    ["Data editing is not enabled."           400]
-                 #{:s :d}    :ok
-                 #{:s :a :d} :ok]]
-            (doseq [[flags expected] (partition 2 tests)
-                    :let [{:keys [settings user responses]} (test-endpoints flags)]
-                    [verb  response] responses]
-              (testing (format "%s user: %s, settings: %s" verb user settings)
-                (is (= expected (error-or-ok response))))))))))
+              ;; Shorthand config notation
+              ;; :a == action-editing should not affect result
+              ;; :d == data-editing   only allowed to edit if editing enabled
+              ;; :s == super-user     only allowed to edit if a superuser
+              tests
+              [#{:a}       ["You don't have permissions to do that." 403]
+               #{:d}       ["You don't have permissions to do that." 403]
+               #{:a :d}    ["You don't have permissions to do that." 403]
+               #{:s}       ["Data editing is not enabled."           400]
+               #{:s :a}    ["Data editing is not enabled."           400]
+               #{:s :d}    :ok
+               #{:s :a :d} :ok]]
+          (doseq [[flags expected] (partition 2 tests)
+                  :let [{:keys [settings user responses]} (test-endpoints flags)]
+                  [verb  response] responses]
+            (testing (format "%s user: %s, settings: %s" verb user settings)
+              (is (= expected (error-or-ok response))))))))))
 
 (deftest create-table-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (let [run-example
-            (fn [flags req-body]
-              (let [{table-name-prefix :name} req-body
-                    table-name      (str table-name-prefix "_" (System/currentTimeMillis))
-                    req-body'       (u/update-if-exists req-body :name (constantly table-name))
-                    db-id           (mt/id)
-                    driver          driver/*driver*
-                    editing-enabled (:d flags)
-                    superuser       (:s flags)
-                    _               (data-editing.tu/toggle-data-editing-enabled! editing-enabled)
-                    user            (if superuser :crowberto :rasta)
-                    url             (format "ee/data-editing/database/%d/table" db-id)
-                    res             (delay (mt/user-http-request-full-response user :post url req-body'))
-                    cleanup!        #(try (driver/drop-table! driver db-id table-name) (catch Exception _))
-                    describe-table
-                    (fn []
-                      (-> (driver/describe-table driver (t2/select-one :model/Database db-id) {:name table-name})
-                          (update :name   {table-name table-name-prefix})
-                          (update :fields #(sort-by :name (for [f %] (select-keys f [:name :base-type :pk?]))))))]
-                (try
-                  (if (<= 200 (:status @res) 299)
-                    (merge
-                     {:status 200}
-                     (describe-table))
-                    (:status @res))
-                  (finally
-                    (cleanup!)))))]
+      (mt/with-empty-db
+        (let [run-example
+              (fn [flags req-body]
+                (let [{table-name-prefix :name} req-body
+                      table-name      (str table-name-prefix "_" (System/currentTimeMillis))
+                      req-body'       (u/update-if-exists req-body :name (constantly table-name))
+                      db-id           (mt/id)
+                      driver          driver/*driver*
+                      editing-enabled (:d flags)
+                      superuser       (:s flags)
+                      _               (data-editing.tu/toggle-data-editing-enabled! (mt/id) editing-enabled)
+                      user            (if superuser :crowberto :rasta)
+                      url             (format "ee/data-editing/database/%d/table" db-id)
+                      res             (delay (mt/user-http-request-full-response user :post url req-body'))
+                      cleanup!        #(try (driver/drop-table! driver db-id table-name) (catch Exception _))
+                      describe-table
+                      (fn []
+                        (-> (driver/describe-table driver (t2/select-one :model/Database db-id) {:name table-name})
+                            (update :name   {table-name table-name-prefix})
+                            (update :fields #(sort-by :name (for [f %] (select-keys f [:name :base-type :pk?]))))))]
+                  (try
+                    (if (<= 200 (:status @res) 299)
+                      (merge
+                       {:status 200}
+                       (describe-table))
+                      (:status @res))
+                    (finally
+                      (cleanup!)))))]
 
-        (are [flags req-body expected]
-             (= expected (run-example flags req-body))
+          (are [flags req-body expected]
+               (= expected (run-example flags req-body))
 
-          #{:s :d}
-          {}
-          400
+            #{:s :d}
+            {}
+            400
 
-          #{:s :d}
-          {:name "a"}
-          400
+            #{:s :d}
+            {:name "a"}
+            400
 
-          #{:s :d}
-          {:name "a"
-           :columns [[{:name "id", :type "int"}]]}
-          400
+            #{:s :d}
+            {:name "a"
+             :columns [[{:name "id", :type "int"}]]}
+            400
 
-          #{:s :d}
-          {:name "a"
-           :columns [{:name "id", :type "int"}
-                     {:name "name", :type "int"}]
-           :primary_key ["id"]}
-           ;; =>
-          {:status 200
-           :name "a"
-           :fields [{:name "id"
-                     :base-type :type/BigInteger
-                     :pk? true}
-                    {:name "name"
-                     :base-type :type/BigInteger}]}
+            #{:s :d}
+            {:name "a"
+             :columns [{:name "id", :type "int"}
+                       {:name "name", :type "int"}]
+             :primary_key ["id"]}
+            ;; =>
+            {:status 200
+             :name "a"
+             :fields [{:name "id"
+                       :base-type :type/BigInteger
+                       :pk? true}
+                      {:name "name"
+                       :base-type :type/BigInteger}]}
 
-          #{:s :d}
-          {:name "a"
-           :columns [{:name "id", :type "not-a-type"}]
-           :primary_key ["id"]}
-         ;; =>
-          400
+            #{:s :d}
+            {:name "a"
+             :columns [{:name "id", :type "not-a-type"}]
+             :primary_key ["id"]}
+            ;; =>
+            400
 
-         ;; escaped quotes are not allowed for now
-          #{:s :d}
-          {:name "a\""
-           :columns [{:name "id", :type "int"}]
-           :primary_key ["id"]}
-          400
-          #{:s :d}
-          {:name "a`"
-           :columns [{:name "id", :type "int"}]
-           :primary_key ["id"]}
-          400
+            ;; escaped quotes are not allowed for now
+            #{:s :d}
+            {:name "a\""
+             :columns [{:name "id", :type "int"}]
+             :primary_key ["id"]}
+            400
+            #{:s :d}
+            {:name "a`"
+             :columns [{:name "id", :type "int"}]
+             :primary_key ["id"]}
+            400
 
-         ;; underscores, dashes, spaces allowed
-          #{:s :d}
-          {:name "a_b1 -"
-           :columns [{:name "id", :type "int"}]
-           :primary_key ["id"]}
-         ;; =>
-          {:status 200
-           :name "a_b1 -"
-           :fields [{:name "id"
-                     :base-type :type/BigInteger
-                     :pk? true}]}
+            ;; underscores, dashes, spaces allowed
+            #{:s :d}
+            {:name "a_b1 -"
+             :columns [{:name "id", :type "int"}]
+             :primary_key ["id"]}
+;; =>
+            {:status 200
+             :name "a_b1 -"
+             :fields [{:name "id"
+                       :base-type :type/BigInteger
+                       :pk? true}]}
 
-         ;; if not admin, denied
-          #{:d}
-          {:name        "a"
-           :columns     [{:name "id", :type "int"}]
-           :primary_key ["id"]}
-          403
+;; if not admin, denied
+            #{:d}
+            {:name        "a"
+             :columns     [{:name "id", :type "int"}]
+             :primary_key ["id"]}
+            403
 
-         ;; data editing disabled, denied
-          #{:s}
-          {:name        "a"
-           :columns     [{:name "id", :type "int"}]
-           :primary_key ["id"]}
-          400
+;; data editing disabled, denied
+            #{:s}
+            {:name        "a"
+             :columns     [{:name "id", :type "int"}]
+             :primary_key ["id"]}
+            400
 
-          ;; compound pk
-          #{:s :d}
-          {:name "a"
-           :columns [{:name "id_p1", :type "int"}
-                     {:name "id_p2", :type "int"}]
-           :primary_key ["id_p1" "id_p2"]}
-          ;; =>
-          {:status 200
-           :name "a"
-           :fields [{:name "id_p1"
-                     :base-type :type/BigInteger
-                     :pk? true}
-                    {:name "id_p2"
-                     :base-type :type/BigInteger
-                     :pk? true}]})))))
+;; compound pk
+            #{:s :d}
+            {:name "a"
+             :columns [{:name "id_p1", :type "int"}
+                       {:name "id_p2", :type "int"}]
+             :primary_key ["id_p1" "id_p2"]}
+;; =>
+            {:status 200
+             :name "a"
+             :fields [{:name "id_p1"
+                       :base-type :type/BigInteger
+                       :pk? true}
+                      {:name "id_p2"
+                       :base-type :type/BigInteger
+                       :pk? true}]}))))))
 
 (deftest create-table-auto-inc-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (data-editing.tu/toggle-data-editing-enabled! true)
-      (let [db-id      (mt/id)
-            url        (format "ee/data-editing/database/%d/table" db-id)
-            user       :crowberto
-            table-name (str "test_table_" (System/currentTimeMillis))
-            req-body   {:name table-name
-                        :columns [{:name "id", :type "auto_incrementing_int_pk"}
-                                  {:name "n",  :type "int"}]
-                        :primary_key ["id"]}]
+      (mt/with-empty-db
+        (data-editing.tu/toggle-data-editing-enabled! (mt/id) true)
+        (let [db-id      (mt/id)
+              url        (format "ee/data-editing/database/%d/table" db-id)
+              user       :crowberto
+              table-name (str "test_table_" (System/currentTimeMillis))
+              req-body   {:name table-name
+                          :columns [{:name "id", :type "auto_incrementing_int_pk"}
+                                    {:name "n",  :type "int"}]
+                          :primary_key ["id"]}]
 
-        (try
           (let [_          (mt/user-http-request user :post 200 url req-body)
                 db         (t2/select-one :model/Database db-id)
                 table-id   (data-editing.tu/sync-new-table! db table-name)
                 create!    #(mt/user-http-request user :post 200 (table-url table-id) {:rows %})]
             (create! [{:n 1} {:n 2}])
-            (is (= [[1 1] [2 2]] (table-rows table-id))))
-          (finally
-            (driver/drop-table! driver/*driver* (mt/id) table-name)
-            (t2/delete! :model/Table :name table-name)))))))
+            (is (= [[1 1] [2 2]] (table-rows table-id)))))))))
 
 (deftest coercion-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (data-editing.tu/toggle-data-editing-enabled! true)
-      (let [user :crowberto
-            req mt/user-http-request
-            create!
-            #(req user :post (data-editing.tu/table-url %1) {:rows %2})
-
-            update!
-            #(req user :put (data-editing.tu/table-url %1) {:rows %2})
-
-            always-lossy
-            #{:Coercion/UNIXNanoSeconds->DateTime
-              :Coercion/UNIXMicroSeconds->DateTime
-              :Coercion/ISO8601->Date
-              :Coercion/ISO8601->Time}
-
-            driver-lossy
-            (case driver/*driver*
-              :postgres #{:Coercion/UNIXMilliSeconds->DateTime}
-              #{})
-
+      (let [create! #(mt/user-http-request :crowberto :post (data-editing.tu/table-url %1) {:rows %2})
+            update! #(mt/user-http-request :crowberto :put (data-editing.tu/table-url %1) {:rows %2})
+            always-lossy #{:Coercion/UNIXNanoSeconds->DateTime
+                           :Coercion/UNIXMicroSeconds->DateTime
+                           :Coercion/ISO8601->Date
+                           :Coercion/ISO8601->Time}
+            driver-lossy (case driver/*driver*
+                           :postgres #{:Coercion/UNIXMilliSeconds->DateTime}
+                           #{})
             lossy? (set/union always-lossy driver-lossy)
+            do-test (fn [t coercion-strategy input expected]
+                      (testing (str t " " coercion-strategy " " input)
+                        (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+                                                                       :o  [t :null]}
+                                                                      {:primary-key [:id]}]]
+                          (let [table-name-kw (t2/select-one-fn (comp keyword :name) [:model/Table :name] table-id)
+                                field-id      (t2/select-one-fn :id [:model/Field :id] :table_id table-id :name "o")
+                                driver        driver/*driver*
+                                get-qp-state  (fn [] (map #(zipmap [:id :o] %) (table-rows table-id)))
+                                get-db-state  (fn [] (sql-jdbc/query driver (mt/id) {:select [:*] :from [table-name-kw]}))]
+                            (t2/update! :model/Field field-id {:coercion_strategy coercion-strategy})
+                            (testing "create"
+                              (let [row {:o input}
+                                    {returned-state :created-rows} (create! table-id [row])
+                                    qp-state (get-qp-state)
+                                    _ (is (= 1 (count returned-state)))]
+                                (when-not (lossy? coercion-strategy)
+                                  (is (= qp-state returned-state) "we should return the same coerced output that table/$table-id/data would return")
+                                  (is (= input (:o (first qp-state))) "the qp value should be the same as the input"))
+                                (is (= expected (:o (first (get-db-state)))))))
+                            (testing "update"
+                              (let [[{id :id}] (:created-rows (create! table-id [{:o nil}]))
+                                    _ (is (some? id))
+                                    {returned-state :updated} (update! table-id [{:id id, :o input}])
+                                    [qp-row] (filter (comp #{id} :id) (get-qp-state))]
+                                (is (= 1 (count returned-state)))
+                                (is (some? qp-row))
+                                (when-not (lossy? coercion-strategy)
+                                  (is (= [qp-row] returned-state))
+                                  (is (= input (:o qp-row))))
+                                (is (= expected (:o (first (get-db-state)))))))))))]
 
-            do-test
-            (fn [t coercion-strategy input expected]
-              (testing (str t " " coercion-strategy " " input)
-                (with-open [table (data-editing.tu/open-test-table!
-                                   {:id 'auto-inc-type
-                                    :o  [t :null]}
-                                   {:primary-key [:id]})]
-                  (let [table-id      @table
-                        table-name-kw (t2/select-one-fn (comp keyword :name) [:model/Table :name] table-id)
-                        field-id      (t2/select-one-fn :id [:model/Field :id] :table_id table-id :name "o")
-                        driver        driver/*driver*
-                        get-qp-state  (fn [] (map #(zipmap [:id :o] %) (table-rows table-id)))
-                        get-db-state  (fn [] (sql-jdbc/query driver (mt/id) {:select [:*] :from [table-name-kw]}))]
-                    (t2/update! :model/Field field-id {:coercion_strategy coercion-strategy})
-                    (testing "create"
-                      (let [row {:o input}
-                            {returned-state :created-rows} (create! table-id [row])
-                            qp-state (get-qp-state)
-                            _ (is (= 1 (count returned-state)))]
-                        (when-not (lossy? coercion-strategy)
-                          (is (= qp-state returned-state) "we should return the same coerced output that table/$table-id/data would return")
-                          (is (= input (:o (first qp-state))) "the qp value should be the same as the input"))
-                        (is (= expected (:o (first (get-db-state)))))))
-                    (testing "update"
-                      (let [[{id :id}] (:created-rows (create! table-id [{:o nil}]))
-                            _ (is (some? id))
-                            {returned-state :updated} (update! table-id [{:id id, :o input}])
-                            [qp-row] (filter (comp #{id} :id) (get-qp-state))]
-                        (is (= 1 (count returned-state)))
-                        (is (some? qp-row))
-                        (when-not (lossy? coercion-strategy)
-                          (is (= [qp-row] returned-state))
-                          (is (= input (:o qp-row))))
-                        (is (= expected (:o (first (get-db-state)))))))))))]
-
-       ;;    type     coercion                                     input                          database
+        ;;    type     coercion                                     input                          database
         (->> [:text    nil                                          "a"                            "a"
               :text    :Coercion/YYYYMMDDHHMMSSString->Temporal     "2025-03-25T14:34:00Z"         "20250325143400"
               :text    :Coercion/ISO8601->DateTime                  "2025-03-25T14:34:42.314Z"     "2025-03-25T14:34:42.314Z"
               :text    :Coercion/ISO8601->Date                      "2025-03-25T00:00:00Z"         "2025-03-25"
               :text    :Coercion/ISO8601->Time                      "1999-04-05T14:34:42Z"         "14:34:42"
 
-             ;; note fractional seconds in input, remains undefined for Seconds
+              ;; note fractional seconds in input, remains undefined for Seconds
               :int     :Coercion/UNIXSeconds->DateTime              "2025-03-25T14:34:42Z"         (quot (inst-ms #inst "2025-03-25T14:34:42Z") 1000)
               :bigint  :Coercion/UNIXMilliSeconds->DateTime         "2025-03-25T14:34:42.314Z"     (inst-ms #inst "2025-03-25T14:34:42.314Z")
 
-             ;; note fractional secs beyond millis are discarded   (lossy)
+              ;; note fractional secs beyond millis are discarded   (lossy)
               :bigint  :Coercion/UNIXMicroSeconds->DateTime         "2025-03-25T14:34:42.314121Z"  (* (inst-ms #inst "2025-03-25T14:34:42.314Z") 1000)
               :bigint  :Coercion/UNIXNanoSeconds->DateTime          "2025-03-25T14:34:42.3141212Z" (* (inst-ms #inst "2025-03-25T14:34:42.314Z") 1000000)
 
-             ;; nil safe
+              ;; nil safe
               :text    :Coercion/YYYYMMDDHHMMSSString->Temporal     nil                            nil
 
-             ;; seconds component does not work properly here, lost by qp output, bug in existing code?
+              ;; seconds component does not work properly here, lost by qp output, bug in existing code?
               #_#_#_#_:text :Coercion/YYYYMMDDHHMMSSString->Temporal     "2025-03-25T14:34:42Z"     "20250325143442"]
              (partition 4)
              (run! #(apply do-test %)))))))
@@ -724,15 +684,13 @@
 (deftest webhook-list-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (with-open [test-table1 (data-editing.tu/open-test-table!)
-                  test-table2 (data-editing.tu/open-test-table!)]
+      (data-editing.tu/with-test-tables! [table-id1 data-editing.tu/default-test-table
+                                          table-id2 data-editing.tu/default-test-table]
         (let [url            "ee/data-editing/webhook"
               req            #(mt/user-http-request-full-response %1 :get url :table-id %2)
               create-url     "ee/data-editing/webhook"
               create         #(:body (mt/user-http-request-full-response :crowberto :post create-url {:table-id %}))
               status         (comp :status req)
-              table-id1      @test-table1
-              table-id2      @test-table2
               not-a-table-id Long/MAX_VALUE]
           (testing "auth fail"
             (is (= 403 (status :rasta table-id1)))
@@ -755,7 +713,7 @@
 (deftest webhook-delete-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (with-open [test-table (data-editing.tu/open-test-table!)]
+      (data-editing.tu/with-test-tables! [table-id data-editing.tu/default-test-table]
         (let [url            #(format "ee/data-editing/webhook/%s" %)
               req            #(mt/user-http-request-full-response %1 :delete (url %2) {})
               create-url     "ee/data-editing/webhook"
@@ -763,7 +721,6 @@
               list-url       "ee/data-editing/webhook"
               list-tokens    #(:body (mt/user-http-request-full-response :crowberto :get list-url :table-id %))
               status         (comp :status req)
-              table-id       @test-table
               {token :token} (create table-id)
               not-a-token    (str (random-uuid))]
           (testing "auth fail"
@@ -781,11 +738,9 @@
 (deftest webhook-ingest-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (data-editing.tu/toggle-data-editing-enabled! true)
-      (with-open [test-table (data-editing.tu/open-test-table!
-                              {:id [:int]
-                               :v [:text]}
-                              {:primary-key [:id]})]
+      (data-editing.tu/with-test-tables! [table-id [{:id [:int]
+                                                     :v [:text]}
+                                                    {:primary-key [:id]}]]
         (let [url            #(format "ee/data-editing-public/webhook/%s/data" %)
               req            #(mt/client-full-response
                                :post (url %1)
@@ -800,7 +755,6 @@
               create         #(:body (mt/user-http-request-full-response :crowberto :post create-url {:table-id %}))
               delete-url     #(format "ee/data-editing/webhook/%s" %)
               delete         #(mt/user-http-request :crowberto :delete (delete-url %))
-              table-id       @test-table
               {token :token} (create table-id)
               not-a-token    (str (random-uuid))]
           (testing "token does not exist"
@@ -829,13 +783,10 @@
           (testing "wrong columns"
             (is (= 400 (status token [{:id 1, :not_a_column "a"}]))))
           (testing "data editing disabled"
-            (try
-              (data-editing.tu/toggle-data-editing-enabled! false)
-              (is (= 400 (status token [{:id 4, :v "d"}])))
-              (data-editing.tu/toggle-data-editing-enabled! true)
-              (is (= {:created 1} (result token [{:id 4, :v "d"}])))
-              (finally
-                (data-editing.tu/toggle-data-editing-enabled! true))))
+            (data-editing.tu/toggle-data-editing-enabled! (mt/id) false)
+            (is (= 400 (status token [{:id 4, :v "d"}])))
+            (data-editing.tu/toggle-data-editing-enabled! (mt/id) true)
+            (is (= {:created 1} (result token [{:id 4, :v "d"}]))))
           (testing "token deleted"
             (delete token)
             (is (= 404 (status token [{:id 5, :v "e"}])))))))))
@@ -845,10 +796,8 @@
 (deftest field-values-invalidated-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (data-editing.tu/toggle-data-editing-enabled! true)
-      (with-open [table (data-editing.tu/open-test-table! {:id 'auto-inc-type, :n [:text]} {:primary-key [:id]})]
-        (let [table-id     @table
-              url          (data-editing.tu/table-url table-id)
+      (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type, :n [:text]} {:primary-key [:id]}]]
+        (let [url          (data-editing.tu/table-url table-id)
               field-id     (t2/select-one-fn :id :model/Field :table_id table-id :name "n")
               _            (t2/update! :model/Field {:id field-id} {:semantic_type "type/Category"})
               field-values #(vec (:values (field-values/get-latest-full-field-values field-id)))
@@ -884,8 +833,8 @@
                                                         (dissoc % :user-id)))]
     (mt/with-premium-features #{:table-data-editing}
       (mt/test-drivers #{:h2 :postgres}
-        (data-editing.tu/toggle-data-editing-enabled! true)
-        (mt/with-actions-enabled
+        (mt/with-empty-db
+          (data-editing.tu/toggle-data-editing-enabled! (mt/id) true)
           (testing "no dashcard"
             (is (= 404 (:status (req {:action_id "dashcard:999999:1"
                                       :scope     {:dashcard-id 999999}
@@ -906,104 +855,103 @@
                                                         (dissoc % :user-id)))]
     (mt/with-premium-features #{:table-data-editing}
       (mt/test-drivers #{:h2 :postgres}
-        (mt/with-actions-enabled
-          (mt/with-non-admin-groups-no-root-collection-perms
-            (with-open [test-table (data-editing.tu/open-test-table! {:id 'auto-inc-type
-                                                                      :name [:text]
-                                                                      :status [:text]}
-                                                                     {:primary-key [:id]})]
-              (mt/with-temp [:model/Card          model    {:type           :model
-                                                            :table_id       @test-table
-                                                            :database_id    (mt/id)
-                                                            :dataset_query  {:database (mt/id)
-                                                                             :type :query
-                                                                             :query {:source-table @test-table}}}
-                             :model/Action        action   {:type           :implicit
-                                                            :name           "update"
-                                                            :model_id       (:id model)
-                                                            :parameters     [{:id "a"
-                                                                              :name "Id"
-                                                                              :slug "id"}
-                                                                             {:id "b"
-                                                                              :name "Name"
-                                                                              :slug "name"}
-                                                                             {:id "c"
-                                                                              :name "Status"
-                                                                              :slug "status"}]}
+        (mt/with-non-admin-groups-no-root-collection-perms
+          (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+                                                         :name [:text]
+                                                         :status [:text]}
+                                                        {:primary-key [:id]}]]
+            (mt/with-temp [:model/Card          model    {:type           :model
+                                                          :table_id       table-id
+                                                          :database_id    (mt/id)
+                                                          :dataset_query  {:database (mt/id)
+                                                                           :type :query
+                                                                           :query {:source-table table-id}}}
+                           :model/Action        action   {:type           :implicit
+                                                          :name           "update"
+                                                          :model_id       (:id model)
+                                                          :parameters     [{:id "a"
+                                                                            :name "Id"
+                                                                            :slug "id"}
+                                                                           {:id "b"
+                                                                            :name "Name"
+                                                                            :slug "name"}
+                                                                           {:id "c"
+                                                                            :name "Status"
+                                                                            :slug "status"}]}
 
-                             :model/ImplicitAction _       {:action_id      (:id action)
-                                                            :kind           "row/update"}
-                             :model/Dashboard     dash     {}
-                             :model/DashboardCard dashcard {:dashboard_id   (:id dash)
-                                                            :card_id        (:id model)
-                                                            :visualization_settings
-                                                            {:table_id @test-table
-                                                             :editableTable.enabledActions
-                                                             (let [param-maps
-                                                                   ;; we might need to change these to use field ids
-                                                                   [{:parameterId "name", :sourceType "row-data", :sourceValueTarget "name"}]]
-                                                               [{:id                "dashcard:unknown:abcdef"
-                                                                 :actionId          (:id action)
-                                                                 :actionType        "data-grid/row-action"
-                                                                 :parameterMappings param-maps
-                                                                 :enabled           true}
-                                                                {:id                "dashcard:unknown:fedcba"
-                                                                 :actionId          "table.row/update"
-                                                                 :actionType        "data-grid/row-action"
-                                                                 :mapping           {:table-id @test-table
-                                                                                     :row      "::root"}
-                                                                 :parameterMappings param-maps
-                                                                 :enabled           true}
-                                                                {:id                "dashcard:unknown:xyzabc"
-                                                                 :actionId          (#'actions/encoded-action-id :table.row/update @test-table)
-                                                                 :actionType        "data-grid/row-action"
-                                                                 :parameterMappings param-maps
-                                                                 :enabled           true}])}}]
-                (testing "no access to the model"
-                  (is (= 403 (:status (req {:user      :rasta
-                                            :action_id (:id action)
-                                            :scope     {:dashcard-id (:id dashcard)}
-                                            :input     {:id 1}
-                                            :params    {:status "approved"}})))))
-                ;; should not need this permission for model actions
-                (data-editing.tu/with-data-editing-enabled! false
-                  (testing "non-row action modifying a row"
+                           :model/ImplicitAction _       {:action_id      (:id action)
+                                                          :kind           "row/update"}
+                           :model/Dashboard     dash     {}
+                           :model/DashboardCard dashcard {:dashboard_id   (:id dash)
+                                                          :card_id        (:id model)
+                                                          :visualization_settings
+                                                          {:table_id table-id
+                                                           :editableTable.enabledActions
+                                                           (let [param-maps
+                                                                 ;; we might need to change these to use field ids
+                                                                 [{:parameterId "name", :sourceType "row-data", :sourceValueTarget "name"}]]
+                                                             [{:id                "dashcard:unknown:abcdef"
+                                                               :actionId          (:id action)
+                                                               :actionType        "data-grid/row-action"
+                                                               :parameterMappings param-maps
+                                                               :enabled           true}
+                                                              {:id                "dashcard:unknown:fedcba"
+                                                               :actionId          "table.row/update"
+                                                               :actionType        "data-grid/row-action"
+                                                               :mapping           {:table-id table-id
+                                                                                   :row      "::root"}
+                                                               :parameterMappings param-maps
+                                                               :enabled           true}
+                                                              {:id                "dashcard:unknown:xyzabc"
+                                                               :actionId          (#'actions/encoded-action-id :table.row/update table-id)
+                                                               :actionType        "data-grid/row-action"
+                                                               :parameterMappings param-maps
+                                                               :enabled           true}])}}]
+              (testing "no access to the model"
+                (is (= 403 (:status (req {:user      :rasta
+                                          :action_id (:id action)
+                                          :scope     {:dashcard-id (:id dashcard)}
+                                          :input     {:id 1}
+                                          :params    {:status "approved"}})))))
+              ;; should not need this permission for model actions
+              (data-editing.tu/with-data-editing-enabled! false
+                (testing "non-row action modifying a row"
+                  (testing "underlying row does not exist, action not executed"
+                    (is (= 400 (:status (req {:action_id (:id action)
+                                              :scope     {:dashcard-id (:id dashcard)}
+                                              :input     {:id 1}
+                                              :params    {:status "approved"}})))))
+                  (testing "underlying row exists, action executed"
+                    (data-editing.tu/with-data-editing-enabled! true
+                      (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url table-id)
+                                            {:rows [{:name "Widgets", :status "waiting"}]}))
+                    (is (= {:status 200
+                            :body   {:outputs [{:rows-updated 1}]}}
+                           (-> (req {:action_id (:id action)
+                                     :scope     {:dashcard-id (:id dashcard)}
+                                     :input     {:id 1}
+                                     :params    {:status "approved"}})
+                               (select-keys [:status :body]))))))
+                (testing "dashcard row action modifying a row - implicit action"
+                  (let [action-id "dashcard:unknown:abcdef"]
                     (testing "underlying row does not exist, action not executed"
-                      (is (= 400 (:status (req {:action_id (:id action)
+                      (is (= 404 (:status (req {:action_id action-id
                                                 :scope     {:dashcard-id (:id dashcard)}
-                                                :input     {:id 1}
+                                                :input     {:id 2}
                                                 :params    {:status "approved"}})))))
                     (testing "underlying row exists, action executed"
                       (data-editing.tu/with-data-editing-enabled! true
-                        (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
-                                              {:rows [{:name "Widgets", :status "waiting"}]}))
+                        (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url table-id)
+                                              {:rows [{:name "Sprockets", :status "waiting"}]}))
                       (is (= {:status 200
                               :body   {:outputs [{:rows-updated 1}]}}
-                             (-> (req {:action_id (:id action)
+                             (-> (req {:action_id action-id
                                        :scope     {:dashcard-id (:id dashcard)}
-                                       :input     {:id 1}
+                                       :input     {:id 2}
                                        :params    {:status "approved"}})
-                                 (select-keys [:status :body]))))))
-                  (testing "dashcard row action modifying a row - implicit action"
-                    (let [action-id "dashcard:unknown:abcdef"]
-                      (testing "underlying row does not exist, action not executed"
-                        (is (= 404 (:status (req {:action_id action-id
-                                                  :scope     {:dashcard-id (:id dashcard)}
-                                                  :input     {:id 2}
-                                                  :params    {:status "approved"}})))))
-                      (testing "underlying row exists, action executed"
-                        (data-editing.tu/with-data-editing-enabled! true
-                          (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
-                                                {:rows [{:name "Sprockets", :status "waiting"}]}))
-                        (is (= {:status 200
-                                :body   {:outputs [{:rows-updated 1}]}}
-                               (-> (req {:action_id action-id
-                                         :scope     {:dashcard-id (:id dashcard)}
-                                         :input     {:id 2}
-                                         :params    {:status "approved"}})
-                                   (select-keys [:status :body]))))))))
-                ;; but it is necessary for the primitives
-                (data-editing.tu/toggle-data-editing-enabled! true)
+                                 (select-keys [:status :body]))))))))
+              ;; but it is necessary for the primitives
+              (data-editing.tu/with-data-editing-enabled! true
                 (testing "dashcard row action modifying a row - primitive action"
                   (let [action-id "dashcard:unknown:fedcba"]
                     (testing "underlying row does not exist, action not executed"
@@ -1012,10 +960,10 @@
                                                 :input     {:id 3}
                                                 :params    {:status "approved"}})))))
                     (testing "underlying row exists, action executed"
-                      (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
+                      (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url table-id)
                                             {:rows [{:name "Braai tongs", :status "waiting"}]})
                       (is (= {:status 200
-                              :body   {:outputs [{:table-id @test-table
+                              :body   {:outputs [{:table-id table-id
                                                   :op       "updated"
                                                   :row      {:id 3, :name "Braai tongs", :status "approved"}}]}}
                              (-> (req {:action_id action-id
@@ -1032,10 +980,10 @@
                                                             :status "approved"}
                                                 #_#_:params    {:status "approved"}})))))
                     (testing "underlying row exists, action executed"
-                      (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @test-table)
+                      (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url table-id)
                                             {:rows [{:name "Salad spinners", :status "waiting"}]})
                       (is (= {:status 200
-                              :body   {:outputs [{:table-id @test-table
+                              :body   {:outputs [{:table-id table-id
                                                   :op       "updated"
                                                   :row      {:id 4, :name "Salad spinners", :status "approved"}}]}}
                              (-> (req {:action_id action-id
@@ -1049,102 +997,98 @@
 (deftest unified-execute-server-side-mapping-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (data-editing.tu/with-data-editing-enabled! true
-        (mt/with-actions-enabled
-          (with-open [table-1-ref (data-editing.tu/open-test-table!
-                                   {:id  'auto-inc-type
-                                    :col [:text]}
-                                   {:primary-key [:id]})
-                      table-2-ref (data-editing.tu/open-test-table!
-                                   {:id 'auto-inc-type
-                                    :a  [:text]
-                                    :b  [:text]
-                                    :c  [:text]
-                                    :d  [:text]}
-                                   {:primary-key [:id]})]
+      (data-editing.tu/with-test-tables! [table-1-id [{:id  'auto-inc-type
+                                                       :col [:text]}
+                                                      {:primary-key [:id]}]
+                                          table-2-id [{:id 'auto-inc-type
+                                                       :a  [:text]
+                                                       :b  [:text]
+                                                       :c  [:text]
+                                                       :d  [:text]}
+                                                      {:primary-key [:id]}]]
 
-            (mt/with-temp [:model/Card          model    {:type           :model
-                                                          :table_id       @table-1-ref
-                                                          :database_id    (mt/id)
-                                                          :dataset_query  {:database (mt/id)
-                                                                           :type     :query
-                                                                           :query    {:source-table @table-1-ref}}}
-                           :model/Dashboard     dash     {}
-                           :model/DashboardCard dashcard {:dashboard_id   (:id dash)
-                                                          :card_id        (:id model)
-                                                          :visualization_settings
-                                                          {:table_id @table-1-ref
-                                                           :editableTable.enabledActions
-                                                           [{:id         "dashcard:unknown:my-row-action"
-                                                             :actionId   "table.row/create"
-                                                             :actionType "data-grid/row-action"
-                                                             :mapping    {:table-id @table-2-ref
-                                                                          :row      {:a ["::key" "aa"]
-                                                                                     :b ["::key" "bb"]
-                                                                                     :c ["::key" "cc"]
-                                                                                     :d ["::key" "dd"]}}
-                                                             :parameterMappings
-                                                             [{:parameterId "aa" :sourceType "row-data" :sourceValueTarget "col"}
-                                                              {:parameterId "bb" :sourceType "ask-user"}
-                                                              {:parameterId "cc" :sourceType "ask-user" :value "default"}
-                                                              {:parameterId "dd" :sourceType "constant" :value "hard-coded"}]
-                                                             :enabled    true}]}}]
-              (testing "dashcard row action modifying a row - primitive action"
-                (let [action-id "dashcard:unknown:my-row-action"]
-                  (testing "underlying row does not exist, action not executed"
-                    (mt/user-http-request :crowberto :post 404 execute-v2-url {:action_id action-id
-                                                                               :scope     {:dashcard-id (:id dashcard)}
-                                                                               :input     {:id 1}
-                                                                               :params    {:status "approved"}}))
-                  (testing "underlying row exists, action executed\n"
-                    (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url @table-1-ref)
-                                          {:rows [{:col "database-value"}]})
-                    (let [base-req {:action_id action-id
-                                    :scope     {:dashcard-id (:id dashcard)}
-                                    :input     {:id 1, :col "stale-value"}
-                                    :params    {:bb nil}}]
-                    ;; TODO don't have a way to make params required for non-legacy actions yet, d'oh
-                    ;;      oh well, let nil spill through
-                      (testing "missing required param"
-                        (is (=? {:outputs [{:table-id @table-2-ref
-                                            :op       "created"
-                                            :row      {:id 1
-                                                       :a  "database-value"
-                                                       :b  nil
-                                                       :c  "default"
-                                                       :d  "hard-coded"}}]}
-                                (mt/user-http-request :crowberto :post 200 execute-v2-url base-req))))
-                      (testing "missing optional param"
-                        (is (=? {:outputs [{:table-id @table-2-ref
-                                            :op       "created"
-                                            :row      {:id 2
-                                                       :a  "database-value"
-                                                       :b  "necessary"
-                                                       :c  "default"
-                                                       :d  "hard-coded"}}]}
-                                (mt/user-http-request :crowberto :post 200 execute-v2-url (assoc-in base-req [:params :bb] "necessary")))))
-                      (testing "null optional param"
-                        (is (= {:outputs [{:table-id @table-2-ref
-                                           :op       "created"
-                                           :row      {:id 3
-                                                      :a  "database-value"
-                                                      :b  "necessary"
-                                                      :c  nil
-                                                      :d  "hard-coded"}}]}
-                               (mt/user-http-request :crowberto :post 200 execute-v2-url (-> base-req
-                                                                                             (assoc-in [:params :bb] "necessary")
-                                                                                             (assoc-in [:params :cc] nil))))))
-                      (testing "provided optional param"
-                        (is (= {:outputs [{:table-id @table-2-ref
-                                           :op       "created"
-                                           :row      {:id 4
-                                                      :a  "database-value"
-                                                      :b  "necessary"
-                                                      :c  "optional"
-                                                      :d  "hard-coded"}}]}
-                               (mt/user-http-request :crowberto :post 200 execute-v2-url (-> base-req
-                                                                                             (assoc-in [:params :bb] "necessary")
-                                                                                             (assoc-in [:params :cc] "optional")))))))))))))))))
+        (mt/with-temp [:model/Card          model    {:type           :model
+                                                      :table_id       table-1-id
+                                                      :database_id    (mt/id)
+                                                      :dataset_query  {:database (mt/id)
+                                                                       :type     :query
+                                                                       :query    {:source-table table-1-id}}}
+                       :model/Dashboard     dash     {}
+                       :model/DashboardCard dashcard {:dashboard_id   (:id dash)
+                                                      :card_id        (:id model)
+                                                      :visualization_settings
+                                                      {:table_id table-1-id
+                                                       :editableTable.enabledActions
+                                                       [{:id         "dashcard:unknown:my-row-action"
+                                                         :actionId   "table.row/create"
+                                                         :actionType "data-grid/row-action"
+                                                         :mapping    {:table-id table-2-id
+                                                                      :row      {:a ["::key" "aa"]
+                                                                                 :b ["::key" "bb"]
+                                                                                 :c ["::key" "cc"]
+                                                                                 :d ["::key" "dd"]}}
+                                                         :parameterMappings
+                                                         [{:parameterId "aa" :sourceType "row-data" :sourceValueTarget "col"}
+                                                          {:parameterId "bb" :sourceType "ask-user"}
+                                                          {:parameterId "cc" :sourceType "ask-user" :value "default"}
+                                                          {:parameterId "dd" :sourceType "constant" :value "hard-coded"}]
+                                                         :enabled    true}]}}]
+          (testing "dashcard row action modifying a row - primitive action"
+            (let [action-id "dashcard:unknown:my-row-action"]
+              (testing "underlying row does not exist, action not executed"
+                (mt/user-http-request :crowberto :post 404 execute-v2-url {:action_id action-id
+                                                                           :scope     {:dashcard-id (:id dashcard)}
+                                                                           :input     {:id 1}
+                                                                           :params    {:status "approved"}}))
+              (testing "underlying row exists, action executed\n"
+                (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url table-1-id)
+                                      {:rows [{:col "database-value"}]})
+                (let [base-req {:action_id action-id
+                                :scope     {:dashcard-id (:id dashcard)}
+                                :input     {:id 1, :col "stale-value"}
+                                :params    {:bb nil}}]
+                  ;; TODO don't have a way to make params required for non-legacy actions yet, d'oh
+                  ;;      oh well, let nil spill through
+                  (testing "missing required param"
+                    (is (=? {:outputs [{:table-id table-2-id
+                                        :op       "created"
+                                        :row      {:id 1
+                                                   :a  "database-value"
+                                                   :b  nil
+                                                   :c  "default"
+                                                   :d  "hard-coded"}}]}
+                            (mt/user-http-request :crowberto :post 200 execute-v2-url base-req))))
+                  (testing "missing optional param"
+                    (is (=? {:outputs [{:table-id table-2-id
+                                        :op       "created"
+                                        :row      {:id 2
+                                                   :a  "database-value"
+                                                   :b  "necessary"
+                                                   :c  "default"
+                                                   :d  "hard-coded"}}]}
+                            (mt/user-http-request :crowberto :post 200 execute-v2-url (assoc-in base-req [:params :bb] "necessary")))))
+                  (testing "null optional param"
+                    (is (= {:outputs [{:table-id table-2-id
+                                       :op       "created"
+                                       :row      {:id 3
+                                                  :a  "database-value"
+                                                  :b  "necessary"
+                                                  :c  nil
+                                                  :d  "hard-coded"}}]}
+                           (mt/user-http-request :crowberto :post 200 execute-v2-url (-> base-req
+                                                                                         (assoc-in [:params :bb] "necessary")
+                                                                                         (assoc-in [:params :cc] nil))))))
+                  (testing "provided optional param"
+                    (is (= {:outputs [{:table-id table-2-id
+                                       :op       "created"
+                                       :row      {:id 4
+                                                  :a  "database-value"
+                                                  :b  "necessary"
+                                                  :c  "optional"
+                                                  :d  "hard-coded"}}]}
+                           (mt/user-http-request :crowberto :post 200 execute-v2-url (-> base-req
+                                                                                         (assoc-in [:params :bb] "necessary")
+                                                                                         (assoc-in [:params :cc] "optional")))))))))))))))
 
 (deftest unified-execute-unsaved-action-id
   (let [url "action/v2/execute"
@@ -1153,28 +1097,25 @@
                   (merge {:scope {:unknown :legacy-action} :input {}} %))
                  (dissoc :headers))]
     (mt/with-premium-features #{:table-data-editing}
-      (data-editing.tu/with-data-editing-enabled! true
-        (mt/with-actions-enabled
-          (mt/with-non-admin-groups-no-root-collection-perms
-            (testing "Cannot execute a temporary action id"
-              (is (=? {:status 400
-                       :body   {:message "Cannot execute an unsaved action given only its temporary id"}}
-                      (req {:action_id (str (random-uuid))
-                            :scope     {:table-id (mt/id :venues)}
-                            :input     {:id 1}
-                            :params    {:status "approved"}}))))))))))
+      (data-editing.tu/with-test-tables! [table-id data-editing.tu/default-test-table]
+        (testing "Cannot execute a temporary action id"
+          (is (=? {:status 400
+                   :body   {:message "Cannot execute an unsaved action given only its temporary id"}}
+                  (req {:action_id (str (random-uuid))
+                        :scope     {:table-id table-id}
+                        :input     {:id 1}
+                        :params    {:status "approved"}}))))))))
 
 (deftest list-and-add-to-dashcard-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (data-editing.tu/toggle-data-editing-enabled! true)
-      (with-open [test-table (data-editing.tu/open-test-table! {:id 'auto-inc-type
-                                                                :text      [:text]
-                                                                :int       [:int]
-                                                                :timestamp [:timestamp]
-                                                                :date      [:date]}
-                                                               {:primary-key [:id]})]
-        (let [table-actions (list-actions @test-table)]
+      (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+                                                     :text      [:text]
+                                                     :int       [:int]
+                                                     :timestamp [:timestamp]
+                                                     :date      [:date]}
+                                                    {:primary-key [:id]}]]
+        (let [table-actions (list-actions table-id)]
           (testing "table actions have neg ids"
             (is (every? neg? (map :id table-actions))))
           (testing "one action for each crud op"
@@ -1238,7 +1179,7 @@
                           {:text      "seeya, world!"})
                 (is (= [[1 "hello, world!" 42 "2025-05-12T14:32:16Z" "2025-05-12T00:00:00Z"]
                         [2 "seeya, world!" nil nil                   nil]]
-                       (->> (table-rows @test-table)
+                       (->> (table-rows table-id)
                             (sort-by first)))))
 
               (testing "update"
@@ -1250,7 +1191,7 @@
                            :int 43})
                 (is (= [[1 "hello, world!" 43 "2025-05-12T14:32:16Z" "2025-05-12T00:00:00Z"]
                         [2 "seeya, world!" nil nil                   nil]]
-                       (->> (table-rows @test-table)
+                       (->> (table-rows table-id)
                             (sort-by first)))))
 
               (testing "create-or-update"
@@ -1259,7 +1200,7 @@
                                          :int 44})
                   (is (= [[1 "hello, world!" 44 "2025-05-12T14:32:16Z" "2025-05-12T00:00:00Z"]
                           [2 "seeya, world!" nil nil                   nil]]
-                         (->> (table-rows @test-table)
+                         (->> (table-rows table-id)
                               (sort-by first)))))
                 ;; This is failing because id is auto-incremented and does not accept a value
                 ;; we need to change the tests so that the upsert is conditioned on columns other than PK
@@ -1281,13 +1222,12 @@
                   (is (= {} (prefill-values delete-card {:id 2}))))
                 (execute! delete-card {:id 2})
                 (is (= [[1 "hello, world!" 44 "2025-05-12T14:32:16Z" "2025-05-12T00:00:00Z"]]
-                       (->> (table-rows @test-table)
+                       (->> (table-rows table-id)
                             (sort-by first))))))))))))
 
 (deftest tmp-modal-saved-action-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (data-editing.tu/toggle-data-editing-enabled! true)
       (testing "saved actions"
         (mt/with-non-admin-groups-no-root-collection-perms
           (mt/with-temp [:model/Table         table    {}
@@ -1341,13 +1281,12 @@
 (deftest tmp-modal-packed-table-action-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (data-editing.tu/toggle-data-editing-enabled! true)
-      (with-open [test-table (data-editing.tu/open-test-table! {:id 'auto-inc-type
-                                                                :text      [:text]
-                                                                :int       [:int]
-                                                                :timestamp [:timestamp]
-                                                                :date      [:date]}
-                                                               {:primary-key [:id]})]
+      (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+                                                     :text      [:text]
+                                                     :int       [:int]
+                                                     :timestamp [:timestamp]
+                                                     :date      [:date]}
+                                                    {:primary-key [:id]}]]
 
         (testing "table actions"
           (let [{create-id           "table.row/create"
@@ -1355,9 +1294,9 @@
                  update-id           "table.row/update"
                  delete-id           "table.row/delete"}            (->> (mt/user-http-request :crowberto :get 200 "action/v2/tmp-action")
                                                                          :actions
-                                                                         (filter #(= @test-table (:table_id %)))
+                                                                         (filter #(= table-id (:table_id %)))
                                                                          (u/index-by :kind :id))
-                scope                                               {:table-id @test-table}]
+                scope                                               {:table-id table-id}]
 
             (testing "create"
               (is (=? {:parameters [{:id "text"      :display_name "Text"      :input_type "text"}
@@ -1397,15 +1336,14 @@
 (deftest tmp-modal-magic-scope-detection-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (data-editing.tu/toggle-data-editing-enabled! true)
-      (with-open [test-table (data-editing.tu/open-test-table! {:id 'auto-inc-type
-                                                                :text      [:text]
-                                                                :int       [:int]
-                                                                :timestamp [:timestamp]
-                                                                :date      [:date]}
-                                                               {:primary-key [:id]})]
+      (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+                                                     :text      [:text]
+                                                     :int       [:int]
+                                                     :timestamp [:timestamp]
+                                                     :date      [:date]}
+                                                    {:primary-key [:id]}]]
         (mt/user-http-request :crowberto :post 200
-                              (data-editing.tu/table-url @test-table)
+                              (data-editing.tu/table-url table-id)
                               {:rows [{:text "a very important string"}]})
 
         (let [create-id "table.row/create"
@@ -1413,7 +1351,7 @@
               delete-id "table.row/delete"]
 
           (testing "using table-id from scope"
-            (let [scope {:table-id @test-table}]
+            (let [scope {:table-id table-id}]
               (testing "create"
                 (is (=? {:parameters [{:id "text" :readonly false}
                                       {:id "int" :readonly false}
@@ -1451,25 +1389,22 @@
 (deftest tmp-modal-table-action-on-editable-on-dashboard-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (with-open [categories (data-editing.tu/open-test-table!
-                              {:id   'auto-inc-type
-                               :name [:text]}
-                              {:primary-key [:id]})
-                  products (data-editing.tu/open-test-table!
-                            {:id          'auto-inc-type
-                             :name        [:text]
-                             :price       [:int]
-                             :category_id [:int]}
-                            {:primary-key [:id]})]
-        (data-editing.tu/toggle-data-editing-enabled! true)
+      (data-editing.tu/with-test-tables! [categories [{:id   'auto-inc-type
+                                                       :name [:text]}
+                                                      {:primary-key [:id]}]
+                                          products   [{:id          'auto-inc-type
+                                                       :name        [:text]
+                                                       :price       [:int]
+                                                       :category_id [:int]}
+                                                      {:primary-key [:id]}]]
         (mt/with-temp
           [:model/Dashboard     dashboard {}
            :model/Card          model     {:type           :model
-                                           :dataset_query  {:database (mt/id), :type :query, :query {:source-table @categories}}}
+                                           :dataset_query  {:database (mt/id), :type :query, :query {:source-table categories}}}
            :model/DashboardCard dashcard  {:dashboard_id (:id dashboard)
                                            :card_id      (:id model)
                                            :visualization_settings
-                                           {:table_id @categories
+                                           {:table_id categories
                                             :table.columns
                                             [{:name "id"          :enabled true}
                                              {:name "name"        :enabled true}]
@@ -1485,7 +1420,7 @@
                                               :actionType "data-grid/built-in"}
                                              {:id                "dashcard:unknown:custom-create"
                                               :name              "create"
-                                              :actionId          (#'actions/encoded-action-id :table.row/create @products)
+                                              :actionId          (#'actions/encoded-action-id :table.row/create products)
                                               :actionType        "data-grid/row-action"
                                               :parameterMappings [{:parameterId "name" :sourceType "row-data" :sourceValueTarget "name"}
                                                                   {:parameterId "price" :sourceType "ask-user"}
@@ -1493,7 +1428,7 @@
                                             :enabled           true}}]
 
           (mt/user-http-request :crowberto :post 200
-                                (data-editing.tu/table-url @categories)
+                                (data-editing.tu/table-url categories)
                                 {:rows [{:name "Important category"}]})
 
           (testing "table actions on a dashcard"
@@ -1541,21 +1476,20 @@
 (deftest tmp-modal-table-action-on-question-on-dashboard-test
   (mt/with-premium-features #{:table-data-editing}
     (mt/test-drivers #{:h2 :postgres}
-      (data-editing.tu/toggle-data-editing-enabled! true)
-      (with-open [test-table (data-editing.tu/open-test-table! {:id 'auto-inc-type
-                                                                :text      [:text]
-                                                                :int       [:int]
-                                                                :timestamp [:timestamp]
-                                                                :date      [:date]}
-                                                               {:primary-key [:id]})]
+      (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+                                                     :text      [:text]
+                                                     :int       [:int]
+                                                     :timestamp [:timestamp]
+                                                     :date      [:date]}
+                                                    {:primary-key [:id]}]]
         (mt/with-temp
           [:model/Dashboard     dashboard {}
            :model/Card          model     {:type           :model
-                                           :dataset_query  {:database (mt/id), :type :query, :query {:source-table @test-table}}}
+                                           :dataset_query  {:database (mt/id), :type :query, :query {:source-table table-id}}}
            :model/DashboardCard dashcard  {:dashboard_id (:id dashboard)
                                            :card_id      (:id model)
                                            :visualization_settings
-                                           {:table_id @test-table
+                                           {:table_id table-id
                                             :table.columns
                                             [{:name "int",      :enabled true}
                                              {:name "text",     :enabled true}
@@ -1578,7 +1512,7 @@
                                              {:id                "dashcard:unknown:custom-create"
                                               :actionId          "table.row/create"
                                               :actionType        "data-grid/row-action"
-                                              :mapping           {:table-id @test-table
+                                              :mapping           {:table-id table-id
                                                                   :row      "::root"}
                                               :parameterMappings [{:parameterId "int"
                                                                    :sourceType  "constant"
@@ -1592,7 +1526,7 @@
 
           ;; insert a row for the row action
           (mt/user-http-request :crowberto :post 200
-                                (data-editing.tu/table-url @test-table)
+                                (data-editing.tu/table-url table-id)
                                 {:rows [{:text "a very important string"}]})
 
           (testing "table actions on a dashcard"

--- a/enterprise/backend/test/metabase_enterprise/data_editing/models/undo_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/models/undo_test.clj
@@ -73,14 +73,12 @@
         ;; Beware: h2 will not allow un-delete, we'll need to adjust the test not to include deletion in its history.
         ;;         and, we'll want to test the failure we get when we try to un-delete
         ;; Blocker for other drivers: https://linear.app/metabase/issue/WRK-223/pk-creation-for-non-h2-drivers
-        (with-open [table-ref (data-editing.tu/open-test-table! {:id             [:int]
-                                                                 :name           [:text]
-                                                                 :favourite_food [:text]}
-                                                                {:primary-key [:id]})]
-          (let [table-id   @table-ref
-                user-id    (mt/user->id :crowberto)
+        (data-editing.tu/with-test-tables! [table-id [{:id             [:int]
+                                                       :name           [:text]
+                                                       :favourite_food [:text]}
+                                                      {:primary-key [:id]}]]
+          (let [user-id    (mt/user->id :crowberto)
                 test-scope {:table-id table-id}]
-            (data-editing.tu/toggle-data-editing-enabled! true)
 
             (write-sequence! table-id {:id 1} [[user-id {:name "Snorkmaiden" :favourite_food "pork"}]
                                                [user-id {:name "Snorkmaiden" :favourite_food "orc"}]
@@ -142,15 +140,13 @@
   (mt/with-empty-h2-app-db!
     (mt/with-premium-features #{:table-data-editing}
       (testing "Multi-user chain"
-        (with-open [table-ref (data-editing.tu/open-test-table! {:id    [:int]
-                                                                 :name  [:text]
-                                                                 :power [:int]}
-                                                                {:primary-key [:id]})]
-          (let [table-id   @table-ref
-                user-1     (mt/user->id :crowberto)
+        (data-editing.tu/with-test-tables! [table-id [{:id    [:int]
+                                                       :name  [:text]
+                                                       :power [:int]}
+                                                      {:primary-key [:id]}]]
+          (let [user-1     (mt/user->id :crowberto)
                 user-2     (mt/user->id :rasta)
                 test-scope {:table-id table-id}]
-            (data-editing.tu/toggle-data-editing-enabled! true)
 
             ;; NOTE: this test relies on the "conflicts even when different columns changed" semantics
             ;; If we improve the semantics, we'll need to improve this test!
@@ -239,14 +235,12 @@
   (mt/with-empty-h2-app-db!
     (mt/with-premium-features #{:table-data-editing}
       (testing "Reverted changes have their snapshots deleted when there are further changes"
-        (with-open [table-ref (data-editing.tu/open-test-table! {:id     [:int]
-                                                                 :name   [:text]
-                                                                 :status [:text]}
-                                                                {:primary-key [:id]})]
-          (let [table-id   @table-ref
-                user-id    (mt/user->id :crowberto)
+        (data-editing.tu/with-test-tables! [table-id [{:id     [:int]
+                                                       :name   [:text]
+                                                       :status [:text]}
+                                                      {:primary-key [:id]}]]
+          (let [user-id    (mt/user->id :crowberto)
                 test-scope {:table-id table-id}]
-            (data-editing.tu/toggle-data-editing-enabled! true)
 
             ;; NOTE: this test relies on the "conflicts even when different columns changed" semantics
             ;; If we improve the semantics, we'll need to improve this test!
@@ -285,13 +279,10 @@
   (mt/with-empty-h2-app-db!
     (mt/with-premium-features #{:table-data-editing}
       (testing "We delete older batches when they exceed our retention limits"
-        (with-open [table-ref-1 (data-editing.tu/open-test-table! {:id [:int]} {:primary-key [:id]})
-                    table-ref-2 (data-editing.tu/open-test-table! {:id [:int]} {:primary-key [:id]})]
-          (let [table-1    @table-ref-1
-                table-2    @table-ref-2
-                user-1     (mt/user->id :crowberto)
+        (data-editing.tu/with-test-tables! [table-1 [{:id [:int]} {:primary-key [:id]}]
+                                            table-2 [{:id [:int]} {:primary-key [:id]}]]
+          (let [user-1     (mt/user->id :crowberto)
                 user-2     (mt/user->id :rasta)]
-            (data-editing.tu/toggle-data-editing-enabled! true)
 
             (testing "Total rows"
               (with-redefs [undo/retention-total-rows 17]
@@ -384,13 +375,11 @@
   (mt/with-empty-h2-app-db!
     (mt/with-premium-features #{:table-data-editing}
       (testing "Cannot undo a batch marked as undoable: false"
-        (with-open [table-ref (data-editing.tu/open-test-table! {:id   [:int]
-                                                                 :name [:text]}
-                                                                {:primary-key [:id]})]
-          (let [table-id   @table-ref
-                user-id    (mt/user->id :crowberto)
+        (data-editing.tu/with-test-tables! [table-id [{:id   [:int]
+                                                       :name [:text]}
+                                                      {:primary-key [:id]}]]
+          (let [user-id    (mt/user->id :crowberto)
                 test-scope {:table-id table-id}]
-            (data-editing.tu/toggle-data-editing-enabled! true)
 
             ;; Create a regular undoable change first
             (create-row! user-id table-id {:id 1, :name "Undoable change"})

--- a/enterprise/backend/test/metabase_enterprise/data_editing/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/test_util.clj
@@ -3,16 +3,11 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.walk :as walk]
-   [metabase.actions.settings :as actions.settings]
    [metabase.actions.test-util :as actions.tu]
    [metabase.driver :as driver]
-   [metabase.premium-features.token-check :as token-check]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
-   [toucan2.core :as t2])
-  (:import
-   (clojure.lang IDeref)
-   (java.io Closeable)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -45,79 +40,13 @@
   [token]
   (format "ee/data-editing-public/webhook/%s/data" token))
 
-(def ^:private ^:dynamic *initial-db-settings* nil)
-
-(defn restore-db-settings-fixture [f]
-  (binding [*initial-db-settings* {}]
-    (try
-      (f)
-      (finally
-        (when *initial-db-settings*
-          (doseq [[id settings] *initial-db-settings*]
-            (t2/update! :model/Database id {:settings settings})))))))
-
-;; TODO: this is an anti pattern to modify the test db (mt/id)
-;; it can mess up with other tests if we make desctructive changes, we should really just create a new db
-(defn alter-db-settings! [f & args]
-  (let [id           (mt/id)
-        settings     (t2/select-one-fn :settings :model/Database id)
-        ;; save initial settings so the restore-appdb-settings-fixture can restore them
-        _            (when-some [db-settings *initial-db-settings*]
-                       (set! *initial-db-settings* (if (contains? db-settings id)
-                                                     db-settings
-                                                     (assoc db-settings id settings))))
-        new-settings (apply f settings args)]
-    (t2/update! :model/Database id {:settings new-settings})))
-
-(defn toggle-data-editing-enabled! [on-or-off]
-  (alter-db-settings! assoc :database-enable-table-editing (boolean on-or-off)))
+(defn toggle-data-editing-enabled! [db-id on-or-off]
+  (let [current-settings (t2/select-one-fn :settings :model/Database db-id)]
+    (t2/update! :model/Database db-id {:settings (assoc current-settings :database-enable-table-editing (boolean on-or-off))})))
 
 (defmacro with-data-editing-enabled! [on-or-off & body]
-  `(let [before# (actions.settings/database-enable-table-editing)]
-     (try
-       (toggle-data-editing-enabled! ~on-or-off)
-       (let [tokens# (cond-> (token-check/*token-features*)
-                       ~on-or-off       (conj "table-data-editing")
-                       (not ~on-or-off) (disj "table-data-editing"))]
-         (binding [token-check/*token-features* (constantly tokens#)]
-           ~@body))
-       (finally
-         (toggle-data-editing-enabled! before#)))))
-
-(defn open-test-table!
-  "Sets up an anonymous table in the test db (mt/id). Return a box that can be deref'd for the table-id.
-
-  Optionally accepts the column map and opts inputs to driver/create-table!.
-  The symbol auto-inc-type can be used to denote the driver-specific auto-incrementing type for primary keys.
-  e.g (open-test-table {:id 'auto-inc-type, :name [:text]} {:primary-key [:id]})
-
-  Returned box is java.io.Closeable so you can clean up with `with-open`.
-  Otherwise .close the box to drop the table when finished."
-  (^Closeable []
-   (open-test-table!
-    {:id    'auto-inc-type
-     :name  [:text]
-     :song  [:text]}
-    {:primary-key [:id]}))
-
-  (^Closeable [column-map create-table-opts]
-   (let [db            (t2/select-one :model/Database (mt/id))
-         driver        (:engine db)
-         auto-inc-type (driver/upload-type->database-type driver :metabase.upload/auto-incrementing-int-pk)
-         column-map    (walk/postwalk-replace {'auto-inc-type auto-inc-type} column-map)
-         table-name    (str "temp_table_" (str/replace (random-uuid) "-" "_"))
-         cleanup       (fn []
-                         (driver/drop-table! driver (mt/id) table-name)
-                         (t2/delete! :model/Table :name table-name))]
-     (try
-       (let [table-id (create-test-table! db table-name column-map create-table-opts)]
-         (reify Closeable
-           IDeref
-           (deref [_] table-id)
-           (close [_] (cleanup))))
-       (catch Exception e
-         (try (cleanup) (catch Exception cleanup-ex (.addSuppressed e cleanup-ex)))
-         (throw e))))))
+  `(mt/with-temp-vals-in-db :model/Database (mt/id) {:settings {:database-enable-table-editing ~on-or-off}}
+     ~@body))
 
 (def default-test-table
   "The default test table config."
@@ -144,8 +73,9 @@
         (throw e)))))
 
 (defmacro with-test-tables!
-  "Execute `body` with temporary table(s) created in the test database. You may specify multiple table specifications
-  to create multiple tables. Each table specification should be a vector containing `[column-map create-table-opts]`.
+  "Execute `body` with temporary table(s) created in the test database that has actions and table editing enabled.
+  You may specify multiple table specifications to create multiple tables.
+  Each table specification should be a vector containing `[column-map create-table-opts]`.
   The symbol `auto-inc-type` can be used in column maps to denote the driver-specific auto-incrementing type for
   primary keys.
 
@@ -165,6 +95,8 @@
       ...)"
   [[table-binding table-spec & more] & body]
   `(mt/with-empty-db
+     (t2/update! :model/Database (mt/id) {:settings {:database-enable-table-editing true
+                                                     :database-enable-actions       true}})
      (do-with-test-tables!
       ~table-spec
       (fn [~table-binding]
@@ -178,5 +110,14 @@
   Use (mt/id), (mt/db) etc to get the database id and database object."
   [& body]
   `(actions.tu/with-actions-test-data
-     (toggle-data-editing-enabled! true)
+     (toggle-data-editing-enabled! (mt/id) true)
      ~@body))
+
+(defmacro with-actions-temp-db
+  "Like [[actions.tu/with-actions-temp-db]] but with table editing enabled"
+  [dataset-definition & body]
+  `(actions.tu/with-actions-temp-db ~dataset-definition
+     (t2/update! :model/Database (mt/id) {:settings {:database-enable-table-editing true
+                                                     :database-enable-actions       true}})
+     ~@body))
+

--- a/enterprise/backend/test/metabase_enterprise/data_editing/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/test_util.clj
@@ -120,4 +120,3 @@
      (t2/update! :model/Database (mt/id) {:settings {:database-enable-table-editing true
                                                      :database-enable-actions       true}})
      ~@body))
-

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -912,12 +912,13 @@
                                :table-id   table-id})))))
 
         (= 1 before-count)
-        (assoc (row-update!* action database {:database   (u/the-id database)
-                                              :type       :query
-                                              :query      {:source-table table-id
-                                                           :filter       (row->mbql-filter-clause
-                                                                          (field-names->field-name->id table-id (keys row-key)) row-key)}
-                                              :update-row row})
+        (assoc (row-update!* action database
+                             {:database   (u/the-id database)
+                              :type       :query
+                              :query      {:source-table table-id
+                                           :filter       (row->mbql-filter-clause
+                                                          (field-names->field-name->id table-id (keys row-key)) row-key)}
+                              :update-row (apply dissoc row (keys row-key))})
                :op :updated)
 
         (> before-count 1)

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -502,7 +502,6 @@
           (let [db-id             (mt/id)
                 user-name-col     (field-id->name (mt/id :user :name))
                 user-group-id-col (field-id->name (mt/id :user :group-id))]
-
             (testing "concurrent creation that result in more than 1 row throw an error and rollback"
               (let [original-row-create!* @#'sql-jdbc.actions/row-create!*
                     error-thrown? (atom false)]
@@ -511,13 +510,14 @@
                                                                 (last (for [_ (range 2)]
                                                                         (apply original-row-create!* args))))]
 
-                    (actions/perform-action-with-single-input-and-output
-                     :table.row/create-or-update
-                     {:database db-id
-                      :table-id (mt/id :user)
-                      :row      {user-name-col     "New User"
-                                 user-group-id-col 1}
-                      :row-key  {user-name-col "New User"}}))
+                    (mt/with-current-user (mt/user->id :crowberto)
+                      (actions/perform-action-with-single-input-and-output
+                       :table.row/create-or-update
+                       {:database db-id
+                        :table-id (mt/id :user)
+                        :row      {user-name-col     "New User"
+                                   user-group-id-col 1}
+                        :row-key  {user-name-col "New User"}})))
                   (catch Throwable e
                     (reset! error-thrown? true)
                     (is (= (str "unintentionally created 2 duplicate rows for key: table \"public\".\"user\" with name = \"new user\". "
@@ -528,12 +528,13 @@
             (testing "Update more than 1 row"
               (let [error-thrown? (atom false)]
                 (try
-                  (actions/perform-action-with-single-input-and-output
-                   :table.row/create-or-update
-                   {:database db-id
-                    :table-id (mt/id :user)
-                    :row      {user-name-col "New User"}
-                    :row-key  {user-group-id-col 1}})
+                  (mt/with-current-user (mt/user->id :crowberto)
+                    (actions/perform-action-with-single-input-and-output
+                     :table.row/create-or-update
+                     {:database db-id
+                      :table-id (mt/id :user)
+                      :row      {user-name-col "New User"}
+                      :row-key  {user-group-id-col 1}}))
                   (catch Throwable e
                     (reset! error-thrown? true)
                     (is (= (str "found 2 duplicate rows in table \"public\".\"user\" with group-id = 1. unsure which row to update. "

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -520,9 +520,10 @@
                         :row-key  {user-name-col "New User"}})))
                   (catch Throwable e
                     (reset! error-thrown? true)
-                    (is (= (str "unintentionally created 2 duplicate rows for key: table \"public\".\"user\" with name = \"new user\". "
-                                "this suggests a concurrent modification. we recommend adding a uniqueness constraint to the table.")
-                           (-> e ex-data :errors first :error u/lower-case-en)))))
+                    (is (some? (re-find (re-pattern
+                                         (str "unintentionally created 2 duplicate rows for key: table .* with name = \"new user\". "
+                                              "this suggests a concurrent modification. we recommend adding a uniqueness constraint to the table."))
+                                        (-> e ex-data :errors first :error u/lower-case-en))))))
                 (is (true? @error-thrown?))))
 
             (testing "Update more than 1 row"
@@ -537,8 +538,9 @@
                       :row-key  {user-group-id-col 1}}))
                   (catch Throwable e
                     (reset! error-thrown? true)
-                    (is (= (str "found 2 duplicate rows in table \"public\".\"user\" with group-id = 1. unsure which row to update. "
-                                "only use this action with key combinations which are meant to be unique. "
-                                "we recommend adding a uniqueness constraint to the table.")
-                           (-> e ex-data :errors first :error u/lower-case-en)))))
+                    (is (some? (re-find
+                                (re-pattern (str "found 2 duplicate rows in table .* with group-id = 1. unsure which row to update. "
+                                                 "only use this action with key combinations which are meant to be unique. "
+                                                 "we recommend adding a uniqueness constraint to the table."))
+                                (-> e ex-data :errors first :error u/lower-case-en))))))
                 (is (true? @error-thrown?))))))))))


### PR DESCRIPTION
Previously our test helpers modify the global test database for testing, this leads to various flaky test in other part of the application like failure in get-db api([link](https://github.com/metabase/metabase/actions/runs/15735245006/job/44346130928?pr=59604#step:3:4028)) due to destructive change to the db settings.

This pattern also stop us from parallel tests in the future.

I've overhauled to make tests that relying on creating tables will operate on a new local db and clean it up after.

Also this should fix all failing tests on the feature branch.