### PR TITLE
Fix can't download PDF on static dashboard when `titled=false` and has no tabs

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -29,7 +29,7 @@ import { openSharingMenu } from "./e2e-sharing-helpers";
  * Programmatically generate token and visit the embedded page for a question or a dashboard
  *
  * @param {EmbedPayload} payload - The {@link EmbedPayload} we pass to this function
- * @param {object=} options
+ * @param {object} [options]
  * @param {object} [options.setFilters]
  * @param {PageStyle} options.pageStyle
  * @param {object} options.additionalHashOptions

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -520,6 +520,24 @@ describe("scenarios > embedding > dashboard parameters", () => {
         H.assertSheetRowsCount(54)(sheet);
       },
     );
+
+    cy.log(
+      "The PDF download button should be clickable when there is no title, but has parameters (metabase#59503)",
+    );
+    cy.get("@dashboardId2").then((dashboardId) => {
+      const payload = {
+        resource: { dashboard: dashboardId },
+        params: {},
+      };
+      H.visitEmbeddedPage(payload, {
+        pageStyle: {
+          downloads: true,
+          titled: false,
+        },
+      });
+    });
+
+    cy.findByTestId("export-as-pdf-button").should("be.visible").click();
   });
 
   it("should send 'X-Metabase-Client' header for api requests", () => {

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.module.css
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/ExportAsPdfButton.module.css
@@ -7,4 +7,10 @@
 
 .CompactExportAsPdfButton.ParametersVisibleWithNoTabs {
   top: 1.75rem;
+  /* (metabase#59503) We want to fix this differently (here's the first attempt https://github.com/metabase/metabase/pull/59418).
+  So we should just make this work for this particular case for now rather than marking a markup change.
+
+  The reason we need `z-index: 4` here is because the parameter container is defined after this download button in the DOM, and it
+  has `z-index: 3`. */
+  z-index: 4;
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/59503

### Backport reason
This feature was [released in 55](https://metaboat.slack.com/archives/C063Q3F1HPF/p1750709241532959), so there's no need to backport further than that.

### Description

We actually wanted to fix this a different way, please see #59418, so we're just patching this [for now](https://metaboat.slack.com/archives/C063Q3F1HPF/p1750743140459749?thread_ts=1750709241.532959&cid=C063Q3F1HPF).

### How to verify

1. Create a dashboard, add one card, add a filter and connect to the card, and ensure you only have a single tab.
1. Embed with static embed, enable the parameter, and hide title.
1. Click on preview, you should be able to click the download PDF icon now.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
