### PR TITLE
[Metabot] Do not clear conversation history when using chart analysis or sql fixing

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisButton.tsx
@@ -4,9 +4,9 @@ import { ToolbarButton } from "metabase/common/components/ToolbarButton";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
 export const AIQuestionAnalysisButton = () => {
-  const { startNewConversation } = useMetabotAgent();
+  const { submitInput } = useMetabotAgent();
 
-  const handleClick = () => startNewConversation("Analyze this chart");
+  const handleClick = () => submitInput("Analyze this chart");
 
   const tooltipLabel = t`Explain this chart`;
 

--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.tsx
@@ -4,11 +4,9 @@ import { Button } from "metabase/ui";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
 export function FixSqlQueryButton() {
-  const { startNewConversation } = useMetabotAgent();
+  const { submitInput } = useMetabotAgent();
 
-  const handleClick = () => {
-    startNewConversation("Fix this SQL query");
-  };
+  const handleClick = () => submitInput("Fix this SQL query");
 
   return <Button onClick={handleClick}>{t`Have Metabot fix it`}</Button>;
 }

--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.unit.spec.tsx
@@ -5,10 +5,10 @@ import { renderWithProviders, screen } from "__support__/ui";
 import { FixSqlQueryButton } from "./FixSqlQueryButton";
 
 // Mock the useMetabotAgent hook
-const mockStartNewConversation = jest.fn();
+const mockSubmitInput = jest.fn();
 jest.mock("metabase-enterprise/metabot/hooks", () => ({
   useMetabotAgent: () => ({
-    startNewConversation: mockStartNewConversation,
+    submitInput: mockSubmitInput,
   }),
 }));
 
@@ -28,13 +28,13 @@ describe("FixSqlQueryButton", () => {
     ).toBeInTheDocument();
   });
 
-  it("should start a new conversation when clicked", async () => {
+  it("should submit a prompt to the metabot agent when clicked", async () => {
     setup();
 
     await userEvent.click(
       screen.getByRole("button", { name: /Have Metabot fix it/ }),
     );
 
-    expect(mockStartNewConversation).toHaveBeenCalledWith("Fix this SQL query");
+    expect(mockSubmitInput).toHaveBeenCalledWith("Fix this SQL query");
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -34,6 +34,10 @@ export const useMetabotAgent = () => {
     typeof getIsProcessing
   >;
 
+  const visible = useSelector(getMetabotVisible as any) as ReturnType<
+    typeof getMetabotVisible
+  >;
+
   const setVisible = useCallback(
     (isVisible: boolean) => dispatch(setVisibleAction(isVisible)),
     [dispatch],
@@ -56,6 +60,10 @@ export const useMetabotAgent = () => {
 
   const submitInput = useCallback(
     async (prompt: string, metabotId?: string) => {
+      if (!visible) {
+        setVisible(true);
+      }
+
       const context = await getChatContext();
       const action = await dispatch(
         submitInputAction({
@@ -71,7 +79,7 @@ export const useMetabotAgent = () => {
 
       return action;
     },
-    [dispatch, getChatContext, prepareRetryIfUnsuccesful],
+    [dispatch, getChatContext, prepareRetryIfUnsuccesful, setVisible, visible],
   );
 
   const retryMessage = useCallback(
@@ -110,9 +118,7 @@ export const useMetabotAgent = () => {
     metabotId: useSelector(getMetabotId as any) as ReturnType<
       typeof getMetabotId
     >,
-    visible: useSelector(getMetabotVisible as any) as ReturnType<
-      typeof getMetabotVisible
-    >,
+    visible,
     messages,
     lastAgentMessages: useSelector(
       getLastAgentMessagesByType as any,


### PR DESCRIPTION
### Description

Based on customer feedback in [this slack thread](https://metaboat.slack.com/archives/C07SJT1P0ET/p1750806464225729).

### How to verify

- Start a convo, have some chat history with metabot
- Analyze a chart and fix a SQL query
- Conversation history should never get cleared

### Demo

https://github.com/user-attachments/assets/d2f3b42d-1886-46f1-881f-1e4dd4c90ddb

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
