### PR TITLE
Locale updates on LanguageStep submit

### DIFF
--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.styled.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.styled.tsx
@@ -40,6 +40,7 @@ export const LocaleButton = styled.span<LocaleContainerProps>`
   background-color: ${(props) =>
     props.checked ? color("brand") : color("bg-white")};
   font-weight: 700;
+  border: 2px solid var(--mb-base-color-white);
 
   &:hover {
     color: var(--mb-color-text-white);
@@ -47,7 +48,7 @@ export const LocaleButton = styled.span<LocaleContainerProps>`
   }
 
   ${LocaleInput}:focus + & {
-    outline: 2px solid var(--mb-color-focus);
+    outline: 2px solid var(--mb-color-brand);
   }
 
   ${LocaleInput}:focus:not(:focus-visible) + & {

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -32,11 +32,18 @@ export const LanguageStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const locales = useMemo(() => getLocales(localeData), [localeData]);
   const dispatch = useDispatch();
 
+  const [selectedLocale, setSelectedLocale] = useState<Locale | undefined>(
+    locale,
+  );
+
   const handleLocaleChange = (locale: Locale) => {
-    dispatch(updateLocale(locale));
+    setSelectedLocale(locale);
   };
 
   const handleStepSubmit = () => {
+    if (selectedLocale) {
+      dispatch(updateLocale(selectedLocale));
+    }
     dispatch(goToNextStep());
   };
 
@@ -63,15 +70,15 @@ export const LanguageStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
           <LocaleItem
             key={item.code}
             locale={item}
-            checked={item.code === locale?.code}
+            checked={item.code === selectedLocale?.code}
             fieldId={fieldId}
             onLocaleChange={handleLocaleChange}
           />
         ))}
       </LocaleGroup>
       <Button
-        primary={locale != null}
-        disabled={locale == null}
+        primary={selectedLocale != null}
+        disabled={selectedLocale == null}
         onClick={handleStepSubmit}
       >
         {t`Next`}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/60183

### Description

For the language dropdown, clicking on a language option or keyboard focusing on it with the arrow keys, will NOT cause the language on the page to change unless the user has committed by clicking or keyboard activating the Next button.

### How to verify

1. Click "Let's get started"
2. For the language dropdown, upon selection of a language, the language on the page should NOT change until the user has committed by clicking the Next button.
3. When the keyboard is focused on the language dropdown, you should navigate through the options using the up/down arrow keys. Tab moves focus to the next interactive element, which is the Next button. Clicking on the Next button will update the language in the next step and onwards.

### Demo

https://github.com/user-attachments/assets/da881b50-cd6c-4c84-a263-1eb16dc745db

### Note
Focus of 'Next" button is implemented via separate pull request: https://github.com/metabase/metabase/pull/60175


