### PR TITLE
show active y-axis split lines on hover

### DIFF
--- a/e2e/support/helpers/e2e-visual-tests-helpers.js
+++ b/e2e/support/helpers/e2e-visual-tests-helpers.js
@@ -67,6 +67,12 @@ export function echartsIcon(name, isSelected = false) {
   return echartsContainer().find(`image[href="${dataUri}"]`);
 }
 
+export function chartGridLines() {
+  return echartsContainer().find(
+    "path[stroke='var(--mb-color-border)'][fill='transparent'][stroke-dasharray='5']",
+  );
+}
+
 export function chartPathWithFillColor(color) {
   return echartsContainer().find(`path[fill="${color}"]`);
 }

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -95,7 +95,7 @@ describe("issue 45255", () => {
   });
 });
 
-describe("issue 49874", () => {
+describe("issue 49874, 48847", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -127,12 +127,15 @@ describe("issue 49874", () => {
       cy.findByText("Sum of Total").should("be.visible");
     });
 
+    H.chartGridLines().should("exist");
+
     H.chartPathWithFillColor("#88BF4D").first().realHover();
 
     H.echartsContainer().within(() => {
       cy.findByText("Sum of Quantity").should("be.visible");
       cy.findByText("Sum of Total").should("not.exist");
     });
+    H.chartGridLines().should("exist");
 
     H.chartPathWithFillColor("#98D9D9").first().realHover();
 
@@ -140,6 +143,7 @@ describe("issue 49874", () => {
       cy.findByText("Sum of Quantity").should("not.exist");
       cy.findByText("Sum of Total").should("be.visible");
     });
+    H.chartGridLines().should("exist");
   });
 });
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -397,15 +397,15 @@ export const buildMetricAxis = (
       axisModel.label,
       shouldFlipAxisName ? -90 : undefined,
     ),
