### PR TITLE
Fix bucketed column names after the annotate PR

### DIFF
--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -108,7 +108,7 @@ describe("binning related reproductions", () => {
 
     H.getNotebookStep("summarize").findByText("CREATED_AT: Month").click();
     H.popover()
-      .findByRole("option", { name: "CREATED_AT: Month" })
+      .findByRole("option", { name: "CREATED_AT" })
       .findByLabelText("Temporal bucket")
       .realHover()
       .click();

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1035,10 +1035,10 @@ describe("issue 8490", () => {
               ],
             ],
             filter: [
-              "time-interval",
+              "between",
               ["field", PRODUCTS.CREATED_AT, { "base-type": "type/DateTime" }],
-              -12,
-              "month",
+              "2024-01-01",
+              "2025-01-01",
             ],
           },
           limit: 100,

--- a/e2e/test/scenarios/metrics/metrics-question.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-question.cy.spec.js
@@ -115,7 +115,7 @@ describe("scenarios > metrics > question", () => {
       .click();
     cy.findByTestId("sidebar-content")
       .findByTestId("pinned-dimensions")
-      .findByLabelText("Created At: Month")
+      .findByLabelText("Created At")
       .findByText("by month")
       .realHover()
       .click();

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -71,7 +71,11 @@ export function QueryColumnPicker({
         const groupInfo = Lib.displayInfo(query, stageIndex, group);
 
         const items = Lib.getColumnsFromColumnGroup(group).map((column) => ({
-          ...Lib.displayInfo(query, stageIndex, column),
+          ...Lib.displayInfo(
+            query,
+            stageIndex,
+            getColumnWithoutBucketing(column, hasTemporalBucketing, hasBinning),
+          ),
           column,
         }));
 
@@ -81,7 +85,7 @@ export function QueryColumnPicker({
           items,
         };
       }),
-    [query, stageIndex, columnGroups],
+    [query, stageIndex, columnGroups, hasTemporalBucketing, hasBinning],
   );
 
   const handleSelect = useCallback(
@@ -219,6 +223,20 @@ export function QueryColumnPicker({
       />
     </DelayGroup>
   );
+}
+
+function getColumnWithoutBucketing(
+  column: Lib.ColumnMetadata,
+  hasTemporalBucketing: boolean,
+  hasBinning: boolean,
+) {
+  if (hasTemporalBucketing && Lib.temporalBucket(column) != null) {
+    return Lib.withTemporalBucket(column, null);
+  }
+  if (hasBinning && Lib.binning(column) != null) {
+    return Lib.withBinning(column, null);
+  }
+  return column;
 }
 
 function renderItemName(item: ColumnListItem) {

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -225,6 +225,8 @@ export function QueryColumnPicker({
   );
 }
 
+// if there is a separate picker for temporal bucketing or binning,
+// we do not want to include it in the column name
 function getColumnWithoutBucketing(
   column: Lib.ColumnMetadata,
   hasTemporalBucketing: boolean,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/util.ts
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/util.ts
@@ -12,8 +12,11 @@ export function getBreakoutListItem(
     return;
   }
 
-  const columnWithoutBinning = Lib.withBinning(column, null);
-  const columnInfo = Lib.displayInfo(query, stageIndex, columnWithoutBinning);
+  const columnWithoutBucketing = Lib.withBinning(
+    Lib.withTemporalBucket(column, null),
+    null,
+  );
+  const columnInfo = Lib.displayInfo(query, stageIndex, columnWithoutBucketing);
   return { ...columnInfo, column, breakout };
 }
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -216,8 +216,7 @@ describe("SummarizeSidebar", () => {
     expect(screen.getAllByLabelText("Created At")).toHaveLength(3);
   });
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("should highlight selected breakout columns", async () => {
+  it("should highlight selected breakout columns", async () => {
     await setup({ query: createSummarizedQuery() });
 
     const [ordersCreatedAt, peopleCreatedAt] =
@@ -229,8 +228,7 @@ describe("SummarizeSidebar", () => {
     expect(peopleCreatedAt).toHaveAttribute("aria-selected", "false");
   });
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("should list breakouts added before opening the sidebar in a separate section", async () => {
+  it("should list breakouts added before opening the sidebar in a separate section", async () => {
     await setup({ query: createSummarizedQuery() });
 
     expect(
@@ -250,8 +248,7 @@ describe("SummarizeSidebar", () => {
     ).toHaveLength(2);
   });
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("should show multiple breakouts of the same column", async () => {
+  it("should show multiple breakouts of the same column", async () => {
     await setup({
       query: createQueryWithBreakoutsForSameColumn(),
     });
@@ -293,8 +290,7 @@ describe("SummarizeSidebar", () => {
     ]);
   });
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("should allow to remove breakouts of the same column", async () => {
+  it("should allow to remove breakouts of the same column", async () => {
     const { getNextBreakouts } = await setup({
       query: createQueryWithBreakoutsForSameColumn(),
     });
@@ -458,8 +454,7 @@ describe("SummarizeSidebar", () => {
     await waitFor(() => expect(getNextBreakouts()).toHaveLength(3));
   });
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("should remove breakout", async () => {
+  it("should remove breakout", async () => {
     const { getNextBreakouts } = await setup({
       query: createSummarizedQuery(),
     });

--- a/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -208,8 +208,7 @@ describe("BreakoutStep", () => {
       expect(breakout.displayName).toBe("Total: 10 bins");
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("should highlight selected binning strategy", async () => {
+    it("should highlight selected binning strategy", async () => {
       const query = createQueryWithBreakoutAndBinningStrategy();
       setup({ step: createMockNotebookStep({ query }) });
 
@@ -222,8 +221,7 @@ describe("BreakoutStep", () => {
       ).toHaveAttribute("aria-selected", "true");
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("shouldn't update a query when clicking a selected binned column", async () => {
+    it("shouldn't update a query when clicking a selected binned column", async () => {
       const query = createQueryWithBreakoutAndBinningStrategy();
       const { updateQuery } = setup({
         step: createMockNotebookStep({ query }),
@@ -277,8 +275,7 @@ describe("BreakoutStep", () => {
       expect(breakout.displayName).toBe("Created At: Quarter");
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("should highlight selected temporal bucket", async () => {
+    it("should highlight selected temporal bucket", async () => {
       const query = createQueryWithBreakoutAndTemporalBucket("Quarter");
       setup({ step: createMockNotebookStep({ query }) });
 
@@ -313,8 +310,7 @@ describe("BreakoutStep", () => {
       ).toHaveAttribute("aria-selected", "true");
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("shouldn't update a query when clicking a selected column with temporal bucketing", async () => {
+    it("shouldn't update a query when clicking a selected column with temporal bucketing", async () => {
       const query = createQueryWithBreakoutAndTemporalBucket("Quarter");
       const { updateQuery } = setup({
         step: createMockNotebookStep({ query }),
@@ -359,8 +355,7 @@ describe("BreakoutStep", () => {
       expect(breakouts[0].displayName).toBe("Tax: 10 bins");
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("should allow to change a breakout for a column with an existing breakout but with a different binning strategy", async () => {
+    it("should allow to change a breakout for a column with an existing breakout but with a different binning strategy", async () => {
       const query = createQueryWithMultipleBreakoutsAndBinningStrategy();
       const { getNextBreakouts } = setup({
         step: createMockNotebookStep({ query }),
@@ -377,8 +372,7 @@ describe("BreakoutStep", () => {
       expect(breakouts[1].displayName).toBe("Tax: 50 bins");
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("should ignore attempts to create duplicate breakouts by changing the binning strategy for an existing breakout", async () => {
+    it("should ignore attempts to create duplicate breakouts by changing the binning strategy for an existing breakout", async () => {
       const query = createQueryWithMultipleBreakoutsAndBinningStrategy();
       const { getNextBreakouts } = setup({
         step: createMockNotebookStep({ query }),
@@ -442,8 +436,7 @@ describe("BreakoutStep", () => {
       expect(breakouts[0].displayName).toBe("Created At: Year");
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("should allow to change a breakout for a column with an existing breakout but with a different temporal bucket", async () => {
+    it("should allow to change a breakout for a column with an existing breakout but with a different temporal bucket", async () => {
       const query = createQueryWithMultipleBreakoutsAndTemporalBucket();
       const { getNextBreakouts } = setup({
         step: createMockNotebookStep({ query }),
@@ -460,8 +453,7 @@ describe("BreakoutStep", () => {
       expect(breakouts[1].displayName).toBe("Created At: Quarter");
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("should ignore attempts to create duplicate breakouts by changing the temporal bucket for an existing breakout", async () => {
+    it("should ignore attempts to create duplicate breakouts by changing the temporal bucket for an existing breakout", async () => {
       const query = createQueryWithMultipleBreakoutsAndTemporalBucket();
       const { getNextBreakouts } = setup({
         step: createMockNotebookStep({ query }),


### PR DESCRIPTION
Fixes a regression introduced by the annotate PR.

How to verify:
- New -> Question -> Orders
- Sum By Count, Group by Created At: Month
- Now click on the selected breakout again to see the column picker. The `Created At` column should appear without the bucket name.

Before:
<img width="440" alt="Screenshot 2025-06-30 at 14 03 59" src="https://github.com/user-attachments/assets/ef9a3e89-b615-4062-93b3-817a1e2b5056" />

After:
<img width="471" alt="Screenshot 2025-06-30 at 14 04 41" src="https://github.com/user-attachments/assets/40855a70-4747-4448-a1d4-84d00e429878" />

