### PR TITLE
sdk(fix): Render legacy popover within the proper portal container for the SDK

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -619,7 +619,7 @@ export function assertDashboardFullWidth() {
   );
 }
 
-export function openClickBehaviorSidebar(
+export function clickBehaviorSidebar(
   dashcardIndex = 0,
 ): Cypress.Chainable<JQuery<HTMLElement>> {
   showDashboardCardActions(dashcardIndex);

--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -618,3 +618,15 @@ export function assertDashboardFullWidth() {
     MAX_WIDTH,
   );
 }
+
+export function openClickBehaviorSidebar(
+  dashcardIndex = 0,
+): Cypress.Chainable<JQuery<HTMLElement>> {
+  showDashboardCardActions(dashcardIndex);
+
+  getDashboardCard(dashcardIndex)
+    .findByLabelText("Click behavior")
+    .click({ force: true });
+
+  return cy.findByTestId("click-behavior-sidebar");
+}

--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -434,7 +434,7 @@ describe("scenarios > embedding-sdk > styles", () => {
           });
 
           H.editDashboard();
-          H.openClickBehaviorSidebar().within(() => {
+          H.clickBehaviorSidebar().within(() => {
             cy.findByText("Update a dashboard filter").click();
             cy.findAllByTestId("click-target-column").first().click();
           });

--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -1,6 +1,7 @@
 import { Button, MantineProvider } from "@mantine/core";
 import {
   CreateDashboardModal,
+  EditableDashboard,
   InteractiveDashboard,
   InteractiveQuestion,
   MetabaseProvider,
@@ -18,8 +19,21 @@ import {
 } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+import type { ConcreteFieldReference, Parameter } from "metabase-types/api";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const DATE_FILTER: Parameter = {
+  id: "2",
+  name: "Date filter",
+  slug: "filter-date",
+  type: "date/all-options",
+};
+const CREATED_AT_FIELD_REF: ConcreteFieldReference = [
+  "field",
+  ORDERS.CREATED_AT,
+  { "base-type": "type/DateTime" },
+];
 
 describe("scenarios > embedding-sdk > styles", () => {
   beforeEach(() => {
@@ -315,7 +329,7 @@ describe("scenarios > embedding-sdk > styles", () => {
     });
   });
 
-  describe("modals and tooltips", () => {
+  describe("modals, popovers and tooltips", () => {
     it("legacy WindowModal modals should render with our styles", () => {
       // this test renders a create dashboard modal that, at this time, is using the legacy WindowModal
       cy.mount(
@@ -361,7 +375,7 @@ describe("scenarios > embedding-sdk > styles", () => {
       // TODO: good place for a visual regression test
     });
 
-    describe("tooltips/overlays styles", () => {
+    describe("popover/tooltips/overlays styles", () => {
       beforeEach(() => {
         signInAsAdminAndEnableEmbeddingSdk();
 
@@ -386,20 +400,49 @@ describe("scenarios > embedding-sdk > styles", () => {
                   row: 0,
                   col: 0,
                   card_id: ordersQuestionId,
+                  parameter_mappings: [
+                    {
+                      parameter_id: DATE_FILTER.id,
+                      card_id: ORDERS_QUESTION_ID,
+                      target: ["dimension", CREATED_AT_FIELD_REF],
+                    },
+                  ],
                 },
               ],
+              parameters: [DATE_FILTER],
             }),
           )
           .then((dashboard) => {
             cy.wrap(dashboard.body.id).as("dashboardId");
           });
-
         cy.signOut();
 
         cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
         cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
           "dashcardQuery",
         );
+      });
+
+      it("should render legacy Popover with our styles", () => {
+        cy.get("@dashboardId").then((dashboardId) => {
+          mountSdkContent(<EditableDashboard dashboardId={dashboardId} />, {
+            sdkProviderProps: {
+              theme: {
+                fontFamily: "Impact",
+              },
+            },
+          });
+
+          H.editDashboard();
+          H.openClickBehaviorSidebar().within(() => {
+            cy.findByText("Update a dashboard filter").click();
+            cy.findAllByTestId("click-target-column").first().click();
+          });
+
+          H.popover()
+            .findByText("Columns")
+            .should("have.css", "font-family", "Impact");
+        });
       });
 
       it("should render Mantine tooltip with our styles", () => {

--- a/frontend/src/metabase/common/components/Popover/Popover.jsx
+++ b/frontend/src/metabase/common/components/Popover/Popover.jsx
@@ -6,6 +6,7 @@ import Tether from "tether";
 
 import OnClickOutsideWrapper from "metabase/common/components/OnClickOutsideWrapper";
 import CS from "metabase/css/core/index.css";
+import { getPortalRootElement } from "metabase/css/core/overlays/utils";
 import ZIndex from "metabase/css/core/z-index.module.css";
 import { isCypressActive } from "metabase/env";
 
@@ -97,6 +98,8 @@ export default class Popover extends Component {
     const resizeTimer = isCypressActive ? 3000 : 100;
 
     if (!this._popoverElement && isOpen) {
+      const portalRootElement = getPortalRootElement();
+
       this._popoverElement = document.createElement("span");
       this._popoverElement.className = cx(
         PopoverS.PopoverContainer,
@@ -104,7 +107,8 @@ export default class Popover extends Component {
         this.props.containerClassName,
       );
       this._popoverElement.dataset.testid = "popover";
-      document.body.appendChild(this._popoverElement);
+
+      portalRootElement.appendChild(this._popoverElement);
 
       this._timer = setInterval(() => {
         const { width, height } = this._popoverElement.getBoundingClientRect();

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -195,6 +195,7 @@ export function ClickBehaviorSidebar({
 
   return (
     <Sidebar
+      data-testid="click-behavior-sidebar"
       onClose={hideClickBehaviorSidebar}
       onCancel={handleCancel}
       isCloseDisabled={isCloseDisabled}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60122
Render legacy popover within the proper portal container for the SDK.

This change affects all legacy popovers for SDK

How to verify:
- CI should be green
- manually (see the video how to reproduce)

How to reproduce:

https://github.com/user-attachments/assets/1432d801-3a0e-41e1-84b0-aa5f3743c87e

