### PR TITLE
feat: merge tenant attributes into user attributes

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1218,7 +1218,8 @@
   tenants
   {:team "Admin Webapp"
    :api #{metabase.tenants.core}
-   :uses #{premium-features}}
+   :uses #{premium-features
+           util}}
 
   testing-api
   {:team "DevEx"
@@ -1826,6 +1827,7 @@
            premium-features
            request
            settings
+           tenants
            util}}
 
   enterprise/upload-management

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/user.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/user.clj
@@ -31,8 +31,8 @@
 (def ^:private max-login-attributes 5000)
 
 (api.macros/defendpoint :get "/attributes"
-  "Fetch a list of possible keys for User `login_attributes`. This just looks at keys that have already been set for
-  existing Users and returns those. "
+  "Fetch a list of possible keys for User `login_attributes`. This includes keys from tenant model
+  attributes and keys that have already been set for existing Users."
   []
   (into (tenants/login-attribute-keys)
         (comp

--- a/enterprise/backend/src/metabase_enterprise/tenants/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/core.clj
@@ -3,6 +3,7 @@
    [metabase-enterprise.tenants.api :as api]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.settings.core :as setting]
+   [metabase.tenants.core :as tenants]
    [toucan2.core :as t2]))
 
 (defenterprise login-attributes
@@ -42,3 +43,18 @@
   :feature :tenants
   [tenant]
   (api/create-tenant! tenant))
+
+(defenterprise attribute-structure
+  "EE version of `attribute-structure` serializes the combination of tenant and user attributes for the
+   given user with metadata about their provenance."
+  :feature :tenants
+  [user]
+  (let [tenant (when-let [tenant-id (:tenant_id user)]
+                 (t2/select-one :model/Tenant :id tenant-id))
+        combined-attributes (tenants/combine (:login_attributes user)
+                                             (:attributes tenant)
+                                             (when tenant
+                                               {"@tenant.slug" (:slug tenant)}))]
+    (assoc user
+           :structured_attributes combined-attributes
+           :login_attributes (update-vals combined-attributes :value))))

--- a/enterprise/backend/src/metabase_enterprise/tenants/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/core.clj
@@ -8,7 +8,7 @@
 
 (defenterprise login-attributes
   "EE version of `login-attributes` - a map of tenant attributes that should be merged into the user's login
-  attributes. Currently overrides any existing user attributes."
+  attributes."
   :feature :tenants
   [{:keys [tenant_id] :as _user}]
   (or (when (and (setting/get :use-tenants) tenant_id)
@@ -17,7 +17,7 @@
       {}))
 
 (defenterprise login-attribute-keys
-  "The set of tenant attribute keys that will be merged into tenant users' attributes"
+  "The set of tenant attribute keys that attempt to be merged into tenant users' attributes"
   :feature :tenants
   []
   (if (setting/get :use-tenants)

--- a/enterprise/backend/src/metabase_enterprise/tenants/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/core.clj
@@ -56,5 +56,4 @@
                                              (when tenant
                                                {"@tenant.slug" (:slug tenant)}))]
     (assoc user
-           :structured_attributes combined-attributes
-           :login_attributes (update-vals combined-attributes :value))))
+           :structured_attributes combined-attributes)))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
@@ -71,6 +71,25 @@
           (is (= 2
                  (count (mt/user-http-request :crowberto :get 200 "mt/user/attributes")))))))))
 
