### PR TITLE
Fix failed host apps tests

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -117,8 +117,8 @@ e2e_ci: &e2e_ci
   - ".github/workflows/e2e-*"
 
 e2e_specs: &e2e_specs
-  - "**/*.cy.*.js"
-  - "**/*.cy.*.ts"
+  - "**/*.cy.*.{js,ts}"
+  - "!e2e/test-host-app/**/*.cy.*.{js,ts}"
 
 e2e_cross_version: &e2e_cross_version
   - ".github/workflows/e2e-cross-version.yml"

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -117,8 +117,7 @@ e2e_ci: &e2e_ci
   - ".github/workflows/e2e-*"
 
 e2e_specs: &e2e_specs
-  - "**/*.cy.*.{js,ts}"
-  - "!e2e/test-host-app/**/*.cy.*.{js,ts}"
+  - e2e/!(test-host-app)**/*.cy.*.{js,ts}
 
 e2e_cross_version: &e2e_cross_version
   - ".github/workflows/e2e-cross-version.yml"

--- a/e2e/test-host-app/shared/compatibility.cy.spec.js
+++ b/e2e/test-host-app/shared/compatibility.cy.spec.js
@@ -1,4 +1,3 @@
-import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import {
   mockAuthProviderAndJwtSignIn,
   signInAsAdminAndEnableEmbeddingSdk,
@@ -22,8 +21,8 @@ describe("Embedding SDK: shared Host Apps compatibility tests", () => {
       url: `${CLIENT_HOST}/interactive-dashboard`,
     });
 
-    getSdkRoot().should("exist");
-    getSdkRoot().within(() => {
+    sdkRoot().should("exist");
+    sdkRoot().within(() => {
       cy.findByTestId("fixed-width-dashboard-header", {
         timeout: TIMEOUT_MS,
       }).within(() => {
@@ -96,3 +95,7 @@ describe("Embedding SDK: shared Host Apps compatibility tests", () => {
     });
   });
 });
+
+function sdkRoot() {
+  return cy.get("#metabase-sdk-root");
+}

--- a/e2e/test-host-app/shared/compatibility.cy.spec.js
+++ b/e2e/test-host-app/shared/compatibility.cy.spec.js
@@ -1,3 +1,4 @@
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import {
   mockAuthProviderAndJwtSignIn,
   signInAsAdminAndEnableEmbeddingSdk,
@@ -21,7 +22,8 @@ describe("Embedding SDK: shared Host Apps compatibility tests", () => {
       url: `${CLIENT_HOST}/interactive-dashboard`,
     });
 
-    cy.findByTestId("embed-frame", { timeout: TIMEOUT_MS }).within(() => {
+    getSdkRoot().should("exist");
+    getSdkRoot().within(() => {
       cy.findByTestId("fixed-width-dashboard-header", {
         timeout: TIMEOUT_MS,
       }).within(() => {


### PR DESCRIPTION
Part of https://linear.app/metabase/issue/EMB-573/fix-sample-apps-failing-on-master-after-merging-59529

### Description

Fix the failed host apps tests, due to the merge of https://github.com/metabase/metabase/pull/59529

### How to verify

1. Run `yarn build-embedding-sdk` (I don't know if you need this step, but it wouldn't hurt)
1. Run different host app suite e.g. `TEST_SUITE=vite-6-host-app-e2e yarn test-cypress`. You can see the rest of the host apps in the Linear issue.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
