### PR TITLE
sdk(fix): Render ColorSelector within ChartNestedSettingSeriesMultiple without portal

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -1,4 +1,5 @@
 import {
+  EditableDashboard,
   InteractiveDashboard,
   InteractiveQuestion,
 } from "@metabase/embedding-sdk-react";
@@ -6,7 +7,11 @@ import {
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import * as H from "e2e/support/helpers";
-import { openVizSettingsSidebar } from "e2e/support/helpers";
+import {
+  editDashboard,
+  openVizSettingsSidebar,
+  showDashcardVisualizerModalSettings,
+} from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
@@ -158,6 +163,27 @@ describe("scenarios > embedding-sdk > popovers", () => {
         cy.findByTestId("color-selector-popover").click(1, 1);
         cy.findByTestId("color-selector-popover").should("be.visible");
       });
+    });
+  });
+
+  it("should properly render the ColorPicker above the visualizer modal (metabase#60116)", () => {
+    cy.get<string>("@dashboardId").then((dashboardId) => {
+      mountSdkContent(<EditableDashboard dashboardId={dashboardId} />);
+    });
+
+    getSdkRoot().within(() => {
+      editDashboard();
+      showDashcardVisualizerModalSettings(0);
+
+      cy.findAllByTestId("color-selector-button").first().click();
+
+      // Clicking at the edge of the color picker popover to be sure that the click does not close it
+      cy.findByTestId("color-selector-popover").click(1, 1);
+      cy.findByTestId("color-selector-popover").should("be.visible");
+
+      // Clicking outside the color picker to be sure that the click closes it
+      cy.findByTestId("chartsettings-sidebar").click(1, 1);
+      cy.findByTestId("color-selector-popover").should("not.exist");
     });
   });
 });

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx
@@ -59,6 +59,7 @@ export default class ChartNestedSettingSeriesMultiple extends Component {
               >
                 <div className={cx(CS.flex, CS.alignCenter)}>
                   <ColorSelector
+                    withinPortal={false}
                     value={settings.color}
                     colors={getAccentColors()}
                     onChange={(value) =>

--- a/frontend/src/metabase/visualizer/components/Header/Header.tsx
+++ b/frontend/src/metabase/visualizer/components/Header/Header.tsx
@@ -90,7 +90,7 @@ export function Header({
       <div style={{ flexGrow: 1 }} />
 
       <Button.Group>
-        <Tooltip label={t`Undo`}>
+        <Tooltip withinPortal={false} label={t`Undo`}>
           <Button
             size="sm"
             aria-label={t`Undo`}
@@ -104,7 +104,7 @@ export function Header({
             }
           />
         </Tooltip>
-        <Tooltip label={t`Redo`}>
+        <Tooltip withinPortal={false} label={t`Redo`}>
           <Button
             size="sm"
             aria-label={t`Redo`}

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.tsx
@@ -116,7 +116,7 @@ export function VisualizationCanvas({ className }: VisualizationCanvasProps) {
           pl="7px"
           style={{ gridArea: "bottom-left" }}
         >
-          <Tooltip label={t`View as table`}>
+          <Tooltip withinPortal={false} label={t`View as table`}>
             <ActionIcon
               data-testid="visualizer-view-as-table-button"
               onClick={() => {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60116
Render ColorSelector within ChartNestedSettingSeriesMultiple without portal

Closes https://linear.app/metabase/issue/GIT-7469/sdk-opening-a-color-picker-from-visualizer-settings-opens-it-under-the

Also the PR fixes tooltips within the Visualizer modal, to render them without portal as well, because for SDK these tooltips are also displayed under the modal.

Bug:


https://github.com/user-attachments/assets/a6925880-f8b7-479e-a88d-3fc04eccb1c8



Fix:
![image](https://github.com/user-attachments/assets/b1582ffb-4f04-425b-ad06-b4af2798e722)



How to verify:
- CI should be green
