### PR TITLE
Remove .only use in Homepage.cy.spec

### DIFF
--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -571,7 +571,7 @@ describe("scenarios > home > custom homepage", () => {
   });
 });
 
-H.describeWithSnowplow.only("scenarios > setup", () => {
+H.describeWithSnowplow("scenarios > setup", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();


### PR DESCRIPTION
### Description
Removes the `.only` usage in `homepage.cy.spec.js`. This was caught and handled in the backport of https://github.com/metabase/metabase/pull/59610

### How to verify
Green CI - all tests should run

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
