### PR TITLE
Add Metabase storage upsell to upload CSV panel

### DIFF
--- a/frontend/src/metabase/admin/upsells/UpsellStorage.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellStorage.tsx
@@ -1,0 +1,40 @@
+import { t } from "ttag";
+
+import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
+import { getStoreUrl } from "metabase/selectors/settings";
+import { List } from "metabase/ui";
+
+import { UpsellBanner } from "./components";
+
+export const UpsellStorage = ({ source }: { source: string }) => {
+  const isHosted = useSetting("is-hosted?");
+  const hasStorage = useHasTokenFeature("attached_dwh");
+
+  if (!isHosted || hasStorage) {
+    return null;
+  }
+
+  const storeAccount = getStoreUrl("account");
+
+  return (
+    <UpsellBanner
+      campaign="storage"
+      buttonText={t`Add`}
+      buttonLink={storeAccount}
+      source={source}
+      title={t`Add Metabase Storage`}
+      large
+    >
+      <List
+        mt="xs"
+        withPadding
+        size="sm"
+        styles={{ root: { paddingInlineStart: "var(--mantine-spacing-sm)" } }}
+      >
+        <List.Item>{t`Secure, fully managed by Metabase`}</List.Item>
+        <List.Item>{t`Upload CSV files`}</List.Item>
+        <List.Item>{t`Sync with Google Sheets`}</List.Item>
+      </List>
+    </UpsellBanner>
+  );
+};

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.stories.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.stories.tsx
@@ -14,6 +14,7 @@ const args = {
   campaign: "upsell-banner",
   source: "storybook",
   title: "Upgrade now",
+  large: false,
 };
 
 const argTypes = {
@@ -34,6 +35,9 @@ const argTypes = {
   },
   title: {
     control: { type: "text" },
+  },
+  large: {
+    control: { type: "boolean" },
   },
 };
 

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { useMount } from "react-use";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
@@ -27,6 +28,7 @@ export type UpsellBannerProps = {
   buttonText: string;
   campaign: string;
   source: string;
+  large?: boolean;
   children: React.ReactNode;
   style?: React.CSSProperties;
 } & CardLinkProps;
@@ -38,6 +40,7 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
   internalLink,
   campaign,
   source,
+  large,
   children,
   ...props
 }: UpsellBannerProps) => {
@@ -51,15 +54,18 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
     trackUpsellViewed({ source, campaign });
   });
 
