### PR TITLE
docs: no helm chart

### DIFF
--- a/docs/installation-and-operation/installing-metabase.md
+++ b/docs/installation-and-operation/installing-metabase.md
@@ -51,7 +51,9 @@ See [Upgrading Metabase](upgrading-metabase.md).
 - [Running on Azure Web Apps](running-metabase-on-azure.md)
 - [Running on Debian as a service](running-metabase-on-debian.md)
 
-We currently do not distribute Metabase on AWS Marketplace or Azure Marketplace.
+We currently do not distribute Metabase on AWS Marketplace or Azure Marketplace. 
+
+Metabase doesn't have an officially supported helm chart.
 
 ## Connect with a Metabase Expert
 


### PR DESCRIPTION
a common thing that people are searching for is the metabase helm chart. unfortunately now they find a weird v28 page that is telling them we have a helm chart that i can't get rid of. I forced removal of that v28 docs page from search console but it'd still be nice to give people the correct answer to the question. hopefully google will index this and show this to users instead.