### PR TITLE
EMB-548 add analytics step

### DIFF
--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -142,16 +142,27 @@ export type VisualizerModalEvent = ValidateEvent<
     }
 >;
 
+export type EmbeddingSetupStepKey =
+  | "welcome"
+  | "user-creation"
+  | "data-connection"
+  | "table-selection"
+  | "processing"
+  | "add-to-your-app"
+  | "done";
 export type EmbeddingSetupStepSeenEvent = ValidateEvent<{
   event: "embedding_setup_step_seen";
+  event_detail: EmbeddingSetupStepKey;
+}>;
+
+export type EmbeddingSetupClickEvent = ValidateEvent<{
+  event: "embedding_setup_click";
   event_detail:
-    | "welcome"
-    | "user-creation"
-    | "data-connection"
-    | "table-selection"
-    | "processing"
-    | "add-to-your-app"
-    | "done";
+    | "setup-up-manually"
+    | "add-data-later-or-skip"
+    | "snippet-copied"
+    | "ill-do-this-later";
+  triggered_from: EmbeddingSetupStepKey;
 }>;
 
 export type EventsClickedEvent = ValidateEvent<{
@@ -179,4 +190,5 @@ export type SimpleEvent =
   | VisualizeAnotherWayClickedEvent
   | VisualizerModalEvent
   | EmbeddingSetupStepSeenEvent
+  | EmbeddingSetupClickEvent
   | EventsClickedEvent;

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/EmbeddingSetupContext.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/EmbeddingSetupContext.tsx
@@ -9,6 +9,7 @@ import {
 import { trackSimpleEvent } from "metabase/lib/analytics";
 import { useSelector } from "metabase/lib/redux";
 import { getLocale } from "metabase/setup/selectors";
+import type { EmbeddingSetupClickEvent } from "metabase-types/analytics";
 import type { DashboardId, DatabaseData, Table } from "metabase-types/api";
 
 import { DataConnectionStep } from "./steps/DataConnectionStep";
@@ -52,6 +53,9 @@ type EmbeddingSetupContextType = {
   totalSteps: number;
   goToNextStep: () => void;
   StepComponent: (typeof STEP_COMPONENTS)[number];
+  trackEmbeddingSetupClick: (
+    eventDetail: EmbeddingSetupClickEvent["event_detail"],
+  ) => void;
 };
 
 const EmbeddingSetupContext = createContext<EmbeddingSetupContextType | null>(
@@ -106,6 +110,17 @@ export const EmbeddingSetupProvider = ({
     });
   }, [stepKey]);
 
+  const trackEmbeddingSetupClick = useCallback(
+    (eventDetail: EmbeddingSetupClickEvent["event_detail"]) => {
+      trackSimpleEvent({
+        event: "embedding_setup_click",
+        event_detail: eventDetail,
+        triggered_from: stepKey,
+      });
+    },
+    [stepKey],
+  );
+
   return (
     <EmbeddingSetupContext.Provider
       value={{
@@ -126,6 +141,7 @@ export const EmbeddingSetupProvider = ({
         totalSteps,
         goToNextStep,
         StepComponent,
+        trackEmbeddingSetupClick,
       }}
     >
       {children}

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DataConnectionStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DataConnectionStep.tsx
@@ -11,7 +11,8 @@ import { useEmbeddingSetup } from "../EmbeddingSetupContext";
 
 export const DataConnectionStep = () => {
   const dispatch = useDispatch();
-  const { setDatabase, goToNextStep } = useEmbeddingSetup();
+  const { setDatabase, goToNextStep, trackEmbeddingSetupClick } =
+    useEmbeddingSetup();
 
   const handleSubmit = async (databaseData: DatabaseData) => {
     const createdDatabase = await dispatch(createDatabase(databaseData));
@@ -31,7 +32,10 @@ export const DataConnectionStep = () => {
       <DatabaseForm
         onSubmit={handleSubmit}
         onEngineChange={() => {}}
-        onCancel={() => dispatch(push("/"))}
+        onCancel={() => {
+          trackEmbeddingSetupClick("add-data-later-or-skip");
+          dispatch(push("/"));
+        }}
       />
     </Stack>
   );

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/FinalStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/FinalStep.tsx
@@ -25,7 +25,7 @@ import type { StepProps } from "./embeddingSetupSteps";
 
 export const FinalStep = ({ nextStep }: StepProps) => {
   const { url: docsUrl } = useDocsUrl("embedding/interactive-embedding");
-  const { createdDashboardIds } = useEmbeddingSetup();
+  const { createdDashboardIds, trackEmbeddingSetupClick } = useEmbeddingSetup();
 
   const { loading, value: dashboards } = useAsync(async () => {
     const dashboardPromises = createdDashboardIds.map((id) =>
@@ -98,7 +98,12 @@ export const FinalStep = ({ nextStep }: StepProps) => {
         {tabs.map((tab) => (
           <Tabs.Panel key={tab.url} value={tab.url}>
             <Box mt="md">
-              <CodeSnippet code={getEmbedCode(tab.url)} />
+              <CodeSnippet
+                code={getEmbedCode(tab.url)}
+                onCopy={() => {
+                  trackEmbeddingSetupClick("snippet-copied");
+                }}
+              />
             </Box>
 
             {/* This shows a loader while the iframe is loading, it's ugly as it's a different loader than the one inside the iframe,
@@ -134,7 +139,7 @@ export const FinalStep = ({ nextStep }: StepProps) => {
           variant="subtle"
           color="text-primary"
           onClick={() => {
-            // TODO: EMB-548 add analytics event
+            trackEmbeddingSetupClick("ill-do-this-later");
             nextStep();
           }}
         >
@@ -149,7 +154,13 @@ export const FinalStep = ({ nextStep }: StepProps) => {
   );
 };
 
-export const CodeSnippet = ({ code }: { code: string }) => {
+export const CodeSnippet = ({
+  code,
+  onCopy,
+}: {
+  code: string;
+  onCopy?: () => void;
+}) => {
   return (
     <Group
       px="lg"
@@ -162,7 +173,7 @@ export const CodeSnippet = ({ code }: { code: string }) => {
       }}
     >
       <Code flex={1} dangerouslySetInnerHTML={{ __html: highlight(code) }} />
-      <CopyButton value={code} />
+      <CopyButton value={code} onCopy={onCopy} />
     </Group>
   );
 };

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/WelcomeStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/WelcomeStep.tsx
@@ -3,9 +3,11 @@ import { t } from "ttag";
 
 import { Box, Button, Space, Text, Title } from "metabase/ui";
 
+import { useEmbeddingSetup } from "../EmbeddingSetupContext";
 import type { StepProps } from "../steps/embeddingSetupSteps";
 
 export const WelcomeStep = ({ nextStep }: StepProps) => {
+  const { trackEmbeddingSetupClick } = useEmbeddingSetup();
   return (
     <Box p="xl" style={{ borderRadius: 16 }} bg="white">
       <Title order={2} mb="lg">
@@ -31,8 +33,13 @@ export const WelcomeStep = ({ nextStep }: StepProps) => {
 
       <Space h="lg" />
 
-      <Text>
-        <Link to="/" style={{ color: "#888" }}>{t`Set up manually`}</Link>
+      <Text color="text-secondary">
+        <Link
+          to="/"
+          onClick={async () => {
+            trackEmbeddingSetupClick("setup-up-manually");
+          }}
+        >{t`Set up manually`}</Link>
       </Text>
     </Box>
   );


### PR DESCRIPTION
Implements the event `embedding_setup_click` from https://www.notion.so/metabase/Embedding-onboarding-flow-in-setup-20069354c9018068a13ef2fd955549c2?source=copy_link#22269354c9018093a27de9b5b18928fd

As always if you want to test this, empty instance and go to `/setup/embedding` while having a valid token in the env