### PR TITLE
Closes VIZ-1181 lost series formatting options

### DIFF
--- a/frontend/src/metabase/visualizer/utils/update-viz-settings-with-refs.ts
+++ b/frontend/src/metabase/visualizer/utils/update-viz-settings-with-refs.ts
@@ -35,7 +35,7 @@ export function updateVizSettingsKeysWithRefs(
 
     for (const key in settings) {
       // If the key exists in columnsToRefs, use the reference as the new key
-      const newKey = columnsToRefs[key] || key;
+      const newKey = getMappedVizSettingValue(key, columnsToRefs);
 
       // Process the value recursively
       const value = settings[key];

--- a/frontend/src/metabase/visualizer/utils/update-viz-settings-with-refs.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/update-viz-settings-with-refs.unit.spec.ts
@@ -234,4 +234,39 @@ describe("updateVizSettingsWithRefs", () => {
       ],
     });
   });
+
+  it("should handle getColumnKey names too", () => {
+    const settings: VisualizationSettings = {
+      "graph.x_axis.scale": "ordinal",
+      "graph.dimensions": ["CATEGORY"],
+      column_settings: {
+        // v-- this key doesn't directly match a column name
+        '["name","count"]': {
+          number_style: "scientific",
+          prefix: "Around ",
+          suffix: "-ish",
+        },
+      },
+      "graph.metrics": ["count"],
+    };
+    const columnsToRefs = {
+      CATEGORY: "COLUMN_1",
+      count: "COLUMN_2",
+    };
+
+    const result = updateVizSettingsWithRefs(settings, columnsToRefs);
+
+    expect(result).toEqual({
+      "graph.x_axis.scale": "ordinal",
+      "graph.dimensions": ["CATEGORY"],
+      column_settings: {
+        '["name","COLUMN_2"]': {
+          number_style: "scientific",
+          prefix: "Around ",
+          suffix: "-ish",
+        },
+      },
+      "graph.metrics": ["count"],
+    });
+  });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59580
Closes [VIZ-1181: Series formatting set in the Question is Lost When you Make any Dashboard Level Change via the Visualizer](https://linear.app/metabase/issue/VIZ-1181/series-formatting-set-in-the-question-is-lost-when-you-make-any)

### Description

<img width="1579" alt="image" src="https://github.com/user-attachments/assets/0bdeeaf3-a758-4a50-8475-bdcbb10c4a71" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
