### PR TITLE
Add cljfmt rule for driver/api-replace + run formatter

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -120,6 +120,8 @@
   metabase.collections.models.collection-test/with-personal-and-impersonal-collections   [[:block 1]]
   metabase.config/build-type-case                                                        [[:block 0]]
   metabase.dashboards.models.dashboard-test/with-dash-in-collection                      [[:inner 0]]
+  metabase.driver-api.core/match                                                         [[:inner 0]]
+  metabase.driver-api.core/match-one                                                     [[:inner 0]]
   metabase.driver-api.core/replace                                                       [[:inner 0]]
   metabase.driver.bigquery-cloud-sdk.query-processor/with-temporal-type                  [[:default]]
   metabase.driver.druid.client/DELETE                                                    [[:default]]

--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -120,6 +120,7 @@
   metabase.collections.models.collection-test/with-personal-and-impersonal-collections   [[:block 1]]
   metabase.config/build-type-case                                                        [[:block 0]]
   metabase.dashboards.models.dashboard-test/with-dash-in-collection                      [[:inner 0]]
+  metabase.driver-api.core/replace                                                       [[:inner 0]]
   metabase.driver.bigquery-cloud-sdk.query-processor/with-temporal-type                  [[:default]]
   metabase.driver.druid.client/DELETE                                                    [[:default]]
   metabase.driver.druid.client/GET                                                       [[:default]]

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -333,17 +333,17 @@
 
 (defn- ->absolute-timestamp ^java.time.temporal.Temporal [clause]
   (driver-api/match-one clause
-                        [:absolute-datetime t :default]
-                        t
+    [:absolute-datetime t :default]
+    t
 
-                        [:absolute-datetime t unit]
-                        (u.date/truncate t unit)
+    [:absolute-datetime t unit]
+    (u.date/truncate t unit)
 
-                        [:relative-datetime amount unit]
-                        (u.date/truncate (u.date/add unit amount) unit)
+    [:relative-datetime amount unit]
+    (u.date/truncate (u.date/add unit amount) unit)
 
-                        _
-                        nil))
+    _
+    nil))
 
 (defmulti ^:private filter-clause->intervals
   "Generate query intervals as appropriate from a `filter-clause` containing a temporal `:field`. `:intervals` are
@@ -676,8 +676,8 @@
    druid-query]
   (let [output-name               (driver-api/aggregation-name *query* ag-clause)
         [ag-type ag-field & args] (driver-api/match-one ag-clause
-                                                        [:aggregation-options ag & _] #_:clj-kondo/ignore (recur ag)
-                                                        _                             &match)]
+                                    [:aggregation-options ag & _] #_:clj-kondo/ignore (recur ag)
+                                    _                             &match)]
     (if-not (isa? query-type ::ag-query)
       druid-query
       (let [[projections ag-clauses] (try
@@ -729,29 +729,29 @@
   [[operator & args, :as expression]]
   (driver-api/match-one expression
     ;; If it's a named expression, we want to preserve the included name, so recurse, but merge in the name
-                        [:aggregation-options ag _]
-                        (merge (expression-post-aggregation (second expression))
-                               {:name (driver-api/aggregation-name *query* expression)})
+    [:aggregation-options ag _]
+    (merge (expression-post-aggregation (second expression))
+           {:name (driver-api/aggregation-name *query* expression)})
 
-                        _
-                        {:type   :arithmetic
-                         :name   (driver-api/aggregation-name *query* expression)
-                         :fn     operator
-                         :fields (vec (for [arg args]
-                                        (driver-api/match-one arg
-                                                              number?
-                                                              {:type :constant, :name (str &match), :value &match}
+    _
+    {:type   :arithmetic
+     :name   (driver-api/aggregation-name *query* expression)
+     :fn     operator
+     :fields (vec (for [arg args]
+                    (driver-api/match-one arg
+                      number?
+                      {:type :constant, :name (str &match), :value &match}
 
-                                                              [:aggregation-options ag (options :guard :name)]
-                                                              {:type (post-aggregator-type ag), :fieldName (:name options)}
+                      [:aggregation-options ag (options :guard :name)]
+                      {:type (post-aggregator-type ag), :fieldName (:name options)}
 
-                                                              #{:+ :- :/ :*}
-                                                              (expression-post-aggregation &match)
+                      #{:+ :- :/ :*}
+                      (expression-post-aggregation &match)
 
                       ;; we should never get here unless our code is B U S T E D
-                                                              _
-                                                              (throw (ex-info (tru "Expected :aggregation-options, constant, or expression.")
-                                                                              {:type :bug, :input arg})))))}))
+                      _
+                      (throw (ex-info (tru "Expected :aggregation-options, constant, or expression.")
+                                      {:type :bug, :input arg})))))}))
 
 (declare handle-aggregations)
 
@@ -791,14 +791,14 @@
   (reduce
    (fn [druid-query aggregation]
      (driver-api/match-one aggregation
-                           [:aggregation-options [(_ :guard #{:+ :- :/ :*}) & _] _]
-                           (handle-expression-aggregation query-type &match druid-query)
+       [:aggregation-options [(_ :guard #{:+ :- :/ :*}) & _] _]
+       (handle-expression-aggregation query-type &match druid-query)
 
-                           #{:+ :- :/ :*}
-                           (handle-expression-aggregation query-type &match druid-query)
+       #{:+ :- :/ :*}
+       (handle-expression-aggregation query-type &match druid-query)
 
-                           _
-                           (handle-aggregation query-type &match druid-query)))
+       _
+       (handle-aggregation query-type &match druid-query)))
    druid-query
    aggregations))
 
@@ -949,11 +949,11 @@
 (defn- field-clause->name
   [field-clause]
   (driver-api/match-one field-clause
-                        [:field (id :guard integer?) _]
-                        (:name (driver-api/field (driver-api/metadata-provider) id))
+    [:field (id :guard integer?) _]
+    (:name (driver-api/field (driver-api/metadata-provider) id))
 
-                        [:field (field-name :guard string?) _]
-                        field-name))
+    [:field (field-name :guard string?) _]
+    field-name))
 
 (defmethod handle-breakout ::topN
   [_ {[breakout-field] :breakout} druid-query]
@@ -997,17 +997,17 @@
         breakout-field    (->rvalue breakout-field)
         sort-by-breakout? (= field breakout-field)
         ag-field          (driver-api/match-one ag
-                                                :distinct
-                                                :distinct___count
+                            :distinct
+                            :distinct___count
 
-                                                [:aggregation-options _ (options :guard :name)]
-                                                (:name options)
+                            [:aggregation-options _ (options :guard :name)]
+                            (:name options)
 
-                                                [:aggregation-options wrapped-ag _]
-                                                #_:clj-kondo/ignore (recur wrapped-ag)
+                            [:aggregation-options wrapped-ag _]
+                            #_:clj-kondo/ignore (recur wrapped-ag)
 
-                                                [(ag-type :guard keyword?) & _]
-                                                ag-type)]
+                            [(ag-type :guard keyword?) & _]
+                            ag-type)]
     (when-not sort-by-breakout?
       (assert ag-field))
     (assoc-in druid-query [:query :metric] (match [sort-by-breakout? direction]
@@ -1029,11 +1029,11 @@
   [field]
   (when field
     (driver-api/match-one field
-                          [:field _id-or-name (_opts :guard :temporal-unit)]
-                          true
+      [:field _id-or-name (_opts :guard :temporal-unit)]
+      true
 
-                          [:field (id :guard pos-int?) _opts]
-                          (driver-api/temporal? (driver-api/field (driver-api/metadata-provider) id)))))
+      [:field (id :guard pos-int?) _opts]
+      (driver-api/temporal? (driver-api/field (driver-api/metadata-provider) id)))))
 
 ;; Handle order by timstamp field
 (defmethod handle-order-by ::grouped-timeseries

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -305,8 +305,8 @@
 (defn- parse-filter [filter-clause]
   ;; strip out all the filters against temporal fields. Those are handled separately, as intervals
   (-> (driver-api/replace filter-clause
-                          [_ [:field _ (_ :guard :temporal-unit)] & _]
-                          nil)
+        [_ [:field _ (_ :guard :temporal-unit)] & _]
+        nil)
       driver-api/simplify-compound-filter
       parse-filter*))
 
