### PR TITLE
fix: ad hoc error messages return the hidden card

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -68,7 +68,7 @@
   (str (metabot-v3.settings/ai-service-base-url) "/v2/agent"))
 
 (defn- agent-v2-streaming-endpoint-url []
-  (str (metabot-v3.settings/ai-proxy-base-url) "/v2/agent/stream"))
+  (str (metabot-v3.settings/ai-service-base-url) "/v2/agent/stream"))
 
 (defn- metric-selection-endpoint-url []
   (str (metabot-v3.settings/ai-service-base-url) "/v1/select-metric"))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -10,7 +10,9 @@
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (clojure.lang ExceptionInfo)))
 
 ;;;; Graph-related stuff
 
@@ -410,3 +412,295 @@
              clojure.lang.ExceptionInfo
              #"You do not have permissions to run this query"
              (mt/rows (mt/user-http-request :rasta :post (format "card/%d/query" query-card-id)))))))))
+
+(deftest e2e-card-source-table-join-no-permissions-test
+  (testing "User cannot run query with card as source table joined to table when they have no permissions to the table"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp-copy-of-db
+          (mt/with-no-data-perms-for-all-users!
+            ;; Allow access to venues table for the card
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/view-data :unrestricted)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/create-queries :query-builder)
+            ;; Block all access to categories table
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :categories) :perms/view-data :blocked)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :categories) :perms/create-queries :no)
+            (mt/with-temp [:model/Collection collection]
+              (perms/grant-collection-read-permissions! (perms/all-users-group) collection)
+              (mt/with-temp [:model/Card {venues-card-id :id} {:collection_id (u/the-id collection)
+                                                               :dataset_query (mt/mbql-query venues
+                                                                                {:fields [$id $name $category_id]
+                                                                                 :order-by [[:asc $id]]
+                                                                                 :limit 5})}]
+                (let [join-query (mt/mbql-query nil
+                                   {:source-table (format "card__%d" venues-card-id)
+                                    :joins [{:fields :all
+                                             :source-table (mt/id :categories)
+                                             :alias "cat"
+                                             :condition [:= [:field (mt/id :venues :category_id) {:base-type :type/Integer}]
+                                                         [:field (mt/id :categories :id) {:base-type :type/Integer, :join-alias "cat"}]]}]
+                                    :limit 2})]
+                  (mt/with-test-user :rasta
+                    (testing "Should not be able to run ad-hoc query with card as source joined to blocked table"
+                      (is (thrown-with-msg?
+                           ExceptionInfo
+                           #"You do not have permissions to run this query"
+                           (qp/process-query join-query))))
+                    (testing "Should not be able to run card query with card as source joined to blocked table"
+                      (mt/with-temp [:model/Card {join-card-id :id} {:collection_id (u/the-id collection)
+                                                                     :dataset_query join-query}]
+                        (binding [qp.perms/*card-id* join-card-id]
+                          (is (thrown-with-msg?
+                               ExceptionInfo
+                               #"You do not have permissions to run this query"
+                               (qp/process-query join-query))))))))))))))))
+
+(deftest e2e-card-with-join-table-join-no-permissions-test
+  (testing "User cannot run query joining card (that contains a join) to table when they have no permissions to the table"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp-copy-of-db
+          (mt/with-no-data-perms-for-all-users!
+            ;; Block all access to checkins table
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :blocked)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/create-queries :no)
+            ;; Allow access to venues and categories tables for the card with join
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/view-data :unrestricted)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/create-queries :query-builder)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :categories) :perms/view-data :unrestricted)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :categories) :perms/create-queries :query-builder)
+            (mt/with-temp [:model/Collection collection]
+              (perms/grant-collection-read-permissions! (perms/all-users-group) collection)
+              (mt/with-temp [:model/Card {venues-with-join-card-id :id} {:collection_id (u/the-id collection)
+                                                                         :dataset_query (mt/mbql-query venues
+                                                                                          {:fields [$id $name $category_id]
+                                                                                           :joins [{:fields :all
+                                                                                                    :source-table (mt/id :categories)
+                                                                                                    :alias "cat"
+                                                                                                    :condition [:= $category_id
+                                                                                                                [:field (mt/id :categories :id) {:base-type :type/Integer, :join-alias "cat"}]]}]
+                                                                                           :order-by [[:asc $id]]
+                                                                                           :limit 5})}]
+                (let [join-query (mt/mbql-query checkins
+                                   {:joins [{:fields :all
+                                             :source-table (format "card__%d" venues-with-join-card-id)
+                                             :alias "venues_card"
+                                             :condition [:= $venue_id
+                                                         [:field (mt/id :venues :id) {:base-type :type/Integer, :join-alias "venues_card"}]]}]
+                                    :limit 2})]
+                  (mt/with-test-user :rasta
+                    (testing "Should not be able to run ad-hoc query joining card with join to blocked table"
+                      (is (thrown-with-msg?
+                           ExceptionInfo
+                           #"You do not have permissions to run this query"
+                           (qp/process-query join-query))))
+                    (testing "Should not be able to run card query joining card with join to blocked table"
+                      (mt/with-temp [:model/Card {join-card-id :id} {:collection_id (u/the-id collection)
+                                                                     :dataset_query join-query}]
+                        (binding [qp.perms/*card-id* join-card-id]
+                          (is (thrown-with-msg?
+                               ExceptionInfo
+                               #"You do not have permissions to run this query"
+                               (qp/process-query join-query))))))))))))))))
+
+(deftest e2e-card-with-join-source-table-join-no-permissions-test
+  (testing "User cannot run query with card (that contains a join) as source joined to table when they have no permissions to the table"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp-copy-of-db
+          (mt/with-no-data-perms-for-all-users!
+            ;; Allow access to venues and categories tables for the card with join
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/view-data :unrestricted)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/create-queries :query-builder)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :categories) :perms/view-data :unrestricted)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :categories) :perms/create-queries :query-builder)
+            ;; Block all access to checkins table
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/view-data :blocked)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :checkins) :perms/create-queries :no)
+            (mt/with-temp [:model/Collection collection]
+              (perms/grant-collection-read-permissions! (perms/all-users-group) collection)
+              (mt/with-temp [:model/Card {venues-with-join-card-id :id} {:collection_id (u/the-id collection)
+                                                                         :dataset_query (mt/mbql-query venues
+                                                                                          {:fields [$id $name $category_id]
+                                                                                           :joins [{:fields :all
+                                                                                                    :source-table (mt/id :categories)
+                                                                                                    :alias "cat"
+                                                                                                    :condition [:= $category_id
+                                                                                                                [:field (mt/id :categories :id) {:base-type :type/Integer, :join-alias "cat"}]]}]
+                                                                                           :order-by [[:asc $id]]
+                                                                                           :limit 5})}]
+                (let [join-query (mt/mbql-query nil
+                                   {:source-table (format "card__%d" venues-with-join-card-id)
+                                    :joins [{:fields :all
+                                             :source-table (mt/id :checkins)
+                                             :alias "checkins"
+                                             :condition [:= [:field (mt/id :venues :id) {:base-type :type/Integer}]
+                                                         [:field (mt/id :checkins :venue_id) {:base-type :type/Integer, :join-alias "checkins"}]]}]
+                                    :limit 2})]
+                  (mt/with-test-user :rasta
+                    (testing "Should not be able to run ad-hoc query with card with join as source joined to blocked table"
+                      (is (thrown-with-msg?
+                           ExceptionInfo
+                           #"You do not have permissions to run this query"
+                           (qp/process-query join-query))))
+                    (testing "Should not be able to run card query with card with join as source joined to blocked table"
+                      (mt/with-temp [:model/Card {join-card-id :id} {:collection_id (u/the-id collection)
+                                                                     :dataset_query join-query}]
+                        (binding [qp.perms/*card-id* join-card-id]
+                          (is (thrown-with-msg?
+                               ExceptionInfo
+                               #"You do not have permissions to run this query"
+                               (qp/process-query join-query))))))))))))))))
+
+(deftest e2e-nested-source-card-partial-view-permissions-mbql-native-test
+  (testing "Make sure permissions are calculated correctly for Card 1 -> Card 2 -> Source Query when there are partial
+           permissions to view-data for both Cards (#12354) - MBQL Card 1, native Card 2"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp-copy-of-db
+          (mt/with-no-data-perms-for-all-users!
+            (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :blocked)
+            (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :no)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/view-data :unrestricted)
+            (mt/with-temp [:model/Collection collection]
+              (perms/grant-collection-read-permissions! (perms/all-users-group) collection)
+              (let [card-1-query (mt/mbql-query venues
+                                   {:order-by [[:asc $id]], :limit 2})]
+                (mt/with-temp [:model/Card {card-1-id :id, :as card-1} {:collection_id (u/the-id collection)
+                                                                        :dataset_query card-1-query}]
+                  (let [card-2-query (mt/native-query
+                                       {:query         "SELECT * FROM {{card}}"
+                                        :template-tags {"card" {:name         "card"
+                                                                :display-name "card"
+                                                                :type         :card
+                                                                :card-id      card-1-id}}})]
+                    (mt/with-temp [:model/Card card-2 {:collection_id (u/the-id collection)
+                                                       :dataset_query card-2-query}]
+                      (testing "should be able to read nested-nested Card if we have Collection permissions"
+                        (mt/with-test-user :rasta
+                          (let [expected [[1 "Red Medicine"           4 10.0646 -165.374 3]
+                                          [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2]]]
+                            (testing "Should be able to run Card 1 directly"
+                              (binding [qp.perms/*card-id* (u/the-id card-1)]
+                                (is (= expected
+                                       (mt/rows
+                                        (qp/process-query (:dataset_query card-1)))))))
+
+                            (testing "Should not be able to run Card 2 directly [Card 2 -> Card 1 -> Source Query]"
+                              (binding [qp.perms/*card-id* (u/the-id card-2)]
+                                (is (thrown-with-msg?
+                                     clojure.lang.ExceptionInfo
+                                     #"You do not have permissions to run this query"
+                                     (qp/process-query (:dataset_query card-2))))))
+
+                            (testing "Should be able to run ad-hoc query with Card 1 as source query [Ad-hoc -> Card -> Source Query]"
+                              (is (= expected
+                                     (mt/rows
+                                      (qp/process-query (mt/mbql-query nil
+                                                          {:source-table (format "card__%d" card-1-id)}))))))
+
+                            (testing "Should not be able to run ad-hoc query with Card 2 as source query [Ad-hoc -> Card -> Card -> Source Query]"
+                              (is (thrown-with-msg?
+                                   clojure.lang.ExceptionInfo
+                                   #"You do not have permissions to run this query"
+                                   (mt/rows
+                                    (qp/process-query
+                                     (qp/userland-query
+                                      (mt/mbql-query nil
+                                        {:source-table (format "card__%d" (u/the-id card-2))})))))))))))))))))))))
+
+(deftest e2e-nested-source-card-partial-permissions-native-mbql-test
+  (testing  "Make sure permissions are calculated correctly for Card 1 -> Card 2 -> Source Query when there are partial
+           permissions to view-data for both Cards (#12354) - Native Card 1, MBQL Card 2"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp-copy-of-db
+          (mt/with-no-data-perms-for-all-users!
+            (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :blocked)
+            (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :no)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/view-data :unrestricted)
+            (mt/with-temp [:model/Collection collection]
+              (perms/grant-collection-read-permissions! (perms/all-users-group) collection)
+              (let [card-1-query (mt/native-query
+                                   {:query (str "SELECT id, name, category_id, latitude, longitude, price "
+                                                "FROM venues "
+                                                "ORDER BY id ASC "
+                                                "LIMIT 2")})]
+                (mt/with-temp [:model/Card {card-1-id :id, :as card-1} {:collection_id (u/the-id collection)
+                                                                        :dataset_query card-1-query}]
+                  (let [card-2-query (mt/mbql-query nil
+                                       {:source-table (format "card__%d" card-1-id)})]
+                    (mt/with-temp [:model/Card card-2 {:collection_id (u/the-id collection)
+                                                       :dataset_query card-2-query}]
+                      (testing "should not be able to run queries due to insufficient permissions"
+                        (mt/with-test-user :rasta
+                          (testing "Should not be able to run Card 1 directly"
+                            (binding [qp.perms/*card-id* (u/the-id card-1)]
+                              (is (thrown-with-msg?
+                                   clojure.lang.ExceptionInfo
+                                   #"You do not have permissions to run this query"
+                                   (qp/process-query (:dataset_query card-1))))))
+
+                          (testing "Should not be able to run Card 2 directly [Card 2 -> Card 1 -> Source Query]"
+                            (binding [qp.perms/*card-id* (u/the-id card-2)]
+                              (is (thrown-with-msg?
+                                   clojure.lang.ExceptionInfo
+                                   #"You do not have permissions to run this query"
+                                   (qp/process-query (:dataset_query card-2))))))
+
+                          (testing "Should not be able to run ad-hoc query with Card 1 as source query [Ad-hoc -> Card -> Source Query]"
+                            (is (thrown-with-msg?
+                                 clojure.lang.ExceptionInfo
+                                 #"You do not have permissions to run this query"
+                                 (qp/process-query (mt/mbql-query nil
+                                                     {:source-table (format "card__%d" card-1-id)})))))
+
+                          (testing "Should not be able to run ad-hoc query with Card 2 as source query [Ad-hoc -> Card -> Card -> Source Query]"
+                            (is (thrown-with-msg?
+                                 clojure.lang.ExceptionInfo
+                                 #"You do not have permissions to run this query"
+                                 (mt/rows
+                                  (qp/process-query
+                                   (qp/userland-query
+                                    (mt/mbql-query nil
+                                      {:source-table (format "card__%d" (u/the-id card-2))}))))))))))))))))))))
+
+(deftest e2e-card-table-join-no-permissions-test
+  (testing "User cannot run query joining card to table when they have no permissions to the table"
+    (mt/with-premium-features #{:advanced-permissions}
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp-copy-of-db
+          (mt/with-no-data-perms-for-all-users!
+            ;; Block all access to venues table
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/view-data :blocked)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :venues) :perms/create-queries :no)
+            ;; Allow access to categories table for the card
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :categories) :perms/view-data :unrestricted)
+            (perms/set-table-permission! (perms/all-users-group) (mt/id :categories) :perms/create-queries :query-builder)
+            (mt/with-temp [:model/Collection collection]
+              (perms/grant-collection-read-permissions! (perms/all-users-group) collection)
+              (mt/with-temp [:model/Card {categories-card-id :id} {:collection_id (u/the-id collection)
+                                                                   :dataset_query (mt/mbql-query categories
+                                                                                    {:fields [$id $name]
+                                                                                     :order-by [[:asc $id]]})}]
+                (let [join-query (mt/mbql-query venues
+                                   {:joins [{:fields :all
+                                             :source-table (format "card__%d" categories-card-id)
+                                             :alias "cat"
+                                             :condition [:= $category_id
+                                                         [:field (mt/id :categories :id) {:base-type :type/Integer, :join-alias "cat"}]]}]
+                                    :limit 2})]
+                  (mt/with-test-user :rasta
+                    (testing "Should not be able to run ad-hoc query joining card to blocked table"
+                      (is (thrown-with-msg?
+                           ExceptionInfo
+                           #"You do not have permissions to run this query"
+                           (qp/process-query join-query))))
+                    (testing "Should not be able to run card query joining card to blocked table"
+                      (mt/with-temp [:model/Card {join-card-id :id} {:collection_id (u/the-id collection)
+                                                                     :dataset_query join-query}]
+                        (binding [qp.perms/*card-id* join-card-id]
+                          (is (thrown-with-msg?
+                               ExceptionInfo
+                               #"You do not have permissions to run this query"
+                               (qp/process-query join-query))))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions_test.clj
@@ -475,3 +475,144 @@
                                   (is (partial=
                                        {:error "You do not have permissions to download the results of this query."}
                                        results)))}})))))))
+
+(deftest joined-cards-with-native-query-test
+  (testing "Do we correctly apply the least permissive download perms when joining cards where one has a native query? (#XXXX)"
+    (mt/with-full-data-perms-for-all-users!
+      (with-redefs [ee.qp.perms/max-rows-in-limited-downloads 3]
+        (mt/with-temp [:model/Card {mbql-card-id :id} {:dataset_query {:database (mt/id)
+                                                                       :type     :query
+                                                                       :query    {:source-table (mt/id :venues)}}}
+                       :model/Card {native-card-id :id} {:dataset_query {:database (mt/id)
+                                                                         :type     :native
+                                                                         :native   {:query "SELECT * FROM checkins"}}}]
+          (testing "When one card has native query, least permissive DB-level permission applies"
+            (with-download-perms! (mt/id) {:schemas {"PUBLIC" {(mt/id :venues)     :full
+                                                               (mt/id :checkins)   :limited
+                                                               (mt/id :users)      :full}}}
+              (streaming-test/do-test!
+               "Join between MBQL card (venues:full) and native card - should use limited perms due to native query"
+               {:query {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (format "card__%d" mbql-card-id)
+                                   :joins        [{:fields       [[:field "ID" {:base-type :type/Integer}]]
+                                                   :source-table (format "card__%d" native-card-id)
+                                                   :alias        "native_card"
+                                                   :condition    [:= [:field "ID" {:base-type :type/Integer}]
+                                                                  [:field "VENUE_ID" {:base-type :type/Integer, :join-alias "native_card"}]]
+                                                   :strategy     :left-join}]
+                                   :limit        10}}
+                :endpoints  [:card :dataset]
+                :assertions {:csv (fn [results] (is (= 3 (csv-row-count results))))}})))
+
+          (testing "When native card references tables with no download perms, download is blocked"
+            (with-download-perms! (mt/id) {:schemas {"PUBLIC" {(mt/id :venues)     :full
+                                                               (mt/id :checkins)   :none
+                                                               (mt/id :users)      :limited}}}
+              (streaming-test/do-test!
+               "Join between MBQL card (venues:full) and native card - should block due to checkins:none"
+               {:query {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (format "card__%d" mbql-card-id)
+                                   :joins        [{:fields       [[:field "ID" {:base-type :type/Integer}]]
+                                                   :source-table (format "card__%d" native-card-id)
+                                                   :alias        "native_card"
+                                                   :condition    [:= [:field "ID" {:base-type :type/Integer}]
+                                                                  [:field "VENUE_ID" {:base-type :type/Integer, :join-alias "native_card"}]]
+                                                   :strategy     :left-join}]
+                                   :limit        10}}
+                :endpoints  [:card :dataset]
+                :assertions {:csv (fn [results]
+                                    (is (partial=
+                                         {:error "You do not have permissions to download the results of this query."}
+                                         results)))}})))
+
+          (testing "When all tables have full perms, download works normally"
+            (with-download-perms! (mt/id) {:schemas {"PUBLIC" {(mt/id :venues)     :full
+                                                               (mt/id :checkins)   :full
+                                                               (mt/id :users)      :full}}}
+              (streaming-test/do-test!
+               "Join between MBQL card and native card - should work with full perms for all tables"
+               {:query {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (format "card__%d" mbql-card-id)
+                                   :joins        [{:fields       [[:field "ID" {:base-type :type/Integer}]]
+                                                   :source-table (format "card__%d" native-card-id)
+                                                   :alias        "native_card"
+                                                   :condition    [:= [:field "ID" {:base-type :type/Integer}]
+                                                                  [:field "VENUE_ID" {:base-type :type/Integer, :join-alias "native_card"}]]
+                                                   :strategy     :left-join}]
+                                   :limit        10}}
+                :endpoints  [:card :dataset]
+                :assertions {:csv (fn [results] (is (= 10 (csv-row-count results))))}}))))))))
+
+(deftest card-with-native-source-card-test
+  (testing "Do we correctly apply download perms when downloading from a card that uses a source card with a native query?"
+    (mt/with-full-data-perms-for-all-users!
+      (with-redefs [ee.qp.perms/max-rows-in-limited-downloads 3]
+        (mt/with-temp [:model/Card {native-source-card-id :id} {:dataset_query {:database (mt/id)
+                                                                                :type     :native
+                                                                                :native   {:query "SELECT * FROM checkins"}}}
+                       :model/Card {mbql-card-id :id} {:dataset_query {:database (mt/id)
+                                                                       :type     :query
+                                                                       :query    {:source-table (format "card__%d" native-source-card-id)
+                                                                                  :aggregation  [[:count]]
+                                                                                  :breakout     [[:field "VENUE_ID" {:base-type :type/Integer}]]}}}]
+          (testing "When source card has native query with limited perms, download is limited"
+            (with-download-perms! (mt/id) {:schemas {"PUBLIC" {(mt/id :venues)     :full
+                                                               (mt/id :checkins)   :limited
+                                                               (mt/id :users)      :full}}}
+              (streaming-test/do-test!
+               "Card with native source card - should use limited perms due to native query in source"
+               {:query {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (format "card__%d" mbql-card-id)
+                                   :limit        10}}
+                :endpoints  [:card :dataset]
+                :assertions {:csv (fn [results] (is (= 3 (csv-row-count results))))}})))
+
+          (testing "When source card has native query with no download perms, download is blocked"
+            (with-download-perms! (mt/id) {:schemas {"PUBLIC" {(mt/id :venues)     :full
+                                                               (mt/id :checkins)   :none
+                                                               (mt/id :users)      :full}}}
+              (streaming-test/do-test!
+               "Card with native source card - should block due to checkins:none in native source"
+               {:query {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (format "card__%d" mbql-card-id)
+                                   :limit        10}}
+                :endpoints  [:card :dataset]
+                :assertions {:csv (fn [results]
+                                    (is (partial=
+                                         {:error "You do not have permissions to download the results of this query."}
+                                         results)))}})))
+
+          (testing "When source card has native query with full perms, download works normally"
+            (with-download-perms! (mt/id) {:schemas {"PUBLIC" {(mt/id :venues)     :full
+                                                               (mt/id :checkins)   :full
+                                                               (mt/id :users)      :full}}}
+              (streaming-test/do-test!
+               "Card with native source card - should work with full perms for all tables"
+               {:query {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (format "card__%d" mbql-card-id)
+                                   :limit        10}}
+                :endpoints  [:card :dataset]
+                :assertions {:csv (fn [results] (is (= 10 (csv-row-count results))))}})))
+
+          (testing "Nested source cards with native query apply least permissive perms"
+            (mt/with-temp [:model/Card {nested-card-id :id} {:dataset_query {:database (mt/id)
+                                                                             :type     :query
+                                                                             :query    {:source-table (format "card__%d" mbql-card-id)
+                                                                                        :filter       [:> [:field "count" {:base-type :type/Integer}] 1]}}}]
+              (with-download-perms! (mt/id) {:schemas {"PUBLIC" {(mt/id :venues)     :full
+                                                                 (mt/id :checkins)   :limited
+                                                                 (mt/id :users)      :full}}}
+                (streaming-test/do-test!
+                 "Nested card with native source card - should use limited perms from deepest native query"
+                 {:query {:database (mt/id)
+                          :type     :query
+                          :query    {:source-table (format "card__%d" nested-card-id)
+                                     :limit        10}}
+                  :endpoints  [:card :dataset]
+                  :assertions {:csv (fn [results] (is (= 3 (csv-row-count results))))}})))))))))

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -78,37 +78,69 @@
 (mu/defn query->source-ids :- [:maybe
                                [:map
                                 [:table-ids {:optional true} [:set ::lib.schema.id/table]]
+                                [:table-query-ids {:optional true} [:set ::lib.schema.id/table]]
                                 [:card-ids  {:optional true} [:set ::lib.schema.id/card]]
                                 [:native?   {:optional true} :boolean]]]
-  "Return a map containing table IDs and/or card IDs referenced by `query`, and/or the :native? boolean flag
-  indicating a native query or subquery. Intended to be used in the context of permissions enforcement."
-  [query :- :map]
-  (apply merge-with merge-source-ids
-         (lib.util.match/match query
-           ;; If we find a table id from a gtapped table add it to the list of table ids here if we fail to get perms
-           ;; for this table we'll check again for this key and try the supplied gtap perms
-           (m :guard (every-pred map? :query-permissions/gtapped-table))
-           (merge-with merge-source-ids
-                       {:table-ids #{(:query-permissions/gtapped-table m)}}
-                       ;; Remove any :native sibling queries since they will be ones supplied by the gtap and we don't
-                       ;; want to mark the whole query as native? if they exist
-                       (query->source-ids (dissoc m :query-permissions/gtapped-table :native)))
+  "Returns a map containing sources necessary for permissions checks. The map will have the full set of resources
+  necessary for ad hoc query execution.
 
-           ;; If we come across a native query, replace it with a card ID if it came from a source card, so we can check
-           ;; permissions on the card and not necessarily require full native query access to the DB
-           (m :guard (every-pred map? :native))
-           (if-let [source-card-id (:qp/stage-is-from-source-card m)]
-             {:card-ids #{source-card-id}}
-             {:native? true})
+  * table-ids - tables that a user will need view-data permissions to access
+  * card-ids - cards that user will need collection-access permissions to use
+  * table-query-ids - tables that a user will create-queries permissions to run an ad hoc query
+  * native? - a flag that will be set if the query requires native permissions.
 
-           (m :guard (every-pred map? #(pos-int? (:source-table %))))
-           (merge-with merge-source-ids
-                       {:table-ids #{(:source-table m)}}
-                       ;; If there's a source card associated with a table ID, include it so that we can ensure that
-                       ;; ad-hoc queries don't access cards with no collection perms
-                       (when-let [source-card-id (:qp/stage-is-from-source-card m)]
-                         {:card-ids #{source-card-id}})
-                       (query->source-ids (dissoc m :source-table))))))
+  The process for assembling this resources matches stages in a legacy-MBQL query:
+
+  1. Does the stage have a :qp/stage-is-from-source-card key?
+
+     If there's no parent-source-card-id, add the source-card id to the card-ids set and
+     continue the match setting parent-source-card-id.
+
+  2. Does the stage have a :query-permissions/gtapped-table key?
+
+     This means the stage came from a Sandbox query, so we add the table to the table-ids set.
+     If there's no parent-source-card-id, also add it to the table-query-ids set.
+     Remove any sibling native permissions before continuing the match.
+
+  3. Does the stage have a :native query?
+
+     If there's no parent-source-card-id, set the native flag and end the match.
+
+  4. Does the stage have a :source-table?
+
+     Add the table to the table-ids set. If there's no parent-source-card-id, also add it
+     to the table-query-ids set, then continue the match."
+  ([query :- :map]
+   (query->source-ids query nil))
+  ([query :- :map
+    parent-source-card-id :- [:maybe :any]]
+   (apply merge-with merge-source-ids
+          (lib.util.match/match query
+            (m :guard (every-pred map? :qp/stage-is-from-source-card))
+            (when-not parent-source-card-id
+              (merge-with merge-source-ids
+                          {:card-ids #{(:qp/stage-is-from-source-card m)}}
+                          (query->source-ids (dissoc m :qp/stage-is-from-source-card) (:qp/stage-is-from-source-card m))))
+
+            (m :guard (every-pred map? :query-permissions/gtapped-table))
+            (merge-with merge-source-ids
+                        {:table-ids #{(:query-permissions/gtapped-table m)}}
+                        (when-not parent-source-card-id
+                          {:table-query-ids #{(:query-permissions/gtapped-table m)}})
+                        ;; Remove any :native sibling queries since they will be ones supplied by the gtap and we don't
+                        ;; want to mark the whole query as native? if they exist
+                        (query->source-ids (dissoc m :query-permissions/gtapped-table :native) parent-source-card-id))
+
+            (m :guard (every-pred map? :native))
+            (when-not parent-source-card-id
+              {:native? true})
+
+            (m :guard (every-pred map? #(pos-int? (:source-table %))))
+            (merge-with merge-source-ids
+                        {:table-ids #{(:source-table m)}}
+                        (when-not parent-source-card-id
+                          {:table-query-ids #{(:source-table m)}})
+                        (query->source-ids (dissoc m :source-table) parent-source-card-id))))))
 
 (mu/defn query->source-table-ids
   "Returns a sequence of all :source-table IDs referenced by a query. Convenience wrapper around `query->source-ids` if
@@ -183,13 +215,14 @@
         ;; otherwise if there's no source card then calculate perms based on the Tables referenced in the query
         (let [query (cond-> query
                       (not already-preprocessed?) preprocess-query)
-              {:keys [table-ids card-ids native?]} (query->source-ids query)]
+              {:keys [table-ids table-query-ids card-ids native?]} (query->source-ids query)]
           (merge
            (when (seq card-ids)
              {:card-ids card-ids})
            (when (seq table-ids)
-             {:perms/create-queries (zipmap table-ids (repeat :query-builder))
-              :perms/view-data      (zipmap table-ids (repeat :unrestricted))})
+             {:perms/view-data      (zipmap table-ids (repeat :unrestricted))})
+           (when (seq table-query-ids)
+             {:perms/create-queries (zipmap table-query-ids (repeat :query-builder))})
            (when native?
              (native-query-perms query))))))
     ;; if for some reason we can't expand the Card (i.e. it's an invalid legacy card) just return a set of permissions

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -78,17 +78,16 @@
 
                            (= (:type source-card) :model)
                            (assoc :metadata/model-metadata (:result_metadata source-card)))]
-      (binding [qp.perms/*card-id* source-card-id]
-        (qp.streaming/streaming-response [rff export-format]
-          (if was-pivot
-            (let [constraints (if (= export-format :api)
-                                (qp.constraints/default-query-constraints)
-                                (:constraints query))]
-              (qp.pivot/run-pivot-query (-> query
-                                            (assoc :constraints constraints)
-                                            (update :info merge info))
-                                        rff))
-            (qp/process-query (update query :info merge info) rff)))))))
+      (qp.streaming/streaming-response [rff export-format]
+        (if was-pivot
+          (let [constraints (if (= export-format :api)
+                              (qp.constraints/default-query-constraints)
+                              (:constraints query))]
+            (qp.pivot/run-pivot-query (-> query
+                                          (assoc :constraints constraints)
+                                          (update :info merge info))
+                                      rff))
+          (qp/process-query (update query :info merge info) rff))))))
 
 (api.macros/defendpoint :post "/"
   "Execute a query and retrieve the results in the usual format. The query will not use the cache."

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -114,15 +114,16 @@
     (when (= audit/audit-db-id database-id)
       (check-audit-db-permissions outer-query))
     (check-query-does-not-access-inactive-tables outer-query)
-    (let [card-id         (or *card-id* (:qp/source-card-id outer-query))
-          required-perms  (query-perms/required-perms-for-query outer-query :already-preprocessed? true)
+    (let [required-perms  (query-perms/required-perms-for-query outer-query :already-preprocessed? true)
           source-card-ids (set/difference (:card-ids required-perms) (:card-ids gtap-perms))]
       ;; On EE, check block permissions up front for all queries. If block perms are in place, reject all native queries
       ;; (unless overriden by `gtap-perms`) and any queries that touch blocked tables/DBs
       (check-block-permissions outer-query)
       (cond
-        card-id
-        (query-perms/check-card-read-perms database-id card-id)
+        ;; if card-id is bound this means that this is not an ad hoc query and we can just
+        ;; check that the user has permission to read this card
+        *card-id*
+        (query-perms/check-card-read-perms database-id *card-id*)
 
         ;; set when querying for field values of dashboard filters, which only require
         ;; collection perms for the dashboard and not ad-hoc query perms
@@ -133,13 +134,15 @@
         ;; Ad-hoc query (not a saved question)
         :else
         (do
-          (query-perms/check-data-perms outer-query required-perms :throw-exceptions? true)
-
+          ;; Check that we permissions for any source cards first, then check that we have requisite data permissions
           ;; Recursively check permissions for any source Cards
           (doseq [card-id source-card-ids]
             (let [{query :dataset-query} (lib.metadata.protocols/card (qp.store/metadata-provider) card-id)]
               (binding [*card-id* card-id]
                 (check-query-permissions* query))))
+
+          ;; Check that we have the data permissions to run this card
+          (query-perms/check-data-perms outer-query required-perms :throw-exceptions? true)
 
           ;; Recursively check permissions for any Cards referenced by this query via template tags
           (doseq [{query :dataset-query} (lib/template-tags-referenced-cards

--- a/test/metabase/query_permissions/impl_test.clj
+++ b/test/metabase/query_permissions/impl_test.clj
@@ -9,6 +9,7 @@
    [metabase.models.interface :as mi]
    [metabase.permissions.path :as permissions.path]
    [metabase.query-permissions.core :as query-perms]
+   [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
    [metabase.util :as u]))
@@ -207,8 +208,7 @@
       (is (= {:card-ids             #{card-id}
               :perms/view-data      {(mt/id :users) :unrestricted
                                      (mt/id :checkins) :unrestricted}
-              :perms/create-queries {(mt/id :users) :query-builder
-                                     (mt/id :checkins) :query-builder}}
+              :perms/create-queries {(mt/id :users) :query-builder}}
              (query-perms/required-perms-for-query
               (mt/mbql-query users
                 {:joins [{:fields       :all
@@ -230,6 +230,31 @@
                           :source-table $$checkins
                           :condition    [:= $id &c.*USER_ID/Integer]}]})
               :throw-exceptions? true))))))
+
+(deftest ^:parallel query->source-ids-join-cards-test
+  (testing "query->source-ids should return both card IDs when joining one card to another"
+    (mt/with-temp [:model/Card {card-1-id :id} (qp.test-util/card-with-source-metadata-for-query
+                                                (mt/mbql-query venues
+                                                  {:aggregation [[:count]]
+                                                   :breakout    [$id]}))
+                   :model/Card {card-2-id :id} (qp.test-util/card-with-source-metadata-for-query
+                                                (mt/mbql-query checkins
+                                                  {:aggregation [[:sum $id]]
+                                                   :breakout    [$venue_id]}))]
+      (let [query {:database (mt/id)
+                   :type     :query
+                   :query    {:source-table (str "card__" card-1-id)
+                              :joins        [{:fields       :all
+                                              :alias        "joined_card"
+                                              :source-table (str "card__" card-2-id)
+                                              :condition    [:=
+                                                             [:field "ID" {:base-type :type/Integer}]
+                                                             [:field "VENUE_ID" {:base-type :type/Integer, :join-alias "joined_card"}]]}]}}]
+        (is (= #{card-1-id card-2-id}
+               (:card-ids
+                (query-perms/query->source-ids
+                 (qp.preprocess/preprocess
+                  query)))))))))
 
 (deftest ^:parallel pmbql-query-test
   (testing "Should be able to calculate permissions for a pMBQL query (#39024)"


### PR DESCRIPTION
### Description

We want error messages when ad hoc querying cards to return `you cannot run this card #{id}" instead of the default error message. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
