### PR TITLE
QUE-1468: Sticky search in AccordionList

### DIFF
--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-3-stage.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-3-stage.cy.spec.ts
@@ -382,14 +382,12 @@ describe("scenarios > dashboard > filters > query stages", () => {
 
           H.getDashboardCard(0).findByText("Select…").click();
           H.popover().within(() => {
-            QSHelpers.getPopoverList().scrollTo("bottom");
-            QSHelpers.getPopoverItem("Category", 2).click();
+            QSHelpers.getPopoverItem("Category", 2).scrollIntoView().click();
           });
 
           H.getDashboardCard(1).findByText("Select…").click();
           H.popover().within(() => {
-            QSHelpers.getPopoverList().scrollTo("bottom");
-            QSHelpers.getPopoverItem("Category", 2).click();
+            QSHelpers.getPopoverItem("Category", 2).scrollIntoView().click();
           });
 
           H.saveDashboard({ waitMs: 250 });

--- a/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
@@ -507,14 +507,12 @@ export function setup1stStageAggregationFilter() {
 
   H.getDashboardCard(0).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverList().scrollTo("bottom");
-    getPopoverItem("Count").click();
+    getPopoverItem("Count").scrollIntoView().click();
   });
 
   H.getDashboardCard(1).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverList().scrollTo("bottom");
-    getPopoverItem("Count").click();
+    getPopoverItem("Count").scrollIntoView().click();
   });
 
   H.saveDashboard({ waitMs: 250 });
@@ -535,14 +533,12 @@ export function setup1stStageBreakoutFilter() {
 
   H.getDashboardCard(0).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverList().scrollTo("bottom");
-    getPopoverItem("Category", 1).click();
+    getPopoverItem("Category", 1).scrollIntoView().click();
   });
 
   H.getDashboardCard(1).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverList().scrollTo("bottom");
-    getPopoverItem("Category", 1).click();
+    getPopoverItem("Category", 1).scrollIntoView().click();
   });
 
   H.saveDashboard({ waitMs: 250 });
@@ -591,14 +587,12 @@ export function setup2ndStageCustomColumnFilter() {
 
   H.getDashboardCard(0).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverList().scrollTo("bottom");
-    getPopoverItem("5 * Count").click();
+    getPopoverItem("5 * Count").scrollIntoView().click();
   });
 
   H.getDashboardCard(1).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverList().scrollTo("bottom");
-    getPopoverItem("5 * Count").click();
+    getPopoverItem("5 * Count").scrollIntoView().click();
   });
 
   H.saveDashboard({ waitMs: 250 });
@@ -622,14 +616,12 @@ export function setup2ndStageAggregationFilter() {
 
   H.getDashboardCard(0).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverList().scrollTo("bottom");
-    getPopoverItem("Count", 1).click();
+    getPopoverItem("Count", 1).scrollIntoView().click();
   });
 
   H.getDashboardCard(1).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverList().scrollTo("bottom");
-    getPopoverItem("Count", 1).click();
+    getPopoverItem("Count", 1).scrollIntoView().click();
   });
 
   H.getDashboardCard(2).findByText("Select…").click();
@@ -661,14 +653,12 @@ export function setup2ndStageBreakoutFilter() {
 
   H.getDashboardCard(0).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverList().scrollTo("bottom");
-    getPopoverItem("Category", 2).click();
+    getPopoverItem("Category", 2).scrollIntoView().click();
   });
 
   H.getDashboardCard(1).findByText("Select…").click();
   H.popover().within(() => {
-    getPopoverList().scrollTo("bottom");
-    getPopoverItem("Category", 2).click();
+    getPopoverItem("Category", 2).scrollIntoView().click();
   });
 
   H.getDashboardCard(2).findByText("Select…").click();

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -1068,7 +1068,6 @@ describe("scenarios > question > filter", () => {
 
     H.popover()
       .findByRole("tree")
-      .parent()
       .then((el) => {
         cy.wrap(el[0].scrollTop).should("be.greaterThan", 0);
       });

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.module.css
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.module.css
@@ -1,4 +1,6 @@
 .accordionListRoot {
   outline: none;
   overflow: auto;
+  max-width: inherit;
+  max-height: inherit;
 }

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.module.css
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.module.css
@@ -4,3 +4,12 @@
   max-width: inherit;
   max-height: inherit;
 }
+
+.hasSearch {
+  /**
+   * When we have a search row, it's sticky, so we need to add
+   * scroll padding for scrollIntoView to work correctly and not
+   * scroll the items into view behind the search row.
+   */
+  scroll-padding-top: 60px;
+}

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -625,7 +625,7 @@ export class AccordionList<
           overflowY: "auto",
           outline: "none",
           maxWidth: width,
-          maxHeight: "inherit",
+          maxHeight,
           ...style,
         }}
         containerStyle={{

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -627,6 +627,7 @@ export class AccordionList<
           // This is a temporary fix to handle cases where the parent component doesn’t pass in the correct `maxHeight`
           overflowY: "auto",
           outline: "none",
+          maxWidth: width,
           ...style,
         }}
         containerStyle={{ pointerEvents: "auto" }}

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -628,9 +628,14 @@ export class AccordionList<
           overflowY: "auto",
           outline: "none",
           maxWidth: width,
