### PR TITLE
Closes VIZ-1104 clear settings after drillthrough

### DIFF
--- a/frontend/src/metabase/querying/drills/utils/underlying-records-drill.ts
+++ b/frontend/src/metabase/querying/drills/utils/underlying-records-drill.ts
@@ -38,7 +38,9 @@ export const underlyingRecordsDrill: Drill<
       question: () =>
         applyDrill(drill)
           .setDisplay("table")
-          .updateSettings({ "table.pivot": false }),
+          // Sometimes the "graph.dimensions" setting lingers around
+          // from a previous graph visualization, so we reset it here. (see metabase#55484)
+          .updateSettings({ "table.pivot": false, "graph.dimensions": [] }),
     },
   ];
 };


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #55484
Closes [VIZ-1104: Changing visualization types after drilling a line chart throws an error](https://linear.app/metabase/issue/VIZ-1104/changing-visualization-types-after-drilling-a-line-chart-throws-an)

### Description

When a cartesian chart has an explicit dimension for its abscissas, it can stick around after drilldown and trigger an error message. This removes the dimensions when drilling down.

### How to verify

 1. Make a new question that contains at least two time columns, explicitely set one of them as the abscissa for a line chart.
 2. Drilldown to a table
 3. Change the visualization to a line chart

###### Expected result:
Not an error

 ###### Actual result:
An error

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
