### PR TITLE
remove useForceLocaleRefresh as the context is now enough

### DIFF
--- a/frontend/src/metabase/setup/components/EmbeddingSetup/EmbeddingSetupContext.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/EmbeddingSetupContext.tsx
@@ -7,6 +7,8 @@ import {
 } from "react";
 
 import { trackSimpleEvent } from "metabase/lib/analytics";
+import { useSelector } from "metabase/lib/redux";
+import { getLocale } from "metabase/setup/selectors";
 import type { DashboardId, DatabaseData, Table } from "metabase-types/api";
 
 import { DataConnectionStep } from "./steps/DataConnectionStep";
@@ -21,7 +23,6 @@ import type {
   StepDefinition,
 } from "./steps/embeddingSetupSteps";
 import { STEPS, getStepIndexByKey } from "./steps/embeddingSetupSteps";
-import { useForceLocaleRefresh } from "./useForceLocaleRefresh";
 
 export const STEP_COMPONENTS = [
   WelcomeStep,
@@ -58,7 +59,10 @@ const EmbeddingSetupContext = createContext<EmbeddingSetupContextType | null>(
 );
 
 export const useEmbeddingSetup = () => {
-  useForceLocaleRefresh();
+  // This forces the components where it's used to re-render, making `t` use the new locale
+  // This is needed because we allow changing the locale from the sidebar, without this trick
+  // the components on the page wouldn't re-render with the new locale
+  useSelector(getLocale);
 
   const context = useContext(EmbeddingSetupContext);
 

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DataConnectionStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DataConnectionStep.tsx
@@ -8,11 +8,8 @@ import { Stack, Text, Title } from "metabase/ui";
 import type { DatabaseData } from "metabase-types/api";
 
 import { useEmbeddingSetup } from "../EmbeddingSetupContext";
-import { useForceLocaleRefresh } from "../useForceLocaleRefresh";
 
 export const DataConnectionStep = () => {
-  useForceLocaleRefresh();
-
   const dispatch = useDispatch();
   const { setDatabase, goToNextStep } = useEmbeddingSetup();
 

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DoneStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DoneStep.tsx
@@ -4,11 +4,7 @@ import { t } from "ttag";
 import { useDocsUrl } from "metabase/common/hooks";
 import { Anchor, Box, Button, Icon, Stack, Text, Title } from "metabase/ui";
 
-import { useForceLocaleRefresh } from "../useForceLocaleRefresh";
-
 export const DoneStep = () => {
-  useForceLocaleRefresh();
-
   const { url: authUrl } = useDocsUrl(
     "embedding/interactive-embedding-quick-start-guide",
   );

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/FinalStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/FinalStep.tsx
@@ -20,13 +20,10 @@ import {
 import type { Dashboard } from "metabase-types/api";
 
 import { useEmbeddingSetup } from "../EmbeddingSetupContext";
-import { useForceLocaleRefresh } from "../useForceLocaleRefresh";
 
 import type { StepProps } from "./embeddingSetupSteps";
 
 export const FinalStep = ({ nextStep }: StepProps) => {
-  useForceLocaleRefresh();
-
   const { url: docsUrl } = useDocsUrl("embedding/interactive-embedding");
   const { createdDashboardIds } = useEmbeddingSetup();
 

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/ProcessingStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/ProcessingStep.tsx
@@ -10,10 +10,8 @@ import { Box, Loader, Stack, Text, Title } from "metabase/ui";
 import type { DashboardId } from "metabase-types/api";
 
 import { useEmbeddingSetup } from "../EmbeddingSetupContext";
-import { useForceLocaleRefresh } from "../useForceLocaleRefresh";
 
 export const ProcessingStep = () => {
-  useForceLocaleRefresh();
   const siteUrl = useSetting("site-url");
 
   const { goToNextStep } = useEmbeddingSetup();

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/TableSelectionStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/TableSelectionStep.tsx
@@ -23,11 +23,8 @@ import {
 import type { Table } from "metabase-types/api";
 
 import { useEmbeddingSetup } from "../EmbeddingSetupContext";
-import { useForceLocaleRefresh } from "../useForceLocaleRefresh";
 
 export const TableSelectionStep = () => {
-  useForceLocaleRefresh();
-
   const [tables, setTables] = useState<Table[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/UserCreationStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/UserCreationStep.tsx
@@ -9,11 +9,8 @@ import { submitUser } from "../../../actions";
 import { getIsHosted, getUser } from "../../../selectors";
 import { UserForm } from "../../UserForm";
 import { useEmbeddingSetup } from "../EmbeddingSetupContext";
-import { useForceLocaleRefresh } from "../useForceLocaleRefresh";
 
 export const UserCreationStep = () => {
-  useForceLocaleRefresh();
-
   const { goToNextStep } = useEmbeddingSetup();
 
   const user = useSelector(getUser);

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/WelcomeStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/WelcomeStep.tsx
@@ -4,11 +4,8 @@ import { t } from "ttag";
 import { Box, Button, Space, Text, Title } from "metabase/ui";
 
 import type { StepProps } from "../steps/embeddingSetupSteps";
-import { useForceLocaleRefresh } from "../useForceLocaleRefresh";
 
 export const WelcomeStep = ({ nextStep }: StepProps) => {
-  useForceLocaleRefresh();
-
   return (
     <Box p="xl" style={{ borderRadius: 16 }} bg="white">
       <Title order={2} mb="lg">

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/useForceLocaleRefresh.ts
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/useForceLocaleRefresh.ts
@@ -1,7 +1,0 @@
-import { useSelector } from "metabase/lib/redux";
-import { getLocale } from "metabase/setup";
-
-export const useForceLocaleRefresh = () => {
-  // this forces the component where it's used to re-render, making `t` use the new locale
-  useSelector(getLocale);
-};


### PR DESCRIPTION
Closes EMB-492

~This is not easy to verify: we don't already have the translations ([slack thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1750950977929259)).
What I did to test this is that I added ```<p>{t`Cancel`}</p>``` on all the steps and on the sidebar and verified that that text changed language. `Cancel` is just an example of a string we know we have the translation of~

Update: we synced the translations (and backported them) and I updated the branch so now you just need to checkout the branch, run `./bin/i18n/build-translation-resources` and this should work 🚀 