### PR TITLE
Closes VIZ-1219 restore 'edit question' for regular cards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -30,7 +30,6 @@ import {
   getInitialStateForMultipleSeries,
   getInitialStateForVisualizerCard,
   isVisualizerDashboardCard,
-  isVisualizerSupportedVisualization,
 } from "metabase/visualizer/utils";
 import type {
   Card,
@@ -430,7 +429,7 @@ function DashCardInner({
           onTogglePreviewing={handlePreviewToggle}
           downloadsEnabled={downloadsEnabled}
           onEditVisualization={
-            isVisualizerSupportedVisualization(dashcard.card.display)
+            isVisualizerDashboardCard(dashcard)
               ? onEditVisualizationClick
               : undefined
           }


### PR DESCRIPTION
Closes [VIZ-1219: Revert our change to override “Edit question” for non-visualizer dashcards](https://linear.app/metabase/issue/VIZ-1219/revert-our-change-to-override-edit-question-for-non-visualizer)

### Description

<img width="1578" alt="image" src="https://github.com/user-attachments/assets/e68034d9-c571-4f64-baca-e93c5c1d979b" />
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/3b6ee4f7-853e-4c6f-bf4f-b3916a327981" />