### PR TITLE
Render ComparisonPicker for SDK without a portal

### DIFF
--- a/e2e/support/helpers/e2e-viz-settings-helpers.js
+++ b/e2e/support/helpers/e2e-viz-settings-helpers.js
@@ -22,6 +22,8 @@ export function openSeriesSettings(field, isBreakout = false) {
 
 export function openVizTypeSidebar() {
   cy.findByTestId("viz-type-button").click();
+
+  return cy.findByTestId("viz-type-button");
 }
 
 export function openVizSettingsSidebar() {

--- a/e2e/support/helpers/e2e-viz-settings-helpers.js
+++ b/e2e/support/helpers/e2e-viz-settings-helpers.js
@@ -22,8 +22,6 @@ export function openSeriesSettings(field, isBreakout = false) {
 
 export function openVizTypeSidebar() {
   cy.findByTestId("viz-type-button").click();
-
-  return cy.findByTestId("viz-type-button");
 }
 
 export function openVizSettingsSidebar() {

--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -7,11 +7,6 @@ import {
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import * as H from "e2e/support/helpers";
-import {
-  editDashboard,
-  openVizSettingsSidebar,
-  showDashcardVisualizerModalSettings,
-} from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
@@ -96,7 +91,7 @@ describe("scenarios > embedding-sdk > popovers", () => {
       <InteractiveQuestion questionId={ORDERS_BY_YEAR_QUESTION_ID} />,
     );
 
-    openVizSettingsSidebar();
+    H.openVizSettingsSidebar();
 
     getSdkRoot().within(() => {
       cy.findByTestId("settings-count").click();
@@ -116,7 +111,7 @@ describe("scenarios > embedding-sdk > popovers", () => {
       mountSdkContent(<InteractiveQuestion questionId={questionId} />);
     });
 
-    openVizSettingsSidebar();
+    H.openVizSettingsSidebar();
 
     getSdkRoot().within(() => {
       cy.findByTestId("chartsettings-sidebar").findByText("Display").click();
@@ -141,7 +136,7 @@ describe("scenarios > embedding-sdk > popovers", () => {
       <InteractiveQuestion questionId={ORDERS_BY_YEAR_QUESTION_ID} />,
     );
 
-    openVizSettingsSidebar();
+    H.openVizSettingsSidebar();
 
     getSdkRoot().within(() => {
       cy.findByTestId("color-selector-button").click();
@@ -172,8 +167,8 @@ describe("scenarios > embedding-sdk > popovers", () => {
     });
 
     getSdkRoot().within(() => {
-      editDashboard();
-      showDashcardVisualizerModalSettings(0);
+      H.editDashboard();
+      H.showDashcardVisualizerModalSettings(0);
 
       cy.findAllByTestId("color-selector-button").first().click();
 
@@ -197,7 +192,7 @@ describe("scenarios > embedding-sdk > popovers", () => {
       cy.findByText("Trend").click();
     });
 
-    openVizSettingsSidebar();
+    H.openVizSettingsSidebar();
 
     getSdkRoot().within(() => {
       cy.findByTestId("comparisons-widget-button").click();

--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -186,4 +186,29 @@ describe("scenarios > embedding-sdk > popovers", () => {
       cy.findByTestId("color-selector-popover").should("not.exist");
     });
   });
+
+  it("should prevent closing the ComparisonPicker when clicking it", () => {
+    cy.get<string>("@questionId").then((questionId) => {
+      mountSdkContent(<InteractiveQuestion questionId={questionId} />);
+    });
+
+    cy.findByTestId("chart-type-selector-button").click();
+    cy.findByRole("menu").within(() => {
+      cy.findByText("Trend").click();
+    });
+
+    openVizSettingsSidebar();
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("comparisons-widget-button").click();
+
+      // Clicking at the edge of the ComparisonPicker popover to be sure that the click does not close it
+      cy.findByTestId("comparison-picker-dropdown").click(2, 2);
+      cy.findByTestId("comparison-picker-dropdown").should("be.visible");
+
+      // Clicking outside of the ComparisonPicker popover to be sure that the click closes it
+      cy.findByTestId("chartsettings-sidebar").click(1, 1);
+      cy.findByTestId("comparison-picker-dropdown").should("not.exist");
+    });
+  });
 });

--- a/frontend/src/metabase/css/core/layout.module.css
+++ b/frontend/src/metabase/css/core/layout.module.css
@@ -94,3 +94,7 @@
 .stackingContext {
   transform: scale(1);
 }
+
+.verticalAlignMiddle {
+  vertical-align: middle;
+}

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/ComparisonPicker.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/ComparisonPicker.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import type { MouseEvent } from "react";
 import { useCallback, useState } from "react";
 import { jt, t } from "ttag";
@@ -5,6 +6,7 @@ import _ from "underscore";
 
 import IconButtonWrapper from "metabase/common/components/IconButtonWrapper";
 import CS from "metabase/css/core/index.css";
+import { isEmbeddingSdk } from "metabase/env";
 import { Menu, Stack, Text, rem } from "metabase/ui";
 import type {
   DatasetColumn,
@@ -150,6 +152,10 @@ export function ComparisonPicker({
       position="bottom-start"
       shadow="sm"
       closeOnItemClick={false}
+      {...(isEmbeddingSdk && {
+        withinPortal: false,
+        floatingStrategy: "fixed",
+      })}
     >
       <Menu.Target>
         <ComparisonPickerButton
@@ -174,11 +180,15 @@ export function ComparisonPicker({
           }}
         >
           <DisplayName value={editedValue} option={selectedOption} />
-          <ExpandIcon className={CS.inline} name="chevrondown" size={14} />
+          <ExpandIcon
+            className={cx(CS.inline, CS.verticalAlignMiddle)}
+            name="chevrondown"
+            size={14}
+          />
         </ComparisonPickerButton>
       </Menu.Target>
 
-      <Menu.Dropdown miw={rem(344)}>
+      <Menu.Dropdown miw={rem(344)} data-testid="comparison-picker-dropdown">
         {renderMenuDropdownContent()}
       </Menu.Dropdown>
     </Menu>


### PR DESCRIPTION
Render ComparisonPicker popover for SDK without a portal

![image](https://github.com/user-attachments/assets/263fd48c-3e74-42a5-97e3-f05404f9c7e7)


For the SDK it is rendered inside a parent Mantine popover, it causes closing the ComparisonPicker popover when clicking it.

How to verify:
- CI is green