### PR TITLE
dev: don't require tier 3 and 4 drivers

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1125,7 +1125,7 @@ jobs:
                 result: jobValues.result
               }));
 
-            jobs.every(job => (console.log("Job:", job)));
+            jobs.forEach(job => (console.log("Job:", job)));
 
             // are all jobs skipped or successful?
             if (jobs.every(job => (job.result === 'skipped' || job.result === 'success'))) {

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1087,9 +1087,6 @@ jobs:
       - be-tests-bigquery-cloud-sdk-ee
       - be-tests-clickhouse-ee
       - be-tests-mysql-mariadb
-
-      - be-tests-mongo-ssl
-      - be-tests-mongo-sharded-cluster-ee
       - be-tests-postgres
       - be-tests-redshift-ee
       - be-tests-snowflake-ee
@@ -1099,6 +1096,8 @@ jobs:
       # - be-tests-databricks-ee
       # - be-tests-druid-jdbc-ee
       # - be-tests-mongo
+      # - be-tests-mongo-ssl
+      # - be-tests-mongo-sharded-cluster-ee
       # - be-tests-oracle
       # - be-tests-presto-jdbc-ee
       # - be-tests-sparksql-ee
@@ -1124,8 +1123,6 @@ jobs:
                 name: jobName,
                 result: jobValues.result
               }));
-
-            jobs.forEach(job => (console.log("Job:", job)));
 
             // are all jobs skipped or successful?
             if (jobs.every(job => (job.result === 'skipped' || job.result === 'success'))) {

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1084,26 +1084,28 @@ jobs:
     needs:
       # if you add a driver job, you must add it to this list for it to be a required check
       - be-tests-h2
-      - be-tests-athena-ee
       - be-tests-bigquery-cloud-sdk-ee
-      - be-tests-druid-ee
-      - be-tests-databricks-ee
-      - be-tests-druid-jdbc-ee
+      - be-tests-clickhouse-ee
       - be-tests-mysql-mariadb
-      - be-tests-mongo
+
       - be-tests-mongo-ssl
       - be-tests-mongo-sharded-cluster-ee
-      - be-tests-oracle
       - be-tests-postgres
-      - be-tests-presto-jdbc-ee
       - be-tests-redshift-ee
       - be-tests-snowflake-ee
-      - be-tests-sparksql-ee
-      - be-tests-sqlite-ee
-      - be-tests-sqlserver
-      - be-tests-starburst-ee
-      - be-tests-vertica-ee
-      - be-tests-clickhouse-ee
+      # Tier 3 and 4 drivers, we do not require them to pass
+      # - be-tests-athena-ee
+      # - be-tests-druid-ee
+      # - be-tests-databricks-ee
+      # - be-tests-druid-jdbc-ee
+      # - be-tests-mongo
+      # - be-tests-oracle
+      # - be-tests-presto-jdbc-ee
+      # - be-tests-sparksql-ee
+      # - be-tests-sqlite-ee
+      # - be-tests-sqlserver
+      # - be-tests-starburst-ee
+      # - be-tests-vertica-ee
     runs-on: ubuntu-latest
     timeout-minutes: 5
     name: drivers-tests-result
@@ -1122,6 +1124,8 @@ jobs:
                 name: jobName,
                 result: jobValues.result
               }));
+
+            jobs.every(job => (console.log("Job:", job)));
 
             // are all jobs skipped or successful?
             if (jobs.every(job => (job.result === 'skipped' || job.result === 'success'))) {

--- a/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -35,8 +35,7 @@
 
 (deftest describe-database-test
   (mt/test-driver :starburst
-    (Thread/sleep (* 1000 60 60 5)) ;; 5 hours
-    (is (= {:tables #{{:name "xcategories" :schema "default"}
+    (is (= {:tables #{{:name "categories" :schema "default"}
                       {:name "venues" :schema "default"}
                       {:name "checkins" :schema "default"}
                       {:name "users" :schema "default"}}}

--- a/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -35,7 +35,7 @@
 
 (deftest describe-database-test
   (mt/test-driver :starburst
-    (is (= {:tables #{{:name "categories" :schema "default"}
+    (is (= {:tables #{{:name "xcategories" :schema "default"}
                       {:name "venues" :schema "default"}
                       {:name "checkins" :schema "default"}
                       {:name "users" :schema "default"}}}

--- a/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -35,6 +35,7 @@
 
 (deftest describe-database-test
   (mt/test-driver :starburst
+    (Thread/sleep (* 1000 60 60 5)) ;; 5 hours
     (is (= {:tables #{{:name "xcategories" :schema "default"}
                       {:name "venues" :schema "default"}
                       {:name "checkins" :schema "default"}


### PR DESCRIPTION
Removes tier 3 and 4 drivers from the required to pass list of `drivers-tests-result`

We can see that if a non-required driver-test goes long or is cancelled, the PR is still mergeable.

<img width="955" alt="image" src="https://github.com/user-attachments/assets/e815f868-8bfa-401f-84f9-f2aec2039f71" />

<img width="923" alt="image" src="https://github.com/user-attachments/assets/2c9e07d8-5ad9-4eb4-97f7-ce627a733a0c" />

