### PR TITLE
Followup on VIZ-1221 (added translation)

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -181,7 +181,7 @@ export function DashCardVisualization({
     });
 
     if (missingCols.flat().length > 0) {
-      return `Some columns are missing, this card might not render correctly.`;
+      return t`Some columns are missing, this card might not render correctly.`;
     }
   }, [dashcard, rawSeries]);
 


### PR DESCRIPTION
Foolowup on [VIZ-1221: Nicer error state for when underlying query changes](https://linear.app/metabase/issue/VIZ-1221/nicer-error-state-for-when-underlying-query-changes)