### PR TITLE
Fix bugs with parameter mapping

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_editing/api_test.clj
@@ -887,8 +887,10 @@
                                                           {:table_id table-id
                                                            :editableTable.enabledActions
                                                            (let [param-maps
-                                                                 ;; we might need to change these to use field ids
-                                                                 [{:parameterId "name", :sourceType "row-data", :sourceValueTarget "name"}]]
+                                                                 ;; TODO change these to use field ids, to test the translation
+                                                                 [{:parameterId "id",     :sourceType "row-data", :sourceValueTarget "id"}
+                                                                  {:parameterId "name",   :sourceType "row-data", :sourceValueTarget "name"}
+                                                                  {:parameterId "status", :sourceType "row-data", :sourceValueTarget "status"}]]
                                                              [{:id                "dashcard:unknown:abcdef"
                                                                :actionId          (:id action)
                                                                :actionType        "data-grid/custom-action"


### PR DESCRIPTION
1. Un-mapped inputs should not pass through automatically.
2. Overrides should take precedence over default.
3. Explicit nulls should be respected.

This stuff is a bit of a mess, because config is a bit of a mess. We can clean it up more after we merge `/config-form`.

I think there will still be a bug here, around slugs versus parameter ids, but we can fix that as a follow on.