### PR TITLE
scroll dashboard when dragging a card

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.module.css
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.module.css
@@ -79,3 +79,12 @@
     max-width: var(--dashboard-fixed-width);
   }
 }
+
+/* Make selected text invisible only during drag operations to preserve auto-scroll */
+:global(body.react-grid-layout-dragging ::selection) {
+  background: transparent;
+}
+
+:global(body.react-grid-layout-dragging ::-moz-selection) {
+  background: transparent;
+}

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   type ItemCallback,
-  Layout,
   Responsive as ReactGridLayout,
 } from "react-grid-layout";
 
@@ -199,18 +198,18 @@ export function GridLayout<T extends { id: number | null }>(
   // https://github.com/react-grid-layout/react-grid-layout#performance
   const children = useMemo(() => items.map(renderItem), [items, renderItem]);
 
-  // // prevent user selection when dragging metabase#53842
-  const originalUserSelect = useRef(document.body.style.userSelect);
+  // Hide text selection during drag without affecting auto-scroll metabase#53842
   const disableTextSelection = useCallback<ItemCallback>(
     (...params) => {
-      document.body.style.userSelect = "none";
+      document.body.classList.add("react-grid-layout-dragging");
       otherProps.onDragStart?.(...params);
     },
     [otherProps],
   );
+
   const enableTextSelection = useCallback<ItemCallback>(
     (...params) => {
-      document.body.style.userSelect = originalUserSelect.current;
+      document.body.classList.remove("react-grid-layout-dragging");
       otherProps.onDragStop?.(...params);
     },
     [otherProps],

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
 
 import { renderWithProviders } from "__support__/ui";
@@ -77,30 +77,5 @@ describe("GridLayout", () => {
     // Check if all items are rendered
     expect(screen.getByTestId("item-1")).toBeInTheDocument();
     expect(screen.getByTestId("item-2")).toBeInTheDocument();
-  });
-
-  test("disables and enables text selection during drag", () => {
-    // Capture original user select style
-    const originalUserSelect = document.body.style.userSelect;
-
-    renderWithProviders(
-      <ThemeProvider>
-        <GridLayout {...defaultProps} isEditing={true} />
-      </ThemeProvider>,
-    );
-
-    const grid = screen.getByTestId("item-1");
-
-    // Test drag start disables text selection
-    fireEvent.mouseDown(grid);
-    fireEvent.mouseMove(grid);
-    expect(document.body).toHaveStyle({ userSelect: "none" });
-
-    // Test drag stop re-enables text selection
-    fireEvent.mouseUp(grid);
-    expect(document.body).toHaveStyle({ userSelect: "" });
-
-    // Restore original style
-    document.body.style.userSelect = originalUserSelect;
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59645
Closes [VIZ-1162](https://linear.app/metabase/issue/VIZ-1162/dragging-a-chart-to-top-of-dashboard-takes-too-long)

### Description

To enable native browser scrolling when dragging dashboard cards `user-select` can't be `none` which was set so to fix another bug https://github.com/metabase/metabase/pull/55528. Instead of actually disabling user-select this PR makes selected text highlight color invisible.

### How to verify

- Create a long dashboard
- Try dragging a card from bottom to top and ensure the dashboard scrolls
- Ensure dragging cards does not visibly make any text selected

### Demo

https://github.com/user-attachments/assets/4cd72f54-932c-4b03-b9df-55086dfc7da4

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR — tricky to test, could not make it work in Cypress
