### PR TITLE
Update button focus styling  in setup flow

### DIFF
--- a/frontend/src/metabase/css/components/buttons.module.css
+++ b/frontend/src/metabase/css/components/buttons.module.css
@@ -25,7 +25,7 @@
 }
 
 .Button:focus {
-  border: 2px solid var(--mb-base-color-white);
+  border: 2px solid var(--mb-color-background);
   outline: 2px solid var(--mb-color-brand);
 }
 
@@ -74,7 +74,7 @@
 }
 
 .ButtonPrimary:focus {
-  border-color: var(--mb-base-color-white);
+  border-color: var(--mb-color-background);
   outline-color: var(--mb-color-brand);
 }
 
@@ -91,7 +91,7 @@
 }
 
 .ButtonWarning:focus {
-  border-color: var(--mb-base-color-white);
+  border-color: var(--mb-color-background);
   outline-color: var(--mb-color-error);
 }
 
@@ -117,15 +117,20 @@
 }
 
 .ButtonBorderless:focus {
-  border-color: var(--mb-base-color-white);
+  border-color: var(--mb-color-background);
   outline-color: var(--mb-color-brand);
 }
 
 .ButtonOnlyIcon {
-  border: none;
+  border-color: transparent;
   background: transparent;
   color: var(--mb-color-text-dark);
   padding: 0;
+}
+
+.ButtonOnlyIcon:focus {
+  border-color: var(--mb-color-background);
+  outline-color: var(--mb-color-brand);
 }
 
 .ButtonGroup {
@@ -188,7 +193,7 @@
 }
 
 .ButtonDanger:focus {
-  border-color: var(--mb-base-color-white);
+  border-color: var(--mb-color-background);
   outline-color: var(--mb-color-error);
 }
 
@@ -205,7 +210,7 @@
 }
 
 .ButtonSuccess:focus {
-  border-color: var(--mb-base-color-white);
+  border-color: var(--mb-color-background);
   outline-color: var(--mb-color-success);
 }
 

--- a/frontend/src/metabase/css/components/buttons.module.css
+++ b/frontend/src/metabase/css/components/buttons.module.css
@@ -8,7 +8,7 @@
   text-decoration: none;
   padding: 0.5rem 0.75rem;
   background: transparent;
-  border: 1px solid color-mix(in srgb, var(--mb-color-border), black 5%);
+  border: 2px solid color-mix(in srgb, var(--mb-color-border), black 5%);
   color: var(--mb-color-text-primary);
   cursor: pointer;
   font-weight: bold;
@@ -25,7 +25,8 @@
 }
 
 .Button:focus {
-  outline: 2px solid var(--mb-color-focus);
+  border: 2px solid var(--mb-base-color-white);
+  outline: 2px solid var(--mb-color-brand);
 }
 
 .Button:focus:not(:focus-visible) {
@@ -63,7 +64,7 @@
 .ButtonPrimary {
   color: var(--mb-color-text-white);
   background: var(--mb-color-brand);
-  border: 1px solid var(--mb-color-brand);
+  border: 2px solid var(--mb-color-brand);
 }
 
 .ButtonPrimary:hover {
@@ -72,16 +73,26 @@
   background-color: var(--mb-color-brand-alpha-88);
 }
 
+.ButtonPrimary:focus {
+  border-color: var(--mb-base-color-white);
+  outline-color: var(--mb-color-brand);
+}
+
 .ButtonWarning {
   color: var(--mb-color-text-white);
   background: var(--mb-color-error);
-  border: 1px solid var(--mb-color-error);
+  border: 2px solid var(--mb-color-error);
 }
 
 .ButtonWarning:hover {
   color: var(--mb-color-text-white);
   border-color: var(--mb-color-error);
   background-color: var(--mb-color-error);
+}
+
+.ButtonWarning:focus {
+  border-color: var(--mb-base-color-white);
+  outline-color: var(--mb-color-error);
 }
 
 .ButtonCancel {
@@ -103,6 +114,11 @@
 .ButtonBorderless:hover {
   border-color: transparent;
   color: var(--mb-color-text-medium);
+}
+
+.ButtonBorderless:focus {
+  border-color: var(--mb-base-color-white);
+  outline-color: var(--mb-color-brand);
 }
 
 .ButtonOnlyIcon {
@@ -171,6 +187,11 @@
   border-color: var(--mb-color-error);
 }
 
+.ButtonDanger:focus {
+  border-color: var(--mb-base-color-white);
+  outline-color: var(--mb-color-error);
+}
+
 .ButtonSuccess {
   background-color: var(--mb-color-success);
   border-color: var(--mb-color-success);
@@ -181,6 +202,11 @@
   background-color: var(--mb-color-success);
   border-color: var(--mb-color-success);
   color: var(--mb-color-text-white);
+}
+
+.ButtonSuccess:focus {
+  border-color: var(--mb-base-color-white);
+  outline-color: var(--mb-color-success);
 }
 
 .ButtonFullWidth {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/60174

### Description

Created a clear, visible keyboard focus on all buttons consisting of a thick border with a gap. This style should apply to all types buttons.

### How to verify

1. Use Tab key to focus the button

### Demo

https://github.com/user-attachments/assets/d12b0782-5bee-4cca-8f48-1881e2f42a01

