### PR TITLE
Add e2e tests for expressions in join conditions

### DIFF
--- a/e2e/test/scenarios/joins/joins-custom-expressions.cy.spec.ts
+++ b/e2e/test/scenarios/joins/joins-custom-expressions.cy.spec.ts
@@ -1,3 +1,5 @@
+import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";
+
 const { H } = cy;
 
 type TestCase = {
@@ -142,5 +144,76 @@ describe("scenarios > joins > custom expressions", () => {
         });
       },
     );
+  });
+
+  it("should support expressions in join conditions referencing model columns", () => {
+    H.visitModel(ORDERS_MODEL_ID);
+    H.openNotebook();
+
+    H.join();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Collections").click();
+      cy.findByText("Orders Model").click();
+    });
+    H.popover().within(() => {
+      cy.findByText("Custom Expression").click();
+      H.enterCustomColumnDetails({ formula: "[ID] + [User ID]" });
+      cy.button("Done").click();
+    });
+    H.popover().within(() => {
+      cy.findByText("Custom Expression").click();
+      H.enterCustomColumnDetails({ formula: "[ID] + [Product ID]" });
+      cy.button("Done").click();
+    });
+
+    H.filter({ mode: "notebook" });
+    H.popover().within(() => {
+      cy.findByText("ID").click();
+      cy.findByPlaceholderText("Enter an ID").type("1");
+      cy.button("Add filter").click();
+    });
+
+    H.visualize();
+    H.assertQueryBuilderRowCount(9);
+  });
+
+  it("should allow to update a join with a join condition with custom expressions", () => {
+    H.openOrdersTable({ mode: "notebook" });
+
+    H.join();
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
+      cy.findByText("Reviews").click();
+    });
+    H.popover().within(() => {
+      cy.findByText("Custom Expression").click();
+      H.enterCustomColumnDetails({ formula: "1" });
+      cy.button("Done").click();
+    });
+    H.popover().within(() => {
+      cy.findByText("Custom Expression").click();
+      H.enterCustomColumnDetails({ formula: "1" });
+      cy.button("Done").click();
+    });
+
+    H.getNotebookStep("join").findByLabelText("Change operator").click();
+    H.popover().findByText("=").click();
+    H.getNotebookStep("join").findByLabelText("Change join type").click();
+    H.popover().findByText("Inner join").click();
+    H.getNotebookStep("join")
+      .findByLabelText("Left column")
+      .findByText("Custom expression")
+      .click();
+    H.enterCustomColumnDetails({ formula: "[ID] + 1" });
+    H.popover().button("Update").click();
+    H.getNotebookStep("join")
+      .findByLabelText("Right column")
+      .findByText("Custom expression")
+      .click();
+    H.enterCustomColumnDetails({ formula: "[Reviews → ID] + 1" });
+    H.popover().button("Update").click();
+
+    H.visualize();
+    H.assertTableRowsCount(1112);
   });
 });

--- a/e2e/test/scenarios/joins/joins-custom-expressions.cy.spec.ts
+++ b/e2e/test/scenarios/joins/joins-custom-expressions.cy.spec.ts
@@ -1,0 +1,101 @@
+const { H } = cy;
+
+type TestCase = {
+  lhsExpression: string;
+  rhsExpression: string;
+  expectedScalarValue: string;
+};
+
+function testJoin({
+  lhsExpression,
+  rhsExpression,
+  expectedScalarValue,
+}: TestCase) {
+  cy.log(`${lhsExpression} = ${rhsExpression}`);
+  H.openOrdersTable({ mode: "notebook" });
+  H.join();
+  H.entityPickerModal().within(() => {
+    H.entityPickerModalTab("Tables").click();
+    cy.findByText("Reviews").click();
+  });
+  H.popover().within(() => {
+    cy.findByText("Custom Expression").click();
+    H.enterCustomColumnDetails({ formula: lhsExpression });
+    cy.button("Done").click();
+  });
+  H.popover().within(() => {
+    cy.findByText("Custom Expression").click();
+    H.enterCustomColumnDetails({ formula: rhsExpression });
+    cy.button("Done").click();
+  });
+  H.summarize({ mode: "notebook" });
+  H.popover().findByText("Count of rows").click();
+  H.visualize();
+  cy.findByTestId("scalar-value").should("have.text", expectedScalarValue);
+}
+
+const LITERAL_TEST_CASES: TestCase[] = [
+  {
+    lhsExpression: "0",
+    rhsExpression: "0",
+    expectedScalarValue: "20,861,120",
+  },
+  {
+    lhsExpression: "1",
+    rhsExpression: "1",
+    expectedScalarValue: "20,861,120",
+  },
+  {
+    lhsExpression: "1",
+    rhsExpression: "0",
+    expectedScalarValue: "18,760",
+  },
+  {
+    lhsExpression: "false",
+    rhsExpression: "false",
+    expectedScalarValue: "20,861,120",
+  },
+  {
+    lhsExpression: "true",
+    rhsExpression: "true",
+    expectedScalarValue: "20,861,120",
+  },
+  {
+    lhsExpression: "false",
+    rhsExpression: "true",
+    expectedScalarValue: "18,760",
+  },
+];
+
+const EXPRESSION_TEST_CASES: TestCase[] = [
+  {
+    lhsExpression: "1 + 2",
+    rhsExpression: "2 + 1",
+    expectedScalarValue: "20,861,120",
+  },
+  {
+    lhsExpression: "[ID] + [User ID]",
+    rhsExpression: "[ID] + [Rating]",
+    expectedScalarValue: "19,048",
+  },
+  {
+    lhsExpression: "month([Created At])",
+    rhsExpression: "month([Created At]",
+    expectedScalarValue: "1,761,044",
+  },
+];
+
+describe("scenarios > joins > custom expressions", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should support literals in join conditions", () => {
+    LITERAL_TEST_CASES.forEach(testJoin);
+  });
+
+  it("should support expressions in join conditions", () => {
+    EXPRESSION_TEST_CASES.forEach(testJoin);
+  });
+});

--- a/e2e/test/scenarios/joins/joins-custom-expressions.cy.spec.ts
+++ b/e2e/test/scenarios/joins/joins-custom-expressions.cy.spec.ts
@@ -106,7 +106,7 @@ describe("scenarios > joins > custom expressions", () => {
     cy.signInAsNormalUser();
   });
 
-  describe("expressions in join conditions", () => {
+  describe("should support expressions in join conditions", () => {
     TEST_CASES.forEach(
       ({ operator, lhsExpression, rhsExpression, expectedRowCount }) => {
         it(`${lhsExpression} ${operator} ${rhsExpression}`, () => {


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-1447/add-e2e-tests

Found an issue that for some reason `!=` doesn't work if both LHS and RHS expressions are literals.

<img width="466" alt="Screenshot 2025-06-30 at 20 37 34" src="https://github.com/user-attachments/assets/565c5476-3de5-4583-830d-41d5d85246b0" />

<img width="722" alt="Screenshot 2025-06-30 at 20 36 05" src="https://github.com/user-attachments/assets/0577c506-0e9b-4dfe-ab37-5e4b45a1e132" />
