### PR TITLE
set a bin range to between filter in dashboard click behavior

### DIFF
--- a/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
@@ -427,6 +427,15 @@ export function formatSourceForTarget(
     }
   }
 
+  if (parameter?.type === "number/between" && "column" in datum) {
+    const value = datum.value;
+    const binWidth = datum.column?.binning_info?.bin_width;
+
+    if (binWidth != null && typeof value === "number") {
+      return [value, value + binWidth];
+    }
+  }
+
   return parameter ? parseParameterValue(datum.value, parameter) : datum.value;
 }
 

--- a/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.unit.spec.ts
@@ -624,5 +624,72 @@ describe("metabase/lib/click-behavior", () => {
       });
       expect(value).toEqual("2020-01-01");
     });
+
+    it("should format number/between parameters with binning info as a range", () => {
+      const source = {
+        type: "column" as const,
+        id: "SOME_NUMBER",
+        name: "number",
+      };
+      const target = { type: "parameter" as const, id: "param123" };
+      const data = {
+        ...emptyData,
+        column: {
+          some_number: {
+            value: 10,
+            column: createMockColumn({
+              effective_type: "type/Integer",
+              binning_info: { bin_width: 5 },
+            }),
+          },
+        },
+      };
+      const extraData = {
+        dashboard: createMockDashboard(),
+        parameters: [
+          createMockParameter({ id: "param123", type: "number/between" }),
+        ],
+      };
+      const clickBehavior = { type: "crossfilter" as const };
+      const value = formatSourceForTarget(source, target, {
+        data,
+        extraData,
+        clickBehavior,
+      });
+      expect(value).toEqual([10, 15]);
+    });
+
+    it("should not format number/between as a range when binning info is missing", () => {
+      const source = {
+        type: "column" as const,
+        id: "SOME_NUMBER",
+        name: "number",
+      };
+      const target = { type: "parameter" as const, id: "param123" };
+      const data = {
+        ...emptyData,
+        column: {
+          some_number: {
+            value: 10,
+            column: createMockColumn({
+              effective_type: "type/Integer",
+            }),
+          },
+        },
+      };
+      const extraData = {
+        dashboard: createMockDashboard(),
+        parameters: [
+          createMockParameter({ id: "param123", type: "number/between" }),
+        ],
+      };
+      const clickBehavior = { type: "crossfilter" as const };
+      const value = formatSourceForTarget(source, target, {
+        data,
+        extraData,
+        clickBehavior,
+      });
+      expect(value).toEqual([10]);
+    });
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #52861
Closes [VIZ-269](https://linear.app/metabase/issue/VIZ-269/binned-data-does-not-get-passed-to-between-filter)

### Description

When clicking on a numeric value with binning that is connected via click behavior to `between` filter we want to set the bin range to the between filter.

### How to verify

- Question 1: Orders: Count by Total [Auto binned]
- Create a dashboard, add Question 1 and any other question with a numeric dimension
- Add a numeric parameter of type `between` and connect it to the other question
- For Question 1 configure click behavior connecting it to the numeric parameter
- Ensure clicking on Question 1 values sets the between numeric parameter range values, not just the first value

### Demo

<video src="https://github.com/user-attachments/assets/52b7d3c3-5a4d-4d2b-ad44-6eda70390a9e" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