+(deftest get-user-attributes-with-tenants-test
+  (mt/with-premium-features #{:tenants :sandboxes}
+    (mt/with-temporary-setting-values [use-tenants true]
+      (testing "includes tenant attributes from tenant models"
+        (mt/with-temp
+          [:model/Tenant _ {:name "Test Tenant"
+                            :slug "test-tenant"
+                            :attributes {"tenant-key-1" "value1"
+                                         "tenant-key-2" "value2"}}
+           :model/Tenant _ {:name "Another Tenant"
+                            :slug "another-tenant"
+                            :attributes {"tenant-key-3" "value3"
+                                         "tenant-key-1" "different-value"}}
+           :model/User _ {:login_attributes {:user-key "user-value"}}]
+
+          (let [attributes (set (mt/user-http-request :crowberto :get 200 "mt/user/attributes"))]
+            (is (set/subset? #{"tenant-key-1" "tenant-key-2" "tenant-key-3" "user-key"}
+                             attributes))))))))
+
 (deftest update-user-attributes-test
   (mt/with-premium-features #{}
     (testing "requires sandbox enabled"

--- a/enterprise/backend/test/metabase_enterprise/tenants/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/core_test.clj
@@ -1,0 +1,124 @@
+(ns metabase-enterprise.tenants.core-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.tenants.core :as tenants]
+   [metabase.test :as mt]))
+
+(deftest login-attribute-keys-disabled-feature-test
+  (testing "returns empty set when tenants feature is disabled"
+    (mt/with-premium-features #{}
+      (is (= #{} (tenants/login-attribute-keys))))))
+
+(deftest login-attribute-keys-disabled-setting-test
+  (testing "returns empty set when use-tenants setting is false"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants false]
+        (is (= #{} (tenants/login-attribute-keys)))))))
+
+(deftest login-attribute-keys-no-tenants-test
+  (testing "returns tenant.slug when tenants are enabled but no tenant models exist"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (is (= #{"@tenant.slug"} (tenants/login-attribute-keys)))))))
+
+(deftest login-attribute-keys-with-tenant-attributes-test
+  (testing "includes tenant model attributes when tenants exist"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant _ {:name "Test Tenant"
+                            :slug "test-tenant"
+                            :attributes {"environment" "production"
+                                         "region" "us-east-1"}}
+           :model/Tenant _ {:name "Dev Tenant"
+                            :slug "dev-tenant"
+                            :attributes {"environment" "development"
+                                         "cluster" "dev-cluster"}}]
+          (is (= #{"@tenant.slug" "environment" "region" "cluster"}
+                 (tenants/login-attribute-keys))))))))
+
+(deftest login-attribute-keys-no-attributes-test
+  (testing "handles tenants with no attributes"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant _ {:name "Empty Tenant"
+                            :slug "empty-tenant"}
+           :model/Tenant _ {:name "Attributed Tenant"
+                            :slug "attributed-tenant"
+                            :attributes {"key" "value"}}]
+          (is (= #{"@tenant.slug" "key"}
+                 (tenants/login-attribute-keys))))))))
+
+(deftest login-attribute-keys-empty-attributes-test
+  (testing "handles tenants with empty attributes map"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant _ {:name "Empty Attrs Tenant"
+                            :slug "empty-attrs-tenant"
+                            :attributes {}}
+           :model/Tenant _ {:name "Normal Tenant"
+                            :slug "normal-tenant"
+                            :attributes {"test-key" "test-value"}}]
+          (is (= #{"@tenant.slug" "test-key"}
+                 (tenants/login-attribute-keys))))))))
+
+(deftest login-attributes-disabled-feature-test
+  (testing "returns an empty map when tenants feature is disabled"
+    (mt/with-premium-features #{}
+      (is (empty? (tenants/login-attributes {:tenant_id 1}))))))
+
+(deftest login-attributes-disabled-setting-test
+  (testing "returns nil when use-tenants setting is false"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants false]
+        (is (empty? (tenants/login-attributes {:tenant_id 1})))))))
+
+(deftest login-attributes-no-tenant-id-test
+  (testing "returns nil when user has no tenant_id"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (is (empty? (tenants/login-attributes {:id 1})))
+        (is (empty? (tenants/login-attributes {:tenant_id nil})))))))
+
+(deftest login-attributes-with-tenant-test
+  (testing "returns tenant attributes merged with @tenant.slug"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Test Tenant"
+                                          :slug "test-tenant"
+                                          :attributes {"environment" "production"
+                                                       "region" "us-east-1"}}]
+          (is (= {"environment" "production"
+                  "region" "us-east-1"
+                  "@tenant.slug" "test-tenant"}
+                 (tenants/login-attributes {:tenant_id tenant-id}))))))))
+
+(deftest login-attributes-no-attributes-test
+  (testing "returns only @tenant.slug when tenant has no attributes"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Empty Tenant"
+                                          :slug "empty-tenant"}]
+          (is (= {"@tenant.slug" "empty-tenant"}
+                 (tenants/login-attributes {:tenant_id tenant-id}))))))))
+
+(deftest login-attributes-empty-attributes-test
+  (testing "returns only @tenant.slug when tenant has empty attributes map"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Empty Attrs Tenant"
+                                          :slug "empty-attrs-tenant"
+                                          :attributes {}}]
+          (is (= {"@tenant.slug" "empty-attrs-tenant"}
+                 (tenants/login-attributes {:tenant_id tenant-id}))))))))
+
+(deftest login-attributes-nonexistent-tenant-test
+  (testing "returns nil when tenant_id doesn't exist"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (is (empty? (tenants/login-attributes {:tenant_id 99999})))))))

