### PR TITLE
Closes VIZ-1145 row chart label cut off

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -328,35 +328,39 @@ class NativeQueryEditor extends Component<Props, NativeQueryEditorState> {
               }
             }}
           >
-            <Flex w="100%" flex="1" className={S.resizableBoxContent}>
-              <CodeMirrorEditor
-                ref={this.editor}
-                query={question.query()}
-                readOnly={readOnly}
-                highlightedLineNumbers={highlightedLineNumbers}
-                onChange={this.onChange}
-                onRunQuery={runQuery}
-                onSelectionChange={setNativeEditorSelectedRange}
-                onCursorMoveOverCardTag={openDataReferenceAtQuestion}
-                onRightClickSelection={this.handleRightClickSelection}
-                onFormatQuery={
-                  canFormatQuery ? this.handleFormatQuery : undefined
-                }
-              />
-
-              {hasEditingSidebar && !readOnly && (
-                <NativeQueryEditorRunButton
-                  cancelQuery={this.props.cancelQuery}
-                  isResultDirty={this.props.isResultDirty}
-                  isRunnable={this.props.isRunnable}
-                  isRunning={this.props.isRunning}
-                  nativeEditorSelectedText={this.props.nativeEditorSelectedText}
-                  runQuery={this.props.runQuery}
+            <>
+              <Flex w="100%" flex="1" className={S.resizableBoxContent}>
+                <CodeMirrorEditor
+                  ref={this.editor}
+                  query={question.query()}
+                  readOnly={readOnly}
+                  highlightedLineNumbers={highlightedLineNumbers}
+                  onChange={this.onChange}
+                  onRunQuery={runQuery}
+                  onSelectionChange={setNativeEditorSelectedRange}
+                  onCursorMoveOverCardTag={openDataReferenceAtQuestion}
+                  onRightClickSelection={this.handleRightClickSelection}
+                  onFormatQuery={
+                    canFormatQuery ? this.handleFormatQuery : undefined
+                  }
                 />
-              )}
-            </Flex>
 
-            <NativeQueryValidationError query={query.question().query()} />
+                {hasEditingSidebar && !readOnly && (
+                  <NativeQueryEditorRunButton
+                    cancelQuery={this.props.cancelQuery}
+                    isResultDirty={this.props.isResultDirty}
+                    isRunnable={this.props.isRunnable}
+                    isRunning={this.props.isRunning}
+                    nativeEditorSelectedText={
+                      this.props.nativeEditorSelectedText
+                    }
+                    runQuery={this.props.runQuery}
+                  />
+                )}
+              </Flex>
+
+              <NativeQueryValidationError query={query.question().query()} />
+            </>
           </ResizableBox>
         </div>
 

--- a/frontend/src/metabase/visualizations/shared/components/RowChartView/utils/data-labels.ts
+++ b/frontend/src/metabase/visualizations/shared/components/RowChartView/utils/data-labels.ts
@@ -17,7 +17,7 @@ export const getDataLabel = <TDatum>(
   }
 
   const [xDomainStart, xDomainEnd] = xScale.domain();
-  const isOutOfDomain = value <= xDomainStart || value >= xDomainEnd;
+  const isOutOfDomain = value < xDomainStart || value > xDomainEnd;
 
   if (isOutOfDomain) {
     return null;

--- a/frontend/src/metabase/visualizations/shared/components/RowChartView/utils/data-labels.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/shared/components/RowChartView/utils/data-labels.unit.spec.ts
@@ -8,7 +8,7 @@ describe("getDataLabel", () => {
   const mockXScale = scaleLinear().domain([0, 100]).range([0, 500]);
   const seriesKey = "test-series";
 
-  const createBarData = (overrides: Partial<BarData<any>> = {}): BarData<any> =>
+  const createBarData = <T>(overrides: Partial<BarData<T>> = {}): BarData<T> =>
     ({
       xStartValue: 10,
       xEndValue: 50,

--- a/frontend/src/metabase/visualizations/shared/components/RowChartView/utils/data-labels.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/shared/components/RowChartView/utils/data-labels.unit.spec.ts
@@ -1,0 +1,97 @@
+import { scaleLinear } from "d3-scale";
+
+import type { BarData } from "../../RowChart/types";
+
+import { getDataLabel } from "./data-labels";
+
+describe("getDataLabel", () => {
+  const mockXScale = scaleLinear().domain([0, 100]).range([0, 500]);
+  const seriesKey = "test-series";
+
+  const createBarData = (overrides: Partial<BarData<any>> = {}): BarData<any> =>
+    ({
+      xStartValue: 10,
+      xEndValue: 50,
+      isNegative: false,
+      isBorderValue: false,
+      ...overrides,
+    }) as any;
+
+  it("returns null when value is null", () => {
+    const bar = createBarData({ xEndValue: null });
+    const result = getDataLabel(bar, mockXScale, seriesKey);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when value is out of domain (below)", () => {
+    const bar = createBarData({ xEndValue: -10 });
+    const result = getDataLabel(bar, mockXScale, seriesKey);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when value is out of domain (above)", () => {
+    const bar = createBarData({ xEndValue: 150 });
+    const result = getDataLabel(bar, mockXScale, seriesKey);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when series is not in labelledSeries", () => {
+    const bar = createBarData();
+    const result = getDataLabel(bar, mockXScale, seriesKey, false, [
+      "other-series",
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when labelledSeries is null", () => {
+    const bar = createBarData();
+    const result = getDataLabel(bar, mockXScale, seriesKey, false, null);
+    expect(result).toBeNull();
+  });
+
+  it("returns value for positive bar when conditions are met", () => {
+    const bar = createBarData({ xEndValue: 75 });
+    const result = getDataLabel(bar, mockXScale, seriesKey, false, [seriesKey]);
+    expect(result).toBe(75);
+  });
+
+  it("returns xStartValue for negative bar", () => {
+    const bar = createBarData({
+      xStartValue: 25,
+      xEndValue: 75,
+      isNegative: true,
+    });
+    const result = getDataLabel(bar, mockXScale, seriesKey, false, [seriesKey]);
+    expect(result).toBe(25);
+  });
+
+  it("returns null for stacked bar that is not border value", () => {
+    const bar = createBarData({ isBorderValue: false });
+    const result = getDataLabel(bar, mockXScale, seriesKey, true, [seriesKey]);
+    expect(result).toBeNull();
+  });
+
+  it("returns value for stacked bar that is border value", () => {
+    const bar = createBarData({
+      xEndValue: 60,
+      isBorderValue: true,
+    });
+    const result = getDataLabel(bar, mockXScale, seriesKey, true, [seriesKey]);
+    expect(result).toBe(60);
+  });
+
+  it("returns value for non-stacked bar regardless of border value", () => {
+    const bar = createBarData({
+      xEndValue: 40,
+      isBorderValue: false,
+    });
+    const result = getDataLabel(bar, mockXScale, seriesKey, false, [seriesKey]);
+    expect(result).toBe(40);
+  });
+
+  it("handles edge case where value equals domain boundary (metabase#59507)", () => {
+    const bar = createBarData({ xEndValue: 100 }); // equals domain end
+    const result = getDataLabel(bar, mockXScale, seriesKey, false, [seriesKey]);
+    expect(result).toBe(100);
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59507
Closes [VIZ-1145: Show values of data points on row charts doesn't show the value of the max](https://linear.app/metabase/issue/VIZ-1145/show-values-of-data-points-on-row-charts-doesnt-show-the-value-of-the)

### Description
<img width="1579" alt="image" src="https://github.com/user-attachments/assets/b9c1802e-4b35-498e-9bb5-e6cff962f349" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
