### PR TITLE
Closes VIZ-1211 default colors for visualizer cards

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
@@ -253,6 +253,24 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
     });
   });
 
+  it("should preserve default colors (VIZ-1211)", () => {
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+    H.openQuestionsSidebar();
+
+    H.sidebar().within(() => {
+      cy.findByRole("menuitem", {
+        name: ORDERS_COUNT_BY_PRODUCT_CATEGORY.name,
+      }).click();
+    });
+
+    H.showDashcardVisualizerModal(1);
+
+    H.modal().within(() => {
+      H.chartPathWithFillColor("#509EE3").should("have.length", 4);
+    });
+  });
+
   it("should handle implicit viz settings (VIZ-947)", () => {
     function assertDataSourceColumnSelected(
       columnName: string,
@@ -277,7 +295,7 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
       assertDataSourceColumnSelected("Average of Quantity", false);
       assertDataSourceColumnSelected("Created At: Year");
       assertDataSourceColumnSelected("Product → Category", false);
-      H.chartPathWithFillColor("#88BF4D").should("have.length", 5);
+      H.chartPathWithFillColor("#509EE3").should("have.length", 5);
       H.verticalWell().findAllByTestId("well-item").should("have.length", 1);
       H.horizontalWell().findAllByTestId("well-item").should("have.length", 1);
 

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -3,6 +3,7 @@ import type {
   LocalFieldReference,
   Parameter,
   ParameterValueOrArray,
+  VisualizerColumnValueSource,
 } from "metabase-types/api";
 
 import type { Card } from "./card";
@@ -173,6 +174,11 @@ export interface NativeDatasetResponse {
 
 export type SingleSeries = {
   card: Card;
+  /**
+   * A record that maps visualizer series keys (in the form of COLUMN_1,
+   * COLUMN_2, etc.) to their original values (count, avg, etc.).
+   */
+  columnValuesMapping?: Record<string, VisualizerColumnValueSource[]>;
 } & Pick<Dataset, "data" | "error" | "started_at">;
 
 export type RawSeries = SingleSeries[];

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -235,6 +235,8 @@ export function DashCardVisualization({
         // Certain visualizations memoize settings computation based on series keys
         // This guarantees a visualization always rerenders on changes
         started_at: new Date().toISOString(),
+
+        columnValuesMapping,
       },
     ];
 

--- a/frontend/src/metabase/lib/colors/charts.ts
+++ b/frontend/src/metabase/lib/colors/charts.ts
@@ -81,7 +81,7 @@ const getOrderBasedMapping = (
  * Generates a mapping of keys to colors based on a hash of the keys.
  *
  * @param keys the keys to assign colors to
- * @param values the availabls colors to assign
+ * @param values the available colors to assign
  * @param existingMapping possibly existing mapping of keys to colors
  * @param getPreferredValue a function that returns a preferred color for a key
  * @param seriesVizSettingsDefaultKeys possible keys to use for hashing

--- a/frontend/src/metabase/lib/colors/charts.ts
+++ b/frontend/src/metabase/lib/colors/charts.ts
@@ -96,11 +96,13 @@ const getHashBasedMapping = (
 ) => {
   const newMapping: Record<string, string> = {};
   const sortedKeys = [...keys].sort();
+  // If seriesVizSettingsDefaultKeys is provided, we sort it in the same order as keys
+  // to ensure that the hash codes are consistent with the sorted keys.
+  const sortedDefaultKeys = seriesVizSettingsDefaultKeys
+    ? sortedKeys.map((k) => seriesVizSettingsDefaultKeys[keys.indexOf(k)])
+    : undefined;
   const keyHashes = Object.fromEntries(
-    keys.map((k, i) => [
-      k,
-      getHashCode(seriesVizSettingsDefaultKeys?.[i] ?? k),
-    ]),
+    keys.map((k, i) => [k, getHashCode(sortedDefaultKeys?.[i] ?? k)]),
   );
   const unsetKeys = new Set(keys);
   const usedValues = new Set<string>();
@@ -128,7 +130,7 @@ const getHashBasedMapping = (
   // see frontend/src/metabase/lib/colors/groups.ts, getPreferredColor()
   sortedKeys.forEach((key, i) => {
     if (!newMapping[key]) {
-      const value = getPreferredValue(seriesVizSettingsDefaultKeys?.[i] ?? key);
+      const value = getPreferredValue(sortedDefaultKeys?.[i] ?? key);
 
       if (value && !usedValues.has(value)) {
         setValue(key, value);

--- a/frontend/src/metabase/lib/colors/charts.ts
+++ b/frontend/src/metabase/lib/colors/charts.ts
@@ -6,6 +6,7 @@ export const getColorsForValues = (
   keys: string[],
   existingMapping?: Record<string, string> | null,
   palette?: ColorPalette,
+  seriesVizSettingsDefaultKeys?: string[],
 ) => {
   if (keys.length <= ACCENT_COUNT) {
     return getHashBasedMapping(
@@ -13,6 +14,7 @@ export const getColorsForValues = (
       getAccentColors({ light: false, dark: false, gray: false }, palette),
       existingMapping,
       (color: string) => getPreferredColor(color, palette),
+      seriesVizSettingsDefaultKeys,
     );
   } else {
     return getOrderBasedMapping(
@@ -75,15 +77,31 @@ const getOrderBasedMapping = (
   return newMapping;
 };
 
+/**
+ * Generates a mapping of keys to colors based on a hash of the keys.
+ *
+ * @param keys the keys to assign colors to
+ * @param values the availabls colors to assign
+ * @param existingMapping possibly existing mapping of keys to colors
+ * @param getPreferredValue a function that returns a preferred color for a key
+ * @param seriesVizSettingsDefaultKeys possible keys to use for hashing
+ * @returns a mapping of keys to colors
+ */
 const getHashBasedMapping = (
   keys: string[],
   values: string[],
   existingMapping: Record<string, string> | null | undefined,
   getPreferredValue: (key: string) => string | undefined,
+  seriesVizSettingsDefaultKeys?: string[],
 ) => {
   const newMapping: Record<string, string> = {};
   const sortedKeys = [...keys].sort();
-  const keyHashes = Object.fromEntries(keys.map((k) => [k, getHashCode(k)]));
+  const keyHashes = Object.fromEntries(
+    keys.map((k, i) => [
+      k,
+      getHashCode(seriesVizSettingsDefaultKeys?.[i] ?? k),
+    ]),
+  );
   const unsetKeys = new Set(keys);
   const usedValues = new Set<string>();
   const unusedValues = new Set(values);
@@ -95,6 +113,8 @@ const getHashBasedMapping = (
     unusedValues.delete(value);
   };
 
+  // Let's look for existing values first (as in, values set explicitly
+  // in the settings) and set them in the new mapping
   sortedKeys.forEach((key) => {
     const value = existingMapping?.[key];
 
@@ -103,9 +123,12 @@ const getHashBasedMapping = (
     }
   });
 
-  sortedKeys.forEach((key) => {
+  // if we haven't found a value for a key,
+  // let's try to find a preferred value for it (e.g. count gets its own specific color)
+  // see frontend/src/metabase/lib/colors/groups.ts, getPreferredColor()
+  sortedKeys.forEach((key, i) => {
     if (!newMapping[key]) {
-      const value = getPreferredValue(key);
+      const value = getPreferredValue(seriesVizSettingsDefaultKeys?.[i] ?? key);
 
       if (value && !usedValues.has(value)) {
         setValue(key, value);
@@ -113,7 +136,13 @@ const getHashBasedMapping = (
     }
   });
 
+  // this loops through the keys that are still unset
+  // and tries to set them to a value that is not used yet
+  // the new color is chosen based on the hash of the key
+  // and the attempt number (to avoid infinite loops)
   for (let attempt = 0; unsetKeys.size > 0; attempt++) {
+    // if we run out of unused values, we reset the set of unused values
+    // with all values again
     if (!unusedValues.size) {
       values.forEach((value) => unusedValues.add(value));
     }

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -25,6 +25,10 @@ export function keyForSingleSeries(single) {
   return single.card._seriesKey || String(single.card.name);
 }
 
+function hasSingleSeriesKey(single) {
+  return Boolean(single.card._seriesKey || single.card.name);
+}
+
 const LINE_DISPLAY_TYPES = new Set(["line", "area"]);
 
 export function seriesSetting({ readDependencies = [], def } = {}) {
@@ -223,10 +227,28 @@ export function seriesSetting({ readDependencies = [], def } = {}) {
     }),
     // colors must be computed as a whole rather than individually
     [SERIES_COLORS_SETTING_KEY]: {
-      getValue(series, settings) {
-        const keys = series.map((single) => keyForSingleSeries(single));
-        return getSeriesColors(keys, settings);
-      },
+      getValue: getColors,
     },
   };
+}
+
+/**
+ * Exported for testing purposes.
+ * Computes the colors for the series based on their keys and settings.
+ * It filters out series that do not have a single key and maps them to their keys.
+ * Then it retrieves the colors using the `getSeriesColors` function.
+ * @param {Array} series - The series to compute colors for.
+ * @param {Object} settings - The visualization settings.
+ * @returns {Object} - An object mapping series keys to their colors.
+ */
+export function getColors(series, settings) {
+  const originalKeys = [];
+
+  const keys = series.filter(hasSingleSeriesKey).map((s) => {
+    const key = keyForSingleSeries(s);
+    originalKeys.push(s.columnValuesMapping?.[key]?.[0]?.originalName);
+    return key;
+  });
+
+  return getSeriesColors(keys, settings, originalKeys);
 }

--- a/frontend/src/metabase/visualizations/lib/settings/series.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/series.unit.spec.ts
@@ -1,0 +1,89 @@
+import {
+  createMockCard,
+  createMockVisualizationSettings,
+} from "metabase-types/api/mocks";
+
+import { getColors } from "./series";
+
+describe("Series unit settings", () => {
+  describe("getColors", () => {
+    it("should work for a card with a name", () => {
+      const series = [{ card: createMockCard({ name: "The card" }) }];
+      const settings = createMockVisualizationSettings({
+        "graph.metrics": ["count"],
+        "graph.dimensions": ["CATEGORY"],
+      });
+
+      const colors = getColors(series, settings);
+      expect(colors).toEqual({
+        "The card": "#7172AD",
+      });
+    });
+
+    it("should work for a card with a _seriesKey", () => {
+      const series = [
+        { card: { ...createMockCard({ name: "Count" }), _seriesKey: "count" } },
+      ];
+      const settings = createMockVisualizationSettings({
+        "graph.metrics": ["count"],
+        "graph.dimensions": ["CATEGORY"],
+      });
+
+      const colors = getColors(series, settings);
+      expect(colors).toEqual({
+        count: "#509EE3",
+      });
+    });
+
+    it("should work for visualizer series", () => {
+      const series = [
+        {
+          // columnValuesMapping is needed by the color assignment logic
+          // because certain series have a specific color based on their name (count, for instance)
+          // see frontend/src/metabase/lib/colors/groups.ts, getPreferredColor()
+          columnValuesMapping: {
+            COLUMN_1: [
+              {
+                sourceId: "card:124",
+                originalName: "CATEGORY",
+                name: "COLUMN_1",
+              },
+            ],
+            COLUMN_2: [
+              {
+                sourceId: "card:124",
+                originalName: "count",
+                name: "COLUMN_2",
+              },
+            ],
+          },
+          card: {
+            ...createMockCard({
+              name: "Count",
+            }),
+            _seriesKey: "COLUMN_2",
+          },
+        },
+      ];
+
+      const settings = createMockVisualizationSettings({
+        "card.title": "Bar chart with formatting options",
+        "graph.metrics": ["COLUMN_2"],
+        column_settings: {
+          '["name","count"]': {
+            number_style: "scientific",
+            prefix: "Around ",
+            suffix: "-ish",
+          },
+        },
+        "graph.dimensions": ["COLUMN_1"],
+        "graph.x_axis.scale": "ordinal",
+      });
+
+      const colors = getColors(series, settings);
+      expect(colors).toEqual({
+        COLUMN_2: "#509EE3", // This is the color for "count"
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/shared/settings/series.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/series.ts
@@ -11,6 +11,7 @@ export const SERIES_COLORS_SETTING_KEY = "series_settings.colors";
 export const getSeriesColors = (
   seriesVizSettingsKeys: string[],
   settings: VisualizationSettings,
+  seriesVizSettingsDefaultKeys: string[],
 ) => {
   const assignments = _.chain(seriesVizSettingsKeys)
     .map((key) => [key, getIn(settings, [SERIES_SETTING_KEY, key, "color"])])
@@ -27,7 +28,12 @@ export const getSeriesColors = (
     }
   }
 
-  return getColorsForValues(seriesVizSettingsKeys, assignments);
+  return getColorsForValues(
+    seriesVizSettingsKeys,
+    assignments,
+    undefined,
+    seriesVizSettingsDefaultKeys,
+  );
 };
 
 export const getSeriesDefaultDisplay = (cardDisplay: string, index: number) => {

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -184,13 +184,18 @@ export const getVisualizerRawSeries = createSelector(
     const dataSourceNameMap = Object.fromEntries(
       dataSources.map((dataSource) => [dataSource.id, dataSource.name]),
     );
-    return isMultiseriesCartesianChart
+    const series = isMultiseriesCartesianChart
       ? splitVisualizerSeries(
           flatSeries,
           columnValuesMapping,
           dataSourceNameMap,
         )
       : flatSeries;
+
+    return series.map((s) => ({
+      ...s,
+      columnValuesMapping,
+    }));
   },
 );
 


### PR DESCRIPTION
Closes [VIZ-1211: Sometimes chart colors aren’t propagated to the visualizer](https://linear.app/metabase/issue/VIZ-1211/sometimes-chart-colors-arent-propagated-to-the-visualizer)

### Description

In regular cards/questions, default colors are computed based on their series' name if it's a special name (count, avg, etc.) or a hash of their name. In visualizer cards, the series names are different (e.g. `COLUMN_1`) and this would make the default color different.

This PR fixes this issue by:
 - propagating `columnValuesMapping` so the color assignment logic has access to it
 - giving the color logic different keys for hashing/getting colors (i.e. even though the series is called `COLUMN_1`, the key for color assignment is the original — e.g. `count`).

### How to verify

 1. Create a question (count of orders per time, for instance) and don't modify the series colors
 2. Add the question to a dashboard (as a regular card, not a visualizer card for now)
 3. Edit the card

The series should keep its color.

### Demo

Before:
https://www.loom.com/share/36c9f119b9ef4ed08bbf1c6c4c0148ac

After:
https://www.loom.com/share/015f39fc85a948f684161b7f6d203b40

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
