### PR TITLE
fix: randomize the sample db sync schedule

### DIFF
--- a/resources/sample-content.edn
+++ b/resources/sample-content.edn
@@ -6,7 +6,7 @@
    :timezone "UTC",
    :is_attached_dwh false,
    :auto_run_queries true,
-   :metadata_sync_schedule "0 43 * * * ? *",
+   :metadata_sync_schedule "0 50 * * * ? *",
    :name "Sample Database",
    :settings nil,
    :caveats

--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -38,9 +38,9 @@
 
 (defn randomly-once-an-hour
   "Schedule map for once an hour at a random minute of the hour."
-  []
-  ;; avoid around near the hour because it's usually when notifications are scheduled.
-  (let [choices (remove #{50} (range 5 55))]
+  [excluded-minute]
+   ;; avoid around near the hour because it's usually when notifications are scheduled.
+  (let [choices (remove #{excluded-minute} (range 5 55))]
     {:schedule_minute (rand-nth choices)
      :schedule_type   "hourly"}))
 
@@ -54,9 +54,11 @@
 (defn default-randomized-schedule
   "Default schedule maps for caching field values and sync. Defaults to `:cache_field_values` randomly once a day and
   `:metadata_sync` randomly once an hour. "
-  []
-  {:cache_field_values (randomly-once-a-day)
-   :metadata_sync      (randomly-once-an-hour)})
+  ([]
+   (default-randomized-schedule {:excluded-minute 50}))
+  ([{:keys [excluded-minute]}]
+   {:cache_field_values (randomly-once-a-day)
+    :metadata_sync      (randomly-once-an-hour excluded-minute)}))
 
 ;; two because application and db each have defaults
 (def default-cache-field-values-schedule-cron-strings

--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -66,3 +66,7 @@
 (def default-metadata-sync-schedule-cron-strings
   "Default `:metadata_sync_schedule`s (two as application and db have different defaults)."
   #{"0 0 * * * ? *" "0 50 * * * ? *"})
+
+(def old-sample-metadata-sync-schedule-cron-string
+  "Before ADM-943, the default value for this sync string was 43 causing issues with stampedes."
+  "0 43 * * * ? *")

--- a/src/metabase/sync/task/sync_databases.clj
+++ b/src/metabase/sync/task/sync_databases.clj
@@ -339,7 +339,11 @@
                 (try
                   (t2/update! :model/Database (u/the-id db)
                               (sync.schedules/schedule-map->cron-strings
-                               (sync.schedules/default-randomized-schedule)))
+                               ;; TODO (edpaget): this can go away after this patch is deployed to cloud
+                               (if (= sync.schedules/old-sample-metadata-sync-schedule-cron-string
+                                      (:metadata_sync_schedule db))
+                                 (sync.schedules/default-randomized-schedule {:excluded-minute 43})
+                                 (sync.schedules/default-randomized-schedule))))
                   (inc counter)
                   (catch Exception e
                     (log/warnf e "Error updating database %d for randomized schedules" (u/the-id db))

--- a/src/metabase/sync/task/sync_databases.clj
+++ b/src/metabase/sync/task/sync_databases.clj
@@ -348,6 +348,8 @@
               {:select [:*]
                :from   [:metabase_database]
                :where  [:or
+                        [:and [:= :is_sample true]
+                         [:= :metadata_sync_schedule sync.schedules/old-sample-metadata-sync-schedule-cron-string]]
                         [:in
                          :metadata_sync_schedule
                          sync.schedules/default-metadata-sync-schedule-cron-strings]

--- a/test/metabase/sync/task/sync_databases_test.clj
+++ b/test/metabase/sync/task/sync_databases_test.clj
@@ -334,3 +334,22 @@
           (is (= fv-default (:cache_field_values_schedule after))
               "Field values schedule erroneously randomized")
           (is (= (:updated_at after) (:updated_at before))))))))
+
+(deftest randomize-db-schedules-if-needed-test-4
+  (testing "Randomizes sample dbs with the old sync string (ADM-943)"
+    (mt/with-model-cleanup [:model/Database]
+      ;; Need to call it this way to avoid callbacks
+      (let [db-id (t2/insert-returning-pk! (t2/table-name :model/Database) {:details   "{}"
+                                                                            :engine    "h2"
+                                                                            :is_sample true
+                                                                            :name      "populate-collection-created-at-test-db-1"
+                                                                            :created_at :%now
+                                                                            :updated_at :%now
+                                                                            :metadata_sync_schedule "0 43 * * * ? *"})
+            before (t2/select-one :model/Database :id db-id)]
+        (#'task.sync-databases/randomize-db-schedules-if-needed!)
+        (let [after (t2/select :model/Database :id db-id)]
+          (is (not (nil? after)) "Sample db exists")
+          ;; Old schedule should be randomized if it existed
+          (is (not= (:metadata_sync_schedule before) (:metadata_sync_schedule after))
+              "Sync schedule randomized"))))))


### PR DESCRIPTION
### Description

Randomizes the schedule of the sample database to avoid stampedes when running in metabase cloud. Also updates the default schedule of the sample database to our standard sentinel value for randomization, so that we can eventually remove the special casing functions for it. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
