### PR TITLE
[Metabot] Fix warning no conversation id

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot-streaming.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot-streaming.unit.spec.tsx
@@ -8,7 +8,6 @@ import { P, isMatching } from "ts-pattern";
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
-import { uuid } from "metabase/lib/uuid";
 import { mockStreamedEndpoint } from "metabase-enterprise/api/ai-streaming/test-utils";
 import type { User } from "metabase-types/api";
 import {
@@ -22,7 +21,7 @@ import { FIXED_METABOT_IDS } from "./constants";
 import { MetabotProvider } from "./context";
 import {
   type MetabotState,
-  metabotInitialState,
+  getMetabotInitialState,
   metabotReducer,
 } from "./state";
 
@@ -54,8 +53,7 @@ function setup(
     ui = <Metabot />,
     currentUser = createMockUser(),
     metabotPluginInitialState = {
-      ...metabotInitialState,
-      conversationId: uuid(),
+      ...getMetabotInitialState(),
       visible: true,
       useStreaming: true,
     },

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -15,7 +15,6 @@ import {
 } from "__support__/ui";
 import { logout } from "metabase/auth/actions";
 import * as domModule from "metabase/lib/dom";
-import { uuid } from "metabase/lib/uuid";
 import { useRegisterMetabotContextProvider } from "metabase/metabot";
 import type { SuggestedMetabotPrompt, User } from "metabase-types/api";
 import {
@@ -34,7 +33,8 @@ import { useMetabotAgent } from "./hooks";
 import {
   type MetabotState,
   addUserMessage,
-  metabotInitialState,
+  getMetabotConversationId,
+  getMetabotInitialState,
   metabotReducer,
   setVisible,
 } from "./state";
@@ -59,8 +59,7 @@ function setup(
     ui = <Metabot />,
     currentUser = createMockUser(),
     metabotPluginInitialState = {
-      ...metabotInitialState,
-      conversationId: uuid(),
+      ...getMetabotInitialState(),
       visible: true,
     },
     promptSuggestions = [],
@@ -207,7 +206,7 @@ describe("metabot", () => {
 
       try {
         const { store } = setup({
-          metabotPluginInitialState: metabotInitialState,
+          metabotPluginInitialState: getMetabotInitialState(),
           currentUser: null,
         });
         await assertNotVisible();
@@ -378,6 +377,12 @@ describe("metabot", () => {
   });
 
   describe("message", () => {
+    it("should have a conversation id before sending any messages", async () => {
+      const { store } = setup();
+      const state = store.getState() as any;
+      expect(getMetabotConversationId(state)).not.toBeUndefined();
+    });
+
     it("should properly send chat messages", async () => {
       setup();
       fetchMock.post(

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -25,7 +25,7 @@ export type MetabotChatMessage =
 export interface MetabotState {
   useStreaming: boolean;
   isProcessing: boolean;
-  conversationId: string | undefined;
+  conversationId: string;
   messages: MetabotChatMessage[];
   visible: boolean;
   history: MetabotHistory;
@@ -33,20 +33,20 @@ export interface MetabotState {
   activeToolCall: { id: string; name: string } | undefined;
 }
 
-export const metabotInitialState: MetabotState = {
+export const getMetabotInitialState = (): MetabotState => ({
   useStreaming: false,
   isProcessing: false,
-  conversationId: undefined,
+  conversationId: uuid(),
   messages: [],
   visible: false,
   history: [],
   state: {},
   activeToolCall: undefined,
-};
+});
 
 export const metabot = createSlice({
   name: "metabase-enterprise/metabot",
-  initialState: metabotInitialState,
+  initialState: getMetabotInitialState(),
   reducers: {
     toggleStreaming: (state) => {
       state.useStreaming = !state.useStreaming;
@@ -127,7 +127,7 @@ export const metabot = createSlice({
   },
   extraReducers: (builder) => {
     builder
-      .addCase(logout.pending, () => metabotInitialState)
+      .addCase(logout.pending, getMetabotInitialState)
       // streamed response handlers
       .addCase(sendStreamedAgentRequest.pending, (state) => {
         state.isProcessing = true;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.unit.spec.ts
@@ -1,33 +1,25 @@
 import { setupEnterprisePlugins } from "__support__/enterprise";
-import { uuid } from "metabase/lib/uuid";
 import { createMockState } from "metabase-types/store/mocks";
 
-import type { MetabotState } from "./reducer";
 import {
+  type MetabotState,
   getLastAgentMessagesByType,
+  getMetabotInitialState,
   getUserPromptForMessageId,
-} from "./selectors";
+} from "./index";
 
 function setup(metabotState: Partial<MetabotState>) {
   setupEnterprisePlugins();
 
-  // NOTE: importing default initial state from ./reducer
-  // breaks the tests for some reason
-  const metabotPlugin: MetabotState = Object.assign(
-    {
-      useStreaming: false,
-      isProcessing: false,
-      messages: [],
-      state: {},
-      history: [],
-      visible: true,
-      conversationId: uuid(),
-      activeToolCall: undefined,
+  return createMockState({
+    plugins: {
+      metabotPlugin: {
+        ...getMetabotInitialState(),
+        visible: true,
+        ...metabotState,
+      },
     },
-    metabotState,
-  );
-
-  return createMockState({ plugins: { metabotPlugin } } as any);
+  } as any);
 }
 
 describe("metabot selectors", () => {


### PR DESCRIPTION
Closes [BOT-207](https://linear.app/metabase/issue/BOT-207/fix-warning-no-conversation-id)

### Description

This PR makes this warning true again:
![CleanShot 2025-06-23 at 22 34 09@2x](https://github.com/user-attachments/assets/e60d062c-a618-4df4-8794-190a4305d1c8)

The conversation id was originally being set when making metabot visible, but that's only true of embedded metabot now. This PR corrects the mistake an creates a conversation id at the time of the initial state creation. Ultimately it was getting set if it didn't exist after the warning was logged, so there's no consequences for this mistake.

### How to verify

- Start a new conversation in master, you should see this warning the first time when sending a message
- Compare to this branch, you will never see the message

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
