### PR TITLE
Fix "undo" when removing a heading dashcard with filters

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1349,6 +1349,56 @@ describe("scenarios > dashboard > parameters", () => {
       });
     });
 
+    it("should correctly undo dashcard removal (VIZ-1236)", () => {
+      H.createQuestionAndDashboard({
+        questionDetails: ordersCountByCategory,
+        dashboardDetails: {
+          parameters: [categoryParameter],
+        },
+      }).then(({ body: dashcard }) => {
+        H.updateDashboardCards({
+          dashboard_id: dashcard.dashboard_id,
+          cards: [
+            createMockHeadingDashboardCard({
+              inline_parameters: [categoryParameter.id],
+              size_x: 24,
+              size_y: 1,
+            }),
+            {
+              id: dashcard.id,
+              row: 1,
+              size_x: 12,
+              size_y: 6,
+              parameter_mappings: [
+                {
+                  parameter_id: categoryParameter.id,
+                  card_id: dashcard.card_id,
+                  target: [
+                    "dimension",
+                    categoryFieldRef,
+                    { "stage-number": 0 },
+                  ],
+                },
+              ],
+            },
+          ],
+        });
+        H.visitDashboard(dashcard.dashboard_id);
+        H.editDashboard();
+      });
+
+      H.removeDashboardCard(0);
+      H.getDashboardCard().findByText("test question").should("exist");
+
+      H.undo();
+
+      H.getDashboardCard(0).findByText("Category").click();
+      H.getDashboardCard(1)
+        .findByTestId("parameter-mapper-container")
+        .findByText(/Category/)
+        .should("exist");
+    });
+
     it("should work correctly in public dashboards", () => {
       H.createQuestionAndDashboard({
         questionDetails: ordersCountByCategory,

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -58,7 +58,6 @@ import {
   setMultipleDashCardAttributes,
   showClickBehaviorSidebar,
   trashDashboardQuestion,
-  undoRemoveCardFromDashboard,
 } from "../actions";
 import { type DashboardContextReturned, useDashboardContext } from "../context";
 import {
@@ -120,7 +119,6 @@ const mapDispatchToProps = {
   markNewCardSeen,
   setMultipleDashCardAttributes,
   setDashCardAttributes,
-  undoRemoveCardFromDashboard,
   replaceCard,
   fetchCardData,
   replaceCardWithVisualization,
@@ -461,15 +459,6 @@ class DashboardGridInner extends Component<
     this.props.removeCardFromDashboard({
       dashcardId: dc.id,
       cardId: dc.card_id,
-    });
-
-    this.props.addUndo({
-      message: this.getIsLastDashboardQuestionDashcard(dc)
-        ? t`Trashed and removed card`
-        : t`Removed card`,
-      undo: true,
-      action: () =>
-        this.props.undoRemoveCardFromDashboard({ dashcardId: dc.id }),
     });
   };
 

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -168,6 +168,10 @@ export const getDashboard = createSelector(
 
 export const getDashcards = (state: State) => state.dashboard.dashcards;
 
+export const getDashcardList = createSelector([getDashcards], (dashcards) =>
+  Object.values(dashcards),
+);
+
 export const getDashCardById = (state: State, dashcardId: DashCardId) => {
   const dashcards = getDashcards(state);
   return dashcards[dashcardId];

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -7,6 +7,7 @@ import {
   DASHBOARD_SLOW_TIMEOUT,
   SIDEBAR_NAME,
 } from "metabase/dashboard/constants";
+import { isNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
 import {
   getDashboardQuestions,
@@ -451,9 +452,9 @@ export const getDashCardInlineValuePopulatedParameters = createSelector(
     if (!dashcard || !hasInlineParameters(dashcard)) {
       return [];
     }
-    const inlineParameters = dashcard.inline_parameters.map((parameterId) =>
-      parameters.find((p) => p.id === parameterId),
-    );
+    const inlineParameters = dashcard.inline_parameters
+      .map((parameterId) => parameters.find((p) => p.id === parameterId))
+      .filter(isNotNull);
     return _getValuePopulatedParameters({
       parameters: inlineParameters,
       values: parameterValues,


### PR DESCRIPTION
Trying to "undo" a dashcard removal was failing if it had an inline filter. The problem is that our "undo" logic was restoring only the dashcard, but not its parameters.

### To verify

1. Create a dashboard with a heading and a question dashcards
2. Add a filter to the heading dashcard and connect it to the question card
3. In edit mode, remove the heading card
4. Click the "Undo" button in a toast that shows up at the bottom left
5. Ensure the card is restored correctly and you can use the filter