### PR TITLE
Code snippet and authentication step for new iframe embed flow

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -13,7 +13,7 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
-    H.setTokenFeatures("all");
+    H.activateToken("bleeding-edge");
 
     cy.intercept("GET", "/api/dashboard/**").as("dashboard");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -65,89 +65,59 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     });
   });
 
-  describe("Code Snippet Generation", () => {
-    it("should display code snippet with syntax highlighting", () => {
-      navigateToGetCodeStep({ experience: "dashboard" });
+  it("should display code snippet with syntax highlighting", () => {
+    navigateToGetCodeStep({ experience: "dashboard" });
 
-      getEmbedSidebar().within(() => {
-        cy.findByText("Embed Code").should("be.visible");
-        cy.get("[data-testid=code-editor]").should("be.visible");
-        cy.get("[data-testid=code-editor]").should("contain", "MetabaseEmbed");
-      });
+    getEmbedSidebar().within(() => {
+      cy.findByText("Embed Code").should("be.visible");
+      codeBlock().should("be.visible");
+      codeBlock().should("contain", "MetabaseEmbed");
     });
+  });
 
-    it("should include useExistingUserSession when user session is selected", () => {
-      navigateToGetCodeStep({ experience: "dashboard" });
+  it("should include useExistingUserSession when user session is selected", () => {
+    navigateToGetCodeStep({ experience: "dashboard" });
 
-      getEmbedSidebar().within(() => {
-        cy.findByLabelText("User Session").should("be.checked");
-        cy.get("[data-testid=code-editor]").should(
-          "contain",
-          "useExistingUserSession: true",
-        );
-      });
+    getEmbedSidebar().within(() => {
+      cy.findByLabelText("User Session").should("be.checked");
+      codeBlock().should("contain", '"useExistingUserSession": true');
     });
+  });
 
-    it("should not include useExistingUserSession when SSO is selected", () => {
-      enableJwtAuth();
-      navigateToGetCodeStep({ experience: "dashboard" });
+  it("should not include useExistingUserSession when SSO is selected", () => {
+    enableJwtAuth();
+    navigateToGetCodeStep({ experience: "dashboard" });
 
-      getEmbedSidebar().within(() => {
-        cy.findByLabelText("SSO Authentication").click();
-        cy.get("[data-testid=code-editor]").should(
-          "not.contain",
-          "useExistingUserSession",
-        );
-      });
+    getEmbedSidebar().within(() => {
+      cy.findByLabelText("SSO Authentication").click();
+      codeBlock().should("not.contain", "useExistingUserSession");
     });
+  });
 
-    it("should reflect dashboard settings in code snippet", () => {
-      navigateToGetCodeStep({ experience: "dashboard" });
+  it("should set dashboardId for dashboard experience", () => {
+    navigateToGetCodeStep({ experience: "dashboard" });
 
-      getEmbedSidebar().within(() => {
-        cy.get("[data-testid=code-editor]").should(
-          "contain",
-          '"type": "dashboard"',
-        );
-        cy.get("[data-testid=code-editor]").should(
-          "contain",
-          `"resourceId": ${ORDERS_DASHBOARD_ID}`,
-        );
-      });
+    getEmbedSidebar().within(() => {
+      codeBlock().should("contain", `"dashboardId": ${ORDERS_DASHBOARD_ID}`);
     });
+  });
 
-    it("should reflect question settings in code snippet", () => {
-      navigateToGetCodeStep({ experience: "chart" });
+  it("should set questionId for chart experience", () => {
+    navigateToGetCodeStep({ experience: "chart" });
 
-      getEmbedSidebar().within(() => {
-        cy.get("[data-testid=code-editor]").should(
-          "contain",
-          '"type": "question"',
-        );
-        cy.get("[data-testid=code-editor]").should(
-          "contain",
-          `"resourceId": ${ORDERS_COUNT_QUESTION_ID}`,
-        );
-      });
+    getEmbedSidebar().within(() => {
+      codeBlock().should(
+        "contain",
+        `"questionId": ${ORDERS_COUNT_QUESTION_ID}`,
+      );
     });
+  });
 
-    it("should handle exploration experience correctly", () => {
-      visitNewEmbedPage();
+  it("should set template=exploration for exploration experience", () => {
+    navigateToGetCodeStep({ experience: "exploration" });
 
-      getEmbedSidebar().within(() => {
-        cy.findByText("Exploration").click();
-
-        navigateToGetCodeStep({ experience: "exploration" });
-
-        cy.get("[data-testid=code-editor]").should(
-          "contain",
-          '"type": "question"',
-        );
-        cy.get("[data-testid=code-editor]").should(
-          "contain",
-          '"resourceId": "new"',
-        );
-      });
+    getEmbedSidebar().within(() => {
+      codeBlock().should("contain", '"template": "exploration"');
     });
   });
 });
@@ -158,6 +128,7 @@ const navigateToGetCodeStep = ({
   experience: "dashboard" | "chart" | "exploration";
 }) => {
   cy.log("visit a resource to populate the activity log");
+
   if (experience === "dashboard") {
     H.visitDashboard(ORDERS_DASHBOARD_ID);
     cy.wait("@dashboard");
@@ -169,6 +140,7 @@ const navigateToGetCodeStep = ({
   visitNewEmbedPage();
 
   cy.log("select an experience");
+
   if (experience === "chart") {
     cy.findByText("Chart").click();
   } else if (experience === "exploration") {
@@ -176,13 +148,15 @@ const navigateToGetCodeStep = ({
   }
 
   cy.log("navigate to the get code step");
+
   getEmbedSidebar().within(() => {
-    // Skip entity selection for exploration
     if (experience !== "exploration") {
-      cy.findByText("Next").click();
+      cy.findByText("Next").click(); // Entity selection step
     }
 
     cy.findByText("Next").click(); // Configure embed options step
     cy.findByText("Get Code").click(); // Get code step
   });
 };
+
+const codeBlock = () => cy.get(".cm-content");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -20,52 +20,51 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     cy.intercept("GET", "/api/activity/recents?*").as("recentActivity");
   });
 
-  describe("Authentication Selection", () => {
-    it("should render authentication radio buttons with user session selected by default", () => {
-      navigateToGetCodeStep({ experience: "dashboard" });
+  it("should select user session auth method by default", () => {
+    navigateToGetCodeStep({ experience: "dashboard" });
 
-      getEmbedSidebar().within(() => {
-        cy.findByText("Authentication").should("be.visible");
-        cy.findByText("Choose the authentication method for embedding:").should(
-          "be.visible",
-        );
+    getEmbedSidebar().within(() => {
+      cy.findByText("Authentication").should("be.visible");
+      cy.findByText("Choose the authentication method for embedding:").should(
+        "be.visible",
+      );
 
-        cy.findByLabelText("User Session")
-          .should("be.visible")
-          .should("be.checked");
-        cy.findByLabelText("SSO Authentication")
-          .should("be.visible")
-          .should("not.be.checked");
-      });
+      cy.findByLabelText("User Session")
+        .should("be.visible")
+        .should("be.checked");
+
+      cy.findByLabelText("SSO Authentication")
+        .should("be.visible")
+        .should("not.be.checked");
     });
+  });
 
-    it("should disable SSO radio button when JWT and SAML are not configured", () => {
-      navigateToGetCodeStep({ experience: "dashboard" });
+  it("should disable SSO radio button when JWT and SAML are not configured", () => {
+    navigateToGetCodeStep({ experience: "dashboard" });
 
-      getEmbedSidebar().within(() => {
-        cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
-        cy.findByLabelText("SSO Authentication").should("be.disabled");
-      });
+    getEmbedSidebar().within(() => {
+      cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
+      cy.findByLabelText("SSO Authentication").should("be.disabled");
     });
+  });
 
-    it("should enable SSO radio button when JWT is configured", () => {
-      enableJwtAuth();
-      navigateToGetCodeStep({ experience: "dashboard" });
+  it("should enable SSO radio button when JWT is configured", () => {
+    enableJwtAuth();
+    navigateToGetCodeStep({ experience: "dashboard" });
 
-      getEmbedSidebar().within(() => {
-        cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
-        cy.findByLabelText("SSO Authentication").should("not.be.disabled");
-      });
+    getEmbedSidebar().within(() => {
+      cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
+      cy.findByLabelText("SSO Authentication").should("not.be.disabled");
     });
+  });
 
-    it("should enable SSO radio button when SAML is configured", () => {
-      enableSamlAuth();
-      navigateToGetCodeStep({ experience: "dashboard" });
+  it("should enable SSO radio button when SAML is configured", () => {
+    enableSamlAuth();
+    navigateToGetCodeStep({ experience: "dashboard" });
 
-      getEmbedSidebar().within(() => {
-        cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
-        cy.findByLabelText("SSO Authentication").should("not.be.disabled");
-      });
+    getEmbedSidebar().within(() => {
+      cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
+      cy.findByLabelText("SSO Authentication").should("not.be.disabled");
     });
   });
 
@@ -187,7 +186,7 @@ const navigateToGetCodeStep = ({
       cy.findByText("Next").click();
     }
 
-    cy.findByText("Next").click(); // Configure step
-    cy.findByText("Next").click(); // Get code step
+    cy.findByText("Next").click(); // Configure embed options step
+    cy.findByText("Get Code").click(); // Get code step
   });
 };

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -29,11 +29,11 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
         "be.visible",
       );
 
-      cy.findByLabelText("User Session")
+      cy.findByLabelText("Existing Metabase Session")
         .should("be.visible")
         .should("be.checked");
 
-      cy.findByLabelText("SSO Authentication")
+      cy.findByLabelText("Single sign-on (SSO)")
         .should("be.visible")
         .should("not.be.checked");
     });
@@ -43,7 +43,7 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     navigateToGetCodeStep({ experience: "dashboard" });
 
     getEmbedSidebar().within(() => {
-      cy.findByLabelText("SSO Authentication").should("be.disabled");
+      cy.findByLabelText("Single sign-on (SSO)").should("be.disabled");
     });
   });
 
@@ -52,7 +52,7 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     navigateToGetCodeStep({ experience: "dashboard" });
 
     getEmbedSidebar().within(() => {
-      cy.findByLabelText("SSO Authentication").should("not.be.disabled");
+      cy.findByLabelText("Single sign-on (SSO)").should("not.be.disabled");
     });
   });
 
@@ -61,7 +61,7 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     navigateToGetCodeStep({ experience: "dashboard" });
 
     getEmbedSidebar().within(() => {
-      cy.findByLabelText("SSO Authentication").should("not.be.disabled");
+      cy.findByLabelText("Single sign-on (SSO)").should("not.be.disabled");
     });
   });
 
@@ -79,7 +79,7 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     navigateToGetCodeStep({ experience: "dashboard" });
 
     getEmbedSidebar().within(() => {
-      cy.findByLabelText("User Session").should("be.checked");
+      cy.findByLabelText("Existing Metabase Session").should("be.checked");
       codeBlock().should("contain", '"useExistingUserSession": true');
     });
   });
@@ -89,7 +89,7 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     navigateToGetCodeStep({ experience: "dashboard" });
 
     getEmbedSidebar().within(() => {
-      cy.findByLabelText("SSO Authentication").click();
+      cy.findByLabelText("Single sign-on (SSO)").click();
       codeBlock().should("not.contain", "useExistingUserSession");
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -1,0 +1,193 @@
+import {
+  ORDERS_COUNT_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
+} from "e2e/support/cypress_sample_instance_data";
+import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
+import { enableSamlAuth } from "e2e/support/helpers/embedding-sdk-testing";
+
+import { getEmbedSidebar, visitNewEmbedPage } from "./helpers";
+
+const { H } = cy;
+
+describe("scenarios > embedding > sdk iframe embed setup > get code step", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.setTokenFeatures("all");
+
+    cy.intercept("GET", "/api/dashboard/**").as("dashboard");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("GET", "/api/activity/recents?*").as("recentActivity");
+  });
+
+  describe("Authentication Selection", () => {
+    it("should render authentication radio buttons with user session selected by default", () => {
+      navigateToGetCodeStep({ experience: "dashboard" });
+
+      getEmbedSidebar().within(() => {
+        cy.findByText("Authentication").should("be.visible");
+        cy.findByText("Choose the authentication method for embedding:").should(
+          "be.visible",
+        );
+
+        cy.findByLabelText("User Session")
+          .should("be.visible")
+          .should("be.checked");
+        cy.findByLabelText("SSO Authentication")
+          .should("be.visible")
+          .should("not.be.checked");
+      });
+    });
+
+    it("should disable SSO radio button when JWT and SAML are not configured", () => {
+      navigateToGetCodeStep({ experience: "dashboard" });
+
+      getEmbedSidebar().within(() => {
+        cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
+        cy.findByLabelText("SSO Authentication").should("be.disabled");
+      });
+    });
+
+    it("should enable SSO radio button when JWT is configured", () => {
+      enableJwtAuth();
+      navigateToGetCodeStep({ experience: "dashboard" });
+
+      getEmbedSidebar().within(() => {
+        cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
+        cy.findByLabelText("SSO Authentication").should("not.be.disabled");
+      });
+    });
+
+    it("should enable SSO radio button when SAML is configured", () => {
+      enableSamlAuth();
+      navigateToGetCodeStep({ experience: "dashboard" });
+
+      getEmbedSidebar().within(() => {
+        cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
+        cy.findByLabelText("SSO Authentication").should("not.be.disabled");
+      });
+    });
+  });
+
+  describe("Code Snippet Generation", () => {
+    it("should display code snippet with syntax highlighting", () => {
+      navigateToGetCodeStep({ experience: "dashboard" });
+
+      getEmbedSidebar().within(() => {
+        cy.findByText("Embed Code").should("be.visible");
+        cy.get("[data-testid=code-editor]").should("be.visible");
+        cy.get("[data-testid=code-editor]").should("contain", "MetabaseEmbed");
+      });
+    });
+
+    it("should include useExistingUserSession when user session is selected", () => {
+      navigateToGetCodeStep({ experience: "dashboard" });
+
+      getEmbedSidebar().within(() => {
+        cy.findByLabelText("User Session").should("be.checked");
+        cy.get("[data-testid=code-editor]").should(
+          "contain",
+          "useExistingUserSession: true",
+        );
+      });
+    });
+
+    it("should not include useExistingUserSession when SSO is selected", () => {
+      enableJwtAuth();
+      navigateToGetCodeStep({ experience: "dashboard" });
+
+      getEmbedSidebar().within(() => {
+        cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
+        cy.findByLabelText("SSO Authentication").click();
+        cy.get("[data-testid=code-editor]").should(
+          "not.contain",
+          "useExistingUserSession",
+        );
+      });
+    });
+
+    it("should reflect dashboard settings in code snippet", () => {
+      navigateToGetCodeStep({ experience: "dashboard" });
+
+      getEmbedSidebar().within(() => {
+        cy.get("[data-testid=code-editor]").should(
+          "contain",
+          '"type": "dashboard"',
+        );
+        cy.get("[data-testid=code-editor]").should(
+          "contain",
+          `"resourceId": ${ORDERS_DASHBOARD_ID}`,
+        );
+      });
+    });
+
+    it("should reflect question settings in code snippet", () => {
+      navigateToGetCodeStep({ experience: "chart" });
+
+      getEmbedSidebar().within(() => {
+        cy.get("[data-testid=code-editor]").should(
+          "contain",
+          '"type": "question"',
+        );
+        cy.get("[data-testid=code-editor]").should(
+          "contain",
+          `"resourceId": ${ORDERS_COUNT_QUESTION_ID}`,
+        );
+      });
+    });
+
+    it("should handle exploration experience correctly", () => {
+      visitNewEmbedPage();
+
+      getEmbedSidebar().within(() => {
+        cy.findByText("Exploration").click();
+
+        navigateToGetCodeStep({ experience: "exploration" });
+
+        cy.get("[data-testid=code-editor]").should(
+          "contain",
+          '"type": "question"',
+        );
+        cy.get("[data-testid=code-editor]").should(
+          "contain",
+          '"resourceId": "new"',
+        );
+      });
+    });
+  });
+});
+
+const navigateToGetCodeStep = ({
+  experience,
+}: {
+  experience: "dashboard" | "chart" | "exploration";
+}) => {
+  cy.log("visit a resource to populate the activity log");
+  if (experience === "dashboard") {
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    cy.wait("@dashboard");
+  } else if (experience === "chart") {
+    H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
+    cy.wait("@cardQuery");
+  }
+
+  visitNewEmbedPage();
+
+  cy.log("select an experience");
+  if (experience === "chart") {
+    cy.findByText("Chart").click();
+  } else if (experience === "exploration") {
+    cy.findByText("Exploration").click();
+  }
+
+  cy.log("navigate to the get code step");
+  getEmbedSidebar().within(() => {
+    // Skip entity selection for exploration
+    if (experience !== "exploration") {
+      cy.findByText("Next").click();
+    }
+
+    cy.findByText("Next").click(); // Configure step
+    cy.findByText("Next").click(); // Get code step
+  });
+};

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -5,7 +5,7 @@ import {
 import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
 import { enableSamlAuth } from "e2e/support/helpers/embedding-sdk-testing";
 
-import { getEmbedSidebar, visitNewEmbedPage } from "./helpers";
+import { getEmbedSidebar, navigateToEntitySelectionStep } from "./helpers";
 
 const { H } = cy;
 
@@ -127,33 +127,11 @@ const navigateToGetCodeStep = ({
 }: {
   experience: "dashboard" | "chart" | "exploration";
 }) => {
-  cy.log("visit a resource to populate the activity log");
+  navigateToEntitySelectionStep({ experience });
 
-  if (experience === "dashboard") {
-    H.visitDashboard(ORDERS_DASHBOARD_ID);
-    cy.wait("@dashboard");
-  } else if (experience === "chart") {
-    H.visitQuestion(ORDERS_COUNT_QUESTION_ID);
-    cy.wait("@cardQuery");
-  }
-
-  visitNewEmbedPage();
-
-  cy.log("select an experience");
-
-  if (experience === "chart") {
-    cy.findByText("Chart").click();
-  } else if (experience === "exploration") {
-    cy.findByText("Exploration").click();
-  }
-
-  cy.log("navigate to the get code step");
+  cy.log("navigate to get code step");
 
   getEmbedSidebar().within(() => {
-    if (experience !== "exploration") {
-      cy.findByText("Next").click(); // Entity selection step
-    }
-
     cy.findByText("Next").click(); // Configure embed options step
     cy.findByText("Get Code").click(); // Get code step
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -43,7 +43,6 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     navigateToGetCodeStep({ experience: "dashboard" });
 
     getEmbedSidebar().within(() => {
-      cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
       cy.findByLabelText("SSO Authentication").should("be.disabled");
     });
   });
@@ -53,7 +52,6 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     navigateToGetCodeStep({ experience: "dashboard" });
 
     getEmbedSidebar().within(() => {
-      cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
       cy.findByLabelText("SSO Authentication").should("not.be.disabled");
     });
   });
@@ -63,7 +61,6 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     navigateToGetCodeStep({ experience: "dashboard" });
 
     getEmbedSidebar().within(() => {
-      cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
       cy.findByLabelText("SSO Authentication").should("not.be.disabled");
     });
   });
@@ -96,7 +93,6 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
       navigateToGetCodeStep({ experience: "dashboard" });
 
       getEmbedSidebar().within(() => {
-        cy.wait(["@getJwtConfigured", "@getSamlConfigured"]);
         cy.findByLabelText("SSO Authentication").click();
         cy.get("[data-testid=code-editor]").should(
           "not.contain",

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -1,3 +1,6 @@
+import { match } from "ts-pattern";
+
+import { entityPickerModal } from "e2e/support/helpers";
 import type { Dashboard, RecentItem } from "metabase-types/api";
 
 type RecentActivityIntercept = {
@@ -43,4 +46,50 @@ export const assertDashboard = ({ id, name }: { id: number; name: string }) => {
     expect(intercept.response?.body.id).to.be.equal(id);
     expect(intercept.response?.body.name).to.be.equal(name);
   });
+};
+
+export const navigateToEntitySelectionStep = ({
+  experience,
+}: {
+  experience: "dashboard" | "chart" | "exploration";
+}) => {
+  visitNewEmbedPage();
+
+  cy.log("select an experience");
+
+  if (experience === "chart") {
+    cy.findByText("Chart").click();
+  } else if (experience === "exploration") {
+    cy.findByText("Exploration").click();
+  }
+
+  cy.log("navigate to the entity selection step");
+
+  // exploration template does not have the entity selection step
+  if (experience !== "exploration") {
+    const defaultResourceName = match(experience)
+      .with("dashboard", () => "Orders in a dashboard")
+      .with("chart", () => "Orders, Count")
+      .otherwise(() => "");
+
+    const resourceType = match(experience)
+      .with("dashboard", () => "Dashboards")
+      .with("chart", () => "Questions")
+      .otherwise(() => "");
+
+    getEmbedSidebar().within(() => {
+      cy.findByText("Next").click();
+      cy.findByTestId("embed-browse-entity-button").click();
+    });
+
+    entityPickerModal().within(() => {
+      cy.findByText(resourceType).click();
+      cy.findAllByText(defaultResourceName).first().click();
+    });
+
+    cy.log("resource title should be visible by default");
+    getEmbedSidebar().within(() => {
+      cy.findByText(defaultResourceName).should("be.visible");
+    });
+  }
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
@@ -18,9 +18,13 @@ import { useSdkIframeEmbedSnippet } from "../hooks/use-sdk-iframe-embed-snippet"
 export const GetCodeStep = () => {
   const { settings, updateSettings } = useSdkIframeEmbedSetupContext();
 
+  const isJwtEnabled = useSetting("jwt-enabled");
+  const isSamlEnabled = useSetting("saml-enabled");
   const isJwtConfigured = useSetting("jwt-configured");
   const isSamlConfigured = useSetting("saml-configured");
-  const isAnySsoConfigured = isJwtConfigured || isSamlConfigured;
+
+  const isSsoEnabledAndConfigured =
+    (isJwtEnabled && isJwtConfigured) || (isSamlEnabled && isSamlConfigured);
 
   const snippet = useSdkIframeEmbedSnippet();
 
@@ -56,7 +60,7 @@ export const GetCodeStep = () => {
               <Radio
                 value="sso"
                 label={t`Single sign-on (SSO)`}
-                disabled={!isAnySsoConfigured}
+                disabled={!isSsoEnabledAndConfigured}
               />
             </Stack>
           </Radio.Group>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
@@ -47,11 +47,15 @@ export const GetCodeStep = () => {
             }
           >
             <Stack gap="sm">
-              <Radio value="user-session" label={t`User Session`} />
+              <Radio
+                value="user-session"
+                // eslint-disable-next-line no-literal-metabase-strings -- this string is only shown for admins.
+                label={t`Existing Metabase Session`}
+              />
 
               <Radio
                 value="sso"
-                label={t`SSO Authentication`}
+                label={t`Single sign-on (SSO)`}
                 disabled={!isAnySsoConfigured}
               />
             </Stack>
@@ -59,13 +63,14 @@ export const GetCodeStep = () => {
 
           {authType === "user-session" && (
             <Text size="sm" c="text-medium">
-              {t`This option uses your existing user session and is only suitable for local development. In production, use SSO authentication with sandboxing to prevent unwanted access.`}
+              {/* eslint-disable-next-line no-literal-metabase-strings -- this string is only shown for admins. */}
+              {t`This option lets you test iframe embedding locally using your existing Metabase session cookie. This only works for testing locally, using your admin account and on this browser.`}
             </Text>
           )}
 
           {authType === "sso" && (
             <Text size="sm" c="text-medium">
-              {t`SSO authentication is automatically configured. This is the recommended approach for production deployments.`}
+              {t`Select this option if you have already set up SSO. This option relies on SSO to sign in your application users into the embedded iframe, and groups and permissions to enforce limits on what users can access. `}
             </Text>
           )}
         </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
@@ -44,7 +44,7 @@ export const GetCodeStep = () => {
               setAuthType(value as SdkIframeEmbedSetupAuthType)
             }
           >
-            <Stack gap="xs">
+            <Stack gap="sm">
               <Radio value="user-session" label={t`User Session`} />
 
               <Radio

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import { CodeEditor } from "metabase/common/components/CodeEditor";
+import { useSetting } from "metabase/common/hooks";
+import {
+  Button,
+  Card,
+  CopyButton,
+  Icon,
+  Radio,
+  Stack,
+  Text,
+} from "metabase/ui";
+
+import { useSdkIframeEmbedSnippet } from "../hooks/use-sdk-iframe-embed-snippet";
+import type { SdkIframeEmbedSetupAuthType } from "../types";
+
+export const GetCodeStep = () => {
+  const [authType, setAuthType] =
+    useState<SdkIframeEmbedSetupAuthType>("user-session");
+
+  const isJwtConfigured = useSetting("jwt-configured");
+  const isSamlConfigured = useSetting("saml-configured");
+  const isAnySsoConfigured = isJwtConfigured || isSamlConfigured;
+
+  const snippet = useSdkIframeEmbedSnippet({ authType });
+
+  return (
+    <Stack gap="md">
+      <Card p="md">
+        <Stack gap="md" p="xs">
+          <Text size="lg" fw="bold">
+            {t`Authentication`}
+          </Text>
+
+          <Text size="sm" c="text-medium">
+            {t`Choose the authentication method for embedding:`}
+          </Text>
+
+          <Radio.Group
+            value={authType}
+            onChange={(value) =>
+              setAuthType(value as SdkIframeEmbedSetupAuthType)
+            }
+          >
+            <Stack gap="xs">
+              <Radio value="user-session" label={t`User Session`} />
+
+              <Radio
+                value="sso"
+                label={t`SSO Authentication`}
+                disabled={!isAnySsoConfigured}
+              />
+            </Stack>
+          </Radio.Group>
+
+          {authType === "user-session" && (
+            <Text size="sm" c="text-medium">
+              {t`This option uses your existing user session and is only suitable for local development. In production, use SSO authentication with sandboxing to prevent unwanted access.`}
+            </Text>
+          )}
+
+          {authType === "sso" && (
+            <Text size="sm" c="text-medium">
+              {t`SSO authentication is automatically configured. This is the recommended approach for production deployments.`}
+            </Text>
+          )}
+        </Stack>
+      </Card>
+
+      <Card p="md">
+        <Text size="lg" fw="bold" mb="md">
+          {t`Embed Code`}
+        </Text>
+
+        <Stack gap="sm">
+          <CodeEditor
+            language="html"
+            value={snippet}
+            readOnly
+            lineNumbers={false}
+          />
+
+          <CopyButton value={snippet}>
+            {({ copied, copy }: { copied: boolean; copy: () => void }) => (
+              <Button
+                leftSection={<Icon name="copy" size={16} />}
+                onClick={copy}
+              >
+                {copied ? t`Copied!` : t`Copy Code`}
+              </Button>
+            )}
+          </CopyButton>
+        </Stack>
+      </Card>
+    </Stack>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { t } from "ttag";
 
 import { CodeEditor } from "metabase/common/components/CodeEditor";
@@ -13,18 +12,19 @@ import {
   Text,
 } from "metabase/ui";
 
+import { useSdkIframeEmbedSetupContext } from "../context";
 import { useSdkIframeEmbedSnippet } from "../hooks/use-sdk-iframe-embed-snippet";
-import type { SdkIframeEmbedSetupAuthType } from "../types";
 
 export const GetCodeStep = () => {
-  const [authType, setAuthType] =
-    useState<SdkIframeEmbedSetupAuthType>("user-session");
+  const { settings, updateSettings } = useSdkIframeEmbedSetupContext();
 
   const isJwtConfigured = useSetting("jwt-configured");
   const isSamlConfigured = useSetting("saml-configured");
   const isAnySsoConfigured = isJwtConfigured || isSamlConfigured;
 
-  const snippet = useSdkIframeEmbedSnippet({ authType });
+  const snippet = useSdkIframeEmbedSnippet();
+
+  const authType = settings.useExistingUserSession ? "user-session" : "sso";
 
   return (
     <Stack gap="md">
@@ -41,7 +41,9 @@ export const GetCodeStep = () => {
           <Radio.Group
             value={authType}
             onChange={(value) =>
-              setAuthType(value as SdkIframeEmbedSetupAuthType)
+              updateSettings({
+                useExistingUserSession: value === "user-session",
+              })
             }
           >
             <Stack gap="sm">

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useSearchParam } from "react-use";
+import _ from "underscore";
 
 import { Box } from "metabase/ui";
 import type { MetabaseEmbed } from "metabase-enterprise/embedding_iframe_sdk/embed";
@@ -69,7 +70,9 @@ export const SdkIframeEmbedPreview = () => {
         questionId: undefined,
         dashboardId: undefined,
 
-        ...settings,
+        // We must always use user sessions in the preview.
+        // We never use SSO in the preview as that adds complexity.
+        ..._.omit(settings, ["useExistingUserSession"]),
       });
     }
   }, [settings, isIframeLoaded]);

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.unit.spec.tsx
@@ -49,7 +49,9 @@ describe("Embed flow > forward and backward navigation", () => {
     ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "Get Code" }));
-    expect(screen.getByText("get code placeholder")).toBeInTheDocument();
+    expect(
+      screen.getByText("Choose the authentication method for embedding:"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Next" }),
     ).not.toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -47,6 +47,10 @@ export const SdkIframeEmbedSetupProvider = ({
 
     // This will be overridden by the last selected dashboard in the activity log.
     dashboardId: EMBED_FALLBACK_DASHBOARD_ID,
+
+    // Default to using user sessions, as we do not know if
+    // SSO for SDK is implemented on the user's backend, even when it is configured.
+    useExistingUserSession: true,
   });
 
   // Which embed experience are we setting up?

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
@@ -29,7 +29,7 @@ export const SelectEmbedExperienceStep = () => {
     const persistedSettings = _.pick(settings, [
       "theme",
       "instanceUrl",
-      "apiKey",
+      "useExistingUserSession",
     ]);
 
     // Use the most recent item for the selected type.

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
@@ -1,3 +1,4 @@
+import { GetCodeStep } from "./components/GetCodeStep";
 import { SelectEmbedExperienceStep } from "./components/SelectEmbedExperienceStep";
 import { SelectEmbedResourceStep } from "./components/SelectEmbedResourceStep";
 import type {
@@ -48,7 +49,7 @@ export const EMBED_STEPS: EmbedStepConfig[] = [
   },
   {
     id: "get-code",
-    component: () => "get code placeholder",
+    component: GetCodeStep,
   },
 ];
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
@@ -1,16 +1,12 @@
 import { useMemo } from "react";
+import _ from "underscore";
 
 import { useSetting } from "metabase/common/hooks";
 import type { SdkIframeEmbedTagSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
-import type { SdkIframeEmbedSetupAuthType } from "../types";
 
-export function useSdkIframeEmbedSnippet({
-  authType,
-}: {
-  authType: SdkIframeEmbedSetupAuthType;
-}) {
+export function useSdkIframeEmbedSnippet() {
   const { settings } = useSdkIframeEmbedSetupContext();
 
   const instanceUrl = useSetting("site-url");
@@ -18,11 +14,15 @@ export function useSdkIframeEmbedSnippet({
   return useMemo(() => {
     return getSnippet({
       target: "#metabase-embed",
-      ...settings,
+      ..._.omit(settings, ["useExistingUserSession"]),
       instanceUrl,
-      ...(authType === "user-session" ? { useExistingUserSession: true } : {}),
+
+      // Only include useExistingUserSession if it is true.
+      ...(settings.useExistingUserSession
+        ? { useExistingUserSession: true }
+        : {}),
     });
-  }, [settings, instanceUrl, authType]);
+  }, [settings, instanceUrl]);
 }
 
 function getSnippet(settings: SdkIframeEmbedTagSettings): string {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
@@ -58,6 +58,7 @@ function getSnippet(settings: SdkIframeEmbedTagSettings): string {
 
 <script>
   const { MetabaseEmbed } = window["metabase.embed"];
+
   const embed = new MetabaseEmbed({
     ${formattedSettings}
   });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
@@ -1,0 +1,65 @@
+import { useMemo } from "react";
+
+import { useSetting } from "metabase/common/hooks";
+import type { SdkIframeEmbedTagSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
+
+import { useSdkIframeEmbedSetupContext } from "../context";
+import type { SdkIframeEmbedSetupAuthType } from "../types";
+
+export function useSdkIframeEmbedSnippet({
+  authType,
+}: {
+  authType: SdkIframeEmbedSetupAuthType;
+}) {
+  const { settings } = useSdkIframeEmbedSetupContext();
+
+  const instanceUrl = useSetting("site-url");
+
+  return useMemo(() => {
+    return getSnippet({
+      target: "#metabase-embed",
+      ...settings,
+      instanceUrl,
+      ...(authType === "user-session" ? { useExistingUserSession: true } : {}),
+    });
+  }, [settings, instanceUrl, authType]);
+}
+
+function getSnippet(settings: SdkIframeEmbedTagSettings): string {
+  // filter out empty arrays, strings, objects, null and undefined.
+  // this keeps the embed settings readable.
+  const filteredSettings = Object.fromEntries(
+    Object.entries(settings).filter(([, value]) => {
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+
+      if (typeof value === "object" && value !== null) {
+        return Object.keys(value).length > 0;
+      }
+
+      return value !== undefined && value !== null && value !== "";
+    }),
+  );
+
+  // format the json settings with proper indentation
+  const formattedSettings = JSON.stringify(filteredSettings, null, 2)
+    .replace(/^{/, "")
+    .replace(/}$/, "")
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n")
+    .trim();
+
+  // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
+  return `<script src="${settings.instanceUrl}/app/embed.js"></script>
+
+<div id="metabase-embed"></div>
+
+<script>
+  const { MetabaseEmbed } = window["metabase.embed"];
+  const embed = new MetabaseEmbed({
+    ${formattedSettings}
+  });
+</script>`;
+}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
@@ -15,5 +15,3 @@ export type SdkIframeEmbedSetupRecentItem = Pick<
   BaseRecentItem,
   "name" | "description"
 > & { id: string | number };
-
-export type SdkIframeEmbedSetupAuthType = "user-session" | "sso";

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
@@ -15,3 +15,5 @@ export type SdkIframeEmbedSetupRecentItem = Pick<
   BaseRecentItem,
   "name" | "description"
 > & { id: string | number };
+
+export type SdkIframeEmbedSetupAuthType = "user-session" | "sso";

--- a/frontend/src/metabase/ui/components/buttons/CopyButton.ts
+++ b/frontend/src/metabase/ui/components/buttons/CopyButton.ts
@@ -1,0 +1,1 @@
+export { CopyButton, type CopyButtonProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/buttons/index.ts
+++ b/frontend/src/metabase/ui/components/buttons/index.ts
@@ -2,3 +2,4 @@ export * from "./ActionIcon";
 export * from "./Button";
 export * from "./PopoverBackButton";
 export * from "./UnstyledButton";
+export * from "./CopyButton";


### PR DESCRIPTION
Closes EMB-512

Adds a step for selecting authentication options and copying the embed snippets.

This step should include a radio button for selecting between existing user session authentication (for local development only) and SSO authentication (for production usages). This influences the code snippets only, not the preview. The embed snippets should align with the embed options, is syntax-highlighted and has a button to copy the entire snippet.

### How to verify

Refer to [Step 5 of the testing plan](https://www.notion.so/metabase/Testing-Plan-Embed-flow-for-new-iframe-embedding-21569354c90180d18ca1f457b10de0ab?source=copy_link#21569354c901807bbfc0ceb0800f6175) for reference.

To test this locally, click on `+ New > Embed`, then click "Next" until you see the "Get Code" step. You can try to change the embed experience and authentication method, and see how that impacts the snippet. As a reminder, the authentication method does not (and should not) impact the preview whatsoever.

The testing plan is copied below for your convenience:

- Step 5: authentication and snippet
    - SSO radio button should be disabled if both JWT and SAML are not configured (i.e. `jwt-configured = false && saml-configured = false`.
    - Switching the radio buttons to “SSO”:
        - the snippets box should no longer contain an `useExistingUserSession` field
    - Switching the radio buttons to “existing user session”:
        - the snippets box should contain an `useExistingUserSession` field
    - The code snippet should reflect the options we have chosen
    - Clicking on “Copy Code” copies the code snippet
        - If SSO is selected, the snippet should not contain `useExistingUserSession`

### Demo

![CleanShot 2568-06-26 at 02 42 43@2x](https://github.com/user-attachments/assets/c41137cf-91f6-4894-a484-7196c9015046)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
