### PR TITLE
[Metabot] Streaming error handling and retry prompt UI

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -57,6 +57,7 @@ export const MetabotChatEmbedding = ({
       EMBEDDING_METABOT_ID,
     );
 
+    // TODO: pretty sure this is broken now...
     metabotRequestPromise
       .then((result) => {
         const redirectUrl = (

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -57,12 +57,9 @@ export const MetabotChatEmbedding = ({
       EMBEDDING_METABOT_ID,
     );
 
-    // TODO: pretty sure this is broken now...
     metabotRequestPromise
       .then((result) => {
-        const redirectUrl = (
-          result.payload as any
-        )?.payload?.data?.reactions?.find(
+        const redirectUrl = (result.payload as any)?.data?.reactions?.find(
           (reaction: { type: string; url: string }) =>
             reaction.type === "metabot.reaction/redirect",
         )?.url;

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/process-stream.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/process-stream.ts
@@ -189,7 +189,7 @@ export type AIStreamingConfig = {
   onStreamStateUpdate?: (
     state: ReturnType<typeof accumulateStreamParts>,
   ) => void;
-  onError?: (error: Error) => void;
+  onError?: (error: StreamPartValue<"error">) => void;
 };
 
 export async function processChatResponse(
@@ -248,9 +248,7 @@ export async function processChatResponse(
         config.onToolResultPart?.(streamPart.value);
       }
       if (streamPart.name === "error") {
-        config.onError?.(
-          new Error(streamPart.value ? `${streamPart.value}` : "Unknown error"),
-        );
+        config.onError?.(streamPart.value);
       }
     }
 

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
@@ -55,7 +55,7 @@ export async function aiStreamingQuery(
     });
 
     if (!response.ok) {
-      throw new Error(response.statusText);
+      throw new Error(`Response status: ${response.status}`);
     }
 
     if (!response.body) {

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.unit.spec.ts
@@ -63,7 +63,7 @@ describe("ai requests", () => {
       fetchMock.post(`path:${ENDPOINT}`, 500);
       await expect(
         aiStreamingQuery({ url: ENDPOINT, body: {} }),
-      ).rejects.toThrow(/Internal Server Error/);
+      ).rejects.toThrow(/Response status: 500/);
     });
 
     it("throw error if no response", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -30,6 +30,7 @@ import { AIMarkdown } from "../AIMarkdown/AIMarkdown";
 
 import Styles from "./MetabotChat.module.css";
 import { useAutoscrollMessages } from "./hooks";
+import { isLastAgentReply } from "./utils";
 
 export const MetabotChat = () => {
   const messagesRef = useRef<HTMLDivElement>(null);
@@ -164,19 +165,9 @@ export const MetabotChat = () => {
             <Box className={Styles.messages}>
               {/* conversation messages */}
               {metabot.messages.map((message, index) => {
-                const nextMessage: MetabotChatMessage | undefined =
-                  metabot.messages[index + 1];
-
-                const isLastAgentReply =
-                  message.role === "agent" &&
-                  message.type === "reply" &&
-                  (!nextMessage ||
-                    nextMessage.role !== "agent" ||
-                    (nextMessage.role === "agent" &&
-                      nextMessage.type !== message.type));
-
-                // NOTE: need e2e support for ids on message to support non-streamed requests
-                const canRetry = metabot.useStreaming && isLastAgentReply;
+                const canRetry =
+                  metabot.useStreaming &&
+                  isLastAgentReply(message, metabot.messages[index + 1]);
 
                 return (
                   <Message

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -317,12 +317,20 @@ const Message = ({
         .exhaustive()}
       <Flex className={Styles.messageActions}>
         {!(message.role === "agent" && message.type === "error") && (
-          <ActionIcon onClick={() => clipboard.copy(message.message)} h="sm">
+          <ActionIcon
+            onClick={() => clipboard.copy(message.message)}
+            h="sm"
+            data-testid="metabot-chat-message-copy"
+          >
             <Icon name="copy" size="1rem" />
           </ActionIcon>
         )}
         {onRetry && (
-          <ActionIcon onClick={() => onRetry(message.id)} h="sm">
+          <ActionIcon
+            onClick={() => onRetry(message.id)}
+            h="sm"
+            data-testid="metabot-chat-message-retry"
+          >
             <Icon name="revert" size="1rem" />
           </ActionIcon>
         )}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -1,6 +1,7 @@
 import { useClipboard, useTimeout } from "@mantine/hooks";
 import cx from "classnames";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { match } from "ts-pattern";
 import { c, jt, t } from "ttag";
 import _ from "underscore";
 
@@ -8,6 +9,7 @@ import EmptyDashboardBot from "assets/img/dashboard-empty.svg?component";
 import { Sidebar } from "metabase/nav/containers/MainNavbar/MainNavbar.styled";
 import {
   ActionIcon,
+  Alert,
   Box,
   type BoxProps,
   Button,
@@ -21,6 +23,7 @@ import {
   UnstyledButton,
 } from "metabase/ui";
 import { useGetSuggestedMetabotPromptsQuery } from "metabase-enterprise/api";
+import type { MetabotChatMessage } from "metabase-enterprise/metabot/state";
 
 import { useMetabotAgent } from "../../hooks";
 import { AIMarkdown } from "../AIMarkdown/AIMarkdown";
@@ -29,11 +32,8 @@ import Styles from "./MetabotChat.module.css";
 import { useAutoscrollMessages } from "./hooks";
 
 export const MetabotChat = () => {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
-
-  const [input, setMessage] = useState("");
 
   const metabot = useMetabotAgent();
 
@@ -59,19 +59,24 @@ export const MetabotChat = () => {
     if (!trimmedInput.length || metabot.isDoingScience) {
       return;
     }
-    setMessage("");
-    textareaRef.current?.focus();
+    metabot.setPrompt("");
+    metabot.promptInputRef?.current?.focus();
     metabot.submitInput(trimmedInput).catch((err) => console.error(err));
   };
 
-  const { setVisible } = metabot;
-  const handleClose = useCallback(() => {
-    setMessage("");
-    setVisible(false);
-  }, [setVisible]);
+  const handleRetryMessage = (messageId: string) => {
+    if (metabot.isDoingScience) {
+      return;
+    }
 
-  const handleInputChange = (value: string) => {
-    setMessage(value);
+    metabot.setPrompt("");
+    metabot.promptInputRef?.current?.focus();
+    metabot.retryMessage(messageId).catch((err) => console.error(err));
+  };
+
+  const handleClose = () => {
+    metabot.setPrompt("");
+    metabot.setVisible(false);
   };
 
   return (
@@ -158,14 +163,30 @@ export const MetabotChat = () => {
           {(hasMessages || metabot.isDoingScience) && (
             <Box className={Styles.messages}>
               {/* conversation messages */}
-              {metabot.messages.map(({ actor, message }, index) => (
-                <Message
-                  key={index}
-                  data-testid="metabot-chat-message"
-                  actor={actor}
-                  message={message}
-                />
-              ))}
+              {metabot.messages.map((message, index) => {
+                const nextMessage: MetabotChatMessage | undefined =
+                  metabot.messages[index + 1];
+
+                const isLastAgentReply =
+                  message.role === "agent" &&
+                  message.type === "reply" &&
+                  (!nextMessage ||
+                    nextMessage.role !== "agent" ||
+                    (nextMessage.role === "agent" &&
+                      nextMessage.type !== message.type));
+
+                // NOTE: need e2e support for ids on message to support non-streamed requests
+                const canRetry = metabot.useStreaming && isLastAgentReply;
+
+                return (
+                  <Message
+                    key={index}
+                    data-testid="metabot-chat-message"
+                    message={message}
+                    onRetry={canRetry ? handleRetryMessage : undefined}
+                  />
+                );
+              })}
 
               {/* loading */}
               {metabot.isDoingScience && (
@@ -203,6 +224,7 @@ export const MetabotChat = () => {
             )}
           >
             <Textarea
+              id="metabot-chat-input"
               data-testid="metabot-chat-input"
               w="100%"
               leftSection={
@@ -220,15 +242,15 @@ export const MetabotChat = () => {
               autosize
               minRows={1}
               maxRows={10}
-              ref={textareaRef}
+              ref={metabot.promptInputRef}
               autoFocus
-              value={input}
+              value={metabot.prompt}
               className={cx(
                 Styles.textarea,
                 metabot.isDoingScience && Styles.textareaLoading,
               )}
               placeholder={t`Tell me to do something, or ask a question`}
-              onChange={(e) => handleInputChange(e.target.value)}
+              onChange={(e) => metabot.setPrompt(e.target.value)}
               onKeyDown={(e) => {
                 const isModifiedKeyPress =
                   e.shiftKey || e.ctrlKey || e.metaKey || e.altKey;
@@ -236,7 +258,7 @@ export const MetabotChat = () => {
                   // prevent event from inserting new line + interacting with other content
                   e.preventDefault();
                   e.stopPropagation();
-                  handleSubmitInput(input);
+                  handleSubmitInput(metabot.prompt);
                 }
               }}
             />
@@ -248,13 +270,13 @@ export const MetabotChat = () => {
 };
 
 const Message = ({
-  actor,
   message,
   className,
+  onRetry,
   ...props
 }: BoxProps & {
-  actor: "agent" | "user";
-  message: string;
+  message: MetabotChatMessage;
+  onRetry?: (messageId: string) => void;
 }) => {
   const clipboard = useClipboard();
 
@@ -262,28 +284,48 @@ const Message = ({
     <Flex
       className={cx(
         Styles.messageContainer,
-        actor === "user"
+        message.role === "user"
           ? Styles.messageContainerUser
           : Styles.messageContainerAgent,
         className,
       )}
-      data-message-actor={actor}
+      data-message-role={message.role}
       direction="column"
       {...props}
     >
-      {actor === "user" ? (
-        <Text
-          className={cx(Styles.message, actor === "user" && Styles.messageUser)}
-        >
-          {message}
-        </Text>
-      ) : (
-        <AIMarkdown className={Styles.message}>{message}</AIMarkdown>
-      )}
+      {match(message)
+        .with({ role: "user" }, () => (
+          <Text
+            className={cx(
+              Styles.message,
+              message.role === "user" && Styles.messageUser,
+            )}
+          >
+            {message.message}
+          </Text>
+        ))
+        .with({ role: "agent", type: "error" }, () => (
+          <Alert color="error" icon={<Icon name="warning" />} mt="sm">
+            <AIMarkdown className={Styles.message}>
+              {message.message}
+            </AIMarkdown>
+          </Alert>
+        ))
+        .with({ role: "agent", type: "reply" }, () => (
+          <AIMarkdown className={Styles.message}>{message.message}</AIMarkdown>
+        ))
+        .exhaustive()}
       <Flex className={Styles.messageActions}>
-        <ActionIcon onClick={() => clipboard.copy(message)} h="sm">
-          <Icon name="copy" size="1rem" />
-        </ActionIcon>
+        {!(message.role === "agent" && message.type === "error") && (
+          <ActionIcon onClick={() => clipboard.copy(message.message)} h="sm">
+            <Icon name="copy" size="1rem" />
+          </ActionIcon>
+        )}
+        {onRetry && (
+          <ActionIcon onClick={() => onRetry(message.id)} h="sm">
+            <Icon name="revert" size="1rem" />
+          </ActionIcon>
+        )}
       </Flex>
     </Flex>
   );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/hooks.ts
@@ -4,7 +4,7 @@ import _ from "underscore";
 
 import type { getMessages } from "metabase-enterprise/metabot/state";
 
-const USER_MSG_SELECTOR = '[data-message-actor="user"]';
+const USER_MSG_SELECTOR = '[data-message-role="user"]';
 const DEFAULT_HEADER_HEIGHT = 81;
 
 export function useAutoscrollMessages(
@@ -32,9 +32,9 @@ export function useAutoscrollMessages(
       // - user submits a message
       // - metabot responds for the first time (it can add multiple messages, we only care about the first)
       const [prevMessage, lastMessage] = messages.slice(-2);
-      const isLastMessageUser = lastMessage?.actor === "user";
+      const isLastMessageUser = lastMessage?.role === "user";
       const isLastMessageFirstMetabotReply =
-        prevMessage?.actor !== "agent" && lastMessage?.actor === "agent";
+        prevMessage?.role !== "agent" && lastMessage?.role === "agent";
 
       const shouldAutoScroll =
         isLastMessageUser || isLastMessageFirstMetabotReply;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/utils.ts
@@ -1,0 +1,14 @@
+import type { MetabotChatMessage } from "metabase-enterprise/metabot/state";
+
+export const isLastAgentReply = (
+  message: MetabotChatMessage,
+  nextMessage: MetabotChatMessage | undefined,
+) => {
+  return (
+    message.role === "agent" &&
+    message.type === "reply" &&
+    (!nextMessage ||
+      nextMessage.role !== "agent" ||
+      (nextMessage.role === "agent" && nextMessage.type !== message.type))
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/context.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/context.tsx
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import type React from "react";
-import { createContext, useCallback, useRef } from "react";
+import { createContext, useCallback, useRef, useState } from "react";
 
 import { useStore } from "metabase/lib/redux";
 import type {
@@ -9,6 +9,10 @@ import type {
 } from "metabase/metabot";
 
 export const defaultContext = {
+  prompt: "",
+  setPrompt: () => {},
+  promptInputRef: undefined,
+
   getChatContext: () =>
     Promise.resolve({
       user_is_viewing: [],
@@ -24,6 +28,11 @@ export const MetabotProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  /* Metabot input */
+  const [prompt, setPrompt] = useState("");
+  const promptInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+
+  /* Metabot context */
   const providerFnsRef = useRef<Set<ChatContextProviderFn>>(new Set());
   const store = useStore();
 
@@ -58,7 +67,13 @@ export const MetabotProvider = ({
 
   return (
     <MetabotContext.Provider
-      value={{ getChatContext, registerChatContextProvider }}
+      value={{
+        prompt,
+        setPrompt,
+        promptInputRef,
+        getChatContext,
+        registerChatContextProvider,
+      }}
     >
       {children}
     </MetabotContext.Provider>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/context.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/context.tsx
@@ -30,7 +30,7 @@ export const MetabotProvider = ({
 }) => {
   /* Metabot input */
   const [prompt, setPrompt] = useState("");
-  const promptInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  const promptInputRef = useRef<HTMLTextAreaElement>(null);
 
   /* Metabot context */
   const providerFnsRef = useRef<Set<ChatContextProviderFn>>(new Set());

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -64,9 +64,12 @@ export const useMetabotAgent = () => {
           metabot_id: metabotId,
         }),
       );
+
       if (isFulfilled(action)) {
         prepareRetryIfUnsuccesful(action.payload);
       }
+
+      return action;
     },
     [dispatch, getChatContext, prepareRetryIfUnsuccesful],
   );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -1,9 +1,11 @@
+import { isFulfilled } from "@reduxjs/toolkit";
 import { useCallback } from "react";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { useMetabotContext } from "metabase/metabot";
 
 import {
+  type MetabotPromptSubmissionResult,
   getActiveToolCall,
   getIsLongMetabotConversation,
   getIsProcessing,
@@ -13,6 +15,7 @@ import {
   getMetabotVisible,
   getUseStreaming,
   resetConversation as resetConversationAction,
+  retryPrompt,
   setVisible as setVisibleAction,
   submitInput as submitInputAction,
   toggleStreaming,
@@ -20,7 +23,8 @@ import {
 
 export const useMetabotAgent = () => {
   const dispatch = useDispatch();
-  const { getChatContext } = useMetabotContext();
+  const { prompt, setPrompt, promptInputRef, getChatContext } =
+    useMetabotContext();
 
   // TODO: create an enterprise useSelector
   const messages = useSelector(getMessages as any) as ReturnType<
@@ -40,19 +44,48 @@ export const useMetabotAgent = () => {
     [dispatch],
   );
 
-  const submitInput = useCallback(
-    async (message: string, metabotId?: string) => {
-      const context = await getChatContext();
+  const prepareRetryIfUnsuccesful = useCallback(
+    (result: MetabotPromptSubmissionResult) => {
+      if (!result.success && result.shouldRetry) {
+        promptInputRef?.current?.focus();
+        setPrompt(result.prompt);
+      }
+    },
+    [promptInputRef, setPrompt],
+  );
 
-      return dispatch(
+  const submitInput = useCallback(
+    async (prompt: string, metabotId?: string) => {
+      const context = await getChatContext();
+      const action = await dispatch(
         submitInputAction({
-          message,
+          message: prompt,
           context,
           metabot_id: metabotId,
         }),
       );
+      if (isFulfilled(action)) {
+        prepareRetryIfUnsuccesful(action.payload);
+      }
     },
-    [dispatch, getChatContext],
+    [dispatch, getChatContext, prepareRetryIfUnsuccesful],
+  );
+
+  const retryMessage = useCallback(
+    async (messageId: string, metabotId?: string) => {
+      const context = await getChatContext();
+      const action = await dispatch(
+        retryPrompt({
+          messageId,
+          context,
+          metabot_id: metabotId,
+        }),
+      );
+      if (isFulfilled(action)) {
+        prepareRetryIfUnsuccesful(action.payload);
+      }
+    },
+    [dispatch, getChatContext, prepareRetryIfUnsuccesful],
   );
 
   const startNewConversation = useCallback(
@@ -62,17 +95,15 @@ export const useMetabotAgent = () => {
       if (message) {
         submitInput(message, metabotId);
       }
-
-      // HACK: if the user opens the command palette via the search button bar focus will be moved
-      // back to the search button bar if the metabot option is chosen, so a small delay is used
-      setTimeout(() => {
-        document.getElementById("metabot-chat-input")?.focus();
-      }, 100);
+      promptInputRef?.current?.focus();
     },
-    [submitInput, resetConversation, setVisible],
+    [submitInput, resetConversation, setVisible, promptInputRef],
   );
 
   return {
+    prompt,
+    setPrompt,
+    promptInputRef,
     metabotId: useSelector(getMetabotId as any) as ReturnType<
       typeof getMetabotId
     >,
@@ -98,5 +129,6 @@ export const useMetabotAgent = () => {
       typeof getUseStreaming
     >,
     toggleStreaming: () => dispatch(toggleStreaming()),
+    retryMessage,
   };
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot-streaming.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot-streaming.unit.spec.tsx
@@ -7,7 +7,7 @@ import { P, isMatching } from "ts-pattern";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { uuid } from "metabase/lib/uuid";
 import { mockStreamedEndpoint } from "metabase-enterprise/api/ai-streaming/test-utils";
 import type { User } from "metabase-types/api";
@@ -83,10 +83,13 @@ function setup(
   });
 }
 
+const chatMessages = () => screen.findAllByTestId("metabot-chat-message");
+const lastChatMessage = async () => (await chatMessages()).at(-1);
 const input = () => screen.findByTestId("metabot-chat-input");
 const enterChatMessage = async (message: string, send = true) =>
   userEvent.type(await input(), `${message}${send ? "{Enter}" : ""}`);
 const responseLoader = () => screen.findByTestId("metabot-response-loader");
+const resetChatButton = () => screen.findByTestId("metabot-reset-chat");
 
 const assertVisible = async () =>
   expect(await screen.findByTestId("metabot-chat")).toBeInTheDocument();
@@ -136,6 +139,68 @@ describe("metabot-streaming", () => {
       expect(heading).toBeInTheDocument();
       expect(heading).toHaveTextContent(`You, but don't tell anyone.`);
     });
+
+    it("should present the user an option to retry a response", async () => {
+      setup();
+      mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
+
+      await enterChatMessage("Who is your favorite?");
+      const lastMessage = await lastChatMessage();
+      expect(lastMessage).toHaveTextContent(/You, but don't tell anyone./);
+      expect(
+        await within(lastMessage!).findByTestId("metabot-chat-message-retry"),
+      ).toBeInTheDocument();
+    });
+
+    it("should successfully rewind a response", async () => {
+      setup();
+      mockAgentEndpoint({
+        // add two messages to ensure we rollback both
+        textChunks: [`0:"Let me think..."`, ...whoIsYourFavoriteResponse],
+      });
+      await enterChatMessage("Who is your favorite?");
+
+      const beforeMessages = await screen.findByTestId("metabot-chat-messages");
+      expect(beforeMessages).toHaveTextContent(/Let me think.../);
+      expect(beforeMessages).toHaveTextContent(/You, but don't tell anyone./);
+
+      mockAgentEndpoint({
+        textChunks: [
+          `0:"The answer is always you."`,
+          `2:{"type":"state","version":1,"value":{"queries":{}}}`,
+          `d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
+        ],
+      });
+      await userEvent.click(
+        await screen.findByTestId("metabot-chat-message-retry"),
+      );
+
+      const afterMessages = await screen.findByTestId("metabot-chat-messages");
+
+      // rolled back both messages
+      expect(afterMessages).not.toHaveTextContent(/Let me think.../);
+      expect(afterMessages).not.toHaveTextContent(
+        /You, but don't tell anyone./,
+      );
+
+      // shows the new one
+      expect(afterMessages).toHaveTextContent(/The answer is always you./);
+    });
+
+    it("should not show retry option for error messages", async () => {
+      setup();
+      fetchMock.post(`path:/api/ee/metabot-v3/v2/agent-streaming`, 500);
+
+      await enterChatMessage("Who is your favorite?");
+
+      const lastMessage = await lastChatMessage();
+      expect(lastMessage).toHaveTextContent(
+        /I'm currently offline, try again later./,
+      );
+      expect(
+        within(lastMessage!).queryByTestId("metabot-chat-message-retry"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("message", () => {
@@ -158,6 +223,63 @@ describe("metabot-streaming", () => {
       // should auto-clear input + refocus
       expect(await input()).toHaveValue("");
       expect(await input()).toHaveFocus();
+    });
+  });
+
+  describe("errors", () => {
+    it("should handle service error response", async () => {
+      setup();
+      fetchMock.post(`path:/api/ee/metabot-v3/v2/agent-streaming`, 500);
+
+      await enterChatMessage("Who is your favorite?");
+
+      expect(await lastChatMessage()).toHaveTextContent(
+        /I'm currently offline, try again later./,
+      );
+      expect(await input()).toHaveValue("Who is your favorite?");
+    });
+
+    it("should handle non-successful responses", async () => {
+      setup();
+      fetchMock.post(`path:/api/ee/metabot-v3/v2/agent-streaming`, 400);
+
+      await enterChatMessage("Who is your favorite?");
+
+      expect(await lastChatMessage()).toHaveTextContent(
+        /Something went wrong, try again./,
+      );
+      expect(await input()).toHaveValue("Who is your favorite?");
+    });
+
+    it("should handle show error if data error part is in response", async () => {
+      setup();
+      mockAgentEndpoint({ textChunks: erroredResponse });
+
+      await enterChatMessage("Who is your favorite?");
+
+      expect(await lastChatMessage()).toHaveTextContent(
+        /Something went wrong, try again./,
+      );
+      expect(await input()).toHaveValue("Who is your favorite?");
+    });
+
+    it("should not show a user error when an AbortError is triggered", async () => {
+      setup();
+      mockAgentEndpoint({
+        textChunks: whoIsYourFavoriteResponse,
+        initialDelay: 50,
+      });
+
+      await enterChatMessage("Who is your favorite?");
+
+      expect(await chatMessages()).toHaveLength(1);
+      await userEvent.click(await resetChatButton());
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("metabot-chat-message"),
+        ).not.toBeInTheDocument();
+      });
+      expect(await input()).toHaveValue("");
     });
   });
 
@@ -186,7 +308,7 @@ describe("metabot-streaming", () => {
       // create some chat history + wait for a response
       mockAgentEndpoint({
         textChunks: whoIsYourFavoriteResponse,
-        initialDelay: 500,
+        initialDelay: 50,
       });
       await enterChatMessage("Who is your favorite?");
       expect(
@@ -211,4 +333,9 @@ const whoIsYourFavoriteResponse = [
   `0:"You, but don't tell anyone."`,
   `2:{"type":"state","version":1,"value":{"queries":{}}}`,
   `d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
+];
+
+const erroredResponse = [
+  `3:{"type": "error", "value": "Couldn't do the thing"}`,
+  `d:{"finishReason":"error","usage":{"promptTokens":4916,"completionTokens":8}}`,
 ];

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot-streaming.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot-streaming.unit.spec.tsx
@@ -265,15 +265,14 @@ describe("metabot-streaming", () => {
 
     it("should not show a user error when an AbortError is triggered", async () => {
       setup();
-      mockAgentEndpoint({
-        textChunks: whoIsYourFavoriteResponse,
-        initialDelay: 50,
+      mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
+      await enterChatMessage("Who is your favorite?");
+      await waitFor(async () => {
+        expect(await chatMessages()).toHaveLength(2);
       });
 
-      await enterChatMessage("Who is your favorite?");
-
-      expect(await chatMessages()).toHaveLength(1);
       await userEvent.click(await resetChatButton());
+
       await waitFor(() => {
         expect(
           screen.queryByTestId("metabot-chat-message"),

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -431,6 +431,7 @@ describe("metabot", () => {
       fetchMock.post(
         `path:/api/ee/metabot-v3/v2/agent`,
         whoIsYourFavoriteResponse,
+        { delay: 50 }, // small delay to cause loading state
       );
 
       await enterChatMessage("Who is your favorite?");

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -2,10 +2,17 @@ import { combineReducers } from "@reduxjs/toolkit";
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 import { P, isMatching } from "ts-pattern";
+import _ from "underscore";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
-import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+import {
+  act,
+  renderWithProviders,
+  screen,
+  waitFor,
+  within,
+} from "__support__/ui";
 import { logout } from "metabase/auth/actions";
 import * as domModule from "metabase/lib/dom";
 import { uuid } from "metabase/lib/uuid";
@@ -23,6 +30,7 @@ import {
   LONG_CONVO_MSG_LENGTH_THRESHOLD,
 } from "./constants";
 import { MetabotProvider } from "./context";
+import { useMetabotAgent } from "./hooks";
 import {
   type MetabotState,
   addUserMessage,
@@ -80,6 +88,8 @@ function setup(
 }
 
 const chat = () => screen.findByTestId("metabot-chat");
+const chatMessages = () => screen.findAllByTestId("metabot-chat-message");
+const lastChatMessage = async () => (await chatMessages()).at(-1);
 const input = () => screen.findByTestId("metabot-chat-input");
 const enterChatMessage = async (message: string, send = true) =>
   userEvent.type(await input(), `${message}${send ? "{Enter}" : ""}`);
@@ -325,6 +335,46 @@ describe("metabot", () => {
         ).toHaveLength(2);
       });
     });
+
+    it("should be able to set the prompt input's value from anywhere in the app", async () => {
+      const AnotherComponent = () => {
+        const { setPrompt } = useMetabotAgent();
+
+        return (
+          <button onClick={() => setPrompt("TEST VAL")}>CLICK HERE</button>
+        );
+      };
+
+      setup({
+        ui: (
+          <div>
+            <AnotherComponent />
+            <Metabot />
+          </div>
+        ),
+      });
+
+      expect(await input()).toHaveValue("");
+      await userEvent.click(await screen.findByText("CLICK HERE"));
+      expect(await input()).toHaveValue("TEST VAL");
+    });
+
+    it("should not present the user an option to retry a prompt (not yet supported)", async () => {
+      setup();
+      fetchMock.post(
+        `path:/api/ee/metabot-v3/v2/agent`,
+        whoIsYourFavoriteResponse,
+      );
+
+      await enterChatMessage("Who is your favorite?");
+      const lastMessage = await lastChatMessage();
+      expect(lastMessage).toHaveTextContent(
+        /You are... but don't tell anyone!/,
+      );
+      expect(
+        within(lastMessage!).queryByTestId("metabot-chat-message-retry"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("message", () => {
@@ -348,6 +398,52 @@ describe("metabot", () => {
       // should auto-clear input + refocus
       expect(await input()).toHaveValue("");
       expect(await input()).toHaveFocus();
+    });
+  });
+
+  describe("errors", () => {
+    it("should handle service error response", async () => {
+      setup();
+      fetchMock.post(`path:/api/ee/metabot-v3/v2/agent`, 500);
+
+      await enterChatMessage("Who is your favorite?");
+
+      expect(await lastChatMessage()).toHaveTextContent(
+        /I'm currently offline, try again later./,
+      );
+      expect(await input()).toHaveValue("Who is your favorite?");
+    });
+
+    it("should handle non-successful responses", async () => {
+      setup();
+      fetchMock.post(`path:/api/ee/metabot-v3/v2/agent`, 400);
+
+      await enterChatMessage("Who is your favorite?");
+
+      expect(await lastChatMessage()).toHaveTextContent(
+        /Something went wrong, try again./,
+      );
+      expect(await input()).toHaveValue("Who is your favorite?");
+    });
+
+    it("should not show a user error when an AbortError is triggered", async () => {
+      setup();
+      fetchMock.post(
+        `path:/api/ee/metabot-v3/v2/agent`,
+        whoIsYourFavoriteResponse,
+        { delay: 50 }, // small delay to cause loading state
+      );
+
+      await enterChatMessage("Who is your favorite?");
+
+      expect(await chatMessages()).toHaveLength(1);
+      await userEvent.click(await resetChatButton());
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("metabot-chat-message"),
+        ).not.toBeInTheDocument();
+      });
+      expect(await input()).toHaveValue("");
     });
   });
 
@@ -475,14 +571,16 @@ describe("metabot", () => {
 
       const beforeResetState = getMetabotState(store);
       expect(beforeResetState.conversationId).not.toBe(null);
-      expect(beforeResetState.messages).toStrictEqual([
-        { role: "user", message: "Who is your favorite?" },
-        {
-          role: "agent",
-          message: "You are... but don't tell anyone!",
-          type: "reply",
-        },
-      ]);
+      expect(beforeResetState.messages).toHaveLength(2);
+      expect(_.omit(beforeResetState.messages[0], "id")).toStrictEqual({
+        role: "user",
+        message: "Who is your favorite?",
+      });
+      expect(_.omit(beforeResetState.messages[1], "id")).toStrictEqual({
+        role: "agent",
+        message: "You are... but don't tell anyone!",
+        type: "reply",
+      });
 
       await userEvent.click(await resetChatButton());
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -476,9 +476,9 @@ describe("metabot", () => {
       const beforeResetState = getMetabotState(store);
       expect(beforeResetState.conversationId).not.toBe(null);
       expect(beforeResetState.messages).toStrictEqual([
-        { actor: "user", message: "Who is your favorite?" },
+        { role: "user", message: "Who is your favorite?" },
         {
-          actor: "agent",
+          role: "agent",
           message: "You are... but don't tell anyone!",
           type: "reply",
         },
@@ -499,7 +499,7 @@ describe("metabot", () => {
 
       // adding messages this long via the ui's input makes the test hang
       act(() => {
-        store.dispatch(addUserMessage(longMsg));
+        store.dispatch(addUserMessage({ id: "1", message: longMsg }));
       });
       expect(await screen.findByText(/xxxxxxx/)).toBeInTheDocument();
       expect(
@@ -507,7 +507,7 @@ describe("metabot", () => {
       ).not.toBeInTheDocument();
 
       act(() => {
-        store.dispatch(addUserMessage(longMsg));
+        store.dispatch(addUserMessage({ id: "2", message: longMsg }));
       });
       expect(
         await screen.findByText(/This chat is getting long/),

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -431,7 +431,6 @@ describe("metabot", () => {
       fetchMock.post(
         `path:/api/ee/metabot-v3/v2/agent`,
         whoIsYourFavoriteResponse,
-        { delay: 50 }, // small delay to cause loading state
       );
 
       await enterChatMessage("Who is your favorite?");

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -1,4 +1,4 @@
-import { type UnknownAction, isRejected, nanoid } from "@reduxjs/toolkit";
+import { type UnknownAction, isRejected } from "@reduxjs/toolkit";
 import { push } from "react-router-redux";
 import { P, match } from "ts-pattern";
 import { t } from "ttag";
@@ -34,6 +34,7 @@ import {
   getUseStreaming,
   getUserPromptForMessageId,
 } from "./selectors";
+import { createMessageId } from "./utils";
 
 export const {
   addAgentMessage,
@@ -113,7 +114,7 @@ export const submitInput = createAsyncThunk<
       // it's important that we get the current metadata containing the history before
       // altering it by adding the current message the user is wanting to send
       const agentMetadata = getAgentRequestMetadata(getState() as any);
-      const messageId = nanoid();
+      const messageId = createMessageId();
       dispatch(addUserMessage({ id: messageId, message: data.message }));
 
       const useStreaming = getUseStreaming(getState() as any);
@@ -146,7 +147,7 @@ export const submitInput = createAsyncThunk<
         };
       }
 
-      return { prompt: data.message, success: true };
+      return { prompt: data.message, success: true, data: result.payload };
     } catch (error) {
       // NOTE: all errors should be caught above, this is is a catch-all
       // to make sure that this async action always resolves to a value

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -1,4 +1,4 @@
-import { type PayloadAction, createSlice, nanoid } from "@reduxjs/toolkit";
+import { type PayloadAction, createSlice } from "@reduxjs/toolkit";
 import _ from "underscore";
 
 import { logout } from "metabase/auth/actions";
@@ -6,6 +6,7 @@ import { uuid } from "metabase/lib/uuid";
 import type { MetabotHistory, MetabotStateContext } from "metabase-types/api";
 
 import { sendAgentRequest, sendStreamedAgentRequest } from "./actions";
+import { createMessageId } from "./utils";
 
 export type MetabotAgentChatMessage =
   | { id: string; role: "agent"; message: string; type: "reply" }
@@ -71,7 +72,7 @@ export const metabot = createSlice({
       action: PayloadAction<Omit<MetabotAgentChatMessage, "id" | "role">>,
     ) => {
       state.messages.push({
-        id: nanoid(),
+        id: createMessageId(),
         role: "agent",
         message: action.payload.message,
         type: action.payload.type,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -98,7 +98,6 @@ export const metabot = createSlice({
     // NOTE: this doesn't work in non-streaming contexts right now
     rewindStateToMessageId: (state, { payload: id }: PayloadAction<string>) => {
       if (state.useStreaming) {
-        // TODO: needs to find first user message before this message, doesn't work if there's two metabot messages in a row
         const messageIndex = state.messages.findLastIndex((m) => id === m.id);
         const historyIndex = state.history.findLastIndex((h) => id === h.id);
         if (historyIndex > -1 && messageIndex > -1) {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -133,9 +133,9 @@ export const metabot = createSlice({
       .addCase(sendStreamedAgentRequest.fulfilled, (state, action) => {
         state.history = [
           ...state.history,
-          ...(action.payload?.data?.history?.slice() ?? []),
+          ...(action.payload?.history?.slice() ?? []),
         ];
-        state.state = { ...(action.payload?.data?.state ?? {}) };
+        state.state = { ...(action.payload?.state ?? {}) };
         state.activeToolCall = undefined;
         state.isProcessing = false;
       })
@@ -148,8 +148,8 @@ export const metabot = createSlice({
         state.isProcessing = true;
       })
       .addCase(sendAgentRequest.fulfilled, (state, action) => {
-        state.history = action.payload?.data?.history?.slice() ?? [];
-        state.state = { ...(action.payload?.data?.state ?? {}) };
+        state.history = action.payload?.history?.slice() ?? [];
+        state.state = { ...(action.payload?.state ?? {}) };
         state.isProcessing = false;
       })
       .addCase(sendAgentRequest.rejected, (state) => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -33,7 +33,7 @@ export interface MetabotState {
 }
 
 export const metabotInitialState: MetabotState = {
-  useStreaming: true,
+  useStreaming: false,
   isProcessing: false,
   conversationId: undefined,
   messages: [],
@@ -97,9 +97,11 @@ export const metabot = createSlice({
     // NOTE: this doesn't work in non-streaming contexts right now
     rewindStateToMessageId: (state, { payload: id }: PayloadAction<string>) => {
       if (state.useStreaming) {
+        // TODO: needs to find first user message before this message, doesn't work if there's two metabot messages in a row
         const messageIndex = state.messages.findLastIndex((m) => id === m.id);
         const historyIndex = state.history.findLastIndex((h) => id === h.id);
         if (historyIndex > -1 && messageIndex > -1) {
+          state.isProcessing = false;
           state.messages = state.messages.slice(0, messageIndex);
           state.history = state.history.slice(0, historyIndex);
         }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -108,6 +108,8 @@ export const getAgentRequestMetadata = createSelector(
   (history, state) => ({
     state,
     // NOTE: need end to end support for ids on messages as BE will error if ids are present
-    history: history.map(({ id, ...h }) => h),
+    history: history.map((h) =>
+      h.id && h.id.startsWith(`msg_`) ? _.omit(h, "id") : h,
+    ),
   }),
 );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.unit.spec.ts
@@ -33,16 +33,16 @@ describe("metabot selectors", () => {
     });
 
     it("should not return any messages if latest message is from a user", () => {
-      const state = setup([{ actor: "user", message: "bleh" }]);
+      const state = setup([{ id: "1", role: "user", message: "bleh" }]);
       const messages = getLastAgentMessagesByType(state as any);
       expect(messages).toEqual([]);
     });
 
     it("should return latest agent reply messages only", () => {
       const state = setup([
-        { actor: "user", message: "bleh" },
-        { actor: "agent", type: "reply", message: "blah" },
-        { actor: "agent", type: "reply", message: "blah" },
+        { id: "1", role: "user", message: "bleh" },
+        { id: "2", role: "agent", type: "reply", message: "blah" },
+        { id: "3", role: "agent", type: "reply", message: "blah" },
       ]);
       const messages = getLastAgentMessagesByType(state as any);
       expect(messages).toEqual(["blah", "blah"]);
@@ -50,9 +50,9 @@ describe("metabot selectors", () => {
 
     it("should return latest agent error messages only", () => {
       const state = setup([
-        { actor: "agent", type: "reply", message: "blah" },
-        { actor: "agent", type: "error", message: "BLAH" },
-        { actor: "agent", type: "error", message: "BLAH" },
+        { id: "1", role: "agent", type: "reply", message: "blah" },
+        { id: "2", role: "agent", type: "error", message: "BLAH" },
+        { id: "3", role: "agent", type: "error", message: "BLAH" },
       ]);
       const messages = getLastAgentMessagesByType(state as any);
       expect(messages).toEqual(["BLAH", "BLAH"]);

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.unit.spec.ts
@@ -3,59 +3,99 @@ import { uuid } from "metabase/lib/uuid";
 import { createMockState } from "metabase-types/store/mocks";
 
 import type { MetabotState } from "./reducer";
-import { getLastAgentMessagesByType } from "./selectors";
+import {
+  getLastAgentMessagesByType,
+  getUserPromptForMessageId,
+} from "./selectors";
+
+function setup(metabotState: Partial<MetabotState>) {
+  setupEnterprisePlugins();
+
+  // NOTE: importing default initial state from ./reducer
+  // breaks the tests for some reason
+  const metabotPlugin: MetabotState = Object.assign(
+    {
+      useStreaming: false,
+      isProcessing: false,
+      messages: [],
+      state: {},
+      history: [],
+      visible: true,
+      conversationId: uuid(),
+      activeToolCall: undefined,
+    },
+    metabotState,
+  );
+
+  return createMockState({ plugins: { metabotPlugin } } as any);
+}
 
 describe("metabot selectors", () => {
   describe("getLastAgentMessagesByType", () => {
-    function setup(messages: MetabotState["messages"]) {
-      setupEnterprisePlugins();
-
-      // NOTE: importing default initial state from ./reducer
-      // breaks the tests for some reason
-      const metabotPlugin: MetabotState = {
-        useStreaming: false,
-        isProcessing: false,
-        messages,
-        state: {},
-        history: [],
-        visible: true,
-        conversationId: uuid(),
-        activeToolCall: undefined,
-      };
-
-      return createMockState({ plugins: { metabotPlugin } } as any);
-    }
-
     it("should not return any messages if there are none", () => {
-      const state = setup([]);
+      const state = setup({ messages: [] });
       const messages = getLastAgentMessagesByType(state as any);
       expect(messages).toEqual([]);
     });
 
     it("should not return any messages if latest message is from a user", () => {
-      const state = setup([{ id: "1", role: "user", message: "bleh" }]);
+      const state = setup({
+        messages: [{ id: "1", role: "user", message: "bleh" }],
+      });
       const messages = getLastAgentMessagesByType(state as any);
       expect(messages).toEqual([]);
     });
 
     it("should return latest agent reply messages only", () => {
-      const state = setup([
-        { id: "1", role: "user", message: "bleh" },
-        { id: "2", role: "agent", type: "reply", message: "blah" },
-        { id: "3", role: "agent", type: "reply", message: "blah" },
-      ]);
+      const state = setup({
+        messages: [
+          { id: "1", role: "user", message: "bleh" },
+          { id: "2", role: "agent", type: "reply", message: "blah" },
+          { id: "3", role: "agent", type: "reply", message: "blah" },
+        ],
+      });
       const messages = getLastAgentMessagesByType(state as any);
       expect(messages).toEqual(["blah", "blah"]);
     });
 
     it("should return latest agent error messages only", () => {
-      const state = setup([
-        { id: "1", role: "agent", type: "reply", message: "blah" },
-        { id: "2", role: "agent", type: "error", message: "BLAH" },
-        { id: "3", role: "agent", type: "error", message: "BLAH" },
-      ]);
+      const state = setup({
+        messages: [
+          { id: "1", role: "agent", type: "reply", message: "blah" },
+          { id: "2", role: "agent", type: "error", message: "BLAH" },
+          { id: "3", role: "agent", type: "error", message: "BLAH" },
+        ],
+      });
       const messages = getLastAgentMessagesByType(state as any);
       expect(messages).toEqual(["BLAH", "BLAH"]);
+    });
+  });
+
+  describe("getUserPromptForMessageId", () => {
+    it("should return the message with the matching id if id is for a user message", () => {
+      const state = setup({
+        messages: [
+          { id: "1", role: "user", message: "bleh" },
+          { id: "2", role: "agent", type: "reply", message: "blah" },
+        ],
+      });
+      const message = getUserPromptForMessageId(state as any, "1");
+      expect(message).toEqual({ id: "1", role: "user", message: "bleh" });
+    });
+
+    it("should return the message with the matching id if id is for an agent message", () => {
+      const state = setup({
+        messages: [
+          { id: "1", role: "user", message: "bleh" },
+          { id: "2", role: "agent", type: "reply", message: "blah" },
+          { id: "3", role: "user", message: "bleh bleh" },
+          { id: "4", role: "agent", type: "reply", message: "blah blah" },
+        ],
+      });
+      const message1 = getUserPromptForMessageId(state as any, "2");
+      expect(message1).toEqual({ id: "1", role: "user", message: "bleh" });
+      const message2 = getUserPromptForMessageId(state as any, "4");
+      expect(message2).toEqual({ id: "3", role: "user", message: "bleh bleh" });
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/utils.ts
@@ -1,0 +1,5 @@
+import { nanoid } from "@reduxjs/toolkit";
+
+export const createMessageId = () => {
+  return `msg_${nanoid()}`;
+};

--- a/frontend/src/metabase/metabot/context.ts
+++ b/frontend/src/metabase/metabot/context.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo } from "react";
+import { type RefObject, useContext, useEffect, useMemo } from "react";
 
 import { PLUGIN_METABOT } from "metabase/plugins";
 import type { MetabotChatContext } from "metabase-types/api";
@@ -7,8 +7,14 @@ import type { State } from "metabase-types/store";
 export type ChatContextProviderFn = (
   state: State,
 ) => Promise<Partial<MetabotChatContext> | void>;
+
 export type DeregisterChatContextProviderFn = () => void;
+
 export interface MetabotContext {
+  prompt: string;
+  setPrompt: (prompt: string) => void;
+  promptInputRef: RefObject<HTMLTextAreaElement> | undefined;
+
   getChatContext: () => Promise<MetabotChatContext>;
   registerChatContextProvider: (
     fn: ChatContextProviderFn,

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -618,6 +618,9 @@ export const PLUGIN_RESOURCE_DOWNLOADS = {
 };
 
 const defaultMetabotContextValue: MetabotContext = {
+  prompt: "",
+  setPrompt: () => {},
+  promptInputRef: undefined,
   getChatContext: () => ({}) as any,
   registerChatContextProvider: () => () => {},
 };


### PR DESCRIPTION
Closes [BOT-202](https://linear.app/metabase/issue/BOT-202/frontend-ai-streaming-error-handling)

### Description

This PR adds functionality to rollback a conversation to before an error occurred. In most cases, we will take the failed prompt and inject it back into the prompt input.

Since the above changes gave the tools to rewind a convo, I threw in a "retry" button on prompt responses so that a user can retry their prompt to get a new response from metabot.

Additionally, I've made an improvement for making the chat input available throughout the app via our metabot context. This allows external components to focus access the current prompt, set the prompt, or even do things like focus the input. This mitigates some of the weirdness I was having to do with timeouts and querying the DOM previously.

Lastly, sorry for the noise, but I've renamed message's `actor` field to `role` to better match the history's schema. Eventually I'd like to get ride of the `messages` state and derive the messages from history via a selector.

### How to verify

- See if you can recover from an error by inducing one on the ai-service side (send a 500, error message in payload, etc).
- Retry a prompt by clicking the retry button on a metabot response

### Demo

https://metaboat.slack.com/archives/C07SJT1P0ET/p1750436288696429)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
