### PR TITLE
docs - links and link fixes

### DIFF
--- a/docs/cloud/migrate/guide-pre-50.md
+++ b/docs/cloud/migrate/guide-pre-50.md
@@ -21,7 +21,7 @@ And don't stress. You won't lose any of your work, and if you get stuck, we're h
 
 ### Understand the limitations
 
-There are some [limitations](../limitations) to Metabase Cloud that may impact your migration.
+There are some [limitations](../limitations.md) to Metabase Cloud that may impact your migration.
 
 ### Confirm you have the right access
 
@@ -37,7 +37,7 @@ All you need to do is stop the Metabase JAR process or Docker container to make 
 
 ### Back up your application database
 
-In the unlikely event that something goes wrong, you'll want a backup. See [Backing up Metabase Application Data](/docs/latest/installation-and-operation/backing-up-metabase-application-data).
+In the unlikely event that something goes wrong, you'll want a backup. See [Backing up Metabase Application Data](../../installation-and-operation/backing-up-metabase-application-data.md).
 
 ## Migrate your Metabase to Metabase Cloud
 
@@ -59,7 +59,7 @@ Before executing the migration script, you may need to set the environment varia
 
 - **Docker**: the environment variables will already be set.
 - **JAR**: set the environment variables by running `MB_DB_CONNECTION_URI=xxxxx migration_script.sh` on the server where you're running the JAR.
-- **Heroku**: please follow a [few extra steps to running the script](heroku).
+- **Heroku**: please follow a [few extra steps to running the script](./heroku.md).
 
 ### Execute the script in your self-hosted environment
 
@@ -74,7 +74,7 @@ If anything goes sideways, follow any prompts the script outputs. If you're stil
 After a successful upload, some finishing touches and a restart is done automatically in a couple of minutes, and then you can log into your shiny new Metabase Cloud instance. You should see all of your questions and dashboards just as you did in your self-hosted instance.
 
 - **If you're using Google Sign-in**, you'll need to go to [Google Developers Console](https://console.developers.google.com/) and add your new Metabase Cloud URL to the Authorized JavaScript Origins of the Google Auth Client ID.
-- **For Pro and Enterprise customers using SAML SSO**, you'll need to update your settings with your identity provider to change the Redirect URL and the Base URL to your new Metabase Cloud URL, otherwise your identity provider will still redirect people to your old (and shut down) Metabase instance. See [Authenticating with SAML](/docs/latest/people-and-groups/authenticating-with-saml) for details on how to set these URLs.
+- **For Pro and Enterprise customers using SAML SSO**, you'll need to update your settings with your identity provider to change the Redirect URL and the Base URL to your new Metabase Cloud URL, otherwise your identity provider will still redirect people to your old (and shut down) Metabase instance. See [Authenticating with SAML](../../people-and-groups/authenticating-with-saml.md).
 
 ## Tell your team about the new Metabase address
 
@@ -92,4 +92,4 @@ We'll take care of your Metabase and keep it up to date from here on out. Welcom
 
 ## Need help?
 
-If you have any questions, just [send us an email](/help/).
+If you have any questions, just [send us an email](https://www.metabase.com/help/).

--- a/docs/dashboards/subscriptions.md
+++ b/docs/dashboards/subscriptions.md
@@ -132,7 +132,7 @@ The section to call out here is the **Set filter values for when this gets sent*
 
 See [Notification permissions](../permissions/notifications.md).
 
-## Removing Metabase branding from alerts
+## Removing Metabase branding from subscriptions
 
 See [Remove Metabase branding from exports](../questions/exporting-results.md#remove-metabase-branding-from-exports).
 

--- a/docs/dashboards/subscriptions.md
+++ b/docs/dashboards/subscriptions.md
@@ -132,6 +132,10 @@ The section to call out here is the **Set filter values for when this gets sent*
 
 See [Notification permissions](../permissions/notifications.md).
 
+## Removing Metabase branding from alerts
+
+See [Remove Metabase branding from exports](../questions/exporting-results.md#remove-metabase-branding-from-exports).
+
 ## Further reading
 
 - [Alerts](../questions/alerts.md)

--- a/docs/questions/alerts.md
+++ b/docs/questions/alerts.md
@@ -150,6 +150,10 @@ See [Notification permissions](../permissions/notifications.md).
 
 See [Sending alerts and subscriptions to private Slack channels](../configuring-metabase/slack.md#sending-alerts-and-subscriptions-to-private-slack-channels).
 
+## Removing Metabase branding from alerts
+
+See [Remove Metabase branding from exports](./exporting-results.md#remove-metabase-branding-from-exports).
+
 ## Further reading
 
 - [Dashboard subscriptions](../dashboards/subscriptions.md)


### PR DESCRIPTION
Adds links re: removing Metabase branding from exports. Fixes some other links.