### PR TITLE
Remove a potentially superfluous step from the default e2e snapshot

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -115,13 +115,6 @@ describe("snapshots", () => {
       "license-token-missing-banner-dismissal-timestamp",
       new Date().toISOString(),
     );
-
-    // update the Sample db connection string so it is valid in both CI and locally
-    cy.request("GET", `/api/database/${SAMPLE_DB_ID}`).then((response) => {
-      response.body.details.db =
-        "./plugins/sample-database.db;USER=GUEST;PASSWORD=guest";
-      cy.request("PUT", `/api/database/${SAMPLE_DB_ID}`, response.body);
-    });
   }
 
   function addUsersAndGroups() {

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -336,7 +336,7 @@ describe("scenarios > home > custom homepage", () => {
         `/dashboard/${ORDERS_DASHBOARD_ID}`,
       );
 
-      // Do a page refresh and test dashboard header
+      cy.log("Do a page refresh and test dashboard header");
       cy.visit("/");
       cy.location("pathname").should(
         "equal",


### PR DESCRIPTION
This step was altering the connection string of the sample database, but it actually doesn't have any effect on any of the tests in our suite.