### PR TITLE
Closes VIZ-642 no more move cursor in mobile

### DIFF
--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -123,7 +123,7 @@
   transition: opacity 0.15s linear;
 }
 
-.DashEditing .DashCard {
+.DashEditing:not(.Mobile) .DashCard {
   cursor: move;
 }
 

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -664,10 +664,12 @@ class DashboardGridInner extends Component<
     const { width } = this.props;
     const { layouts, visualizerModalStatus } = this.state;
     const rowHeight = this.getRowHeight();
+
     return (
       <GridLayout<DashboardCard>
         className={cx({
           [DashboardS.DashEditing]: this.isEditingLayout,
+          [DashboardS.Mobile]: width < GRID_BREAKPOINTS.mobile,
           [DashboardS.DashDragging]: this.state.isDragging,
           // we use this class to hide a dashcard actions
           // panel during dragging


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #56495
Closes [VIZ-642: Dashboard edit mode on small screen widths doesn't allow dragging cards, but cursor still changes to a drag icon](https://linear.app/metabase/issue/VIZ-642/dashboard-edit-mode-on-small-screen-widths-doesnt-allow-dragging-cards)

### Description

Dragging around dash cards is not possible in mobile dashboards, so the "move" cursor was irrelevant.