### PR TITLE
Update new embed setup route name to embed-iframe

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -18,7 +18,7 @@ export const getRecentItemCards = () =>
 
 export const visitNewEmbedPage = () => {
   cy.intercept("GET", "/api/dashboard/*").as("dashboard");
-  cy.visit("/embed/new");
+  cy.visit("/embed-wizard");
   cy.wait("@dashboard");
 
   cy.get("#iframe-embed-container").should(

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -18,7 +18,7 @@ export const getRecentItemCards = () =>
 
 export const visitNewEmbedPage = () => {
   cy.intercept("GET", "/api/dashboard/*").as("dashboard");
-  cy.visit("/embed-wizard");
+  cy.visit("/embed-iframe");
   cy.wait("@dashboard");
 
   cy.get("#iframe-embed-container").should(

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -125,7 +125,7 @@ H.describeWithSnowplow(suiteTitle, () => {
   });
 
   it("localizes the iframe preview when ?locale is passed", () => {
-    cy.visit("/embed/new?locale=fr");
+    cy.visit("/embed-iframe?locale=fr");
     cy.wait("@dashboard");
 
     // TODO: update this test once "Exploration" is localized in french.

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
@@ -96,7 +96,7 @@ const NewItemMenuView = ({
         <Menu.Item
           key="embed"
           component={ForwardRefLink}
-          to="/embed/new"
+          to="/embed-wizard"
           leftSection={<Icon name="embed" />}
         >
           {t`Embed`}

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
@@ -96,7 +96,7 @@ const NewItemMenuView = ({
         <Menu.Item
           key="embed"
           component={ForwardRefLink}
-          to="/embed-wizard"
+          to="/embed-iframe"
           leftSection={<Icon name="embed" />}
         >
           {t`Embed`}

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -117,7 +117,7 @@ describe("nav > containers > Navbar > Core App", () => {
     expect(screen.queryByTestId("main-navbar-root")).not.toBeInTheDocument();
   });
 
-  ["question/1", "model/1", "dashboard/1", "embed-wizard"].forEach(
+  ["question/1", "model/1", "dashboard/1", "embed-iframe"].forEach(
     (pathname) => {
       it(`should be hidden on initial load for a ${pathname}`, async () => {
         await setup({ pathname: `/${pathname}` });

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -117,12 +117,14 @@ describe("nav > containers > Navbar > Core App", () => {
     expect(screen.queryByTestId("main-navbar-root")).not.toBeInTheDocument();
   });
 
-  ["question/1", "model/1", "dashboard/1", "embed/new"].forEach((pathname) => {
-    it(`should be hidden on initial load for a ${pathname}`, async () => {
-      await setup({ pathname: `/${pathname}` });
-      await expectNavbarClosed();
-    });
-  });
+  ["question/1", "model/1", "dashboard/1", "embed-wizard"].forEach(
+    (pathname) => {
+      it(`should be hidden on initial load for a ${pathname}`, async () => {
+        await setup({ pathname: `/${pathname}` });
+        await expectNavbarClosed();
+      });
+    },
+  );
 
   it("should hide when visiting a question", async () => {
     const store = await setup({ pathname: "/" });

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -76,7 +76,7 @@ const errorPage = handleActions(
 // regexr.com/7r89i
 // A word boundary is added to /model so it doesn't match /browse/models
 const PATH_WITH_COLLAPSED_NAVBAR =
-  /\/(model\b|question|dashboard|metabot|embed-wizard).*/;
+  /\/(model\b|question|dashboard|metabot|embed-iframe).*/;
 
 export function isNavbarOpenForPathname(pathname: string, prevState: boolean) {
   return (

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -76,7 +76,7 @@ const errorPage = handleActions(
 // regexr.com/7r89i
 // A word boundary is added to /model so it doesn't match /browse/models
 const PATH_WITH_COLLAPSED_NAVBAR =
-  /\/(model\b|question|dashboard|metabot|embed).*/;
+  /\/(model\b|question|dashboard|metabot|embed-wizard).*/;
 
 export function isNavbarOpenForPathname(pathname: string, prevState: boolean) {
   return (

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -179,7 +179,7 @@ export const getRoutes = (store) => {
           />
 
           <Route
-            path="embed-wizard"
+            path="embed-iframe"
             component={PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.SdkIframeEmbedSetup}
           />
 

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -179,7 +179,7 @@ export const getRoutes = (store) => {
           />
 
           <Route
-            path="embed/new"
+            path="embed-wizard"
             component={PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.SdkIframeEmbedSetup}
           />
 

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -93,8 +93,6 @@
      (route/not-found {:status 404, :body "Not found."}))
    ;; ^/public/ -> Public frontend and download routes
    (context "/public" [] public-routes)
-   ;; ^/embed/new -> Iframe embedding setup route
-   (GET "/embed/new" [] index/index)
    ;; ^/emebed/ -> Embed frontend and download routes
    (context "/embed" [] embed-routes)
    ;; Anything else (e.g. /user/edit_current) should serve up index.html; React app will handle the rest


### PR DESCRIPTION
Closes EMB-574

The `/embed/new` route can cause developer confusion as we use `/embed/*` for static embedding routes, so changing the embed setup route to `/embed-iframe` reduces the confusion. Route name [proposed here](https://linear.app/metabase/issue/EMB-574/update-new-embed-route-name-to-embed-iframe#comment-f410d859).