### PR TITLE
remove beta badge from the sdk on the embedding homepage

### DIFF
--- a/frontend/src/metabase/home/components/EmbedHomepage/Badge.ts
+++ b/frontend/src/metabase/home/components/EmbedHomepage/Badge.ts
@@ -17,7 +17,9 @@ const COLOR_VARIANTS = {
   },
 };
 
-// TODO: use Badge from metabase/ui when it's available
+/**
+ * @deprecated use Badge from metabase/ui
+ */
 export const Badge = styled.span<{
   color: BadgeColor;
   uppercase?: boolean;

--- a/frontend/src/metabase/home/components/EmbedHomepage/SDKContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/SDKContent.tsx
@@ -3,8 +3,6 @@ import { t } from "ttag";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { Box, Button, Group, Text } from "metabase/ui";
 
-import { Badge } from "./Badge";
-
 type SDKContentProps = {
   sdkQuickstartUrl: string;
   sdkDocsUrl: string;
@@ -19,13 +17,6 @@ export const SDKContent = ({
       <Text fw="bold" size="lg" color="text-medium">
         {t`Embedded analytics SDK`}
       </Text>
-      <Badge
-        color="gray"
-        fz="sm"
-        px="sm"
-        py="xs"
-        uppercase={false}
-      >{t`Beta`}</Badge>
     </Group>
     <Text mb="md">
       {t`Embed individual components like charts, dashboards, the query builder, and more with React. Get advanced customization with CSS styling and manage granular access and interactivity per component.`}


### PR DESCRIPTION
Closes EMB-539

Before:
<img width="724" alt="image" src="https://github.com/user-attachments/assets/aa089197-9ea9-42f2-8f61-04f857e96895" />

After:
<img width="702" alt="image" src="https://github.com/user-attachments/assets/31f549ae-9bd0-4e00-90c1-84f8a919e433" />
