### PR TITLE
fix trend native formatting

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -75,7 +75,6 @@ export function SmartScalar({
   const { trend, error } = useMemo(
     () =>
       computeTrend(series, insights, settings, {
-        formatValue,
         getColor: color,
       }),
     [series, insights, settings],

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
@@ -191,10 +191,12 @@ function getCurrentMetricData({ series, insights, settings }) {
   );
   const dateUnit = metricInsight?.unit;
   const dateColumn = cols[dimensionColIndex];
-  const dateColumnSettings = settings?.column?.(dateColumn) ?? {};
+  const dateColummnWithUnit = { ...dateColumn };
+  dateColummnWithUnit.unit ??= dateUnit;
+  const dateColumnSettings = settings?.column?.(dateColummnWithUnit) ?? {};
 
   const dateUnitSettings = {
-    dateColumn,
+    dateColumn: dateColummnWithUnit,
     dateColumnSettings,
     dateUnit,
     queryType,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #40949
Closes [VIZ-123](https://linear.app/metabase/issue/VIZ-123/inconsistancy-between-sql-and-gui-query-for-date-display-of-trend)

### Description

Fixes trend chart date formatting on SQL differs from MBQL queries.

### How to verify

- Orders: Count by Created At [Year]
- Make it a trend chart
- Ensure the formatted date does not include month, day, time — this is how it has been working for MBQL queries
- Convert the question into a SQL question
- Ensure the date shows only year as for MBQL questions

### Demo

Before
<img width="766" alt="Screenshot 2025-06-27 at 4 26 28 PM" src="https://github.com/user-attachments/assets/3a46ea0b-b266-4878-80b1-34e2e9f8c32f" />

After (same as for MBQL queries)
<img width="981" alt="Screenshot 2025-06-27 at 4 25 58 PM" src="https://github.com/user-attachments/assets/3651995e-1a43-4d0a-9286-4706bcbd9e8a" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
