### PR TITLE
Render ChartSettingMultiSelect without a portal for SDK

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -1,16 +1,29 @@
-import { InteractiveDashboard } from "@metabase/embedding-sdk-react";
+import {
+  InteractiveDashboard,
+  InteractiveQuestion,
+} from "@metabase/embedding-sdk-react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import * as H from "e2e/support/helpers";
+import { openVizSettingsSidebar } from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+import type { ConcreteFieldReference } from "metabase-types/api";
 
 const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
 
+const ORDERS_TOTAL_FIELD: ConcreteFieldReference = [
+  "field",
+  ORDERS.TOTAL,
+  {
+    "base-type": "type/Float",
+  },
+];
+
 describe("scenarios > embedding-sdk > popovers", () => {
-  it("should show legend overflow popover for charts with many series (metabase#57131)", () => {
+  beforeEach(() => {
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
       "dashcardQuery",
     );
@@ -24,7 +37,7 @@ describe("scenarios > embedding-sdk > popovers", () => {
           display: "line",
           query: {
             "source-table": ORDERS_ID,
-            aggregation: [["count"]],
+            aggregation: [["count"], ["sum", ORDERS_TOTAL_FIELD]],
             breakout: [
               [
                 "field",
@@ -40,17 +53,22 @@ describe("scenarios > embedding-sdk > popovers", () => {
           },
           visualization_settings: {
             "graph.dimensions": ["CREATED_AT", "STATE"],
-            "graph.metrics": ["count"],
+            "graph.metrics": ["count", "sum"],
           },
         },
       ],
       cards: [{ col: 0, row: 0, size_x: 24, size_y: 6 }],
-    }).then(({ dashboard }) => cy.wrap(dashboard.id).as("dashboardId"));
+    }).then(({ dashboard, questions }) => {
+      cy.wrap(dashboard.id).as("dashboardId");
+      cy.wrap(questions[0].id).as("questionId");
+    });
 
     cy.signOut();
 
     mockAuthProviderAndJwtSignIn();
+  });
 
+  it("should show legend overflow popover for charts with many series (metabase#57131)", () => {
     cy.get<string>("@dashboardId").then((dashboardId) => {
       mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
     });
@@ -65,5 +83,30 @@ describe("scenarios > embedding-sdk > popovers", () => {
     cy.log("check that the popover is showing chart legends");
     H.popover().findByText("IA").should("be.visible");
     H.popover().findByText("ID").should("be.visible");
+  });
+
+  it("should prevent closing the ChartSettingMultiSelect when clicking it", () => {
+    cy.get<string>("@questionId").then((questionId) => {
+      mountSdkContent(<InteractiveQuestion questionId={questionId} />);
+    });
+
+    openVizSettingsSidebar();
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("chartsettings-sidebar").findByText("Display").click();
+
+      cy.findByTestId("chart-settings-widget-graph.tooltip_columns").within(
+        () => {
+          cy.findByTestId("multi-select").click();
+          // Clicking at the edge of the multiselect popover to be sure that the click does not close it
+          cy.get('[data-element-id="mantine-popover"]').click(2, 2);
+          cy.get('[data-element-id="mantine-popover"]').should("be.visible");
+
+          // Clicking outside of the multiselect popover to be sure that the click closes it
+          cy.findByText("Additional tooltip columns").click();
+          cy.get('[data-element-id="mantine-popover"]').should("be.hidden");
+        },
+      );
+    });
   });
 });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingMultiSelect.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingMultiSelect.tsx
@@ -1,3 +1,4 @@
+import { isEmbeddingSdk } from "metabase/env";
 import { MultiSelect } from "metabase/ui";
 
 type Value = string[] | undefined;
@@ -34,6 +35,7 @@ export const ChartSettingMultiSelect = ({
   const handleChange = (v: string[]) => {
     onChange(v);
   };
+
   return (
     <MultiSelect
       value={value}
@@ -41,6 +43,12 @@ export const ChartSettingMultiSelect = ({
       placeholder={options.length === 0 ? placeholderNoOptions : placeholder}
       data={uniqByValue(options) /* dedupe to avoid making Mantine crash */}
       searchable
+      comboboxProps={{
+        // For the SDK the ChartSettingMultiSelect is rendered inside a parent popover,
+        // so as a nested popover it should not be rendered within a portal
+        withinPortal: !isEmbeddingSdk,
+        floatingStrategy: "fixed",
+      }}
       aria-label={placeholder}
     />
   );


### PR DESCRIPTION
See context here:
https://linear.app/metabase/issue/EMB-529/dont-close-the-chartsettingmultiselect-popover-when-clicking-inside-it

For SDK it is rendered inside a parent Mantine Popover rendered in a portal, and in such cases nested popovers should NOT be rendered in a portal.

How to verify:
- ci should be green
- manually select `area` viz type, select 2 different `summarize` options, open viz settings, for `y-axis` if there are 2 item, remove one of them, go to `display` tab within this popover, and play with `Additional tooltip columns popover`. 