### PR TITLE
SEM-434 Missing metadata in FieldDataSelector

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.ts
@@ -838,8 +838,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       cy.findByText("User ID").should("be.visible");
     });
 
-    // TODO: https://linear.app/metabase/issue/SEM-434
-    it.skip("should allow setting foreign key mapping for accessible tables", () => {
+    it("should allow setting foreign key mapping for accessible tables", () => {
       setDataModelPermissions({
         tableIds: [ORDERS_ID, REVIEWS_ID, PRODUCTS_ID],
       });

--- a/frontend/src/metabase/metadata/components/RemappingPicker/RemappingPicker.tsx
+++ b/frontend/src/metabase/metadata/components/RemappingPicker/RemappingPicker.tsx
@@ -37,6 +37,7 @@ import {
   getFkTargetTableEntityNameOrNull,
   getOptions,
   getValue,
+  hydrateTableFields,
   is403Error,
 } from "./utils";
 
@@ -68,7 +69,7 @@ export const RemappingPicker = ({
           ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
         },
   );
-  const { data: fkTargetTable } = useGetTableQueryMetadataQuery(
+  const { data: fkTargetTableData } = useGetTableQueryMetadataQuery(
     fkTargetField?.table_id == null
       ? skipToken
       : {
@@ -76,6 +77,10 @@ export const RemappingPicker = ({
           include_sensitive_fields: true,
           ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
         },
+  );
+  const fkTargetTable = useMemo(
+    () => hydrateTableFields(fkTargetTableData),
+    [fkTargetTableData],
   );
   const { data: fieldValues } = useGetFieldValuesQuery(id);
 
@@ -186,6 +191,7 @@ export const RemappingPicker = ({
               selectedTable={fkTargetTable}
               selectedTableId={fkTargetTable?.id}
               setFieldFn={handleFkRemappingFieldChange}
+              tables={[fkTargetTable]}
               triggerElement={
                 <Select
                   data={[

--- a/frontend/src/metabase/metadata/components/RemappingPicker/RemappingPicker.tsx
+++ b/frontend/src/metabase/metadata/components/RemappingPicker/RemappingPicker.tsx
@@ -82,6 +82,7 @@ export const RemappingPicker = ({
     () => hydrateTableFields(fkTargetTableData),
     [fkTargetTableData],
   );
+  const tables = useMemo(() => [fkTargetTable], [fkTargetTable]);
   const { data: fieldValues } = useGetFieldValuesQuery(id);
 
   const value = useMemo(() => getValue(field), [field]);
@@ -191,7 +192,7 @@ export const RemappingPicker = ({
               selectedTable={fkTargetTable}
               selectedTableId={fkTargetTable?.id}
               setFieldFn={handleFkRemappingFieldChange}
-              tables={[fkTargetTable]}
+              tables={tables}
               triggerElement={
                 <Select
                   data={[

--- a/frontend/src/metabase/metadata/components/RemappingPicker/utils.ts
+++ b/frontend/src/metabase/metadata/components/RemappingPicker/utils.ts
@@ -2,10 +2,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { getColumnIcon } from "metabase/common/utils/columns";
-import {
-  getFieldDisplayName,
-  getRawTableFieldId,
-} from "metabase/metadata/utils/field";
+import { getRawTableFieldId } from "metabase/metadata/utils/field";
 import * as Lib from "metabase-lib";
 import { getRemappings } from "metabase-lib/v1/queries/utils/field";
 import { isEntityName, isFK } from "metabase-lib/v1/types/utils/isa";
@@ -108,7 +105,7 @@ export function hydrateTableFields(
     ...table,
     fields: table.fields?.map((field) => ({
       ...field,
-      displayName: () => getFieldDisplayName(field),
+      displayName: () => field.display_name,
       icon: () => getColumnIcon(Lib.legacyColumnTypeInfo(field)),
       table,
     })),

--- a/frontend/src/metabase/metadata/components/RemappingPicker/utils.ts
+++ b/frontend/src/metabase/metadata/components/RemappingPicker/utils.ts
@@ -106,13 +106,11 @@ export function hydrateTableFields(
 
   return {
     ...table,
-    fields: table.fields?.map((field) => {
-      return {
-        ...field,
-        displayName: () => getFieldDisplayName(field),
-        icon: () => getColumnIcon(Lib.legacyColumnTypeInfo(field)),
-        table,
-      };
-    }),
+    fields: table.fields?.map((field) => ({
+      ...field,
+      displayName: () => getFieldDisplayName(field),
+      icon: () => getColumnIcon(Lib.legacyColumnTypeInfo(field)),
+      table,
+    })),
   };
 }

--- a/frontend/src/metabase/metadata/components/RemappingPicker/utils.ts
+++ b/frontend/src/metabase/metadata/components/RemappingPicker/utils.ts
@@ -1,7 +1,12 @@
 import { t } from "ttag";
 import _ from "underscore";
 
-import { getRawTableFieldId } from "metabase/metadata/utils/field";
+import { getColumnIcon } from "metabase/common/utils/columns";
+import {
+  getFieldDisplayName,
+  getRawTableFieldId,
+} from "metabase/metadata/utils/field";
+import * as Lib from "metabase-lib";
 import { getRemappings } from "metabase-lib/v1/queries/utils/field";
 import { isEntityName, isFK } from "metabase-lib/v1/types/utils/isa";
 import type { Field, FieldId, FieldValue, Table } from "metabase-types/api";
@@ -85,4 +90,29 @@ export function getFieldRemappedValues(
   fieldValues: FieldValue[] | undefined,
 ): Map<number, string> {
   return new Map(getRemappings({ values: fieldValues }));
+}
+
+/**
+ * Adds 3 extra attributes to every Field, so that DataSelector does not break.
+ * DataSelector component expects metabase-lib/v1/metadata/Field objects (entity framework),
+ * but this modern module uses Field from metabase-types/api/field.ts instead.
+ */
+export function hydrateTableFields(
+  table: Table | undefined,
+): Table | undefined {
+  if (!table) {
+    return undefined;
+  }
+
+  return {
+    ...table,
+    fields: table.fields?.map((field) => {
+      return {
+        ...field,
+        displayName: () => getFieldDisplayName(field),
+        icon: () => getColumnIcon(Lib.legacyColumnTypeInfo(field)),
+        table,
+      };
+    }),
+  };
 }

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -394,6 +394,7 @@ export class UnconnectedDataSelector extends Component {
     const invalidSchema =
       selectedDatabase &&
       selectedSchema &&
+      selectedSchema.database &&
       selectedSchema.database.id !== selectedDatabase.id &&
       selectedSchema.database.id !== SAVED_QUESTIONS_VIRTUAL_DB_ID;
 


### PR DESCRIPTION
Closes [SEM-434](https://linear.app/metabase/issue/SEM-434/missing-metadata-in-fielddataselector)


### How to verify

Unskipped test passes.
There are no errors in JS console when interacting with foreign key column picker in Display values section.

1. Admin > Table metadata
2. Navigate to a Foreign Key field
3. Choose "Foreign key" in "Display values" input
4. Foreign key column picker appears below
5. Foreign key column picker works as expected
