### PR TITLE
Closes VIZ-195 - Bar chart data labels jump 1px on hover

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -84,14 +84,15 @@ export const getBarLabelLayout =
       return {};
     }
 
-    const barHeight = rect.height;
-    const labelOffset =
-      barHeight / 2 +
-      CHART_STYLE.seriesLabels.size / 2 +
-      CHART_STYLE.seriesLabels.offset;
+    let dy = 0;
+    if (labelValue < 0) {
+      const distance = 5; // https://echarts.apache.org/en/option.html#series-line.label.distance
+      dy = rect.height + CHART_STYLE.seriesLabels.size + distance * 2;
+    }
+
     return {
       hideOverlap: settings["graph.label_value_frequency"] === "fit",
-      dy: labelValue < 0 ? labelOffset : -labelOffset,
+      dy,
     };
   };
 
@@ -503,6 +504,7 @@ const buildEChartsBarSeries = (
           labelFormatter,
           settings,
           chartDataDensity,
+          "top",
         ),
     labelLayout: isStacked
       ? getBarInsideLabelLayout(


### PR DESCRIPTION
Closes #48846
Closes VIZ-195

### Description

Fixes bar chart hover issues by using the same offset calculations for `seriesOption` and `labelOptions`.

### How to verify

1. Create a bar chart with positive and negative bars
2. Enable data labels
3. Hover bars
4. Verify data labels don't change their position

### Demo

**BEFORE**

https://github.com/user-attachments/assets/08e4da45-8be6-4341-ba59-7356cb233bd7

**AFTER**

https://github.com/user-attachments/assets/059002e3-a839-4529-b275-8f36bd321e1c

**TMI**
Erring on the side of over-documenting. Hovering over bars when "Some" is selected works the same as before just without the 1px jump.

https://github.com/user-attachments/assets/a7a3379a-b142-441e-a146-cf04b4c04ab3
