### PR TITLE
Fix `HostAppTestSuiteName` type

### DIFF
--- a/e2e/runner/embedding-sdk/host-apps/types.ts
+++ b/e2e/runner/embedding-sdk/host-apps/types.ts
@@ -2,4 +2,4 @@ export type HostAppTestSuiteName =
   | "vite-6-host-app-e2e"
   | "next-15-app-router-host-app-e2e"
   | "next-15-pages-router-host-app-e2e"
-  | "angular-20--host-app-e2e";
+  | "angular-20-host-app-e2e";


### PR DESCRIPTION
There was a typo in the angular-20 entry causing this

![image](https://github.com/user-attachments/assets/66763500-922d-4ef3-8029-a3308d70088f)
