### PR TITLE
fix: driver-tier-3-check-output

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -25,7 +25,6 @@ jobs:
         id: check_team_and_branch
         run: |
           IS_MASTER_OR_RELEASE="${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') }}"
-          echo "LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}"
           HAS_TEAM_LABEL="${{ contains(github.event.pull_request.labels.*.name, '.Team/Drivers') || contains(github.event.pull_request.labels.*.name, '.Team/Querying') || contains(github.event.pull_request.labels.*.name, '.Team/SemanticLayer') }}"
 
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9db33156-ef97-41a8-8e84-764794335dea)
Logging ampersands breaks this, we don't need to log.

Introduced in https://github.com/metabase/metabase/pull/60016