### PR TITLE
Use dynamic var for locale in datetime formatting for exports

### DIFF
--- a/src/metabase/formatter/datetime.clj
+++ b/src/metabase/formatter/datetime.clj
@@ -15,6 +15,11 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:dynamic *formatting-locale*
+  "Dynamic var to hold the current locale for datetime formatting.
+  Defaults to the site locale from system settings."
+  (Locale. (system/site-locale)))
+
 (defn temporal-string?
   "Returns `true` if the string `s` is parseable as a datetime.
 
@@ -27,29 +32,29 @@
      (catch Exception _e false))))
 
 (defn- reformat-temporal-str [timezone-id s new-format-string]
-  (t/format new-format-string (u.date/parse s timezone-id)))
+  (u.date/format new-format-string (u.date/parse s timezone-id) *formatting-locale*))
 
 (defn- day-of-week
   [n abbreviate]
-  (let [fmtr (java.time.format.DateTimeFormatter/ofPattern (if abbreviate "EEE" "EEEE"))]
+  (let [fmtr (java.time.format.DateTimeFormatter/ofPattern (if abbreviate "EEE" "EEEE") *formatting-locale*)]
     (.format fmtr (java.time.DayOfWeek/of n))))
 
 (defn- month-of-year
   [n abbreviate]
-  (let [fmtr (java.time.format.DateTimeFormatter/ofPattern (if abbreviate "MMM" "MMMM"))]
+  (let [fmtr (java.time.format.DateTimeFormatter/ofPattern (if abbreviate "MMM" "MMMM") *formatting-locale*)]
     (.format fmtr (java.time.Month/of n))))
 
 (defn- x-of-y
   "Format an integer as x-th of y, for example, 2nd week of year."
   [n]
-  (let [nf (RuleBasedNumberFormat. (Locale. (system/site-locale)) RuleBasedNumberFormat/ORDINAL)]
+  (let [nf (RuleBasedNumberFormat. ^java.util.Locale *formatting-locale* RuleBasedNumberFormat/ORDINAL)]
     (.format nf n)))
 
 (defn- hour-of-day
   [s time-style]
   (let [n  (parse-long s)
         ts (u.date/parse "2022-01-01-00:00:00")]
-    (u.date/format time-style (t/plus ts (t/hours n)))))
+    (u.date/format time-style (t/plus ts (t/hours n)) *formatting-locale*)))
 
 (defn- viz-settings-for-col
   "Get the column-settings map for the given column from the viz-settings."
@@ -215,7 +220,7 @@
                                 time-style
                                 (str ", " time-style))
         default-format-string (post-process-date-style date-time-style viz-settings)]
-    (t/format default-format-string (u.date/parse temporal-str timezone-id))))
+    (u.date/format default-format-string (u.date/parse temporal-str timezone-id) *formatting-locale*)))
 
 (defmethod format-timestring :default [timezone-id temporal-str {:keys [unit] :as col} {:keys [date-style] :as viz-settings}]
   (if (= :default unit)
@@ -240,10 +245,10 @@
   "Return a formatter which, given a temporal literal string, reformats it by combining time zone, column, and viz
   setting information to create a final desired output format."
   [timezone-id col viz-settings]
-  (Locale/setDefault (Locale. (system/site-locale)))
   (let [merged-viz-settings (streaming.common/normalize-keys
                              (streaming.common/viz-settings-for-col col viz-settings))]
     (fn [temporal-str]
       (if (str/blank? temporal-str)
         ""
-        (format-timestring timezone-id temporal-str col merged-viz-settings)))))
+        (binding [*formatting-locale* (Locale. (system/site-locale))]
+          (format-timestring timezone-id temporal-str col merged-viz-settings))))))

--- a/test/metabase/formatter/datetime_test.clj
+++ b/test/metabase/formatter/datetime_test.clj
@@ -5,10 +5,11 @@
    [metabase.appearance.core :as appearance]
    [metabase.formatter.datetime :as datetime]
    [metabase.models.visualization-settings :as mb.viz]
-   [metabase.test :as mt]
-   [metabase.util.i18n :as i18n])
+   [metabase.test :as mt])
   (:import
    (java.util Locale)))
+
+(set! *warn-on-reflection* true)
 
 (def ^:private now "2020-07-16T18:04:00Z[UTC]")
 

--- a/test/metabase/formatter/datetime_test.clj
+++ b/test/metabase/formatter/datetime_test.clj
@@ -5,7 +5,10 @@
    [metabase.appearance.core :as appearance]
    [metabase.formatter.datetime :as datetime]
    [metabase.models.visualization-settings :as mb.viz]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.i18n :as i18n])
+  (:import
+   (java.util Locale)))
 
 (def ^:private now "2020-07-16T18:04:00Z[UTC]")
 
@@ -286,3 +289,20 @@
                                       {{::mb.viz/column-name "created_at"} {::mb.viz/date-style "YYYY-MM-dd"}}}))]
       (doseq [the-date (mapcat dates (range 2008 3008))]
         (is (= the-date (fmt the-date)))))))
+
+(deftest site-locale-used-for-formatting-test
+  (testing "Datetime formatting uses site-locale and does not modify JVM locale"
+    (let [original-jvm-locale (Locale/getDefault)
+          test-datetime       "2020-07-16T18:04:00Z[UTC]"
+          col                 {:effective_type :type/DateTime}]
+      (mt/with-temporary-setting-values [site-locale "de"]
+        (let [german-result (format-temporal-str "UTC" test-datetime col)]
+          (is (re-find #"Juli" german-result))
+          (is (= original-jvm-locale (Locale/getDefault)))))
+
+      (mt/with-temporary-setting-values [site-locale "fr"]
+        (let [french-result (format-temporal-str "UTC" test-datetime col)]
+          (is (re-find #"juillet" french-result))
+          (is (= original-jvm-locale (Locale/getDefault)))))
+
+      (is (= original-jvm-locale (Locale/getDefault))))))


### PR DESCRIPTION
Stores the current `site-locale` in a dynamic var and uses it for all datetime formatting on the backend.