### PR TITLE
show error message for databases that don't support routing

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.tsx
@@ -12,6 +12,7 @@ import {
 } from "metabase/admin/databases/components/DatabaseInfoSection";
 import { hasDbRoutingEnabled } from "metabase/admin/databases/utils";
 import { skipToken, useListUserAttributesQuery } from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { addUndo } from "metabase/redux/undo";
 import { getUserIsAdmin } from "metabase/selectors/user";
@@ -114,7 +115,7 @@ export const DatabaseRoutingSection = ({
           </Label>
           {error ? (
             <Error role="alert" color="error">
-              {String(error)}
+              {getErrorMessage(error)}
             </Error>
           ) : null}
         </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.unit.spec.tsx
@@ -1,0 +1,66 @@
+import userEvent from "@testing-library/user-event";
+
+import {
+  setupDatabasesEndpoints,
+  setupUserAttributesEndpoint,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { Database } from "metabase-types/api";
+import { createMockDatabase, createMockUser } from "metabase-types/api/mocks";
+
+import { DatabaseRoutingSection } from "./DatabaseRoutingSection";
+
+const setup = (database: Partial<Database>) => {
+  const db = createMockDatabase(database);
+
+  setupUserAttributesEndpoint(["cool_guy", "boss_gal"]);
+  setupDatabasesEndpoints([db]);
+
+  renderWithProviders(<DatabaseRoutingSection database={db} />, {
+    storeInitialState: {
+      currentUser: createMockUser({ is_superuser: true }),
+    },
+  });
+};
+
+describe("DatabaseRoutingSection", () => {
+  it("should render DatabaseRoutingSection", () => {
+    setup({ engine: "postgres", features: ["database-routing"] });
+
+    expect(screen.getByText("Database routing")).toBeInTheDocument();
+    expect(screen.getByText("Enable database routing")).toBeInTheDocument();
+    expect(screen.getByLabelText("Enable database routing")).toBeEnabled();
+  });
+
+  it("should hide section if database is attached DWH", () => {
+    setup({
+      engine: "postgres",
+      is_attached_dwh: true,
+      features: ["database-routing"],
+    });
+
+    expect(screen.queryByText("Database routing")).not.toBeInTheDocument();
+  });
+
+  it("should hide section if database is sample", () => {
+    setup({
+      engine: "postgres",
+      is_sample: true,
+      features: ["database-routing"],
+    });
+
+    expect(screen.queryByText("Database routing")).not.toBeInTheDocument();
+  });
+
+  it("should disable db routing if database routing is not supported by the db engine", async () => {
+    setup({ engine: "clickhouse", features: [] });
+    expect(screen.getByLabelText("Enable database routing")).toBeDisabled();
+    const openSection = screen.getByLabelText("chevrondown icon");
+    await userEvent.click(openSection);
+    expect(
+      screen.getByText(
+        "Database routing is not supported for this database type.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
@@ -11,7 +11,12 @@ export const getDisabledFeatureMessage = (database: Database) => {
     hasActionsEnabled: hasActionsEnabled(database),
     isPersisted: hasFeature(database, "persist-models-enabled"),
     isUploadDb: database.uploads_enabled,
+    supportsRouting: !!database.features?.includes("database-routing"),
   })
+    .with(
+      { supportsRouting: false },
+      () => t`Database routing is not supported for this databases type.`,
+    )
     .with(
       { hasActionsEnabled: true, isPersisted: true },
       () =>

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
@@ -15,7 +15,7 @@ export const getDisabledFeatureMessage = (database: Database) => {
   })
     .with(
       { supportsRouting: false },
-      () => t`Database routing is not supported for this databases type.`,
+      () => t`Database routing is not supported for this database type.`,
     )
     .with(
       { hasActionsEnabled: true, isPersisted: true },

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -19,6 +19,7 @@ export type DatabaseFeature =
   | "case-sensitivity-string-filter-options"
   | "convert-timezone"
   | "datetime-diff"
+  | "database-routing"
   | "dynamic-schema"
   | "expression-aggregations"
   | "expression-literals"


### PR DESCRIPTION
closes ADM-1008

## Description

Shows a nice error UI if the db engine doesn't support db routing.

![Screenshot 2025-06-20 at 9 43 13 AM](https://github.com/user-attachments/assets/f458f6d7-c8f5-40d6-87a6-c86cd2ce81ce)

