### PR TITLE
Support custom action being both a 'row' and 'header' action

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/api.clj
@@ -316,7 +316,7 @@
                              viz-action  (api/check-404 (first (filter (comp #{raw-id} :id) actions)))
                              inner-id    (:actionId viz-action)
                              inner       (fetch-unified-action scope inner-id)
-                             action-type (:actionType viz-action "data-grid/row-action")
+                             action-type (:actionType viz-action "data-grid/custom-action")
                              mapping     (:mapping viz-action)
                              ;; TODO we should do this *later* because it's lossy - we lose the configured ordering.
                              param-map   (->> (:parameterMappings viz-action {})
@@ -325,6 +325,8 @@
                          (assert (:enabled viz-action true) "Cannot call disabled actions")
                          (case action-type
                            ("data-grid/built-in"
+                            "data-grid/custom-action"
+                            ;; deprecated
                             "data-grid/row-action")
                            {:inner-action inner
                             :mapping      mapping

--- a/enterprise/backend/test/metabase_enterprise/data_editing/action_v2_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/action_v2_api_test.clj
@@ -219,7 +219,7 @@
                                                :parameterMappings nil}
                                               {:id                "dashcard:unknown:update"
                                                :actionId          "table.row/update"
-                                               :actionType        "data-grid/row-action"
+                                               :actionType        "data-grid/custom-action"
                                                :enabled           true
                                                ;; TODO make sure this stuff makes sense.
                                                ;;      What does the FE really write? Have we messed anything up?

--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -891,19 +891,19 @@
                                                                  [{:parameterId "name", :sourceType "row-data", :sourceValueTarget "name"}]]
                                                              [{:id                "dashcard:unknown:abcdef"
                                                                :actionId          (:id action)
-                                                               :actionType        "data-grid/row-action"
+                                                               :actionType        "data-grid/custom-action"
                                                                :parameterMappings param-maps
                                                                :enabled           true}
                                                               {:id                "dashcard:unknown:fedcba"
                                                                :actionId          "table.row/update"
-                                                               :actionType        "data-grid/row-action"
+                                                               :actionType        "data-grid/custom-action"
                                                                :mapping           {:table-id table-id
                                                                                    :row      "::root"}
                                                                :parameterMappings param-maps
                                                                :enabled           true}
                                                               {:id                "dashcard:unknown:xyzabc"
                                                                :actionId          (#'actions/encoded-action-id :table.row/update table-id)
-                                                               :actionType        "data-grid/row-action"
+                                                               :actionType        "data-grid/custom-action"
                                                                :parameterMappings param-maps
                                                                :enabled           true}])}}]
               (testing "no access to the model"
@@ -1020,7 +1020,7 @@
                                                        :editableTable.enabledActions
                                                        [{:id         "dashcard:unknown:my-row-action"
                                                          :actionId   "table.row/create"
-                                                         :actionType "data-grid/row-action"
+                                                         :actionType "data-grid/custom-action"
                                                          :mapping    {:table-id table-2-id
                                                                       :row      {:a ["::key" "aa"]
                                                                                  :b ["::key" "bb"]
@@ -1440,7 +1440,7 @@
                                              {:id                "dashcard:unknown:custom"
                                               :name              "create"
                                               :actionId          (:id action)
-                                              :actionType        "data-grid/row-action"
+                                              :actionType        "data-grid/custom-action"
                                               :parameterMappings [{:parameterId "a" :sourceType "row-data" :sourceValueTarget "name"}
                                                                   {:parameterId "b" :sourceType "ask-user"}
                                                                   {:parameterId "c" :sourceType "row-data" :sourceValueTarget "id", :visibility "hidden"}]}]
@@ -1512,7 +1512,7 @@
                                              {:id                "dashcard:unknown:custom-create"
                                               :name              "create"
                                               :actionId          (#'actions/encoded-action-id :table.row/create products)
-                                              :actionType        "data-grid/row-action"
+                                              :actionType        "data-grid/custom-action"
                                               :parameterMappings [{:parameterId "name" :sourceType "row-data" :sourceValueTarget "name"}
                                                                   {:parameterId "price" :sourceType "ask-user"}
                                                                   {:parameterId "category_id" :sourceType "row-data" :sourceValueTarget "id"}]}]
@@ -1602,7 +1602,7 @@
                                               :actionType        "data-grid/built-in"}
                                              {:id                "dashcard:unknown:custom-create"
                                               :actionId          "table.row/create"
-                                              :actionType        "data-grid/row-action"
+                                              :actionType        "data-grid/custom-action"
                                               :mapping           {:table-id table-id
                                                                   :row      "::root"}
                                               :parameterMappings [{:parameterId "int"

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
@@ -98,7 +98,6 @@ export const ConfigureTableActions = ({
         id: id || uuid(),
         name: name || action.name,
         actionId: action.id,
-        actionType: "data-grid/row-action",
         actionType: "data-grid/custom-action",
         isRowAction: true,
         isHeaderAction: false,

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
@@ -49,7 +49,9 @@ export const ConfigureTableActions = ({
         id: uuid(),
         name: name || action.name,
         actionId: action.id,
-        actionType: "data-grid/row-action",
+        actionType: "data-grid/custom-action",
+        isRowAction: true,
+        isHeaderAction: false,
         parameterMappings,
         enabled: true,
       };
@@ -97,6 +99,9 @@ export const ConfigureTableActions = ({
         name: name || action.name,
         actionId: action.id,
         actionType: "data-grid/row-action",
+        actionType: "data-grid/custom-action",
+        isRowAction: true,
+        isHeaderAction: false,
         parameterMappings,
         enabled: editingAction?.enabled ?? true,
       };

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -177,7 +177,9 @@ export type TableRowActionDisplaySettings = {
   id: string;
   actionId: WritebackActionId;
   name: string;
-  actionType: "data-grid/row-action";
+  actionType: "data-grid/custom-action";
+  isRowAction?: boolean;
+  isHeaderAction?: boolean;
   parameterMappings?: RowActionFieldSettings[];
   enabled: boolean;
 };

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -383,7 +383,9 @@
       ;; Make sure the id is globally unique, and sufficient to retrieve the definition.
       (update :id (partial create-or-fix-action-id parent-type parent-id))
       ;; At the time of writing, FE only allows the creation of row actions. Make sure this is explicit.
-      (update :actionType #(or % "data-grid/row-action"))
+      (update :actionType #(if (or (not %) = "data-grid/row-action" %) "data-grid/custom-action" %))
+      (update :isRowAction #(or % (not (:isHeaderAction grid-action))))
+      (update :isHeaderAction #(or % (not (:isRowAction grid-action))))
       ;; By default actions are enabled.
       (update :enabled #(if (some? %) % true))))
 

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -383,7 +383,7 @@
       ;; Make sure the id is globally unique, and sufficient to retrieve the definition.
       (update :id (partial create-or-fix-action-id parent-type parent-id))
       ;; At the time of writing, FE only allows the creation of row actions. Make sure this is explicit.
-      (update :actionType #(if (or (not %) = "data-grid/row-action" %) "data-grid/custom-action" %))
+      (update :actionType #(if (or (not %) (= "data-grid/row-action" %)) "data-grid/custom-action" %))
       (update :isRowAction #(or % (not (:isHeaderAction grid-action))))
       (update :isHeaderAction #(or % (not (:isRowAction grid-action))))
       ;; By default actions are enabled.

--- a/test/metabase/queries/api/card_test.clj
+++ b/test/metabase/queries/api/card_test.clj
@@ -929,7 +929,7 @@
                      :visualization_settings {:table.enabled_actions
                                               [{:id         (str "card:unknown:" temp-id),
                                                 :action-id  1
-                                                :actionType "data-grid/row-action"
+                                                :actionType "data-grid/custom-action"
                                                 :enabled    true}]}}
                     (mt/user-http-request :crowberto :post 200 "card"
                                           (merge (mt/with-temp-defaults :model/Card)


### PR DESCRIPTION
Closes WRK-550

Renames `actionType` from `data-grid/row-action` to `data-grid/custom-action` ~~and adds the `isRowAction` and `isHeaderAction` booleans.~~

~~Hmm, maybe these should be `showInRow` and `showInHeader` rather? Cue bike shedding!~~

Strip the new configuration for now, let's wait for the UI to land first.