### PR TITLE
feat: add support for setting tenant attributes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/tenants/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/api.clj
@@ -19,6 +19,7 @@
 
 (def ^:private CreateTenantArguments [:map {:closed true}
                                       [:name ms/NonBlankString]
+                                      [:attributes {:optional true} [:maybe tenant/Attributes]]
                                       [:slug Slug]])
 
 (defn create-tenant!
@@ -65,6 +66,7 @@
 (def ^:private UpdateTenantArguments
   [:map {:closed true}
    [:name {:optional true} [:maybe ms/NonBlankString]]
+   [:attributes {:optional true} [:maybe tenant/Attributes]]
    [:is_active {:optional true} [:maybe ms/BooleanValue]]])
 
 (mu/defn- update-tenant! [tenant-id :- ms/PositiveInt

--- a/enterprise/backend/src/metabase_enterprise/tenants/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/api.clj
@@ -44,7 +44,7 @@
 
 (defn- present-tenants [tenants]
   (->> (t2/hydrate tenants :member_count)
-       (map #(select-keys % [:id :name :slug :is_active :member_count]))))
+       (map #(select-keys % [:id :name :slug :is_active :member_count :attributes]))))
 
 (defn- present-tenant [tenant]
   (first (present-tenants [tenant])))
@@ -85,12 +85,12 @@
     tenant-after-update))
 
 (api.macros/defendpoint :put ["/:id" :id #"[^/]+"]
-  "Update a tenant (right now, only name)"
+  "Update a tenant, can set name, attributes, or whether this tenant is active."
   [{id :id} :- [:map {:closed true} [:id ms/PositiveInt]]
    _query-params
    tenant :- UpdateTenantArguments]
   (when (:name tenant)
-    (api/check-400 (not (t2/exists? :model/Tenant :name (:name tenant)))
+    (api/check-400 (not (t2/exists? :model/Tenant :name (:name tenant) :id [:not= id]))
                    "This name is already taken."))
   (update-tenant! id tenant)
   (present-tenant (update-tenant! id tenant)))

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -356,10 +356,11 @@ databaseChangeLog:
       id: v56.2025-07-07T08:59:40
       author: edpaget
       comment: add column for tenant attributes
+      preConditions: # not needed
       changes:
-        addColumn:
-          table: tenant
-          columns:
+        - addColumn:
+            tableName: tenant
+            columns:
               - column:
                   name: attributes
                   type: ${text.type}

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -351,6 +351,22 @@ databaseChangeLog:
                   type: ${boolean.type}
                   constraints:
                     nullable: true
+
+  - changeSet:
+      id: v56.2025-07-07T08:59:40
+      author: edpaget
+      comment: add column for tenant attributes
+      changes:
+        addColumn:
+          table: tenant
+          columns:
+              - column:
+                  name: attributes
+                  type: ${text.type}
+                  remarks: JSON object containing custom tenant attributes
+                  constraints:
+                    nullable: true
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
### Description

Supports setting tenant attributes in the POST and PUT endpoints.

Since this now seriously lets a tenant model be updated I also added timestamp columns and hooks. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