--- a/enterprise/backend/test/metabase_enterprise/tenants/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/core_test.clj
@@ -141,10 +141,7 @@
                     :email "test@example.com"
                     :tenant_id tenant-id
                     :login_attributes {"role" "admin"
-                                       "department" "engineering"
-                                       "environment" "production"
-                                       "region" "us-east-1"
-                                       "@tenant.slug" "test-tenant"}
+                                       "department" "engineering"}
                     :structured_attributes {"role" {:source :user :frozen false :value "admin"}
                                             "department" {:source :user :frozen false :value "engineering"}
                                             "environment" {:source :tenant :frozen false :value "production"}
@@ -170,9 +167,7 @@
                     :email "test@example.com"
                     :tenant_id tenant-id
                     :login_attributes {"role" "user-role"
-                                       "department" "engineering"
-                                       "environment" "production"
-                                       "@tenant.slug" "test-tenant"}
+                                       "department" "engineering"}
                     :structured_attributes {"role" {:source :user :frozen false :value "user-role"
                                                     :original {:source :tenant :frozen false :value "tenant-role"}}
                                             "department" {:source :user :frozen false :value "engineering"}
@@ -242,8 +237,7 @@
             (is (= {:id 1
                     :email "test@example.com"
                     :tenant_id tenant-id
-                    :login_attributes {"role" "admin"
-                                       "@tenant.slug" "empty-tenant"}
+                    :login_attributes {"role" "admin"}
                     :structured_attributes {"role" {:source :user :frozen false :value "admin"}
                                             "@tenant.slug" {:source :system :frozen true :value "empty-tenant"}}}
                    result))))))))
@@ -264,8 +258,7 @@
             (is (= {:id 1
                     :email "test@example.com"
                     :tenant_id tenant-id
-                    :login_attributes {"role" "admin"
-                                       "@tenant.slug" "empty-attrs-tenant"}
+                    :login_attributes {"role" "admin"}
                     :structured_attributes {"role" {:source :user :frozen false :value "admin"}
                                             "@tenant.slug" {:source :system :frozen true :value "empty-attrs-tenant"}}}
                    result))))))))
@@ -285,9 +278,7 @@
                 result (tenants/attribute-structure user)]
             (is (= {:id 1
                     :email "test@example.com"
-                    :tenant_id tenant-id
-                    :login_attributes {"environment" "production"
-                                       "@tenant.slug" "test-tenant"}
+                    :tenant_id tenant-id :login_attributes nil
                     :structured_attributes {"environment" {:source :tenant :frozen false :value "production"}
                                             "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
                    result))))))))
@@ -308,8 +299,7 @@
             (is (= {:id 1
                     :email "test@example.com"
                     :tenant_id tenant-id
-                    :login_attributes {"environment" "production"
-                                       "@tenant.slug" "test-tenant"}
+                    :login_attributes {}
                     :structured_attributes {"environment" {:source :tenant :frozen false :value "production"}
                                             "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
                    result))))))))
@@ -336,9 +326,7 @@
                     :last_name "Doe"
                     :is_active true
                     :tenant_id tenant-id
-                    :login_attributes {"role" "user"
-                                       "environment" "production"
-                                       "@tenant.slug" "test-tenant"}
+                    :login_attributes {"role" "user"}
                     :structured_attributes {"role" {:source :user :frozen false :value "user"}
                                             "environment" {:source :tenant :frozen false :value "production"}
                                             "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}

--- a/enterprise/backend/test/metabase_enterprise/tenants/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/core_test.clj
@@ -122,3 +122,239 @@
     (mt/with-premium-features #{:tenants}
       (mt/with-temporary-setting-values [use-tenants true]
         (is (empty? (tenants/login-attributes {:tenant_id 99999})))))))
