### PR TITLE
Remove bulk edit checkbox if there are no bulk actions available

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDashcardVisualization.tsx
@@ -192,6 +192,7 @@ export const EditTableDashcardVisualization = memo(
       );
     }, [data.cols, tableFieldMetadataMap, columnsConfig]);
     const hasBulkEditing = hasEditableAndVisibleColumns;
+    const hasRowSelection = hasBulkEditing || hasDeleteAction;
 
     const {
       rowActions,
@@ -393,6 +394,7 @@ export const EditTableDashcardVisualization = memo(
                 getColumnSortDirection={getColumnSortDirection}
                 rowActions={rowActions}
                 onActionClick={onRowActionButtonClick}
+                hasRowSelection={hasRowSelection}
                 rowSelection={rowSelection}
                 onRowSelectionChange={setRowSelection}
               />

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataContainer.tsx
@@ -256,6 +256,7 @@ export const EditTableDataContainer = ({
                 onCellValueUpdate={handleCellValueUpdate}
                 onRowExpandClick={openUpdateRowModal}
                 onRowSelectionChange={setRowSelection}
+                hasRowSelection
                 rowSelection={rowSelection}
                 onColumnSort={handleChangeColumnSort}
               />

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/EditTableDataGrid.tsx
@@ -52,6 +52,7 @@ type EditTableDataGridProps = {
   cellsWithFailedUpdatesMap?: Record<CellUniqKey, true>;
   rowActions?: DataGridRowAction[];
   onActionClick?: (action: DataGridRowAction, row: Row<RowValues>) => void;
+  hasRowSelection: boolean;
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
   onColumnSort?: (field: Field) => void;
@@ -67,6 +68,7 @@ export const EditTableDataGrid = ({
   cellsWithFailedUpdatesMap,
   rowActions,
   onActionClick,
+  hasRowSelection,
   rowSelection,
   onRowSelectionChange,
   onColumnSort,
@@ -175,7 +177,7 @@ export const EditTableDataGrid = ({
     [onRowExpandClick],
   );
 
-  const columnRowSelectOptions = useTableColumnRowSelect();
+  const columnRowSelectOptions = useTableColumnRowSelect(hasRowSelection);
 
   const tableProps = useDataGridInstance({
     data: rows,
@@ -185,7 +187,7 @@ export const EditTableDataGrid = ({
     columnsOptions,
     columnVisibility,
     columnPinning: { left: [ROW_SELECT_COLUMN_ID, ROW_ID_COLUMN_ID] },
-    enableRowSelection: true,
+    enableRowSelection: hasRowSelection,
     rowSelection,
     onRowSelectionChange,
     columnRowSelectOptions: columnRowSelectOptions,

--- a/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-column-row-select.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_editing/tables/edit/use-table-column-row-select.tsx
@@ -7,10 +7,10 @@ import type { RowValue, RowValues } from "metabase-types/api";
 
 export const ROW_SELECT_COLUMN_ID = "__MB_ROW_SELECT";
 
-export function useTableColumnRowSelect() {
-  return useMemo<ColumnOptions<RowValues, RowValue>>(
-    () => getRowSelectColumn(),
-    [],
+export function useTableColumnRowSelect(hasRowSelection: boolean) {
+  return useMemo<ColumnOptions<RowValues, RowValue> | undefined>(
+    () => (hasRowSelection ? getRowSelectColumn() : undefined),
+    [hasRowSelection],
   );
 }
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/WRK-536/checkboxes-are-useless-on-editable-component-if-bulk-actions-disabled

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
