### PR TITLE
collection: null in native queries doesn't break things

### DIFF
--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -42,7 +42,12 @@
 (mr/def ::stage.native
   [:and
    [:map
-    {:decode/normalize common/normalize-map}
+    {:decode/normalize #(->> %
+                             common/normalize-map
+                             ;; filter out null :collection keys -- see #59675
+                             (m/filter-kv (fn [k v]
+                                            (not (and (= k :collection)
+                                                      (nil? v))))))}
     [:lib/type [:= {:decode/normalize common/normalize-keyword} :mbql.stage/native]]
     ;; the actual native query, depends on the underlying database. Could be a raw SQL string or something like that.
     ;; Only restriction is that, if present, it is non-nil.

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -195,6 +195,22 @@
            (lib.query/query meta/metadata-provider
                             {:database 74001, :type :query, :query {:source-table 74040}})))))
 
+(deftest ^:parallel handle-null-collection-test
+  (testing "collection: null doesn't cause errors #59675"
+    (is (= {:database               (meta/id)
+            :lib/type               :mbql/query
+            :lib/metadata           meta/metadata-provider
+            :stages                 [{:lib/type :mbql.stage/native
+                                      :template-tags {}
+                                      :native "select * from products limit 3;"}]
+            :lib.convert/converted? true}
+           (lib.query/query meta/metadata-provider
+                            {:database 1703
+                             :type :native
+                             :native {:template-tags {}
+                                      :query "select * from products limit 3;"
+                                      :collection nil}})))))
+
 (deftest ^:parallel can-run-test
   (mu/disable-enforcement
     #_{:clj-kondo/ignore [:equals-true]}
@@ -203,7 +219,7 @@
            (= can-run? (lib.query/can-run query card-type) (lib.query/can-preview query))
            (= can-run? (lib.query/can-run query card-type)))
       true  :question (lib.tu/venues-query)
-      false :question (assoc (lib.tu/venues-query) :database nil)           ; database unknown - no permissions
+      false :question (assoc (lib.tu/venues-query) :database nil) ; database unknown - no permissions
       true  :question (lib/native-query meta/metadata-provider "SELECT")
       false :question (lib/native-query meta/metadata-provider "")
       false :metric   (lib.tu/venues-query)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/59675

### Description

Apparently, it is possible to get collection: null in a card's dataset query.  It is unclear why this happens, but this change ensures that nothing will break when it does happen.

### How to verify

1. Manually add collection: null to a card's dataset_query (see the case for where exactly it is in the query)
2. Verify that you can still load the card/dashboard

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
