### PR TITLE
[Metabot] Fix too large of chart images not being able to be converted to base64

### DIFF
--- a/frontend/src/metabase/visualizations/lib/image-exports.ts
+++ b/frontend/src/metabase/visualizations/lib/image-exports.ts
@@ -6,6 +6,7 @@ import DashboardS from "metabase/dashboard/components/Dashboard/Dashboard.module
 import DashboardGridS from "metabase/dashboard/components/DashboardGrid.module.css";
 import { DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 import { isEmbeddingSdk, isStorybookActive } from "metabase/env";
+import { utf8_to_b64 } from "metabase/lib/encoding";
 import { openImageBlobOnStorybook } from "metabase/lib/loki-utils";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 
@@ -190,9 +191,7 @@ export const getVisualizationSvgDataUri = (
   }
 
   const svgString = new XMLSerializer().serializeToString(element);
-  const utf8Bytes = new TextEncoder().encode(svgString);
-  const binaryString = String.fromCharCode(...utf8Bytes);
-  return `data:image/svg+xml;base64,${window.btoa(binaryString)}`;
+  return `data:image/svg+xml;base64,${utf8_to_b64(svgString)}`;
 };
 
 export const getChartSelector = (


### PR DESCRIPTION
### Description

Looked into an issue @sanex3339 was running into where metabot didn't have access to the current chart. It looks like it was due to my use of the spread (`...` ) operator with String.fromCharCode when args length exceed `65536`.
![CleanShot 2025-06-25 at 18 26 18@2x](https://github.com/user-attachments/assets/73e53dbd-c9bf-4a8c-8681-34ff9cfdbfea). 

I was doing this to support utf8, but after glancing around this was already a solved problem + we have a `utf8_to_b64` function already.

### How to verify

Go to a really large charge with lots going on, something like this:
![CleanShot 2025-06-25 at 18 32 13@2x](https://github.com/user-attachments/assets/dee04abc-3a38-4a80-a826-b09802f8e094)

It shouldn't work before this and it should after this change.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR