### PR TITLE
[Metabot] Remove AI Proxy references

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -43,7 +43,7 @@
      :state     (metabot-v3.envelope/state env)}))
 
 (api.macros/defendpoint :post "/v2/agent"
-  "Send a chat message to the LLM via the AI Proxy."
+  "Send a chat message to the LLM via the AI Service."
   [_route-params
    _query-params
    {:keys [conversation_id] :as body} :- [:map

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -62,31 +62,31 @@
         (deliver response-status (some-> <> :status))))))
 
 (defn- agent-v2-endpoint-url []
-  (str (metabot-v3.settings/ai-proxy-base-url) "/v2/agent"))
+  (str (metabot-v3.settings/ai-service-base-url) "/v2/agent"))
 
 (defn- metric-selection-endpoint-url []
-  (str (metabot-v3.settings/ai-proxy-base-url) "/v1/select-metric"))
+  (str (metabot-v3.settings/ai-service-base-url) "/v1/select-metric"))
 
 (defn- find-outliers-endpoint-url []
-  (str (metabot-v3.settings/ai-proxy-base-url) "/v1/find-outliers"))
+  (str (metabot-v3.settings/ai-service-base-url) "/v1/find-outliers"))
 
 (defn- fix-sql-endpoint []
-  (str (metabot-v3.settings/ai-proxy-base-url) "/v1/sql/fix"))
+  (str (metabot-v3.settings/ai-service-base-url) "/v1/sql/fix"))
 
 (defn- generate-sql-endpoint []
-  (str (metabot-v3.settings/ai-proxy-base-url) "/v1/sql/generate"))
+  (str (metabot-v3.settings/ai-service-base-url) "/v1/sql/generate"))
 
 (defn- analyze-chart-endpoint []
-  (str (metabot-v3.settings/ai-proxy-base-url) "/v1/analyze/chart"))
+  (str (metabot-v3.settings/ai-service-base-url) "/v1/analyze/chart"))
 
 (defn- analyze-dashboard-endpoint []
-  (str (metabot-v3.settings/ai-proxy-base-url) "/v1/analyze/dashboard"))
+  (str (metabot-v3.settings/ai-service-base-url) "/v1/analyze/dashboard"))
 
 (defn- example-question-generation-endpoint []
-  (str (metabot-v3.settings/ai-proxy-base-url) "/v1/example-question-generation/batch"))
+  (str (metabot-v3.settings/ai-service-base-url) "/v1/example-question-generation/batch"))
 
-(mu/defn request :- ::metabot-v3.client.schema/ai-proxy.response
-  "Make a V2 request to the AI Proxy."
+(mu/defn request :- ::metabot-v3.client.schema/ai-service.response
+  "Make a V2 request to the AI Service."
   [{:keys [context messages profile-id conversation-id session-id state]}
    :- [:map
        [:context :map]
@@ -106,7 +106,7 @@
                         :user_id         api/*current-user-id*}
                        (metabot-v3.u/recursive-update-keys metabot-v3.u/safe->snake_case_en))
           _        (metabot-v3.context/log body :llm.log/be->llm)
-          _        (log/debugf "V2 request to AI Proxy:\n%s" (u/pprint-to-str body))
+          _        (log/debugf "V2 request to AI Service:\n%s" (u/pprint-to-str body))
           options  (cond-> {:headers          {"Accept"                    "application/json"
                                                "Content-Type"              "application/json;charset=UTF-8"
                                                "x-metabase-instance-token" (premium-features/premium-embedding-token)
@@ -117,9 +117,9 @@
                      *debug* (assoc :debug true))
           response (post! url options)]
       (metabot-v3.context/log (:body response) :llm.log/llm->be)
-      (log/debugf "Response from AI Proxy:\n%s" (u/pprint-to-str (select-keys response #{:body :status :headers})))
+      (log/debugf "Response from AI Service:\n%s" (u/pprint-to-str (select-keys response #{:body :status :headers})))
       (if (= (:status response) 200)
-        (u/prog1 (mc/decode ::metabot-v3.client.schema/ai-proxy.response
+        (u/prog1 (mc/decode ::metabot-v3.client.schema/ai-service.response
                             (:body response)
                             (mtx/transformer {:name :api-response}))
           (log/debugf "Response (decoded):\n%s" (u/pprint-to-str <>)))
@@ -127,7 +127,7 @@
                         {:request (assoc options :body body)
                          :response response}))))
     (catch Throwable e
-      (throw (ex-info (format "Error in request to AI Proxy: %s" (ex-message e)) {} e)))))
+      (throw (ex-info (format "Error in request to AI Service: %s" (ex-message e)) {} e)))))
 
 (mu/defn select-metric-request
   "Make a request to AI Service to select a metric."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client/schema.clj
@@ -29,7 +29,7 @@
    [:name :string]
    [:description [:maybe :string]]])
 
-(mr/def ::ai-proxy.response
+(mr/def ::ai-service.response
   "Schema of the AI agent response."
   [:map
    [:messages ::messages]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/repl.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/repl.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.metabot-v3.repl
-  "Basic user message => AI Proxy => response chat flow. This namespace implements a text-based REPL you can use from
+  "Basic user message => AI Service => response chat flow. This namespace implements a text-based REPL you can use from
   Clojure or the CLI with
 
     clj -X:ee:metabot-v3/repl"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
@@ -3,8 +3,8 @@
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru]]))
 
-(defsetting ai-proxy-base-url
-  (deferred-tru "URL for the a AI Proxy service")
+(defsetting ai-service-base-url
+  (deferred-tru "URL for the a AI Service")
   :type       :string
   :encryption :no
   :default    "http://localhost:8000"


### PR DESCRIPTION
### Description

Kept noticing some strings / variables that reference AI Proxy which has since been renamed to AI Service.

The only major thing of note is the `ai-proxy-base-url` being renamed to `ai-service-base-url`. I'll check with the cloud team to make sure that this change won't affect customers in the beta program.