### PR TITLE
Closes VIZ-1220 proper icons for visualizer actions

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -154,7 +154,7 @@ function DashCardActionsPanelInner({
           aria-label={t`Edit visualization`}
           onClick={onEditVisualization}
         >
-          <DashCardActionButton.Icon name="pencil" />
+          <DashCardActionButton.Icon name="lineandbar" />
         </DashCardActionButton>,
       );
     }
@@ -197,7 +197,7 @@ function DashCardActionsPanelInner({
             onEditVisualization();
           }}
         >
-          <DashCardActionButton.Icon name="add_data" />
+          <DashCardActionButton.Icon name="lineandbar" />
         </DashCardActionButton>,
       );
     }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenuItems.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenuItems.tsx
@@ -59,7 +59,7 @@ export const DashCardMenuItems = ({
     if (onEditVisualization) {
       items.push({
         key: "MB_EDIT_VISUALIZER_QUESTION",
-        iconName: "pencil",
+        iconName: "lineandbar",
         label: t`Edit visualization`,
         onClick: onEditVisualization,
       });

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
@@ -167,7 +167,7 @@ export function QuestionList({
                   setVisualizerModalCardId(Number(item.id));
                 }}
               >
-                <Icon name="add_data" />
+                <Icon name="lineandbar" />
               </ActionIcon>
             </Tooltip>
           </Flex>


### PR DESCRIPTION
Closes [VIZ-1220: Updated icon for visualizer entrypoints](https://linear.app/metabase/issue/VIZ-1220/updated-icon-for-visualizer-entrypoints)

### Description

Updates the icons to make a visualizer card or edit one

<img width="1578" alt="SCR-20250625-jnqi" src="https://github.com/user-attachments/assets/425a550c-a62e-437c-ab4e-597f7b8ac20f" />
