### PR TITLE
Do not include expressions in LHS columns

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -815,7 +815,8 @@
                                       (joins query stage-number))]
      (->> (lib.metadata.calculation/visible-columns query stage-number
                                                     (lib.util/query-stage query stage-number)
-                                                    {:include-implicitly-joinable? false})
+                                                    {:include-expressions? false
+                                                     :include-implicitly-joinable? false})
           (remove (fn [col]
                     (when-let [col-join-alias (lib.join.util/current-join-alias col)]
                       (contains? join-aliases-to-ignore col-join-alias))))

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -815,7 +815,7 @@
                                       (joins query stage-number))]
      (->> (lib.metadata.calculation/visible-columns query stage-number
                                                     (lib.util/query-stage query stage-number)
-                                                    {:include-expressions? false
+                                                    {:include-expressions?         false
                                                      :include-implicitly-joinable? false})
           (remove (fn [col]
                     (when-let [col-join-alias (lib.join.util/current-join-alias col)]

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -707,6 +707,18 @@
                  {:lib/desired-column-alias "PRICE"}]
                 (lib/join-condition-lhs-columns query nil nil rhs)))))))
 
+(deftest ^:parallel join-condition-lhs-columns-expression-test
+  (testing "Should not include expressions in LHS columns"
+    (let [query (-> (lib.tu/venues-query)
+                    (lib/expression "double-price" (lib/* (meta/field-metadata :venues :price) 2)))]
+      (is (=? [{:lib/desired-column-alias "ID"}
+               {:lib/desired-column-alias "CATEGORY_ID"}
+               {:lib/desired-column-alias "NAME"}
+               {:lib/desired-column-alias "LATITUDE"}
+               {:lib/desired-column-alias "LONGITUDE"}
+               {:lib/desired-column-alias "PRICE"}]
+              (lib/join-condition-lhs-columns query nil nil nil))))))
+
 (deftest ^:parallel join-condition-lhs-columns-with-previous-join-test
   (testing "Include columns from previous join(s)"
     (let [query (lib.tu/query-with-join-with-explicit-fields)]


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-1481/remove-custom-expressions-from-lhs-join-condition-columns