### PR TITLE
[Metabot] Make streaming the default

### DIFF
--- a/e2e/support/helpers/e2e-metabot-helpers.ts
+++ b/e2e/support/helpers/e2e-metabot-helpers.ts
@@ -93,8 +93,14 @@ export function lastChatMessage() {
 
 export const mockMetabotResponse = (response: StaticResponse) => {
   return cy
-    .intercept("POST", "/api/ee/metabot-v3/v2/agent", (req) => {
-      req.reply(response);
+    .intercept("POST", "/api/ee/metabot-v3/v2/agent-streaming", (req) => {
+      req.reply({
+        ...response,
+        headers: {
+          "content-type": "text/event-stream; charset=utf-8",
+          ...response.headers,
+        },
+      });
     })
     .as("metabotAgent");
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -232,14 +232,10 @@ export const MetabotChat = () => {
               data-testid="metabot-chat-input"
               w="100%"
               leftSection={
-                <Box
-                  h="100%"
-                  pt="11px"
-                  onDoubleClick={() => metabot.toggleStreaming()}
-                >
+                <Box h="100%" pt="11px" onDoubleClick={metabot.toggleStreaming}>
                   <Icon
                     name="metabot"
-                    c={metabot.useStreaming ? "warning" : "brand"}
+                    c={metabot.useStreaming ? "brand" : "warning"}
                   />
                 </Box>
               }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -41,7 +41,7 @@ export interface MetabotState {
 }
 
 export const getMetabotInitialState = (): MetabotState => ({
-  useStreaming: false,
+  useStreaming: true,
   isProcessing: false,
   conversationId: uuid(),
   messages: [],


### PR DESCRIPTION
Closes [BOT-115](https://linear.app/metabase/issue/BOT-115/frontend-ai-sdk-streaming-implementation)

### Description

Makes streaming the default and adjusts e2e test to test for streaming. I'm leaving the old code around for a week or so, just in case.

### How to verify

- Interact with metabot and see that streaming endpoint is now used by default

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
