### PR TITLE
Convert DashboardTabs to context

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -247,11 +247,7 @@ export function DashboardHeaderView({
             data-testid="fixed-width-dashboard-tabs"
             isFixedWidth={dashboard?.width === "fixed"}
           >
-            <DashboardTabs
-              dashboardId={dashboard.id}
-              isEditing={isEditing}
-              isNightMode={isNightMode}
-            />
+            <DashboardTabs />
           </FixedWidthContainer>
         </FullWidthContainer>
       </div>

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/tests/setup.tsx
@@ -10,6 +10,7 @@ import { setupNotificationChannelsEndpoints } from "__support__/server-mocks/pul
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, waitForLoaderToBeRemoved } from "__support__/ui";
 import { getDefaultTab } from "metabase/dashboard/actions";
+import { MockDashboardContext } from "metabase/public/containers/PublicOrEmbeddedDashboard/mock-context";
 import {
   createMockDashboard,
   createMockDashboardCard,
@@ -114,8 +115,16 @@ export const setup = async ({
   renderWithProviders(
     <Route
       path="*"
-      component={() => <DashboardHeader {...dashboardHeaderProps} />}
-    ></Route>,
+      component={() => (
+        <MockDashboardContext
+          dashboardId={dashboard.id}
+          dashboard={dashboard}
+          navigateToNewCardFromDashboard={null}
+        >
+          <DashboardHeader {...dashboardHeaderProps} />
+        </MockDashboardContext>
+      )}
+    />,
     {
       withRouter: true,
       storeInitialState: {

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
@@ -6,27 +6,17 @@ import { Sortable } from "metabase/common/components/Sortable";
 import type { TabButtonMenuItem } from "metabase/common/components/TabButton";
 import { TabButton } from "metabase/common/components/TabButton";
 import { TabRow } from "metabase/common/components/TabRow";
+import { useDashboardContext } from "metabase/dashboard/context";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { Flex } from "metabase/ui";
-import type { DashboardId } from "metabase-types/api";
 import type { SelectedTabId } from "metabase-types/store";
 
 import S from "./DashboardTabs.module.css";
 import { useDashboardTabs } from "./use-dashboard-tabs";
 
-export type DashboardTabsProps = {
-  dashboardId: DashboardId;
-  isEditing?: boolean;
-  isNightMode?: boolean;
-  className?: string;
-};
+export function DashboardTabs() {
+  const { isEditing = false, isNightMode } = useDashboardContext();
 
-export function DashboardTabs({
-  dashboardId,
-  isEditing = false,
-  isNightMode,
-  className,
-}: DashboardTabsProps) {
   const {
     tabs,
     createNewTab,
@@ -36,7 +26,7 @@ export function DashboardTabs({
     selectTab,
     selectedTabId,
     moveTab,
-  } = useDashboardTabs({ dashboardId });
+  } = useDashboardTabs();
   const hasMultipleTabs = tabs.length > 1;
   const showTabs = hasMultipleTabs || isEditing;
   const showPlaceholder = tabs.length === 0 && isEditing;
@@ -82,7 +72,7 @@ export function DashboardTabs({
       align="start"
       gap="lg"
       w="100%"
-      className={cx(S.dashboardTabs, className, {
+      className={cx(S.dashboardTabs, {
         [S.isNightMode]: isNightMode,
       })}
     >

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -1,6 +1,12 @@
 import userEvent from "@testing-library/user-event";
 import type { Location } from "history";
-import { type InjectedRouter, Link, Route, withRouter } from "react-router";
+import {
+  type InjectedRouter,
+  Link,
+  Route,
+  type WithRouterProps,
+  withRouter,
+} from "react-router";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import { INPUT_WRAPPER_TEST_ID } from "metabase/common/components/TabButton";
@@ -9,6 +15,7 @@ import { useDashboardUrlQuery } from "metabase/dashboard/hooks/use-dashboard-url
 import { getSelectedTabId } from "metabase/dashboard/selectors";
 import { createTabSlug } from "metabase/dashboard/utils";
 import { useSelector } from "metabase/lib/redux";
+import { MockDashboardContext } from "metabase/public/containers/PublicOrEmbeddedDashboard/mock-context";
 import type { DashboardTab } from "metabase-types/api";
 import type { DashboardState, State } from "metabase-types/store";
 
@@ -37,11 +44,11 @@ function setup({
 
   const RoutedDashboardComponent = withRouter(
     ({ location }: { location: Location }) => {
-      const { selectedTabId } = useDashboardTabs({ dashboardId: 1 });
+      const { selectedTabId } = useDashboardTabs();
       useDashboardUrlQuery(createMockRouter(), location);
       return (
         <>
-          <DashboardTabs dashboardId={1} isEditing={isEditing} />
+          <DashboardTabs />
           <span>Selected tab id is {selectedTabId}</span>
           <br />
           <span>Path is {location.pathname + location.search}</span>
@@ -67,7 +74,24 @@ function setup({
     <>
       <Route
         path="dashboard/:slug(/:tabSlug)"
-        component={RoutedDashboardComponent}
+        component={(props: WithRouterProps) => {
+          return (
+            <MockDashboardContext
+              dashboardId={1}
+              dashboard={{
+                ...TEST_DASHBOARD_STATE.dashboards[1],
+                dashcards: TEST_DASHBOARD_STATE.dashboards[1].dashcards.map(
+                  (dcId) => TEST_DASHBOARD_STATE.dashcards[dcId],
+                ),
+                tabs: tabs ?? TEST_DASHBOARD_STATE.dashboards[1].tabs,
+              }}
+              navigateToNewCardFromDashboard={null}
+              isEditing={isEditing}
+            >
+              <RoutedDashboardComponent {...props} />
+            </MockDashboardContext>
+          );
+        }}
       />
       <Route path="someotherpath" component={OtherComponent} />
     </>,

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
@@ -1,20 +1,10 @@
 import type { UniqueIdentifier } from "@dnd-kit/core";
 import { t } from "ttag";
 
-import {
-  createNewTab,
-  deleteTab as deleteTabAction,
-  duplicateTab as duplicateTabAction,
-  moveTab as moveTabAction,
-  renameTab,
-  selectTab,
-  undoDeleteTab,
-} from "metabase/dashboard/actions/tabs";
 import { trackTabDuplicated } from "metabase/dashboard/analytics";
-import { getSelectedTabId, getTabs } from "metabase/dashboard/selectors";
-import { useDispatch, useSelector } from "metabase/lib/redux";
+import { useDashboardContext } from "metabase/dashboard/context";
+import { useDispatch } from "metabase/lib/redux";
 import { addUndo } from "metabase/redux/undo";
-import type { DashboardId } from "metabase-types/api";
 import type { SelectedTabId } from "metabase-types/store";
 
 let tabDeletionId = 1;
@@ -23,22 +13,31 @@ function isTabIdType(id: unknown): id is SelectedTabId {
   return typeof id === "number" || id === null;
 }
 
-export function useDashboardTabs({
-  dashboardId,
-}: {
-  dashboardId: DashboardId;
-}) {
+export function useDashboardTabs() {
+  const {
+    dashboardId,
+    tabs,
+    selectedTabId,
+    duplicateTab: duplicateTabAction,
+    deleteTab: deleteTabAction,
+    undoDeleteTab,
+    moveTab: moveTabAction,
+    selectTab,
+    renameTab,
+    createNewTab,
+  } = useDashboardContext();
+
   const dispatch = useDispatch();
-  const tabs = useSelector(getTabs);
-  const selectedTabId = useSelector(getSelectedTabId);
 
   const duplicateTab = (tabId: UniqueIdentifier | null) => {
     if (!isTabIdType(tabId)) {
       throw Error("duplicateTab was called but tab id is invalid");
     }
 
-    dispatch(duplicateTabAction(tabId));
-    trackTabDuplicated(dashboardId);
+    duplicateTabAction(tabId);
+    if (dashboardId) {
+      trackTabDuplicated(dashboardId);
+    }
   };
 
   const deleteTab = (tabId: UniqueIdentifier | null) => {
@@ -52,35 +51,31 @@ export function useDashboardTabs({
     }
     const id = tabDeletionId++;
 
-    dispatch(deleteTabAction({ tabId, tabDeletionId: id }));
+    deleteTabAction({ tabId, tabDeletionId: id });
     dispatch(
       addUndo({
         message: t`Deleted "${tabName}"`,
         undo: true,
-        action: () => dispatch(undoDeleteTab({ tabDeletionId: id })),
+        action: () => undoDeleteTab({ tabDeletionId: id }),
       }),
     );
   };
 
   const moveTab = (activeId: UniqueIdentifier, overId: UniqueIdentifier) =>
-    dispatch(
-      moveTabAction({
-        sourceTabId:
-          typeof activeId === "number" ? activeId : parseInt(activeId),
-        destinationTabId:
-          typeof overId === "number" ? overId : parseInt(overId),
-      }),
-    );
+    moveTabAction({
+      sourceTabId: typeof activeId === "number" ? activeId : parseInt(activeId),
+      destinationTabId: typeof overId === "number" ? overId : parseInt(overId),
+    });
 
   return {
     tabs,
     selectedTabId,
-    createNewTab: () => dispatch(createNewTab()),
+    createNewTab,
     duplicateTab,
     deleteTab,
     renameTab: (tabId: SelectedTabId, name: string) =>
-      dispatch(renameTab({ tabId, name })),
-    selectTab: (tabId: SelectedTabId) => dispatch(selectTab({ tabId })),
+      renameTab({ tabId, name }),
+    selectTab: (tabId: SelectedTabId) => selectTab({ tabId }),
     moveTab,
   };
 }

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx
@@ -146,7 +146,7 @@ const AutomaticDashboardAppInner = () => {
                 </div>
                 {dashboard && tabs.length > 1 && (
                   <div className={cx(CS.wrapper, CS.flex, CS.alignCenter)}>
-                    <DashboardTabs dashboardId={dashboard.id} />
+                    <DashboardTabs />
                   </div>
                 )}
               </FixedWidthContainer>

--- a/frontend/src/metabase/dashboard/context/context.redux.ts
+++ b/frontend/src/metabase/dashboard/context/context.redux.ts
@@ -41,6 +41,15 @@ import {
   toggleSidebar,
   updateDashboardAndCards,
 } from "metabase/dashboard/actions";
+import {
+  createNewTab,
+  deleteTab,
+  duplicateTab,
+  moveTab,
+  renameTab,
+  selectTab,
+  undoDeleteTab,
+} from "metabase/dashboard/actions/tabs";
 import { connect } from "metabase/lib/redux";
 import {
   canManageSubscriptions,
@@ -142,6 +151,14 @@ export const mapDispatchToProps = {
   setArchivedDashboard,
   deletePermanently,
   moveDashboardToCollection,
+
+  createNewTab,
+  deleteTab,
+  duplicateTab,
+  moveTab,
+  renameTab,
+  selectTab,
+  undoDeleteTab,
 };
 
 export const connector = connect(mapStateToProps, mapDispatchToProps);

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx
@@ -128,12 +128,7 @@ export function PublicOrEmbeddedDashboardView() {
       setParameterValueToDefault={setParameterValueToDefault}
       enableParameterRequiredBehavior
       actionButtons={buttons ? <div className={CS.flex}>{buttons}</div> : null}
-      dashboardTabs={
-        dashboardId &&
-        dashboardHasTabs && (
-          <DashboardTabs dashboardId={dashboardId} isNightMode={isNightMode} />
-        )
-      }
+      dashboardTabs={dashboardId && dashboardHasTabs && <DashboardTabs />}
       background={background}
       bordered={bordered}
       titled={titled}


### PR DESCRIPTION
Closes EMB-551

Converts the DashboardTabs component into a context component. This will allow us to continue to modularize the Dashboard component.


---

from copilot:

This pull request refactors the `DashboardTabs` component and its dependencies to simplify its implementation by leveraging the `DashboardContext`. It removes redundant props and dispatch logic, consolidates tab-related actions within the context, and updates related tests and usages accordingly.

### Refactoring of `DashboardTabs` Component

* [`frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx`](diffhunk://#diff-290b606307ce55c6a21fbc091b2b5bb6de6f9306d585aa39b784201c2596c77aR9-L29): Refactored `DashboardTabs` to use `DashboardContext` for accessing `dashboardId`, `isEditing`, `isNightMode`, and tab-related actions, eliminating the need for explicit props. [[1]](diffhunk://#diff-290b606307ce55c6a21fbc091b2b5bb6de6f9306d585aa39b784201c2596c77aR9-L29) [[2]](diffhunk://#diff-290b606307ce55c6a21fbc091b2b5bb6de6f9306d585aa39b784201c2596c77aL39-R29) [[3]](diffhunk://#diff-290b606307ce55c6a21fbc091b2b5bb6de6f9306d585aa39b784201c2596c77aL85-R75)

* [`frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts`](diffhunk://#diff-8d3a4a9e8f29ee090e9c4af0cd1e888d553a781fb87afbf262183d8e70f08b36L4-L17): Updated `useDashboardTabs` hook to rely on `DashboardContext` for tab-related actions and state, removing direct Redux usage. [[1]](diffhunk://#diff-8d3a4a9e8f29ee090e9c4af0cd1e888d553a781fb87afbf262183d8e70f08b36L4-L17) [[2]](diffhunk://#diff-8d3a4a9e8f29ee090e9c4af0cd1e888d553a781fb87afbf262183d8e70f08b36L26-R40) [[3]](diffhunk://#diff-8d3a4a9e8f29ee090e9c4af0cd1e888d553a781fb87afbf262183d8e70f08b36L55-R78)

### Updates to Component Usage

* [`frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx`](diffhunk://#diff-382948855bb5f3cf36bc9f62e5b266b4d7943473b4b30b4fd26890062f5eddbbL250-R250): Simplified `DashboardTabs` usage by removing unnecessary props.

* [`frontend/src/metabase/dashboard/containers/AutomaticDashboardApp/AutomaticDashboardApp.tsx`](diffhunk://#diff-f2b11a3fafcc689c8e139c27b6f57a4702c5025d1d771b689fef380536faaf1eL149-R149): Updated `DashboardTabs` usage to align with the refactored component.

* [`frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardView.tsx`](diffhunk://#diff-b2e1a137be209e92fd484a32e17519c4d2e5d8b5808fea5f2563c3561470263dL131-R131): Adjusted `DashboardTabs` rendering to reflect the new implementation.

### Test Adjustments

* [`frontend/src/metabase/dashboard/components/DashboardHeader/tests/setup.tsx`](diffhunk://#diff-ee74f08b9cf5e58b5ed9dcb4aee52537aac52e54233c6bd943841cb361055ffcR13): Wrapped `DashboardHeader` in `MockDashboardContext` during tests to provide required context. [[1]](diffhunk://#diff-ee74f08b9cf5e58b5ed9dcb4aee52537aac52e54233c6bd943841cb361055ffcR13) [[2]](diffhunk://#diff-ee74f08b9cf5e58b5ed9dcb4aee52537aac52e54233c6bd943841cb361055ffcL117-R127)

* [`frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx`](diffhunk://#diff-8f03ad36586302ef8df59c2a7ada3de8da26e77a3edf6ea6372d70878e3109dfL3-R9): Updated tests to use `MockDashboardContext` for `DashboardTabs` and removed redundant `dashboardId` prop. [[1]](diffhunk://#diff-8f03ad36586302ef8df59c2a7ada3de8da26e77a3edf6ea6372d70878e3109dfL3-R9) [[2]](diffhunk://#diff-8f03ad36586302ef8df59c2a7ada3de8da26e77a3edf6ea6372d70878e3109dfR18) [[3]](diffhunk://#diff-8f03ad36586302ef8df59c2a7ada3de8da26e77a3edf6ea6372d70878e3109dfL40-R51) [[4]](diffhunk://#diff-8f03ad36586302ef8df59c2a7ada3de8da26e77a3edf6ea6372d70878e3109dfL70-R94)

### Consolidation of Tab Actions

* [`frontend/src/metabase/dashboard/context/context.redux.ts`](diffhunk://#diff-6fe72bca74bfb59b89b23e284a03f5f78dd092ebe0274a57ce2a0b89935b45e7R44-R52): Added tab-related actions (`createNewTab`, `deleteTab`, `duplicateTab`, etc.) to `DashboardContext` for centralized management. [[1]](diffhunk://#diff-6fe72bca74bfb59b89b23e284a03f5f78dd092ebe0274a57ce2a0b89935b45e7R44-R52) [[2]](diffhunk://#diff-6fe72bca74bfb59b89b23e284a03f5f78dd092ebe0274a57ce2a0b89935b45e7R154-R161)