### PR TITLE
Fix duplicate filter names

### DIFF
--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -39,12 +39,21 @@ export function createParameter(
   opts: NewParameterOpts,
   parameters: Parameter[] = [],
 ) {
-  let name = opts.name;
-
+  let baseName = opts.name;
   let nameIndex = 0;
+
+  // Extract base name and existing index if present
+  const indexMatch = baseName.match(/^(.+)\s+(\d+)$/);
+  if (indexMatch) {
+    baseName = indexMatch[1];
+    nameIndex = parseInt(indexMatch[2], 10);
+  }
+
+  let name = nameIndex === 0 ? baseName : `${baseName} ${nameIndex}`;
+
   while (parameters.some((p) => p.name === name)) {
     nameIndex++;
-    name = `${name} ${nameIndex}`;
+    name = `${baseName} ${nameIndex}`;
   }
 
   const parameter: Parameter = {

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.js
@@ -40,29 +40,43 @@ describe("metabase/parameters/utils/dashboards", () => {
     });
 
     it("should prevent a duplicate name", () => {
-      expect(
-        createParameter(
-          {
-            name: "foo bar",
-            type: "category",
-            sectionId: "abc",
-          },
-          [
-            createParameter(
-              {
-                name: "foo bar",
-                type: "category",
-                sectionId: "abc",
-              },
-              [],
-            ),
-          ],
-        ),
-      ).toEqual({
+      const parameter1 = createParameter({
+        name: "foo bar",
+        type: "category",
+        sectionId: "abc",
+      });
+
+      const parameter2 = createParameter(
+        {
+          name: "foo bar",
+          type: "category",
+          sectionId: "abc",
+        },
+        [parameter1],
+      );
+
+      expect(parameter2).toEqual({
         id: expect.any(String),
         name: "foo bar 1",
         sectionId: "abc",
         slug: "foo_bar_1",
+        type: "category",
+      });
+
+      const parameter3 = createParameter(
+        {
+          name: "foo bar",
+          type: "category",
+          sectionId: "abc",
+        },
+        [parameter1, parameter2],
+      );
+
+      expect(parameter3).toEqual({
+        id: expect.any(String),
+        name: "foo bar 2",
+        sectionId: "abc",
+        slug: "foo_bar_2",
         type: "category",
       });
     });


### PR DESCRIPTION
Updates `createParameter` to handle a case when we're duplicating a dashcard with inline parameters, so instead of "Filter 1 1" we'd get "Filter 2"

### To verify

1. Create a dashboard with a heading card and a filter on it
2. Duplicate the heading card several times
3. Ensure new filter names look like "Filter 1", "Filter 2", "Filter 3", etc.

### Demo

**Before**

https://github.com/user-attachments/assets/b0054ea9-adec-4d82-b007-b9659d0f14b4

**After**

https://github.com/user-attachments/assets/e7c02449-ff70-4158-ac7b-0a5e3c2b238a

