### PR TITLE
fix: collection archive/move w/out parent perms

### DIFF
--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -766,9 +766,8 @@
 
 (deftest perms-for-archiving-test
   (with-collection-hierarchy! [{:keys [a b c d], :as collections}]
-    (testing "To Archive A, you should need *write* perms for A and all of its descendants, and also the Root Collection..."
-      (is (= #{"/collection/root/"
-               "/collection/A/"
+    (testing "To Archive A, you should need *write* perms for A and all of its descendants, but NOT the Root Collection"
+      (is (= #{"/collection/A/"
                "/collection/B/"
                "/collection/C/"
                "/collection/D/"
@@ -778,16 +777,14 @@
              (->> (collection/perms-for-archiving a)
                   (perms-path-ids->names collections)))))
 
-    (testing (str "Now let's move down a level. To archive B, you should need permissions for A and B, since B doesn't "
-                  "have any descendants")
-      (is (= #{"/collection/A/"
-               "/collection/B/"}
+    (testing (str "Now let's move down a level. To archive B, you should need permissions for B only, since B doesn't "
+                  "have any descendants and we don't need parent permissions")
+      (is (= #{"/collection/B/"}
              (->> (collection/perms-for-archiving b)
                   (perms-path-ids->names collections)))))
 
-    (testing "but for C, you should need perms for A (parent); C; and D, E, F, and G (descendants)"
-      (is (= #{"/collection/A/"
-               "/collection/C/"
+    (testing "but for C, you should need perms for C and D, E, F, and G (descendants) but NOT A (parent)"
+      (is (= #{"/collection/C/"
                "/collection/D/"
                "/collection/E/"
                "/collection/F/"
@@ -795,9 +792,8 @@
              (->> (collection/perms-for-archiving c)
                   (perms-path-ids->names collections)))))
 
-    (testing "For D you should need C (parent), D, and E (descendant)"
-      (is (= #{"/collection/C/"
-               "/collection/D/"
+    (testing "For D you should need D and E (descendant) but NOT C (parent)"
+      (is (= #{"/collection/D/"
                "/collection/E/"}
              (->> (collection/perms-for-archiving d)
                   (perms-path-ids->names collections)))))))
@@ -806,7 +802,7 @@
   (testing "If you try to calculate permissions to archive the Root Collection, throw an Exception!"
     (is (thrown-with-msg?
          Exception
-         #"You cannot archive the Root Collection."
+         #"You cannot operate on the Root Collection."
          (collection/perms-for-archiving collection/root-collection))))
 
   (testing "Let's make sure we get an Exception when we try to archive the Custom Reports Collection"
@@ -814,13 +810,13 @@
       (with-redefs [audit/default-custom-reports-collection (constantly cr-collection)]
         (is (thrown-with-msg?
              Exception
-             #"You cannot archive the Custom Reports Collection."
+             #"You cannot operate on the Custom Reports Collection."
              (collection/perms-for-archiving cr-collection))))))
 
   (testing "Let's make sure we get an Exception when we try to archive a Personal Collection"
     (is (thrown-with-msg?
          Exception
-         #"You cannot archive a Personal Collection."
+         #"You cannot operate on a Personal Collection."
          (collection/perms-for-archiving (collection/user->personal-collection (mt/fetch-user :lucky))))))
 
   (testing "invalid input"
@@ -836,33 +832,32 @@
 
 (deftest perms-for-moving-test
   (with-collection-hierarchy! [{:keys [b c], :as collections}]
-    (testing "If we want to move B into C, we should need perms for A, B, and C."
-      ;; B because it is being moved; C we are moving
-      ;; something into it, A because we are moving something out of it
+    (testing "If we want to move B into C, we should need perms for B and C, but NOT for A."
+      ;; B because it is being moved; C because we are moving something into it
+      ;; We do NOT need permissions for A because we are just moving something out of it
       ;;
       ;;    +-> B                              +-> B*
       ;;    |                                  |
-      ;; A -+-> C -+-> D -> E  ===>  A* -> C* -+-> D -> E
+      ;; A -+-> C -+-> D -> E  ===>  A -> C* -+-> D -> E
       ;;           |                           |
       ;;           +-> F -> G                  +-> F -> G
 
-      (is (= #{"/collection/A/"
-               "/collection/B/"
+      (is (= #{"/collection/B/"
                "/collection/C/"}
              (->> (collection/perms-for-moving b c)
                   (perms-path-ids->names collections)))))
 
     (testing "Ok, now let's try moving something with descendants."
       ;; If we move C into B, we need perms for C and all its
-      ;; descendants, and B, since it's the new parent; and A, the old parent
+      ;; descendants, and B, since it's the new parent
+      ;; We do NOT need permissions for A, the old parent
       ;;
       ;;    +-> B
       ;;    |
-      ;; A -+-> C -+-> D -> E  ===>  A* -> B* -> C* -+-> D* -> E*
+      ;; A -+-> C -+-> D -> E  ===>  A -> B* -> C* -+-> D* -> E*
       ;;           |                                 |
       ;;           +-> F -> G                        +-> F* -> G*
-      (is (= #{"/collection/A/"
-               "/collection/B/"
+      (is (= #{"/collection/B/"
                "/collection/C/"
                "/collection/D/"
                "/collection/E/"
@@ -874,23 +869,21 @@
     (testing "Ok, now how about moving B into the Root Collection?"
       ;;    +-> B                    B* [and Root*]
       ;;    |
-      ;; A -+-> C -+-> D -> E  ===>  A* -> C -+-> D -> E
+      ;; A -+-> C -+-> D -> E  ===>  A -> C -+-> D -> E
       ;;           |                          |
       ;;           +-> F -> G                 +-> F -> G
       (is (= #{"/collection/root/"
-               "/collection/A/"
                "/collection/B/"}
              (->> (collection/perms-for-moving b collection/root-collection)
                   (perms-path-ids->names collections)))))
 
     (testing "How about moving C into the Root Collection?"
-      ;;    +-> B                    A* -> B
+      ;;    +-> B                    A -> B
       ;;    |
       ;; A -+-> C -+-> D -> E  ===>  C* -+-> D* -> E* [and Root*]
       ;;           |                     |
       ;;           +-> F -> G            +-> F* -> G*
       (is (= #{"/collection/root/"
-               "/collection/A/"
                "/collection/C/"
                "/collection/D/"
                "/collection/E/"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59652
### Description

Allow users to archive and move collections even when they do not have read-write permissions on the parent collection.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
