### PR TITLE
[QP] Respect the time if absolute datetime dashboard filter provides it

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -203,7 +203,7 @@ function dateFilterSelector({ filterType, filterValue } = {}) {
 
     case "Single Date":
       DateFilter.setSingleDate(filterValue);
-      DateFilter.setTime({ hours: 11, minutes: 0 });
+      DateFilter.setTime({ hours: 9, minutes: 27 });
       cy.findByText("Add filter").click();
       break;
 

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -335,8 +335,11 @@
     :range  (fn [{:keys [date]} _]
               {:start date :end date :unit (absolute-date->unit date)})
     :filter (fn [{:keys [date]} field-clause]
-              (let [iso8601date (->iso-8601-date date)]
-                [:= (with-temporal-unit-if-field field-clause :day) iso8601date]))}
+              (let [unit        (absolute-date->unit date)
+                    iso8601str  (case unit
+                                  :day    (->iso-8601-date date)
+                                  :minute (->iso-8601-date-time date))]
+                [:= (with-temporal-unit-if-field field-clause unit) iso8601str]))}
    ;; day range
    {:parser (regex->parser #"([0-9-T]+)~([0-9-T]+)" [:date-1 :date-2])
     :range  (fn [{:keys [date-1 date-2]} _]
@@ -556,8 +559,8 @@
         format-date-range)))
 
 (mu/defn date-string->filter :- mbql.s/Filter
-  "Takes a string description of a *date* (not datetime) range such as 'lastmonth' or '2016-07-15~2016-08-6' and
-   returns a corresponding MBQL filter clause for a given field reference."
+  "Takes a string description of a *date* (not datetime) range such as 'lastmonth' or '2016-07-15~2016-08-6', or
+  an absolute date *or datetime* string, and returns a corresponding MBQL filter clause for a given field reference."
   [date-string :- :string
    field       :- [:or ::lib.schema.id/field mbql.s/Field]]
   (or (execute-decoders all-date-string-decoders :filter (mbql.u/wrap-field-id-if-needed field) date-string)

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -26,6 +26,11 @@
             [:field "field" {:base-type :type/DateTime, :temporal-unit :day}]
             "2019-04-01"]
            (params.dates/date-string->filter "2019-04-01" [:field "field" {:base-type :type/DateTime}]))))
+  (testing "single minute"
+    (is (= [:=
+            [:field "field" {:base-type :type/DateTime, :temporal-unit :minute}]
+            "2019-04-01T09:33:00"]
+           (params.dates/date-string->filter "2019-04-01T09:33:00" [:field "field" {:base-type :type/DateTime}]))))
   (testing "day range"
     (is (= [:between
             [:field "field" {:base-type :type/DateTime, :temporal-unit :day}]

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -133,6 +133,22 @@
                   :target [:dimension [:field (mt/id :users :last_login) nil]]
                   :value  value}))))))))
 
+(deftest ^:parallel single-date-parameters-test
+  (testing "absolute date parameters"
+    (doseq [[value expected-filter-clause]
+            {"2014-05-10"          [:= [:field (mt/id :users :last_login) {:temporal-unit :day}] "2014-05-10"]
+             "2014-05-10T09:30:00" [:= [:field (mt/id :users :last_login) {:temporal-unit :minute}]
+                                    "2014-05-10T09:30:00"]}]
+      (testing (format "value = %s" (pr-str value))
+        (is (= (expanded-query-with-filter expected-filter-clause)
+               (expand-parameters
+                (query-with-parameters
+                 {:hash   "abc123"
+                  :name   "foo"
+                  :type   :date/single
+                  :target [:dimension [:field (mt/id :users :last_login) nil]]
+                  :value  value}))))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                END-TO-END TESTS                                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Closes #59778.

### Description

Previously this was always rounded to `:day` for a single absolute datetime filter.
(Absolute date ranges already respected the times if provided.)

### How to verify

1. Create a dashboard with a "single date" filter.
2. Add a card with a `:type/DateTime` column (eg. `Orders` table)
3. Map the filter to that column and save.
4. Set a **date** value for the filter, for a day with multiple rows.
    - Observe that all those rows are returned.
5. Reopen the filter, click `Add Time` and select a time.
    - Observe that only rows for that precise minute are returned.

### Demo

TODO: Screenshots

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
