### PR TITLE
Closes VIZ-1242 visualize another way copy

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-visualizer-helpers.ts
@@ -270,12 +270,18 @@ export function chartLegendItem(name: string) {
   return chartLegend().findByText(name);
 }
 
-export function showDashcardVisualizerModal(index = 0) {
+type ShowDashcardVisualizerModalOptions = {
+  buttonText?: "Edit visualization" | "Visualize another way";
+};
+
+export function showDashcardVisualizerModal(
+  index = 0,
+  options: ShowDashcardVisualizerModalOptions = {},
+) {
+  const { buttonText = "Edit visualization" } = options;
   showDashboardCardActions(index);
 
-  getDashboardCard(index)
-    .findByLabelText("Edit visualization")
-    .click({ force: true });
+  getDashboardCard(index).findByLabelText(buttonText).click({ force: true });
 
   modal().within(() => {
     cy.findByTestId("visualization-canvas-loader").should("not.exist");
@@ -283,8 +289,11 @@ export function showDashcardVisualizerModal(index = 0) {
   });
 }
 
-export function showDashcardVisualizerModalSettings(index = 0) {
-  showDashcardVisualizerModal(index);
+export function showDashcardVisualizerModalSettings(
+  index = 0,
+  options: ShowDashcardVisualizerModalOptions = {},
+) {
+  showDashcardVisualizerModal(index, options);
 
   return modal().within(() => {
     toggleVisualizerSettingsSidebar();

--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -168,7 +168,9 @@ describe("scenarios > embedding-sdk > popovers", () => {
 
     getSdkRoot().within(() => {
       H.editDashboard();
-      H.showDashcardVisualizerModalSettings(0);
+      H.showDashcardVisualizerModalSettings(0, {
+        buttonText: "Visualize another way",
+      });
 
       cy.findAllByTestId("color-selector-button").first().click();
 

--- a/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
@@ -152,7 +152,9 @@ function selectQuestion(question) {
 }
 
 function overwriteDashCardTitle(index, originalTitle, newTitle) {
-  H.showDashcardVisualizerModalSettings(index);
+  H.showDashcardVisualizerModalSettings(index, {
+    buttonText: "Edit question",
+  });
   cy.findByDisplayValue(originalTitle).clear().type(newTitle).blur();
   H.saveDashcardVisualizerModalSettings();
 }

--- a/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
@@ -153,7 +153,7 @@ function selectQuestion(question) {
 
 function overwriteDashCardTitle(index, originalTitle, newTitle) {
   H.showDashcardVisualizerModalSettings(index, {
-    buttonText: "Edit question",
+    buttonText: "Visualize another way",
   });
   cy.findByDisplayValue(originalTitle).clear().type(newTitle).blur();
   H.saveDashcardVisualizerModalSettings();

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -857,7 +857,9 @@ describe("Dashboard > Dashboard Questions", () => {
       H.sidebar().findByText("Average Order Total by Month Question").click();
 
       // overlay the quantity series in the purple dashboard
-      H.findDashCardAction(H.getDashboardCard(0), "Edit visualization").click();
+      H.showDashcardVisualizerModal(0, {
+        buttonText: "Visualize another way",
+      });
 
       H.modal().within(() => {
         H.switchToAddMoreData();

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -154,7 +154,9 @@ describe("scenarios > dashboard > visualizer > basics", () => {
       },
     );
 
-    H.showDashcardVisualizerModal(1);
+    H.showDashcardVisualizerModal(1, {
+      buttonText: "Visualize another way",
+    });
 
     H.modal().within(() => {
       cy.button("Add more data").click();

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -344,7 +344,9 @@ describe("scenarios > dashboard > visualizer > basics", () => {
 
     // Rename the third card and check
     // PRODUCTS_COUNT_BY_CREATED_AT.name -> "Another chart"
-    H.showDashcardVisualizerModal(3);
+    H.showDashcardVisualizerModal(3, {
+      buttonText: "Visualize another way",
+    });
     H.modal().within(() => {
       cy.findByDisplayValue(PRODUCTS_COUNT_BY_CREATED_AT.name)
         .clear()

--- a/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
@@ -264,7 +264,9 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
       }).click();
     });
 
-    H.showDashcardVisualizerModal(1);
+    H.showDashcardVisualizerModal(1, {
+      buttonText: "Visualize another way",
+    });
 
     H.modal().within(() => {
       H.chartPathWithFillColor("#509EE3").should("have.length", 4);
@@ -601,7 +603,9 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
         .should("have.length", 2);
 
       H.editDashboard();
-      H.showDashcardVisualizerModal(0);
+      H.showDashcardVisualizerModal(0, {
+        buttonText: "Visualize another way",
+      });
 
       H.modal().within(() => {
         cy.findAllByTestId("legend-item").should("have.length", 2);

--- a/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-dashboard.cy.spec.js
@@ -122,7 +122,9 @@ describe("scenarios > metrics > dashboard", () => {
     });
     H.editDashboard();
 
-    H.findDashCardAction(H.getDashboardCard(0), "Edit visualization").click();
+    H.showDashcardVisualizerModal(0, {
+      buttonText: "Visualize another way",
+    });
     H.modal().within(() => {
       H.switchToAddMoreData();
       H.addDataset(PRODUCTS_TIMESERIES_METRIC.name);

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -136,7 +136,10 @@ describe("issue 44171", () => {
     H.sidebar().findByText("Metric 44171-A").click();
 
     H.showDashboardCardActions(0);
-    H.findDashCardAction(H.getDashboardCard(0), "Edit question").click();
+    H.findDashCardAction(
+      H.getDashboardCard(0),
+      "Visualize another way",
+    ).click();
     H.modal().within(() => {
       H.switchToAddMoreData();
       H.addDataset("Metric 44171-B");

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -136,7 +136,7 @@ describe("issue 44171", () => {
     H.sidebar().findByText("Metric 44171-A").click();
 
     H.showDashboardCardActions(0);
-    H.findDashCardAction(H.getDashboardCard(0), "Edit visualization").click();
+    H.findDashCardAction(H.getDashboardCard(0), "Edit question").click();
     H.modal().within(() => {
       H.switchToAddMoreData();
       H.addDataset("Metric 44171-B");

--- a/e2e/test/scenarios/visualizations-charts/legend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/legend.cy.spec.js
@@ -388,7 +388,9 @@ describe("scenarios > visualizations > legend", () => {
       H.chartPathWithFillColor(CATEGORY_COLOR.WIDGET).should("have.length", 5);
     }
 
-    H.showDashcardVisualizerModal(0);
+    H.showDashcardVisualizerModal(0, {
+      buttonText: "Visualize another way",
+    });
 
     H.modal().within(() => {
       ensureCanNotToggleSeriesVisibility();

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -372,7 +372,9 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       H.editDashboard();
-      H.showDashcardVisualizerModalSettings();
+      H.showDashcardVisualizerModalSettings(0, {
+        buttonText: "Visualize another way",
+      });
 
       updateColumnTitle(originalName, customName);
 
@@ -501,7 +503,9 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       H.editDashboard();
-      H.showDashcardVisualizerModalSettings();
+      H.showDashcardVisualizerModalSettings(0, {
+        buttonText: "Visualize another way",
+      });
 
       updateColumnTitle(originalAvgSeriesName, customAvgSeriesName);
       updateColumnTitle(originalCumSumSeriesName, customCumSumSeriesName);
@@ -648,7 +652,9 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       H.editDashboard();
-      H.showDashcardVisualizerModalSettings();
+      H.showDashcardVisualizerModalSettings(0, {
+        buttonText: "Visualize another way",
+      });
 
       updateColumnTitle(originalAvgSeriesName, updatedOriginalAvgSeriesName);
       updateColumnTitle(
@@ -726,7 +732,9 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       H.editDashboard();
-      H.showDashcardVisualizerModalSettings();
+      H.showDashcardVisualizerModalSettings(0, {
+        buttonText: "Visualize another way",
+      });
 
       updateColumnTitle(originalName, updatedName);
 
@@ -794,7 +802,9 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       H.editDashboard();
-      H.showDashcardVisualizerModalSettings();
+      H.showDashcardVisualizerModalSettings(0, {
+        buttonText: "Visualize another way",
+      });
 
       updateColumnTitle(originalSeriesName, updatedOriginalSeriesName);
       updateColumnTitle(addedSeriesName, updatedAddedSeriesName);

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -430,7 +430,9 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
       });
 
       H.editDashboard();
-      H.findDashCardAction(H.getDashboardCard(0), "Edit visualization").click();
+      H.showDashcardVisualizerModal(0, {
+        buttonText: "Visualize another way",
+      });
       H.modal().within(() => {
         cy.button("Settings").click();
         updateColumnTitle(originalSeriesName, updatedOriginalSeriesName);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -183,11 +183,15 @@ function DashCardActionsPanelInner({
       isVisualizerDashboardCard(dashcard) ||
       isVisualizerSupportedVisualization(dashcard?.card.display)
     ) {
+      const label = isVisualizerDashboardCard(dashcard)
+        ? t`Edit visualization`
+        : t`Visualize another way`;
+
       buttons.push(
         <DashCardActionButton
           key="visualizer-button"
-          tooltip={t`Edit visualization`}
-          aria-label={t`Edit visualization`}
+          tooltip={label}
+          aria-label={label}
           onClick={onEditVisualization}
         >
           <DashCardActionButton.Icon name="lineandbar" />

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -389,10 +389,9 @@ describe("DashCard", () => {
         isEditing: true,
       });
 
-      expect(screen.getByLabelText("Edit visualization")).toBeInTheDocument();
       expect(
-        screen.queryByLabelText("Visualize another way"),
-      ).not.toBeInTheDocument();
+        screen.getByLabelText("Visualize another way"),
+      ).toBeInTheDocument();
       expect(
         screen.queryByLabelText("Show visualization options"),
       ).not.toBeInTheDocument();


### PR DESCRIPTION
Closes [VIZ-1242: Tweak visualizer entrypoint tooltip copy to "Visualize another way"](https://linear.app/metabase/issue/VIZ-1242/tweak-visualizer-entrypoint-tooltip-copy-to-visualize-another-way)

### Description
<img width="1549" alt="SCR-20250701-ntel" src="https://github.com/user-attachments/assets/b0a879d6-04a1-48de-b179-d8ccc3014d3d" />
