### PR TITLE
Add live previews for new iframe embed flow

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/sdk-iframe-embedding-setup.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/sdk-iframe-embedding-setup.cy.spec.ts
@@ -32,7 +32,7 @@ describe("scenarios > embedding > sdk iframe embedding setup flow", () => {
 
     const iframe = getPreviewIframe();
     iframe.within(() => {
-      cy.log("Query log should be visible");
+      cy.log("question title is visible");
       cy.findByText("Query log").should("be.visible");
     });
   });
@@ -45,6 +45,7 @@ describe("scenarios > embedding > sdk iframe embedding setup flow", () => {
 
     const iframe = getPreviewIframe();
     iframe.within(() => {
+      cy.log("data picker is visible");
       cy.findByText("Pick your starting data").should("be.visible");
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/sdk-iframe-embedding-setup.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/sdk-iframe-embedding-setup.cy.spec.ts
@@ -27,7 +27,6 @@ describe("scenarios > embedding > sdk iframe embedding setup flow", () => {
     cy.visit("/embed/new");
     cy.wait("@dashboard");
 
-    cy.log("clicking on Chart tab");
     getEmbedSidebar().findByText("Chart").click();
 
     const iframe = getPreviewIframe();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/sdk-iframe-embedding-setup.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/sdk-iframe-embedding-setup.cy.spec.ts
@@ -1,0 +1,13 @@
+const { H } = cy;
+
+describe("scenarios > embedding", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+  });
+
+  it("can setup an embed", () => {
+    cy.visit("/embed/new");
+  });
+});

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/sdk-iframe-embedding-setup.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/sdk-iframe-embedding-setup.cy.spec.ts
@@ -1,13 +1,34 @@
 const { H } = cy;
 
-describe("scenarios > embedding", () => {
+describe("scenarios > embedding > sdk iframe embedding setup flow", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
     H.setTokenFeatures("all");
+
+    cy.intercept("GET", "/api/dashboard/**").as("dashboard");
   });
 
-  it("can setup an embed", () => {
+  it("shows a preview iframe when visiting the new embed page", () => {
     cy.visit("/embed/new");
+    cy.wait("@dashboard");
+
+    const iframe = getPreviewIframe();
+    iframe.within(() => {
+      cy.log("dashboard title is visible");
+      cy.findByText("Person overview").should("be.visible");
+
+      cy.log("dashboard card is visible");
+      cy.findByText("Person detail").should("be.visible");
+    });
   });
 });
+
+const getPreviewIframe = () =>
+  cy
+    .get("iframe")
+    .should("be.visible")
+    .its("0.contentDocument")
+    .should("exist")
+    .its("body")
+    .should("not.be.empty");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/sdk-iframe-embedding-setup.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/sdk-iframe-embedding-setup.cy.spec.ts
@@ -9,7 +9,7 @@ describe("scenarios > embedding > sdk iframe embedding setup flow", () => {
     cy.intercept("GET", "/api/dashboard/**").as("dashboard");
   });
 
-  it("shows a preview iframe when visiting the new embed page", () => {
+  it("shows dashboard experience by default", () => {
     cy.visit("/embed/new");
     cy.wait("@dashboard");
 
@@ -22,6 +22,32 @@ describe("scenarios > embedding > sdk iframe embedding setup flow", () => {
       cy.findByText("Person detail").should("be.visible");
     });
   });
+
+  it("shows chart experience when selected", () => {
+    cy.visit("/embed/new");
+    cy.wait("@dashboard");
+
+    cy.log("clicking on Chart tab");
+    getEmbedSidebar().findByText("Chart").click();
+
+    const iframe = getPreviewIframe();
+    iframe.within(() => {
+      cy.log("Query log should be visible");
+      cy.findByText("Query log").should("be.visible");
+    });
+  });
+
+  it("shows exploration template when selected", () => {
+    cy.visit("/embed/new");
+    cy.wait("@dashboard");
+
+    getEmbedSidebar().findByText("Exploration").click();
+
+    const iframe = getPreviewIframe();
+    iframe.within(() => {
+      cy.findByText("Pick your starting data").should("be.visible");
+    });
+  });
 });
 
 const getPreviewIframe = () =>
@@ -32,3 +58,5 @@ const getPreviewIframe = () =>
     .should("exist")
     .its("body")
     .should("not.be.empty");
+
+const getEmbedSidebar = () => cy.findByTestId("embed-sidebar-content");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -4,7 +4,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
-    H.setTokenFeatures("all");
+    H.activateToken("bleeding-edge");
 
     cy.intercept("GET", "/api/dashboard/**").as("dashboard");
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -13,8 +13,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
     cy.visit("/embed/new");
     cy.wait("@dashboard");
 
-    const iframe = H.getIframeBody();
-    iframe.within(() => {
+    H.getIframeBody().within(() => {
       cy.log("dashboard title is visible");
       cy.findByText("Person overview").should("be.visible");
 
@@ -29,8 +28,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
 
     getEmbedSidebar().findByText("Chart").click();
 
-    const iframe = H.getIframeBody();
-    iframe.within(() => {
+    H.getIframeBody().within(() => {
       cy.log("question title is visible");
       cy.findByText("Query log").should("be.visible");
     });
@@ -42,8 +40,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
 
     getEmbedSidebar().findByText("Exploration").click();
 
-    const iframe = H.getIframeBody();
-    iframe.within(() => {
+    H.getIframeBody().within(() => {
       cy.log("data picker is visible");
       cy.findByText("Pick your starting data").should("be.visible");
     });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -13,7 +13,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
     cy.visit("/embed/new");
     cy.wait("@dashboard");
 
-    const iframe = getPreviewIframe();
+    const iframe = H.getIframeBody();
     iframe.within(() => {
       cy.log("dashboard title is visible");
       cy.findByText("Person overview").should("be.visible");
@@ -29,7 +29,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
 
     getEmbedSidebar().findByText("Chart").click();
 
-    const iframe = getPreviewIframe();
+    const iframe = H.getIframeBody();
     iframe.within(() => {
       cy.log("question title is visible");
       cy.findByText("Query log").should("be.visible");
@@ -42,21 +42,12 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
 
     getEmbedSidebar().findByText("Exploration").click();
 
-    const iframe = getPreviewIframe();
+    const iframe = H.getIframeBody();
     iframe.within(() => {
       cy.log("data picker is visible");
       cy.findByText("Pick your starting data").should("be.visible");
     });
   });
 });
-
-const getPreviewIframe = () =>
-  cy
-    .get("iframe")
-    .should("be.visible")
-    .its("0.contentDocument")
-    .should("exist")
-    .its("body")
-    .should("not.be.empty");
 
 const getEmbedSidebar = () => cy.findByTestId("embed-sidebar-content");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -1,6 +1,6 @@
 const { H } = cy;
 
-describe("scenarios > embedding > sdk iframe embedding setup flow", () => {
+describe("scenarios > embedding > sdk iframe embed setup > select embed experience", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -27,7 +27,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
     cy.visit("/embed/new");
     cy.wait("@dashboard");
 
-    getEmbedSidebar().findByText("Chart").click();
+    cy.findByRole("aside").findByText("Chart").click();
 
     const iframe = H.getIframeBody();
     iframe.within(() => {
@@ -40,7 +40,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
     cy.visit("/embed/new");
     cy.wait("@dashboard");
 
-    getEmbedSidebar().findByText("Exploration").click();
+    cy.findByRole("aside").findByText("Exploration").click();
 
     const iframe = H.getIframeBody();
     iframe.within(() => {
@@ -49,5 +49,3 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
     });
   });
 });
-
-const getEmbedSidebar = () => cy.findByTestId("embed-sidebar-content");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -27,7 +27,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
     cy.visit("/embed/new");
     cy.wait("@dashboard");
 
-    cy.findByRole("aside").findByText("Chart").click();
+    getEmbedSidebar().findByText("Chart").click();
 
     const iframe = H.getIframeBody();
     iframe.within(() => {
@@ -40,7 +40,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
     cy.visit("/embed/new");
     cy.wait("@dashboard");
 
-    cy.findByRole("aside").findByText("Exploration").click();
+    getEmbedSidebar().findByText("Exploration").click();
 
     const iframe = H.getIframeBody();
     iframe.within(() => {
@@ -49,3 +49,5 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
     });
   });
 });
+
+const getEmbedSidebar = () => cy.findByRole("complementary");

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -35,9 +35,7 @@ export const SdkIframeEmbedPreview = () => {
         instanceUrl,
         target: "#iframe-embed-container",
         iframeClassName: S.EmbedPreviewIframe,
-
-        // TODO: replace with `useExistingUserSession: true` once EMB-507 is merged.
-        apiKey: "will-be-replaced-with-user-session-flag",
+        useExistingUserSession: true,
       });
     };
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -23,7 +23,7 @@ export const SdkIframeEmbedPreview = () => {
 
   useEffect(() => {
     const script = document.createElement("script");
-    script.src = "/app/embed.js";
+    script.src = `${instanceUrl}/app/embed.js`;
     document.body.appendChild(script);
 
     script.onload = () => {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -45,8 +45,6 @@ export const SdkIframeEmbedPreview = () => {
       embedJsRef.current?.destroy();
       script.remove();
     };
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- settings are updated in the useEffect below
   }, [instanceUrl]);
 
   useEffect(() => {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -1,3 +1,69 @@
+import { useEffect, useRef } from "react";
+
+import { useSetting } from "metabase/common/hooks";
+import { Box } from "metabase/ui";
+import type { MetabaseEmbed } from "metabase-enterprise/embedding_iframe_sdk/embed";
+
+import { useSdkIframeEmbedSetupContext } from "../context";
+
+import S from "./SdkIframeEmbedSetup.module.css";
+
+declare global {
+  interface Window {
+    "metabase.embed": { MetabaseEmbed: typeof MetabaseEmbed };
+  }
+}
+
 export const SdkIframeEmbedPreview = () => {
-  return null;
+  const { settings } = useSdkIframeEmbedSetupContext();
+  const instanceUrl = useSetting("site-url");
+
+  const embedJsRef = useRef<MetabaseEmbed | null>(null);
+
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "/app/embed.js";
+    document.body.appendChild(script);
+
+    script.onload = () => {
+      const { MetabaseEmbed } = window["metabase.embed"];
+
+      embedJsRef.current = new MetabaseEmbed({
+        ...settings,
+        instanceUrl,
+
+        // This is an invalid API key.
+        // The embed uses the admin's session if the provided API key is invalid.
+        apiKey: "invalid-api-key-for-embed-preview",
+
+        target: "#iframe-embed-container",
+        iframeClassName: S.EmbedPreviewIframe,
+      });
+    };
+
+    return () => {
+      embedJsRef.current?.destroy();
+      script.remove();
+    };
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- settings are updated in the useEffect below
+  }, [instanceUrl]);
+
+  useEffect(() => {
+    if (embedJsRef.current) {
+      embedJsRef.current.updateSettings({
+        template: undefined,
+        questionId: undefined,
+        dashboardId: undefined,
+
+        ...settings,
+      });
+    }
+  }, [settings]);
+
+  return (
+    <div>
+      <Box id="iframe-embed-container" />
+    </div>
+  );
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -5,6 +5,7 @@ import { Box } from "metabase/ui";
 import type { MetabaseEmbed } from "metabase-enterprise/embedding_iframe_sdk/embed";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
+import { DEFAULT_SDK_IFRAME_EMBED_SETTINGS } from "../utils/default-embed-setting";
 
 import S from "./SdkIframeEmbedSetup.module.css";
 
@@ -29,15 +30,14 @@ export const SdkIframeEmbedPreview = () => {
       const { MetabaseEmbed } = window["metabase.embed"];
 
       embedJsRef.current = new MetabaseEmbed({
-        ...settings,
+        ...DEFAULT_SDK_IFRAME_EMBED_SETTINGS,
+
         instanceUrl,
-
-        // This is an invalid API key.
-        // The embed uses the admin's session if the provided API key is invalid.
-        apiKey: "invalid-api-key-for-embed-preview",
-
         target: "#iframe-embed-container",
         iframeClassName: S.EmbedPreviewIframe,
+
+        // TODO: replace with `useExistingUserSession: true` once EMB-507 is merged.
+        apiKey: "will-be-replaced-with-user-session-flag",
       });
     };
 
@@ -52,6 +52,8 @@ export const SdkIframeEmbedPreview = () => {
   useEffect(() => {
     if (embedJsRef.current) {
       embedJsRef.current.updateSettings({
+        // Clear the existing experiences.
+        // This is necessary as `updateSettings` merges new settings with existing ones.
         template: undefined,
         questionId: undefined,
         dashboardId: undefined,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -28,8 +28,8 @@ const SdkIframeEmbedSetupContent = () => {
   return (
     <Box className={S.Container}>
       <SidebarResizer>
-        <Box className={S.Sidebar}>
-          <Box className={S.SidebarContent} data-testid="embed-sidebar-content">
+        <Box className={S.Sidebar} component="aside">
+          <Box className={S.SidebarContent}>
             <StepContent />
           </Box>
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -29,7 +29,7 @@ const SdkIframeEmbedSetupContent = () => {
     <Box className={S.Container}>
       <SidebarResizer>
         <Box className={S.Sidebar}>
-          <Box className={S.SidebarContent}>
+          <Box className={S.SidebarContent} data-testid="embed-sidebar-content">
             <StepContent />
           </Box>
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -12,6 +12,7 @@ import type {
   SdkIframeEmbedSetupExperience,
   SdkIframeEmbedSetupStep,
 } from "../types";
+import { DEFAULT_SDK_IFRAME_EMBED_SETTINGS } from "../utils/default-embed-setting";
 
 interface SdkIframeEmbedSetupProviderProps {
   children: ReactNode;
@@ -27,9 +28,9 @@ export const SdkIframeEmbedSetupProvider = ({
   const instanceUrl = useSetting("site-url");
 
   const [settings, setSettings] = useState<SdkIframeEmbedSettings>({
-    apiKey: "",
+    ...DEFAULT_SDK_IFRAME_EMBED_SETTINGS,
     instanceUrl,
-    dashboardId: 1,
+    apiKey: "",
   });
 
   // Which embed experience are we setting up?

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -30,7 +30,6 @@ export const SdkIframeEmbedSetupProvider = ({
   const [settings, setSettings] = useState<SdkIframeEmbedSettings>({
     ...DEFAULT_SDK_IFRAME_EMBED_SETTINGS,
     instanceUrl,
-    apiKey: "",
   });
 
   // Which embed experience are we setting up?

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
@@ -22,14 +22,14 @@ export const SelectEmbedExperienceStep = () => {
     ]);
 
     // TODO(EMB-508): use the most recent question or dashboard.
-    const defaultEntityId = 1;
+    const defaultResourceId = 1;
 
     setSettings({
       // these settings do not change when the embed type changes
       ...persistedSettings,
 
       // these settings are overridden when the embed type changes
-      ...getDefaultSdkIframeEmbedSettings(experience, defaultEntityId),
+      ...getDefaultSdkIframeEmbedSettings(experience, defaultResourceId),
     } as SdkIframeEmbedSettings);
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
@@ -10,13 +10,13 @@ import type { SdkIframeEmbedSetupExperience } from "../types";
 
 export const getDefaultSdkIframeEmbedSettings = (
   type: SdkIframeEmbedSetupExperience,
-  defaultEntityId: string | number,
+  defaultResourceId: string | number,
 ) =>
   match(type)
     .with(
       "dashboard",
       (): DashboardEmbedOptions => ({
-        dashboardId: defaultEntityId,
+        dashboardId: defaultResourceId,
         isDrillThroughEnabled: true,
         withDownloads: false,
         withTitle: true,
@@ -25,7 +25,7 @@ export const getDefaultSdkIframeEmbedSettings = (
     .with(
       "chart",
       (): QuestionEmbedOptions => ({
-        questionId: defaultEntityId,
+        questionId: defaultResourceId,
         isDrillThroughEnabled: true,
         withDownloads: false,
         withTitle: true,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
@@ -1,5 +1,11 @@
 import { match } from "ts-pattern";
 
+import type {
+  DashboardEmbedOptions,
+  ExplorationEmbedOptions,
+  QuestionEmbedOptions,
+} from "metabase-enterprise/embedding_iframe_sdk/types/embed";
+
 import type { SdkIframeEmbedSetupExperience } from "../types";
 
 export const getDefaultSdkIframeEmbedSettings = (
@@ -7,20 +13,32 @@ export const getDefaultSdkIframeEmbedSettings = (
   defaultEntityId: string | number,
 ) =>
   match(type)
-    .with("dashboard", () => ({
-      dashboardId: defaultEntityId,
-      isDrillThroughEnabled: true,
-      withDownloads: false,
-      withTitle: true,
-    }))
-    .with("chart", () => ({
-      questionId: defaultEntityId,
-      isDrillThroughEnabled: true,
-      withDownloads: false,
-      withTitle: true,
-    }))
-    .with("exploration", () => ({
-      template: "exploration",
-      isSaveEnabled: true,
-    }))
+    .with(
+      "dashboard",
+      (): DashboardEmbedOptions => ({
+        dashboardId: defaultEntityId,
+        isDrillThroughEnabled: true,
+        withDownloads: false,
+        withTitle: true,
+      }),
+    )
+    .with(
+      "chart",
+      (): QuestionEmbedOptions => ({
+        questionId: defaultEntityId,
+        isDrillThroughEnabled: true,
+        withDownloads: false,
+        withTitle: true,
+      }),
+    )
+    .with(
+      "exploration",
+      (): ExplorationEmbedOptions => ({
+        template: "exploration",
+        isSaveEnabled: true,
+      }),
+    )
     .exhaustive();
+
+export const DEFAULT_SDK_IFRAME_EMBED_SETTINGS =
+  getDefaultSdkIframeEmbedSettings("dashboard", 1);

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
@@ -40,5 +40,6 @@ export const getDefaultSdkIframeEmbedSettings = (
     )
     .exhaustive();
 
+// TODO: will be replaced with the most recently visited dashboard once EMB-508 is merged.
 export const DEFAULT_SDK_IFRAME_EMBED_SETTINGS =
   getDefaultSdkIframeEmbedSettings("dashboard", 1);


### PR DESCRIPTION
Closes EMB-506

Adds a basic live preview to the new iframe embedding's setup flow. This preview will be used for previewing the entities and embed options that will be in later PRs, EMB-508 and EMB-509. The default entity id of `1` is just a placeholder for now, and will be made dynamic in EMB-508.

### How to verify

Go to "+ New" > "Embed". Make sure you have `embedding_iframe_sdk` in your feature token.

- The preview iframe starts off with the dashboard experience.
- The preview iframe changes when switching experience to chart.
- The preview iframe changes when switching experience to exploration.

### Known Issues

- ~When switching to "chart" then to "exploration", there was a bug where it showed "To run your code, click on the Run button or type (⌘ + return). Here's where your results will appear". This actually was an Embedding SDK bug, see https://github.com/metabase/metabase/issues/60075.~ This is now fixed by https://github.com/metabase/metabase/pull/60077 🎉 

- ~If you visit any native question first to populate your activity log, then switch from "exploration" to "chart", the preview will crash.~ This is fixed by https://github.com/metabase/metabase/pull/60161.

### Demo

![CleanShot 2568-06-21 at 02 30 44@2x](https://github.com/user-attachments/assets/91c94625-2c9d-4f6f-b014-a145a2d175f9)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
