### PR TITLE
Add toast upon successful database connection during setup

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -353,6 +353,8 @@ describe("scenarios > setup", () => {
       cy.button("Connect database").click();
     });
 
+    cy.findByRole("status").should("contain", `Connected to ${dbName}`);
+
     skipLicenseStepOnEE();
 
     // usage data

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.styled.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.styled.tsx
@@ -1,7 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-import styled from "@emotion/styled";
-
-export const StepDescription = styled.div`
-  margin: 0.875rem 0 2rem;
-  color: var(--mb-color-text-medium);
-`;

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -1,8 +1,10 @@
 import { updateIn } from "icepick";
 import { c, t } from "ttag";
 
+import { useToast } from "metabase/common/hooks";
 import { DatabaseForm } from "metabase/databases/components/DatabaseForm";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import { Box } from "metabase/ui";
 import type { DatabaseData } from "metabase-types/api";
 import type { InviteInfo } from "metabase-types/store";
 
@@ -25,9 +27,6 @@ import { InactiveStep } from "../InactiveStep";
 import { InviteUserForm } from "../InviteUserForm";
 import { SetupSection } from "../SetupSection";
 import type { NumberedStepProps } from "../types";
-
-import { useToast } from "metabase/common/hooks";
-import { Box } from "metabase/ui";
 
 export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const { isStepActive, isStepCompleted } = useStep("db_connection");

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -1,5 +1,5 @@
 import { updateIn } from "icepick";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import { DatabaseForm } from "metabase/databases/components/DatabaseForm";
 import { useDispatch, useSelector } from "metabase/lib/redux";
@@ -26,7 +26,8 @@ import { InviteUserForm } from "../InviteUserForm";
 import { SetupSection } from "../SetupSection";
 import type { NumberedStepProps } from "../types";
 
-import { StepDescription } from "./DatabaseStep.styled";
+import { useToast } from "metabase/common/hooks";
+import { Box } from "metabase/ui";
 
 export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const { isStepActive, isStepCompleted } = useStep("db_connection");
@@ -37,6 +38,7 @@ export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const isEmailConfigured = useSelector(getIsEmailConfigured);
 
   const dispatch = useDispatch();
+  const [sendToast] = useToast();
 
   const handleEngineChange = (engine?: string) => {
     dispatch(updateDatabaseEngine(engine));
@@ -45,6 +47,9 @@ export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const handleDatabaseSubmit = async (database: DatabaseData) => {
     try {
       await dispatch(submitDatabase(database)).unwrap();
+      sendToast({
+        message: c("{0} is a database name").t`Connected to ${database.name}`,
+      });
     } catch (error) {
       throw getSubmitError(error);
     }
@@ -73,10 +78,10 @@ export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
       title={getStepTitle(database, invite, isStepCompleted)}
       label={stepLabel}
     >
-      <StepDescription>
+      <Box mt="sm" mb="xl">
         <div>{t`Are you ready to start exploring your data? Add it below.`}</div>
         <div>{t`Not ready? Skip and play around with our Sample Database.`}</div>
-      </StepDescription>
+      </Box>
       <DatabaseForm
         initialValues={database}
         onSubmit={handleDatabaseSubmit}


### PR DESCRIPTION
Resolves PRG-72 by adding a toast message upon the successful database connection during Metabase instance setup.

### Demo

https://github.com/user-attachments/assets/ad6506e9-79ba-4129-89aa-3a486a75435f


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
