### PR TITLE
Gracefully shutdown notification workers

### DIFF
--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -103,6 +103,7 @@
   (task/stop-scheduler!)
   (server/stop-web-server!)
   (analytics/shutdown!)
+  (notification/shutdown!)
   ;; This timeout was chosen based on a 30s default termination grace period in Kubernetes.
   (let [timeout-seconds 20]
     (mdb/release-migration-locks! timeout-seconds))

--- a/src/metabase/notification/core.clj
+++ b/src/metabase/notification/core.clj
@@ -23,7 +23,8 @@
  [metabase.notification.seed
   seed-notification!]
  [metabase.notification.send
-  send-notification!])
+  send-notification!
+  shutdown!])
 
 (defmacro with-skip-sending-notification
   "Execute `body` with [[metabase.notification.events.notification/*skip-sending-notification?*]] bound to `skip?`."

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -147,7 +147,6 @@
         (prometheus/observe! :metabase-notification/wait-duration-ms {:payload-type payload_type} wait-time))
       (try
         (log/info "Sending")
-        (Thread/sleep 5000)
         (prometheus/inc! :metabase-notification/concurrent-tasks)
         (let [hydrated-notification (hydrate-notification notification-info)
               handlers              (:handlers hydrated-notification)]

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -367,7 +367,7 @@
                                              (while (and (not (Thread/interrupted))
                                                          (or (not (.get shutdown-flag))
                                                              ;; Continue processing if shutdown flag is set but queue is not empty
-                                                             (pos? #p (queue-size queue))))
+                                                             (pos? (queue-size queue))))
                                                (try
                                                  (let [notification (take-notification-with-timeout! queue 1000)]
                                                    (when notification
@@ -417,12 +417,11 @@
 
 (defn- dispatch!
   [notification]
-  (let [dispatch-fn (:dispatch-fn @simple-blocking-dispatcher
-                                  #_(case (:payload_type notification)
-                                      :notification/system-event
-                                      @simple-blocking-dispatcher
-                                      ;; notification/card, notification/dashboard
-                                      @dedup-priority-dispatcher))]
+  (let [dispatch-fn (:dispatch-fn (case (:payload_type notification)
+                                    :notification/system-event
+                                    @simple-blocking-dispatcher
+                                    ;; notification/card, notification/dashboard
+                                    @dedup-priority-dispatcher))]
     (dispatch-fn notification)))
 
 (mu/defn ^:private send-notification-async!

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -549,7 +549,7 @@
 
       (is (= [high-priority middle-priority low-priority]
              (for [_ (range 3)]
-               (#'notification.send/take-notification! queue)))))))
+               (#'notification.send/take-notification-with-timeout! queue 1000)))))))
 
 (deftest notification-queue-preserves-deadline-on-replacement-test
   (testing "notifications with same ID are replaced in queue while preserving original deadline"
@@ -575,7 +575,7 @@
              ;; If deadline is preserved, high-priority should come first since it was added after notification-v1
              ;; If deadline was recalculated, notification-v2 would come first due to its minutely schedule
              (for [_ (range 2)]
-               (#'notification.send/take-notification! queue)))))))
+               (#'notification.send/take-notification-with-timeout! queue 1000)))))))
 
 (deftest notification-dedup-priority-test
   (let [queue (#'notification.send/create-dedup-priority-queue)]
@@ -583,14 +583,14 @@
     (testing "put and take operations work correctly"
       (#'notification.send/put-notification! queue {:id 1 :payload_type :notification/testing :test-value "A"})
       (is (= {:id 1 :payload_type :notification/testing :test-value "A"}
-             (#'notification.send/take-notification! queue))))
+             (#'notification.send/take-notification-with-timeout! queue 1000))))
 
     (testing "notifications with same ID are replaced in queue"
       (let [queue (#'notification.send/create-dedup-priority-queue)]
         (#'notification.send/put-notification! queue {:id 1 :payload_type :notification/testing :test-value "A"})
         (#'notification.send/put-notification! queue {:id 1 :payload_type :notification/testing :test-value "B"})
         (is (= {:id 1 :payload_type :notification/testing :test-value "B"}
-               (#'notification.send/take-notification! queue)))))
+               (#'notification.send/take-notification-with-timeout! queue 1000)))))
 
     (testing "multiple notifications are processed in order"
       (let [queue (#'notification.send/create-dedup-priority-queue)]
@@ -599,11 +599,11 @@
         (#'notification.send/put-notification! queue {:id 3 :payload_type :notification/testing :test-value "C"})
 
         (is (= {:id 1 :payload_type :notification/testing :test-value "A"}
-               (#'notification.send/take-notification! queue)))
+               (#'notification.send/take-notification-with-timeout! queue 1000)))
         (is (= {:id 2 :payload_type :notification/testing :test-value "B"}
-               (#'notification.send/take-notification! queue)))
+               (#'notification.send/take-notification-with-timeout! queue 1000)))
         (is (= {:id 3 :payload_type :notification/testing :test-value "C"}
-               (#'notification.send/take-notification! queue)))))
+               (#'notification.send/take-notification-with-timeout! queue 1000)))))
 
     (testing "take blocks until notification is available"
       (let [result (atom nil)
@@ -611,7 +611,7 @@
             take-latch (java.util.concurrent.CountDownLatch. 1)
             thread (Thread. (fn []
                               (.countDown ready-latch) ; signal thread is ready to take
-                              (reset! result (#'notification.send/take-notification! queue))
+                              (reset! result (#'notification.send/take-notification-with-timeout! queue 1000))
                               (.countDown take-latch)))] ; signal take is complete
         (.start thread)
         (.await ready-latch) ; wait for thread to be ready to take
@@ -643,7 +643,7 @@
           consumer-fn            (fn [consumer-id]
                                    (try
                                      (while (pos? (.getCount consumer-latch))
-                                       (let [item (#'notification.send/take-notification! queue)]
+                                       (let [item (#'notification.send/take-notification-with-timeout! queue 1000)]
                                          (swap! received-items conj [(:id item) item {:consumer consumer-id}])
                                          (.countDown consumer-latch)))
                                      (catch Exception e
@@ -700,7 +700,7 @@
     (testing "put and take operations work correctly"
       (#'notification.send/put-notification! queue {:id 1 :payload_type :notification/testing :test-value "A"})
       (is (= {:id 1 :payload_type :notification/testing :test-value "A"}
-             (#'notification.send/take-notification! queue))))
+             (#'notification.send/take-notification-with-timeout! queue 1000))))
 
     (testing "multiple notifications are processed in order, no dedup"
       (#'notification.send/put-notification! queue {:id 1 :payload_type :notification/testing :test-value "A"})
@@ -708,11 +708,11 @@
       (#'notification.send/put-notification! queue {:id 2 :payload_type :notification/testing :test-value "C"})
 
       (is (= {:id 1 :payload_type :notification/testing :test-value "A"}
-             (#'notification.send/take-notification! queue)))
+             (#'notification.send/take-notification-with-timeout! queue 1000)))
       (is (= {:id 1 :payload_type :notification/testing :test-value "B"}
-             (#'notification.send/take-notification! queue)))
+             (#'notification.send/take-notification-with-timeout! queue 1000)))
       (is (= {:id 2 :payload_type :notification/testing :test-value "C"}
-             (#'notification.send/take-notification! queue))))
+             (#'notification.send/take-notification-with-timeout! queue 1000))))
 
     (testing "take blocks until notification is available"
       (let [result (atom nil)
@@ -720,7 +720,7 @@
             take-latch (java.util.concurrent.CountDownLatch. 1)
             thread (Thread. (fn []
                               (.countDown ready-latch) ; signal thread is ready to take
-                              (reset! result (#'notification.send/take-notification! queue))
+                              (reset! result (#'notification.send/take-notification-with-timeout! queue 1000))
                               (.countDown take-latch)))] ; signal take is complete
         (.start thread)
         (.await ready-latch) ; wait for thread to be ready to take

--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -484,7 +484,7 @@
                                                                 (Thread/sleep 20)
                                                                 (swap! sent-notifications conj notification))]
         (let [queue           (#'notification.send/create-dedup-priority-queue)
-              test-dispatcher (#'notification.send/create-notification-dispatcher 2 queue)]
+              test-dispatcher (:dispatch-fn (#'notification.send/create-notification-dispatcher 2 queue))]
           (testing "basic processing"
             (reset! sent-notifications [])
             (let [notification {:id 1 :test-value "A"}]


### PR DESCRIPTION
Context: https://metaboat.slack.com/archives/C05MPF0TM3L/p1750708549233899

This makes the notification queue shutdown gracefully.