### PR TITLE
Improve Sample apps health check logic

### DIFF
--- a/e2e/runner/embedding-sdk/host-apps/helpers/start-app.ts
+++ b/e2e/runner/embedding-sdk/host-apps/helpers/start-app.ts
@@ -17,7 +17,7 @@ export async function startApp({
   try {
     shell(appRunCommand, { detached: true, cwd, env });
 
-    await waitForHealth(`http://localhost:${env.CLIENT_PORT}`);
+    await waitForHealth(`http://localhost:${env.CLIENT_PORT}`, "Host App");
   } catch {
     shell(appDownCommand, { cwd, env });
   }

--- a/e2e/runner/embedding-sdk/sample-apps/constants/sample-app-setup-configs.js
+++ b/e2e/runner/embedding-sdk/sample-apps/constants/sample-app-setup-configs.js
@@ -16,6 +16,7 @@ const BASE_SETUP_CONFIG = {
   "docker-env-path": ".env.docker",
   defaultBranch: BRANCH_NAME,
   env: BASE_ENV,
+  healthcheckPorts: [BASE_ENV.MB_PORT, BASE_ENV.CLIENT_PORT],
 };
 
 export const SAMPLE_APP_SETUP_CONFIGS = {
@@ -31,6 +32,11 @@ export const SAMPLE_APP_SETUP_CONFIGS = {
       CLIENT_PORT_APP_ROUTER: BASE_ENV.CLIENT_PORT,
       CLIENT_PORT_PAGES_ROUTER: BASE_ENV.CLIENT_PORT + 1,
     },
+    healthcheckPorts: [
+      BASE_ENV.MB_PORT,
+      BASE_ENV.CLIENT_PORT,
+      BASE_ENV.CLIENT_PORT + 1,
+    ],
   },
   "shoppy-e2e": {
     ...BASE_SETUP_CONFIG,

--- a/e2e/runner/embedding-sdk/sample-apps/helpers/start-containers.ts
+++ b/e2e/runner/embedding-sdk/sample-apps/helpers/start-containers.ts
@@ -6,18 +6,28 @@ export async function startContainers({
   env,
   dockerUpCommand,
   dockerDownCommand,
+  healthcheckPorts,
 }: {
   cwd: string;
   env: Record<string, string | number>;
   dockerUpCommand: string;
   dockerDownCommand: string;
+  healthcheckPorts: number[];
 }) {
   console.log("Starting app in background...");
 
   try {
     shell(`${dockerUpCommand} -d`, { cwd, env });
 
-    await waitForHealth(`http://localhost:${env.MB_PORT}/api/health`);
+    const healthcheckPromises = healthcheckPorts.map((port) => {
+      if (port === env.MB_PORT) {
+        return waitForHealth(`http://localhost:${port}/api/health`, "Metabase");
+      }
+
+      return waitForHealth(`http://localhost:${port}`, `Sample App: ${port}`);
+    });
+
+    await Promise.all(healthcheckPromises);
   } catch {
     shell(dockerDownCommand, { cwd, env });
   }

--- a/e2e/runner/embedding-sdk/sample-apps/start-sample-app-containers.ts
+++ b/e2e/runner/embedding-sdk/sample-apps/start-sample-app-containers.ts
@@ -39,6 +39,7 @@ export async function startSampleAppContainers(
     "docker-env-example-path": dockerEnvExamplePath,
     "docker-env-path": dockerEnvPath,
     env,
+    healthcheckPorts,
   } = setupConfig;
   const branch = userOptions.SAMPLE_APP_BRANCH_NAME || defaultBranch;
 
@@ -72,6 +73,7 @@ export async function startSampleAppContainers(
       env,
       dockerUpCommand,
       dockerDownCommand,
+      healthcheckPorts,
     });
 
     printBold(`All done! The ${appName} sample app is now running.`);

--- a/e2e/runner/embedding-sdk/shared/helpers/wait-for-health.ts
+++ b/e2e/runner/embedding-sdk/shared/helpers/wait-for-health.ts
@@ -3,12 +3,12 @@ import { delay } from "../../../cypress-runner-utils";
 const HEALTH_CHECK_ATTEMPTS_COUNT = 60 * 5;
 const HEALTH_CHECK_WAIT_TIME_MS = 2000;
 
-export async function waitForHealth(url: string) {
+export async function waitForHealth(url: string, identifier: string) {
   for (let i = 0; i < HEALTH_CHECK_ATTEMPTS_COUNT; i++) {
     try {
       const res = await fetch(url);
       if (res.ok) {
-        console.log("App is ready");
+        console.log(`${identifier} is ready`);
         return;
       }
     } catch {}


### PR DESCRIPTION
We have to wait until a sample app actually returns a status code before running Cypress, because for Next.js in dev mode, it compiles a bundle on the fly while a page is loading, and it may cause flakiness.

CI should pass