### PR TITLE
Fix static viz error caused by using css variable in svg (caused by PR #59956)

### DIFF
--- a/frontend/src/metabase/visualizations/shared/utils/theme.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/theme.ts
@@ -57,9 +57,11 @@ export function getVisualizationTheme({
       },
       splitLine: {
         lineStyle: {
-          color: isNightMode
-            ? "var(--mb-color-border-alpha-30)"
-            : cartesian.splitLine.lineStyle.color,
+          color: isStaticViz
+            ? color("border")
+            : isNightMode
+              ? "var(--mb-color-border-alpha-30)"
+              : cartesian.splitLine.lineStyle.color,
         },
       },
     },


### PR DESCRIPTION
### Description

Fix static viz error caused by using css variable in svg. Uses `color("border")` when rendering for static viz, which is what was used prior to #59956.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Navigate to a dashboard with a cartesian chart (e.g. line, area, etc)
2. Send the dashboard to yourself over email or slack (Sharing > Subscriptions)
3. Verify tick lines are present in the generated images
4. Verify no regressions with the cartesian chart in other light/dark mode dashboards (main site, etc)

### Demo

**CI noise:**
![image (1)](https://github.com/user-attachments/assets/79becce5-a544-4953-a285-dec10921ed04)

**Before**
This is from an email I sent to myself locally (via Sharing > Subscriptions) w/o these changes. The same thing happens if you share via Slack. No tick lines.
![before](https://github.com/user-attachments/assets/88174fbd-6cfc-46a1-be0a-9b50433a5d2a)

**After**
![after](https://github.com/user-attachments/assets/719b8eaf-1a32-44a5-b633-e7752cdf23d8)