### PR TITLE
Flake Chore: `blocking-queue-concurrency-test`

### DIFF
--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -637,6 +637,9 @@
           total-items            (* num-producers num-items-per-producer)
           received-items         (atom #{})
           producer-latch         (java.util.concurrent.CountDownLatch. 1)
+          ;; inter-consumer coordination:
+          consumer-countdown     (atom total-items)
+          ;; coordination with main test thread:
           consumer-latch         (java.util.concurrent.CountDownLatch. total-items)
           producer-fn            (fn [producer-id]
                                    (.await producer-latch)
@@ -646,14 +649,14 @@
                                        (#'notification.send/put-notification! queue item))))
           consumer-fn            (fn [consumer-id]
                                    (try
-                                     (while (pos? (.getCount consumer-latch))
+                                     (while (<= 0 (swap! consumer-countdown dec))
                                        (let [item (take-notification! queue)]
                                          (swap! received-items conj [(:id item) item {:consumer consumer-id}])
                                          (.countDown consumer-latch)))
                                      (catch Exception e
                                        (log/errorf e "Consumer %s error:" consumer-id))))
-          producers               (mapv #(doto (Thread. (fn [] (producer-fn %))) .start) (range num-producers))
-          _consumers              (mapv #(doto (Thread. (fn [] (consumer-fn %))) .start) (range num-consumers))]
+          _consumers              (mapv #(doto (Thread. (fn [] (consumer-fn %))) .start) (range num-consumers))
+          producers               (mapv #(doto (Thread. (fn [] (producer-fn %))) .start) (range num-producers))]
 
       ; Start all producers simultaneously
       (.countDown producer-latch)


### PR DESCRIPTION
### Description

This test failed on me in CI, for no good reason -- basically just thread scheduling issues. Testing locally, I received 62 failures across 1M runs, with a lot of close calls (measured by how many items were received by a single thread). I would expect more in a compute-constrained environment.

With these changes, #onmymachine it failed 0 times out of 1M. Without the producers/consumers line swap, it failed 3 times out of 1M.

As an tangential benefit, it fixes a minor async coordination incorrectness. The original version had a higher chance of having consumer threads hanging out waiting on the `take-notification!` timeout after the test had completed.

🤞 I am hoping this test is less flaky in CI now; different machine details and all.

### How to verify

Run the test!

- [x] Tests have been added/updated to cover changes in this PR
