### PR TITLE
Postgres driver throws better error message when it misinterprets ?

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -31,7 +31,7 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.i18n :refer [trs]]
+   [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu])
   (:import
@@ -1006,6 +1006,19 @@
   [driver prepared-statement i t]
   (let [local-time (t/local-time (t/with-offset-same-instant t (t/zone-offset 0)))]
     (sql-jdbc.execute/set-parameter driver prepared-statement i local-time)))
+
+(defmethod sql-jdbc.execute/execute-prepared-statement! :postgres
+  [driver stmt]
+  (let [orig-method (get-method sql-jdbc.execute/execute-prepared-statement! :sql-jdbc)]
+    (try
+      (orig-method driver stmt)
+      (catch Throwable e
+        (if (re-find #"No value specified for parameter" (ex-message e))
+          (throw (ex-info (tru "It looks like you have a ''?'' in your code which Postgres''s JDBC driver interprets as a parameter. You might need to escape it like ''??''.")
+                          {:driver driver
+                           :sql    (str stmt)
+                           :type   driver-api/qp.error-type.invalid-query}))
+          (throw e))))))
 
 (defmethod driver/upload-type->database-type :postgres
   [_driver upload-type]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1322,14 +1322,14 @@
                        (mt/rows)))))
           (testing "Make sure we get a good error message when using ? with other parameters"
             (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                                  #"It looks like you have a ''\?'' in your code which Postgres''s JDBC driver interprets as a parameter\. You might need to escape it like ''\?\?''\."
+                                  #"It looks like you have a '\?' in your code which Postgres's JDBC driver interprets as a parameter\. You might need to escape it like '\?\?'\."
                                   (-> {:query         (str "SELECT * FROM json_table "
                                                            "WHERE json_val::jsonb ? 'a' "
-                                                           "AND json_val::jsonb -> 'a' = {{val}}")
+                                                           "AND json_val::jsonb ->> 'a' = {{val}}")
                                        :template-tags {:val
                                                        {:name         "val"
                                                         :display_name "Val"
-                                                        :type         "number"}}}
+                                                        :type         "text"}}}
                                       mt/native-query
                                       (assoc :parameters
                                              [{:type   "number/="

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1299,27 +1299,43 @@
                  (t2/select-fn-set :name :model/Table :db_id (:id database)))))))))
 
 (deftest json-operator-?-works
-  (testing "Make sure the Postgres ? operators (for JSON types) work in native queries"
-    (mt/test-driver :postgres
-      (tx/drop-if-exists-and-create-db! driver/*driver*  "json-test")
-      (let [details (mt/dbdef->connection-details :postgres :db {:database-name "json-test"})
-            spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
-        (doseq [statement ["DROP TABLE IF EXISTS PUBLIC.json_table;"
-                           "CREATE TABLE PUBLIC.json_table (json_val JSON NOT NULL);"
-                           "INSERT INTO PUBLIC.json_table (json_val) VALUES ('{\"a\": 1, \"b\": 2}');"]]
-          (jdbc/execute! spec [statement])))
-      (let [json-db-details (mt/dbdef->connection-details :postgres :db {:database-name "json-test"})
-            query           (str "SELECT json_val::jsonb ? 'a',"
-                                 "json_val::jsonb ?| array['c', 'd'],"
-                                 "json_val::jsonb ?& array['a', 'b']"
-                                 "FROM \"json_table\";")]
-        (mt/with-temp [:model/Database database {:engine :postgres, :details json-db-details}]
-          (mt/with-db database (sync/sync-database! database)
+  (mt/test-driver :postgres
+    (tx/drop-if-exists-and-create-db! driver/*driver*  "json-test")
+    (let [details (mt/dbdef->connection-details :postgres :db {:database-name "json-test"})
+          spec    (sql-jdbc.conn/connection-details->spec :postgres details)]
+      (doseq [statement ["DROP TABLE IF EXISTS PUBLIC.json_table;"
+                         "CREATE TABLE PUBLIC.json_table (json_val JSON NOT NULL);"
+                         "INSERT INTO PUBLIC.json_table (json_val) VALUES ('{\"a\": 1, \"b\": 2}');"]]
+        (jdbc/execute! spec [statement])))
+    (let [json-db-details (mt/dbdef->connection-details :postgres :db {:database-name "json-test"})
+          query           (str "SELECT json_val::jsonb ? 'a',"
+                               "json_val::jsonb ?| array['c', 'd'],"
+                               "json_val::jsonb ?& array['a', 'b']"
+                               "FROM \"json_table\";")]
+      (mt/with-temp [:model/Database database {:engine :postgres, :details json-db-details}]
+        (mt/with-db database (sync/sync-database! database)
+          (testing "Make sure the Postgres ? operators (for JSON types) work in native queries"
             (is (= [[true false true]]
                    (-> {:query query}
                        (mt/native-query)
                        (qp/process-query)
-                       (mt/rows))))))))))
+                       (mt/rows)))))
+          (testing "Make sure we get a good error message when using ? with other parameters"
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"It looks like you have a ''\?'' in your code which Postgres''s JDBC driver interprets as a parameter\. You might need to escape it like ''\?\?''\."
+                                  (-> {:query         (str "SELECT * FROM json_table "
+                                                           "WHERE json_val::jsonb ? 'a' "
+                                                           "AND json_val::jsonb -> 'a' = {{val}}")
+                                       :template-tags {:val
+                                                       {:name         "val"
+                                                        :display_name "Val"
+                                                        :type         "number"}}}
+                                      mt/native-query
+                                      (assoc :parameters
+                                             [{:type   "number/="
+                                               :target ["variable" ["template-tag" "val"]]
+                                               :value  ["1"]}])
+                                      qp/process-query)))))))))
 
 (deftest sync-json-with-composite-pks-test
   (testing "Make sure sync a table with json columns that have composite pks works"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/49373

### Description

? is used as a jdbc parameter placeholder and is also an operator in postgres.  If you want to use it as an operator, you often need to escape it with ??.  This gives a better error message when that happens.

### How to verify

1. Create a table with a json column
2. Create a native query like 
```
SELECT entities.id
FROM entities
WHERE entities.setup -> 'some_array' ? 'a' and {{test}}
```
3. Verify that you get an error message that mentions escaping ?s.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
