### PR TITLE
Fix pre-release test environment vars

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -107,6 +107,10 @@ jobs:
       CYPRESS_MB_STARTER_CLOUD_TOKEN: ${{ secrets.MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_MB_PRO_CLOUD_TOKEN: ${{ secrets.MB_PRO_CLOUD_TOKEN }}
       CYPRESS_MB_PRO_SELF_HOSTED_TOKEN: ${{ secrets.MB_PRO_SELF_HOSTED_TOKEN }}
+      # these are needed for backwards compatibility with release branches earlier than v55, since
+      # this workflow always runs from master, but we run tests from the release branch
+      CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.MB_ALL_FEATURES_TOKEN }}
+      CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.MB_STARTER_CLOUD_TOKEN }}
       # disabled because of out of memory issues
       # probably related to https://github.com/cypress-io/cypress/issues/27415
       CYPRESS_NO_COMMAND_LOG: 1


### PR DESCRIPTION

### Description

follow up to #59802
related to #60032

see failed [release](https://metaboat.slack.com/archives/C864UT5CZ/p1750885445937449)

The release failed because we updated these environment variables in master, but they're referenced differently in older release branches. Since this workflow always runs on master, but it checks out tests from the releasing branch.