+
+(deftest attribute-structure-ee-with-user-and-tenant-attributes-test
+  (testing "EE version of attribute-structure with user and tenant attributes"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Test Tenant"
+                                          :slug "test-tenant"
+                                          :attributes {"environment" "production"
+                                                       "region" "us-east-1"}}]
+          (let [user {:id 1
+                      :email "test@example.com"
+                      :tenant_id tenant-id
+                      :login_attributes {"role" "admin" "department" "engineering"}}
+                result (tenants/attribute-structure user)]
+            (is (= {:id 1
+                    :email "test@example.com"
+                    :tenant_id tenant-id
+                    :login_attributes {"role" "admin"
+                                       "department" "engineering"
+                                       "environment" "production"
+                                       "region" "us-east-1"
+                                       "@tenant.slug" "test-tenant"}
+                    :structured_attributes {"role" {:source :user :frozen false :value "admin"}
+                                            "department" {:source :user :frozen false :value "engineering"}
+                                            "environment" {:source :tenant :frozen false :value "production"}
+                                            "region" {:source :tenant :frozen false :value "us-east-1"}
+                                            "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
+                   result))))))))
+
+(deftest attribute-structure-ee-user-overrides-tenant-test
+  (testing "EE version where user attributes override tenant attributes"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Test Tenant"
+                                          :slug "test-tenant"
+                                          :attributes {"environment" "production"
+                                                       "role" "tenant-role"}}]
+          (let [user {:id 1
+                      :email "test@example.com"
+                      :tenant_id tenant-id
+                      :login_attributes {"role" "user-role" "department" "engineering"}}
+                result (tenants/attribute-structure user)]
+            (is (= {:id 1
+                    :email "test@example.com"
+                    :tenant_id tenant-id
+                    :login_attributes {"role" "user-role"
+                                       "department" "engineering"
+                                       "environment" "production"
+                                       "@tenant.slug" "test-tenant"}
+                    :structured_attributes {"role" {:source :user :frozen false :value "user-role"
+                                                    :original {:source :tenant :frozen false :value "tenant-role"}}
+                                            "department" {:source :user :frozen false :value "engineering"}
+                                            "environment" {:source :tenant :frozen false :value "production"}
+                                            "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
+                   result))))))))
+
+(deftest attribute-structure-ee-no-tenant-id-test
+  (testing "EE version with user without tenant_id"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (let [user {:id 1
+                    :email "test@example.com"
+                    :login_attributes {"role" "admin" "department" "engineering"}}
+              result (tenants/attribute-structure user)]
+          (is (= {:id 1
+                  :email "test@example.com"
+                  :login_attributes {"role" "admin" "department" "engineering"}
+                  :structured_attributes {"role" {:source :user :frozen false :value "admin"}
+                                          "department" {:source :user :frozen false :value "engineering"}}}
+                 result)))))))
+
+(deftest attribute-structure-ee-nil-tenant-id-test
+  (testing "EE version with user with nil tenant_id"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (let [user {:id 1
+                    :email "test@example.com"
+                    :tenant_id nil
+                    :login_attributes {"role" "admin"}}
+              result (tenants/attribute-structure user)]
+          (is (= {:id 1
+                  :email "test@example.com"
+                  :tenant_id nil
+                  :login_attributes {"role" "admin"}
+                  :structured_attributes {"role" {:source :user :frozen false :value "admin"}}}
+                 result)))))))
+
+(deftest attribute-structure-ee-nonexistent-tenant-test
+  (testing "EE version with user referencing nonexistent tenant"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (let [user {:id 1
+                    :email "test@example.com"
+                    :tenant_id 99999
+                    :login_attributes {"role" "admin"}}
+              result (tenants/attribute-structure user)]
+          (is (= {:id 1
+                  :email "test@example.com"
+                  :tenant_id 99999
+                  :login_attributes {"role" "admin"}
+                  :structured_attributes {"role" {:source :user :frozen false :value "admin"}}}
+                 result)))))))
+
+(deftest attribute-structure-ee-tenant-no-attributes-test
+  (testing "EE version with tenant that has no attributes"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Empty Tenant"
+                                          :slug "empty-tenant"}]
+          (let [user {:id 1
+                      :email "test@example.com"
+                      :tenant_id tenant-id
+                      :login_attributes {"role" "admin"}}
+                result (tenants/attribute-structure user)]
+            (is (= {:id 1
+                    :email "test@example.com"
+                    :tenant_id tenant-id
+                    :login_attributes {"role" "admin"
+                                       "@tenant.slug" "empty-tenant"}
+                    :structured_attributes {"role" {:source :user :frozen false :value "admin"}
+                                            "@tenant.slug" {:source :system :frozen true :value "empty-tenant"}}}
+                   result))))))))
+
+(deftest attribute-structure-ee-tenant-empty-attributes-test
+  (testing "EE version with tenant that has empty attributes map"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Empty Attrs Tenant"
+                                          :slug "empty-attrs-tenant"
+                                          :attributes {}}]
+          (let [user {:id 1
+                      :email "test@example.com"
+                      :tenant_id tenant-id
+                      :login_attributes {"role" "admin"}}
+                result (tenants/attribute-structure user)]
+            (is (= {:id 1
+                    :email "test@example.com"
+                    :tenant_id tenant-id
+                    :login_attributes {"role" "admin"
+                                       "@tenant.slug" "empty-attrs-tenant"}
+                    :structured_attributes {"role" {:source :user :frozen false :value "admin"}
+                                            "@tenant.slug" {:source :system :frozen true :value "empty-attrs-tenant"}}}
+                   result))))))))
+
+(deftest attribute-structure-ee-nil-login-attributes-test
+  (testing "EE version with user with nil login_attributes"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Test Tenant"
+                                          :slug "test-tenant"
+                                          :attributes {"environment" "production"}}]
+          (let [user {:id 1
+                      :email "test@example.com"
+                      :tenant_id tenant-id
+                      :login_attributes nil}
+                result (tenants/attribute-structure user)]
+            (is (= {:id 1
+                    :email "test@example.com"
+                    :tenant_id tenant-id
+                    :login_attributes {"environment" "production"
+                                       "@tenant.slug" "test-tenant"}
+                    :structured_attributes {"environment" {:source :tenant :frozen false :value "production"}
+                                            "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
+                   result))))))))
+
+(deftest attribute-structure-ee-empty-login-attributes-test
+  (testing "EE version with user with empty login_attributes"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Test Tenant"
+                                          :slug "test-tenant"
+                                          :attributes {"environment" "production"}}]
+          (let [user {:id 1
+                      :email "test@example.com"
+                      :tenant_id tenant-id
+                      :login_attributes {}}
+                result (tenants/attribute-structure user)]
+            (is (= {:id 1
+                    :email "test@example.com"
+                    :tenant_id tenant-id
+                    :login_attributes {"environment" "production"
+                                       "@tenant.slug" "test-tenant"}
+                    :structured_attributes {"environment" {:source :tenant :frozen false :value "production"}
+                                            "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
+                   result))))))))
+
+(deftest attribute-structure-ee-preserves-other-user-fields-test
+  (testing "EE version preserves other user fields"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Test Tenant"
+                                          :slug "test-tenant"
+                                          :attributes {"environment" "production"}}]
+          (let [user {:id 1
+                      :email "test@example.com"
+                      :first_name "John"
+                      :last_name "Doe"
+                      :is_active true
+                      :tenant_id tenant-id
+                      :login_attributes {"role" "user"}}
+                result (tenants/attribute-structure user)]
+            (is (= {:id 1
+                    :email "test@example.com"
+                    :first_name "John"
+                    :last_name "Doe"
+                    :is_active true
+                    :tenant_id tenant-id
+                    :login_attributes {"role" "user"
+                                       "environment" "production"
+                                       "@tenant.slug" "test-tenant"}
+                    :structured_attributes {"role" {:source :user :frozen false :value "user"}
+                                            "environment" {:source :tenant :frozen false :value "production"}
+                                            "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
+                   result))))))))
+
+(deftest attribute-structure-ee-feature-disabled-test
+  (testing "EE version falls back to OSS behavior when tenants feature is disabled"
+    (mt/with-premium-features #{}
+      (let [user {:id 1
+                  :email "test@example.com"
+                  :tenant_id 1
+                  :login_attributes {"role" "admin"}}
+            result (tenants/attribute-structure user)]
+        (is (= {:id 1
+                :email "test@example.com"
+                :tenant_id 1
+                :login_attributes {"role" "admin"}
+                :structured_attributes {"role" {:source :user :frozen false :value "admin"}}}
+               result))))))

