### PR TITLE
embedding setup: use cloud token in e2e and hide appbar and database status

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
@@ -274,7 +274,7 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
 });
 
 /**
- * Before the use creation we can't set the token, as that uses api calls that require being logged as admin.
+ * Before the user creation we can't set the token, as that uses api calls that require being logged as admin.
  * This simulates at least the `hosted/is-hosted?`
  */
 const mockCloudHosted = () => {

--- a/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
@@ -82,7 +82,12 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
       .should("be.visible");
   });
 
-  it("should allow users to go through the embedding setup and onboarding flow", () => {
+  it("[cloud-hosted] should allow users to go through the embedding setup and onboarding flow", () => {
+    // mock `is-hosted`, we can't set the token before the user is created, we'll set it right after that
+    H.activateToken("pro-cloud");
+
+    mockCloudHosted();
+
     cy.visit(
       "/setup/embedding?first_name=Firstname&last_name=Lastname&email=testy@metabase.test&site_name=Epic Team",
     );
@@ -137,7 +142,9 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
       "Now we have a user we simulate being on cloud by setting a Metatabase Token",
     );
     cy.wait("@setup");
-    H.activateToken("pro-self-hosted");
+
+    // set a real token so we have real token-features for the rest of the flow
+    H.activateToken("pro-cloud");
 
     cy.log("2: Data connection step");
     sidebar().within(() => {
@@ -190,8 +197,7 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
       })
       .should("be.visible");
 
-    cy.log("Ensure the database sync status is not shown");
-    cy.findByRole("status").should("not.exist");
+    expectNoDatabaseStatus();
 
     step().within(() => {
       cy.findByRole("checkbox", { name: "feedback" })
@@ -263,8 +269,30 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
         1,
       );
     });
+    expectNoDatabaseStatus();
   });
 });
