### PR TITLE
Support round-trip for pending parameter config

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/data_editing/configure.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_editing/configure.clj
@@ -45,9 +45,9 @@
                     :sourceType "ask-user"})}))
 
 ;; TODO handle exposing new inputs required by the inner-action
-(defn- configuration-for-pending-action [{:keys [param-map] :as _action}]
+(defn- configuration-for-pending-action [{:keys [param-map] :as action}]
   ;; TODO Delegate to get this
-  {:title "TODO - depends on existing configuration if already saved, otherwise from the inner action as the default."
+  {:title      (:name action "TODO - depends on existing configuration if already saved, otherwise from the inner action as the default.")
    :parameters (for [[param-id param-settings] param-map]
                  (assoc param-settings :id (name param-id)))})
 

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1043,6 +1043,11 @@
   [& args]
   `(->> (for ~@args) (into {})))
 
+(defmacro for-ordered-map
+  "Like `for-map` but builds an order-preserving map for the result stream of pairs."
+  [& args]
+  `(->> (for ~@args) (into (ordered-map))))
+
 (defn string-byte-count
   "Number of bytes in a string using UTF-8 encoding."
   [s]


### PR DESCRIPTION
This supports us re-rendering the configuration form when we have pending changes on the FE that we have not saved yet.

Basically instead of sending the opaque `:id`, we send the expression for the action itself (without the id):

### Opaque:

```json
{"action-id": "dashcard:123:abcd-efgh-ijkl-mnop"}
```

### Expression:

```json
{
  "action-id":  -123
  "name":       "my custom action",
  "parameters": [{"id": "name", "sourceType": "ask-user"}]
}
```

Where this is the state on the FE:

```json
{
 "id":          "dashcard:123:abcd-efgh-ijkl-mnop"
  "action-id":  -123
  "name":       "my custom action",
  "_comment_":  "/* Not here in payload from BE, but gets put here after we edit the config on FE */"
  "parameters": [{"id": "name", "sourceType": "ask-user"}]
}
```

Basically we make call style 1 if we have "parameters" in the map, otherwise call style 2.