--- a/src/metabase/tenants/core.clj
+++ b/src/metabase/tenants/core.clj
@@ -81,5 +81,4 @@
   [user]
   (let [combined-attributes (combine (:login_attributes user))]
     (assoc user
-           :structured_attributes combined-attributes
-           :login_attributes (update-vals combined-attributes :value))))
+           :structured_attributes combined-attributes)))

--- a/src/metabase/tenants/core.clj
+++ b/src/metabase/tenants/core.clj
@@ -1,7 +1,8 @@
 (ns metabase.tenants.core
   "Shim namespace for `metabase-enterprise.tenants.core`"
   (:require
-   [metabase.premium-features.core :refer [defenterprise]]))
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.malli :as mu]))
 
 (defenterprise login-attributes
   "OSS version of `login-attributes`"
@@ -27,3 +28,58 @@
   metabase-enterprise.tenants.core
   [_tenant]
   (throw (ex-info "Cannot create tenant in OSS." {})))
+
+(def ^:private SimpleAttributes
+  "Basic attributes for users and tenants are a map of string keys to string values."
+  [:map-of :string :string])
+
+(def ^:private SystemAttributes
+  "Attributes generated from system properties must be prefixed with @."
+  [:map-of [:re #"@.*"] :string])
+
+(def ^:private AttributeStatus
+  "Describes a possible value of an attribute and where it is sourced from."
+  [:map
+   [:source [:enum :user :tenant :system]]
+   [:frozen boolean?]
+   [:value :string]])
+
+(def ^:private CombinedAttributes
+  "Map of user attributes to their current value and metadata describing where they are sourced from."
+  [:map-of :string
+   [:merge AttributeStatus
+    [:map
+     [:original {:optional true}
+      AttributeStatus]]]])
+
+(mu/defn combine :- CombinedAttributes
+  "Combines user, tenant, and system attributes. User can override "
+  ([user :- [:maybe SimpleAttributes]]
+   (combine user nil nil))
+  ([user :- [:maybe SimpleAttributes]
+    tenant :- [:maybe SimpleAttributes]
+    system :- [:maybe SystemAttributes]]
+   (letfn [(value-map [s f vs] (into {}
+                                     (for [[k v] vs]
+                                       [k {:source s :frozen f :value v}])))
+           (shadow [original new] (if original (assoc new :original original) new))
+           (error [original new] (if original
+                                   (throw (ex-info "Cannot clobber"
+                                                   {:bad-attribute original
+                                                    :attribute new}))
+                                   new))]
+     (merge-with error
+                 (merge-with shadow
+                             (value-map :tenant false tenant)
+                             (value-map :user false user))
+                 (value-map :system true system)))))
+
+(defenterprise attribute-structure
+  "Serializes the combination of tenant and user attributes for the given user with
+   metadata about their provenance."
+  metabase-enterprise.tenants.core
+  [user]
+  (let [combined-attributes (combine (:login_attributes user))]
+    (assoc user
+           :structured_attributes combined-attributes
+           :login_attributes (update-vals combined-attributes :value))))

--- a/src/metabase/users/api.clj
+++ b/src/metabase/users/api.clj
@@ -397,7 +397,8 @@
     (catch clojure.lang.ExceptionInfo _e
       (perms/check-group-manager)))
   (-> (api/check-404 (fetch-user :id id))
-      (t2/hydrate :user_group_memberships)))
+      (t2/hydrate :user_group_memberships)
+      tenants/attribute-structure))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                     Creating a new User -- POST /api/user                                      |

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -406,4 +406,4 @@
 (defn add-attributes
   "Adds the `:attributes` key to a user."
   [{:keys [login_attributes] :as user}]
-  (assoc user :attributes (merge login_attributes (tenants/login-attributes user))))
+  (assoc user :attributes (merge {} (tenants/login-attributes user) login_attributes)))

