### PR TITLE
Fix nextjs sample app env config

### DIFF
--- a/e2e/runner/embedding-sdk/sample-apps/constants/sample-app-setup-configs.js
+++ b/e2e/runner/embedding-sdk/sample-apps/constants/sample-app-setup-configs.js
@@ -27,9 +27,7 @@ export const SAMPLE_APP_SETUP_CONFIGS = {
     ...BASE_SETUP_CONFIG,
     appName: "metabase-nextjs-sdk-embedding-sample",
     env: {
-      WATCH: BASE_ENV.WATCH,
-      PREMIUM_EMBEDDING_TOKEN: BASE_ENV.PREMIUM_EMBEDDING_TOKEN,
-      MB_PORT: BASE_ENV.MB_PORT,
+      ...BASE_ENV,
       CLIENT_PORT_APP_ROUTER: BASE_ENV.CLIENT_PORT,
       CLIENT_PORT_PAGES_ROUTER: BASE_ENV.CLIENT_PORT + 1,
     },


### PR DESCRIPTION
The previous variant it seems didn't cause any issues, though the variant in this PR passes a missing `AUTH_PROVIDER_PORT` value