### PR TITLE
Better `defsetting` validation

### DIFF
--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -73,6 +73,7 @@
   has-attached-dwh?
   hide-embed-branding?
   is-hosted?
+  known-features
   premium-embedding-token
   site-uuid-for-premium-features-token-checks
   token-features

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -72,7 +72,7 @@
 
 (def ^:private premium-features
   "Set of defined premium feature keywords."
-  (atom #{}))
+  (atom (sorted-set)))
 
 (defn- default-premium-feature-getter [feature]
   (fn []
@@ -304,3 +304,8 @@
   :setter     :none
   :getter     -token-features
   :doc        false)
+
+(defn known-features
+  "Set of all known premium features."
+  []
+  @premium-features)


### PR DESCRIPTION
1. Error if you include unknown options keys in `defsetting` (this is probably a typo; at any rate, it means it's not doing what you think it is)
2. Validate `:feature` so you can't use an invalid/unknown feature
3. Make the set of known premium features a `sorted-set` so it's easier to look at in the REPL.