+  const gemSize = large ? 24 : undefined;
+  const contentAlignment = large ? "flex-start" : "center";
+
   return (
     <Box
-      className={S.UpsellBannerComponent}
+      className={cx(S.UpsellBannerComponent, large && S.Large)}
       data-testid="upsell-banner"
       bg="bg-white"
       {...props}
     >
-      <Flex align="center" gap="md" wrap="nowrap">
-        <UpsellGem />
+      <Flex align={contentAlignment} gap="md" wrap="nowrap">
+        <UpsellGem size={gemSize} />
         <Box>
           <Title lh={1.25} order={3} size="md">
             {title}

--- a/frontend/src/metabase/admin/upsells/components/Upsells.module.css
+++ b/frontend/src/metabase/admin/upsells/components/Upsells.module.css
@@ -48,6 +48,14 @@
   .UpsellCTALink {
     flex-shrink: 0;
   }
+
+  &.Large {
+    align-items: flex-start;
+
+    .UpsellCTALink {
+      padding: 0.5rem 1rem;
+    }
+  }
 }
 
 .SecondaryCTALink {

--- a/frontend/src/metabase/admin/upsells/index.ts
+++ b/frontend/src/metabase/admin/upsells/index.ts
@@ -6,6 +6,7 @@ export * from "./UpsellMetabaseBanner";
 export * from "./UpsellPerformanceTools";
 export * from "./UpsellPermissions";
 export * from "./UpsellSSO";
+export * from "./UpsellStorage";
 export * from "./UpsellUploads";
 export * from "./UpsellUsageAnalytics";
 export * from "./UpsellWhitelabel";

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
@@ -20,6 +20,9 @@ import {
 
 import IconCSV from "./illustrations/csv.svg?component";
 
+const CONTENT_MAX_WIDTH = "22.5rem";
+const INNER_WIDTH = "12.5rem";
+
 type ContactReason =
   | "add-database"
   | "enable-csv-upload"
@@ -51,7 +54,7 @@ const ContactAdminAlert = ({ reason }: { reason: ContactReason }) => {
     .exhaustive();
 
   return (
-    <Alert icon={<Icon name="info_filled" />}>
+    <Alert icon={<Icon name="info_filled" />} maw={CONTENT_MAX_WIDTH}>
       <Text fz="md" lh="lg">
         {getAlertCopy}
       </Text>
@@ -70,6 +73,7 @@ interface EmptyStateProps {
   illustration: ReactNode;
   ctaLink?: CTALink;
   contactAdminReason?: ContactReason;
+  upsell?: ReactNode;
 }
 
 const AddDataEmptyState = ({
@@ -78,27 +82,30 @@ const AddDataEmptyState = ({
   illustration,
   ctaLink,
   contactAdminReason,
+  upsell,
 }: EmptyStateProps) => {
   return (
-    <Center pt="3rem">
-      <Stack gap="lg" align="center" justify="center" maw="22.5rem">
-        {illustration}
-        <Box component="header" ta="center">
-          <Title order={2} size="h4" mb="xs">
-            {title}
-          </Title>
-          <Text c="text-medium">{subtitle}</Text>
-        </Box>
-        {ctaLink && (
-          <Button variant="filled" w="12.5rem" component={Link} to={ctaLink.to}>
-            {ctaLink.text}
-          </Button>
-        )}
-        {contactAdminReason && (
-          <ContactAdminAlert reason={contactAdminReason} />
-        )}
-      </Stack>
-    </Center>
+    <Stack gap="lg" align="center" justify="center" pt="3rem">
+      {illustration}
+      <Box component="header" ta="center" maw={CONTENT_MAX_WIDTH}>
+        <Title order={2} size="h4" mb="xs">
+          {title}
+        </Title>
+        <Text c="text-medium">{subtitle}</Text>
+      </Box>
+      {ctaLink && (
+        <Button
+          variant="filled"
+          w={INNER_WIDTH}
+          component={Link}
+          to={ctaLink.to}
+        >
+          {ctaLink.text}
+        </Button>
+      )}
+      {contactAdminReason && <ContactAdminAlert reason={contactAdminReason} />}
+      {upsell}
+    </Stack>
   );
 };
 
@@ -120,20 +127,23 @@ export const DatabasePanelEmptyState = () => {
 export const CSVPanelEmptyState = ({
   ctaLink,
   contactAdminReason,
+  upsell,
 }:
   | {
       ctaLink: CTALink;
       contactAdminReason?: never;
+      upsell?: ReactNode;
     }
   | {
       ctaLink?: never;
       contactAdminReason: ContactReason;
+      upsell?: never;
     }) => {
   const ctaSubtitle = c("{0} refers to the string 'your database'")
     .jt`To work with CSVs, enable file uploads in ${(
     <Tooltip
       inline
-      maw="12.5rem"
+      maw={INNER_WIDTH}
       multiline
       label={t`PostgreSQL, MySQL, Redshift, and ClickHouse databases are supported for file storage.`}
       key="database-tooltip"
@@ -153,6 +163,7 @@ export const CSVPanelEmptyState = ({
       illustration={<Box component={IconCSV} c="brand" h={66} />}
       contactAdminReason={contactAdminReason}
       ctaLink={ctaLink}
+      upsell={upsell}
     />
   );
 };

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/CSVPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/CSVPanel.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { UpsellStorage } from "metabase/admin/upsells";
 import * as Urls from "metabase/lib/urls";
 
 import { CSVPanelEmptyState } from "./AddDataModalEmptyStates";
@@ -40,6 +41,7 @@ export const CSVPanel = ({
           text: t`Enable uploads`,
           to: Urls.uploadsSettings(),
         }}
+        upsell={<UpsellStorage source="add-data-modal-csv" />}
       />
     );
   }

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/common.unit.spec.tsx
@@ -137,6 +137,19 @@ describe("AddDataModal", () => {
         screen.getByText(/^To work with CSVs, enable file uploads/),
       ).toBeInTheDocument();
       expect(screen.getByText("Enable uploads")).toBeInTheDocument();
+      // Upsell banner should not show for self-hosted instances.
+      expect(
+        screen.queryByText("Add Metabase Storage"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should prompt the admin to enable uploads with an upsell on a hosted instance", async () => {
+      setup({ isAdmin: true, uploadsEnabled: false, isHosted: true });
+
+      await openTab("CSV");
+      expect(screen.getByText("Manage uploads")).toBeInTheDocument();
+      expect(screen.getByText("Enable uploads")).toBeInTheDocument();
+      expect(screen.getByText("Add Metabase Storage")).toBeInTheDocument();
     });
 
     it("regular user should be instructed to contact their admin in order to enable uploads", async () => {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/setup.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/setup.tsx
@@ -22,6 +22,7 @@ interface SetupOpts {
   uploadsEnabled?: boolean;
   canUpload?: boolean;
   canManageSettings?: boolean;
+  isHosted?: boolean;
   hasEnterprisePlugins?: boolean;
   tokenFeatures?: Partial<TokenFeatures>;
 }
@@ -32,6 +33,7 @@ export const setup = ({
   uploadsEnabled = false,
   canUpload = true,
   canManageSettings = false,
+  isHosted = false,
   hasEnterprisePlugins = false,
   tokenFeatures = {},
 }: SetupOpts = {}) => {
@@ -67,6 +69,7 @@ export const setup = ({
       collections,
     }),
     settings: mockSettings({
+      "is-hosted?": isHosted,
       "token-features": createMockTokenFeatures(tokenFeatures),
       "uploads-settings": {
         db_id: uploadsEnabled ? database.id : null,


### PR DESCRIPTION
Resolves PRG-57

### Description

- Expands the `UpsellBanner` component with the `large` variant
- Introduces the `UpsellStorage` component
- Adds the storage upsell to the CSV uploads panel in the _Add data_ modal

> [!NOTE]
> You can preview this new variant using Storybook.

### How to verify

1. Be an admin
2. Disable uploads
3. Have a hosted instance without the attached data warehouse
4. Open the CSV tab in the _Add data_ modal

### Demo

<img width="738" alt="image" src="https://github.com/user-attachments/assets/68400b90-e2e3-4ac6-bf7a-ba19368da9bb" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
