### PR TITLE
Query processor supports native custom filters

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -1020,7 +1020,11 @@
 (mu/defmethod sql.params.substitution/->replacement-snippet-info [:bigquery-cloud-sdk FieldFilter]
   [driver                            :- :keyword
    {:keys [field], :as field-filter} :- [:map
-                                         [:field :any]]]
+                                         [:field [:or
+                                                  driver-api/schema.metadata.column
+                                                  [:map
+                                                   [:column driver-api/schema.common.non-blank-string]
+                                                   [:effective-type driver-api/schema.common.base-type]]]]]]
   (let [field-temporal-type (temporal-type field)
         parent-method       (get-method sql.params.substitution/->replacement-snippet-info [:sql FieldFilter])
         result              (parent-method driver field-filter)]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -1020,11 +1020,7 @@
 (mu/defmethod sql.params.substitution/->replacement-snippet-info [:bigquery-cloud-sdk FieldFilter]
   [driver                            :- :keyword
    {:keys [field], :as field-filter} :- [:map
-                                         [:field [:or
-                                                  driver-api/schema.metadata.column
-                                                  [:map
-                                                   [:column driver-api/schema.common.non-blank-string]
-                                                   [:effective-type driver-api/schema.common.base-type]]]]]]
+                                         [:field [:or driver-api/schema.metadata.column sql.params.substitution/raw-field]]]]
   (let [field-temporal-type (temporal-type field)
         parent-method       (get-method sql.params.substitution/->replacement-snippet-info [:sql FieldFilter])
         result              (parent-method driver field-filter)]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -1020,7 +1020,7 @@
 (mu/defmethod sql.params.substitution/->replacement-snippet-info [:bigquery-cloud-sdk FieldFilter]
   [driver                            :- :keyword
    {:keys [field], :as field-filter} :- [:map
-                                         [:field driver-api/schema.metadata.column]]]
+                                         [:field :any]]]
   (let [field-temporal-type (temporal-type field)
         parent-method       (get-method sql.params.substitution/->replacement-snippet-info [:sql FieldFilter])
         result              (parent-method driver field-filter)]

--- a/modules/drivers/sparksql/test/metabase/test/data/sparksql.clj
+++ b/modules/drivers/sparksql/test/metabase/test/data/sparksql.clj
@@ -143,7 +143,7 @@
 ;; strip out the default table alias `t1` from the generated native query
 (defmethod tx/count-with-field-filter-query :sparksql
   ([driver table field]
-   (tx/count-with-field-filter-query driver table field 1))
-  ([driver table field sample-value]
-   (-> ((get-method tx/count-with-field-filter-query :sql/test-extensions) driver table field sample-value)
+   (tx/count-with-field-filter-query driver table field {}))
+  ([driver table field options]
+   (-> ((get-method tx/count-with-field-filter-query :sql/test-extensions) driver table field options)
        (update :query str/replace #"`t1` " ""))))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -691,6 +691,9 @@
     ;; Does this driver support "temporal-unit" template tags in native queries?
     :native-temporal-units
 
+    ;; Does this driver support "custom-filter" template tags in native queries?
+    :native-custom-filters
+
     ;; Whether the driver supports loading dynamic test datasets on each test run. Eg. datasets with names like
     ;; `checkins:4-per-minute` are created dynamically in each test run. This should be truthy for every driver we test
     ;; against except for Athena and Databricks which currently require test data to be loaded separately.

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -692,7 +692,7 @@
     :native-temporal-units
 
     ;; Does this driver support "custom-filter" template tags in native queries?
-    :native-custom-filters
+    :native/custom-filters
 
     ;; Whether the driver supports loading dynamic test datasets on each test run. Eg. datasets with names like
     ;; `checkins:4-per-minute` are created dynamically in each test run. This should be truthy for every driver we test

--- a/src/metabase/driver/common/parameters.clj
+++ b/src/metabase/driver/common/parameters.clj
@@ -54,7 +54,7 @@
 (defn TemporalUnitWithCol?
   "Is `x` an instance of the `TemporalUnitWithCol` record type?"
   [x]
-  (instance? TemporalUnit x))
+  (instance? TemporalUnitWithCol x))
 
 ;; A "ReferencedCardQuery" parameter expands to the native query of the referenced card.
 ;;

--- a/src/metabase/driver/common/parameters.clj
+++ b/src/metabase/driver/common/parameters.clj
@@ -26,6 +26,16 @@
   [x]
   (instance? FieldFilter x))
 
+(p.types/defrecord+ CustomFilter [name effective-type value]
+  pretty/PrettyPrintable
+  (pretty [this]
+    (list (pretty/qualify-symbol-for-*ns* `map->CustomFilter) (into {} this))))
+
+(defn CustomFilter?
+  "Is `x` an instance of the `CustomFilter` record type?"
+  [x]
+  (instance? CustomFilter x))
+
 (p.types/defrecord+ TemporalUnit [name value]
   pretty/PrettyPrintable
   (pretty [this]
@@ -33,6 +43,16 @@
 
 (defn TemporalUnit?
   "Is `x` an instance of the `TemporalUnit` record type?"
+  [x]
+  (instance? TemporalUnit x))
+
+(p.types/defrecord+ TemporalUnitWithCol [name value column]
+  pretty/PrettyPrintable
+  (pretty [this]
+    (list (pretty/qualify-symbol-for-*ns* `map->TemporalUnitWithCol) (into {} this))))
+
+(defn TemporalUnitWithCol?
+  "Is `x` an instance of the `TemporalUnitWithCol` record type?"
   [x]
   (instance? TemporalUnit x))
 

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -38,6 +38,7 @@
 
 (def ^:private Date                   (lib.schema.common/instance-of-class metabase.driver.common.parameters.Date))
 (def ^:private FieldFilter            (lib.schema.common/instance-of-class metabase.driver.common.parameters.FieldFilter))
+(def ^:private CustomFilter           (lib.schema.common/instance-of-class metabase.driver.common.parameters.CustomFilter))
 (def ^:private ReferencedQuerySnippet (lib.schema.common/instance-of-class metabase.driver.common.parameters.ReferencedQuerySnippet))
 (def ^:private ReferencedCardQuery    (lib.schema.common/instance-of-class metabase.driver.common.parameters.ReferencedCardQuery))
 
@@ -278,6 +279,14 @@
                  (if required
                    (throw (missing-required-param-exception (:display-name tag)))
                    params/no-value))})))
