### PR TITLE
fix(sdk): crash when changing questionId from new to native question

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -71,23 +71,26 @@ export const InteractiveQuestionDefaultView = ({
     withDownloads,
   } = useInteractiveQuestionContext();
 
-  const isCreatingQuestionFromScratch =
-    originalId === "new" && !question?.isSaved();
+  const isNewQuestion = originalId === "new";
+  const isQuestionSaved = question?.isSaved();
 
   const [
     isEditorOpen,
     { close: closeEditor, toggle: toggleEditor, open: openEditor },
-  ] = useDisclosure(isCreatingQuestionFromScratch);
+  ] = useDisclosure(isNewQuestion && !isQuestionSaved);
 
   const [isSaveModalOpen, { open: openSaveModal, close: closeSaveModal }] =
     useDisclosure(false);
 
   useEffect(() => {
-    // When switching to new question, open the editor
-    if (isCreatingQuestionFromScratch) {
+    if (isNewQuestion && !isQuestionSaved) {
+      // When switching to new question, open the notebook editor
       openEditor();
+    } else if (!isNewQuestion) {
+      // When no longer in a notebook editor, switch back to visualization.
+      closeEditor();
     }
-  }, [isCreatingQuestionFromScratch, openEditor]);
+  }, [isNewQuestion, isQuestionSaved, openEditor, closeEditor]);
 
   // When visualizing a question for the first time, there is no query result yet.
   const isQueryResultLoading =

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -88,6 +88,7 @@ export const InteractiveQuestionDefaultView = ({
       openEditor();
     } else if (!isNewQuestion) {
       // When no longer in a notebook editor, switch back to visualization.
+      // When a question is saved, also switch back to visualization.
       closeEditor();
     }
   }, [isNewQuestion, isQuestionSaved, openEditor, closeEditor]);


### PR DESCRIPTION
Closes EMB-567
Closes https://github.com/metabase/metabase/issues/60160

When changing from a new question (e.g. `questionId="new"`) to a native question (e.g. `questionId="your-native-question-entity-id"`), metabase-lib crashes with `preview-query cannot be called on native queries`. This is because the SDK incorrectly attempts to render a notebook editor on a native question.

## Why?

This is primarily because of this line in the SDK, [once again](https://github.com/metabase/metabase/issues/60075):

https://github.com/metabase/metabase/blob/afc9fdee5e874f3f05e1614be2f5d9ecc60c5d8d/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx#L74-L80

When creating a new question, `isCreatingQuestionFromScratch` is `true`, which makes `useDisclosure` defaults to `true`, which means we render the `<InteractiveQuestion.Editor />` (query builder) by default.

However, when switching to a native question we do not update the `useDisclosure` to `false`, which means it still renders the notebook editor! It does not make any sense whatsoever to render a notebook editor for a native question.


### How to verify

Try this snippet:

```tsx
// change this to your native question id!
const nativeQuestionId = 1337

const [questionId, setQuestionId] = useState("new")

<InteractiveQuestion questionId={questionId} />
<button onClick={() => setQuestionId(nativeQuestionId)}>native question</button>
```

When clicking on "native question", the SDK should no longer crash.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
