### PR TITLE
Use Indicator for update notifications

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
@@ -5,7 +5,7 @@ import { useGetVersionInfoQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { newVersionAvailable } from "metabase/lib/utils";
-import { Badge } from "metabase/ui";
+import { Indicator } from "metabase/ui";
 
 import { SettingsNavItem } from "./SettingsNav";
 
@@ -21,23 +21,21 @@ export function UpdatesNavItem() {
   return (
     <SettingsNavItem
       path="updates"
-      label={<div>{t`Updates`}</div>}
-      icon="sparkles"
-      rightSection={
-        isNewVersionAvailable ? (
-          <Badge
-            data-testid="updates-nav-badge"
-            styles={{
-              root: {
-                color: "var(--mb-color-text-white)",
-                backgroundColor: "var(--mb-color-error)",
-              },
-            }}
-          >
-            1
-          </Badge>
-        ) : null
+      label={
+        <Indicator
+          data-testid="testing"
+          disabled={!isNewVersionAvailable}
+          styles={{
+            indicator: {
+              transform: "translateX(0.5rem)",
+            },
+          }}
+          color="error"
+          size={6}
+          w="fit-content"
+        >{t`Updates`}</Indicator>
       }
+      icon="sparkles"
     />
   );
 }

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
@@ -27,12 +27,12 @@ export function UpdatesNavItem() {
           disabled={!isNewVersionAvailable}
           styles={{
             indicator: {
-              transform: "translateX(0.5rem)",
+              right: "0.5rem",
             },
           }}
-          color="error"
-          size={6}
-          w="fit-content"
+          size={7}
+          // position the indicator to the right - can't use rightSection because it rotates on click
+          position="middle-end"
         >{t`Updates`}</Indicator>
       }
       icon="sparkles"

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.unit.spec.tsx
@@ -3,7 +3,7 @@ import {
   setupSettingEndpoint,
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import type { SettingKey, UpdateChannel } from "metabase-types/api";
 import {
   createMockSettingDefinition,
@@ -69,11 +69,22 @@ const setup = async (props: {
 describe("UpdatesNavItem", () => {
   it("should not show badge if there are no updates available", async () => {
     await setup({ versionTag: "v1.53.8", updateChannel: "latest" });
-    expect(screen.queryByTestId("updates-nav-badge")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      const indicatorDot = document.querySelector(
+        '[class*="Indicator-indicator"]',
+      );
+      expect(indicatorDot).not.toBeInTheDocument();
+    });
   });
 
   it("should show badge updates are available", async () => {
     await setup({ versionTag: "v1.53.8", updateChannel: "beta" });
-    expect(await screen.findByTestId("updates-nav-badge")).toBeInTheDocument();
+    await waitFor(() => {
+      const indicatorDot = document.querySelector(
+        '[class*="Indicator-indicator"]',
+      );
+      expect(indicatorDot).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #30114

closes #59987

The old badge indicator was confusing because the number `1` looked like it had meaning, such as number of updates behind, but in fact it meant nothing. [ Slack thread](https://metaboat.slack.com/archives/C02H619CJ8K/p1750282804596389)

![image](https://github.com/user-attachments/assets/752c9659-89c1-47ab-bd78-79edda2d0b94)



