### PR TITLE
[Metabot] Setting hotfix

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -68,7 +68,7 @@
   (str (metabot-v3.settings/ai-service-base-url) "/v2/agent"))
 
 (defn- agent-v2-streaming-endpoint-url []
-  (str (metabot-v3.settings/ai-proxy-base-url) "/v2/agent/stream"))
+  (str (metabot-v3.settings/ai-service-base-url) "/v2/agent/stream"))
 
 (defn- metric-selection-endpoint-url []
   (str (metabot-v3.settings/ai-service-base-url) "/v1/select-metric"))


### PR DESCRIPTION
### Description

Fixes this
`"Syntax error compiling at (metabase_enterprise/metabot_v3/client.clj:71:8).\nNo such var: metabot-v3.settings/ai-proxy-base-url\n",`
![CleanShot 2025-06-25 at 11 14 58@2x](https://github.com/user-attachments/assets/bd8c83c2-4a04-4066-851a-a231b98162ca)

From a bad rebase... not sure how i was able to merge the PR with this issue.