### PR TITLE
Update internal slack + smtp settings links

### DIFF
--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -70,7 +70,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       cy.findByRole("link", { name: /configure Slack/i }).should(
         "have.attr",
         "href",
-        "/admin/settings/notifications/slack",
+        "/admin/settings/notifications",
       );
     });
   });

--- a/frontend/src/metabase/admin/app/components/DeprecationNotice/DeprecationNotice.tsx
+++ b/frontend/src/metabase/admin/app/components/DeprecationNotice/DeprecationNotice.tsx
@@ -42,7 +42,7 @@ const getBannerContent = (
   hasDeprecatedDatabase: boolean,
 ) => {
   const databaseListUrl = "/admin/databases";
-  const slackSettingsUrl = "/admin/settings/notifications/slack";
+  const slackSettingsUrl = "/admin/settings/notifications";
 
   if (hasSlackBot && hasDeprecatedDatabase) {
     return jt`You’re using a ${(

--- a/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
+++ b/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
@@ -515,7 +515,7 @@ export const Onboarding = () => {
                         <Link
                           className={CS.link}
                           key="subscription-email"
-                          to="/admin/settings/email/smtp"
+                          to="/admin/settings/email"
                         >{t`Set up email`}</Link>
                       )} or ${(
                         <Link
@@ -579,7 +579,7 @@ export const Onboarding = () => {
                         <Link
                           className={CS.link}
                           key="alert-email"
-                          to="/admin/settings/email/smtp"
+                          to="/admin/settings/email"
                         >{t`Set up email`}</Link>
                       )} or ${(
                         <Link

--- a/frontend/src/metabase/home/components/Onboarding/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/Onboarding/tests/common.unit.spec.tsx
@@ -340,7 +340,7 @@ describe("Onboarding", () => {
 
       expect(
         within(commsSetup).getByRole("link", { name: "Set up email" }),
-      ).toHaveAttribute("href", "/admin/settings/email/smtp");
+      ).toHaveAttribute("href", "/admin/settings/email");
       expect(
         within(commsSetup).getByRole("link", { name: "Slack" }),
       ).toHaveAttribute("href", "/admin/settings/notifications");
@@ -384,7 +384,7 @@ describe("Onboarding", () => {
 
       expect(
         within(commsSetup).getByRole("link", { name: "Set up email" }),
-      ).toHaveAttribute("href", "/admin/settings/email/smtp");
+      ).toHaveAttribute("href", "/admin/settings/email");
       expect(
         within(commsSetup).getByRole("link", { name: "Slack" }),
       ).toHaveAttribute("href", "/admin/settings/notifications");

--- a/frontend/src/metabase/notifications/NewPulseSidebar.tsx
+++ b/frontend/src/metabase/notifications/NewPulseSidebar.tsx
@@ -50,7 +50,7 @@ export function NewPulseSidebar({
             onClick={onNewSlackPulse}
           />
         ) : (
-          <Link to="/admin/settings/notifications/slack">
+          <Link to="/admin/settings/notifications">
             <ChannelCard title={t`Configure Slack`} channel="slack" />
           </Link>
         )}

--- a/src/metabase/channel/email/slack_token_error.hbs
+++ b/src/metabase/channel/email/slack_token_error.hbs
@@ -7,6 +7,6 @@
       <h2 style="font-weight: normal; color: #4C545B; line-height: 34px;">Your Slack connection stopped working</h2>
       <p style="line-height: 22px; margin-bottom: 40px">This may affect existing dashboard subscriptions. Follow the steps in settings to reconnect Slack and get things up and running again.</p>
     </div>
-    <a style="{{context.style.button}}" href="{{context.site_url}}/admin/settings/notifications/slack">Go to settings</a>
+    <a style="{{context.style.button}}" href="{{context.site_url}}/admin/settings/notifications">Go to settings</a>
   </div>
 {{> metabase/channel/email/_footer.hbs }}

--- a/test/metabase/notification/payload/impl/system_event_test.clj
+++ b/test/metabase/notification/payload/impl/system_event_test.clj
@@ -200,7 +200,7 @@
         admin-emails (t2/select-fn-set :email :model/User :is_superuser true)]
     (testing "send to admins with a link to setting page"
       (check admin-emails [#"Your Slack connection stopped working"
-                           #"<a[^>]*href=\"https?://metabase\.com/admin/settings/notifications/slack\"[^>]*>Go to settings</a>"]))
+                           #"<a[^>]*href=\"https?://metabase\.com/admin/settings/notifications\"[^>]*>Go to settings</a>"]))
 
     (mt/with-temporary-setting-values
       [admin-email "it@metabase.com"]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60015
closes ADM-1049

### Description

We removed 2 admin settings pages recently and combined their functionality into other existing pages: `/admin/email/smtp` and `/admin/notifications/slack` - this updates internal links in other parts of the product accordingly.
