### PR TITLE
fix embedding-reproduction test, "issue  8490" failing because it finds

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1224,7 +1224,7 @@ describe("issue 8490", () => {
       cy.log("assert the line chart");
       H.getDashboardCard(0).within(() => {
         // X-axis labels: Jan 2024 (or some other year)
-        cy.findByText(/1월 20\d\d\b/).should("be.visible");
+        cy.findByText(/^1월 20\d\d\b/).should("be.visible");
         // Aggregation "count"
         cy.findByText("카운트").should("be.visible");
       });


### PR DESCRIPTION
multiple elements

From: https://metaboat.slack.com/archives/C5XHN8GLW/p1751372684366549, the test is now finding multiple elements (one is `11` instead of `1`) and it's failing