### PR TITLE
Closes VIZ-1217 undo/redo labels

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -409,8 +409,8 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
 
     H.modal().within(() => {
-      cy.findByLabelText("Back").as("undoButton");
-      cy.findByLabelText("Forward").as("redoButton");
+      cy.findByLabelText("Undo").as("undoButton");
+      cy.findByLabelText("Redo").as("redoButton");
 
       cy.get("@undoButton").should("be.disabled");
       cy.get("@redoButton").should("be.disabled");
@@ -497,8 +497,8 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     H.clickVisualizeAnotherWay(ORDERS_COUNT_BY_CREATED_AT.name);
 
     H.modal().within(() => {
-      cy.findByLabelText("Back").as("undoButton");
-      cy.findByLabelText("Forward").as("redoButton");
+      cy.findByLabelText("Undo").as("undoButton");
+      cy.findByLabelText("Redo").as("redoButton");
 
       cy.get("@undoButton").should("be.disabled");
       cy.get("@redoButton").should("be.disabled");

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -90,10 +90,10 @@ export function Header({
       <div style={{ flexGrow: 1 }} />
 
       <Button.Group>
-        <Tooltip label={t`Back`}>
+        <Tooltip label={t`Undo`}>
           <Button
             size="sm"
-            aria-label={t`Back`}
+            aria-label={t`Undo`}
             disabled={!canUndo}
             onClick={undo}
             leftSection={
@@ -104,10 +104,10 @@ export function Header({
             }
           />
         </Tooltip>
-        <Tooltip label={t`Forward`}>
+        <Tooltip label={t`Redo`}>
           <Button
             size="sm"
-            aria-label={t`Forward`}
+            aria-label={t`Redo`}
             disabled={!canRedo}
             onClick={redo}
             leftSection={


### PR DESCRIPTION
Closes [VIZ-1217: Tooltips on undo / redo aren’t self-explanatory what they do](https://linear.app/metabase/issue/VIZ-1217/tooltips-on-undo-redo-arent-self-explanatory-what-they-do)

### Description
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/85316880-bed6-43f8-bc85-8680620cf584" />


<img width="1578" alt="image" src="https://github.com/user-attachments/assets/0da639e9-c40d-4296-8129-295708040013" />
