### PR TITLE
Stop unfurling links in Slack notifications

### DIFF
--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -182,14 +182,6 @@
   []
   (not (premium-features/enable-whitelabeling?)))
 
-(def metabase-branding-link
-  "Metabase link with UTM params related to the branding exports campaign"
-  "https://www.metabase.com?utm_source=product&utm_medium=export&utm_campaign=exports_branding&utm_content=slack")
-
-(def metabase-branding-copy
-  "Human visible Markdown content that we use for branding purposes in Slack links"
-  "Made with :blue_heart: at")
-
 (defn- slack-dashboard-header
   "Returns a block element that includes a dashboard's name, creator, and filters, for inclusion in a
   Slack dashboard subscription"
@@ -208,9 +200,7 @@
                                    (include-branding?)
                                    (conj
                                     {:type "mrkdwn"
-                                     :text (str metabase-branding-copy " " (mkdwn-link-text
-                                                                            metabase-branding-link
-                                                                            "metabase.com"))}))}
+                                     :text  "Made with Metabase :blue_heart:"}))}
         filter-fields   (for [parameter top-level-params]
                           {:type "mrkdwn"
                            :text (parameter-markdown parameter)})

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -208,9 +208,9 @@
                                    (include-branding?)
                                    (conj
                                     {:type "mrkdwn"
-                                     :text (str metabase-branding-copy (mkdwn-link-text
-                                                                        metabase-branding-link
-                                                                        "metabase.com"))}))}
+                                     :text (str metabase-branding-copy " " (mkdwn-link-text
+                                                                            metabase-branding-link
+                                                                            "metabase.com"))}))}
         filter-fields   (for [parameter top-level-params]
                           {:type "mrkdwn"
                            :text (parameter-markdown parameter)})

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -188,7 +188,7 @@
 
 (def metabase-branding-copy
   "Human visible Markdown content that we use for branding purposes in Slack links"
-  "Made with Metabase :blue_heart:")
+  "Made with :blue_heart: at")
 
 (defn- slack-dashboard-header
   "Returns a block element that includes a dashboard's name, creator, and filters, for inclusion in a
@@ -208,9 +208,9 @@
                                    (include-branding?)
                                    (conj
                                     {:type "mrkdwn"
-                                     :text (mkdwn-link-text
-                                            metabase-branding-link
-                                            metabase-branding-copy)}))}
+                                     :text (str metabase-branding-copy (mkdwn-link-text
+                                                                        metabase-branding-link
+                                                                        "metabase.com"))}))}
         filter-fields   (for [parameter top-level-params]
                           {:type "mrkdwn"
                            :text (parameter-markdown parameter)})

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -182,18 +182,11 @@
                       processed    (with-redefs [slack/upload-file! (constantly {:url "a.com", :id "id"})]
                                      (channel/render-notification :channel/slack notification nil [recipient]))]
                   (->> processed first :attachments first :blocks last :fields
-                       (map :text))))))
-          (markdown-link? [s]
-            (is (string? s))
-            (let [[_whole url label] (re-find #"\<(.*)\|(.*)\>" s)]
-              (is (string? label))
-              (is (u/url? url))))]
+                       (map :text))))))]
     (when config/ee-available?
-      (testing "When whitelabeling is enabled, branding link should not be included"
+      (testing "When whitelabeling is enabled, branding content should not be included"
         (let [links (render-dashboard-links true)]
-          (is (every? markdown-link? links))
           (is (= 1 (count links))))))
-    (testing "When whitelabeling is disabled, branding link should be included"
+    (testing "When whitelabeling is disabled, branding content should be included"
       (let [links (render-dashboard-links false)]
-        (is (every? markdown-link? links))
         (is (= 2 (count links)))))))

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -5,8 +5,7 @@
    [metabase.channel.impl.slack :as channel.slack]
    [metabase.channel.slack :as slack]
    [metabase.config.core :as config]
-   [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -225,7 +225,7 @@
   "Appends branding content to the :fields list in the Slack link-section.
    Unless we're running the Pro/Enterprise plan, all Slack header links will include branding"
   [fields]
-  (conj fields {:text (str "<" channel.slack/metabase-branding-link "|" channel.slack/metabase-branding-copy ">")
+  (conj fields {:text "Made with Metabase :blue_heart:"
                 :type "mrkdwn"}))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Resolves PRG-75

We have to remove the link altogether because we can't stop it from unfurling. My suggestion is to keep only the text part of the branding like so
![image](https://github.com/user-attachments/assets/5856623d-0e96-411d-8871-c3dcc0e79d26)

