### PR TITLE
Remove docs-build triggering comment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -295,4 +295,3 @@ Data jargon explained.
 ### [Metabase Experts](https://www.metabase.com/partners/)
 
 If you’d like more technical resources to set up your data stack with Metabase, connect with a [Metabase Expert](https://www.metabase.com/partners/).
-<!-- bump 2 -->


### PR DESCRIPTION
This was bumped to facilitate an early docs build, no longer needed.

If you are curious about the lifcycle of a docs build, there's an action that tracks this PR, builds the site, and opens a corresponding PR with updated _docs and _site/docs here: https://github.com/metabase/docs.metabase.github.io/actions/runs/15913573570

Docs repo PR: https://github.com/metabase/docs.metabase.github.io/pull/245

Cloudflare Pages Preview: https://remove-dox-bump--master.docs-metabase-github-io.pages.dev/