### PR TITLE
docs - permissions strategies for embedding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -187,6 +187,7 @@ Metabase's reference documentation.
 - [Database routing](./permissions/database-routing.md)
 - [Snippets folder permissions](./permissions/snippets.md)
 - [Notification permissions](./permissions/notifications.md)
+- [Configuring permissions for embedding](./permissions/embedding.md)
 
 ### Embedding
 

--- a/docs/permissions/data.md
+++ b/docs/permissions/data.md
@@ -36,6 +36,14 @@ You can set the following types of permissions on a database, schema, or table:
 
 If you need to change the target database based on who is logged in, check out [Database routing](./database-routing.md). Database routing is particularly useful when each of your customers has their own database.
 
+## Before you apply specific permissions, block the All users group
+
+Before you apply more specific permissions, you'll want to make sure that no one can see any data. Since everyone's automatically in the All Users group, you'll want to block this group from seeing any data.
+
+In the **Admin settings** > **Permissions** > **Data**, block the All Users group's access to the database.
+
+From there, you can selectively grant privileges to different groups.
+
 ## View data permissions
 
 {% include plans-blockquote.html feature="View data permissions" %}

--- a/docs/permissions/data.md
+++ b/docs/permissions/data.md
@@ -36,7 +36,7 @@ You can set the following types of permissions on a database, schema, or table:
 
 If you need to change the target database based on who is logged in, check out [Database routing](./database-routing.md). Database routing is particularly useful when each of your customers has their own database.
 
-## Before you apply specific permissions, block the All users group
+## Before you apply specific permissions, block the All Users group
 
 Before you apply more specific permissions, you'll want to make sure that no one can see any data. Since everyone's automatically in the All Users group, you'll want to block this group from seeing any data.
 

--- a/docs/permissions/embedding.md
+++ b/docs/permissions/embedding.md
@@ -137,14 +137,14 @@ Say you have a single database with ten different tables, each corresponding to 
 
 If you need native SQL queries:
 
-1. Create a database-level user account for your first customer (in your database, not in Metabase). This db user should only have access to their specific tables or schema. For Postgres for example, you could add a user via psql and only grant them permissions to their tables.
+1. **Create a database-level user account** for your first customer (in your database, not in Metabase). This db user should only have access to their specific tables or schema. For Postgres for example, you could add a user via psql and only grant them permissions to their tables.
 
-2. In Metabase, [add a connection to your database](../databases/connecting.md) using the database user account you just created.
+2. **Connect Metabase to your database** using the database user account you just created. See [databases](../databases/connecting.md).
 