--- a/test/metabase/tenants/core_test.clj
+++ b/test/metabase/tenants/core_test.clj
@@ -1,0 +1,121 @@
+(ns metabase.tenants.core-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.tenants.core :as tenants]))
+
+(deftest combine-user-attributes-only-test
+  (testing "combine function with user attributes only"
+    (is (= {"key1" {:source :user :frozen false :value "value1"}
+            "key2" {:source :user :frozen false :value "value2"}}
+           (tenants/combine {"key1" "value1" "key2" "value2"})))))
+
+(deftest combine-user-and-tenant-attributes-test
+  (testing "combine function with user and tenant attributes"
+    (is (= {"user-key" {:source :user :frozen false :value "user-value"}
+            "tenant-key" {:source :tenant :frozen false :value "tenant-value"}}
+           (tenants/combine {"user-key" "user-value"}
+                            {"tenant-key" "tenant-value"}
+                            nil)))))
+
+(deftest combine-user-overrides-tenant-attributes-test
+  (testing "combine function where user overrides tenant attributes"
+    (is (= {"shared-key" {:source :user
+                          :frozen false
+                          :value "user-value"
+                          :original {:source :tenant :frozen false :value "tenant-value"}}}
+           (tenants/combine {"shared-key" "user-value"}
+                            {"shared-key" "tenant-value"}
+                            nil)))))
+
+(deftest combine-system-attributes-override-everything-test
+  (testing "combine function where system attributes in conflict cause it to throw"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Cannot clobber"
+                          (tenants/combine {"@system-key" "user-value"}
+                                           {"@system-key" "tenant-value"}
+                                           {"@system-key" "system-value"})))))
+
+(deftest combine-empty-inputs-nil-test
+  (testing "combine function with nil input"
+    (is (= {} (tenants/combine nil)))))
+
+(deftest combine-empty-inputs-all-nil-test
+  (testing "combine function with all nil inputs"
+    (is (= {} (tenants/combine nil nil nil)))))
+
+(deftest combine-empty-inputs-empty-maps-test
+  (testing "combine function with empty maps"
+    (is (= {} (tenants/combine {} {} {})))))
+
+(deftest combine-nil-user-with-tenant-and-system-test
+  (testing "combine function with nil user but tenant and system attributes"
+    (is (= {"tenant-key" {:source :tenant :frozen false :value "tenant-value"}
+            "@system-key" {:source :system :frozen true :value "system-value"}}
+           (tenants/combine nil
+                            {"tenant-key" "tenant-value"}
+                            {"@system-key" "system-value"})))))
+
+(deftest attribute-structure-oss-with-user-login-attributes-test
+  (testing "OSS version of attribute-structure with user login attributes"
+    (let [user {:id 1
+                :email "test@example.com"
+                :login_attributes {"role" "admin" "department" "engineering"}}
+          result (tenants/attribute-structure user)]
+      (is (= {:id 1
+              :email "test@example.com"
+              :login_attributes {"role" "admin" "department" "engineering"}
+              :structured_attributes {"role" {:source :user :frozen false :value "admin"}
+                                      "department" {:source :user :frozen false :value "engineering"}}}
+             result)))))
+
+(deftest attribute-structure-oss-with-nil-login-attributes-test
+  (testing "OSS version of attribute-structure with nil login attributes"
+    (let [user {:id 1
+                :email "test@example.com"
+                :login_attributes nil}
+          result (tenants/attribute-structure user)]
+      (is (= {:id 1
+              :email "test@example.com"
+              :login_attributes {}
+              :structured_attributes {}}
+             result)))))
+
+(deftest attribute-structure-oss-with-empty-login-attributes-test
+  (testing "OSS version of attribute-structure with empty login attributes"
+    (let [user {:id 1
+                :email "test@example.com"
+                :login_attributes {}}
+          result (tenants/attribute-structure user)]
+      (is (= {:id 1
+              :email "test@example.com"
+              :login_attributes {}
+              :structured_attributes {}}
+             result)))))
+
+(deftest attribute-structure-oss-user-without-login-attributes-key-test
+  (testing "OSS version of attribute-structure with user without login_attributes key"
+    (let [user {:id 1
+                :email "test@example.com"}
+          result (tenants/attribute-structure user)]
+      (is (= {:id 1
+              :email "test@example.com"
+              :login_attributes {}
+              :structured_attributes {}}
+             result)))))
+
+(deftest attribute-structure-oss-preserves-other-user-fields-test
+  (testing "OSS version of attribute-structure preserves other user fields"
+    (let [user {:id 1
+                :email "test@example.com"
+                :first_name "John"
+                :last_name "Doe"
+                :is_active true
+                :login_attributes {"role" "user"}}
+          result (tenants/attribute-structure user)]
+      (is (= {:id 1
+              :email "test@example.com"
+              :first_name "John"
+              :last_name "Doe"
+              :is_active true
+              :login_attributes {"role" "user"}
+              :structured_attributes {"role" {:source :user :frozen false :value "user"}}}
+             result)))))