+
+/**
+ * Before the use creation we can't set the token, as that uses api calls that require being logged as admin.
+ * This simulates at least the `hosted/is-hosted?`
+ */
+const mockCloudHosted = () => {
+  cy.intercept("GET", "api/session/properties", (req) => {
+    req.on("response", (res) => {
+      res.body["is-hosted?"] = true;
+      res.body["token-features"] = {
+        ...res.body["token-features"],
+        hosting: true,
+      };
+    });
+  });
+};
+
+function expectNoDatabaseStatus() {
+  cy.log("Ensure the database sync status is not shown");
+  cy.findByRole("status").should("not.exist");
+}
 
 function assertEmbeddingOnboardingPageLoaded() {
   cy.findByLabelText("Embedding Setup Sidebar")
@@ -294,7 +322,7 @@ function fillOutUserForm() {
     .clear()
     .type("Epic Team", { delay: TYPE_DELAY });
 
-  cy.findByLabelText("Create a password").type("metabase123", {
+  cy.findByLabelText(/Create a password/).type("metabase123", {
     delay: TYPE_DELAY,
   });
   cy.findByLabelText("Confirm your password").type("metabase123", {

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -25,6 +25,7 @@ import {
   getErrorPage,
   getIsAdminApp,
   getIsAppBarVisible,
+  getIsEmbeddingSetup,
   getIsNavBarEnabled,
 } from "metabase/selectors/app";
 import StatusListing from "metabase/status/components/StatusListing";
@@ -55,6 +56,7 @@ const getErrorComponent = ({ status, data, context }: AppErrorDescriptor) => {
 interface AppStateProps {
   errorPage: AppErrorDescriptor | null;
   isAdminApp: boolean;
+  isEmbeddingSetup: boolean;
   bannerMessageDescriptor?: string;
   isAppBarVisible: boolean;
   isNavBarEnabled: boolean;
@@ -77,6 +79,7 @@ const mapStateToProps = (
 ): AppStateProps => ({
   errorPage: getErrorPage(state),
   isAdminApp: getIsAdminApp(state, props),
+  isEmbeddingSetup: getIsEmbeddingSetup(state, props),
   isAppBarVisible: getIsAppBarVisible(state, props),
   isNavBarEnabled: getIsNavBarEnabled(state, props),
 });
@@ -88,6 +91,7 @@ const mapDispatchToProps: AppDispatchProps = {
 function App({
   errorPage,
   isAdminApp,
+  isEmbeddingSetup,
   isAppBarVisible,
   isNavBarEnabled,
   children,
@@ -100,13 +104,16 @@ function App({
     initializeIframeResizer();
   }, []);
 
+  const isAppBannerVisible = !isEmbeddingSetup;
+  const isStatusListingVisible = !isEmbeddingSetup;
+
   return (
     <ErrorBoundary onError={onError}>
       <ScrollToTop>
         <KBarProvider>
           <KeyboardTriggeredErrorModal />
           <AppContainer className={CS.spread}>
-            <AppBanner />
+            {isAppBannerVisible && <AppBanner />}
             {isAppBarVisible && <AppBar />}
             <AppContentContainer isAdminApp={isAdminApp}>
               {isNavBarEnabled && <Navbar />}
@@ -118,7 +125,7 @@ function App({
                 </ContentViewportContext.Provider>
               </AppContent>
               <UndoListing />
-              <StatusListing />
+              {isStatusListingVisible && <StatusListing />}
               <NewModals />
               <PLUGIN_METABOT.Metabot hide={isAdminApp} />
             </AppContentContainer>

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -57,6 +57,10 @@ export const getIsAdminApp = createSelector([getRouterPath], (path) => {
   return path.startsWith("/admin/");
 });
 
+export const getIsEmbeddingSetup = createSelector([getRouterPath], (path) => {
+  return path.startsWith("/setup/embedding");
+});
+
 export const getIsCollectionPathVisible = createSelector(
   [
     getQuestion,

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DoneStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DoneStep.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import { t } from "ttag";
 
 import { useDocsUrl } from "metabase/common/hooks";
@@ -38,7 +37,11 @@ export const DoneStep = () => {
           description={t`Evolve these starter dashboards or create new analysis.`}
         />
       </Stack>
-      <Button component={Link} to="/" variant="filled">
+      {/* This needs to be a client side navigation for a couple of reasons:
+      - when we'll have the token step, we'll need to refresh the page to load the updated plugins
+      - in /setup/embedding we're skipping rendering the DatabaseStatus component, but as soon as the user lands on /
+      that will get rendered and shown, because we'll need the browser navigation anyway, this is a "cheap" solution to that as weel */}
+      <Button component="a" href="/" variant="filled">
         {t`Take me to Metabase`}
       </Button>
     </Box>

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DoneStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DoneStep.tsx
@@ -40,7 +40,7 @@ export const DoneStep = () => {
       {/* This needs to be a client side navigation for a couple of reasons:
       - when we'll have the token step, we'll need to refresh the page to load the updated plugins
       - in /setup/embedding we're skipping rendering the DatabaseStatus component, but as soon as the user lands on /
-      that will get rendered and shown, because we'll need the browser navigation anyway, this is a "cheap" solution to that as weel */}
+      that will get rendered and shown, because we'll need the browser navigation anyway, this is a "cheap" solution to that as well */}
       <Button component="a" href="/" variant="filled">
         {t`Take me to Metabase`}
       </Button>

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/UserCreationStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/UserCreationStep.tsx
@@ -2,6 +2,7 @@ import { t } from "ttag";
 
 import { useUpdateSettingsMutation } from "metabase/api";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import { loadCurrentUser } from "metabase/redux/user";
 import { Box, Text, Title } from "metabase/ui";
 import type { UserInfo } from "metabase-types/store";
 
@@ -20,6 +21,8 @@ export const UserCreationStep = () => {
 
   const handleSubmit = async (user: UserInfo) => {
     await dispatch(submitUser(user)).unwrap();
+    await dispatch(loadCurrentUser());
+
     // We want to set the embedding homepage visible if the user skips the rest of the flow.
     // This is the first place where we can do this, as we need the initial setup to be done.
     await updateSettings({ "embedding-homepage": "visible" });


### PR DESCRIPTION
This closes two tasks, as one task affected the other, each task is done on its own commit for an easier review.

closes EMB-533: makes the E2E uses the cloud token so it checks a realistic scenario, this is helpful especially because the other task may have differences because of the `is-hosted` feature


closes EMB-532: we had a bug that, only sometimes, the database status sync was shown.
The reason it was usually not shown is that it's rendered conditionally only for admins, and we didn't load the user during this setup so, in theory, that should not have been shown.
For some reason this sometimes was shown, when this happened locally I always blamed hot reload but it also happened in staging so I created a task to fix this.
As part of the fix I'm explicitly loading the user after we create it, so that we catch all issues right away and we don't rely on "the user is not loaded".


## How to verify

From an fresh instance, started with a pro-cloud token in the env, go to `/setup/embedding`
