### PR TITLE
Fixed database option announcement issues on the setup page.

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -94,7 +94,7 @@ describe("scenarios > setup", () => {
           cy.findByText("MySQL").click();
           cy.findByText("Need help connecting?").should("be.visible");
           cy.findByLabelText("Remove database").click();
-          cy.findByPlaceholderText("Search for a database…").type("SQL");
+          cy.findByLabelText("Search for a database").type("SQL");
           cy.findByText("SQLite").click();
           cy.findByText("Need help connecting?");
 
@@ -344,7 +344,7 @@ describe("scenarios > setup", () => {
       .click();
 
     cy.findByTestId("database-form").within(() => {
-      cy.findByPlaceholderText("Search for a database…").type("lite").blur();
+      cy.findByLabelText("Search for a database").type("SQL");
       cy.findByText("SQLite").click();
       cy.findByLabelText("Display name").type(dbName);
       cy.findByLabelText("Filename").type("./resources/sqlite-fixture.db", {

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -344,7 +344,7 @@ describe("scenarios > setup", () => {
       .click();
 
     cy.findByTestId("database-form").within(() => {
-      cy.findByLabelText("Search for a database").type("SQL");
+      cy.findByLabelText("Search for a database").type("lite").blur();
       cy.findByText("SQLite").click();
       cy.findByLabelText("Display name").type(dbName);
       cy.findByLabelText("Filename").type("./resources/sqlite-fixture.db", {

--- a/frontend/src/metabase/common/components/HiddenAriaMessage.tsx
+++ b/frontend/src/metabase/common/components/HiddenAriaMessage.tsx
@@ -1,0 +1,26 @@
+interface HiddenAriaMessageProps {
+  message: string;
+  ariaLive?: "polite" | "assertive";
+  ariaAtomic?: boolean;
+}
+
+export const HiddenAriaMessage = ({
+  message,
+  ariaLive = "polite",
+  ariaAtomic = true,
+}: HiddenAriaMessageProps) => (
+  <div
+    className="visually-hidden"
+    aria-live={ariaLive}
+    aria-atomic={ariaAtomic}
+    style={{
+      position: "absolute",
+      left: "-9999px",
+      width: "1px",
+      height: "1px",
+      overflow: "hidden",
+    }}
+  >
+    {message}
+  </div>
+);

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.styled.tsx
@@ -34,15 +34,20 @@ export const EngineCardRoot = styled.button<EngineCardRootProps>`
   justify-content: center;
   height: 5.375rem;
   padding: 1rem;
-  border: 1px solid var(--mb-color-bg-medium);
+  border: 2px solid var(--mb-color-background);
   border-radius: 0.375rem;
   background-color: var(--mb-color-bg-white);
   cursor: pointer;
-  outline: ${(props) => props.isActive && `2px solid var(--mb-color-focus)`};
+  outline: ${(props) => props.isActive && `2px solid var(--mb-color-brand)`};
 
   &:hover {
     border-color: var(--mb-color-brand);
     background-color: ${() => lighten("brand", 0.6)};
+  }
+
+  &:focus {
+    border: 2px solid var(--mb-color-background);
+    outline: 2px solid var(--mb-color-brand);
   }
 `;
 

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.tsx
@@ -273,13 +273,13 @@ const EngineEmptyState = ({ isHosted }: EngineEmptyStateProps): JSX.Element => {
     <EngineEmptyStateRoot>
       <EngineEmptyIcon name="search" size={32} />
       {isHosted ? (
-        <EngineEmptyText>{t`Didn't find anything`}</EngineEmptyText>
+        <EngineEmptyText>{t`Didn’t find anything`}</EngineEmptyText>
       ) : (
-        <EngineEmptyText>{jt`Don't see your database? Check out our ${(
+        <EngineEmptyText>{jt`Don’t see your database? Check out our ${(
           <ExternalLink key="link" href={docsUrl}>
             {t`Community Drivers`}
           </ExternalLink>
-        )} page to see if it's available for self-hosting.`}</EngineEmptyText>
+        )} page to see if it’s available for self-hosting.`}</EngineEmptyText>
       )}
     </EngineEmptyStateRoot>
   );


### PR DESCRIPTION


Closes https://github.com/metabase/metabase/issues/60260

### Description
Accessibility of the database options step in the setup page is improved. A label is added for the searchInput field, the screen reader now announces the database options available, and the focus of the database option is improved.
 
### How to verify
- Added a label to the search input field called "Search for a database" and removed the placeholder.
- The auto-suggest list of databases is announced by screen readers as soon as the list of database options changes.
- Implemented the Tab key for keyboard focus on database options, rather than just relying on arrow keys.
- Made the keyboard focus style for the database options the same thick box border with gap as in the button focus.
 
### Demo


https://github.com/user-attachments/assets/939cb6f2-5676-44df-9b03-27a070f7ab31


### Note

- Focus of the 'Next" button is implemented via a separate pull request: https://github.com/metabase/metabase/pull/60175

- Screen reader announcement for the database options has been implemented only for the English language.
