### PR TITLE
test db routing on dbs which support it

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -197,15 +197,16 @@
                     (is (= {:values [["destination-2"]] :field_id field-id :has_more_values false}
                            response))))))))))))
 
+;; used to be named table but that is reserved on bigquery
 (tx/defdataset router-data
-  [["table"
-    [{:field-name "t", :base-type :type/Text}]
+  [["t"
+    [{:field-name "f", :base-type :type/Text}]
     [["original-foo"]
      ["original-bar"]]]])
 
 (tx/defdataset routed-data
-  [["table"
-    [{:field-name "t", :base-type :type/Text}]
+  [["t"
+    [{:field-name "f", :base-type :type/Text}]
     [["routed-foo"]
      ["routed-bar"]]]])
 
@@ -230,7 +231,7 @@
                                                         :user_attribute "db_name"}]
                   (met/with-user-attributes! :rasta {"db_name" (:name routed)}
                     (let [crowberto (mt/with-current-user (mt/user->id :crowberto)
-                                      (mt/rows (mt/process-query (mt/query table))))
+                                      (mt/rows (mt/process-query (mt/query t))))
                           rasta (mt/with-current-user (mt/user->id :rasta)
-                                  (mt/rows (mt/process-query (mt/query table))))]
+                                  (mt/rows (mt/process-query (mt/query t))))]
                       (is (not= crowberto rasta) "rows were identical meaning it did not route"))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.database-routing.e2e-test
+(ns ^:mb/driver-tests metabase-enterprise.database-routing.e2e-test
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer [deftest is testing]]
@@ -10,6 +10,7 @@
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.test.data :as data]
+   [metabase.test.data.interface :as tx]
    [metabase.test.data.one-off-dbs :as one-off-dbs]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -195,3 +196,42 @@
                   (let [response (mt/user-http-request :lucky :get 200 (str "field/" field-id "/values"))]
                     (is (= {:values [["destination-2"]] :field_id field-id :has_more_values false}
                            response))))))))))))
+
+
+(tx/defdataset router-data
+  [["table"
+    [{:field-name "t", :base-type :type/Text}]
+    [["original-foo"]
+     ["original-bar"]]]])
+
+(tx/defdataset routed-data
+  [["table"
+    [{:field-name "t", :base-type :type/Text}]
+    [["routed-foo"]
+     ["routed-bar"]]]])
+
+(deftest db-routing-e2e-test
+  ;; todo: this is to quickly get tests against all drivers right now. We probably want to extract the `wire-routing`
+  ;; funciton below, make a few more nice helpers, and remove some of the above tests which are duplicative of the
+  ;; below.
+  (mt/test-drivers (conj (mt/normal-drivers-with-feature :database-routing) :clickhouse)
+    (letfn [(wire-routing [{:keys [parent children]}]
+              (t2/update! :model/Database :id [:in (map :id children)]
+                          {:router_database_id (:id parent)})
+              (doseq [child children]
+                (t2/update! :model/Database :id (:id child)
+                            {:details (assoc (:details child) :destination-database true)})))]
+      (mt/with-premium-features #{:database-routing}
+        (mt/dataset routed-data
+          (let [routed (mt/db)]
+            (mt/dataset router-data
+              (let [router (mt/db)]
+                (wire-routing {:parent router :children [routed]})
+                (mt/with-temp [:model/DatabaseRouter _ {:database_id    (u/the-id router)
+                                                        :user_attribute "db_name"}]
+                  (met/with-user-attributes! :rasta {"db_name" (:name routed)}
+                    (let [crowberto (mt/with-current-user (mt/user->id :crowberto)
+                                      (mt/rows (mt/process-query (mt/query table))))
+                          rasta (mt/with-current-user (mt/user->id :rasta)
+                                  (mt/rows (mt/process-query (mt/query table))))]
+                      (is (not= crowberto rasta) "rows were identical meaning it did not route"))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -213,7 +213,7 @@
   ;; todo: this is to quickly get tests against all drivers right now. We probably want to extract the `wire-routing`
   ;; funciton below, make a few more nice helpers, and remove some of the above tests which are duplicative of the
   ;; below.
-  (mt/test-drivers (conj (mt/normal-drivers-with-feature :database-routing) :clickhouse)
+  (mt/test-drivers (mt/normal-drivers-with-feature :database-routing)
     (letfn [(wire-routing [{:keys [parent children]}]
               (t2/update! :model/Database :id [:in (map :id children)]
                           {:router_database_id (:id parent)})

--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -197,7 +197,6 @@
                     (is (= {:values [["destination-2"]] :field_id field-id :has_more_values false}
                            response))))))))))))
 
-
 (tx/defdataset router-data
   [["table"
     [{:field-name "t", :base-type :type/Text}]

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -46,7 +46,8 @@
                               :expression-literals           true
                               :identifiers-with-spaces       false
                               :metadata/key-constraints      false
-                              :test/jvm-timezone-setting     false}]
+                              :test/jvm-timezone-setting     false
+                              :database-routing              false}]
   (defmethod driver/database-supports? [:athena feature] [_driver _feature _db] supported?))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -699,7 +699,8 @@
                               ;; supporting set-timezone anyway so that reporting timezones are returned and used, and
                               ;; tests expect the converted values.
                               :set-timezone             true
-                              :expression-literals      true}]
+                              :expression-literals      true
+                              :database-routing         false}]
   (defmethod driver/database-supports? [:bigquery-cloud-sdk feature] [_driver _feature _db] supported?))
 
 ;; BigQuery is always in UTC

