### PR TITLE
Avoid invalid prop errors in Cypress from the mock undolisting

### DIFF
--- a/frontend/src/metabase/common/components/UndoListing.tsx
+++ b/frontend/src/metabase/common/components/UndoListing.tsx
@@ -170,7 +170,12 @@ document.body.appendChild(target);
 
 // The react transition group state transitions are flaky in cypress
 // so disable them for altogether.
-const Group = "Cypress" in window ? Fragment : TransitionGroup;
+const Group = "Cypress" in window ? MockGroup : TransitionGroup;
+
+function MockGroup({ children }: { children: ReactNode }) {
+  return <Fragment>{children}</Fragment>;
+}
+
 const Item =
   "Cypress" in window
     ? function MockItem({


### PR DESCRIPTION
I had introduced some invalid prop warnings in Cypress in #59863.

This PR removes these warnings.