### PR TITLE
Added dev.h2/tcp-listen

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -785,7 +785,7 @@
   ;; get the H2 shell with clojure -X:dev:h2
   :h2
   {:extra-paths ["dev/src"]
-   :exec-fn     dev.h2-shell/shell
+   :exec-fn     dev.h2/shell
    :jvm-opts    ["-Dfile.encoding=UTF-8"]}
 
   :generate-automagic-dashboards-pot

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -55,6 +55,7 @@
    [clojure.test]
    [dev.debug-qp :as debug-qp]
    [dev.explain :as dev.explain]
+   [dev.h2 :as dev.h2]
    [dev.memory :as dev.memory]
    [dev.migrate :as dev.migrate]
    [dev.model-tracking :as model-tracking]
@@ -95,7 +96,8 @@
 
 (comment
   debug-qp/keep-me
-  model-tracking/keep-me)
+  model-tracking/keep-me
+  dev.h2/keep-me)
 
 #_:clj-kondo/ignore
 (defn tap>-spy [x]

--- a/dev/src/dev/h2.clj
+++ b/dev/src/dev/h2.clj
@@ -1,8 +1,9 @@
-(ns dev.h2-shell
+(ns dev.h2
   (:require
    [environ.core :as env]
    [metabase.app-db.data-source :as mdb.data-source]
-   [metabase.app-db.env :as mdb.env]))
+   [metabase.app-db.env :as mdb.env])
+  (:import (org.h2.tools Server)))
 
 (comment mdb.data-source/keep-me)
 
@@ -19,3 +20,13 @@
                   url                                             (.url data-source)]
               (println "Connecting to database at URL" url)
               url)])))
+
+(def ^:private tcp-listener (atom nil))
+
+(defn tcp-listen
+  "Starts a TCP server for the H2 app-db database on port 9092."
+  []
+  (when @tcp-listener
+    (throw (ex-info "TCP listener is already running" {:port 9092})))
+  (reset! tcp-listener (.start (Server/createTcpServer (into-array ["-tcp" "-tcpAllowOthers" "-tcpPort" "9092"]))))
+  (println (str "H2 TCP server started (no username or password): jdbc:h2:tcp://localhost:9092/" (#'metabase.app-db.env/env->db-file metabase.app-db.env/env))))


### PR DESCRIPTION
### Description

When working with an h2 app-db, it's nice to be able to see what's going on with external DB browser tools.

This adds a `(dev.h2/tcp-listen)` function which will open a tcp port to the current app-db for easier development use.

### How to verify

1. Start the server with `dev` enabled
2. In repl, run `(dev.h2/tcp-listen)`
3. Connect with the jdbc string output

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
