### PR TITLE
Fix keyboard navigation in database tab of the add data modal

### DIFF
--- a/frontend/src/metabase/databases/components/DatabaseEngineList/DatabaseEngineList.module.css
+++ b/frontend/src/metabase/databases/components/DatabaseEngineList/DatabaseEngineList.module.css
@@ -22,8 +22,10 @@
       border-bottom: 1px solid var(--mb-color-border);
     }
 
-    &:hover {
+    &:hover,
+    &[data-combobox-selected="true"] {
       background-color: var(--mb-color-background-hover);
+      color: inherit;
     }
   }
 }

--- a/frontend/src/metabase/databases/components/DatabaseEngineList/DatabaseEngineList.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineList/DatabaseEngineList.tsx
@@ -51,19 +51,16 @@ export const DatabaseEngineList = ({
           option: S.option,
         }}
       >
-        <Combobox.EventsTarget>
-          <Combobox.Search
-            placeholder={t`Search databases`}
-            leftSection={<Icon name="search" />}
-            value={search}
-            onChange={(event) => {
-              const searchTerm = event.currentTarget.value;
-              setSearch(searchTerm);
-              setIsExpanded(searchTerm.length > 0);
-              combobox.updateSelectedOptionIndex();
-            }}
-          />
-        </Combobox.EventsTarget>
+        <Combobox.Search
+          placeholder={t`Search databases`}
+          leftSection={<Icon name="search" />}
+          value={search}
+          onChange={(event) => {
+            const searchTerm = event.currentTarget.value;
+            setSearch(searchTerm);
+            setIsExpanded(searchTerm.length > 0);
+          }}
+        />
 
         {databasesList.length > 0 ? (
           <ScrollArea type="hover" scrollHideDelay={300}>
@@ -88,8 +85,6 @@ export const DatabaseEngineList = ({
               aria-expanded={isExpanded}
               isExpanded={isExpanded}
               onClick={() => {
-                combobox.updateSelectedOptionIndex();
-
                 if (isExpanded) {
                   setSearch("");
                 }

--- a/frontend/src/metabase/databases/components/DatabaseEngineList/DatabaseEngineList.unit.spec.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineList/DatabaseEngineList.unit.spec.tsx
@@ -111,6 +111,37 @@ describe("DatabaseEngineList", () => {
     expect(screen.queryByText("MySQL")).not.toBeInTheDocument();
   });
 
+  it("should allow keyboard navigation", async () => {
+    const { onSelect } = setup();
+
+    const searchInput = screen.getByPlaceholderText("Search databases");
+    await userEvent.click(searchInput);
+
+    const [mysql, postgres, sqlServer] = screen.getAllByRole("option");
+
+    await userEvent.keyboard("{ArrowDown}");
+    expect(mysql).toHaveAttribute("aria-selected", "true");
+    expect(mysql).toHaveAttribute("data-combobox-selected", "true");
+
+    await userEvent.keyboard("{ArrowDown}");
+    expect(mysql).not.toHaveAttribute("aria-selected");
+    expect(mysql).not.toHaveAttribute("data-combobox-selected");
+    expect(postgres).toHaveAttribute("aria-selected", "true");
+    expect(postgres).toHaveAttribute("data-combobox-selected", "true");
+
+    await userEvent.keyboard("{ArrowDown}");
+    expect(postgres).not.toHaveAttribute("aria-selected");
+    expect(postgres).not.toHaveAttribute("data-combobox-selected");
+    expect(sqlServer).toHaveAttribute("aria-selected", "true");
+    expect(sqlServer).toHaveAttribute("data-combobox-selected", "true");
+
+    // Pressing enter should submit the selected option
+    await userEvent.keyboard("{Enter}");
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith("sqlserver");
+  });
+
   it("should show no results message when search has no matches", async () => {
     setup();
 


### PR DESCRIPTION
Fixes PRG-58

This PR not only fixes the keyboard navigation, but also adjusts the style of the actively selected option to make it more pleasing to the eye, and in line with [the actual design](https://www.figma.com/design/okiGovzZTn4rqhWYuMjraA/Find-place-for-adding-data-to-Metabase-and-locating-it-later?node-id=10281-4963&m=dev).

### Demo

Before
![kapture_2025-06-09_at_15 37 33](https://github.com/user-attachments/assets/d51f5f4e-5529-4ab3-9523-0b8f43a018b2)

Now
![Kapture 2025-06-27 at 19 25 55](https://github.com/user-attachments/assets/886b5787-4103-46df-9d9a-6015b4d3c54c)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