@@ -325,11 +325,11 @@
   milliseconds, because that is the smallest unit Druid supports."
   [clause n]
   (driver-api/replace clause
-                      [:absolute-datetime t :default]
-                      [:absolute-datetime (u.date/add t :millisecond n) :millisecond]
+    [:absolute-datetime t :default]
+    [:absolute-datetime (u.date/add t :millisecond n) :millisecond]
 
-                      _
-                      (add-datetime-units* clause n)))
+    _
+    (add-datetime-units* clause n)))
 
 (defn- ->absolute-timestamp ^java.time.temporal.Temporal [clause]
   (driver-api/match-one clause
@@ -696,8 +696,8 @@
 
 (defn- deduplicate-aggregation-options [expression]
   (driver-api/replace expression
-                      [:aggregation-options [:aggregation-options ag options-1] options-2]
-                      [:aggregation-options ag (merge options-1 options-2)]))
+    [:aggregation-options [:aggregation-options ag options-1] options-2]
+    [:aggregation-options ag (merge options-1 options-2)]))
 
 (def ^:private ^:dynamic *query-unique-identifier-counter*
   "Counter used for generating unique identifiers for use in the query. Bound to `(atom 0)` and incremented on each use
@@ -710,11 +710,11 @@
 (defn- add-expression-aggregation-output-names
   [expression]
   (driver-api/replace expression
-                      [:aggregation-options ag options]
-                      (deduplicate-aggregation-options [:aggregation-options (add-expression-aggregation-output-names ag) options])
+    [:aggregation-options ag options]
+    (deduplicate-aggregation-options [:aggregation-options (add-expression-aggregation-output-names ag) options])
 
-                      [(clause :guard #{:count :avg :distinct :stddev :sum :min :max}) & _]
-                      [:aggregation-options &match {:name (aggregation-unique-identifier clause)}]))
+    [(clause :guard #{:count :avg :distinct :stddev :sum :min :max}) & _]
+    [:aggregation-options &match {:name (aggregation-unique-identifier clause)}]))
 
 (defn- post-aggregator-type
   "Complex aggregators like `cardinality` and ``hyperUnique` (which we use to implement MBQL

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -999,37 +999,37 @@
 
 (defn- aggregation->rvalue [ag]
   (driver-api/match-one ag
-                        [:aggregation-options ag' _]
-                        (recur ag')
+    [:aggregation-options ag' _]
+    (recur ag')
 
-                        [:count]
-                        {$sum 1}
+    [:count]
+    {$sum 1}
 
-                        [:count arg]
-                        {$sum {$cond {:if   (->rvalue arg)
-                                      :then 1
-                                      :else 0}}}
+    [:count arg]
+    {$sum {$cond {:if   (->rvalue arg)
+                  :then 1
+                  :else 0}}}
 
     ;; these aggregation types can all be used in expressions as well so their implementations live above in the
     ;; general [[->rvalue]] implementations
-                        #{:avg :stddev :sum :min :max}
-                        (->rvalue &match)
+    #{:avg :stddev :sum :min :max}
+    (->rvalue &match)
 
-                        [:distinct arg]
-                        {$addToSet (->rvalue arg)}
+    [:distinct arg]
+    {$addToSet (->rvalue arg)}
 
-                        [:sum-where arg pred]
-                        {$sum {$cond {:if   (compile-cond pred)
-                                      :then (->rvalue arg)
-                                      :else 0}}}
+    [:sum-where arg pred]
+    {$sum {$cond {:if   (compile-cond pred)
+                  :then (->rvalue arg)
+                  :else 0}}}
 
-                        [:count-where pred]
-                        (recur [:sum-where [:value 1] pred])
+    [:count-where pred]
+    (recur [:sum-where [:value 1] pred])
 
-                        :else
-                        (throw
-                         (ex-info (tru "Don''t know how to handle aggregation {0}" ag)
-                                  {:type :invalid-query, :clause ag}))))
+    :else
+    (throw
+     (ex-info (tru "Don''t know how to handle aggregation {0}" ag)
+              {:type :invalid-query, :clause ag}))))
 
 (defn- unwrap-named-ag [[ag-type arg :as ag]]
   (if (= ag-type :aggregation-options)
@@ -1339,14 +1339,14 @@
      (assoc-in
       m
       (driver-api/match-one field-clause
-                            [:field (field-id :guard integer?) _]
-                            (str/split (field-alias field-clause) #"\.")
+        [:field (field-id :guard integer?) _]
+        (str/split (field-alias field-clause) #"\.")
 
-                            [:field (field-name :guard string?) _]
-                            [field-name]
+        [:field (field-name :guard string?) _]
+        [field-name]
 
-                            [:expression expr-name _]
-                            [expr-name])
+        [:expression expr-name _]
+        [expr-name])
       (->rvalue field-clause)))
    (ordered-map/ordered-map)
    fields))
@@ -1540,12 +1540,12 @@
   "Return `:collection` from a source query, if it exists."
   [query]
   (driver-api/match-one query
-                        (_ :guard (every-pred map? :collection))
+    (_ :guard (every-pred map? :collection))
     ;; ignore source queries inside `:joins` or `:collection` outside of a `:source-query`
-                        (when (let [parents (set &parents)]
-                                (and (contains? parents :source-query)
-                                     (not (contains? parents :joins))))
-                          (:collection &match))))
+    (when (let [parents (set &parents)]
+            (and (contains? parents :source-query)
+                 (not (contains? parents :joins))))
+      (:collection &match))))
 
 (defn- log-aggregation-pipeline [form]
   (when-not driver-api/*disable-qp-logging*

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -922,8 +922,8 @@
   See [[find-mapped-field-name]] for an explanation why this is done."
   [expr alias]
   (driver-api/replace expr
-                      [:field _ {:join-alias alias}]
-                      (update &match 2 set/rename-keys {:join-alias ::join-local})))
+    [:field _ {:join-alias alias}]
+    (update &match 2 set/rename-keys {:join-alias ::join-local})))
 
 (defn- get-field-mappings [source-query projections]
   (when source-query

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -499,9 +499,9 @@
                   [(:name param) (:value param)]
 
                   (when-let [field-id (driver-api/match-one param
-                                                            [:field (field-id :guard integer?) _]
-                                                            (when (contains? (set &parents) :dimension)
-                                                              field-id))]
+                                        [:field (field-id :guard integer?) _]
+                                        (when (contains? (set &parents) :dimension)
+                                          field-id))]
                     [(:name (driver-api/field (driver-api/metadata-provider) field-id))
                      (:value param)]))))
         user-parameters))

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -775,11 +775,11 @@
                  (in-source-query? path)))]
     (driver-api/replace inner-query
       ;; remove order by and then recurse in case we need to do more tranformations at another level
-                        (m :guard (partial remove-order-by? &parents))
-                        (fix-order-bys (dissoc m :order-by))
+      (m :guard (partial remove-order-by? &parents))
+      (fix-order-bys (dissoc m :order-by))
 
-                        (m :guard (partial add-limit? &parents))
-                        (fix-order-bys (assoc m :limit driver-api/absolute-max-results)))))
+      (m :guard (partial add-limit? &parents))
+      (fix-order-bys (assoc m :limit driver-api/absolute-max-results)))))
 
 (defmethod sql.qp/preprocess :sqlserver
   [driver inner-query]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1273,31 +1273,31 @@
 (defmethod ->honeysql [:sql :aggregation]
   [driver [_ index]]
   (driver-api/match-one
-   (nth (:aggregation *inner-query*) index)
-   [:aggregation-options ag (options :guard :name)]
-   (->honeysql driver (h2x/identifier :field-alias (:name options)))
+    (nth (:aggregation *inner-query*) index)
+    [:aggregation-options ag (options :guard :name)]
+    (->honeysql driver (h2x/identifier :field-alias (:name options)))
 
-   [:aggregation-options ag _]
-   #_:clj-kondo/ignore
-   (recur ag)
+    [:aggregation-options ag _]
+    #_:clj-kondo/ignore
+    (recur ag)
 
     ;; For some arcane reason we name the results of a distinct aggregation "count", everything else is named the
     ;; same as the aggregation
-   :distinct
-   (->honeysql driver (h2x/identifier :field-alias :count))
+    :distinct
+    (->honeysql driver (h2x/identifier :field-alias :count))
 
-   #{:+ :- :* :/}
-   (->honeysql driver &match)
+    #{:+ :- :* :/}
+    (->honeysql driver &match)
 
-   [:offset (options :guard :name) _expr _n]
-   (->honeysql driver (h2x/identifier :field-alias (:name options)))
+    [:offset (options :guard :name) _expr _n]
+    (->honeysql driver (h2x/identifier :field-alias (:name options)))
 
     ;; for everything else just use the name of the aggregation as an identifer, e.g. `:sum`
     ;;
     ;; TODO -- I don't think we will ever actually get to this anymore because everything should have been given a name
     ;; by [[metabase.query-processor.middleware.pre-alias-aggregations]]
-   [ag-type & _]
-   (->honeysql driver (h2x/identifier :field-alias ag-type))))
+    [ag-type & _]
+    (->honeysql driver (h2x/identifier :field-alias ag-type))))
 
 (mu/defmethod ->honeysql [:sql :absolute-datetime] :- some?
   [driver [_ timestamp unit]]
@@ -1670,8 +1670,8 @@
 (defn- correct-null-behaviour
   [driver [op & args :as clause]]
   (if-let [field-arg (driver-api/match-one args
-                                           :field          &match
-                                           :expression     &match)]
+                       :field          &match
+                       :expression     &match)]
     ;; We must not transform the head again else we'll have an infinite loop
     ;; (and we can't do it at the call-site as then it will be harder to fish out field references)
     [:or

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1443,21 +1443,21 @@
    (rewrite-fields-to-force-using-column-aliases form {:is-breakout false}))
   ([form {is-breakout :is-breakout}]
    (driver-api/replace
-    form
-    [:field id-or-name opts]
-    [:field id-or-name (cond-> opts
-                         true
-                         (assoc driver-api/qp.add.source-alias        (get opts driver-api/qp.add.desired-alias)
-                                driver-api/qp.add.source-table        driver-api/qp.add.none
+     form
+     [:field id-or-name opts]
+     [:field id-or-name (cond-> opts
+                          true
+                          (assoc driver-api/qp.add.source-alias        (get opts driver-api/qp.add.desired-alias)
+                                 driver-api/qp.add.source-table        driver-api/qp.add.none
                                  ;; this key will tell the SQL QP not to apply casting here either.
-                                :qp/ignore-coercion       true
+                                 :qp/ignore-coercion       true
                                  ;; used to indicate that this is a forced alias
-                                ::forced-alias            true)
+                                 ::forced-alias            true)
                           ;; don't want to do temporal bucketing or binning inside the order by only.
                           ;; That happens inside the `SELECT`
                           ;; (#22831) however, we do want it in breakout
-                         (not is-breakout)
-                         (dissoc :temporal-unit :binning))])))
+                          (not is-breakout)
+                          (dissoc :temporal-unit :binning))])))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                Clause Handlers                                                 |


### PR DESCRIPTION
When introducing a new function, even if it's just potempkin-imported + renamed, check that it's indentation looks right. FWIW hardly anyone would have thought of making sure the format rules were adjusted.