### PR TITLE
Improve error messages for FK violations

### DIFF
--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -271,7 +271,7 @@ describe(
 
         cy.findByLabelText("User ID").should("not.exist");
         cy.findByLabelText(
-          'User ID: This value does not exist in table "users".',
+          'User ID: This value does not exist in table "people".',
         ).should("exist");
 
         cy.findByText("Unable to update the record.").should("exist");

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -270,9 +270,9 @@ describe(
         cy.wait("@executeAction");
 
         cy.findByLabelText("User ID").should("not.exist");
-        cy.findByLabelText("User ID: This User_id does not exist.").should(
-          "exist",
-        );
+        cy.findByLabelText(
+          'User ID: This value does not exist in table "users".',
+        ).should("exist");
 
         cy.findByText("Unable to update the record.").should("exist");
       });

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -258,12 +258,12 @@
           (testing "delete without delete-children param will return errors with children count"
             (is (=? {:errors [{:index       0
                                :type        "metabase.actions.error/violate-foreign-key-constraint",
-                               :message     "Other tables rely on this row so it cannot be deleted.",
+                               :message     "Other rows refer to this row so it cannot be deleted.",
                                :errors      {}
                                :status-code 400}
                               {:index       1,
                                :type        "metabase.actions.error/violate-foreign-key-constraint",
-                               :message     "Other tables rely on this row so it cannot be deleted.",
+                               :message     "Other rows refer to this row so it cannot be deleted.",
                                :errors      {},
                                :status-code 400}]}
                     (mt/user-http-request :crowberto :post 400 execute-bulk-url
@@ -315,7 +315,7 @@
         (testing "delete parent with self-referential children should return error without delete-children param"
           (is (=? {:errors [{:index       0
                              :type        "metabase.actions.error/violate-foreign-key-constraint",
-                             :message     "Other tables rely on this row so it cannot be deleted.",
+                             :message     "Other rows refer to this row so it cannot be deleted.",
                              :errors      {}
                              :status-code 400}]}
                   (mt/user-http-request :crowberto :post 400 execute-bulk-url body))))
@@ -371,7 +371,7 @@
           (testing "delete user involved in mutual recursion should return error without delete-children param"
             (is (=? {:errors [{:index       0
                                :type        "metabase.actions.error/violate-foreign-key-constraint",
-                               :message     "Other tables rely on this row so it cannot be deleted.",
+                               :message     "Other rows refer to this row so it cannot be deleted.",
                                :errors      {}
                                :status-code 400}]}
                     (mt/user-http-request :crowberto :post 400 execute-bulk-url delete-user-body))))

--- a/src/metabase/driver/h2/actions.clj
+++ b/src/metabase/driver/h2/actions.clj
@@ -88,7 +88,7 @@
   (when-let [[_match column table]
              (re-find #"Referential integrity constraint violation: \"[^\:]+: [^\s]+ FOREIGN KEY\(([^\s]+)\) REFERENCES ([^(]+)" error-message)]
     (let [column (db-identifier->name column)
-          table  (-> table (str/replace #"^PUBLIC\." "") (str/replace "\"\"" "") str/lower-case)]
+          table  (-> table (str/replace #"^PUBLIC\." "") (str/replace "\"\"" "") u/lower-case-en)]
       (merge {:type error-type}
              (case action-type
                (:table.row/create :model.row/create)

--- a/src/metabase/driver/h2/actions.clj
+++ b/src/metabase/driver/h2/actions.clj
@@ -96,7 +96,7 @@
                 :errors {column (tru "This value does not exist in table \"{0}\"." table)}}
 
                (:table.row/delete :model.row/delete)
-               {:message (tru "Other tables rely on this row so it cannot be deleted.")
+               {:message (tru "Other rows refer to this row so it cannot be deleted.")
                 :errors  {}}
 
                (:table.row/update :model.row/update)

--- a/src/metabase/driver/h2/actions.clj
+++ b/src/metabase/driver/h2/actions.clj
@@ -85,14 +85,15 @@
 
 (defmethod sql-jdbc.actions/maybe-parse-sql-error [:h2 driver-api/violate-foreign-key-constraint]
   [_driver error-type _database action-type error-message]
-  (when-let [[_match column]
-             (re-find #"Referential integrity constraint violation: \"[^\:]+: [^\s]+ FOREIGN KEY\(([^\s]+)\)" error-message)]
-    (let [column (db-identifier->name column)]
+  (when-let [[_match column table]
+             (re-find #"Referential integrity constraint violation: \"[^\:]+: [^\s]+ FOREIGN KEY\(([^\s]+)\) REFERENCES ([^(]+)" error-message)]
+    (let [column (db-identifier->name column)
+          table  (-> table (str/replace #"^PUBLIC\." "") (str/replace "\"\"" "") str/lower-case)]
       (merge {:type error-type}
              (case action-type
                (:table.row/create :model.row/create)
                {:message (tru "Unable to create a new record.")
-                :errors {column (tru "This {0} does not exist." (str/capitalize column))}}
+                :errors {column (tru "This value does not exist in table \"{0}\"." table)}}
 
                (:table.row/delete :model.row/delete)
                {:message (tru "Other tables rely on this row so it cannot be deleted.")
@@ -100,7 +101,7 @@
 
                (:table.row/update :model.row/update)
                {:message (tru "Unable to update the record.")
-                :errors  {column (tru "This {0} does not exist." (str/capitalize column))}})))))
+                :errors  {column (tru "This value does not exist in table \"{0}\"." table)}})))))
 
 (defmethod sql-jdbc.actions/maybe-parse-sql-error [:h2 driver-api/incorrect-value-type]
   [_driver error-type _database _action-type error-message]

--- a/src/metabase/driver/mysql/actions.clj
+++ b/src/metabase/driver/mysql/actions.clj
@@ -87,10 +87,10 @@
                :errors  {}}
 
               :model.row/update
-              (let [column (remove-backticks column)]
-                {:message (tru "Unable to update the record.")
-                 :errors  {column (tru "This {0} does not exist." (str/capitalize column))}}))))
-   (when-let [[_match _ref-table _constraint column _fk-table _fk-col]
+
+              {:message (tru "Other tables rely on this row so it cannot be changed.")
+               :errors  {}})))
+   (when-let [[_match _ref-table _constraint column fk-table _fk-col]
               (re-find #"Cannot add or update a child row: a foreign key constraint fails \((.+), CONSTRAINT (.+) FOREIGN KEY \((.+)\) REFERENCES (.+) \((.+)\)\)" error-message)]
      (let [column (remove-backticks column)]
        {:type    error-type
@@ -100,12 +100,12 @@
 
                    (:table.row/update :model.row/update)
                    (tru "Unable to update the record."))
-        :errors  {(remove-backticks column) (tru "This {0} does not exist." (str/capitalize (remove-backticks column)))}}))))
+        :errors  {(remove-backticks column) (tru "This value does not exist in table \"{0}\"." (remove-backticks fk-table))}}))))
 
 (defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql driver-api/incorrect-value-type]
   [_driver error-type _database _action-type error-message]
   (when-let [[_ expected-type _value _database _table column _row]
-             (re-find #"Incorrect (.+?) value: '(.+)' for column (?:(.+)\.)??(?:(.+)\.)?(.+) at row (\d+)"  error-message)]
+             (re-find #"Incorrect (.+?) value: '(.+)' for column (?:(.+)\.)??(?:(.+)\.)?(.+) at row (\d+)" error-message)]
     (let [column (-> column (str/replace #"^'(.*)'$" "$1") remove-backticks)]
       {:type    error-type
        :message (tru "Some of your values aren’t of the correct type for the database.")

--- a/src/metabase/driver/mysql/actions.clj
+++ b/src/metabase/driver/mysql/actions.clj
@@ -31,6 +31,10 @@
         (str/replace "``" "`")
         (str/replace #"^`?(.+?)`?$" "$1"))))
 
+(defn- remove-backticks-table [id]
+  (when id
+    (remove-backticks (last (str/split id #"`.`")))))
+
 (defn- constraint->column-names
   "Given a constraint with `constraint-name` fetch the column names associated with that constraint."
   [database constraint-name]
@@ -78,18 +82,18 @@
 (defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql driver-api/violate-foreign-key-constraint]
   [_driver error-type _database action-type error-message]
   (or
-   (when-let [[_match _ref-table _constraint _fkey-cols column _key-cols]
+   (when-let [[_match ref-table _constraint _fkey-cols column _key-cols]
               (re-find #"Cannot delete or update a parent row: a foreign key constraint fails \((.+), CONSTRAINT (.+) FOREIGN KEY \((.+)\) REFERENCES (.+) \((.+)\)\)" error-message)]
      (merge {:type error-type}
             (case action-type
               (:table.row/delete :model.row/delete)
-              {:message (tru "Other tables rely on this row so it cannot be deleted.")
-               :errors  {}}
+              {:message (tru "Other rows refer to this row so it cannot be deleted.")
+               :errors  {(remove-backticks column) (tru "Referenced in table \"{0}\"." (remove-backticks-table ref-table))}}
 
               :model.row/update
 
-              {:message (tru "Other tables rely on this row so it cannot be changed.")
-               :errors  {}})))
+              {:message (tru "Other rows refer to this row so it cannot be changed.")
+               :errors  {(remove-backticks column) (tru "Referenced in table \"{0}\"." (remove-backticks-table ref-table))}})))
    (when-let [[_match _ref-table _constraint column fk-table _fk-col]
               (re-find #"Cannot add or update a child row: a foreign key constraint fails \((.+), CONSTRAINT (.+) FOREIGN KEY \((.+)\) REFERENCES (.+) \((.+)\)\)" error-message)]
      (let [column (remove-backticks column)]
@@ -100,7 +104,7 @@
 
                    (:table.row/update :model.row/update)
                    (tru "Unable to update the record."))
-        :errors  {(remove-backticks column) (tru "This value does not exist in table \"{0}\"." (remove-backticks fk-table))}}))))
+        :errors  {(remove-backticks column) (tru "This value does not exist in table \"{0}\"." (remove-backticks-table fk-table))}}))))
 
 (defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql driver-api/incorrect-value-type]
   [_driver error-type _database _action-type error-message]

--- a/src/metabase/driver/postgres/actions.clj
+++ b/src/metabase/driver/postgres/actions.clj
@@ -54,9 +54,9 @@
                   :errors  {}}
 
                  (:table.row/update :model.row/update)
-                 {:message (tru "Unable to update the record.")
-                  :errors  {column (tru "This {0} does not exist." (str/capitalize column))}})))
-      (when-let [[_match _table _constraint column _value _ref-table]
+                 {:message (tru "Other tables rely on this row so it cannot be changed.")
+                  :errors  {}})))
+      (when-let [[_match _table _constraint column _value ref-table]
                  (re-find #"insert or update on table \"([^\"]+)\" violates foreign key constraint \"([^\"]+)\"\n  Detail: Key \((.*?)\)=\((.*?)\) is not present in table \"([^\"]+)\"" error-message)]
         {:type    error-type
          :message (case action-type
@@ -65,7 +65,7 @@
 
                     (:table.row/update :model.row/update)
                     (tru "Unable to update the record."))
-         :errors  {column (tru "This {0} does not exist." (str/capitalize column))}})))
+         :errors  {column (tru "This value does not exist in table \"{0}\"." ref-table)}})))
 
 (defmethod sql-jdbc.actions/maybe-parse-sql-error [:postgres driver-api/incorrect-value-type]
   [_driver error-type _database _action-type error-message]

--- a/test/metabase/actions/api_test.clj
+++ b/test/metabase/actions/api_test.clj
@@ -680,6 +680,6 @@
           (testing "an error in SQL will be caught and parsed to a readable erorr message"
 
             (is (= {:message "Unable to update the record."
-                    :errors {:user_id "This User_id does not exist."}}
+                    :errors {:user_id "This value does not exist in table \"users\"."}}
                    (mt/user-http-request :rasta :post 400 (format "action/%d/execute" update-action)
                                          {:parameters {"id" 1 "user_id" 99999}})))))))))

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -393,7 +393,7 @@
 (deftest ^:parallel actions-maybe-parse-sql-error-test-4
   (testing "violate fk constraints"
     (is (= {:type :metabase.actions.error/violate-foreign-key-constraint,
-            :message "Other tables rely on this row so it cannot be deleted.",
+            :message "Other rows refer to this row so it cannot be deleted.",
             :errors {}}
            (sql-jdbc.actions/maybe-parse-sql-error
             :h2 actions.error/violate-foreign-key-constraint {:id 1} :model.row/delete
@@ -403,7 +403,7 @@
   (testing "violate fk constraints"
     (is (= {:type :metabase.actions.error/violate-foreign-key-constraint,
             :message "Unable to create a new record.",
-            :errors {"GROUP-ID" "This Group-id does not exist."}}
+            :errors {"GROUP-ID" "This value does not exist in table \"group\"."}}
            (sql-jdbc.actions/maybe-parse-sql-error
             :h2 actions.error/violate-foreign-key-constraint {:id 1} :model.row/create
             "Referential integrity constraint violation: \"USER_GROUP-ID_GROUP_-159406530: PUBLIC.\"\"USER\"\" FOREIGN KEY(\"\"GROUP-ID\"\") REFERENCES PUBLIC.\"\"GROUP\"\"(ID) (CAST(999 AS BIGINT))\"; SQL statement:\nINSERT INTO \"PUBLIC\".\"USER\" (\"NAME\", \"GROUP-ID\") VALUES (CAST(? AS VARCHAR), CAST(? AS INTEGER)) [23506-214]")))))
@@ -412,7 +412,7 @@
   (testing "violate fk constraints"
     (is (= {:type :metabase.actions.error/violate-foreign-key-constraint,
             :message "Unable to update the record.",
-            :errors {"GROUP-ID" "This Group-id does not exist."}}
+            :errors {"GROUP-ID" "This value does not exist in table \"group\"."}}
            (sql-jdbc.actions/maybe-parse-sql-error
             :h2 actions.error/violate-foreign-key-constraint {:id 1} :model.row/update
             "Referential integrity constraint violation: \"USER_GROUP-ID_GROUP_-159406530: PUBLIC.\"\"USER\"\" FOREIGN KEY(\"\"GROUP-ID\"\") REFERENCES PUBLIC.\"\"GROUP\"\"(ID) (CAST(999 AS BIGINT))\"; SQL statement:\nINSERT INTO \"PUBLIC\".\"USER\" (\"NAME\", \"GROUP-ID\") VALUES (CAST(? AS VARCHAR), CAST(? AS INTEGER)) [23506-214]")))))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -622,7 +622,7 @@
   (testing "violate fk constraints"
     (is (=? {:type :metabase.actions.error/violate-foreign-key-constraint
              :message "Unable to create a new record."
-             :errors {"group-id" "This Group-id does not exist."}}
+             :errors {"group-id" "This value does not exist in table \"group\"."}}
             (sql-jdbc.actions/maybe-parse-sql-error
              :mysql actions.error/violate-foreign-key-constraint nil :model.row/create
              "(conn=45) Cannot add or update a child row: a foreign key constraint fails (`action-error-handling`.`user`, CONSTRAINT `user_group-id_group_-159406530` FOREIGN KEY (`group-id`) REFERENCES `group` (`id`))")))))
@@ -630,17 +630,17 @@
 (deftest ^:parallel actions-maybe-parse-sql-error-test-5
   (testing "violate fk constraints"
     (is (=? {:type :metabase.actions.error/violate-foreign-key-constraint,
-             :message "Unable to update the record.",
-             :errors {"group" "This Group does not exist."}}
+             :message "Other rows refer to this row so it cannot be changed."
+             :errors {"group" "Referenced in table \"user\"."}}
             (sql-jdbc.actions/maybe-parse-sql-error
              :mysql actions.error/violate-foreign-key-constraint nil :model.row/update
              "(conn=21) Cannot delete or update a parent row: a foreign key constraint fails (`action-error-handling`.`user`, CONSTRAINT `user_group-id_group_-159406530` FOREIGN KEY (`group-id`) REFERENCES `group` (`id`))")))))
 
 (deftest ^:parallel actions-maybe-parse-sql-error-test-6
   (testing "violate fk constraints"
-    (is (=? {:type :metabase.actions.error/violate-foreign-key-constraint
-             :message "Other tables rely on this row so it cannot be deleted."
-             :errors {}}
+    (is (=? {:type    :metabase.actions.error/violate-foreign-key-constraint
+             :message "Other rows refer to this row so it cannot be deleted."
+             :errors  {"group" "Referenced in table \"user\"."}}
             (sql-jdbc.actions/maybe-parse-sql-error
              :mysql actions.error/violate-foreign-key-constraint nil :model.row/delete
              "(conn=21) Cannot delete or update a parent row: a foreign key constraint fails (`action-error-handling`.`user`, CONSTRAINT `user_group-id_group_-159406530` FOREIGN KEY (`group-id`) REFERENCES `group` (`id`))")))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1094,18 +1094,18 @@
 
 (deftest ^:parallel actions-maybe-parse-sql-error-violate-fk-constraints-test
   (testing "violate fk constraints"
-    (is (=? {:type :metabase.actions.error/violate-foreign-key-constraint,
-             :message "Unable to create a new record.",
-             :errors {"group-id" "This Group-id does not exist."}}
+    (is (=? {:type    :metabase.actions.error/violate-foreign-key-constraint,
+             :message "Unable to create a new record."
+             :errors  {"group-id" "This value does not exist in table \"group\"."}}
             (sql-jdbc.actions/maybe-parse-sql-error
              :postgres actions.error/violate-foreign-key-constraint nil :model.row/create
              "ERROR: insert or update on table \"user\" violates foreign key constraint \"user_group-id_group_-159406530\"\n  Detail: Key (group-id)=(999) is not present in table \"group\".")))))
 
 (deftest ^:parallel actions-maybe-parse-sql-error-violate-fk-constraints-test-2
   (testing "violate fk constraints"
-    (is (=? {:type :metabase.actions.error/violate-foreign-key-constraint,
-             :message "Unable to update the record.",
-             :errors {"id" "This Id does not exist."}}
+    (is (=? {:type    :metabase.actions.error/violate-foreign-key-constraint,
+             :message "Other rows refer to this value so it cannot be changed."
+             :errors  {"id" "Referenced in table \"user\"."}}
             (sql-jdbc.actions/maybe-parse-sql-error
              :postgres actions.error/violate-foreign-key-constraint nil :model.row/update
              "ERROR: update or delete on table \"group\" violates foreign key constraint \"user_group-id_group_-159406530\" on table \"user\"\n  Detail: Key (id)=(1) is still referenced from table \"user\".")))))
@@ -1113,7 +1113,7 @@
 (deftest ^:parallel actions-maybe-parse-sql-error-violate-fk-constraints-test-3
   (testing "violate fk constraints"
     (is (=? {:type :metabase.actions.error/violate-foreign-key-constraint,
-             :message "Other tables rely on this row so it cannot be deleted.",
+             :message "Other rows refer to this row so it cannot be deleted.",
              :errors {}}
             (sql-jdbc.actions/maybe-parse-sql-error
              :postgres actions.error/violate-foreign-key-constraint nil :model.row/delete

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -260,7 +260,7 @@
    (fn [{:keys [db-id]}]
      (testing "violate fk constraint"
        (testing "when deleting"
-         (is (=? {:message "Other tables rely on this row so it cannot be deleted."
+         (is (=? {:message "Other rows refer to this row so it cannot be deleted."
                   :errors {}
                   :type        actions.error/violate-foreign-key-constraint
                   :status-code 400}

--- a/test/metabase/driver/sql_jdbc/actions_test.clj
+++ b/test/metabase/driver/sql_jdbc/actions_test.clj
@@ -231,7 +231,7 @@
      (testing "violate fk constraint"
        (testing "when creating"
          (is (=? {:message     "Unable to create a new record."
-                  :errors      {"group_id" "This Group-id does not exist."}
+                  :errors      {"group_id" "This value does not exist in table \"group\"."}
                   :type        actions.error/violate-foreign-key-constraint
                   :status-code 400}
                  (perform-action-ex-data :model.row/create (mt/$ids {:create-row {user-name    "new"
@@ -246,7 +246,7 @@
      (testing "violate fk constraint"
        (testing "when updating"
          (is (=? {:message     "Unable to update the record."
-                  :errors      {"group_id" "This Group-id does not exist."}
+                  :errors      {"group_id" "This value does not exist in table \"group\"."}
                   :type        actions.error/violate-foreign-key-constraint
                   :status-code 400}
                  (perform-action-ex-data :model.row/update (mt/$ids {:update-row {user-group-id 999}


### PR DESCRIPTION
It's much more useful if our error messages mention the table in question. 
They already mention the column implicitly in the key.

Closes WRK-491