### PR TITLE
fix heading parameter mapping layout

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
@@ -62,6 +62,7 @@ interface DashcardCardParameterMapperProps {
   mappingOptions: ParameterMappingOption[];
   isRecentlyAutoConnected: boolean;
   editingParameterInlineDashcard?: DashboardCard;
+  compact?: boolean;
 }
 
 export function DashCardCardParameterMapper({
@@ -74,6 +75,7 @@ export function DashCardCardParameterMapper({
   mappingOptions,
   isRecentlyAutoConnected,
   editingParameterInlineDashcard,
+  compact,
 }: DashcardCardParameterMapperProps) {
   const isQuestion = isQuestionDashCard(dashcard);
   const hasSeries = isQuestion && dashcard.series && dashcard.series.length > 0;
@@ -124,6 +126,7 @@ export function DashCardCardParameterMapper({
         target={target}
         shouldShowAutoConnectHint={shouldShowAutoConnectHint}
         layoutHeight={layoutHeight}
+        compact={compact}
       />
       <Transition
         mounted={shouldShowAutoConnectHint && layoutHeight > 3}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperButton.tsx
@@ -25,6 +25,7 @@ interface DashCardCardParameterMapperButtonProps {
   selectedMappingOption: ParameterMappingOption | undefined;
   target: ParameterTarget | null | undefined;
   mappingOptions: ParameterMappingOption[];
+  compact?: boolean;
 }
 
 export const DashCardCardParameterMapperButton = ({
@@ -37,6 +38,7 @@ export const DashCardCardParameterMapperButton = ({
   selectedMappingOption,
   target,
   mappingOptions,
+  compact,
 }: DashCardCardParameterMapperButtonProps) => {
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
 
@@ -160,7 +162,7 @@ export const DashCardCardParameterMapperButton = ({
           justify="space-between"
           mx="xs"
           px="sm"
-          py="xs"
+          py={compact ? undefined : "xs"}
           aria-label={buttonTooltip ?? undefined}
           aria-haspopup="listbox"
           aria-expanded={isDropdownVisible}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
@@ -41,6 +41,7 @@ interface DashCardCardParameterMapperContentProps {
   target: ParameterTarget | null | undefined;
   layoutHeight: number;
   editingParameterInlineDashcard?: DashboardCard;
+  compact?: boolean;
 }
 
 export const DashCardCardParameterMapperContent = ({
@@ -58,6 +59,7 @@ export const DashCardCardParameterMapperContent = ({
   target,
   shouldShowAutoConnectHint,
   editingParameterInlineDashcard,
+  compact,
 }: DashCardCardParameterMapperContentProps) => {
   const isVirtual = isVirtualDashCard(dashcard);
   const virtualCardType = getVirtualCardType(dashcard);
@@ -175,6 +177,7 @@ export const DashCardCardParameterMapperContent = ({
           card={card}
           target={target}
           mappingOptions={mappingOptions}
+          compact={compact}
         />
         {shouldShowAutoConnectIcon && <AutoConnectedAnimatedIcon />}
       </Flex>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper.jsx
@@ -9,7 +9,11 @@ import { Flex } from "metabase/ui";
 import { DashCardCardParameterMapperConnected } from "./DashCardCardParameterMapper";
 import S from "./DashCardParameterMapper.module.css";
 
-export const DashCardParameterMapper = ({ dashcard, isMobile }) => (
+export const DashCardParameterMapper = ({
+  dashcard,
+  isMobile,
+  compact = false,
+}) => (
   <div
     className={cx(
       CS.relative,
@@ -33,7 +37,7 @@ export const DashCardParameterMapper = ({ dashcard, isMobile }) => (
     <Flex
       justify="space-around"
       maw="100%"
-      m="0 2rem"
+      m={compact ? undefined : "0 2rem"}
       className={S.MapperSettingsContainer}
       data-testid="parameter-mapper-container"
     >
@@ -43,6 +47,7 @@ export const DashCardParameterMapper = ({ dashcard, isMobile }) => (
           dashcard={dashcard}
           card={card}
           isMobile={isMobile}
+          compact={compact}
         />
       ))}
     </Flex>

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -17,7 +17,7 @@ import { useTranslateContent } from "metabase/i18n/hooks";
 import { useSelector } from "metabase/lib/redux";
 import resizeObserver from "metabase/lib/resize-observer";
 import { isEmpty } from "metabase/lib/validate";
-import { Flex, Icon, Menu } from "metabase/ui";
+import { Box, Flex, Icon, Menu } from "metabase/ui";
 import { fillParametersInText } from "metabase/visualizations/shared/utils/parameter-substitution";
 import type {
   Dashboard,
@@ -134,7 +134,13 @@ export function Heading({
 
   if (hasVariables && isEditingParameter) {
     leftContent = (
-      <DashCardParameterMapper dashcard={dashcard} isMobile={isMobile} />
+      <Box h="100%" style={{ overflow: "hidden" }}>
+        <DashCardParameterMapper
+          compact
+          dashcard={dashcard}
+          isMobile={isMobile}
+        />
+      </Box>
     );
   } else if (isPreviewing) {
     leftContent = (


### PR DESCRIPTION
Closes [VIZ-1175](https://linear.app/metabase/issue/VIZ-1175/fix-header-bottom-border-cut-off-with-linked-filter-variable)

### Description

Fixes parameter mapping UI in heading cards.

### Demo

Before
<img width="1081" alt="Screenshot 2025-06-26 at 9 04 13 PM" src="https://github.com/user-attachments/assets/6f7451ab-d748-4b78-afa6-4509c28a05f5" />

After
<img width="1077" alt="Screenshot 2025-06-26 at 9 03 45 PM" src="https://github.com/user-attachments/assets/da53a3ce-174b-41c6-9ad0-4ec8627973be" />

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
