### PR TITLE
Hide db routing for unsupported DB engines

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.tsx
@@ -45,7 +45,9 @@ export const DatabaseRoutingSection = ({
 
   const isAdmin = useSelector(getUserIsAdmin);
   const userAttribute = database.router_user_attribute ?? undefined;
-  const shouldHideSection = database.is_attached_dwh || database.is_sample;
+  const dbSupportsRouting = database.features?.includes("database-routing");
+  const shouldHideSection =
+    database.is_attached_dwh || database.is_sample || !dbSupportsRouting;
 
   const [tempEnabled, setTempEnabled] = useState(false);
   const enabled = tempEnabled || hasDbRoutingEnabled(database);

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.unit.spec.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import {
   setupDatabasesEndpoints,
   setupUserAttributesEndpoint,
@@ -52,15 +50,8 @@ describe("DatabaseRoutingSection", () => {
     expect(screen.queryByText("Database routing")).not.toBeInTheDocument();
   });
 
-  it("should disable db routing if database routing is not supported by the db engine", async () => {
+  it("should hide section if database routing is not supported by the db engine", async () => {
     setup({ engine: "clickhouse", features: [] });
-    expect(screen.getByLabelText("Enable database routing")).toBeDisabled();
-    const openSection = screen.getByLabelText("chevrondown icon");
-    await userEvent.click(openSection);
-    expect(
-      screen.getByText(
-        "Database routing is not supported for this database type.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Database routing")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes ADM-1029

### Description

Will not show the db routing config for database engines that don't support db routing, like clickhouse.

![Screenshot 2025-06-23 at 8 03 32 AM](https://github.com/user-attachments/assets/8dee0dc9-a4ea-4206-92fb-7ffe65c69b3f)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