--- a/test/metabase/tenants/core_test.clj
+++ b/test/metabase/tenants/core_test.clj
@@ -75,7 +75,7 @@
           result (tenants/attribute-structure user)]
       (is (= {:id 1
               :email "test@example.com"
-              :login_attributes {}
+              :login_attributes nil
               :structured_attributes {}}
              result)))))
 
@@ -98,7 +98,6 @@
           result (tenants/attribute-structure user)]
       (is (= {:id 1
               :email "test@example.com"
-              :login_attributes {}
               :structured_attributes {}}
              result)))))
 

--- a/test/metabase/users/models/user_test.clj
+++ b/test/metabase/users/models/user_test.clj
@@ -13,6 +13,7 @@
    [metabase.session.core :as session]
    [metabase.settings.core :as setting]
    [metabase.sso.ldap-test-util :as ldap.test]
+   [metabase.tenants.core :as tenants]
    [metabase.test :as mt]
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
@@ -525,3 +526,74 @@
       (t2/update! :model/User user-id {:is_active true})
       (let [deactivated-at (t2/select-one-fn :deactivated_at :model/User user-id)]
         (is (nil? deactivated-at))))))
+
+(deftest add-attributes-test
+  (testing "add-attributes function"
+    (testing "should add :attributes key with merged login attributes"
+      (with-redefs [tenants/login-attributes (constantly {"tenant_attr" "tenant_value"})]
+        (let [user {:login_attributes {"user_attr" "user_value"}
+                    :email "test@example.com"}
+              result (user/add-attributes user)]
+          (is (= {"tenant_attr" "tenant_value"
+                  "user_attr" "user_value"}
+                 (:attributes result)))
+          (is (= user (dissoc result :attributes))))))
+
+    (testing "should handle nil login_attributes"
+      (with-redefs [tenants/login-attributes (constantly {"tenant_attr" "tenant_value"})]
+        (let [user {:email "test@example.com"}
+              result (user/add-attributes user)]
+          (is (= {"tenant_attr" "tenant_value"}
+                 (:attributes result))))))
+
+    (testing "should handle empty login_attributes"
+      (with-redefs [tenants/login-attributes (constantly {"tenant_attr" "tenant_value"})]
+        (let [user {:login_attributes {}
+                    :email "test@example.com"}
+              result (user/add-attributes user)]
+          (is (= {"tenant_attr" "tenant_value"}
+                 (:attributes result))))))
+
+    (testing "should handle nil tenant attributes"
+      (with-redefs [tenants/login-attributes (constantly nil)]
+        (let [user {:login_attributes {"user_attr" "user_value"}
+                    :email "test@example.com"}
+              result (user/add-attributes user)]
+          (is (= {"user_attr" "user_value"}
+                 (:attributes result))))))
+
+    (testing "should handle both nil tenant and user attributes"
+      (with-redefs [tenants/login-attributes (constantly nil)]
+        (let [user {:email "test@example.com"}
+              result (user/add-attributes user)]
+          (is (= {}
+                 (:attributes result))))))
+
+    (testing "user attributes should override tenant attributes with same keys"
+      (with-redefs [tenants/login-attributes (constantly {"shared_key" "tenant_value"
+                                                          "tenant_only" "tenant_val"})]
+        (let [user {:login_attributes {"shared_key" "user_value"
+                                       "user_only" "user_val"}
+                    :email "test@example.com"}
+              result (user/add-attributes user)]
+          (is (= {"shared_key" "user_value"
+                  "tenant_only" "tenant_val"
+                  "user_only" "user_val"}
+                 (:attributes result))))))
+
+    (testing "should preserve all other user fields"
+      (with-redefs [tenants/login-attributes (constantly {"tenant_attr" "tenant_value"})]
+        (let [user {:id 123
+                    :email "test@example.com"
+                    :first_name "John"
+                    :last_name "Doe"
+                    :login_attributes {"user_attr" "user_value"}}
+              result (user/add-attributes user)]
+          (is (= 123 (:id result)))
+          (is (= "test@example.com" (:email result)))
+          (is (= "John" (:first_name result)))
+          (is (= "Doe" (:last_name result)))
+          (is (= {"user_attr" "user_value"} (:login_attributes result)))
+          (is (= {"tenant_attr" "tenant_value"
+                  "user_attr" "user_value"}
+                 (:attributes result))))))))


### PR DESCRIPTION
### Description

Merges the tenant attributes into the set of attributes returned by `/mt/user/attributes`. Also updates login-attributes to include attributes for the current user's tenant.

### Demo

<img width="653" alt="Screenshot 2025-06-26 at 1 07 22 PM" src="https://github.com/user-attachments/assets/7b6bc0fb-0413-4e0e-8970-cc91a1379b2d" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