--- a/modules/drivers/databricks/src/metabase/driver/databricks.clj
+++ b/modules/drivers/databricks/src/metabase/driver/databricks.clj
@@ -50,7 +50,7 @@
                               :set-timezone                    true
                               :standard-deviation-aggregations true
                               :test/jvm-timezone-setting       false
-                              :database-routing                true}]
+                              :database-routing                false}]
   (defmethod driver/database-supports? [:databricks feature] [_driver _feature _db] supported?))
 
 (defmethod sql-jdbc.sync/database-type->base-type :databricks

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -52,7 +52,8 @@
                               :now                     true
                               :identifiers-with-spaces true
                               :convert-timezone        true
-                              :expressions/date        false}]
+                              :expressions/date        false
+                              :database-routing        false}]
   (defmethod driver/database-supports? [:oracle feature] [_driver _feature _db] supported?))
 
 (mr/def ::details

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -56,7 +56,8 @@
                               :now                             true
                               :set-timezone                    true
                               :standard-deviation-aggregations true
-                              :metadata/key-constraints        false}]
+                              :metadata/key-constraints        false
+                              :database-routing                false}]
   (defmethod driver/database-supports? [:presto-jdbc feature] [_driver _feature _db] supported?))
 
 ;;; Presto API helpers

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -41,7 +41,8 @@
                               :identifiers-with-spaces   false
                               :uuid-type                 false
                               :nested-field-columns      false
-                              :test/jvm-timezone-setting false}]
+                              :test/jvm-timezone-setting false
+                              :database-routing          false}]
   (defmethod driver/database-supports? [:redshift feature] [_driver _feat _db] supported?))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -63,7 +63,8 @@
                               :expressions/date                       true
                               :identifiers-with-spaces                true
                               :split-part                             true
-                              :now                                    true}]
+                              :now                                    true
+                              :database-routing                       true}]
   (defmethod driver/database-supports? [:snowflake feature] [_driver _feature _db] supported?))
 
 (defmethod driver/humanize-connection-error-message :snowflake

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -64,7 +64,7 @@
                               :identifiers-with-spaces                true
                               :split-part                             true
                               :now                                    true
-                              :database-routing                       true}]
+                              :database-routing                       false}]
   (defmethod driver/database-supports? [:snowflake feature] [_driver _feature _db] supported?))
 
 (defmethod driver/humanize-connection-error-message :snowflake

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -241,7 +241,8 @@
                               :metadata/key-constraints        false
                               :test/jvm-timezone-setting       false
                               ;; disabled for now, see issue #40991 to fix this.
-                              :window-functions/cumulative     false}]
+                              :window-functions/cumulative     false
+                              :database-routing                false}]
   (defmethod driver/database-supports? [:sparksql feature] [_driver _feature _db] supported?))
 
 (defmethod sql.qp/quote-style :sparksql

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -35,7 +35,8 @@
                               :now                       true
                               :identifiers-with-spaces   true
                               :percentile-aggregations   false
-                              :test/jvm-timezone-setting false}]
+                              :test/jvm-timezone-setting false
+                              :database-routing          false}]
   (defmethod driver/database-supports? [:vertica feature] [_driver _feature _db] supported?))
 
 (defmethod driver/db-start-of-week :vertica


### PR DESCRIPTION
running a simple db-routing against all dbs that support it.
It's trivial to support it, you get a different db connection. But clickhouse includes database names in queries so it appears to not work if you route to the same clickhouse instance. It of course works correctly on separate clickhouse hosts.

This change is a bit overly restrictive.
A few databases we do not support yet. Snowflake is like this because it includes database names in table names.

```sql
select * from router.public.table
```

If the connection is changed from database router to database routed, it still points at `router.public.table` and annoyingly, that doesn't error, it just does a cross database query.

Clickhouse only has `database.table` and can do cross db queries.

```sql
select * from database.table
```

Oracle has issues with data loading that I have not been able to diagnose yet.

Bigquery and redshift don't work because of how we load data in tests. Bigquery needs separate projects, not datasets. Again the sensitivity to levels.