### PR TITLE
add events to track modal viewed and confirmed

### DIFF
--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -159,6 +159,22 @@ export type EventsClickedEvent = ValidateEvent<{
   triggered_from: "chart" | "collection";
 }>;
 
+export type MoveQuestionsIntoDashboardViewedEvent = ValidateEvent<{
+  event: "move_questions_into_dashboard_viewed";
+  target_id: null;
+  triggered_from: "collection_menu";
+  duration_ms: null;
+  result: string;
+}>;
+
+export type MoveQuestionsIntoDashboardConfirmedEvent = ValidateEvent<{
+  event: "move_questions_into_dashboard_confirmed";
+  target_id: null;
+  triggered_from: "move_questions_into_dashboards_modal";
+  duration_ms: number;
+  result: string;
+}>;
+
 export type SimpleEvent =
   | CSVUploadClickedEvent
   | DatabaseAddClickedEvent
@@ -179,4 +195,6 @@ export type SimpleEvent =
   | VisualizeAnotherWayClickedEvent
   | VisualizerModalEvent
   | EmbeddingSetupStepSeenEvent
-  | EventsClickedEvent;
+  | EventsClickedEvent
+  | MoveQuestionsIntoDashboardViewedEvent
+  | MoveQuestionsIntoDashboardConfirmedEvent;

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -161,15 +161,12 @@ export type EventsClickedEvent = ValidateEvent<{
 
 export type MoveQuestionsIntoDashboardViewedEvent = ValidateEvent<{
   event: "move_questions_into_dashboard_viewed";
-  target_id: null;
   triggered_from: "move_questions_into_dashboards_modal";
-  duration_ms: null;
   result: string;
 }>;
 
 export type MoveQuestionsIntoDashboardConfirmedEvent = ValidateEvent<{
   event: "move_questions_into_dashboard_confirmed";
-  target_id: null;
   triggered_from: "move_questions_into_dashboards_modal";
   duration_ms: number;
   result: string;

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -162,7 +162,7 @@ export type EventsClickedEvent = ValidateEvent<{
 export type MoveQuestionsIntoDashboardViewedEvent = ValidateEvent<{
   event: "move_questions_into_dashboard_viewed";
   target_id: null;
-  triggered_from: "collection_menu";
+  triggered_from: "move_questions_into_dashboards_modal";
   duration_ms: null;
   result: string;
 }>;

--- a/frontend/src/metabase/common/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsModal.tsx
+++ b/frontend/src/metabase/common/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsModal.tsx
@@ -55,7 +55,7 @@ export const MoveQuestionsIntoDashboardsModal = withRouter(
         trackSimpleEvent({
           event: "move_questions_into_dashboard_viewed",
           target_id: null,
-          triggered_from: "collection_menu",
+          triggered_from: "move_questions_into_dashboards_modal",
           duration_ms: null,
           result: candidatesReq.data.total.toString(),
         });

--- a/frontend/src/metabase/common/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsModal.tsx
+++ b/frontend/src/metabase/common/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsModal.tsx
@@ -45,22 +45,21 @@ export const MoveQuestionsIntoDashboardsModal = withRouter(
     const [bulkMove, bulkMoveReq] =
       useMoveCollectionDashboardQuestionCandidatesMutation();
 
-    // Track the click event when the modal is displayed for the first time
+    // Track the viewed event when the modal is displayed for the first time with candidates
     useEffect(() => {
-      if (
+      const shouldTrackModalViewed =
         !isAckedInfoLoading &&
         !ackedInfoStep &&
-        candidatesReq.data?.total !== undefined
-      ) {
+        (candidatesReq.data?.total ?? 0) > 0;
+
+      if (shouldTrackModalViewed) {
         trackSimpleEvent({
           event: "move_questions_into_dashboard_viewed",
-          target_id: null,
           triggered_from: "move_questions_into_dashboards_modal",
-          duration_ms: null,
-          result: candidatesReq.data.total.toString(),
+          result: candidatesReq.data!.total.toString(),
         });
       }
-    }, [isAckedInfoLoading, ackedInfoStep, candidatesReq.data?.total]);
+    }, [isAckedInfoLoading, ackedInfoStep, candidatesReq.data]);
 
     // redirect to base collection page if there's an invalid collection id
     useEffect(() => {
@@ -81,7 +80,6 @@ export const MoveQuestionsIntoDashboardsModal = withRouter(
 
           trackSimpleEvent({
             event: "move_questions_into_dashboard_confirmed",
-            target_id: null,
             triggered_from: "move_questions_into_dashboards_modal",
             duration_ms: duration,
             result: cardIds.length.toString(),


### PR DESCRIPTION
## Summary

Adds analytics tracking for the "Move questions into their dashboards" feature to measure user engagement and understand usage patterns of this collection cleanup functionality.

## What does this PR do?

This PR implements two analytics events to track user interactions with the "Move questions into dashboards" modal:

1. **Modal viewed event** - Tracks when users view the move questions modal
2. **Confirmation event** - Tracks when users successfully move questions with timing data

## Events Added

### 1. `move_questions_into_dashboard_viewed`
**Triggered:** When the info modal is first displayed to the user  
**Properties:**
- `event`: `"move_questions_into_dashboard_viewed"`
- `target_id`: `null`
- `triggered_from`: `"move_questions_into_dashboards_modal"`
- `duration_ms`: `null` 
- `result`: Number of questions found (as string)

### 2. `move_questions_into_dashboard_confirmed` 
**Triggered:** When user confirms and successfully moves questions  
**Properties:**
- `event`: `"move_questions_into_dashboard_confirmed"`
- `target_id`: `null`
- `triggered_from`: `"move_questions_into_dashboards_modal"`
- `duration_ms`: Total time for move operation (number)
- `result`: Number of questions moved (as string)

## Implementation Details

- **Accurate counting**: Uses actual API data (`candidatesReq.data.total`) instead of boolean indicators
- **Proper timing**: Measures the complete duration of the bulk move operation
- **Event location**: Tracks the viewed event when modal is displayed (not on button click) to ensure we have loaded data
- **Type safety**: Added TypeScript definitions for both events in the analytics schema

## Why this change?

This tracking will help the product team understand:
- How often users discover questions that can be moved into dashboards
- Conversion rates from viewing the modal to actually performing the cleanup
- Performance characteristics of the bulk move operation
- Usage patterns to inform future UX improvements

## Files Changed

- `frontend/src/metabase-types/analytics/event.ts` - Added new event type definitions
- `frontend/src/metabase/common/components/MoveQuestionsIntoDashboardsModal/MoveQuestionsIntoDashboardsModal.tsx` - Added analytics tracking

## Testing

The events can be observed in browser console when `shouldLogAnalytics` is enabled, showing the event data and whether it was sent to Snowplow.