### PR TITLE
Closes VIZ-1221 nicer error state for missing columns

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -668,7 +668,9 @@ describe("issue 21665", () => {
 
     cy.get("@dashboardLoaded").should("have.callCount", 3);
     cy.findByTestId("dashcard")
-      .findByText("There was a problem displaying this chart.")
+      .findByText(
+        "Some columns are missing, this card might not render correctly.",
+      )
       .should("be.visible");
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -60,7 +60,10 @@ import type {
   CardSlownessStatus,
   DashCardOnChangeCardAndRunHandler,
 } from "./types";
-import { shouldShowParameterMapper } from "./utils";
+import {
+  getMissingColumnsFromVisualizationSettings,
+  shouldShowParameterMapper,
+} from "./utils";
 
 interface DashCardVisualizationProps {
   dashboard: Dashboard;
@@ -160,6 +163,26 @@ export function DashCardVisualization({
   const rawSeries = PLUGIN_CONTENT_TRANSLATION.useTranslateSeries(
     untranslatedRawSeries,
   );
+
+  const visualizerErrMsg = useMemo(() => {
+    if (
+      !dashcard ||
+      !rawSeries ||
+      rawSeries.length === 0 ||
+      !isVisualizerDashboardCard(dashcard)
+    ) {
+      return;
+    }
+
+    const missingCols = getMissingColumnsFromVisualizationSettings({
+      visualizerEntity: dashcard.visualization_settings.visualization,
+      rawSeries,
+    });
+
+    if (missingCols.flat().length > 0) {
+      return `Some columns are missing, this card might not render correctly.`;
+    }
+  }, [dashcard, rawSeries]);
 
   const series = useMemo(() => {
     if (
@@ -484,6 +507,7 @@ export function DashCardVisualization({
       token={token}
       uuid={uuid}
       titleMenuItems={titleMenuItems}
+      errorMessageOverride={visualizerErrMsg}
     />
   );
 }

--- a/frontend/src/metabase/dashboard/components/DashCard/utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/utils.ts
@@ -53,7 +53,10 @@ export function getMissingColumnsFromVisualizationSettings(options: {
         return false; // This is a data source name reference, not a column
       }
 
-      return !colsForCards[column.sourceId].has(column.originalName);
+      return (
+        !colsForCards[column.sourceId] ||
+        !colsForCards[column.sourceId].has(column.originalName)
+      );
     });
 
     if (missing.length > 0) {

--- a/frontend/src/metabase/dashboard/components/DashCard/utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/utils.ts
@@ -1,5 +1,11 @@
 import { getVirtualCardType } from "metabase/dashboard/utils";
-import type { BaseDashboardCard } from "metabase-types/api";
+import type {
+  BaseDashboardCard,
+  Series,
+  VisualizerColumnValueSource,
+  VisualizerDataSourceId,
+  VisualizerVizDefinition,
+} from "metabase-types/api";
 
 const VIZ_WITH_CUSTOM_MAPPING_UI = ["placeholder"];
 
@@ -15,4 +21,45 @@ export function shouldShowParameterMapper({
     isEditingParameter &&
     !(display && VIZ_WITH_CUSTOM_MAPPING_UI.includes(display))
   );
+}
+
+export function getMissingColumnsFromVisualizationSettings(options: {
+  visualizerEntity: VisualizerVizDefinition | undefined;
+  rawSeries: Series;
+}) {
+  const { visualizerEntity, rawSeries } = options;
+
+  if (!visualizerEntity || !rawSeries?.length) {
+    return [];
+  }
+
+  const { columnValuesMapping } = visualizerEntity;
+
+  const colsForCards: Record<VisualizerDataSourceId, Set<string>> = {};
+  rawSeries.forEach((series) => {
+    const cardId: VisualizerDataSourceId = `card:${series.card.id}`;
+    if (!colsForCards[cardId]) {
+      colsForCards[cardId] = new Set();
+    }
+    series.data?.cols.forEach((col) => {
+      colsForCards[cardId].add(col.name);
+    });
+  });
+
+  const missingCols: VisualizerColumnValueSource[][] = [];
+  Object.entries(columnValuesMapping).forEach(([_columnRef, columns]) => {
+    const missing = columns.filter((column) => {
+      if (typeof column === "string") {
+        return false; // This is a data source name reference, not a column
+      }
+
+      return !colsForCards[column.sourceId].has(column.originalName);
+    });
+
+    if (missing.length > 0) {
+      missingCols.push(missing);
+    }
+  });
+
+  return missingCols;
 }

--- a/frontend/src/metabase/dashboard/components/DashCard/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/utils.unit.spec.ts
@@ -67,4 +67,26 @@ describe("getMissingColumnsFromVisualizationSettings", () => {
       [{ sourceId: "card:2", originalName: "col2", name: "col2" }],
     ]);
   });
+
+  it("handles missing series gracefully", () => {
+    const visualizerEntity: VisualizerVizDefinition = {
+      columnValuesMapping: {
+        col1: [{ sourceId: "card:1", originalName: "col1", name: "col1" }],
+        col2: [{ sourceId: "card:2", originalName: "col2", name: "col2" }],
+      },
+      display: "bar",
+      settings: {},
+    };
+
+    const rawSeries = createMockSeriesWithCols(1, ["col1"]);
+
+    const result = getMissingColumnsFromVisualizationSettings({
+      visualizerEntity,
+      rawSeries,
+    });
+
+    expect(result).toEqual([
+      [{ sourceId: "card:2", originalName: "col2", name: "col2" }],
+    ]);
+  });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/utils.unit.spec.ts
@@ -1,0 +1,70 @@
+import type { VisualizerVizDefinition } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDataset,
+  createMockDatasetData,
+  createMockSeries,
+  createMockSingleSeries,
+} from "metabase-types/api/mocks";
+
+import { getMissingColumnsFromVisualizationSettings } from "./utils";
+
+describe("getMissingColumnsFromVisualizationSettings", () => {
+  const createMockSeriesWithCols = (cardId: number, cols: string[]) => [
+    createMockSingleSeries(
+      createMockCard({ id: cardId }),
+      createMockDataset({
+        data: createMockDatasetData({
+          cols: cols.map((name) => createMockColumn({ name })),
+        }),
+      }),
+    ),
+  ];
+
+  it("returns an empty array when visualizerEntity is undefined", () => {
+    const result = getMissingColumnsFromVisualizationSettings({
+      visualizerEntity: undefined,
+      rawSeries: [],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns an empty array when rawSeries is empty", () => {
+    const result = getMissingColumnsFromVisualizationSettings({
+      visualizerEntity: {
+        columnValuesMapping: {},
+        display: "bar",
+        settings: {},
+      },
+      rawSeries: [],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns missing columns based on columnValuesMapping", () => {
+    const visualizerEntity: VisualizerVizDefinition = {
+      columnValuesMapping: {
+        col1: [{ sourceId: "card:1", originalName: "col1", name: "col1" }],
+        col2: [{ sourceId: "card:2", originalName: "col2", name: "col2" }],
+      },
+      display: "bar",
+      settings: {},
+    };
+    createMockSeries;
+
+    const rawSeries = [
+      ...createMockSeriesWithCols(1, ["col1"]),
+      ...createMockSeriesWithCols(2, ["col3"]),
+    ];
+
+    const result = getMissingColumnsFromVisualizationSettings({
+      visualizerEntity,
+      rawSeries,
+    });
+
+    expect(result).toEqual([
+      [{ sourceId: "card:2", originalName: "col2", name: "col2" }],
+    ]);
+  });
+});


### PR DESCRIPTION
Closes [VIZ-1221: Nicer error state for when underlying query changes](https://linear.app/metabase/issue/VIZ-1221/nicer-error-state-for-when-underlying-query-changes)

### Description

Adds an extra check for visualizer cards, where we basically try to match columns mappings with actual columns on the underlying cards.

### Demo

https://www.loom.com/share/a278dce2d78942abb48f3698ed4bd0f6

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
