### PR TITLE
fix native gridmap binning calculation

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx
@@ -5,7 +5,6 @@ import { t } from "ttag";
 import { color } from "metabase/lib/colors";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
-import { rangeForValue } from "metabase-lib/v1/queries/utils/range-for-value";
 import { isMetric, isNumeric } from "metabase-lib/v1/types/utils/isa";
 
 import { computeNumericDataInterval } from "../lib/numeric";
@@ -14,16 +13,6 @@ import LeafletMap from "./LeafletMap";
 
 const isValidCoordinatesColumn = (column) =>
   column.binning_info || (column.source === "native" && isNumeric(column));
-
-const computeValueRange = (value, values) => [
-  value,
-  value + computeNumericDataInterval(values),
-];
-
-const getValueRange = (value, column, values) => {
-  const binningBasedResult = rangeForValue(value, column);
-  return binningBasedResult || computeValueRange(value, values);
-};
 
 export default class LeafletGridHeatMap extends LeafletMap {
   static isSensible({ cols }) {
@@ -68,7 +57,15 @@ export default class LeafletGridHeatMap extends LeafletMap {
       const totalSquares = Math.max(points.length, gridSquares.length);
 
       const latitudeValues = points.map((row) => row[latitudeIndex]);
-      const longitureValues = points.map((row) => row[longitudeIndex]);
+      const longitudeValues = points.map((row) => row[longitudeIndex]);
+
+      const latitudeBinning =
+        latitudeColumn?.binning_info?.bin_width ??
+        computeNumericDataInterval(latitudeValues);
+
+      const longitudeBinning =
+        longitudeColumn?.binning_info?.bin_width ??
+        computeNumericDataInterval(longitudeValues);
 
       for (let i = 0; i < totalSquares; i++) {
         if (i >= points.length) {
@@ -81,21 +78,16 @@ export default class LeafletGridHeatMap extends LeafletMap {
         }
 
         if (i < points.length) {
-          const [latitude, longiture, metric] = points[i];
+          const [latitude, longitude, metric] = points[i];
 
           gridSquares[i].setStyle({ color: colorScale(metric) });
 
-          const [latMin, latMax] = getValueRange(
-            latitude,
-            latitudeColumn,
-            latitudeValues,
-          );
+          const latMin = latitude;
+          const latMax = latitude + latitudeBinning;
 
-          const [lonMin, lonMax] = getValueRange(
-            longiture,
-            longitudeColumn,
-            longitureValues,
-          );
+          const lonMin = longitude;
+          const lonMax = longitude + longitudeBinning;
+
           gridSquares[i].setBounds([
             [latMin, lonMin],
             [latMax, lonMax],

--- a/frontend/src/metabase/visualizations/lib/numeric.js
+++ b/frontend/src/metabase/visualizations/lib/numeric.js
@@ -22,7 +22,7 @@ export const isMultipleOf = (value, base) => {
 };
 
 // We seem to run into float bugs if we get any more precise than this.
-const SMALLEST_PRECISION_EXP = -14;
+const SMALLEST_PRECISION_EXP = -13;
 
 export function precision(a) {
   if (!isFinite(a)) {

--- a/frontend/src/metabase/visualizations/lib/numeric.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/numeric.unit.spec.js
@@ -31,10 +31,10 @@ describe("visualization.lib.numeric", () => {
       [1.2345678, 1e-7],
       [1.23456789, 1e-8],
       [-1.23456789, 1e-8],
+      // very precise numbers are cut off at 10^-13
       [-1.2345678912345, 1e-13],
-      [-1.23456789123456, 1e-14],
-      // very precise numbers are cut off at 10^-14
-      [-1.23456789123456789123456789, 1e-14],
+      [-1.23456789123456, 1e-13],
+      [-1.234567891234568, 1e-13],
     ];
     for (const [n, p] of CASES) {
       it(`precision of ${n} should be ${p}`, () => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #49462
Closes [VIZ-203](https://linear.app/metabase/issue/VIZ-203/grid-map-broken-with-native-queries-when-binning-longlat-by-1)

### Description

Fixes native grid maps binning calculation when bin widths are less than 1. Latitude and longitude bin widths define dimensions of rectangles on grid map.

While MBQL queries columns include the actual bin widths in `column.binning_info.bin_width`, for native queries we have to compute bin widths from data. Due to limited precision of floating-point numbers the bin width was incorrectly calculated.

### How to verify

1. New question -> Sample Dataset -> People: Count group by Latitude[Bin every 0.1 degrees] and Longitude[Bin every 0.1 degrees]
2. Make it a grid map visualization
3. Open the notebook mode -> view sql -> convert this question to SQL
4. Try visualizing it as a grid map, set correct latitude and longitude columns
5. Ensure the bin rectangles are rendered correctly

### Demo

Before
<img width="167" alt="Screenshot 2025-06-20 at 7 32 21 PM" src="https://github.com/user-attachments/assets/8360e409-5c4b-4a6b-9935-22c869fbf0fe" />

After
<img width="329" alt="Screenshot 2025-06-20 at 7 32 53 PM" src="https://github.com/user-attachments/assets/4b355a60-bac0-4c39-bcda-3f21e0749931" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
