### PR TITLE
Push multi-arch images when tagging

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -250,19 +250,9 @@ jobs:
 
     - name: Tag the docker image
       run: | # sh
-        docker pull $DOCKERHUB_REPO\:$DOCKERHUB_VERSION
-        docker tag $DOCKERHUB_REPO\:$DOCKERHUB_VERSION $DOCKERHUB_REPO\:$TAG_NAME
-        docker image ls $DOCKERHUB_REPO
-
-        SOURCE_ID=$(docker image ls $DOCKERHUB_REPO\:$DOCKERHUB_VERSION -q)
-        TAGGED_ID=$(docker image ls $DOCKERHUB_REPO\:$TAG_NAME -q)
-
-        if [[ $SOURCE_ID != $TAGGED_ID ]]; then
-          echo "Error tagging docker image"
-          exit 1
-        fi
-
-        docker push $DOCKERHUB_REPO\:$TAG_NAME
+        docker buildx imagetools create --tag \
+          $DOCKERHUB_REPO\:$TAG_NAME \
+          $DOCKERHUB_REPO\:$DOCKERHUB_VERSION
 
   push-git-tags:
     permissions: write-all


### PR DESCRIPTION
finally 😅 closes https://github.com/metabase/metabase/issues/57380 
closes DEV-365

### Description

Push multi-arch images for re-tagged images (like `:latest` and `:55.x`)

test (in my fork): https://github.com/iethree/metabase/actions/runs/15862771680/job/44723589558
pushed to: https://hub.docker.com/r/iethree/metabase/tags


