### PR TITLE
Closes VIZ-147 - Title fonts are cut off when exporting a card as png from a dashboard

### DIFF
--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.tsx
@@ -9,6 +9,7 @@ import DashboardS from "metabase/css/dashboard.module.css";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import type { IconProps } from "metabase/ui";
 import { Icon, Menu, Tooltip } from "metabase/ui";
+import { SAVING_DOM_IMAGE_OVERFLOW_VISIBLE_CLASS } from "metabase/visualizations/lib/image-exports";
 
 import LegendActions from "../LegendActions";
 
@@ -89,13 +90,21 @@ export const LegendCaption = ({
         DashboardS.fullscreenNightText,
         EmbedFrameS.fullscreenNightText,
         CS.h3,
+
+        // html2canvas doesn't support `text-overflow: ellipsis` (#45499) https://github.com/niklasvh/html2canvas/issues/324
+        SAVING_DOM_IMAGE_OVERFLOW_VISIBLE_CLASS,
       )}
       href={hasTitleMenuItems ? undefined : href}
       onClick={hasTitleMenuItems ? undefined : onSelectTitle}
       onFocus={handleFocus}
       onMouseEnter={handleMouseEnter}
     >
-      <Ellipsified data-testid="legend-caption-title">{title}</Ellipsified>
+      <Ellipsified
+        data-testid="legend-caption-title"
+        className={SAVING_DOM_IMAGE_OVERFLOW_VISIBLE_CLASS}
+      >
+        {title}
+      </Ellipsified>
       {title && hasTitleMenuItems && (
         <Icon
           style={{ flexShrink: 0, marginRight: 10 }}

--- a/frontend/src/metabase/visualizations/lib/image-exports.ts
+++ b/frontend/src/metabase/visualizations/lib/image-exports.ts
@@ -18,6 +18,8 @@ export const SAVING_DOM_IMAGE_CLASS = "saving-dom-image";
 export const SAVING_DOM_IMAGE_HIDDEN_CLASS = "saving-dom-image-hidden";
 export const SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS =
   "saving-dom-image-display-none";
+export const SAVING_DOM_IMAGE_OVERFLOW_VISIBLE_CLASS =
+  "saving-dom-image-overflow-visible";
 export const PARAMETERS_MARGIN_BOTTOM = 12;
 
 export const saveDomImageStyles = css`
@@ -27,6 +29,9 @@ export const saveDomImageStyles = css`
     }
     .${SAVING_DOM_IMAGE_DISPLAY_NONE_CLASS} {
       display: none;
+    }
+    .${SAVING_DOM_IMAGE_OVERFLOW_VISIBLE_CLASS} {
+      overflow: visible;
     }
 
     .${DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME} {


### PR DESCRIPTION
Closes #45499
Closes VIZ-147

### Description

Adds `saving-dom-image-overflow-visible` override to dashboard card titles since html2canvas doesn't support `text-overflow: ellipsis` so it cuts off the text in a suboptimal way (even the ascenders/descenders).

### How to verify

1. Have a dashboard card with a title containing ascenders and descenders (e.g. "rolling average")
2. Click "more" kebab > "Download results" > ".png" > "Download"
3. Open downloaded image
4. Verify the ascenders and descenders aren't cut off

### Demo

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/7cb77cb5-894c-47f0-b36d-5370d5bf0acb) | ![after](https://github.com/user-attachments/assets/05b57ef8-c168-4d39-a6b6-27ea9d7c0952) |
| ![before-trunc](https://github.com/user-attachments/assets/ab374067-5013-4cf4-8186-fe65a4d6b8df) | ![after-trunc](https://github.com/user-attachments/assets/0f9c60d3-0938-4d4f-b94b-03764602c0fb) |
