### PR TITLE
Remove all instances (except one) of the old and deprecated `Tooltip` component 

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperButton.tsx
@@ -5,10 +5,9 @@ import { t } from "ttag";
 import Button from "metabase/common/components/Button";
 import { Ellipsified } from "metabase/common/components/Ellipsified";
 import TippyPopover from "metabase/common/components/Popover/TippyPopover";
-import DeprecatedTooltip from "metabase/common/components/Tooltip";
 import { ParameterTargetList } from "metabase/parameters/components/ParameterTargetList";
 import type { ParameterMappingOption } from "metabase/parameters/utils/mapping-options";
-import { Box, Flex, Icon } from "metabase/ui";
+import { Box, Flex, Icon, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { Card, ParameterTarget } from "metabase-types/api";
@@ -134,7 +133,7 @@ export const DashCardCardParameterMapperButton = ({
     ]);
 
   return (
-    <DeprecatedTooltip tooltip={buttonTooltip}>
+    <Tooltip label={buttonTooltip}>
       <TippyPopover
         visible={isDropdownVisible && !isDisabled && hasPermissionsToMap}
         onClickOutside={() => setIsDropdownVisible(false)}
@@ -191,7 +190,7 @@ export const DashCardCardParameterMapperButton = ({
           {buttonIcon}
         </Flex>
       </TippyPopover>
-    </DeprecatedTooltip>
+    </Tooltip>
   );
 };
 

--- a/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel.tsx
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
-import Tooltip from "metabase/common/components/Tooltip";
-import { Icon } from "metabase/ui";
+import { Icon, Tooltip } from "metabase/ui";
 
 import S from "./DashboardCopyModalShallowCheckboxLabel.module.css";
 
@@ -13,7 +12,7 @@ export const DashboardCopyModalShallowCheckboxLabel = ({
   <div className={S.checkboxLabelRoot}>
     {t`Only duplicate the dashboard`}
     <Tooltip
-      tooltip={
+      label={
         hasDashboardQuestions
           ? t`Only available when none of the questions are saved to the dashboard.`
           : t`If you check this, the cards in the duplicated dashboard will reference the original questions.`

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
@@ -14,15 +14,12 @@ import KeyValuePairChartTooltip from "./KeyValuePairChartTooltip";
 import StackedDataTooltip from "./StackedDataTooltip";
 import TimelineEventTooltip from "./TimelineEventTooltip";
 
-export interface ChartTooltipProps {
+interface ChartTooltipProps {
   hovered?: HoveredObject | null;
   settings: VisualizationSettings;
 }
 
-export const ChartTooltipContent = ({
-  hovered,
-  settings,
-}: ChartTooltipProps) => {
+const ChartTooltipContent = ({ hovered, settings }: ChartTooltipProps) => {
   if (!hovered) {
     return null;
   }


### PR DESCRIPTION
Unfortunately, we cannot fully remove the deprecated Tooltip at this moment since it's still being used by the `ChartTooltip` component. At this moment, it's not easy to replace that implementation with anything that Mantine provides out of the box.

This PR replaces the other (two) instances of the old Tooltip with a newer Mantine variant.