### PR TITLE
feat: move-out built-in actions on editables into a separate settings tab

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
@@ -122,11 +122,16 @@ export const ConfigureTableActions = ({
   );
 
   return (
-    <Stack gap="sm" data-testid="editable-table-connected-actions-list">
-      <Text fw={700}>{t`Connected actions`}</Text>
-      <Stack gap="sm" mb="lg">
-        {tableActions?.length ? (
-          tableActions?.map((action) => {
+    <Stack gap="xl" data-testid="editable-table-connected-actions-list">
+      <Button
+        variant="active"
+        onClick={openEditingModal}
+      >{t`Add new connected action`}</Button>
+
+      {tableActions && tableActions.length > 0 && (
+        <Stack gap="sm">
+          <Text fw={700} size="lg">{t`Connected actions`}</Text>
+          {tableActions?.map((action) => {
             return (
               <RowActionItem
                 key={action.id}
@@ -136,16 +141,9 @@ export const ConfigureTableActions = ({
                 onEnable={updateAction}
               />
             );
-          })
-        ) : (
-          <Text>{t`Create, connect, pass data around`}</Text>
-        )}
-      </Stack>
-
-      <Button
-        variant="active"
-        onClick={openEditingModal}
-      >{t`Add new connected action`}</Button>
+          })}
+        </Stack>
+      )}
 
       {isEditingModalOpen && (
         <Modal.Root

--- a/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/ConfigureEditableTableSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/ConfigureEditableTableSidebar.tsx
@@ -9,7 +9,8 @@ import { getDashCardById, getSidebar } from "../../selectors";
 
 import { ConfigureEditableTableColumns } from "./ConfigureEditableTableColumns";
 import { ConfigureEditableTableFilters } from "./ConfigureEditableTableFilters";
-import { ConfigureDashcardEditableTableActions } from "./actions/ConfigureDashcardEditableTableActions";
+import { ConfigureDashcardBuiltInTableActions } from "./actions/ConfigureDashcardBuiltInTableActions";
+import { ConfigureDashcardCustomTableActions } from "./actions/ConfigureDashcardCustomTableActions";
 
 interface ConfigureEditableTableSidebarProps {
   dashboard: Dashboard;
@@ -38,6 +39,7 @@ export function ConfigureEditableTableSidebar({
             <Tabs.Tab value="columns">{t`Columns`}</Tabs.Tab>
             <Tabs.Tab value="filters">{t`Filters`}</Tabs.Tab>
             <Tabs.Tab value="actions">{t`Actions`}</Tabs.Tab>
+            <Tabs.Tab value="settings">{t`Settings`}</Tabs.Tab>
 
             <Flex flex="1" justify="flex-end" align="center">
               <ActionIcon onClick={onClose}>
@@ -54,10 +56,13 @@ export function ConfigureEditableTableSidebar({
               <ConfigureEditableTableFilters dashcard={dashcard} />
             </Tabs.Panel>
             <Tabs.Panel value="actions">
-              <ConfigureDashcardEditableTableActions
+              <ConfigureDashcardCustomTableActions
                 dashboard={dashboard}
                 dashcard={dashcard}
               />
+            </Tabs.Panel>
+            <Tabs.Panel value="settings">
+              <ConfigureDashcardBuiltInTableActions dashcard={dashcard} />
             </Tabs.Panel>
           </Box>
         </Tabs>

--- a/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/actions/ConfigureDashcardBuiltInTableActions.tsx
+++ b/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/actions/ConfigureDashcardBuiltInTableActions.tsx
@@ -7,11 +7,8 @@ import { uuid } from "metabase/lib/uuid";
 import { PLUGIN_TABLE_ACTIONS } from "metabase/plugins";
 import { Checkbox, Stack, Text } from "metabase/ui";
 import type {
-  Dashboard,
   DashboardCard,
   EditableTableBuiltInActionDisplaySettings,
-  TableActionDisplaySettings,
-  TableRowActionDisplaySettings,
 } from "metabase-types/api";
 
 const DEFAULT_ACTIONS = [
@@ -35,16 +32,14 @@ const DEFAULT_ACTIONS = [
   },
 ];
 
-export const ConfigureDashcardEditableTableActions = ({
-  dashboard,
+export const ConfigureDashcardBuiltInTableActions = ({
   dashcard,
 }: {
-  dashboard: Dashboard;
   dashcard: DashboardCard;
 }) => {
   const dispatch = useDispatch();
 
-  const { enabledActions, tableActions, builtInActionsMap } = useMemo(() => {
+  const { enabledActions, builtInActionsMap } = useMemo(() => {
     const enabledActions =
       dashcard.visualization_settings?.["editableTable.enabledActions"] ?? [];
 
@@ -52,8 +47,6 @@ export const ConfigureDashcardEditableTableActions = ({
       EditableTableBuiltInActionDisplaySettings["actionId"],
       EditableTableBuiltInActionDisplaySettings
     >();
-
-    const tableActions: TableRowActionDisplaySettings[] = [];
 
     enabledActions.forEach((tableActionSettings) => {
       if (
@@ -63,12 +56,10 @@ export const ConfigureDashcardEditableTableActions = ({
           tableActionSettings.actionId,
           tableActionSettings,
         );
-      } else {
-        tableActions.push(tableActionSettings as TableRowActionDisplaySettings);
       }
     });
 
-    return { enabledActions, tableActions, builtInActionsMap };
+    return { enabledActions, builtInActionsMap };
   }, [dashcard.visualization_settings]);
 
   const tableColumns = useMemo(() => {
@@ -135,57 +126,34 @@ export const ConfigureDashcardEditableTableActions = ({
     [enabledActions, dispatch, dashcard.id, tableColumns],
   );
 
-  const handleUpdateRowActions = useCallback(
-    (newActions: TableActionDisplaySettings[]) => {
-      const builtIns = enabledActions.filter(
-        PLUGIN_TABLE_ACTIONS.isBuiltInEditableTableAction,
-      );
-
-      dispatch(
-        onUpdateDashCardVisualizationSettings(dashcard.id, {
-          "editableTable.enabledActions": [...builtIns, ...newActions],
-        }),
-      );
-    },
-    [dashcard.id, dispatch, enabledActions],
-  );
-
-  const ConfigureTableActions = PLUGIN_TABLE_ACTIONS.ConfigureTableActions;
-
   return (
-    <Stack gap="lg">
-      <Stack gap="sm">
-        <Text fw={700}>{t`Default actions`}</Text>
-        <Stack gap="sm">
-          {DEFAULT_ACTIONS.map(({ actionId, label }) => {
-            const isEnabled = builtInActionsMap.get(actionId)?.enabled || false;
-            const isIndeterminate =
-              actionId === "data-grid.row/update" &&
-              !isEnabled &&
-              editableColumns.length > 0;
+    <Stack gap="sm">
+      <Text size="lg" fw={700}>{t`Permissions`}</Text>
+      <Text
+        c="text-secondary"
+        lh={1.4}
+      >{t`Configure what default actions end users will be able to do when viewing this dashcard.`}</Text>
+      <Stack gap="sm" mt="sm">
+        {DEFAULT_ACTIONS.map(({ actionId, label }) => {
+          const isEnabled = builtInActionsMap.get(actionId)?.enabled || false;
+          const isIndeterminate =
+            actionId === "data-grid.row/update" &&
+            !isEnabled &&
+            editableColumns.length > 0;
 
-            return (
-              <Checkbox
-                key={actionId}
-                label={label}
-                indeterminate={isIndeterminate}
-                checked={isIndeterminate || isEnabled}
-                onChange={() =>
-                  handleToggleBuiltInAction({ actionId, enabled: !isEnabled })
-                }
-              />
-            );
-          })}
-        </Stack>
+          return (
+            <Checkbox
+              key={actionId}
+              label={label}
+              indeterminate={isIndeterminate}
+              checked={isIndeterminate || isEnabled}
+              onChange={() =>
+                handleToggleBuiltInAction({ actionId, enabled: !isEnabled })
+              }
+            />
+          );
+        })}
       </Stack>
-
-      {dashboard && (
-        <ConfigureTableActions
-          value={tableActions}
-          onChange={handleUpdateRowActions}
-          cols={tableColumns}
-        />
-      )}
     </Stack>
   );
 };

--- a/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/actions/ConfigureDashcardCustomTableActions.tsx
+++ b/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/actions/ConfigureDashcardCustomTableActions.tsx
@@ -83,7 +83,7 @@ export const ConfigureDashcardCustomTableActions = ({
           {showMetabaseLinks && (
             <>
               {" "}
-              {jt`You can ${(<ExternalLink href={docsLink}>{t`learn more`}</ExternalLink>)}  about it here.`}
+              {jt`You can ${(<ExternalLink href={docsLink}>{t`learn more`}</ExternalLink>)} about it here.`}
             </>
           )}
         </Text>

--- a/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/actions/ConfigureDashcardCustomTableActions.tsx
+++ b/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/actions/ConfigureDashcardCustomTableActions.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useMemo } from "react";
+import { jt, t } from "ttag";
+
+import ExternalLink from "metabase/common/components/ExternalLink";
+import { onUpdateDashCardVisualizationSettings } from "metabase/dashboard/actions";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { PLUGIN_TABLE_ACTIONS } from "metabase/plugins";
+import { getDocsUrl } from "metabase/selectors/settings";
+import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
+import { Box, Stack, Text } from "metabase/ui";
+import type {
+  Dashboard,
+  DashboardCard,
+  TableActionDisplaySettings,
+  TableRowActionDisplaySettings,
+} from "metabase-types/api";
+
+export const ConfigureDashcardCustomTableActions = ({
+  dashboard,
+  dashcard,
+}: {
+  dashboard: Dashboard;
+  dashcard: DashboardCard;
+}) => {
+  const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+  const docsLink = useSelector((state) =>
+    getDocsUrl(state, { page: "actions/custom" }),
+  );
+  const dispatch = useDispatch();
+
+  const { enabledActions, tableActions } = useMemo(() => {
+    const enabledActions =
+      dashcard.visualization_settings?.["editableTable.enabledActions"] ?? [];
+
+    const tableActions: TableRowActionDisplaySettings[] = [];
+
+    enabledActions.forEach((tableActionSettings) => {
+      if (
+        !PLUGIN_TABLE_ACTIONS.isBuiltInEditableTableAction(tableActionSettings)
+      ) {
+        tableActions.push(tableActionSettings as TableRowActionDisplaySettings);
+      }
+    });
+
+    return { enabledActions, tableActions };
+  }, [dashcard.visualization_settings]);
+
+  const tableColumns = useMemo(() => {
+    const fieldsWithRemmapedColumns = dashcard.card.result_metadata ?? [];
+    const fields = fieldsWithRemmapedColumns.filter((field) => {
+      if ("remapped_from" in field) {
+        return !field.remapped_from;
+      }
+      return true;
+    });
+
+    return fields;
+  }, [dashcard.card.result_metadata]);
+
+  const handleUpdateRowActions = useCallback(
+    (newActions: TableActionDisplaySettings[]) => {
+      const builtIns = enabledActions.filter(
+        PLUGIN_TABLE_ACTIONS.isBuiltInEditableTableAction,
+      );
+
+      dispatch(
+        onUpdateDashCardVisualizationSettings(dashcard.id, {
+          "editableTable.enabledActions": [...builtIns, ...newActions],
+        }),
+      );
+    },
+    [dashcard.id, dispatch, enabledActions],
+  );
+
+  const ConfigureTableActions = PLUGIN_TABLE_ACTIONS.ConfigureTableActions;
+
+  return (
+    <Stack gap="lg">
+      <Stack gap="sm">
+        <Text size="lg" fw={700}>{t`Table actions`}</Text>
+        <Text c="text-secondary" lh={1.4}>
+          {jt`Create powerful actions to automate tasks or keep values across tables in sync.`}
+          {showMetabaseLinks && (
+            <>
+              {" "}
+              {jt`You can ${(<ExternalLink href={docsLink}>{t`learn more`}</ExternalLink>)}  about it here.`}
+            </>
+          )}
+        </Text>
+
+        {dashboard && (
+          <Box mt="md">
+            <ConfigureTableActions
+              value={tableActions}
+              onChange={handleUpdateRowActions}
+              cols={tableColumns}
+            />
+          </Box>
+        )}
+      </Stack>
+    </Stack>
+  );
+};


### PR DESCRIPTION
Resolves [WRK-557](https://linear.app/metabase/issue/WRK-557/move-out-built-in-actions-on-editables-into-a-separate-settings-tab)

<img width="433" alt="image" src="https://github.com/user-attachments/assets/337f09fa-7f47-4184-a527-c11741a5a6b4" />
<img width="395" alt="image" src="https://github.com/user-attachments/assets/44323a3c-d54f-47a0-9e11-0671ecfedc97" />

