### PR TITLE
Closes #60285 - Top padding on dashboards is too small when there are no filters

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -176,7 +176,10 @@ function Dashboard({ className }: { className?: string }) {
           data-testid="dashboard-parameters-and-cards"
         >
           <DashboardParameterPanel />
-          <FullWidthContainer data-element-id="dashboard-cards-container">
+          <FullWidthContainer
+            className={S.CardsContainer}
+            data-element-id="dashboard-cards-container"
+          >
             <Grid />
           </FullWidthContainer>
         </Box>


### PR DESCRIPTION
Closes #60285

### Description

Brings back `.CardsContainer` class that was removed in #59529

### How to verify

1. Navigate to a dashboard with cards and no filters
2. Verify there's a small gap between the header bottom border and the top of the cards

### Demo

| Filters? | Master | Branch |
| --- | --- | --- |
| N | ![master-no-tabs](https://github.com/user-attachments/assets/9c44e9fb-466f-48b3-806e-3383fd55dce4) | ![branch-no-tabs](https://github.com/user-attachments/assets/42913147-80df-48ba-8aa8-8671cd6e903f) |
| Y | ![master-tabs](https://github.com/user-attachments/assets/6b3c51f8-be56-479a-8eb2-a2df594bab0b) | ![branch-tabs](https://github.com/user-attachments/assets/40eb2962-cc60-4315-a419-fe22914faf7e) |