### PR TITLE
Improve chart context

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
@@ -17,6 +17,7 @@ import { useMetabotAgent } from "./hooks";
 import { getMetabotVisible, metabotReducer } from "./state";
 
 if (hasPremiumFeature("metabot_v3")) {
+  PLUGIN_METABOT.isEnabled = () => true;
   PLUGIN_METABOT.Metabot = Metabot;
 
   PLUGIN_METABOT.adminNavItem = [

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -104,6 +104,8 @@ export type MetabotChartConfig = {
     description?: string;
     timestamp: string;
   }>;
+  query?: DatasetQuery;
+  display_type?: CardDisplayType;
 };
 
 export type MetabotCardInfo = {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -684,6 +684,7 @@ export const PLUGIN_AI_ENTITY_ANALYSIS: PluginAIEntityAnalysis = {
 };
 
 export const PLUGIN_METABOT = {
+  isEnabled: () => false,
   Metabot: (_props: { hide?: boolean }) => null as React.ReactElement | null,
   defaultMetabotContextValue,
   MetabotContext: React.createContext(defaultMetabotContextValue),

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import { match } from "ts-pattern";
 
 import { useRegisterMetabotContextProvider } from "metabase/metabot";
-import { PLUGIN_AI_ENTITY_ANALYSIS } from "metabase/plugins";
+import { PLUGIN_AI_ENTITY_ANALYSIS, PLUGIN_METABOT } from "metabase/plugins";
 import {
   getChartImagePngDataUri,
   getChartSelector,
@@ -215,6 +215,9 @@ export const registerQueryBuilderMetabotContextFn = async ({
   timelines: Timeline[];
   queryResult: any;
 }) => {
+  if (!PLUGIN_METABOT.isEnabled()) {
+    return {};
+  }
   if (!question) {
     return {};
   }
@@ -250,7 +253,7 @@ export const registerQueryBuilderMetabotContextFn = async ({
 };
 
 export const useRegisterQueryBuilderMetabotContext = () => {
-  useRegisterMetabotContextProvider((state) => {
+  useRegisterMetabotContextProvider(async (state) => {
     const question = getQuestion(state);
     const series = getTransformedSeries(state);
     const visualizationSettings = getVisualizationSettings(state);

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
@@ -185,10 +185,6 @@ const getChartConfigs = async ({
   timelines: Timeline[];
 }): Promise<MetabotChartConfig[]> => {
   try {
-    if (!PLUGIN_AI_ENTITY_ANALYSIS.canAnalyzeQuestion(question)) {
-      return [];
-    }
-
     return [
       {
         image_base_64: await getVisualizationDataUri(question),
@@ -196,6 +192,8 @@ const getChartConfigs = async ({
         description: question.description(),
         series: processSeriesData(series, visualizationSettings),
         timeline_events: processTimelineEvents(timelines),
+        query: question.datasetQuery(),
+        display_type: question.display(),
       },
     ];
   } catch (err) {
@@ -245,8 +243,6 @@ export const registerQueryBuilderMetabotContextFn = async ({
       {
         ...questionCtx,
         ...queryCtx,
-        query: question.datasetQuery(),
-        display_type: question.display(),
         chart_configs,
       },
     ],


### PR DESCRIPTION
### Description

We had a couple of [feedback](https://metaboat.slack.com/archives/C07SJT1P0ET/p1750434036727059) from internal folks that editing chart types would be a handy features.
After some early exploration, we decided to implement it.

Closes: https://linear.app/metabase/issue/BOT-206/move-query-in-context-into-chart-configs-to-make-pattern-reusable-for

Changes to Metabot context:
* Send query
* Send display type
* Refactor existing code to only provide query once and not send display type on the root

Relates to[ this ai-service branch.](https://github.com/metabase/ai-service/pull/260)


### Demo

See [slack](https://metaboat.slack.com/archives/C07SJT1P0ET/p1750850044653649)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