+
+(mu/defmethod parse-tag :custom-filter :- [:maybe CustomFilter]
+  [{tag-name :name :keys [effective-type] :as tag} :- mbql.s/TemplateTag
+   params                                          :- [:maybe [:sequential mbql.s/Parameter]]]
+  (params/map->CustomFilter
+   {:name tag-name
+    :effective-type effective-type
+    :value (field-filter-value tag params)}))
 
 ;;; Non-FieldFilter Params (e.g. WHERE x = {{x}})
 

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -36,7 +36,7 @@
                  :window-functions/offset
                  :distinct-where
                  :native-temporal-units
-                 :native-custom-filters
+                 :native/custom-filters
                  :expressions/datetime
                  :expressions/date
                  :expressions/text

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -36,6 +36,7 @@
                  :window-functions/offset
                  :distinct-where
                  :native-temporal-units
+                 :native-custom-filters
                  :expressions/datetime
                  :expressions/date
                  :expressions/text

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -64,12 +64,11 @@
   [[sql args missing] {[k column] :args} {:keys [effective-type value] :as v}]
   (if (and (params/CustomFilter? v) (string? k) (string? column))
     (let [{:keys [replacement-snippet prepared-statement-args]}
-          (mu/disable-enforcement
-            (sql.params.substitution/->replacement-snippet-info driver/*driver*
-                                                                (params/map->FieldFilter
-                                                                 {:field {:column column
-                                                                          :effective-type effective-type}
-                                                                  :value value})))]
+          (sql.params.substitution/->replacement-snippet-info driver/*driver*
+                                                              (params/map->FieldFilter
+                                                               {:field {:column column
+                                                                        :effective-type effective-type}
+                                                                :value value}))]
       [(str sql replacement-snippet) (concat args prepared-statement-args) missing])
     [sql args (conj missing k)]))
 

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -8,8 +8,7 @@
     :as sql.params.substitution]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.log :as log]))
 
 (defn- substitute-field-filter [[sql args missing] in-optional? k {:keys [_field value], :as v}]
   (if (and (= params/no-value value) in-optional?)

--- a/src/metabase/driver/sql/parameters/substitute.clj
+++ b/src/metabase/driver/sql/parameters/substitute.clj
@@ -8,7 +8,8 @@
     :as sql.params.substitution]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]))
 
 (defn- substitute-field-filter [[sql args missing] in-optional? k {:keys [_field value], :as v}]
   (if (and (= params/no-value value) in-optional?)
@@ -63,11 +64,12 @@
   [[sql args missing] {[k column] :args} {:keys [effective-type value] :as v}]
   (if (and (params/CustomFilter? v) (string? k) (string? column))
     (let [{:keys [replacement-snippet prepared-statement-args]}
-          (sql.params.substitution/->replacement-snippet-info driver/*driver*
-                                                              (params/map->FieldFilter
-                                                               {:field {:column column
-                                                                        :effective-type effective-type}
-                                                                :value value}))]
+          (mu/disable-enforcement
+            (sql.params.substitution/->replacement-snippet-info driver/*driver*
+                                                                (params/map->FieldFilter
+                                                                 {:field {:column column
+                                                                          :effective-type effective-type}
+                                                                  :value value})))]
       [(str sql replacement-snippet) (concat args prepared-statement-args) missing])
     [sql args (conj missing k)]))
 

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -363,7 +363,11 @@
 (mu/defmethod ->replacement-snippet-info [:sql FieldFilter]
   [driver                            :- :keyword
    {:keys [value], :as field-filter} :- [:map
-                                         [:field :any]
+                                         [:field [:or
+                                                  driver-api/schema.metadata.column
+                                                  [:map
+                                                   [:column driver-api/schema.common.non-blank-string]
+                                                   [:effective-type driver-api/schema.common.base-type]]]]
                                          [:value :any]]]
   (cond
     ;; otherwise if the value isn't present just put in something that will always be true, such as `1` (e.g. `WHERE 1

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -266,13 +266,15 @@
   (and (:column field)
        (:effective-type field)))
 
+(def raw-field
+  "Schema for a 'raw field' that a field filter will accept and treat as raw sql."
+  [:map
+   [:column driver-api/schema.common.non-blank-string]
+   [:effective-type driver-api/schema.common.base-type]])
+
 (mu/defn- field->clause :- [:or driver-api/mbql.schema.field driver-api/mbql.schema.raw]
   [driver     :- :keyword
-   field      :- [:or
-                  driver-api/schema.metadata.column
-                  [:map
-                   [:column driver-api/schema.common.non-blank-string]
-                   [:effective-type driver-api/schema.common.base-type]]]
+   field      :- [:or driver-api/schema.metadata.column raw-field]
    param-type :- driver-api/schema.parameter.type
    value]
   ;; The [[metabase.query-processor.middleware.parameters/substitute-parameters]] QP middleware actually happens before
@@ -363,11 +365,7 @@
 (mu/defmethod ->replacement-snippet-info [:sql FieldFilter]
   [driver                            :- :keyword
    {:keys [value], :as field-filter} :- [:map
-                                         [:field [:or
-                                                  driver-api/schema.metadata.column
-                                                  [:map
-                                                   [:column driver-api/schema.common.non-blank-string]
-                                                   [:effective-type driver-api/schema.common.base-type]]]]
+                                         [:field [:or driver-api/schema.metadata.column raw-field]]
                                          [:value :any]]]
   (cond
     ;; otherwise if the value isn't present just put in something that will always be true, such as `1` (e.g. `WHERE 1

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -278,8 +278,7 @@
   ;; the parameter. There's probably _some_ way to structure things that would make this "duplicate" call unneeded, but
   ;; I haven't figured out what that is yet
   (if (is-raw-field? field)
-    [:field (:column field) {:base-type :type/Raw
-                             :effective-type (:effective-type field)}]
+    [:raw (:column field)]
     [:field
      (u/the-id field)
      {:base-type                     (:base-type field)

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -29,7 +29,8 @@
     DateTimeRange
     FieldFilter
     ReferencedCardQuery
-    ReferencedQuerySnippet)))
+    ReferencedQuerySnippet
+    TemporalUnitWithCol)))
 
 ;;; ------------------------------------ ->prepared-substitution & default impls -------------------------------------
 
@@ -261,9 +262,13 @@
     {:replacement-snippet     snippet
      :prepared-statement-args args}))
 
+(defn- is-raw-field? [field]
+  (and (:column field)
+       (:effective-type field)))
+
 (mu/defn- field->clause :- driver-api/mbql.schema.field
   [driver     :- :keyword
-   field      :- driver-api/schema.metadata.column
+   field      :- :any
    param-type :- driver-api/schema.parameter.type
    value]
   ;; The [[metabase.query-processor.middleware.parameters/substitute-parameters]] QP middleware actually happens before
@@ -272,23 +277,28 @@
   ;; middleware would work either because we don't know what Field this parameter actually refers to until we resolve
   ;; the parameter. There's probably _some_ way to structure things that would make this "duplicate" call unneeded, but
   ;; I haven't figured out what that is yet
-  [:field
-   (u/the-id field)
-   {:base-type                     (:base-type field)
-    :temporal-unit                 (align-temporal-unit-with-param-type-and-value driver field param-type value)
-    driver-api/qp.add.source-table (:table-id field)
-    ;; in case anyone needs to know we're compiling a Field filter.
-    ::compiling-field-filter?      true}])
+  (if (is-raw-field? field)
+    [:field (:column field) {:base-type :type/Raw
+                             :effective-type (:effective-type field)}]
+    [:field
+     (u/the-id field)
+     {:base-type                     (:base-type field)
+      :temporal-unit                 (align-temporal-unit-with-param-type-and-value driver field param-type value)
+      driver-api/qp.add.source-table (:table-id field)
+      ;; in case anyone needs to know we're compiling a Field filter.
+      ::compiling-field-filter?      true}]))
 
 (mu/defn- field->identifier :- driver-api/schema.common.non-blank-string
   "Return an approprate snippet to represent this `field` in SQL given its param type.
    For non-date Fields, this is just a quoted identifier; for dates, the SQL includes appropriately bucketing based on
    the `param-type`."
   [driver field param-type value]
-  (->> (field->clause driver field param-type value)
-       (sql.qp/->honeysql driver)
-       (honeysql->replacement-snippet-info driver)
-       :replacement-snippet))
+  (if (is-raw-field? field)
+    (:column field)
+    (->> (field->clause driver field param-type value)
+         (sql.qp/->honeysql driver)
+         (honeysql->replacement-snippet-info driver)
+         :replacement-snippet)))
 
 (defn- field-filter->replacement-snippet-for-datetime-field
   "Generate replacement snippet for field filter on datetime field. For details on how range is generated see
@@ -304,7 +314,8 @@
 (mu/defn- field-filter->replacement-snippet-info :- ParamSnippetInfo
   "Return `[replacement-snippet & prepared-statement-args]` appropriate for a field filter parameter."
   [driver {{param-type :type, value :value, :as params} :value, field :field, :as field-filter}]
-  (assert (:id field) (format "Why doesn't Field have an ID?\n%s" (u/pprint-to-str field)))
+  (assert (or (:id field) (is-raw-field? field))
+          (format "Why doesn't Field have an ID?\n%s" (u/pprint-to-str field)))
   (letfn [(prepend-field [x]
             (update x :replacement-snippet
                     (partial str (field->identifier driver field param-type value) " ")))
@@ -349,7 +360,7 @@
 (mu/defmethod ->replacement-snippet-info [:sql FieldFilter]
   [driver                            :- :keyword
    {:keys [value], :as field-filter} :- [:map
-                                         [:field driver-api/schema.metadata.column]
+                                         [:field :any]
                                          [:value :any]]]
   (cond
     ;; otherwise if the value isn't present just put in something that will always be true, such as `1` (e.g. `WHERE 1
@@ -379,20 +390,12 @@
   {:prepared-statement-args nil
    :replacement-snippet     content})
 
-(defmulti time-grouping->replacement-snippet-info
-  "Like ->replacement-snipped-info, but specialized for converting time-groupings.  This is separate from the main
-  ->replacement-snippet-info because it requires an extra argument."
-  {:arglists '([driver column temporal-unit])
-   :added "0.55.0"}
-  driver/dispatch-on-initialized-driver
-  :hierarchy #'driver/hierarchy)
-
 (def date-groupings
   "Set of time groupings that should be coerced to dates"
   #{"day" "week" "month" "quarter" "year"})
 
-(defmethod time-grouping->replacement-snippet-info :sql
-  [driver column {:keys [value]}]
+(defmethod ->replacement-snippet-info [:sql TemporalUnitWithCol]
+  [driver {:keys [value column]}]
   (honeysql->replacement-snippet-info driver
                                       (if (= value params/no-value)
                                         [:raw column]

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -266,9 +266,13 @@
   (and (:column field)
        (:effective-type field)))
 
-(mu/defn- field->clause :- driver-api/mbql.schema.field
+(mu/defn- field->clause :- [:or driver-api/mbql.schema.field driver-api/mbql.schema.raw]
   [driver     :- :keyword
-   field      :- :any
+   field      :- [:or
+                  driver-api/schema.metadata.column
+                  [:map
+                   [:column driver-api/schema.common.non-blank-string]
+                   [:effective-type driver-api/schema.common.base-type]]]
    param-type :- driver-api/schema.parameter.type
    value]
   ;; The [[metabase.query-processor.middleware.parameters/substitute-parameters]] QP middleware actually happens before

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1354,7 +1354,7 @@
     (datetime-diff driver unit x y)))
 
 (defmethod ->honeysql [:sql :raw]
-  [driver [_ sql _opts]]
+  [_driver [_ sql _opts]]
   [:raw sql])
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -1368,7 +1368,7 @@
   `::add/desired-alias` key in the clause options.
 
   Optional third parameter `unique-name-fn` is no longer used as of 0.42.0."
-  ([_driver                                               :- :keyword
+  ([driver                                                :- :keyword
     [clause-type id-or-name opts] :- vector?]
    (let [desired-alias (or (get opts driver-api/qp.add.desired-alias)
                            ;; fallback behavior for anyone using SQL QP functions directly without including the stuff

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1368,7 +1368,7 @@
   `::add/desired-alias` key in the clause options.
 
   Optional third parameter `unique-name-fn` is no longer used as of 0.42.0."
-  ([driver                                                :- :keyword
+  ([_driver                                               :- :keyword
     [clause-type id-or-name opts] :- vector?]
    (let [desired-alias (or (get opts driver-api/qp.add.desired-alias)
                            ;; fallback behavior for anyone using SQL QP functions directly without including the stuff

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -865,43 +865,45 @@
 
 (defmethod ->honeysql [:sql :field]
   [driver [_ id-or-name options :as field-clause]]
-  (try
-    (let [source-table-aliases (field-source-table-aliases field-clause)
-          source-nfc-path      (field-nfc-path field-clause)
-          source-alias         (field-source-alias field-clause)
-          ;; we can only get database type if we have a field-id
-          ;; which means nested native queries will cause bugs like #42817
-          ;; but this should all be fixed with field refs overhaul!
-          ;; https://linear.app/metabase-inc/issue/ENG-8766/[epic]-field-refs-overhaul
-          field-metadata       (when (integer? id-or-name)
-                                 (driver-api/field (driver-api/metadata-provider) id-or-name))
-          allow-casting?       (and field-metadata
-                                    (not (:qp/ignore-coercion options)))
-          ;; preserve metadata attached to the original field clause, for example BigQuery temporal type information.
-          identifier           (-> (apply h2x/identifier :field
-                                          (concat source-table-aliases (->honeysql driver [::nfc-path source-nfc-path]) [source-alias]))
-                                   (with-meta (meta field-clause)))
-          identifier           (->honeysql driver identifier)
-          casted-field         (cast-field-if-needed driver field-metadata identifier)
-          database-type        (or (h2x/database-type casted-field)
-                                   (:database-type field-metadata))
-          maybe-add-db-type    (fn [expr]
-                                 (if (h2x/type-info->db-type (h2x/type-info expr))
-                                   expr
-                                   (h2x/with-database-type-info expr database-type)))]
-      (u/prog1
-        (cond->> (if allow-casting? casted-field identifier)
-          ;; only add type info if it wasn't added by [[cast-field-if-needed]]
-          database-type            maybe-add-db-type
-          (:temporal-unit options) (apply-temporal-bucketing driver options)
-          (:binning options)       (apply-binning options))
-        (log/trace (binding [*print-meta* true]
-                     (format "Compiled field clause\n%s\n=>\n%s"
-                             (u/pprint-to-str field-clause) (u/pprint-to-str <>))))))
-    (catch Throwable e
-      (throw (ex-info (tru "Error compiling :field clause: {0}" (ex-message e))
-                      {:clause field-clause}
-                      e)))))
+  (if (= (:base-type options) :type/Raw)
+    [:raw id-or-name]
+    (try
+      (let [source-table-aliases (field-source-table-aliases field-clause)
+            source-nfc-path      (field-nfc-path field-clause)
+            source-alias         (field-source-alias field-clause)
+            ;; we can only get database type if we have a field-id
+            ;; which means nested native queries will cause bugs like #42817
+            ;; but this should all be fixed with field refs overhaul!
+            ;; https://linear.app/metabase-inc/issue/ENG-8766/[epic]-field-refs-overhaul
+            field-metadata       (when (integer? id-or-name)
+                                   (driver-api/field (driver-api/metadata-provider) id-or-name))
+            allow-casting?       (and field-metadata
+                                      (not (:qp/ignore-coercion options)))
+            ;; preserve metadata attached to the original field clause, for example BigQuery temporal type information.
+            identifier           (-> (apply h2x/identifier :field
+                                            (concat source-table-aliases (->honeysql driver [::nfc-path source-nfc-path]) [source-alias]))
+                                     (with-meta (meta field-clause)))
+            identifier           (->honeysql driver identifier)
+            casted-field         (cast-field-if-needed driver field-metadata identifier)
+            database-type        (or (h2x/database-type casted-field)
+                                     (:database-type field-metadata))
+            maybe-add-db-type    (fn [expr]
+                                   (if (h2x/type-info->db-type (h2x/type-info expr))
+                                     expr
+                                     (h2x/with-database-type-info expr database-type)))]
+        (u/prog1
+          (cond->> (if allow-casting? casted-field identifier)
+            ;; only add type info if it wasn't added by [[cast-field-if-needed]]
+            database-type            maybe-add-db-type
+            (:temporal-unit options) (apply-temporal-bucketing driver options)
+            (:binning options)       (apply-binning options))
+          (log/trace (binding [*print-meta* true]
+                       (format "Compiled field clause\n%s\n=>\n%s"
+                               (u/pprint-to-str field-clause) (u/pprint-to-str <>))))))
+      (catch Throwable e
+        (throw (ex-info (tru "Error compiling :field clause: {0}" (ex-message e))
+                        {:clause field-clause}
+                        e))))))
 
 (defmethod ->honeysql [:sql :count]
   [driver [_ field]]

--- a/src/metabase/driver_api/core.clj
+++ b/src/metabase/driver_api/core.clj
@@ -190,6 +190,10 @@
   (p/import-def qp.error-type/qp qp.error-type.qp)
   (p/import-def qp.error-type/unsupported-feature qp.error-type.unsupported-feature))
 
+(def schema.common.base-type
+  "::lib.schema.common/base-type"
+  ::lib.schema.common/base-type)
+
 (def schema.common.non-blank-string
   "::lib.schema.common/non-blank-string"
   ::lib.schema.common/non-blank-string)
@@ -253,6 +257,10 @@
 (def mbql.schema.value
   "mbql.s/value"
   mbql.s/value)
+
+(def mbql.schema.raw
+  "mbql.s/raw"
+  mbql.s/raw)
 
 (def mbql.schema.field
   "mbql.s/field"

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -301,9 +301,10 @@
 (defn- template-tag-definition-key->transform-fn
   "Get the function that should be used to transform values for normalized key `k` in a template tag definition."
   [k]
-  (get {:default     identity
-        :type        maybe-normalize-token
-        :widget-type maybe-normalize-token}
+  (get {:default        identity
+        :type           maybe-normalize-token
+        :widget-type    maybe-normalize-token
+        :effective-type lib.schema.common/normalize-keyword}
        k
        ;; if there's not a special transform function for the key in the map above, just wrap the key-value
        ;; pair in a dummy map and let [[normalize-tokens]] take care of it. Then unwrap

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -327,6 +327,15 @@
        base-type
        true))])
 
+(mr/def ::raw
+  (helpers/clause
+   :raw
+   "sql" ::lib.schema.common/non-blank-string))
+
+(def ^{:added "0.56.0"} raw
+  "Schema for a `:raw` clause."
+  (with-meta [:ref ::raw] {:clause-name :raw}))
+
 (mr/def ::field
   [:and
    {:doc/title [:span [:code ":field"] " clause"]}
@@ -414,10 +423,12 @@
                   (string? x)                     :string
                   (is-clause? string-functions x) :string-expression
                   (is-clause? :value x)           :value
+                  (is-clause? :raw x)             :raw
                   :else                           :else))}
    [:string            :string]
    [:string-expression StringExpression]
    [:value             value]
+   [:raw               raw]
    [:else              Field]])
 
 (def ^:private StringExpressionArg
@@ -469,11 +480,13 @@
                        (is-clause? numeric-functions x) :numeric-expression
                        (is-clause? aggregations x)      :aggregation
                        (is-clause? :value x)            :value
+                       (is-clause? :raw x)              :raw
                        :else                            :field))}
    [:number             number?]
    [:numeric-expression NumericExpression]
    [:aggregation        Aggregation]
    [:value              value]
+   [:raw                raw]
    [:field              Field]])
 
 (def ^:private NumericExpressionArg
@@ -487,10 +500,12 @@
                        (is-clause? aggregations x)       :aggregation
                        (is-clause? :value x)             :value
                        (is-clause? datetime-functions x) :datetime-expression
+                       (is-clause? :raw x)               :raw
                        :else                             :else))}
    [:aggregation         Aggregation]
    [:value               value]
    [:datetime-expression DatetimeExpression]
+   [:raw                 raw]
    [:else                [:or [:ref ::DateOrDatetimeLiteral] Field]]])
 
 (def ^:private DateTimeExpressionArg
@@ -510,6 +525,7 @@
                        (string? x)                       :string
                        (is-clause? string-functions x)   :string-expression
                        (is-clause? :value x)             :value
+                       (is-clause? :raw x)               :raw
                        :else                             :else))}
    [:number               number?]
    [:boolean              :boolean]
@@ -520,6 +536,7 @@
    [:string               :string]
    [:string-expression    StringExpression]
    [:value                value]
+   [:raw                  raw]
    [:else                 Field]])
 
 (def ^:private ExpressionArg

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1222,6 +1222,35 @@
 
 ;; Example:
 ;;
+;;    {:id           "c20851c7-8a80-0ffa-8a99-ae636f0e9539"
+;;     :name         "date"
+;;     :display-name "Date"
+;;     :type         :custom-filter,
+;;     :dimension    [:field 4 nil]
+;;     :widget-type  :date/all-options}
+(mr/def ::TemplateTag:CustomFilter
+  "Schema for a field filter template tag."
+  [:merge
+   TemplateTag:Value:Common
+   [:map
+    [:type           [:= :custom-filter]]
+    [:dimension      {:optional true} field]
+    [:effective-type [:ref ::lib.schema.common/base-type]]
+
+    [:widget-type
+     [:ref
+      {:description
+       "which type of widget the frontend should show for this Field Filter; this also affects which parameter types
+  are allowed to be specified for it."}
+      ::WidgetType]]
+
+    [:options
+     {:optional    true
+      :description "optional map to be appended to filter clause"}
+     [:maybe [:map-of :keyword :any]]]]])
+
+;; Example:
+;;
 ;;   {:id "cd35d6dc-285b-4944-8a83-21e4c38d6584",
 ;;    :type "temporal-unit",
 ;;    :name "unit",
@@ -1290,6 +1319,7 @@
    [:snippet       [:ref ::TemplateTag:Snippet]]
    [:card          [:ref ::TemplateTag:SourceQuery]]
    [:temporal-unit [:ref ::TemplateTag:TemporalUnit]]
+   [:custom-filter [:ref ::TemplateTag:CustomFilter]]
    [::mc/default   [:ref ::TemplateTag:RawValue]]])
 
 (def TemplateTag

--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -21,7 +21,7 @@
 (mr/def ::type
   [:enum
    {:decode/normalize common/normalize-keyword}
-   :snippet :card :dimension :number :text :date :temporal-unit])
+   :snippet :card :dimension :number :text :date :temporal-unit :custom-filter])
 
 (mr/def ::name
   [:ref
@@ -60,6 +60,30 @@
    [:ref ::common]
    [:map
     [:type [:= :temporal-unit]]]])
+
+;; Example:
+;;
+;;    {:id           "c20851c7-8a80-0ffa-8a99-ae636f0e9539"
+;;     :name         "date"
+;;     :display-name "Date"
+;;     :type         :custom-filter,
+;;     :dimension    [:field 4 nil]
+;;     :widget-type  :date/all-options}
+(mr/def ::custom-filter
+  [:merge
+   [:ref ::value.common]
+   [:map
+    [:type        [:= :custom-filter]]
+    ;; custom filters do not need a dimension, since they sub in user-defined sql instead of a field reference.  They
+    ;; can have a dimension to provide field values, however.
+    [:dimension {:optional true} [:ref :mbql.clause/field]]
+    ;; needs an effective-type that tells the query processor what to do with the literal sql it will receive
+    [:effective-type [:ref ::common/base-type]]
+    ;; which type of widget the frontend should show for this Field Filter; this also affects which parameter types
+    ;; are allowed to be specified for it.
+    [:widget-type [:ref ::widget-type]]
+    ;; optional map to be appended to filter clause
+    [:options {:optional true} [:maybe :map]]]])
 
 ;; Example:
 ;;
@@ -157,6 +181,7 @@
     [:type [:ref ::type]]]
    [:multi {:dispatch #(keyword (:type %))}
     [:temporal-unit [:ref ::temporal-unit]]
+    [:custom-filter [:ref ::custom-filter]]
     [:dimension     [:ref ::field-filter]]
     [:snippet       [:ref ::snippet]]
     [:card          [:ref ::source-query]]

--- a/src/metabase/types/core.cljc
+++ b/src/metabase/types/core.cljc
@@ -341,6 +341,10 @@
 (derive :type/FK :Relation/*)
 (derive :type/PK :Relation/*)
 
+;; Raw sql type -- used to insert raw sql in place of a normal field reference
+
+(derive :type/Raw :type/*)
+
 ;;; Coercion strategies
 
 (derive :Coercion/String->Temporal :Coercion/*)

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -231,7 +231,7 @@
              (run-count-query query))))))
 
 (deftest ^:parallel custom-filter-param-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters :native-custom-filters :test/dynamic-dataset-loading)
+  (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters :native/custom-filters :test/dynamic-dataset-loading)
     (testing "temporal custom filters"
       (mt/dataset attempted-murders-no-time
         (doseq [[field field-type]
@@ -251,7 +251,7 @@
                                                    :attempts field-type field value-type value))))))))
 
 (deftest ^:parallel custom-filter-param-test-2
-  (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters :native-custom-filters ::field-filter-param-test-2)
+  (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters :native/custom-filters ::field-filter-param-test-2)
     (testing "text custom filters"
       (custom-filter-param-test-is-count-= 1
                                            :venues :type/Text :name :text "In-N-Out Burger"))

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -257,7 +257,7 @@
                                            :venues :type/Text :name :text "In-N-Out Burger"))
     (testing "number custom filters"
       (custom-filter-param-test-is-count-= 22
-                                           :venues :type/Number :price :number "1"))
+                                           :venues :type/Number :price :number 1))
     (testing "boolean custom filters"
       (mt/dataset places-cam-likes
         (custom-filter-param-test-is-count-= 2

--- a/test/metabase/query_processor_test/uuid_test.clj
+++ b/test/metabase/query_processor_test/uuid_test.clj
@@ -39,7 +39,8 @@
     (testing "uuid field filters"
       (mt/dataset uuid-dogs
         (let [query (assoc (mt/native-query
-                             (assoc (mt/count-with-field-filter-query driver/*driver* :people :id "27e164bc-54f8-47a0-a85a-9f0e90dd7667")
+                             (assoc (mt/count-with-field-filter-query driver/*driver* :people :id
+                                                                      {:sample-value "27e164bc-54f8-47a0-a85a-9f0e90dd7667"})
                                     :template-tags {"id" {:name         "id"
                                                           :display-name "id"
                                                           :type         :dimension

--- a/test/metabase/test/data/sql.clj
+++ b/test/metabase/test/data/sql.clj
@@ -365,7 +365,8 @@
    (let [parent-method (get-method tx/field-reference :sql/test-extensions)
          full-reference (parent-method driver field-id)
          [_ _ field-name] (str/split full-reference #"\.")]
-     (format "`t1`.%s" field-name))))
+     #_(format "`t1`.%s" field-name)
+     field-name)))
 
 ;; With bigquery, ->honeysql returns `db`.`orders`.`created_at`, but for whatever reason, the query actually wants
 ;; `db.orders`.`created_at`.

--- a/test/metabase/test/data/sql.clj
+++ b/test/metabase/test/data/sql.clj
@@ -359,13 +359,12 @@
         first)))
 
 ;; With sparksql, ->honeysql returns a fully qualified name (eg `test_data`.`orders`.`created_at`), but sparksql
-;; expects you to use the relevant alias instead (eg `t1`.`created_at`).
+;; doesn't like fully qualified names here.  Instead, it wants either the bare column name or the relevant alias.
 (defmethod tx/field-reference :sparksql
   ([driver field-id]
    (let [parent-method (get-method tx/field-reference :sql/test-extensions)
          full-reference (parent-method driver field-id)
          [_ _ field-name] (str/split full-reference #"\.")]
-     #_(format "`t1`.%s" field-name)
      field-name)))
 
 ;; With bigquery, ->honeysql returns `db`.`orders`.`created_at`, but for whatever reason, the query actually wants


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-1473/query-processor-supports-enhanced-native-filters

### Description

The query processor should now support {{mb.filter(...)}} syntax.

### How to verify

Create a query like

    {:database 1,
     :type "native",
     :native
     {:template-tags
      {:param
       {:type "custom-filter",
        :name "param",
        :id "e670b3b3-d1eb-43ad-9972-d775c886142a",
        :display-name "Param",
        :widget-type "string/=",
        :effective-type "type/Text",
        :dimension ["field" 58 nil]}},
      :query "SELECT * from products where {{mb.filter('param', 'category')}}"},
     :parameters
     [{:id "e670b3b3-d1eb-43ad-9972-d775c886142a",
       :type "string/=",
       :value ["Gizmo"],
       :target [:variable ["template-tag" "param"]]}]}

and pass it to qp/process-query

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