+          maxHeight: "inherit",
           ...style,
         }}
-        containerStyle={{ pointerEvents: "auto" }}
+        containerStyle={{
+          pointerEvents: "auto",
+          overflow: "auto",
+          maxHeight: "inherit",
+        }}
         // @ts-expect-error: TODO
         width={width}
         height={height}

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -341,12 +341,6 @@ export class AccordionList<
 
       this.toggleSection(cursor.sectionIndex);
     }
-
-    const searchRow = this.getRows().findIndex((row) => row.type === "search");
-
-    if (searchRow >= 0 && this.isVirtualized()) {
-      this.listRef.current?.scrollToRow(searchRow);
-    }
   };
 
   getRows = (): Row<TItem, TSection>[] => {

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -567,11 +567,14 @@ export class AccordionList<
       cursor != null ? rows.findIndex(this.isRowSelected) : undefined;
 
     const searchRowIndex = rows.findIndex((row) => row.type === "search");
+    const hasSearch = searchRowIndex >= 0;
 
     if (!this.isVirtualized()) {
       return (
         <Box
-          className={cx(S.accordionListRoot, className)}
+          className={cx(S.accordionListRoot, className, {
+            [S.hasSearch]: hasSearch,
+          })}
           ref={this.listRootRef}
           role="tree"
           onKeyDown={this.handleKeyDown}
@@ -621,7 +624,7 @@ export class AccordionList<
       <List
         id={id}
         ref={this.listRef}
-        className={className}
+        className={cx(className, { [S.hasSearch]: hasSearch })}
         style={{
           // HACK - Ensure the component can scroll
           // This is a temporary fix to handle cases where the parent component doesn’t pass in the correct `maxHeight`

--- a/frontend/src/metabase/common/components/AccordionList/AccordionListCell.module.css
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionListCell.module.css
@@ -28,6 +28,7 @@
 
 .sticky {
   position: sticky;
+  z-index: 10;
   top: 0;
   background: var(--mb-color-bg-white);
 }

--- a/frontend/src/metabase/common/components/AccordionList/AccordionListCell.module.css
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionListCell.module.css
@@ -25,3 +25,9 @@
     color: inherit;
   }
 }
+
+.search {
+  position: sticky;
+  top: 0;
+  background: var(--mb-color-bg-white);
+}

--- a/frontend/src/metabase/common/components/AccordionList/AccordionListCell.module.css
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionListCell.module.css
@@ -26,7 +26,7 @@
   }
 }
 
-.search {
+.sticky {
   position: sticky;
   top: 0;
   background: var(--mb-color-bg-white);

--- a/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
@@ -424,7 +424,10 @@ export const AccordionListCell = forwardRef(function AccordionListCell<
   return (
     <div
       ref={mergedRef}
-      style={style}
+      style={{
+        ...style,
+        position: isSticky ? "sticky" : undefined,
+      }}
       data-element-id="list-section"
       className={cx(section.className, {
         [ListS.ListSectionExpanded]: sectionIsExpanded(sectionIndex),

--- a/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
@@ -424,10 +424,7 @@ export const AccordionListCell = forwardRef(function AccordionListCell<
   return (
     <div
       ref={mergedRef}
-      style={{
-        ...style,
-        position: isSticky ? "sticky" : undefined,
-      }}
+      style={style}
       data-element-id="list-section"
       className={cx(section.className, {
         [ListS.ListSectionExpanded]: sectionIsExpanded(sectionIndex),

--- a/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
@@ -419,6 +419,8 @@ export const AccordionListCell = forwardRef(function AccordionListCell<
     }
   }
 
+  const isSticky = type === "search";
+
   return (
     <div
       ref={mergedRef}
@@ -429,7 +431,7 @@ export const AccordionListCell = forwardRef(function AccordionListCell<
         [ListS.ListSectionToggleAble]: canToggleSections,
         [styles.borderTop]: withBorders && borderTop,
         [styles.borderBottom]: withBorders && borderBottom,
-        [styles.search]: type === "search",
+        [styles.sticky]: isSticky,
       })}
     >
       {content}

--- a/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionListCell.tsx
@@ -429,6 +429,7 @@ export const AccordionListCell = forwardRef(function AccordionListCell<
         [ListS.ListSectionToggleAble]: canToggleSections,
         [styles.borderTop]: withBorders && borderTop,
         [styles.borderBottom]: withBorders && borderBottom,
+        [styles.search]: type === "search",
       })}
     >
       {content}

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -336,23 +336,24 @@ export function AggregationPicker({
   }
 
   return (
-    <Box className={className} c="summarize" data-testid="aggregation-picker">
-      <AccordionList<Item, Section>
-        sections={sections}
-        onChange={handleChange}
-        onChangeSection={handleSectionChange}
-        onChangeSearchText={handleChangeSearchText}
-        itemIsSelected={checkIsItemSelected}
-        renderItemName={renderItemName}
-        renderItemDescription={omitItemDescription}
-        renderItemExtra={renderItemIcon}
-        renderItemWrapper={renderItemWrapper}
-        maxHeight={Infinity}
-        withBorders
-        globalSearch
-        fuzzySearch
-      />
-    </Box>
+    <AccordionList<Item, Section>
+      data-testid="aggregation-picker"
+      style={{ color: "var(--mb-color-summarize)" }}
+      sections={sections}
+      onChange={handleChange}
+      onChangeSection={handleSectionChange}
+      onChangeSearchText={handleChangeSearchText}
+      itemIsSelected={checkIsItemSelected}
+      renderItemName={renderItemName}
+      renderItemDescription={omitItemDescription}
+      renderItemExtra={renderItemIcon}
+      renderItemWrapper={renderItemWrapper}
+      maxHeight={Infinity}
+      itemTestId="dimension-list-item"
+      withBorders
+      globalSearch
+      fuzzySearch
+    />
   );
 }
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -347,8 +347,6 @@ export function AggregationPicker({
         renderItemDescription={omitItemDescription}
         renderItemExtra={renderItemIcon}
         renderItemWrapper={renderItemWrapper}
-        // disable scrollbars inside the list
-        style={{ overflow: "visible" }}
         maxHeight={Infinity}
         withBorders
         globalSearch

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -142,7 +142,7 @@ export function FilterColumnPicker({
           withColumnItemIcon ? renderItemIcon(query, item) : null
         }
         // disable scrollbars inside the list
-        style={{ width: WIDTH }}
+        width={WIDTH}
         maxHeight={Infinity}
         // Compat with E2E tests around MLv1-based components
         // Prefer using a11y role selectors

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -142,10 +142,7 @@ export function FilterColumnPicker({
           withColumnItemIcon ? renderItemIcon(query, item) : null
         }
         // disable scrollbars inside the list
-        style={{
-          overflow: "visible",
-          width: WIDTH,
-        }}
+        style={{ width: WIDTH }}
         maxHeight={Infinity}
         // Compat with E2E tests around MLv1-based components
         // Prefer using a11y role selectors


### PR DESCRIPTION
Closes QUE-1468

Make the scrollbar in `AccordionList` sticky.

## To verify 

1. New -> Question
2. Add filter
3. Resize the screen so the dropdown is too small for all the items (or type something to trigger search).
4. Scroll down to make sure the search bar remains sticky
5. Play with the cursor keys