### PR TITLE
End-to-end tests for selecting resources to embed for new iframe

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -8,15 +8,6 @@ type DashboardIntercept = {
   response: Cypress.Response<Dashboard>;
 };
 
-export const getPreviewIframe = () =>
-  cy
-    .get("iframe")
-    .should("be.visible")
-    .its("0.contentDocument")
-    .should("exist")
-    .its("body")
-    .should("not.be.empty");
-
 export const getEmbedSidebar = () => cy.findByRole("complementary");
 
 export const getRecentItemCards = () =>

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -14,6 +14,7 @@ export const getRecentItemCards = () =>
   cy.findAllByTestId("embed-recent-item-card");
 
 export const visitNewEmbedPage = () => {
+  cy.intercept("GET", "/api/dashboard/**").as("dashboard");
   cy.visit("/embed/new");
   cy.wait("@dashboard");
 };

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -17,6 +17,12 @@ export const visitNewEmbedPage = () => {
   cy.intercept("GET", "/api/dashboard/**").as("dashboard");
   cy.visit("/embed/new");
   cy.wait("@dashboard");
+
+  cy.get("#iframe-embed-container").should(
+    "have.attr",
+    "data-iframe-loaded",
+    "true",
+  );
 };
 
 export const assertRecentItemName = (

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -1,0 +1,45 @@
+import type { Dashboard, RecentItem } from "metabase-types/api";
+
+type RecentActivityIntercept = {
+  response: Cypress.Response<{ recents: RecentItem[] }>;
+};
+
+type DashboardIntercept = {
+  response: Cypress.Response<Dashboard>;
+};
+
+export const getPreviewIframe = () =>
+  cy
+    .get("iframe")
+    .should("be.visible")
+    .its("0.contentDocument")
+    .should("exist")
+    .its("body")
+    .should("not.be.empty");
+
+export const getEmbedSidebar = () => cy.findByRole("complementary");
+
+export const visitNewEmbedPage = () => {
+  cy.visit("/embed/new");
+  cy.wait("@dashboard");
+};
+
+export const assertRecentItemName = (
+  model: "dashboard" | "card",
+  resourceName: string,
+) => {
+  cy.get<RecentActivityIntercept>("@recentActivity").should((intercept) => {
+    const recentItem = intercept.response?.body.recents?.filter(
+      (recent) => recent.model === model,
+    )?.[0];
+
+    expect(recentItem.name).to.be.equal(resourceName);
+  });
+};
+
+export const assertDashboard = ({ id, name }: { id: number; name: string }) => {
+  cy.get<DashboardIntercept>("@dashboard").should((intercept) => {
+    expect(intercept.response?.body.id).to.be.equal(id);
+    expect(intercept.response?.body.name).to.be.equal(name);
+  });
+};

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -14,7 +14,7 @@ export const getRecentItemCards = () =>
   cy.findAllByTestId("embed-recent-item-card");
 
 export const visitNewEmbedPage = () => {
-  cy.intercept("GET", "/api/dashboard/**").as("dashboard");
+  cy.intercept("GET", "/api/dashboard/*").as("dashboard");
   cy.visit("/embed/new");
   cy.wait("@dashboard");
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -19,6 +19,9 @@ export const getPreviewIframe = () =>
 
 export const getEmbedSidebar = () => cy.findByRole("complementary");
 
+export const getRecentItemCards = () =>
+  cy.findAllByTestId("embed-recent-item-card");
+
 export const visitNewEmbedPage = () => {
   cy.visit("/embed/new");
   cy.wait("@dashboard");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -5,7 +5,7 @@ import {
 
 const { H } = cy;
 
-describe("scenarios > embedding > sdk iframe embedding setup > select embed entity", () => {
+describe("scenarios > embedding > sdk iframe embed setup > select embed entity", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -16,8 +16,10 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     cy.intercept("GET", "/api/activity/recents?*").as("recentActivity");
   });
 
-  it("selects the most recently visited dashboard from the recents list", () => {
-    cy.log("add dashboard to activity log");
+  it("can select a dashboard from the recents list", () => {
+    cy.log("add two dashboards to activity log");
+    cy.visit("/dashboard/1");
+    cy.wait("@dashboard");
     cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
     cy.wait("@dashboard");
 
@@ -25,16 +27,17 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
 
     getEmbedSidebar().within(() => {
       cy.findByText("Next").click();
-      cy.findByText("Orders in a dashboard").should("be.visible");
 
-      cy.log("only one recent item should be visible");
-      cy.findAllByTestId("embed-recent-item-card").should("have.length", 1);
+      cy.log("two dashboards should be visible");
+      cy.findAllByTestId("embed-recent-item-card").should("have.length", 2);
+      cy.findByText("Person overview").should("be.visible");
+      cy.findByText("Orders in a dashboard").should("be.visible");
     });
 
     cy.log("dashboard should be displayed in the preview");
     cy.wait("@dashboard");
     getPreviewIframe().within(() => {
-      cy.findByText("Orders in a dashboard").should("be.visible");
+      cy.findByText("Person overview").should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -105,47 +105,24 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     });
   });
 
-  describe.skip("Entity selection with empty recents", () => {
-    beforeEach(() => {
-      // Simulate empty activity log for fresh user testing
-      cy.intercept("GET", "/api/activity/recents?*", {
-        recents: [],
-      }).as("emptyRecentItems");
+  it.skip("shows an empty state on the sidebar when there is no recent activity", () => {
+    cy.intercept("GET", "/api/activity/recents?*", {
+      recents: [],
+    }).as("emptyRecentItems");
+
+    visitNewEmbedPage();
+    cy.wait("@emptyRecentItems");
+
+    getEmbedSidebar().within(() => {
+      cy.findByText("Next").click();
+
+      cy.findByText("Choose from your recently visited dashboards").should(
+        "not.exist",
+      );
     });
 
-    it("shows empty state for fresh user with no recent activities", () => {
-      cy.visit("/embed/new");
-      cy.wait("@dashboard");
-      cy.wait("@emptyRecentItems");
-
-      // TODO: Once Step 3 UI is implemented, verify:
-      // - Empty state is shown when no recent activities
-      // - Empty state has illustration and search button
-      // - Search button opens dashboard/question search modal
-
-      // For now, verify fallback behavior (default entities)
-      const iframe = getPreviewIframe();
-      iframe.within(() => {
-        cy.findByText("Person overview").should("be.visible");
-      });
-    });
-
-    it("allows searching for entities when recents list is empty", () => {
-      cy.visit("/embed/new");
-      cy.wait("@dashboard");
-      cy.wait("@emptyRecentItems");
-
-      // TODO: Once Step 3 UI is implemented, add test for:
-      // - Empty state with search button is visible
-      // - Click search button opens modal
-      // - Can search and select dashboards/questions
-      // - Selected entity updates preview
-
-      // Placeholder verification
-      const iframe = getPreviewIframe();
-      iframe.within(() => {
-        cy.findByText("Person overview").should("be.visible");
-      });
-    });
+    // - Empty state is shown when no recent activities
+    // - Empty state has illustration and search button
+    // - Search button opens dashboard/question search modal
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -16,129 +16,49 @@ describe("scenarios > embedding > sdk iframe embedding setup > select embed enti
     cy.intercept("GET", "/api/activity/recents?*").as("recentActivity");
   });
 
-  describe("Selecting entities to embed", () => {
-    it("shows most recently visited dashboard in the recents list", () => {
-      cy.log("add dashboard to activity log");
-      cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
-      cy.wait("@dashboard");
+  it("selects the most recently visited dashboard from the recents list", () => {
+    cy.log("add dashboard to activity log");
+    cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
+    cy.wait("@dashboard");
 
-      visitNewEmbedPage();
+    visitNewEmbedPage();
 
-      getEmbedSidebar().within(() => {
-        cy.findByText("Next").click();
-        cy.findByText("Orders in a dashboard").should("be.visible");
+    getEmbedSidebar().within(() => {
+      cy.findByText("Next").click();
+      cy.findByText("Orders in a dashboard").should("be.visible");
 
-        cy.log("only one recent item should be visible");
-        cy.findAllByTestId("embed-recent-item-card").should("have.length", 1);
-      });
-
-      cy.log("dashboard should be displayed in the preview");
-      cy.wait("@dashboard");
-      getPreviewIframe().within(() => {
-        cy.findByText("Orders in a dashboard").should("be.visible");
-      });
+      cy.log("only one recent item should be visible");
+      cy.findAllByTestId("embed-recent-item-card").should("have.length", 1);
     });
 
-    it("shows most recently visited question in the recents list", () => {
-      cy.log("add question to activity log");
-      cy.visit(`/question/${ORDERS_COUNT_QUESTION_ID}`);
-      cy.wait("@cardQuery");
+    cy.log("dashboard should be displayed in the preview");
+    cy.wait("@dashboard");
+    getPreviewIframe().within(() => {
+      cy.findByText("Orders in a dashboard").should("be.visible");
+    });
+  });
 
-      visitNewEmbedPage();
+  it("selects the most recently visited question from the recents list", () => {
+    cy.log("add question to activity log");
+    cy.visit(`/question/${ORDERS_COUNT_QUESTION_ID}`);
+    cy.wait("@cardQuery");
 
-      getEmbedSidebar().within(() => {
-        cy.findByText("Chart").click();
-        cy.findByText("Next").click();
-        cy.findByText("Orders, Count").should("be.visible");
+    visitNewEmbedPage();
 
-        cy.log("only one recent item should be visible");
-        cy.findAllByTestId("embed-recent-item-card").should("have.length", 1);
-      });
+    getEmbedSidebar().within(() => {
+      cy.findByText("Chart").click();
+      cy.findByText("Next").click();
+      cy.findByText("Orders, Count").should("be.visible");
 
-      cy.wait("@cardQuery");
-
-      cy.log("question should be displayed in the preview");
-      getPreviewIframe().within(() => {
-        cy.findByText("Orders, Count").should("be.visible");
-      });
+      cy.log("only one recent item should be visible");
+      cy.findAllByTestId("embed-recent-item-card").should("have.length", 1);
     });
 
-    it("selecting a dashboard from recents changes the preview to that dashboard", () => {
-      // Visit a specific dashboard to ensure it's in recents
-      const dashboardId = 1;
-      cy.visit(`/dashboard/${dashboardId}`);
-      cy.wait("@dashboard");
+    cy.wait("@cardQuery");
 
-      // Navigate to embed page
-      cy.visit("/embed/new");
-      cy.wait("@dashboard");
-
-      // TODO: Once Step 3 UI is implemented, add test for:
-      // - Click on recent dashboard in the recents list
-      // - Verify preview updates to show the selected dashboard
-
-      // For now, verify the most recent dashboard is displayed
-      const iframe = getPreviewIframe();
-      iframe.within(() => {
-        cy.findByText("Person overview").should("be.visible");
-      });
-    });
-
-    it("clicking on the search icon and selecting a dashboard changes the preview to that dashboard", () => {
-      cy.visit("/embed/new");
-      cy.wait("@dashboard");
-
-      // TODO: Once Step 3 UI is implemented, add test for:
-      // - Click on search icon
-      // - Search modal opens
-      // - Search for a specific dashboard
-      // - Select dashboard from search results
-      // - Verify preview updates to show the selected dashboard
-
-      // For now, verify current dashboard preview functionality
-      const iframe = getPreviewIframe();
-      iframe.within(() => {
-        cy.findByText("Person overview").should("be.visible");
-      });
-    });
-
-    it("clicking on the search icon and selecting a question changes the preview to that question", () => {
-      cy.visit("/embed/new");
-      cy.wait("@dashboard");
-
-      // Switch to Chart template
-      getEmbedSidebar().findByText("Chart").click();
-
-      // TODO: Once Step 3 UI is implemented, add test for:
-      // - Click on search icon
-      // - Search modal opens
-      // - Search for a specific question
-      // - Select question from search results
-      // - Verify preview updates to show the selected question
-
-      // For now, verify current question preview functionality
-      const iframe = getPreviewIframe();
-      iframe.within(() => {
-        // Default question when no recents available
-        cy.findByText("Query log").should("be.visible");
-      });
-    });
-
-    it("exploration template skips entity selection step", () => {
-      cy.visit("/embed/new");
-      cy.wait("@dashboard");
-
-      // Select exploration template
-      getEmbedSidebar().findByText("Exploration").click();
-
-      // Verify exploration content is shown directly (no entity selection step)
-      const iframe = getPreviewIframe();
-      iframe.within(() => {
-        cy.findByText("Pick your starting data").should("be.visible");
-      });
-
-      // TODO: Once step navigation is fully implemented, verify that
-      // Step 3 (entity selection) is skipped for exploration template
+    cy.log("question should be displayed in the preview");
+    getPreviewIframe().within(() => {
+      cy.findByText("Orders, Count").should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -22,7 +22,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
-    H.setTokenFeatures("all");
+    H.activateToken("bleeding-edge");
 
     H.createDashboard({ name: SECOND_DASHBOARD_NAME }).then(
       ({ body: { id: dashboardId } }) => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -23,6 +23,9 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     H.restore();
     cy.signInAsAdmin();
     H.activateToken("bleeding-edge");
+
+    cy.intercept("GET", "/api/dashboard/**").as("dashboard");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
   });
 
   it("can select a recent dashboard to embed", () => {
@@ -36,7 +39,6 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     );
 
     visitNewEmbedPage();
-    cy.intercept("GET", "/api/dashboard/**").as("dashboard");
 
     getEmbedSidebar().within(() => {
       cy.findByText("Next").click();
@@ -69,7 +71,6 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     logRecent("card", ORDERS_COUNT_QUESTION_ID);
 
     visitNewEmbedPage();
-    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
     getEmbedSidebar().within(() => {
       cy.findByText("Chart").click();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -1,4 +1,5 @@
 import {
+  ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
@@ -12,15 +13,20 @@ import {
 
 const { H } = cy;
 
+const FIRST_DASHBOARD_NAME = "Orders in a dashboard";
+const SECOND_DASHBOARD_NAME = "Acme Inc";
+const FIRST_QUESTION_NAME = "Orders, Count";
+const SECOND_QUESTION_NAME = "Orders, Count, Grouped by Created At (year)";
+
 describe("scenarios > embedding > sdk iframe embed setup > select embed entity", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
     H.setTokenFeatures("all");
 
-    H.createDashboard({ name: "Acme Inc" }).then(
+    H.createDashboard({ name: SECOND_DASHBOARD_NAME }).then(
       ({ body: { id: dashboardId } }) => {
-        cy.wrap(dashboardId).as("acmeDashboardId");
+        cy.wrap(dashboardId).as("secondDashboardId");
       },
     );
 
@@ -29,9 +35,9 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     cy.intercept("GET", "/api/activity/recents?*").as("recentActivity");
   });
 
-  it("can select a dashboard from the recents list", () => {
+  it("can select a recent dashboard to embed", () => {
     cy.log("add two dashboards to activity log");
-    H.visitDashboard("@acmeDashboardId");
+    H.visitDashboard("@secondDashboardId");
     cy.wait("@dashboard");
     H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.wait("@dashboard");
@@ -40,6 +46,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
 
     getEmbedSidebar().within(() => {
       cy.findByText("Next").click();
+      cy.findByText("Select a dashboard to embed").should("be.visible");
 
       cy.log("first dashboard should be selected by default");
       getRecentItemCards()
@@ -47,23 +54,25 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
         .first()
         .should("have.attr", "data-selected", "true");
 
-      cy.findByText("Acme Inc").should("be.visible");
-      cy.findByText("Orders in a dashboard").should("be.visible");
+      cy.findByText(FIRST_DASHBOARD_NAME).should("be.visible");
+      cy.findByText(SECOND_DASHBOARD_NAME).should("be.visible");
 
       cy.log("second dashboard can be selected");
-      cy.findByText("Acme Inc").click();
+      cy.findByText(SECOND_DASHBOARD_NAME).click();
       getRecentItemCards().eq(1).should("have.attr", "data-selected", "true");
     });
 
     cy.log("selected dashboard should be shown in the preview");
     cy.wait("@dashboard");
     getPreviewIframe().within(() => {
-      cy.findByText("Acme Inc").should("be.visible");
+      cy.findByText(SECOND_DASHBOARD_NAME).should("be.visible");
     });
   });
 
-  it("selects the most recently visited question from the recents list", () => {
-    cy.log("add question to activity log");
+  it("can select a recent question to embed", () => {
+    cy.log("add two questions to activity log");
+    H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+    cy.wait("@cardQuery");
     H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
     cy.wait("@cardQuery");
 
@@ -72,21 +81,31 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     getEmbedSidebar().within(() => {
       cy.findByText("Chart").click();
       cy.findByText("Next").click();
-      cy.findByText("Orders, Count").should("be.visible");
 
-      cy.log("only one recent item should be visible");
-      getRecentItemCards().should("have.length", 1);
+      cy.findByText("Select a chart to embed").should("be.visible");
+
+      cy.log("first question should be selected by default");
+      getRecentItemCards()
+        .should("have.length", 2)
+        .first()
+        .should("have.attr", "data-selected", "true");
+
+      cy.findByText(FIRST_QUESTION_NAME).should("be.visible");
+      cy.findByText(SECOND_QUESTION_NAME).should("be.visible");
+
+      cy.log("second question can be selected");
+      cy.findByText(SECOND_QUESTION_NAME).click();
+      getRecentItemCards().eq(1).should("have.attr", "data-selected", "true");
     });
 
+    cy.log("selected question should be shown in the preview");
     cy.wait("@cardQuery");
-
-    cy.log("question should be displayed in the preview");
     getPreviewIframe().within(() => {
-      cy.findByText("Orders, Count").should("be.visible");
+      cy.findByText(SECOND_QUESTION_NAME).should("be.visible");
     });
   });
 
-  describe("Entity selection with empty recents", () => {
+  describe.skip("Entity selection with empty recents", () => {
     beforeEach(() => {
       // Simulate empty activity log for fresh user testing
       cy.intercept("GET", "/api/activity/recents?*", {
@@ -126,49 +145,6 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
       const iframe = getPreviewIframe();
       iframe.within(() => {
         cy.findByText("Person overview").should("be.visible");
-      });
-    });
-  });
-
-  describe("Entity selection integration", () => {
-    it("selected entity persists when navigating between embed steps", () => {
-      H.visitDashboard("@acmeDashboardId");
-      cy.wait("@dashboard");
-
-      cy.visit("/embed/new");
-      cy.wait("@dashboard");
-
-      // TODO: Once full step navigation is implemented, verify:
-      // - Select entity in Step 3
-      // - Navigate to Step 4 (embed options)
-      // - Navigate back to Step 3
-      // - Verify selected entity is still selected
-      // - Navigate to Step 5 (code snippets)
-      // - Verify selected entity appears in code snippets
-
-      // For now, verify current functionality
-      const iframe = getPreviewIframe();
-      iframe.within(() => {
-        cy.findByText("Person overview").should("be.visible");
-      });
-    });
-
-    it("changing selected entity updates preview immediately", () => {
-      cy.visit("/embed/new");
-      cy.wait("@dashboard");
-
-      // TODO: Once Step 3 UI is implemented, add test for:
-      // - Select different entities from recents or search
-      // - Verify preview updates immediately without page reload
-      // - Test switching between dashboards and questions
-      // - Verify preview reflects correct content
-
-      // Verify current immediate preview functionality
-      getEmbedSidebar().findByText("Chart").click();
-
-      const iframe = getPreviewIframe();
-      iframe.within(() => {
-        cy.findByText("Query log").should("be.visible");
       });
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -116,13 +116,40 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     getEmbedSidebar().within(() => {
       cy.findByText("Next").click();
 
+      cy.log("should not show recent dashboards description when no recents");
       cy.findByText("Choose from your recently visited dashboards").should(
         "not.exist",
       );
+
+      cy.log("should show empty state with title and description");
+      cy.findByTestId("embed-empty-state").should("be.visible");
+      cy.findByText("No recent dashboards").should("be.visible");
+      cy.findByText(/You haven't visited any dashboards recently/).should(
+        "be.visible",
+      );
+
+      cy.log("should show search link in empty state description");
+      cy.findByText("search for dashboards").should("be.visible");
+
+      cy.log("should not show any recent item cards");
+      cy.findByTestId("embed-recent-item-card").should("not.exist");
     });
 
-    // - Empty state is shown when no recent activities
-    // - Empty state has illustration and search button
-    // - Search button opens dashboard/question search modal
+    cy.log("test empty state for chart experience");
+    getEmbedSidebar().within(() => {
+      cy.findByText("Back").click();
+      cy.findByText("Chart").click();
+
+      cy.findByText("Choose from your recently visited charts").should(
+        "not.exist",
+      );
+
+      cy.findByTestId("embed-empty-state").should("be.visible");
+      cy.findByText("No recent charts").should("be.visible");
+      cy.findByText(/You haven't visited any charts recently/).should(
+        "be.visible",
+      );
+      cy.findByText("search for charts").should("be.visible");
+    });
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -1,0 +1,280 @@
+import { ORDERS_COUNT_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import type { RecentItem } from "metabase-types/api";
+
+const { H } = cy;
+
+type RecentActivityIntercept = {
+  response: { body: { recents: RecentItem[] } };
+};
+
+describe("scenarios > embedding > sdk iframe embedding setup > select embed entity", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+
+    cy.intercept("GET", "/api/dashboard/**").as("dashboard");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("GET", "/api/activity/recents?*").as("recentActivity");
+  });
+
+  describe("EMB-549: Step 3 - Select entity to embed", () => {
+    it("visiting a new dashboard adds it to the recents list in the embed page", () => {
+      // Visit a specific dashboard to add it to recents
+      const dashboardId = 1;
+      cy.visit(`/dashboard/${dashboardId}`);
+      cy.wait("@dashboard");
+
+      // Navigate to embed page
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+
+      // Verify the visited dashboard appears in recents
+      cy.get<RecentActivityIntercept>("@recentActivity").should((intercept) => {
+        const recentDashboards = intercept.response?.body.recents?.filter(
+          (recent) => recent.model === "dashboard",
+        );
+
+        expect(recentDashboards).to.have.length.greaterThan(0);
+        expect(recentDashboards?.[0]?.id).to.equal(dashboardId);
+      });
+
+      // Verify the dashboard is shown in the preview
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        cy.findByText("Person overview").should("be.visible");
+      });
+    });
+
+    it("visiting a new question adds it to the recents list in the embed page", () => {
+      // Visit a specific question to add it to recents
+      cy.visit(`/question/${ORDERS_COUNT_QUESTION_ID}`);
+      cy.wait("@cardQuery");
+
+      // Navigate to embed page and select chart template
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+
+      getEmbedSidebar().findByText("Chart").click();
+      cy.wait("@cardQuery");
+
+      // Verify the visited question appears in recents
+      cy.get<RecentActivityIntercept>("@recentActivity").should((intercept) => {
+        const recentQuestions = intercept.response?.body.recents?.filter(
+          (recent) => recent.model === "card",
+        );
+
+        expect(recentQuestions).to.have.length.greaterThan(0);
+        expect(recentQuestions?.[0]?.id).to.equal(ORDERS_COUNT_QUESTION_ID);
+      });
+
+      // Verify the question is shown in the preview
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        cy.findByText("Orders, Count").should("be.visible");
+      });
+    });
+
+    it("selecting a question from recents changes the preview to that question", () => {
+      // First, visit a question to ensure it's in recents
+      cy.visit(`/question/${ORDERS_COUNT_QUESTION_ID}`);
+      cy.wait("@cardQuery");
+
+      // Navigate to embed page
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+
+      // Switch to Chart template
+      getEmbedSidebar().findByText("Chart").click();
+      cy.wait("@cardQuery");
+
+      // TODO: Once Step 3 UI is implemented, add test for:
+      // - Click on recent question in the recents list
+      // - Verify preview updates to show the selected question
+
+      // For now, verify the most recent question is displayed
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        cy.findByText("Orders, Count").should("be.visible");
+      });
+    });
+
+    it("selecting a dashboard from recents changes the preview to that dashboard", () => {
+      // Visit a specific dashboard to ensure it's in recents
+      const dashboardId = 1;
+      cy.visit(`/dashboard/${dashboardId}`);
+      cy.wait("@dashboard");
+
+      // Navigate to embed page
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+
+      // TODO: Once Step 3 UI is implemented, add test for:
+      // - Click on recent dashboard in the recents list
+      // - Verify preview updates to show the selected dashboard
+
+      // For now, verify the most recent dashboard is displayed
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        cy.findByText("Person overview").should("be.visible");
+      });
+    });
+
+    it("clicking on the search icon and selecting a dashboard changes the preview to that dashboard", () => {
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+
+      // TODO: Once Step 3 UI is implemented, add test for:
+      // - Click on search icon
+      // - Search modal opens
+      // - Search for a specific dashboard
+      // - Select dashboard from search results
+      // - Verify preview updates to show the selected dashboard
+
+      // For now, verify current dashboard preview functionality
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        cy.findByText("Person overview").should("be.visible");
+      });
+    });
+
+    it("clicking on the search icon and selecting a question changes the preview to that question", () => {
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+
+      // Switch to Chart template
+      getEmbedSidebar().findByText("Chart").click();
+
+      // TODO: Once Step 3 UI is implemented, add test for:
+      // - Click on search icon
+      // - Search modal opens
+      // - Search for a specific question
+      // - Select question from search results
+      // - Verify preview updates to show the selected question
+
+      // For now, verify current question preview functionality
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        // Default question when no recents available
+        cy.findByText("Query log").should("be.visible");
+      });
+    });
+
+    it("exploration template skips entity selection step", () => {
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+
+      // Select exploration template
+      getEmbedSidebar().findByText("Exploration").click();
+
+      // Verify exploration content is shown directly (no entity selection step)
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        cy.findByText("Pick your starting data").should("be.visible");
+      });
+
+      // TODO: Once step navigation is fully implemented, verify that
+      // Step 3 (entity selection) is skipped for exploration template
+    });
+  });
+
+  describe("Entity selection with empty recents", () => {
+    beforeEach(() => {
+      // Simulate empty activity log for fresh user testing
+      cy.intercept("GET", "/api/activity/recents?*", {
+        recents: [],
+      }).as("emptyRecentItems");
+    });
+
+    it("shows empty state for fresh user with no recent activities", () => {
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+      cy.wait("@emptyRecentItems");
+
+      // TODO: Once Step 3 UI is implemented, verify:
+      // - Empty state is shown when no recent activities
+      // - Empty state has illustration and search button
+      // - Search button opens dashboard/question search modal
+
+      // For now, verify fallback behavior (default entities)
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        cy.findByText("Person overview").should("be.visible");
+      });
+    });
+
+    it("allows searching for entities when recents list is empty", () => {
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+      cy.wait("@emptyRecentItems");
+
+      // TODO: Once Step 3 UI is implemented, add test for:
+      // - Empty state with search button is visible
+      // - Click search button opens modal
+      // - Can search and select dashboards/questions
+      // - Selected entity updates preview
+
+      // Placeholder verification
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        cy.findByText("Person overview").should("be.visible");
+      });
+    });
+  });
+
+  describe("Entity selection integration", () => {
+    it("selected entity persists when navigating between embed steps", () => {
+      // Visit a specific dashboard to add to recents
+      const dashboardId = 1;
+      cy.visit(`/dashboard/${dashboardId}`);
+      cy.wait("@dashboard");
+
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+
+      // TODO: Once full step navigation is implemented, verify:
+      // - Select entity in Step 3
+      // - Navigate to Step 4 (embed options)
+      // - Navigate back to Step 3
+      // - Verify selected entity is still selected
+      // - Navigate to Step 5 (code snippets)
+      // - Verify selected entity appears in code snippets
+
+      // For now, verify current functionality
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        cy.findByText("Person overview").should("be.visible");
+      });
+    });
+
+    it("changing selected entity updates preview immediately", () => {
+      cy.visit("/embed/new");
+      cy.wait("@dashboard");
+
+      // TODO: Once Step 3 UI is implemented, add test for:
+      // - Select different entities from recents or search
+      // - Verify preview updates immediately without page reload
+      // - Test switching between dashboards and questions
+      // - Verify preview reflects correct content
+
+      // Verify current immediate preview functionality
+      getEmbedSidebar().findByText("Chart").click();
+
+      const iframe = getPreviewIframe();
+      iframe.within(() => {
+        cy.findByText("Query log").should("be.visible");
+      });
+    });
+  });
+});
+
+const getPreviewIframe = () =>
+  cy
+    .get("iframe")
+    .should("be.visible")
+    .its("0.contentDocument")
+    .should("exist")
+    .its("body")
+    .should("not.be.empty");
+
+const getEmbedSidebar = () => cy.findByTestId("embed-sidebar-content");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -3,6 +3,13 @@ import {
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
+import {
+  getEmbedSidebar,
+  getPreviewIframe,
+  getRecentItemCards,
+  visitNewEmbedPage,
+} from "./helpers";
+
 const { H } = cy;
 
 describe("scenarios > embedding > sdk iframe embed setup > select embed entity", () => {
@@ -34,24 +41,21 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     getEmbedSidebar().within(() => {
       cy.findByText("Next").click();
 
-      cy.log("two dashboards should be visible in the recents list");
-      cy.findAllByTestId("embed-recent-item-card").should("have.length", 2);
+      cy.log("first dashboard should be selected by default");
+      getRecentItemCards()
+        .should("have.length", 2)
+        .first()
+        .should("have.attr", "data-selected", "true");
+
       cy.findByText("Acme Inc").should("be.visible");
       cy.findByText("Orders in a dashboard").should("be.visible");
 
-      cy.findAllByTestId("embed-recent-item-card")
-        .eq(0)
-        .should("have.attr", "data-selected", "true");
-
-      cy.log("select a different dashboard");
+      cy.log("second dashboard can be selected");
       cy.findByText("Acme Inc").click();
-
-      cy.findAllByTestId("embed-recent-item-card")
-        .eq(1)
-        .should("have.attr", "data-selected", "true");
+      getRecentItemCards().eq(1).should("have.attr", "data-selected", "true");
     });
 
-    cy.log("dashboard should be displayed in the preview");
+    cy.log("selected dashboard should be shown in the preview");
     cy.wait("@dashboard");
     getPreviewIframe().within(() => {
       cy.findByText("Acme Inc").should("be.visible");
@@ -71,7 +75,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
       cy.findByText("Orders, Count").should("be.visible");
 
       cy.log("only one recent item should be visible");
-      cy.findAllByTestId("embed-recent-item-card").should("have.length", 1);
+      getRecentItemCards().should("have.length", 1);
     });
 
     cy.wait("@cardQuery");
@@ -169,19 +173,3 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     });
   });
 });
-
-const getPreviewIframe = () =>
-  cy
-    .get("iframe")
-    .should("be.visible")
-    .its("0.contentDocument")
-    .should("exist")
-    .its("body")
-    .should("not.be.empty");
-
-const getEmbedSidebar = () => cy.findByTestId("embed-sidebar");
-
-const visitNewEmbedPage = () => {
-  cy.visit("/embed/new");
-  cy.wait("@dashboard");
-};

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -7,7 +7,6 @@ import { entityPickerModal } from "e2e/support/helpers";
 
 import {
   getEmbedSidebar,
-  getPreviewIframe,
   getRecentItemCards,
   visitNewEmbedPage,
 } from "./helpers";
@@ -65,7 +64,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
 
     cy.log("selected dashboard should be shown in the preview");
     cy.wait("@dashboard");
-    getPreviewIframe().within(() => {
+    H.getIframeBody().within(() => {
       cy.findByText(SECOND_DASHBOARD_NAME).should("be.visible");
     });
   });
@@ -101,7 +100,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
 
     cy.log("selected question should be shown in the preview");
     cy.wait("@cardQuery");
-    getPreviewIframe().within(() => {
+    H.getIframeBody().within(() => {
       cy.findByText(SECOND_QUESTION_NAME).should("be.visible");
     });
   });
@@ -130,7 +129,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     });
 
     cy.wait("@dashboard");
-    getPreviewIframe().within(() => {
+    H.getIframeBody().within(() => {
       cy.findByText(SECOND_DASHBOARD_NAME).should("be.visible");
     });
   });
@@ -160,7 +159,7 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed entity",
     });
 
     cy.wait("@cardQuery");
-    getPreviewIframe().within(() => {
+    H.getIframeBody().within(() => {
       cy.findByText(FIRST_QUESTION_NAME).should("be.visible");
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -1,15 +1,12 @@
 import { ORDERS_COUNT_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
-import type { Dashboard, RecentItem } from "metabase-types/api";
+
+import {
+  assertRecentItemName,
+  getEmbedSidebar,
+  visitNewEmbedPage,
+} from "./helpers";
 
 const { H } = cy;
-
-type RecentActivityIntercept = {
-  response: Cypress.Response<{ recents: RecentItem[] }>;
-};
-
-type DashboardIntercept = {
-  response: Cypress.Response<Dashboard>;
-};
 
 describe("scenarios > embedding > sdk iframe embed setup > select embed experience", () => {
   beforeEach(() => {
@@ -114,30 +111,3 @@ describe("scenarios > embedding > sdk iframe embed setup > select embed experien
     });
   });
 });
-
-const getEmbedSidebar = () => cy.findByRole("complementary");
-
-const visitNewEmbedPage = () => {
-  cy.visit("/embed/new");
-  cy.wait("@dashboard");
-};
-
-const assertRecentItemName = (
-  model: "dashboard" | "card",
-  resourceName: string,
-) => {
-  cy.get<RecentActivityIntercept>("@recentActivity").should((intercept) => {
-    const recentItem = intercept.response?.body.recents?.find(
-      (recent) => recent.model === model,
-    );
-
-    expect(recentItem?.name).to.be.equal(resourceName);
-  });
-};
-
-const assertDashboard = ({ id, name }: { id: number; name: string }) => {
-  cy.get<DashboardIntercept>("@dashboard").should((intercept) => {
-    expect(intercept.response?.body.id).to.be.equal(id);
-    expect(intercept.response?.body.name).to.be.equal(name);
-  });
-};

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -1,6 +1,7 @@
 import { ORDERS_COUNT_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
 import {
+  assertDashboard,
   assertRecentItemName,
   getEmbedSidebar,
   visitNewEmbedPage,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -76,7 +76,7 @@ export const SdkIframeEmbedPreview = () => {
 
   return (
     <div>
-      <Box id="iframe-embed-container" />
+      <Box id="iframe-embed-container" data-iframe-loaded={isIframeLoaded} />
     </div>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceStep.tsx
@@ -163,6 +163,7 @@ export const SelectEmbedResourceStep = () => {
                 : t`Browse questions`
             }
             onClick={openPicker}
+            data-testid="embed-browse-entity-button"
           >
             <Icon name="search" size={16} />
           </ActionIcon>


### PR DESCRIPTION
Closes EMB-549

Adds end-to-end tests for selecting resources to embed (e.g. question and dashboard) for new iframe embedding.

### How to verify

Refer to [these test cases](https://www.notion.so/metabase/Testing-Plan-Embed-flow-for-new-iframe-embedding-21569354c90180d18ca1f457b10de0ab?source=copy_link#21569354c90180c3aec0dc6987eb19d8) from the testing plan:

- Visiting a new dashboard or question adds that to the recents list in the embed page
    - Selecting a question from recents changes the preview to that question
    - Selecting a dashboard from recents changes the preview to that dashboard
- When the activity log is completely empty (i.e. the user has never visited any dashboards before), display an empty state.
- Clicking on the search icon and selecting a dashboard changes the preview to that dashboard
- Clicking on the search icon and selecting a question changes the preview to that question

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
