### PR TITLE
Enable the :expression-literals feature for the mongo driver

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -404,6 +404,7 @@
 
 (doseq [[feature supported?] {:basic-aggregations              true
                               :expression-aggregations         true
+                              :expression-literals             true
                               :inner-join                      true
                               :left-join                       true
                               :nested-fields                   true

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -203,7 +203,9 @@
 
 (defmethod ->rvalue :expression
   [[_ expression-name]]
-  (->rvalue (driver-api/expression-with-name (:query *query*) expression-name)))
+  (let [expression-value (driver-api/expression-with-name (:query *query*) expression-name)]
+    (cond->> (->rvalue expression-value)
+      (driver-api/is-clause? :value expression-value) (hash-map $literal))))
 
 (defmethod ->rvalue :metadata/column
   [{coercion :coercion-strategy, ::keys [source-alias join-field] :as field}]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -853,6 +853,15 @@
 (defmethod compile-filter :not [[_ subclause]]
   (compile-filter (negate subclause)))
 
+(defmethod compile-filter :expression [expression-clause]
+  (compile-filter [:= expression-clause true]))
+
+(defmethod compile-filter :field [field-clause]
+  (compile-filter [:= field-clause true]))
+
+(defmethod compile-filter :value [value-clause]
+  (compile-filter [:= value-clause true]))
+
 (defn- handle-filter [{filter-clause :filter} pipeline-ctx]
   (if-not filter-clause
     pipeline-ctx
@@ -908,6 +917,15 @@
 
 (defmethod compile-cond :not [[_ subclause]]
   (compile-cond (negate subclause)))
+
+(defmethod compile-cond :expression [expression-clause]
+  (->rvalue expression-clause))
+
+(defmethod compile-cond :field [field-clause]
+  (->rvalue field-clause))
+
+(defmethod compile-cond :value [value-clause]
+  (->rvalue value-clause))
 
 ;;; ----------------------------------------------------- joins ------------------------------------------------------
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -205,7 +205,7 @@
   [[_ expression-name]]
   (let [expression-value (driver-api/expression-with-name (:query *query*) expression-name)]
     (cond->> (->rvalue expression-value)
-      (driver-api/is-clause? :value expression-value) (hash-map $literal))))
+      (driver-api/is-clause? :value expression-value) (array-map $literal))))
 
 (defmethod ->rvalue :metadata/column
   [{coercion :coercion-strategy, ::keys [source-alias join-field] :as field}]


### PR DESCRIPTION
Closes QUE-1451

### Description

* Enable the :expression-literals feature for the mongo driver
* Wrap :value expressions in $literal when compiling for mongo
* Add mongo compile-cond and compile-filter impls for :expression, :field, and :value

### How to verify

Existing `:expression-literals` tests should pass

* Connect to MongoDB
* Add a custom column with literal value like `"hi"`, `0`, or `True`
* Verify you can use the value in aggregations, breakouts, filters, order by, etc

### Demo

![Screenshot 2025-06-25 at 5 05 33 PM](https://github.com/user-attachments/assets/438e077a-b797-4912-95dd-af72c3bdb598)
![Screenshot 2025-06-25 at 5 05 56 PM](https://github.com/user-attachments/assets/db747a05-e8bc-485d-8fa0-61e2c92735fb)
![Screenshot 2025-06-25 at 5 06 25 PM](https://github.com/user-attachments/assets/a7c0c192-1905-42d5-9405-b05c9ff25261)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