-    splitLine:
-      hasSplitLine && !!settings["graph.y_axis.axis_enabled"]
-        ? {
-            lineStyle: {
-              type: 5,
-              ...renderingContext.theme.cartesian.splitLine.lineStyle,
-            },
-          }
-        : undefined,
+    splitLine: settings["graph.y_axis.axis_enabled"]
+      ? {
+          lineStyle: {
+            type: 5,
+            opacity: hasSplitLine ? 1 : 0,
+            ...renderingContext.theme.cartesian.splitLine.lineStyle,
+          },
+        }
+      : undefined,
     position,
     axisLine: {
       show: false,
@@ -417,7 +417,6 @@ export const buildMetricAxis = (
       margin: CHART_STYLE.axisTicksMarginY,
       show: !!settings["graph.y_axis.axis_enabled"],
       ...getTicksDefaultOption(renderingContext),
-      // @ts-expect-error TODO: figure out EChart types
       formatter: (rawValue) =>
         axisModel.formatter(
           yAxisScaleTransforms.fromEChartsAxisValue(rawValue),

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -491,3 +491,14 @@ export const buildAxes = (
     ),
   };
 };
+
+export const createAxisVisibilityOption = ({
+  show,
+  splitLineVisible,
+}: {
+  show: boolean;
+  splitLineVisible: boolean;
+}) => ({
+  show,
+  splitLine: { lineStyle: { opacity: splitLineVisible ? 1 : 0 } },
+});

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -417,6 +417,7 @@ export const buildMetricAxis = (
       margin: CHART_STYLE.axisTicksMarginY,
       show: !!settings["graph.y_axis.axis_enabled"],
       ...getTicksDefaultOption(renderingContext),
+      // @ts-expect-error TODO: figure out EChart types
       formatter: (rawValue) =>
         axisModel.formatter(
           yAxisScaleTransforms.fromEChartsAxisValue(rawValue),

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -107,15 +107,22 @@ export const useChartEvents = (
         return;
       }
 
-      const yAxisShowOption = [{ show: true }, { show: true }];
+      const visibleSplitLineOption = { lineStyle: { opacity: 1 } };
+      const hiddenSplitLineOption = { lineStyle: { opacity: 0 } };
+      const yAxisShowOption = [
+        { show: true, splitLine: visibleSplitLineOption },
+        { show: true, splitLine: hiddenSplitLineOption },
+      ];
       if (hoveredSeriesDataKey != null) {
         const hiddenYAxisIndex = chartModel.leftAxisModel?.seriesKeys.includes(
           hoveredSeriesDataKey,
         )
           ? 1
           : 0;
+        const visibleYAxisIndex = 1 - hiddenYAxisIndex;
 
         yAxisShowOption[hiddenYAxisIndex].show = false;
+        yAxisShowOption[visibleYAxisIndex].splitLine = visibleSplitLineOption;
       }
 
       chartRef.current?.setOption({ yAxis: yAxisShowOption }, false, true);

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -108,7 +108,7 @@ export const useChartEvents = (
         return;
       }
 
-      let yAxisShowOption;
+      let yAxisShowOption: ReturnType<typeof createAxisVisibilityOption>[];
 
       const noSeriesHovered = hoveredSeriesDataKey == null;
       const leftAxisSeriesHovered =

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -17,6 +17,7 @@ import type {
   BaseCartesianChartModel,
   ChartDataset,
 } from "metabase/visualizations/echarts/cartesian/model/types";
+import { createAxisVisibilityOption } from "metabase/visualizations/echarts/cartesian/option/axis";
 import type { TimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
 import { useClickedStateTooltipSync } from "metabase/visualizations/echarts/tooltip";
 import type {
@@ -107,22 +108,29 @@ export const useChartEvents = (
         return;
       }
 
-      const visibleSplitLineOption = { lineStyle: { opacity: 1 } };
-      const hiddenSplitLineOption = { lineStyle: { opacity: 0 } };
-      const yAxisShowOption = [
-        { show: true, splitLine: visibleSplitLineOption },
-        { show: true, splitLine: hiddenSplitLineOption },
-      ];
-      if (hoveredSeriesDataKey != null) {
-        const hiddenYAxisIndex = chartModel.leftAxisModel?.seriesKeys.includes(
-          hoveredSeriesDataKey,
-        )
-          ? 1
-          : 0;
-        const visibleYAxisIndex = 1 - hiddenYAxisIndex;
+      let yAxisShowOption;
 
-        yAxisShowOption[hiddenYAxisIndex].show = false;
-        yAxisShowOption[visibleYAxisIndex].splitLine = visibleSplitLineOption;
+      const noSeriesHovered = hoveredSeriesDataKey == null;
+      const leftAxisSeriesHovered =
+        hoveredSeriesDataKey != null &&
+        chartModel.leftAxisModel?.seriesKeys.includes(hoveredSeriesDataKey);
+
+      if (noSeriesHovered) {
+        yAxisShowOption = [
+          createAxisVisibilityOption({ show: true, splitLineVisible: true }),
+          createAxisVisibilityOption({ show: true, splitLineVisible: false }),
+        ];
+      } else if (leftAxisSeriesHovered) {
+        yAxisShowOption = [
+          createAxisVisibilityOption({ show: true, splitLineVisible: true }),
+          createAxisVisibilityOption({ show: false, splitLineVisible: false }),
+        ];
+      } else {
+        // right axis series hovered
+        yAxisShowOption = [
+          createAxisVisibilityOption({ show: false, splitLineVisible: false }),
+          createAxisVisibilityOption({ show: true, splitLineVisible: true }),
+        ];
       }
 
       chartRef.current?.setOption({ yAxis: yAxisShowOption }, false, true);


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #48847
Closes [VIZ-196](https://linear.app/metabase/issue/VIZ-196/show-grid-lines-for-right-y-axis-on-two-y-axes-charts-when-a-series)

### Description

Describe the overall approach and the problem being solved.

### How to verify

- Create a cartesian chart with two axes
- Ensure it shows only left y-axis split lines (dashed lines for every axis tick)
- Hover a series that uses the left axis: ensure only left y-axis with split lines is visibile 
- Hover a series that uses the right axis: ensure only right y-axis with split lines is visibile 

### Demo

<video src="https://github.com/user-attachments/assets/4dd1fdeb-e05f-4828-9763-53226d43ac32" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
