### PR TITLE
QUE-1363: Custom expression fallback

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/clause.ts
+++ b/frontend/src/metabase-lib/v1/expressions/clause.ts
@@ -69,11 +69,10 @@ export const clausesForMode = _.memoize(
     return Object.keys(base)
       .map(getClauseDefinition)
       .filter(isNotNull)
-      .filter(function disableOffsetInFilterExpressions(clause) {
+      .filter(function excludeOffsetInFilterExpressions(clause) {
         const isOffset = clause.name === "offset";
         const isFilterExpression = expressionMode === "filter";
-        const isOffsetInFilterExpression = isOffset && isFilterExpression;
-        return !isOffsetInFilterExpression;
+        return !isOffset || !isFilterExpression;
       })
       .sort((a, b) => a.name.localeCompare(b.name));
   },

--- a/frontend/src/metabase-lib/v1/expressions/clause.ts
+++ b/frontend/src/metabase-lib/v1/expressions/clause.ts
@@ -1,4 +1,4 @@
-import { memoize } from "underscore";
+import _ from "underscore";
 
 import { isNotNull } from "metabase/lib/types";
 import type * as Lib from "metabase-lib";
@@ -59,7 +59,7 @@ export function getMBQLName(
   return EXPRESSION_TO_MBQL_NAME.get(expressionName.trim().toLowerCase());
 }
 
-export const clausesForMode = memoize(
+export const clausesForMode = _.memoize(
   (expressionMode: Lib.ExpressionMode) => {
     const base =
       expressionMode === "aggregation"

--- a/frontend/src/metabase-lib/v1/expressions/complete/aggregations.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/aggregations.ts
@@ -1,11 +1,9 @@
 import type { CompletionContext } from "@codemirror/autocomplete";
 
-import { isNotNull } from "metabase/lib/types";
 import type * as Lib from "metabase-lib";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 
-import { getClauseDefinition } from "../clause";
-import { AGGREGATION_FUNCTIONS } from "../config";
+import { clausesForMode } from "../clause";
 import { GROUP } from "../pratt";
 import { getDatabase } from "../utils";
 
@@ -36,11 +34,8 @@ export function suggestAggregations({
   }
 
   const database = getDatabase(query, metadata);
-  const aggregations = Object.keys(AGGREGATION_FUNCTIONS)
-    .map(getClauseDefinition)
-    .filter(isNotNull)
+  const aggregations = clausesForMode(expressionMode)
     .filter((clause) => database?.hasFeature(clause.requiresFeature))
-    .sort((a, b) => a.name.localeCompare(b.name))
     .map((agg) =>
       expressionClauseCompletion(agg, {
         type: "aggregation",

--- a/frontend/src/metabase-lib/v1/expressions/complete/aggregations.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/aggregations.ts
@@ -20,7 +20,6 @@ export type Options = {
   query: Lib.Query;
   expressionMode: Lib.ExpressionMode;
   metadata: Metadata;
-  reportTimezone?: string;
 };
 
 export function suggestAggregations({

--- a/frontend/src/metabase-lib/v1/expressions/complete/aggregations.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/aggregations.ts
@@ -27,7 +27,6 @@ export function suggestAggregations({
   expressionMode,
   query,
   metadata,
-  reportTimezone,
 }: Options) {
   if (expressionMode !== "aggregation") {
     return null;
@@ -36,13 +35,7 @@ export function suggestAggregations({
   const database = getDatabase(query, metadata);
   const aggregations = clausesForMode(expressionMode)
     .filter((clause) => database?.hasFeature(clause.requiresFeature))
-    .map((agg) =>
-      expressionClauseCompletion(agg, {
-        type: "aggregation",
-        database,
-        reportTimezone,
-      }),
-    );
+    .map((agg) => expressionClauseCompletion(agg, { type: "aggregation" }));
 
   const matcher = fuzzyMatcher(aggregations);
 

--- a/frontend/src/metabase-lib/v1/expressions/complete/aggregations.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/aggregations.unit.spec.ts
@@ -61,7 +61,6 @@ describe("suggestAggregations", () => {
       options: [
         {
           apply: expect.any(Function),
-          detail: "Returns the count of rows in the selected data.",
           displayLabel: "Count",
           icon: "function",
           label: "Count",
@@ -70,7 +69,6 @@ describe("suggestAggregations", () => {
         },
         {
           apply: expect.any(Function),
-          detail: "Only counts rows where the condition is `true`.",
           displayLabel: "CountIf",
           icon: "function",
           label: "CountIf",
@@ -79,7 +77,6 @@ describe("suggestAggregations", () => {
         },
         {
           apply: expect.any(Function),
-          detail: "The additive total of rows across a breakout.",
           displayLabel: "CumulativeCount",
           icon: "function",
           label: "CumulativeCount",
@@ -91,7 +88,6 @@ describe("suggestAggregations", () => {
           type: "aggregation",
         },
         {
-          detail: "The rolling sum of a column across a breakout.",
           displayLabel: "CumulativeSum",
           label: "CumulativeSum",
           matches: [
@@ -144,7 +140,6 @@ describe("suggestAggregations", () => {
           {
             label: "StandardDeviation",
             displayLabel: "StandardDeviation",
-            detail: "Calculates the standard deviation of the column.",
             matches: [[0, 10]],
             type: "aggregation",
             icon: "function",

--- a/frontend/src/metabase-lib/v1/expressions/complete/aggregations.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/aggregations.unit.spec.ts
@@ -25,7 +25,6 @@ describe("suggestAggregations", () => {
       expressionMode,
       query,
       metadata,
-      reportTimezone: "America/New_York",
     });
 
     return function (doc: string) {

--- a/frontend/src/metabase-lib/v1/expressions/complete/complete.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/complete.ts
@@ -8,7 +8,6 @@ export type SuggestOptions = {
   query: Lib.Query;
   stageIndex: number;
   metadata: Metadata;
-  reportTimezone?: string;
   expressionMode: Lib.ExpressionMode;
   expressionIndex: number | undefined;
 };

--- a/frontend/src/metabase-lib/v1/expressions/complete/functions.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/functions.ts
@@ -29,12 +29,7 @@ export type Options = {
   reportTimezone?: string;
 };
 
-export function suggestFunctions({
-  expressionMode,
-  query,
-  metadata,
-  reportTimezone,
-}: Options) {
+export function suggestFunctions({ expressionMode, query, metadata }: Options) {
   if (expressionMode !== "expression" && expressionMode !== "filter") {
     return null;
   }
@@ -45,8 +40,6 @@ export function suggestFunctions({
     .map((func) =>
       expressionClauseCompletion(func, {
         type: "function",
-        database,
-        reportTimezone,
       }),
     );
 

--- a/frontend/src/metabase-lib/v1/expressions/complete/functions.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/functions.ts
@@ -26,7 +26,6 @@ export type Options = {
   expressionMode: Lib.ExpressionMode;
   query: Lib.Query;
   metadata: Metadata;
-  reportTimezone?: string;
 };
 
 export function suggestFunctions({ expressionMode, query, metadata }: Options) {

--- a/frontend/src/metabase-lib/v1/expressions/complete/functions.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/functions.ts
@@ -1,11 +1,9 @@
 import type { CompletionContext } from "@codemirror/autocomplete";
 
-import { isNotNull } from "metabase/lib/types";
 import type * as Lib from "metabase-lib";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 
-import { getClauseDefinition } from "../clause";
-import { EXPRESSION_FUNCTIONS } from "../config";
+import { clausesForMode } from "../clause";
 import {
   GROUP,
   LOGICAL_AND,
@@ -42,17 +40,8 @@ export function suggestFunctions({
   }
 
   const database = getDatabase(query, metadata);
-  const functions = Object.keys(EXPRESSION_FUNCTIONS)
-    .map(getClauseDefinition)
-    .filter(isNotNull)
+  const functions = clausesForMode(expressionMode)
     .filter((clause) => database?.hasFeature(clause.requiresFeature))
-    .filter(function disableOffsetInFilterExpressions(clause) {
-      const isOffset = clause.name === "offset";
-      const isFilterExpression = expressionMode === "filter";
-      const isOffsetInFilterExpression = isOffset && isFilterExpression;
-      return !isOffsetInFilterExpression;
-    })
-    .sort((a, b) => a.name.localeCompare(b.name))
     .map((func) =>
       expressionClauseCompletion(func, {
         type: "function",

--- a/frontend/src/metabase-lib/v1/expressions/complete/functions.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/functions.unit.spec.ts
@@ -41,7 +41,6 @@ describe("suggestFunctions", () => {
       {
         label: "concat",
         displayLabel: "concat",
-        detail: "Combine two or more strings of text together.",
         matches: [[0, 3]],
         type: "function",
         icon: "function",
@@ -50,8 +49,6 @@ describe("suggestFunctions", () => {
       {
         label: "contains",
         displayLabel: "contains",
-        detail:
-          "Returns `true` if `$string1` contains `$string2` within it (or `$string3`, etc. if specified).",
         matches: [
           [0, 2],
           [6, 6],
@@ -63,8 +60,6 @@ describe("suggestFunctions", () => {
       {
         label: "second",
         displayLabel: "second",
-        detail:
-          "Takes a datetime and returns an integer (`0`-`59`) with the number of the seconds in the minute.",
         matches: [[2, 4]],
         type: "function",
         icon: "function",
@@ -73,8 +68,6 @@ describe("suggestFunctions", () => {
       {
         label: "doesNotContain",
         displayLabel: "doesNotContain",
-        detail:
-          "Returns `true` if `$string1` does not contain `$string2` within it (and `$string3`, etc. if specified).",
         matches: [
           [1, 1],
           [4, 5],
@@ -87,8 +80,6 @@ describe("suggestFunctions", () => {
       },
       {
         apply: expect.any(Function),
-        detail:
-          "Looks at the values in each argument in order and returns the first non-null value for each row.",
         displayLabel: "coalesce",
         icon: "function",
         label: "coalesce",
@@ -100,8 +91,6 @@ describe("suggestFunctions", () => {
       },
       {
         apply: expect.any(Function),
-        detail:
-          "Takes a datetime and returns an integer (`1`-`12`) with the number of the month in the year.",
         displayLabel: "month",
         icon: "function",
         label: "month",
@@ -110,8 +99,6 @@ describe("suggestFunctions", () => {
       },
       {
         apply: expect.any(Function),
-        detail:
-          'Returns the localized short name (eg. `"Apr"`) for the given month number (eg. `4`)',
         displayLabel: "monthName",
         icon: "function",
         label: "monthName",
@@ -192,8 +179,6 @@ describe("suggestFunctions", () => {
         {
           label: "case",
           displayLabel: "case",
-          detail:
-            "Alias for `if()`. Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met.",
           matches: [[0, 2]],
           type: "function",
           icon: "function",
@@ -224,8 +209,6 @@ describe("suggestFunctions", () => {
       ).toEqual({
         label: "regexExtract",
         displayLabel: "regexExtract",
-        detail:
-          "Extracts matching substrings according to a regular expression.",
         matches: [[0, 3]],
         icon: "function",
         type: "function",

--- a/frontend/src/metabase-lib/v1/expressions/complete/functions.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/functions.unit.spec.ts
@@ -9,7 +9,6 @@ import { type Options, suggestFunctions } from "./functions";
 describe("suggestFunctions", () => {
   function setup({
     expressionMode = "expression",
-    reportTimezone = "America/New_York",
     features = undefined,
   }: Partial<Options> & {
     features?: DatabaseFeature[];
@@ -26,7 +25,6 @@ describe("suggestFunctions", () => {
       expressionMode,
       query,
       metadata,
-      reportTimezone,
     });
 
     return function (doc: string) {

--- a/frontend/src/metabase-lib/v1/expressions/complete/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/index.ts
@@ -1,2 +1,3 @@
 export * from "./complete";
+export { expressionClauseSnippet } from "./util";
 export { type Completion } from "./types";

--- a/frontend/src/metabase-lib/v1/expressions/complete/util.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/util.ts
@@ -1,9 +1,6 @@
 import { snippetCompletion } from "@codemirror/autocomplete";
 import Fuse from "fuse.js";
 
-import type Database from "metabase-lib/v1/metadata/Database";
-
-import { getHelpText } from "../help-text";
 import {
   CALL,
   END_OF_INPUT,
@@ -21,38 +18,18 @@ export function expressionClauseCompletion(
   clause: MBQLClauseFunctionConfig,
   {
     type,
-    database,
-    reportTimezone,
     matches,
   }: {
     type: string;
-    database: Database | null;
-    reportTimezone?: string;
     matches?: [number, number][];
   },
 ): Completion {
-  const helpText =
-    clause.name &&
-    database &&
-    getHelpText(clause.name, database, reportTimezone);
-
-  if (helpText) {
-    const completion = snippetCompletion(expressionClauseSnippet(clause), {
-      type,
-      label: clause.displayName,
-      displayLabel: clause.displayName,
-      detail: helpText.description,
-    });
-    return { ...completion, icon: "function", matches };
-  }
-
-  return {
+  const completion = snippetCompletion(expressionClauseSnippet(clause), {
     type,
     label: clause.displayName,
     displayLabel: clause.displayName,
-    icon: "function",
-    matches,
-  };
+  });
+  return { ...completion, icon: "function", matches };
 }
 
 export function expressionClauseSnippet(clause: MBQLClauseFunctionConfig) {

--- a/frontend/src/metabase-lib/v1/expressions/complete/util.ts
+++ b/frontend/src/metabase-lib/v1/expressions/complete/util.ts
@@ -3,7 +3,7 @@ import Fuse from "fuse.js";
 
 import type Database from "metabase-lib/v1/metadata/Database";
 
-import { type HelpText, getHelpText } from "../help-text";
+import { getHelpText } from "../help-text";
 import {
   CALL,
   END_OF_INPUT,
@@ -37,7 +37,7 @@ export function expressionClauseCompletion(
     getHelpText(clause.name, database, reportTimezone);
 
   if (helpText) {
-    const completion = snippetCompletion(getSnippet(helpText), {
+    const completion = snippetCompletion(expressionClauseSnippet(clause), {
       type,
       label: clause.displayName,
       displayLabel: clause.displayName,
@@ -55,14 +55,14 @@ export function expressionClauseCompletion(
   };
 }
 
-function getSnippet(helpText: HelpText) {
+export function expressionClauseSnippet(clause: MBQLClauseFunctionConfig) {
   const args =
-    helpText.args
+    clause.args
       .filter((arg) => arg.name !== "…")
       .map((arg) => "${" + (arg.template ?? arg.name) + "}")
       .join(", ") ?? "";
 
-  return `${helpText.displayName}(${args})`;
+  return `${clause.displayName}(${args})`;
 }
 
 export function fuzzyMatcher(options: Completion[]) {

--- a/frontend/src/metabase-lib/v1/expressions/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/index.ts
@@ -8,3 +8,4 @@ export * from "./errors";
 export * from "./clause";
 export * from "./mode";
 export * from "./help-text";
+export * from "./complete";

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -43,6 +43,7 @@ type Props<
   id?: string;
   onChange?: (item: TItem) => void;
   onChangeSection?: (section: TSection, sectionIndex: number) => boolean | void;
+  onChangeSearchText?: (searchText: string) => void;
   openSection?: number;
   role?: string;
   searchProp?: SearchProps<TItem>;
@@ -250,6 +251,7 @@ export class AccordionList<
 
   handleChangeSearchText = (searchText: string) => {
     this.setState({ searchText, cursor: null });
+    this.props.onChangeSearchText?.(searchText);
   };
 
   getFirstSelectedItemCursor = () => {

--- a/frontend/src/metabase/common/components/AccordionList/types.ts
+++ b/frontend/src/metabase/common/components/AccordionList/types.ts
@@ -19,6 +19,7 @@ export type Section<TItem extends Item = Item> = {
   loading?: boolean;
   className?: string;
   items?: TItem[];
+  alwaysSortLast?: boolean;
 };
 
 export type Row<TItem extends Item, TSection extends Section<TItem>> = {

--- a/frontend/src/metabase/common/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/common/components/AccordionList/utils.ts
@@ -283,7 +283,18 @@ function sortAndFilterSections<
       ({ sectionScore, section }) =>
         section.type || sectionScore < scores.threshold,
     )
-    .sort((a, b) => a.sectionScore - b.sectionScore);
+    .sort((a, b) => {
+      if (a.section.alwaysSortLast && b.section.alwaysSortLast) {
+        return 0;
+      }
+      if (a.section.alwaysSortLast) {
+        return 1;
+      }
+      if (b.section.alwaysSortLast) {
+        return -1;
+      }
+      return a.sectionScore - b.sectionScore;
+    });
 }
 
 function sortAndFilterItems<TItem extends Item>(

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -253,7 +253,7 @@ describe("AggregationPicker", () => {
       ).toHaveAttribute("aria-selected", "true");
       expect(
         screen.getByRole("option", { name: "Sum of ..." }),
-      ).not.toHaveAttribute("aria-selected");
+      ).toHaveAttribute("aria-selected", "false");
     });
 
     it("should highlight selected operator column", () => {

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -1,9 +1,6 @@
-import type { EditorState } from "@codemirror/state";
+import { EditorSelection, type EditorState } from "@codemirror/state";
 import { useDisclosure } from "@mantine/hooks";
-import CodeMirror, {
-  EditorSelection,
-  type ReactCodeMirrorRef,
-} from "@uiw/react-codemirror";
+import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import cx from "classnames";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useMount } from "react-use";
@@ -15,6 +12,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { Button, Tooltip as ButtonTooltip, Flex, Icon } from "metabase/ui";
 import type * as Lib from "metabase-lib";
 import {
+  type DefinedClauseName,
   type ExpressionError,
   diagnoseAndCompile,
   format,
@@ -36,6 +34,7 @@ import { Tooltip } from "./Tooltip";
 import { DEBOUNCE_VALIDATION_MS } from "./constants";
 import { useCustomTooltip } from "./custom-tooltip";
 import { useExtensions } from "./extensions";
+import { useInitialClause } from "./utils";
 
 type EditorProps = {
   id?: string;
@@ -49,6 +48,7 @@ type EditorProps = {
   error?: ExpressionError | Error | null;
   hasHeader?: boolean;
   onCloseEditor?: () => void;
+  initialExpressionClause?: DefinedClauseName | null;
 
   onChange: (
     clause: Lib.ExpressionClause | null,
@@ -74,6 +74,7 @@ export function Editor(props: EditorProps) {
     shortcuts,
     hasHeader,
     onCloseEditor,
+    initialExpressionClause,
   } = props;
 
   const ref = useRef<ReactCodeMirrorRef>(null);
@@ -145,6 +146,10 @@ export function Editor(props: EditorProps) {
     );
   }, []);
 
+  const applyInitialSnippet = useInitialClause({
+    initialExpressionClause,
+  });
+
   return (
     <>
       <LayoutMain className={cx(S.wrapper, { [S.formatting]: isFormatting })}>
@@ -163,6 +168,7 @@ export function Editor(props: EditorProps) {
           width="100%"
           indentWithTab={false}
           autoFocus
+          onCreateEditor={applyInitialSnippet}
         />
         <Errors error={error} />
 

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -119,7 +119,6 @@ export function Editor(props: EditorProps) {
     query,
     stageIndex,
     expressionIndex,
-    reportTimezone,
     metadata,
     extensions: [customTooltip],
   });

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/extensions.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/extensions.ts
@@ -23,7 +23,6 @@ type Options = {
   stageIndex: number;
   expressionIndex: number | undefined;
   metadata: Metadata;
-  reportTimezone?: string;
   extensions?: Extension[];
 };
 
@@ -46,7 +45,6 @@ export function useExtensions(options: Options): Extension[] {
     query,
     stageIndex,
     expressionIndex,
-    reportTimezone,
     metadata,
     extensions: extra = [],
   } = options;
@@ -95,7 +93,6 @@ export function useExtensions(options: Options): Extension[] {
       suggestions({
         query,
         stageIndex,
-        reportTimezone,
         expressionMode,
         expressionIndex,
         metadata,
@@ -115,7 +112,6 @@ export function useExtensions(options: Options): Extension[] {
     stageIndex,
     expressionIndex,
     metadata,
-    reportTimezone,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     ...extra,
   ]);

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/utils.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/utils.ts
@@ -1,0 +1,36 @@
+import { snippet } from "@codemirror/autocomplete";
+import type { EditorView } from "@codemirror/view";
+import { useCallback } from "react";
+
+import {
+  type DefinedClauseName,
+  expressionClauseSnippet,
+  getClauseDefinition,
+} from "metabase-lib/v1/expressions";
+
+export function useInitialClause({
+  initialExpressionClause,
+}: {
+  initialExpressionClause?: DefinedClauseName | null;
+}) {
+  return useCallback(
+    (view: EditorView) => {
+      if (!initialExpressionClause) {
+        return;
+      }
+
+      const clause = getClauseDefinition(initialExpressionClause);
+
+      snippet(expressionClauseSnippet(clause))(
+        {
+          state: view.state,
+          dispatch: view.dispatch,
+        },
+        null,
+        view.state.selection.main.from,
+        view.state.selection.main.to,
+      );
+    },
+    [initialExpressionClause],
+  );
+}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -5,7 +5,10 @@ import { t } from "ttag";
 import { isNotNull } from "metabase/lib/types";
 import { Box, Button, Flex } from "metabase/ui";
 import type * as Lib from "metabase-lib";
-import type { ExpressionError } from "metabase-lib/v1/expressions";
+import type {
+  DefinedClauseName,
+  ExpressionError,
+} from "metabase-lib/v1/expressions";
 
 import {
   trackColumnCombineViaShortcut,
@@ -32,6 +35,7 @@ export type ExpressionWidgetProps = {
   reportTimezone?: string;
   header?: ReactNode;
   expressionIndex?: number;
+  initialExpressionClause?: DefinedClauseName | null;
 
   onChangeClause?: (name: string, clause: Lib.ExpressionClause) => void;
   onClose?: () => void;
@@ -50,6 +54,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
     expressionIndex,
     onChangeClause,
     onClose,
+    initialExpressionClause,
   } = props;
 
   const [name, setName] = useState(initialName || "");
@@ -192,6 +197,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
         error={error}
         hasHeader={Boolean(header)}
         onCloseEditor={onClose}
+        initialExpressionClause={initialExpressionClause}
       />
 
       <LayoutFooter>

--- a/frontend/src/metabase/query_builder/components/expressions/FunctionBrowser/utils.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/FunctionBrowser/utils.ts
@@ -3,11 +3,8 @@ import { t } from "ttag";
 import { isNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import {
-  AGGREGATION_FUNCTIONS,
-  EXPRESSION_FUNCTIONS,
   type HelpText,
-  type MBQLClauseFunctionConfig,
-  getClauseDefinition,
+  clausesForMode,
   getHelpText,
 } from "metabase-lib/v1/expressions";
 import type Database from "metabase-lib/v1/metadata/Database";
@@ -20,22 +17,6 @@ export function getSearchPlaceholder(expressionMode: Lib.ExpressionMode) {
   if (expressionMode === "aggregation") {
     return t`Search aggregations…`;
   }
-}
-
-function getClauses(
-  expressionMode: Lib.ExpressionMode,
-): MBQLClauseFunctionConfig[] {
-  if (expressionMode === "expression" || expressionMode === "filter") {
-    return Object.keys(EXPRESSION_FUNCTIONS)
-      .map(getClauseDefinition)
-      .filter(isNotNull);
-  }
-  if (expressionMode === "aggregation") {
-    return Object.keys(AGGREGATION_FUNCTIONS)
-      .map(getClauseDefinition)
-      .filter(isNotNull);
-  }
-  return [];
 }
 
 function getCategoryName(category: string) {
@@ -68,7 +49,7 @@ export function getFilteredClauses({
   database: Database | null;
   reportTimezone?: string;
 }) {
-  const clauses = getClauses(expressionMode);
+  const clauses = clausesForMode(expressionMode);
   const filteredClauses = clauses
     .filter(
       (clause) =>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -50,7 +50,7 @@ export interface FilterColumnPickerProps {
   checkItemIsSelected?: (item: Item) => boolean;
   onColumnSelect: (item: ColumnListItem) => void;
   onSegmentSelect: (item: SegmentListItem) => void;
-  onExpressionSelect?: () => void;
+  onExpressionSelect?: (clause?: DefinedClauseName) => void;
 
   withCustomExpression?: boolean;
   withColumnGroupIcon?: boolean;
@@ -104,8 +104,7 @@ export function FilterColumnPicker({
     if (isSegmentListItem(item)) {
       onSegmentSelect(item);
     } else if (isExpressionClauseItem(item)) {
-      // TODO
-      return;
+      onExpressionSelect?.(item.clause);
     } else {
       onColumnSelect(item);
     }

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -17,6 +17,7 @@ import * as Lib from "metabase-lib";
 import {
   type DefinedClauseName,
   clausesForMode,
+  getClauseDefinition,
 } from "metabase-lib/v1/expressions";
 
 import { WIDTH } from "../constants";
@@ -103,6 +104,16 @@ export function FilterColumnPicker({
     }
   };
 
+  const handleSearchTextChange = (searchText: string) => {
+    if (searchText.trim().endsWith("(")) {
+      const name = searchText.trim().slice(0, -1);
+      const clause = getClauseDefinition(name);
+      if (clause) {
+        onExpressionSelect?.(clause.name);
+      }
+    }
+  };
+
   return (
     <DelayGroup>
       <AccordionList<Item, Section>
@@ -110,6 +121,7 @@ export function FilterColumnPicker({
         sections={sections}
         onChange={handleSelect}
         onChangeSection={handleSectionChange}
+        onChangeSearchText={handleSearchTextChange}
         itemIsSelected={checkItemIsSelected}
         renderItemWrapper={renderItemWrapper}
         renderItemName={renderItemName}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -223,22 +223,22 @@ function getSections({
       clause: clause.name,
       displayName: clause.displayName,
     })),
+    alwaysSortLast: true,
+  };
+  const expressionClauseAction = {
+    key: "custom-expression",
+    type: "action" as const,
+    name: t`Custom Expression`,
+    items: [],
+    icon: "filter" as const,
+    alwaysSortLast: true,
   };
 
-  const expressionSections = withCustomExpression
-    ? [
-        isSearching ? expressionClausesSection : null,
-        {
-          key: "custom-expression",
-          type: "action" as const,
-          name: t`Custom Expression`,
-          items: [],
-          icon: "filter" as const,
-        },
-      ]
-    : [];
-
-  return [...columnSections, ...expressionSections].filter(isNotNull);
+  return [
+    ...columnSections,
+    withCustomExpression && isSearching ? expressionClausesSection : null,
+    withCustomExpression ? expressionClauseAction : null,
+  ].filter(isNotNull);
 }
 
 function renderItemName(item: Item) {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -20,22 +20,15 @@ import {
 } from "metabase-lib/v1/expressions";
 
 import { WIDTH } from "../constants";
-import type { ColumnListItem, SegmentListItem } from "../types";
+import type {
+  ColumnListItem,
+  ExpressionClauseItem,
+  SegmentListItem,
+} from "../types";
 
 import S from "./FilterColumnPicker.module.css";
 
-type ExpressionClauseItem = {
-  type: "expression-clause";
-  clause: DefinedClauseName;
-  displayName: string;
-};
-
-type Item =
-  | ColumnListItem
-  | (SegmentListItem & {
-      combinedDisplayName?: string;
-    })
-  | ExpressionClauseItem;
+type Item = ColumnListItem | SegmentListItem | ExpressionClauseItem;
 
 type Section = BaseSection<Item> & {
   key?: string;

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.tsx
@@ -11,7 +11,11 @@ import {
   type FilterColumnPickerProps,
 } from "./FilterColumnPicker";
 import { FilterPickerBody } from "./FilterPickerBody";
-import type { ColumnListItem, SegmentListItem } from "./types";
+import type {
+  ColumnListItem,
+  ExpressionClauseItem,
+  SegmentListItem,
+} from "./types";
 
 export type FilterPickerProps = {
   className?: string;
@@ -85,9 +89,11 @@ export function FilterPicker({
   };
 
   const checkItemIsSelected = useCallback(
-    (item: ColumnListItem | SegmentListItem) => {
+    (item: ColumnListItem | SegmentListItem | ExpressionClauseItem) => {
       return Boolean(
-        filterIndex != null && item.filterPositions?.includes?.(filterIndex),
+        filterIndex != null &&
+          "filterPositions" in item &&
+          item.filterPositions?.includes?.(filterIndex),
       );
     },
     [filterIndex],

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.tsx
@@ -4,6 +4,7 @@ import { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { ExpressionWidget } from "metabase/query_builder/components/expressions/ExpressionWidget";
 import { ExpressionWidgetHeader } from "metabase/query_builder/components/expressions/ExpressionWidgetHeader";
 import * as Lib from "metabase-lib";
+import type { DefinedClauseName } from "metabase-lib/v1/expressions";
 
 import {
   FilterColumnPicker,
@@ -45,6 +46,8 @@ export function FilterPicker({
     getInitialColumn(query, stageIndex, filter),
   );
   const stageIndexes = useMemo(() => [stageIndex], [stageIndex]);
+  const [initialExpressionClause, setInitialExpressionClause] =
+    useState<DefinedClauseName | null>(null);
 
   const [
     isEditingExpression,
@@ -76,6 +79,11 @@ export function FilterPicker({
     handleChange(item.segment);
   };
 
+  const handleExpressionSelect = (clause?: DefinedClauseName) => {
+    setInitialExpressionClause(clause ?? null);
+    openExpressionEditor();
+  };
+
   const checkItemIsSelected = useCallback(
     (item: ColumnListItem | SegmentListItem) => {
       return Boolean(
@@ -103,6 +111,7 @@ export function FilterPicker({
         header={<ExpressionWidgetHeader onBack={closeExpressionEditor} />}
         onChangeClause={handleClauseChange}
         onClose={closeExpressionEditor}
+        initialExpressionClause={initialExpressionClause}
       />
     );
   }
@@ -116,7 +125,7 @@ export function FilterPicker({
         checkItemIsSelected={checkItemIsSelected}
         onColumnSelect={handleColumnSelect}
         onSegmentSelect={handleSegmentSelect}
-        onExpressionSelect={openExpressionEditor}
+        onExpressionSelect={handleExpressionSelect}
         withColumnGroupIcon={withColumnGroupIcon}
         withColumnItemIcon={withColumnItemIcon}
         withCustomExpression={withCustomExpression}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
@@ -1,4 +1,5 @@
 import type * as Lib from "metabase-lib";
+import type { DefinedClauseName } from "metabase-lib/v1/expressions";
 
 export type FilterPickerWidgetProps = {
   query: Lib.Query;
@@ -21,6 +22,7 @@ export type ColumnListItem = {
   column: Lib.ColumnMetadata;
   stageIndex: number;
   filterPositions?: number[];
+  combinedDisplayName: string;
 };
 
 export type SegmentListItem = Lib.SegmentDisplayInfo & {
@@ -28,4 +30,10 @@ export type SegmentListItem = Lib.SegmentDisplayInfo & {
   displayName: string;
   segment: Lib.SegmentMetadata;
   stageIndex: number;
+};
+
+export type ExpressionClauseItem = {
+  type: "expression-clause";
+  clause: DefinedClauseName;
+  displayName: string;
 };


### PR DESCRIPTION
Closes QUE-1363

Allows custom expressions to by typed into the filter column picker.

### To verify

1. New -> Question -> Sample Database -> Orders
2. Add filter
3. Type `coalesce`: there should be results for custom expression functions
4. Select one: you should see the custom expression editor with the correct snippet applied
5. Add another filter
6. Type `case(`: you should immediately be taken to the custom expression editor with the `case` snippet applied

<img width="441" alt="Screenshot 2025-06-25 at 09 32 46" src="https://github.com/user-attachments/assets/634ecc72-7ba2-42f0-b1e4-6c2e6547629c" />



Tests will be added in a follow up PR.
