### PR TITLE
fix(sdk): switching from existing to new question should keep query builder open

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -498,4 +498,40 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       });
     });
   });
+
+  it("should show the editor when switching from existing question to new question (metabase#60075)", () => {
+    const TestComponent = () => {
+      const [questionId, setQuestionId] = useState<string | number>(1);
+
+      return (
+        <Box>
+          <InteractiveQuestion questionId={questionId} />
+          <Button onClick={() => setQuestionId("new")}>New Question</Button>
+        </Box>
+      );
+    };
+
+    cy.get<number>("@questionId").then(() => {
+      mountSdkContent(<TestComponent />);
+
+      cy.log("shows an existing question initially");
+      getSdkRoot().within(() => {
+        cy.findByText("Product ID").should("be.visible");
+        cy.findByText("Max of Quantity").should("be.visible");
+      });
+
+      cy.log("switch to questionId=new");
+      cy.findByText("New Question").click();
+
+      getSdkRoot().within(() => {
+        cy.log("should show the query builder");
+        cy.findByText("Pick your starting data").should("be.visible");
+
+        cy.log("should not show an empty visualization state (metabase#60075)");
+        cy.findByText(/To run your code, click on the Run button/).should(
+          "not.exist",
+        );
+      });
+    });
+  });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-question.cy.spec.tsx
@@ -500,8 +500,14 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
   });
 
   it("should show the editor when switching from existing question to new question (metabase#60075)", () => {
-    const TestComponent = () => {
-      const [questionId, setQuestionId] = useState<string | number>(1);
+    const TestComponent = ({
+      initialQuestionId,
+    }: {
+      initialQuestionId: string | number;
+    }) => {
+      const [questionId, setQuestionId] = useState<string | number>(
+        initialQuestionId,
+      );
 
       return (
         <Box>
@@ -511,8 +517,8 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       );
     };
 
-    cy.get<number>("@questionId").then(() => {
-      mountSdkContent(<TestComponent />);
+    cy.get<number>("@questionId").then((questionId) => {
+      mountSdkContent(<TestComponent initialQuestionId={questionId} />);
 
       cy.log("shows an existing question initially");
       getSdkRoot().within(() => {

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -1,6 +1,7 @@
 import { useDisclosure } from "@mantine/hooks";
 import cx from "classnames";
 import type { ReactElement } from "react";
+import { useEffect } from "react";
 import { t } from "ttag";
 
 import {
@@ -73,11 +74,20 @@ export const InteractiveQuestionDefaultView = ({
   const isCreatingQuestionFromScratch =
     originalId === "new" && !question?.isSaved();
 
-  const [isEditorOpen, { close: closeEditor, toggle: toggleEditor }] =
-    useDisclosure(isCreatingQuestionFromScratch);
+  const [
+    isEditorOpen,
+    { close: closeEditor, toggle: toggleEditor, open: openEditor },
+  ] = useDisclosure(isCreatingQuestionFromScratch);
 
   const [isSaveModalOpen, { open: openSaveModal, close: closeSaveModal }] =
     useDisclosure(false);
+
+  useEffect(() => {
+    // When switching to new question, open the editor
+    if (isCreatingQuestionFromScratch) {
+      openEditor();
+    }
+  }, [isCreatingQuestionFromScratch, openEditor]);
 
   // When visualizing a question for the first time, there is no query result yet.
   const isQueryResultLoading =


### PR DESCRIPTION
Closes EMB-563
Closes https://github.com/metabase/metabase/issues/60075

### Description

When there is an already existing question in InteractiveQuestion, but we switch the questionId to "new", the question shows an empty state instead of showing the editor as we expects.

There is a prop `isEditorOpen` that determines whether to show the Editor (the query builder) or the Visualization (which renders `VisualizationEmptyState` in this case).

https://github.com/metabase/metabase/blob/55395c6f167367d9412fc91076dfd26cd66cfdcb/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx#L181-L185

Now, `isEditorOpen` defaults to whether we are creating the question from scratch, so it defaults to "false" when we first click on the "Chart". When we switch to "Exploration", the `isEditorOpen` prop still defaults to `false` therefore we show the empty state via `QuestionVisualization`.

https://github.com/metabase/metabase/blob/55395c6f167367d9412fc91076dfd26cd66cfdcb/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx#L73-L78

This PR adds a `useEffect` to open the question editor (query builder) once more when we switch from `questionId={1}` to `questionId="new"`.

This PR is a blocker for [EMB-506](https://linear.app/metabase/issue/EMB-506) (https://github.com/metabase/metabase/pull/59874)

### How to verify

Using this snippet for reproduction:

```tsx
const [questionId, setQuestionId] = useState(1)

return (
  <InteractiveQuestion questionId={questionId} />
  <button onClick={() => setQuestionId("new")}>new question</button>
)
```

- Render the above snippet in your component
- Clicking on the "new question" should show the query builder as expected, and should not show an empty state.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
