### PR TITLE
Log :dataset_query and stacktrace when looking up the field-form fails in param-target->field-clause

### DIFF
--- a/src/metabase/parameters/params.clj
+++ b/src/metabase/parameters/params.clj
@@ -84,7 +84,13 @@
             (mbql.u/unwrap-field-or-expression-clause field-form)
             (catch Exception e
               (log/error e "Failed unwrap field form" field-form)))
-          (log/error "Could not find matching field clause for target:" target))))))
+          (do (log/error "Could not find matching field clause for target:" target)
+              (when (mbql.u/is-clause? :template-tag dimension)
+                (log/debug (ex-info "Failed to lookup template-tag dimension"
+                                    {:dataset_query (:dataset_query card)
+                                     :dimension dimension
+                                     :tag-name (u/qualified-name (second dimension))})
+                           "Failed to lookup template-tag dimension"))))))))
 
 (defn- pk-fields
   "Return the `fields` that are PK Fields."

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -715,7 +715,22 @@
         (is (some? (mt/user-http-request :rasta :get 200 (str "dashboard/" dash-id))))
         (is (=? [{:level   :error
                   :message "Could not find matching field clause for target: [:dimension [:template-tag not-existed-filter]]"}]
-                (messages)))))))
+                (messages))))
+      (mt/with-log-messages-for-level [messages [metabase.parameters.params :debug]]
+        (is (some? (mt/user-http-request :rasta :get 200 (str "dashboard/" dash-id))))
+        (is (=? [{:level :error
+                  :message "Could not find matching field clause for target: [:dimension [:template-tag not-existed-filter]]"}
+                 {:level :debug
+                  :message "Failed to lookup template-tag dimension"
+                  :e  {:cause "Failed to lookup template-tag dimension"
+                       :data {:dataset_query
+                              {:type :native
+                               :native {:query "SELECT category FROM products LIMIT 10;"}}
+                              :dimension [:template-tag "not-existed-filter"]
+                              :tag-name "not-existed-filter"}}}]
+                (->> (messages)
+                     (map #(update % :e (fn [ex] {:cause (ex-message ex)
+                                                  :data (ex-data ex)}))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             PUT /api/dashboard/:id                                             |


### PR DESCRIPTION
Closes QUE-1417

### Description

Add some additional debug log info when `template-tag->field-form` fails to lookup the `field-form` for a given `dimension` in `param-target->field-clause`.

Adds (1) a stack trace and (2) the `:dataset_query` for the given card. The `:dataset_query` should allow us to see why the `template-tag->field-form` lookup failed.

Note that previously this error message included a stack trace and it was removed in #33613. The plan is to re-enable it temporarily to help diagnose this issue and revert it after.

Slack thread: https://metaboat.slack.com/archives/C0645JP1W81/p1750345387350349

### How to verify

To trigger this error in UI:

* Create a new SQL question with a template tag variables
* Save the question
* Add the card to a dashboard and connect filters to the variables
* Save the dashboard
* Edit the question and remove one or more of the variables from the native query
* Save the question
* Go back to the dashboard which now has dangling filters


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
