### PR TITLE
fix: do not call field search if select dropdown is not opened

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputSearchableSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/ActionInputSearchableSelect.tsx
@@ -55,6 +55,7 @@ export const ActionInputSearchableSelect = ({
     search,
     fieldId: fieldId,
     searchFieldId: searchFieldId,
+    skipSearchQuery: !combobox.dropdownOpened,
   });
 
   const handleOptionSubmit = useCallback(
@@ -70,10 +71,19 @@ export const ActionInputSearchableSelect = ({
   );
 
   const inputLabel = useMemo(() => {
-    if (isLoading) {
-      return (
-        <Input.Placeholder c="text-light">{t`Loading...`}</Input.Placeholder>
-      );
+    if (value) {
+      // Display remapped label if `searchFieldId` is provided
+      if (searchFieldId) {
+        const option = options.find((item) => item.value === value);
+        if (option) {
+          return <Text truncate="end">{option.label}</Text>;
+        }
+      }
+
+      // Display the raw value if `searchFieldId` is not provided (e.g. for FKs)
+      else {
+        return <Text truncate="end">{value}</Text>;
+      }
     }
 
     if (!value && inputProps?.placeholder) {
@@ -84,16 +94,14 @@ export const ActionInputSearchableSelect = ({
       );
     }
 
-    if (value) {
-      // If searchFieldId is provided, display the label instead of the value
-      if (searchFieldId) {
-        const option = options.find((item) => item.value === value);
-        if (option) {
-          return <Text truncate="end">{option.label}</Text>;
-        }
-      }
+    if (isLoading) {
+      return (
+        <Input.Placeholder c="text-light">{t`Loading...`}</Input.Placeholder>
+      );
+    }
 
-      // Fallback to the raw value instead of a label
+    // Fallback to the raw value instead of a label
+    if (value) {
       return <Text truncate="end">{value}</Text>;
     }
 

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/use-action-input-searchable-options.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/inputs_v2/use-action-input-searchable-options.tsx
@@ -17,6 +17,7 @@ type UseActionInputSearchableOptionsProps = {
   fieldId: number;
   searchFieldId?: number;
   limit?: number;
+  skipSearchQuery?: boolean;
 };
 
 export function useActionInputSearchableOptions({
@@ -25,6 +26,7 @@ export function useActionInputSearchableOptions({
   fieldId,
   searchFieldId = fieldId,
   limit = SEARCH_LIMIT_DEFAULT,
+  skipSearchQuery = false,
 }: UseActionInputSearchableOptionsProps) {
   const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE);
   const [searchValueToFetch, setSearchValueToFetch] = useState(debouncedSearch);
@@ -50,13 +52,16 @@ export function useActionInputSearchableOptions({
     data: fieldValues,
     isLoading,
     isFetching,
-  } = useSearchFieldValuesQuery({
-    fieldId: fieldId,
-    searchFieldId: searchFieldId,
-    // empty string is invalid from the API perspective
-    value: searchValueToFetch === "" ? undefined : searchValueToFetch,
-    limit: SEARCH_LIMIT_DEFAULT,
-  });
+  } = useSearchFieldValuesQuery(
+    {
+      fieldId: fieldId,
+      searchFieldId: searchFieldId,
+      // empty string is invalid from the API perspective
+      value: searchValueToFetch === "" ? undefined : searchValueToFetch,
+      limit: SEARCH_LIMIT_DEFAULT,
+    },
+    { skip: skipSearchQuery },
+  );
 
   const { data: initialFieldValue } = useGetRemappedFieldValueQuery(
     {
@@ -98,6 +103,10 @@ export function useActionInputSearchableOptions({
       }
 
       return options;
+    }
+
+    if (initialFieldValue) {
+      return getFieldOptions([initialFieldValue]);
     }
 
     return [];


### PR DESCRIPTION
Currently searchable select fetches 20 initial search values on mount. We would like to avoid redundant BE requests and call the API only if select dropdown is opened