### PR TITLE
fix: include sit-url in embedding-app-origins-interactive to make the preview work on cloud

### DIFF
--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/ProcessingStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/ProcessingStep.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { useUpdateSettingsMutation } from "metabase/api/settings";
+import { useSetting } from "metabase/common/hooks";
 import { Box, Loader, Stack, Text, Title } from "metabase/ui";
 
 import { useEmbeddingSetup } from "../EmbeddingSetupContext";
@@ -9,6 +10,7 @@ import { useForceLocaleRefresh } from "../useForceLocaleRefresh";
 
 export const ProcessingStep = () => {
   useForceLocaleRefresh();
+  const siteUrl = useSetting("site-url");
 
   const { goToNextStep } = useEmbeddingSetup();
 
@@ -28,10 +30,10 @@ export const ProcessingStep = () => {
     await updateSettings({
       "embedding-homepage": "visible",
       "enable-embedding-interactive": true,
-      "embedding-app-origins-interactive": "localhost:*",
+      "embedding-app-origins-interactive": `localhost:* ${siteUrl}`,
       "session-cookie-samesite": "none",
-    }).unwrap();
-  }, [updateSettings]);
+    });
+  }, [updateSettings, siteUrl]);
 
   useEffect(() => {
     const process = async () => {


### PR DESCRIPTION

Closes EMB-526
I tested it locally with a domain with https:
<img width="1319" alt="image" src="https://github.com/user-attachments/assets/f10c3849-8275-49a5-b991-e3d798ddc312" />
