### PR TITLE
Prg-26-add-upsells-for-dev-instances-in-admin-settings

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
@@ -7,6 +7,7 @@ import {
 import { EmbeddingToggle } from "metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle";
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
 import { AdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
+import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import { Box, Button } from "metabase/ui";
@@ -32,6 +33,7 @@ export function InteractiveEmbeddingSettings() {
 
   return (
     <SettingsPageWrapper title={t`Interactive embedding`}>
+      <UpsellDevInstances source="embedding-page" />
       <SettingsSection>
         <EmbeddingToggle
           settingKey="enable-embedding-interactive"

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
@@ -7,7 +7,7 @@ import {
 import { EmbeddingToggle } from "metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle";
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
 import { AdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
-import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
+import { UpsellDevInstances } from "metabase/admin/upsells";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import { Box, Button } from "metabase/ui";

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -5,7 +5,7 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
-import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
+import { UpsellDevInstances } from "metabase/admin/upsells";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl, useSetting, useUrlWithUtm } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -5,6 +5,7 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
+import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl, useSetting, useUrlWithUtm } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
@@ -105,6 +106,7 @@ export function EmbeddingSdkSettings() {
 
   return (
     <SettingsPageWrapper title={t`Embedding SDK`}>
+      <UpsellDevInstances source="embedding-page" />
       <SettingsSection>
         <EmbeddingToggle
           label={t`Enable Embedded analytics SDK for React`}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/StaticEmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/StaticEmbeddingSettings.tsx
@@ -1,13 +1,11 @@
 import { t } from "ttag";
 
-import {
-  SettingsPageWrapper,
-  SettingsSection,
-} from "metabase/admin/components/SettingsSection";
+import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
 import { useSetting } from "metabase/common/hooks";
 import { Box } from "metabase/ui";
 
 import { SettingTitle } from "../SettingHeader";
+import { SettingsPageWrapper, SettingsSection } from "../SettingsSection";
 import { EmbeddedResources } from "../widgets/PublicLinksListing/EmbeddedResources";
 
 import { EmbeddingSecretKeyWidget } from "./EmbeddingSecretKeyWidget";
@@ -18,6 +16,7 @@ export function StaticEmbeddingSettings() {
 
   return (
     <SettingsPageWrapper title={t`Static embedding`}>
+      <UpsellDevInstances source="embedding-page" />
       <SettingsSection>
         <EmbeddingToggle
           settingKey="enable-embedding-static"

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/StaticEmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/StaticEmbeddingSettings.tsx
@@ -4,7 +4,7 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
-import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
+import { UpsellDevInstances } from "metabase/admin/upsells";
 import { useSetting } from "metabase/common/hooks";
 import { Box } from "metabase/ui";
 

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/StaticEmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/StaticEmbeddingSettings.tsx
@@ -1,11 +1,14 @@
 import { t } from "ttag";
 
+import {
+  SettingsPageWrapper,
+  SettingsSection,
+} from "metabase/admin/components/SettingsSection";
 import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
 import { useSetting } from "metabase/common/hooks";
 import { Box } from "metabase/ui";
 
 import { SettingTitle } from "../SettingHeader";
-import { SettingsPageWrapper, SettingsSection } from "../SettingsSection";
 import { EmbeddedResources } from "../widgets/PublicLinksListing/EmbeddedResources";
 
 import { EmbeddingSecretKeyWidget } from "./EmbeddingSecretKeyWidget";

--- a/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
+++ b/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
@@ -40,7 +40,7 @@ function BannerBody({
   return (
     <Text lh="1.25rem">
       {copyText}{" "}
-      <Anchor fw="bold" href={getStoreUrl()}>
+      <Anchor fw="bold" href={getStoreUrl()} target="_blank">
         {linkText}
       </Anchor>
     </Text>

--- a/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
+++ b/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
@@ -1,4 +1,4 @@
-import { jt, t } from "ttag";
+import { t } from "ttag";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useSetting } from "metabase/common/hooks";
@@ -16,12 +16,21 @@ export function DevInstanceBanner() {
   return (
     <Alert icon={<Icon name="info_filled" />}>
       {isHosted && (
-        <Text lh="1.25rem">{jt`This instance is in development mode and can be used for development or testing purposes only.
-        ${(<ExternalLink style={{ fontWeight: "bold" }} href={getStoreUrl()}>{t`Manage instance`}</ExternalLink>)}`}</Text>
+        <Text lh="1.25rem">
+          {t`This instance is in development mode and can be used for development or testing purposes only.`}
+          <ExternalLink style={{ fontWeight: "bold" }} href={getStoreUrl()}>
+            {t`Manage instance`}
+          </ExternalLink>
+        </Text>
       )}
       {!isHosted && (
-        <Text lh="1.25rem">{jt`This instance is in development mode and can be used for development or testing purposes only. To spin up more development instances, use your development license token.
-        ${(<ExternalLink style={{ fontWeight: "bold" }} href={getStoreUrl()}>{t`Get your token`}</ExternalLink>)}`}</Text>
+        <Text lh="1.25rem">
+          {t`This instance is in development mode and can be used for development or testing purposes only. To spin up more development instances, use your development license token.`}
+          <ExternalLink
+            style={{ fontWeight: "bold" }}
+            href={getStoreUrl()}
+          >{t`Get your token`}</ExternalLink>
+        </Text>
       )}
     </Alert>
   );

--- a/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
+++ b/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
@@ -1,9 +1,8 @@
 import { t } from "ttag";
 
-import ExternalLink from "metabase/common/components/ExternalLink";
 import { useSetting } from "metabase/common/hooks";
 import { getStoreUrl } from "metabase/selectors/settings";
-import { Alert, Icon, Text } from "metabase/ui";
+import { Alert, Anchor, Icon, Text } from "metabase/ui";
 
 export function DevInstanceBanner() {
   const isDevMode = useSetting("development-mode?");
@@ -41,9 +40,9 @@ function BannerBody({
   return (
     <Text lh="1.25rem">
       {copyText}{" "}
-      <ExternalLink style={{ fontWeight: "bold" }} href={getStoreUrl()}>
+      <Anchor fw="bold" href={getStoreUrl()}>
         {linkText}
-      </ExternalLink>
+      </Anchor>
     </Text>
   );
 }

--- a/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
+++ b/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
@@ -16,22 +16,34 @@ export function DevInstanceBanner() {
   return (
     <Alert icon={<Icon name="info_filled" />}>
       {isHosted && (
-        <Text lh="1.25rem">
-          {t`This instance is in development mode and can be used for development or testing purposes only.`}
-          <ExternalLink style={{ fontWeight: "bold" }} href={getStoreUrl()}>
-            {t`Manage instance`}
-          </ExternalLink>
-        </Text>
+        <BannerBody
+          copyText={t`This instance is in development mode and can be used for development or testing purposes only.`}
+          linkText={t`Manage instance`}
+        />
       )}
       {!isHosted && (
-        <Text lh="1.25rem">
-          {t`This instance is in development mode and can be used for development or testing purposes only. To spin up more development instances, use your development license token.`}
-          <ExternalLink
-            style={{ fontWeight: "bold" }}
-            href={getStoreUrl()}
-          >{t`Get your token`}</ExternalLink>
-        </Text>
+        <BannerBody
+          copyText={t`This instance is in development mode and can be used for development or testing purposes only. To spin up more development instances, use your development license token.`}
+          linkText={t`Get your token`}
+        />
       )}
     </Alert>
+  );
+}
+
+function BannerBody({
+  copyText,
+  linkText,
+}: {
+  linkText: string;
+  copyText: string;
+}) {
+  return (
+    <Text lh="1.25rem">
+      {copyText}{" "}
+      <ExternalLink style={{ fontWeight: "bold" }} href={getStoreUrl()}>
+        {linkText}
+      </ExternalLink>
+    </Text>
   );
 }

--- a/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
+++ b/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
@@ -2,10 +2,8 @@ import { jt, t } from "ttag";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useSetting } from "metabase/common/hooks";
+import { getStoreUrl } from "metabase/selectors/settings";
 import { Alert, Icon, Text } from "metabase/ui";
-
-const MANAGE_INSTANCE_URL = "https://metabase.com/";
-const GET_TOKEN_URL = "https://metabase.com/";
 
 export function DevInstanceBanner() {
   const isDevMode = useSetting("development-mode?");
@@ -19,11 +17,11 @@ export function DevInstanceBanner() {
     <Alert icon={<Icon name="info_filled" />}>
       {isHosted && (
         <Text lh="1.25rem">{jt`This instance is in development mode and can be used for development or testing purposes only.
-        ${(<ExternalLink style={{ fontWeight: "bold" }} href={MANAGE_INSTANCE_URL}>{t`Manage instance`}</ExternalLink>)}`}</Text>
+        ${(<ExternalLink style={{ fontWeight: "bold" }} href={getStoreUrl()}>{t`Manage instance`}</ExternalLink>)}`}</Text>
       )}
       {!isHosted && (
         <Text lh="1.25rem">{jt`This instance is in development mode and can be used for development or testing purposes only. To spin up more development instances, use your development license token.
-        ${(<ExternalLink style={{ fontWeight: "bold" }} href={GET_TOKEN_URL}>{t`Get your token`}</ExternalLink>)}`}</Text>
+        ${(<ExternalLink style={{ fontWeight: "bold" }} href={getStoreUrl()}>{t`Get your token`}</ExternalLink>)}`}</Text>
       )}
     </Alert>
   );

--- a/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.unit.spec.tsx
@@ -1,0 +1,61 @@
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { DevInstanceBanner } from "./DevInstanceBanner";
+
+interface SetupOpts {
+  isDevMode?: boolean;
+  isHosted?: boolean;
+}
+
+const setup = ({ isDevMode = false, isHosted = false }: SetupOpts = {}) => {
+  const settings = createMockSettings({
+    "development-mode?": isDevMode,
+    "is-hosted?": isHosted,
+  });
+
+  const state = createMockState({
+    settings: mockSettings(settings),
+  });
+
+  renderWithProviders(<DevInstanceBanner />, {
+    storeInitialState: state,
+  });
+};
+
+describe("DevInstanceBanner", () => {
+  it("should not render when development mode is disabled", () => {
+    setup({ isDevMode: false, isHosted: false });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("should render for hosted instances", () => {
+    setup({ isDevMode: true, isHosted: true });
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /This instance is in development mode and can be used for development or testing purposes only./,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Manage instance" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render for self-hosted instances", () => {
+    setup({ isDevMode: true, isHosted: false });
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /This instance is in development mode and can be used for development or testing purposes only. To spin up more development instances, use your development license token./,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Get your token" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/DevInstanceBanner.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/DevInstanceBanner.tsx
@@ -1,0 +1,30 @@
+import { jt, t } from "ttag";
+
+import ExternalLink from "metabase/common/components/ExternalLink";
+import { useSetting } from "metabase/common/hooks";
+import { Alert, Icon, Text } from "metabase/ui";
+
+const MANAGE_INSTANCE_URL = "https://metabase.com/";
+const GET_TOKEN_URL = "https://metabase.com/";
+
+export function DevInstanceBanner() {
+  const isDevMode = useSetting("development-mode?");
+  const isHosted = useSetting("is-hosted?");
+
+  if (!isDevMode) {
+    return null;
+  }
+
+  return (
+    <Alert icon={<Icon name="info_filled" />}>
+      {isHosted && (
+        <Text lh="1.25rem">{jt`This instance is in development mode and can be used for development or testing purposes only.
+        ${(<ExternalLink style={{ fontWeight: "bold" }} href={MANAGE_INSTANCE_URL}>{t`Manage instance`}</ExternalLink>)}`}</Text>
+      )}
+      {!isHosted && (
+        <Text lh="1.25rem">{jt`This instance is in development mode and can be used for development or testing purposes only. To spin up more development instances, use your development license token.
+        ${(<ExternalLink style={{ fontWeight: "bold" }} href={GET_TOKEN_URL}>{t`Get your token`}</ExternalLink>)}`}</Text>
+      )}
+    </Alert>
+  );
+}

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/EmbeddingSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/EmbeddingSettingsPage.tsx
@@ -1,12 +1,13 @@
 import { t } from "ttag";
 
-import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
+import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
 
 import {
   EmbeddingSdkOptionCard,
   InteractiveEmbeddingOptionCard,
   StaticEmbeddingOptionCard,
 } from "../EmbeddingSettings/EmbeddingOption";
+import { SettingsPageWrapper } from "../SettingsSection";
 
 export function EmbeddingSettingsPage() {
   return (
@@ -14,6 +15,7 @@ export function EmbeddingSettingsPage() {
       title={t`Embedding`}
       description={t`Embed dashboards, questions, or the entire Metabase app into your application. Integrate with your server code to create a secure environment, limited to specific users or organizations.`}
     >
+      <UpsellDevInstances source="embedding-page" />
       <StaticEmbeddingOptionCard />
       <InteractiveEmbeddingOptionCard />
       <EmbeddingSdkOptionCard />

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/EmbeddingSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/EmbeddingSettingsPage.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
-import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
+import { UpsellDevInstances } from "metabase/admin/upsells";
 
 import {
   EmbeddingSdkOptionCard,

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/EmbeddingSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/EmbeddingSettingsPage.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
 
 import {
@@ -7,7 +8,6 @@ import {
   InteractiveEmbeddingOptionCard,
   StaticEmbeddingOptionCard,
 } from "../EmbeddingSettings/EmbeddingOption";
-import { SettingsPageWrapper } from "../SettingsSection";
 
 export function EmbeddingSettingsPage() {
   return (

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -25,6 +25,7 @@ export function GeneralSettingsPage() {
   return (
     <SettingsPageWrapper title={t`General`}>
       <DevInstanceBanner />
+
       <SettingsSection title={t`App config`}>
         <AdminSettingInput
           name="site-name"

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -4,7 +4,7 @@ import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
-import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
+import { UpsellDevInstances } from "metabase/admin/upsells";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import { PLUGIN_LANDING_PAGE } from "metabase/plugins";

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -1,16 +1,21 @@
 import { jt, t } from "ttag";
 
+import {
+  SettingsPageWrapper,
+  SettingsSection,
+} from "metabase/admin/components/SettingsSection";
 import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import { PLUGIN_LANDING_PAGE } from "metabase/plugins";
 
-import { SettingsPageWrapper, SettingsSection } from "../SettingsSection";
 import { AdminSettingInput } from "../widgets/AdminSettingInput";
 import { AnonymousTrackingInput } from "../widgets/AnonymousTrackingInput";
 import { CustomHomepageDashboardSetting } from "../widgets/CustomHomepageDashboardSetting";
 import { HttpsOnlyWidget } from "../widgets/HttpsOnlyWidget";
 import { SiteUrlWidget } from "../widgets/SiteUrlWidget";
+
+import { DevInstanceBanner } from "./DevInstanceBanner";
 
 export function GeneralSettingsPage() {
   const { url: iframeDocsUrl } = useDocsUrl("configuring-metabase/settings", {
@@ -19,6 +24,7 @@ export function GeneralSettingsPage() {
 
   return (
     <SettingsPageWrapper title={t`General`}>
+      <DevInstanceBanner />
       <SettingsSection title={t`App config`}>
         <AdminSettingInput
           name="site-name"

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -9,13 +9,12 @@ import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import { PLUGIN_LANDING_PAGE } from "metabase/plugins";
 
+import { DevInstanceBanner } from "../GeneralSettings/DevInstanceBanner";
 import { AdminSettingInput } from "../widgets/AdminSettingInput";
 import { AnonymousTrackingInput } from "../widgets/AnonymousTrackingInput";
 import { CustomHomepageDashboardSetting } from "../widgets/CustomHomepageDashboardSetting";
 import { HttpsOnlyWidget } from "../widgets/HttpsOnlyWidget";
 import { SiteUrlWidget } from "../widgets/SiteUrlWidget";
-
-import { DevInstanceBanner } from "./DevInstanceBanner";
 
 export function GeneralSettingsPage() {
   const { url: iframeDocsUrl } = useDocsUrl("configuring-metabase/settings", {

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -1,18 +1,17 @@
 import { jt, t } from "ttag";
 
-import {
-  SettingsPageWrapper,
-  SettingsSection,
-} from "metabase/admin/components/SettingsSection";
+import { UpsellDevInstances } from "metabase/admin/upsells/UpsellDevInstances";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import { PLUGIN_LANDING_PAGE } from "metabase/plugins";
 
+import { SettingsPageWrapper, SettingsSection } from "../SettingsSection";
 import { AdminSettingInput } from "../widgets/AdminSettingInput";
 import { AnonymousTrackingInput } from "../widgets/AnonymousTrackingInput";
 import { CustomHomepageDashboardSetting } from "../widgets/CustomHomepageDashboardSetting";
 import { HttpsOnlyWidget } from "../widgets/HttpsOnlyWidget";
 import { SiteUrlWidget } from "../widgets/SiteUrlWidget";
+
 export function GeneralSettingsPage() {
   const { url: iframeDocsUrl } = useDocsUrl("configuring-metabase/settings", {
     anchor: "allowed-domains-for-iframes-in-dashboards",
@@ -77,6 +76,7 @@ export function GeneralSettingsPage() {
           inputType="textarea"
         />
       </SettingsSection>
+      <UpsellDevInstances source="settings-general" />
     </SettingsPageWrapper>
   );
 }

--- a/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
@@ -1,10 +1,10 @@
 import { t } from "ttag";
 
 import { useSetting } from "metabase/common/hooks";
+import { getStoreUrl } from "metabase/selectors/settings";
 import { Text } from "metabase/ui";
 
 import { UpsellBanner } from "./components";
-import { UPGRADE_URL } from "./constants";
 
 type SOURCE = "embedding-page" | "settings-general";
 
@@ -20,7 +20,7 @@ export function UpsellDevInstances({ source }: { source: SOURCE }) {
       title={t`Get a development instance`}
       campaign="dev_instances"
       buttonText={t`Set up`}
-      buttonLink={UPGRADE_URL}
+      buttonLink={getStoreUrl("account/new-dev-instance")}
       source={source}
     >
       <Text size="sm">

--- a/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
@@ -1,0 +1,24 @@
+import { t } from "ttag";
+
+import { Text } from "metabase/ui";
+
+import { UpsellBanner } from "./components";
+import { UPGRADE_URL } from "./constants";
+
+type SOURCE = "embedding-page" | "settings-general";
+
+export function UpsellDevInstances({ source }: { source: SOURCE }) {
+  return (
+    <UpsellBanner
+      title={t`Get a development instance`}
+      campaign="dev_instances"
+      buttonText={t`Set up`}
+      buttonLink={UPGRADE_URL}
+      source={source}
+    >
+      <Text size="sm">
+        {t`Test out code in staging in a separate Metabase instance before deploying to production.`}
+      </Text>
+    </UpsellBanner>
+  );
+}

--- a/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { useSetting } from "metabase/common/hooks";
 import { Text } from "metabase/ui";
 
 import { UpsellBanner } from "./components";
@@ -8,6 +9,12 @@ import { UPGRADE_URL } from "./constants";
 type SOURCE = "embedding-page" | "settings-general";
 
 export function UpsellDevInstances({ source }: { source: SOURCE }) {
+  const isDevMode = useSetting("development-mode?");
+
+  if (isDevMode) {
+    return null;
+  }
+
   return (
     <UpsellBanner
       title={t`Get a development instance`}

--- a/frontend/src/metabase/admin/upsells/index.ts
+++ b/frontend/src/metabase/admin/upsells/index.ts
@@ -9,3 +9,4 @@ export * from "./UpsellSSO";
 export * from "./UpsellUploads";
 export * from "./UpsellUsageAnalytics";
 export * from "./UpsellWhitelabel";
+export { UpsellDevInstances } from "./UpsellDevInstances";

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -34,10 +34,14 @@ export const isSsoEnabled = (state: State) =>
   getSetting(state, "other-sso-enabled?");
 
 type StorePaths =
+  /* store main page */
   | ""
-  | "account/new-dev-instance"
+  /* checkout page */
   | "checkout"
-  | "account/manage/plans";
+  /* plans management page */
+  | "account/manage/plans"
+  /* development instance specific upsell */
+  | "account/new-dev-instance";
 
 export const getStoreUrl = (path: StorePaths = "") => {
   return `https://store.metabase.com/${path}`;

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -33,7 +33,13 @@ export const isSsoEnabled = (state: State) =>
   getSetting(state, "saml-enabled") ||
   getSetting(state, "other-sso-enabled?");
 
-export const getStoreUrl = (path = "") => {
+type StorePaths =
+  | ""
+  | "account/new-dev-instance"
+  | "checkout"
+  | "account/manage/plans";
+
+export const getStoreUrl = (path: StorePaths = "") => {
   return `https://store.metabase.com/${path}`;
 };
 


### PR DESCRIPTION
Closes: https://linear.app/metabase/issue/PRG-26/add-upsells-for-dev-instances-in-admin-settings

### Description

This PR adds new Upsell for dev instances. The upsell will be presented General and Embedding settings page. The upsell is hidden on a dev instance itself and will be dismissible after this task is finished: https://linear.app/metabase/issue/PRG-69/make-upsells-dismissible

Additionally on dev instance a banner will be displayed on General settings page. This banner clearly states that given instance is a development one and has a link to the stare where additional instances can be purchased.

Designs: https://www.figma.com/design/HEeJbTvfvGRV3IK2AYHlw0/Sell-development-instances?node-id=10139-1775&m=dev

### Demo

![CleanShot 2025-06-30 at 17 52 19@2x](https://github.com/user-attachments/assets/747ae88e-42f6-4737-9621-fc4c41c58b85)

![CleanShot 2025-06-30 at 17 52 52@2x](https://github.com/user-attachments/assets/22420f9e-d364-497c-b5ae-269036e266e4)

![CleanShot 2025-06-30 at 17 54 11@2x](https://github.com/user-attachments/assets/d72b6cec-eda3-43f0-972d-729cd42be9f0)
