### PR TITLE
feat: pass action scope to action form configurator

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-actions/settings/AddOrEditActionSettingsContent/AddOrEditActionSettingsContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/settings/AddOrEditActionSettingsContent/AddOrEditActionSettingsContent.tsx
@@ -14,6 +14,7 @@ import { Button, Center, Icon, Modal } from "metabase/ui";
 import type { BasicTableViewColumn } from "metabase/visualizations/types/table-actions";
 import { useGetActionsQuery } from "metabase-enterprise/api";
 import type {
+  ActionScope,
   DataGridWritebackAction,
   DatabaseId,
   RowActionFieldSettings,
@@ -26,6 +27,7 @@ interface Props {
   actionSettings: TableActionDisplaySettings | null | undefined;
   tableColumns: BasicTableViewColumn[];
   databaseId: DatabaseId | undefined;
+  actionScope: ActionScope;
   onClose: () => void;
   onSubmit: (actionParams: {
     id?: string;

--- a/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-actions/settings/ConfigureTableActions/ConfigureTableActions.tsx
@@ -5,6 +5,7 @@ import { uuid } from "metabase/lib/uuid";
 import { Button, Modal, Stack, Text } from "metabase/ui";
 import type { BasicTableViewColumn } from "metabase/visualizations/types/table-actions";
 import type {
+  ActionScope,
   DatabaseId,
   RowActionFieldSettings,
   TableAction,
@@ -21,6 +22,7 @@ type ConfigureTableActionsProps = {
   value: TableActionDisplaySettings[] | undefined;
   cols: BasicTableViewColumn[];
   databaseId: DatabaseId | undefined;
+  actionScope: ActionScope;
   onChange: (newValue: TableActionDisplaySettings[]) => void;
 };
 
@@ -28,6 +30,7 @@ export const ConfigureTableActions = ({
   value: tableActions,
   cols: columns,
   databaseId,
+  actionScope,
   onChange,
 }: ConfigureTableActionsProps) => {
   const {
@@ -146,6 +149,7 @@ export const ConfigureTableActions = ({
         >
           <Modal.Overlay />
           <AddOrEditActionSettingsContent
+            actionScope={actionScope}
             actionSettings={editingAction}
             tableColumns={columns}
             databaseId={databaseId}

--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -1,8 +1,10 @@
 import type { CardId } from "./card";
+import type { DashCardId, DashboardId } from "./dashboard";
 import type { DatabaseId } from "./database";
 import type { BaseEntityId } from "./entity-id";
 import type { Parameter, ParameterId, ParameterTarget } from "./parameters";
 import type { NativeDatasetQuery } from "./query";
+import type { ConcreteTableId } from "./table";
 import type { UserId, UserInfo } from "./user";
 
 export interface ListActionsRequest {
@@ -280,6 +282,7 @@ export type DataGridWritebackAction = WritebackAction | TableAction;
 export type DataGridWritebackActionId = DataGridWritebackAction["id"];
 
 export type ActionScope =
-  | { "table-id": number } // table actions
-  | { "dashcard-id": number } // dashboard actions
-  | { "card-id": number }; // question actions (non dashboard context)
+  | { "table-id": ConcreteTableId } // table actions
+  | { "dashcard-id": DashCardId } // saved dashcard actions
+  | { "card-id": CardId } // question actions (non dashboard context)
+  | { "dashboard-id": DashboardId }; // unsaved dashboard actions (mostly used for form configuration)

--- a/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/actions/ConfigureDashcardCustomTableActions.tsx
+++ b/frontend/src/metabase/dashboard/components/ConfigureEditableTableSidebar/actions/ConfigureDashcardCustomTableActions.tsx
@@ -9,6 +9,7 @@ import { getDocsUrl } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import { Box, Stack, Text } from "metabase/ui";
 import type {
+  ActionScope,
   Dashboard,
   DashboardCard,
   TableActionDisplaySettings,
@@ -74,6 +75,14 @@ export const ConfigureDashcardCustomTableActions = ({
     [dashcard.id, dispatch, enabledActions],
   );
 
+  const actionScope = useMemo<ActionScope>(
+    () =>
+      dashcard.id !== -1
+        ? { "dashcard-id": dashcard.id }
+        : { "dashboard-id": dashboard.id },
+    [dashcard.id, dashboard.id],
+  );
+
   const ConfigureTableActions = PLUGIN_TABLE_ACTIONS.ConfigureTableActions;
 
   return (
@@ -85,7 +94,7 @@ export const ConfigureDashcardCustomTableActions = ({
           {showMetabaseLinks && (
             <>
               {" "}
-              {jt`You can ${(<ExternalLink href={docsLink}>{t`learn more`}</ExternalLink>)} about it here.`}
+              {jt`You can ${(<ExternalLink key="action-docs-link" href={docsLink}>{t`learn more`}</ExternalLink>)} about it here.`}
             </>
           )}
         </Text>
@@ -95,6 +104,7 @@ export const ConfigureDashcardCustomTableActions = ({
             <ConfigureTableActions
               value={tableActions}
               databaseId={databaseId}
+              actionScope={actionScope}
               onChange={handleUpdateRowActions}
               cols={tableColumns}
             />

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -833,6 +833,7 @@ export const PLUGIN_TABLE_ACTIONS = {
     value: TableActionDisplaySettings[] | undefined;
     cols: BasicTableViewColumn[];
     databaseId: DatabaseId | undefined;
+    actionScope: ActionScope;
     onChange: (newValue: TableActionDisplaySettings[]) => void;
   }>,
 };

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -233,6 +233,7 @@ class Table extends Component<TableProps, TableState> {
         // TODO: ideally scope should be `dashcard-id` for saved dashcards inside dashboard,
         // however it seems like we don't have easy access to dashcard id here,
         // so we'll reconsider this later
+        // This works fine for form configuration, however semantically it is not correct.
         actionScope: { "card-id": series[0].card.id },
       }),
 

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -230,6 +230,10 @@ class Table extends Component<TableProps, TableState> {
       getProps: (series: Series, settings: VisualizationSettings) => ({
         cols: series[0].data.cols,
         isPivoted: settings["table.pivot"],
+        // TODO: ideally scope should be `dashcard-id` for saved dashcards inside dashboard,
+        // however it seems like we don't have easy access to dashcard id here,
+        // so we'll reconsider this later
+        actionScope: { "card-id": series[0].card.id },
       }),
 
       getHidden: ([


### PR DESCRIPTION
Dependency for [WRK-547](https://linear.app/metabase/issue/WRK-547/use-configure-for-row-actions)

In order to call form config API, we need to know the current action scope. Right now `actionScope` property is only passed to the component, however is not used. We'll need the scope once we start using new form config API