-3. Create a new [group](../people-and-groups/managing.md#groups) in Metabase and grant it access to the new database connection. Since the database user role controls what's visible, you can grant the group **Can view** access to the database and **Query builder and native** access.
+3. **Create a new group** in Metabase and grant it access to the new database connection. Since the database user role controls what's visible, you can grant the group **Can view** access to the database and **Query builder and native** access. See [groups](../people-and-groups/managing.md#groups).
 
    Group members will see all tables that the database user can access. To hide tables later, you'll need to change permissions in the database itself, not Metabase.
 
-4. Invite your first user and add them to the appropriate group. If you're using [SSO](../people-and-groups/google-sign-in.md), you can skip this step.
+4. **Invite your first user** and add them to the appropriate group. If you're using [SSO](../people-and-groups/google-sign-in.md), you can skip this step.
 
-5. Repeat steps 1–4 for each customer. You'll end up with as many database connections as customers.
+5. **Repeat the process** for each customer by following steps 1-4. You'll end up with as many database connections as customers.

--- a/docs/permissions/embedding.md
+++ b/docs/permissions/embedding.md
@@ -55,7 +55,7 @@ Here's how the basic sandbox will work:
 
 ### Restricting columns based on tenancy
 
-Let's say your **Insights** column is a premium feature, and Tenant B is the only customer paying to see these **Insights**. 
+Let's say your **Insights** column is a premium feature, and Tenant B is the only customer paying to see these **Insights**.
 
 | Tenant ID | Metrics | Insights                          |
 | --------- | ------- | --------------------------------- |
@@ -75,6 +75,7 @@ To keep A and C from viewing the `Insights` column, you can create a [custom san
    FROM data
    WHERE Tenant_ID = {%raw%} {{ tenant_user_attribute }} {%endraw%}
    ```
+
 5. Save the SQL question as "Customer Metrics".
 6. [Create a custom sandbox](./data-sandboxes.md#types-of-data-sandboxes) using the "Metrics-Only Tenants" group and "Customer Metrics" SQL question.
 
@@ -92,7 +93,7 @@ If each of your customers has their own database, you can use [database routing]
 
 For database routing to work, however, the schemas in each database must be identical.
 
-On top of database routing, you can also use all the other tools Metabase provides, like [data sandboxing](./data-sandboxes.md) and [connection impersonation](./impersonation.md), for more fine-grained control over what individuals can see, even within the same tenants.
+For more fine-grained control over what individuals can see, even within the same tenants, you can also use the other tools Metabase provides, like [data sandboxing](./data-sandboxes.md) and [connection impersonation](./impersonation.md), in combination with database routing.
 
 ## Multiple schemas (one schema per customer)
 
@@ -129,29 +130,28 @@ Say you have a single database with ten different tables, each corresponding to 
 
 2. **Grant table access** by going to **Permissions** > **Data** > **Databases** and granting your new group access to the customer's table. If you want customers to create questions and dashboards within their table, set **Create query** permissions to **Query builder**.
 
-   For employees who should only view data, create collections to house those specific questions and dashboards. See [collection permissions](./collections.md).
+   For employees who should only view data and create collections to house those specific questions and dashboards. See [collection permissions](./collections.md).
 
-   Don't grant native SQL editor access — it lets people query tables they shouldn't see.
-   
+   Avoid granting native SQL editor access — it lets people query tables they shouldn't see.
+
    If you scope each group's permissions to a single table, Metabase will hide any new tables you add to the database.
 
-3. **Invite your first user** and add them to the appropriate group. Skip this step if you're using [SSO](../people-and-groups/google-sign-in.md).
+3. **Invite your first user** and add them to the appropriate group. If you're using [SSO](../people-and-groups/google-sign-in.md), you can skip this step.
 
 4. **Repeat the process** for each customer by following steps 1–3.
 
 ### Granting customers native SQL access to their schema
 
-The SQL editor needs unrestricted database access, so the above method would let customers query tables they shouldn't see. If you need native SQL queries:
+If you need native SQL queries:
 
-1. Create a database-level user account for your first customer (not in Metabase). This user should only have access to their specific tables or schema. For Postgres, add a user via psql and grant them permissions only to their tables.
+1. Create a database-level user account for your first customer (in your database, not in Metabase). This db user should only have access to their specific tables or schema. For Postgres for example, you could add a user via psql and only grant them permissions to their tables.
 
 2. In Metabase, [add a connection to your database](../databases/connecting.md) using the database user account you just created.
 
 3. Create a new [group](../people-and-groups/managing.md#groups) in Metabase and grant it access to the new database connection. Since the database user role controls what's visible, you can grant the group **Can view** access to the database and **Query builder and native** access.
 
-   Group members will see all tables that the database user can access. To hide tables later, change permissions in the database itself, not Metabase.
+   Group members will see all tables that the database user can access. To hide tables later, you'll need to change permissions in the database itself, not Metabase.
 
-4. Invite your first user and add them to the appropriate group. Skip this if using [SSO](../people-and-groups/google-sign-in.md).
+4. Invite your first user and add them to the appropriate group. If you're using [SSO](../people-and-groups/google-sign-in.md), you can skip this step.
 
 5. Repeat steps 1–4 for each customer. You'll end up with as many database connections as customers.
-

--- a/docs/permissions/embedding.md
+++ b/docs/permissions/embedding.md
@@ -1,0 +1,153 @@
+---
+title: Configuring permissions for embedding
+---
+
+# Configuring permissions for embedding
+
+You can use a single Metabase to manage permissions for all of your customers. Which Metabase permissions tool you use depends on how you store your customer data.
+
+- [One database for all customers (commingled setups)](#one-database-for-all-customers-commingled-setups)
+- [One database per customer (single-tenant setups)](#one-database-per-customer-single-tenant-setups)
+- [One schema per customer](#multiple-schemas-one-schema-per-customer)
+
+## Block the All users group
+
+Before you apply more specific permissions, you'll want to make sure that no one can see any data.
+
+Everyone's automatically in the All Users group. For your permissions to apply, you'll want to block the group from seeing any data.
+
+In the **Admin settings** > **Permissions** > **Data**, block the All Users group's access to the database.
+
+From here, you can selectively grant privileges to different groups.
+
+## One database for all customers (commingled setups)
+
+If all your customer data is in the same schema and on the same tables (often referred to as "data commingling"):
+
+| Tenant_ID | Column 1 | Column 2 |
+| --------- | -------- | -------- |
+| A         | ...      | ...      |
+| B         | ...      | ...      |
+| C         | ...      | ...      |
+
+You could use:
+
+- [Data sandboxing](./data-sandboxes.md) to restrict rows and columns.
+- [Connection impersonation](./impersonation.md) to mimic roles set by your database. A good choice if you want to grant native SQL access to your data.
+
+### Restricting rows based on tenant ID
+
+Let's say you have a table called **Data** that looks like this:
+
+| Tenant_ID | Metrics | Insights |
+| --------- | ------- | -------- |
+| A         | ...     | ...      |
+| B         | ...     | ...      |
+| C         | ...     | ...      |
+
+To display a filtered version of **Data** to different tenants based on a `Tenant_ID`. You can create a [basic sandbox](/docs/latest/permissions/data-sandboxes#types-of-data-sandboxes).
+
+That means Tenant A will see the rows where `Tenant_ID = A`, and Tenant B will see the rows where `Tenant_ID = B`.
+
+Here's how the basic sandbox will work:
+
+1. **Create a group**, for example "Sandboxed Tenants", and add people's Metabase accounts to that group.
+2. **Add a user attribute**. For each person's account, [add a user attribute](/docs/latest/people-and-groups/managing#adding-a-user-attribute) like `Tenant_ID`, with the user attribute value set to "A", "B", or "C".
+3. **Sandbox the table** to apply the [row-level security based on user attributes](./data-sandboxes.md#types-of-data-sandboxes).
+
+### Restricting columns based on tenancy
+
+Let's say your **Insights** column is a premium feature, and Tenant B is the only customer paying to see these **Insights**. 
+
+| Tenant ID | Metrics | Insights                          |
+| --------- | ------- | --------------------------------- |
+| A         | ...     | {% include svg-icons/cross.svg %} |
+| B         | ...     | ...                               |
+| C         | ...     | {% include svg-icons/cross.svg %} |
+
+To keep A and C from viewing the `Insights` column, you can create a [custom sandbox](/docs/latest/permissions/data-sandboxes#types-of-data-sandboxes) to restrict both the rows and columns they see when they view the table.
+
+1. **Create a group** called "Metrics-Only Tenants".
+2. **Add Tenants A and C to the group**. Note that when you're sandboxing the **Data** table in different ways for different groups, make sure that each Metabase account only belongs to a single group.
+3. [Add a user attribute](/docs/latest/people-and-groups/managing#adding-a-user-attribute) like `Tenant_ID`, with the user attribute value set to "A" or "C".
+4. Next, you'll create a SQL question using the **Data** table like this:
+
+   ```sql
+   SELECT Tenant_ID, Metrics
+   FROM data
+   WHERE Tenant_ID = {%raw%} {{ tenant_user_attribute }} {%endraw%}
+   ```
+5. Save the SQL question as "Customer Metrics".
+6. [Create a custom sandbox](/docs/latest/permissions/data-sandboxes#types-of-data-sandboxes) using the "Metrics-Only Tenants" group and "Customer Metrics" SQL question.
+
+When, for example, Tenant A logs in, they'll only see the `Tenant_ID` and `Metrics` columns, and only the rows where `Tenant_ID = A`.
+
+## One database per customer (single-tenant setups)
+
+If each of your customers has their own database, you can use [database routing](./database-routing.md) to swap out the data source for queries. With DB routing, you just need to build a dashboard once, and Metabase will switch the database it queries depending on who's logged in.
+
+For database routing to work, however, the schemas in each database must be identical.
+
+On top of database routing, you can also use all the other tools Metabase provides, like [data sandboxing](./data-sandboxes.md) and [connection impersonation](./impersonation.md), for more fine-grained control over what individuals can see, even within the same tenants.
+
+## Multiple schemas (one schema per customer)
+
+If your customer data is stored in separate tables in the same schema or different schemas within one database, like this:
+
+**Tenant A's schema**
+
+| Tenant A | Column 1 | Column 2 |
+| -------- | -------- | -------- |
+| Row 1    | ...      | ...      |
+| Row 2    | ...      | ...      |
+| Row 3    | ...      | ...      |
+
+**Tenant B's schema**
+
+| Tenant B | Column 1 | Column 2 |
+| -------- | -------- | -------- |
+| Row 1    | ...      | ...      |
+| Row 2    | ...      | ...      |
+| Row 3    | ...      | ...      |
+
+You could:
+
+- [Grant self-service or view-only access to a schema](#granting-customers-self-service-or-view-only-access-to-their-schema).
+- [Grant native SQL access to a schema](#granting-customers-native-sql-access-to-their-schema).
+
+Unlike commingled data, one-schema-per-customer data is incompatible with data sandboxes, because a sandbox can only assign permissions at the row and column level, not the schema level.
+
+### Granting customers self-service or view-only access to their schema
+
+Say you have a single database with ten different tables, each corresponding to a different customer (company). You want each customer to only access their own table.
+
+1. **Create a group** for your first customer in **Admin settings** > **People**. If you need different permission levels within a company (some employees can ask questions, others can only view), create multiple groups like **Company A (Self-service)** and **Company A (View only)**.
+
+2. **Grant table access** by going to **Permissions** > **Data** > **Databases** and granting your new group access to the customer's table. If you want customers to create questions and dashboards within their table, set **Create query** permissions to **Query builder**.
+
+   For employees who should only view data, create collections to house those specific questions and dashboards. See [collection permissions](./collection-permissions).
+
+   Don't grant native SQL editor access — it lets people query tables they shouldn't see.
+   
+   If you scope each group's permissions to a single table, Metabase will hide any new tables you add to the database.
+
+3. **Invite your first user** and add them to the appropriate group. Skip this step if you're using [SSO](/docs/latest/people-and-groups/google-sign-in).
+
+4. **Repeat the process** for each customer by following steps 1–3.
+
+### Granting customers native SQL access to their schema
+
+The SQL editor needs unrestricted database access, so the above method would let customers query tables they shouldn't see. If you need native SQL queries:
+
+1. Create a database-level user account for your first customer (not in Metabase). This user should only have access to their specific tables or schema. For Postgres, add a user via psql and grant them permissions only to their tables.
+
+2. In Metabase, [add a connection to your database](/docs/latest/databases/connecting) using the database user account you just created.
+
+3. Create a new [group](/docs/latest/people-and-groups/managing#groups) in Metabase and grant it access to the new database connection. Since the database user role controls what's visible, you can grant the group **Can view** access to the database and **Query builder and native** access.
+
+   Group members will see all tables that the database user can access. To hide tables later, change permissions in the database itself, not Metabase.
+
+4. Invite your first user and add them to the appropriate group. Skip this if using [SSO](/docs/latest/people-and-groups/google-sign-in).
+
+5. Repeat steps 1–4 for each customer. You'll end up with as many database connections as customers.
+

--- a/docs/permissions/embedding.md
+++ b/docs/permissions/embedding.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring permissions for embedding
+summary: Learn about which permissions tooling you should use depending on whether your customer data is in one database or split across multiple databases.
 ---
 
 # Configuring permissions for embedding

--- a/docs/permissions/embedding.md
+++ b/docs/permissions/embedding.md
@@ -11,14 +11,6 @@ You can use a single Metabase to manage permissions for all of your customers. W
 - [One database per customer](#one-database-per-customer-single-tenant-setups)
 - [One schema per customer](#multiple-schemas-one-schema-per-customer)
 
-## Block the All users group
-
-Before you apply more specific permissions, you'll want to make sure that no one can see any data. Since everyone's automatically in the All Users group, you'll want to block this group from seeing any data.
-
-In the **Admin settings** > **Permissions** > **Data**, block the All Users group's access to the database.
-
-From there, you can selectively grant privileges to different groups.
-
 ## One database for all customers (commingled setups)
 
 If all your customer data is in the same schema and on the same tables (often referred to as "data commingling"):

--- a/docs/permissions/embedding.md
+++ b/docs/permissions/embedding.md
@@ -12,13 +12,11 @@ You can use a single Metabase to manage permissions for all of your customers. W
 
 ## Block the All users group
 
-Before you apply more specific permissions, you'll want to make sure that no one can see any data.
-
-Everyone's automatically in the All Users group. For your permissions to apply, you'll want to block the group from seeing any data.
+Before you apply more specific permissions, you'll want to make sure that no one can see any data. Since everyone's automatically in the All Users group, you'll want to block this group from seeing any data.
 
 In the **Admin settings** > **Permissions** > **Data**, block the All Users group's access to the database.
 
-From here, you can selectively grant privileges to different groups.
+From there, you can selectively grant privileges to different groups.
 
 ## One database for all customers (commingled setups)
 
@@ -33,7 +31,7 @@ If all your customer data is in the same schema and on the same tables (often re
 You could use:
 
 - [Data sandboxing](./data-sandboxes.md) to restrict rows and columns.
-- [Connection impersonation](./impersonation.md) to mimic roles set by your database. A good choice if you want to grant native SQL access to your data.
+- [Connection impersonation](./impersonation.md) to mimic roles set by your database. Impersonation is a good choice if you want to grant native SQL access to your data.
 
 ### Restricting rows based on tenant ID
 
@@ -81,6 +79,12 @@ To keep A and C from viewing the `Insights` column, you can create a [custom san
 6. [Create a custom sandbox](./data-sandboxes.md#types-of-data-sandboxes) using the "Metrics-Only Tenants" group and "Customer Metrics" SQL question.
 
 When, for example, Tenant A logs in, they'll only see the `Tenant_ID` and `Metrics` columns, and only the rows where `Tenant_ID = A`.
+
+### Impersonation lets you manage access with database roles
+
+Impersonation lets you map user attributes to database roles, which lets you do row-level security based on the privileges you give eachd role.
+
+Check out this [article on impersonation](https://www.metabase.com/learn/metabase-basics/administration/permissions/impersonation).
 
 ## One database per customer (single-tenant setups)
 

--- a/docs/permissions/embedding.md
+++ b/docs/permissions/embedding.md
@@ -45,14 +45,14 @@ Let's say you have a table called **Data** that looks like this:
 | B         | ...     | ...      |
 | C         | ...     | ...      |
 
-To display a filtered version of **Data** to different tenants based on a `Tenant_ID`. You can create a [basic sandbox](/docs/latest/permissions/data-sandboxes#types-of-data-sandboxes).
+To display a filtered version of **Data** to different tenants based on a `Tenant_ID`. You can create a [basic sandbox](./data-sandboxes.md#types-of-data-sandboxes).
 
 That means Tenant A will see the rows where `Tenant_ID = A`, and Tenant B will see the rows where `Tenant_ID = B`.
 
 Here's how the basic sandbox will work:
 
 1. **Create a group**, for example "Sandboxed Tenants", and add people's Metabase accounts to that group.
-2. **Add a user attribute**. For each person's account, [add a user attribute](/docs/latest/people-and-groups/managing#adding-a-user-attribute) like `Tenant_ID`, with the user attribute value set to "A", "B", or "C".
+2. **Add a user attribute**. For each person's account, [add a user attribute](../people-and-groups/managing.md#adding-a-user-attribute) like `Tenant_ID`, with the user attribute value set to "A", "B", or "C".
 3. **Sandbox the table** to apply the [row-level security based on user attributes](./data-sandboxes.md#types-of-data-sandboxes).
 
 ### Restricting columns based on tenancy
@@ -65,11 +65,11 @@ Let's say your **Insights** column is a premium feature, and Tenant B is the onl
 | B         | ...     | ...                               |
 | C         | ...     | {% include svg-icons/cross.svg %} |
 
-To keep A and C from viewing the `Insights` column, you can create a [custom sandbox](/docs/latest/permissions/data-sandboxes#types-of-data-sandboxes) to restrict both the rows and columns they see when they view the table.
+To keep A and C from viewing the `Insights` column, you can create a [custom sandbox](./data-sandboxes.md#types-of-data-sandboxes) to restrict both the rows and columns they see when they view the table.
 
 1. **Create a group** called "Metrics-Only Tenants".
 2. **Add Tenants A and C to the group**. Note that when you're sandboxing the **Data** table in different ways for different groups, make sure that each Metabase account only belongs to a single group.
-3. [Add a user attribute](/docs/latest/people-and-groups/managing#adding-a-user-attribute) like `Tenant_ID`, with the user attribute value set to "A" or "C".
+3. [Add a user attribute](../people-and-groups/managing.md#adding-a-user-attribute) like `Tenant_ID`, with the user attribute value set to "A" or "C".
 4. Next, you'll create a SQL question using the **Data** table like this:
 
    ```sql
@@ -78,7 +78,7 @@ To keep A and C from viewing the `Insights` column, you can create a [custom san
    WHERE Tenant_ID = {%raw%} {{ tenant_user_attribute }} {%endraw%}
    ```
 5. Save the SQL question as "Customer Metrics".
-6. [Create a custom sandbox](/docs/latest/permissions/data-sandboxes#types-of-data-sandboxes) using the "Metrics-Only Tenants" group and "Customer Metrics" SQL question.
+6. [Create a custom sandbox](./data-sandboxes.md#types-of-data-sandboxes) using the "Metrics-Only Tenants" group and "Customer Metrics" SQL question.
 
 When, for example, Tenant A logs in, they'll only see the `Tenant_ID` and `Metrics` columns, and only the rows where `Tenant_ID = A`.
 
@@ -125,13 +125,13 @@ Say you have a single database with ten different tables, each corresponding to 
 
 2. **Grant table access** by going to **Permissions** > **Data** > **Databases** and granting your new group access to the customer's table. If you want customers to create questions and dashboards within their table, set **Create query** permissions to **Query builder**.
 
-   For employees who should only view data, create collections to house those specific questions and dashboards. See [collection permissions](./collection-permissions).
+   For employees who should only view data, create collections to house those specific questions and dashboards. See [collection permissions](./collections.md).
 
    Don't grant native SQL editor access — it lets people query tables they shouldn't see.
    
    If you scope each group's permissions to a single table, Metabase will hide any new tables you add to the database.
 
-3. **Invite your first user** and add them to the appropriate group. Skip this step if you're using [SSO](/docs/latest/people-and-groups/google-sign-in).
+3. **Invite your first user** and add them to the appropriate group. Skip this step if you're using [SSO](../people-and-groups/google-sign-in.md).
 
 4. **Repeat the process** for each customer by following steps 1–3.
 
@@ -141,13 +141,13 @@ The SQL editor needs unrestricted database access, so the above method would let
 
 1. Create a database-level user account for your first customer (not in Metabase). This user should only have access to their specific tables or schema. For Postgres, add a user via psql and grant them permissions only to their tables.
 
-2. In Metabase, [add a connection to your database](/docs/latest/databases/connecting) using the database user account you just created.
+2. In Metabase, [add a connection to your database](../databases/connecting.md) using the database user account you just created.
 
-3. Create a new [group](/docs/latest/people-and-groups/managing#groups) in Metabase and grant it access to the new database connection. Since the database user role controls what's visible, you can grant the group **Can view** access to the database and **Query builder and native** access.
+3. Create a new [group](../people-and-groups/managing.md#groups) in Metabase and grant it access to the new database connection. Since the database user role controls what's visible, you can grant the group **Can view** access to the database and **Query builder and native** access.
 
    Group members will see all tables that the database user can access. To hide tables later, change permissions in the database itself, not Metabase.
 
-4. Invite your first user and add them to the appropriate group. Skip this if using [SSO](/docs/latest/people-and-groups/google-sign-in).
+4. Invite your first user and add them to the appropriate group. Skip this if using [SSO](../people-and-groups/google-sign-in.md).
 
 5. Repeat steps 1–4 for each customer. You'll end up with as many database connections as customers.
 

--- a/docs/permissions/embedding.md
+++ b/docs/permissions/embedding.md
@@ -36,7 +36,7 @@ Let's say you have a table called **Data** that looks like this:
 | B         | ...     | ...      |
 | C         | ...     | ...      |
 
-To display a filtered version of **Data** to different tenants based on a `Tenant_ID`. You can create a [basic sandbox](./data-sandboxes.md#types-of-data-sandboxes).
+To display a filtered version of **Data** to different tenants based on a `Tenant_ID`, you can create a [basic sandbox](./data-sandboxes.md#types-of-data-sandboxes).
 
 That means Tenant A will see the rows where `Tenant_ID = A`, and Tenant B will see the rows where `Tenant_ID = B`.
 
@@ -44,7 +44,7 @@ Here's how the basic sandbox will work:
 
 1. **Create a group**, for example "Sandboxed Tenants", and add people's Metabase accounts to that group.
 2. **Add a user attribute**. For each person's account, [add a user attribute](../people-and-groups/managing.md#adding-a-user-attribute) like `Tenant_ID`, with the user attribute value set to "A", "B", or "C".
-3. **Sandbox the table** to apply the [row-level security based on user attributes](./data-sandboxes.md#types-of-data-sandboxes).
+3. **Sandbox the table** for the group to apply the [row-level security based on user attributes](./data-sandboxes.md#types-of-data-sandboxes).
 
 ### Restricting columns based on tenancy
 
@@ -76,7 +76,7 @@ When, for example, Tenant A logs in, they'll only see the `Tenant_ID` and `Metri
 
 ### Impersonation lets you manage access with database roles
 
-Impersonation lets you map user attributes to database roles, which lets you do row-level security based on the privileges you give eachd role.
+Impersonation lets you map user attributes to database roles, which lets you do row-level security based on the database privileges you give each role.
 
 Check out this [article on impersonation](https://www.metabase.com/learn/metabase-basics/administration/permissions/impersonation).
 
@@ -123,7 +123,7 @@ Say you have a single database with ten different tables, each corresponding to 
 
 2. **Grant table access** by going to **Permissions** > **Data** > **Databases** and granting your new group access to the customer's table. If you want customers to create questions and dashboards within their table, set **Create query** permissions to **Query builder**.
 
-   For employees who should only view data and create collections to house those specific questions and dashboards. See [collection permissions](./collections.md).
+   For employees who should only view data and create collections to house those specific questions and dashboards, see [collection permissions](./collections.md).
 
    Avoid granting native SQL editor access — it lets people query tables they shouldn't see.
 
@@ -137,7 +137,7 @@ Say you have a single database with ten different tables, each corresponding to 
 
 If you need native SQL queries:
 
-1. **Create a database-level user account** for your first customer (in your database, not in Metabase). This db user should only have access to their specific tables or schema. For Postgres for example, you could add a user via psql and only grant them permissions to their tables.
+1. **Create a database-level user account** for your first customer (in your database, not in Metabase). This database user should only have access to their specific tables or schema. For PostgreSQL for example, you could add a user via psql and only grant them permissions to their tables.
 
 2. **Connect Metabase to your database** using the database user account you just created. See [databases](../databases/connecting.md).
 

--- a/docs/permissions/embedding.md
+++ b/docs/permissions/embedding.md
@@ -8,7 +8,7 @@ summary: Learn about which permissions tooling you should use depending on wheth
 You can use a single Metabase to manage permissions for all of your customers. Which Metabase permissions tool you use depends on how you store your customer data.
 
 - [One database for all customers (commingled setups)](#one-database-for-all-customers-commingled-setups)
-- [One database per customer (single-tenant setups)](#one-database-per-customer-single-tenant-setups)
+- [One database per customer](#one-database-per-customer-single-tenant-setups)
 - [One schema per customer](#multiple-schemas-one-schema-per-customer)
 
 ## Block the All users group
@@ -88,7 +88,7 @@ Impersonation lets you map user attributes to database roles, which lets you do 
 
 Check out this [article on impersonation](https://www.metabase.com/learn/metabase-basics/administration/permissions/impersonation).
 
-## One database per customer (single-tenant setups)
+## One database per customer
 
 If each of your customers has their own database, you can use [database routing](./database-routing.md) to swap out the data source for queries. With DB routing, you just need to build a dashboard once, and Metabase will switch the database it queries depending on who's logged in.
 

--- a/docs/permissions/introduction.md
+++ b/docs/permissions/introduction.md
@@ -12,9 +12,10 @@ If instead you're wondering about what data Metabase the company can see, check 
 
 ## Key points regarding permissions
 
-- Permissions are granted to [groups](../people-and-groups/managing.md#groups), not people.
+- Permissions are granted to [groups](../people-and-groups/managing.md#groups), not people. Though you can define user attributes to apply permissions person to person.
 - People can be in more than one group.
 - If a person is in multiple groups, they will have the _most permissive_ access granted to them across all of their groups. For example, if a person is in three groups, and any one of those groups has Curate access to a collection, then that person will have curate access to that collection.
+- By default, everyone is in the All users group, so be sure to block that group's access before granting permissions to other groups. Thankfully, Metabase will warn you if the All users group has more permissive permissions than the group you're restricting.
 
 ## What you can set permissions on
 

--- a/docs/permissions/start.md
+++ b/docs/permissions/start.md
@@ -35,3 +35,7 @@ Organize snippets into folders that require permissions to view.
 ## [Notification permissions](./notifications.md)
 
 Notes on how permissions interact with dashboard subscriptions and alerts.
+
+## [Configuring permissions for embedding](./embedding.md)
+
+The permissions tooling available for different embedding setups.


### PR DESCRIPTION
Update and relocation of https://www.metabase.com/learn/metabase-basics/administration/permissions/multi-tenant-permissions to incorporate db routing and impersonation.

We have a lot of material on this tooling elsewhere, so this doc should stay high-level about the options for different kinds of tenant setups.