### PR TITLE
Filter inactive metadata for nested deletion

### DIFF
--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -668,15 +668,15 @@
   (driver-api/cached-value
    [::table-fk-relationship table-id]
    (fn []
-     (let [table-fields   (t2/select [:model/Field :id :name :semantic_type] :table_id table-id)
+     (let [table-fields   (t2/select [:model/Field :id :name :semantic_type] :table_id table-id :active true)
            table-pks      (filter #(isa? (:semantic_type %) :type/PK) table-fields)
            pk-names       (map :name table-pks)
            fk-fields      (when-let [pk-ids (seq (map :id table-pks))]
-                            (t2/select :model/Field :fk_target_field_id [:in pk-ids]))
+                            (t2/select :model/Field :fk_target_field_id [:in pk-ids] :active true))
            ;; Pre-fetch table names to avoid repeated queries
            table-ids      (distinct (map :table_id fk-fields))
            table-id->ref  (when (seq table-ids)
-                            (t2/select-pk->fn table->ref :model/Table :id [:in table-ids]))
+                            (t2/select-pk->fn table->ref :model/Table :id [:in table-ids] :active true))
            field-id->name (u/index-by :id table-fields)]
        (for [{:keys [name table_id fk_target_field_id]} fk-fields]
          {:table-id   table_id


### PR DESCRIPTION
Similar bug to https://github.com/metabase/metabase/pull/58767, but breaking delete instead of update.

Maybe we need a linter...