### PR TITLE
Fix busted import path

### DIFF
--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { ForwardRefLink } from "metabase/core/components/Link";
+import { ForwardRefLink } from "metabase/common/components/Link";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { setOpenModal } from "metabase/redux/ui";


### PR DESCRIPTION
This happened because of the unfortunate timing of backports.

@iethree was moving a lot of files around while @npfitz's PR related to the NewItemMenu was struggling with the CI for a bit. Once they merged, they created a failure because of the wrong import path.

These are the related PRs:
- https://github.com/metabase/metabase/pull/60013
- https://github.com/metabase/metabase/pull/59875