### PR TITLE
Adjust embedding sdk ci triggers

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -16,10 +16,12 @@ frontend_ci: &frontend_ci
   - ".github/actions/prepare-backend/**"
   - ".github/workflows/frontend.yml"
 
-frontend_sources: &frontend_sources
-  - *shared_sources
-  - "enterprise/frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
-  - "frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
+frontend_embedding_sdk_ci: &frontend_embedding_sdk_ci
+  - ".github/actions/prepare-frontend/**"
+  - ".github/actions/prepare-backend/**"
+  - ".github/workflows/*embedding-sdk*.yml"
+
+frontend_configs: &frontend_configs
   - "yarn.lock"
   - "**/tsconfig*.json"
   - "package.json"
@@ -32,8 +34,15 @@ frontend_sources: &frontend_sources
   - "webpack.static-viz.config.js"
   - ".nvmrc"
 
+frontend_sources: &frontend_sources
+  - *shared_sources
+  - *frontend_configs
+  - "enterprise/frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
+  - "frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
+
 frontend_embedding_sdk_sources:
-  - *frontend_sources
+  - *frontend_configs
+  - "enterprise/frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
 
 frontend_specs: &frontend_specs
   - *shared_specs
@@ -116,14 +125,18 @@ e2e_cross_version: &e2e_cross_version
   - ".github/workflows/e2e-cross-version.yml"
   - "e2e/test/scenarios/cross-version/**"
 
+e2e_embedding_sdk:
+  - *frontend_embedding_sdk_ci
+  - *sources
+  - "e2e/component/**/*.cy.*.{js,ts}"
+
 e2e_embedding_sdk_compatibility:
   - *default
-  - *e2e_ci
+  - *frontend_embedding_sdk_ci
   - *frontend_sources
   - "e2e/embedding-sdk-host-apps/**"
   - "e2e/runner/embedding-sdk/**"
-  - "e2e/runner/test-host-app/**/*.cy.*.js"
-  - "e2e/runner/test-host-app/**/*.cy.*.ts"
+  - "e2e/test-host-app/**/*.cy.*.{js,ts}"
 
 e2e_all:
   - *default
@@ -137,9 +150,12 @@ snowplow:
   - "snowplow/**"
 
 documentation:
-  - ".typedoc/**"
   - "docs/**"
   - "**/*.md"
+
+embedding_documentation:
+  - ".typedoc/**"
+  - "docs/embedding/**"
 
 yaml:
   - "**/*.yml"

--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     outputs:
-      e2e_all: ${{ steps.changes.outputs.e2e_all }}
+      e2e_embedding_sdk: ${{ steps.changes.outputs.e2e_embedding_sdk }}
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
@@ -62,7 +62,7 @@ jobs:
     needs: [files-changed, get-build-requirements]
     if: |
       !cancelled() &&
-      needs.files-changed.outputs.e2e_all == 'true'
+      needs.files-changed.outputs.e2e_embedding_sdk == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     env:

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -18,8 +18,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 3
     outputs:
-      documentation: ${{ steps.changes.outputs.documentation }}
+      e2e_embedding_sdk: ${{ steps.changes.outputs.e2e_embedding_sdk }}
       frontend_embedding_sdk_sources: ${{ steps.changes.outputs.frontend_embedding_sdk_sources }}
+      embedding_documentation: ${{ steps.changes.outputs.embedding_documentation }}
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
@@ -33,8 +34,9 @@ jobs:
     needs: [files-changed]
     if: |
       !cancelled() &&
-      (needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' ||
-      needs.files-changed.outputs.documentation == 'true')
+      (needs.files-changed.outputs.e2e_embedding_sdk == 'true' ||
+      needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' ||
+      needs.files-changed.outputs.embedding_documentation == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     steps:
@@ -75,7 +77,7 @@ jobs:
   embedding-sdk-docs-snippets-type-check:
     needs: [files-changed, build]
     if: |
-      needs.files-changed.outputs.documentation == 'true' &&
+      needs.files-changed.outputs.embedding_documentation == 'true' &&
       needs.build.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 20


### PR DESCRIPTION
Adjust embedding sdk ci triggers.

Context:
https://metaboat.slack.com/archives/C0669P4AF9N/p1750702584093469


Notes:
- for SDK component e2e one of the triggers is `sources`, so we run it both on FE and BE sources changes
- for SDK compatibility testing (host/sample apps) the trigger does not includes BE sources to reduce amount of job calls. 
- `frontend_embedding_sdk_ci` trigger includes `".github/workflows/*embedding-sdk*.yml"` so we rely on having the `embedding-sdk` in a workflow file name