### PR TITLE
Add QP integration tests for custom expressions in join conditions

### DIFF
--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -1281,8 +1281,17 @@
      [[1 "Red Medicine" "Dim Sum"]
       [2 "Stout Burgers & Beers" "Dim Sum"]])))
 
+;; FIXME QUE-1500 Fix join condition compilation on mongo and remove this feature
+(defmethod driver/database-supports? [::driver/driver ::join-expressions-lhs-cols-rhs-literal]
+  [_driver _feature _database]
+  true)
+
+(defmethod driver/database-supports? [:mongo ::join-expressions-lhs-col-rhs-literal]
+  [_driver _feature _database]
+  false)
+
 (deftest ^:parallel join-expressions-lhs-col-rhs-literal-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions ::join-expressions-lhs-col-rhs-literal)
     (check-venues+categories-on-condition
      [:=
       (mt/$ids venues $name)

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -9,6 +9,7 @@
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
+   [metabase.lib.expression :as lib.expression]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.test-util :as lib.tu]
@@ -21,6 +22,7 @@
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
+   [metabase.util :as u]
    [metabase.util.date-2 :as u.date]))
 
 (deftest ^:parallel explict-join-with-default-options-test
@@ -1159,3 +1161,337 @@
              (mt/formatted-rows
               [int 1.0 4.0 1.0]
               (qp/process-query query)))))))
+
+(def ^:private venues+categories-expected-rows-for-fk=pk-join-condition
+  [[1 "Red Medicine" "Asian"]
+   [2 "Stout Burgers & Beers" "Burger"]
+   [3 "The Apple Pan" "Burger"]
+   [4 "Wurstküche" "German"]])
+
+(def ^:private venues+categories-expected-rows-for-always-true-condition
+  [[1 "Red Medicine" "African"]
+   [1 "Red Medicine" "American"]
+   [1 "Red Medicine" "Artisan"]
+   [1 "Red Medicine" "Asian"]])
+
+(def ^:private venues+categories-expected-rows-for-always-false-condition
+  [[1 "Red Medicine" nil]
+   [2 "Stout Burgers & Beers" nil]
+   [3 "The Apple Pan" nil]
+   [4 "Wurstküche" nil]])
+
+(defn- check-venues+categories-on-condition
+  [condition expected-rows]
+  (let [query (mt/mbql-query venues
+                {:joins       [{:condition    condition
+                                :source-table $$categories
+                                :alias        "c"
+                                :fields       [&c.categories.name]}]
+                 :fields      [$id $name &c.categories.name]
+                 :order-by    [[:asc $id]
+                               [:asc &c.categories.id]]
+                 :limit       (count expected-rows)})]
+    (testing (str "\nMBQL Query =\n" (u/pprint-to-str query))
+      (mt/with-native-query-testing-context query
+        (is (= expected-rows
+               (mt/formatted-rows
+                [int str str]
+                (qp/process-query query))))))))
+
+(deftest ^:parallel join-expressions-lhs-and-rhs-both-columns-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:=
+      (mt/$ids venues $category_id)
+      (mt/$ids categories &c.categories.id)]
+     venues+categories-expected-rows-for-fk=pk-join-condition)))
+
+(deftest ^:parallel join-expressions-lhs-and-rhs-both-expressions-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:=
+      [:* 1 (mt/$ids venues $category_id)]
+      [:+ 0 (mt/$ids categories &c.categories.id)]]
+     venues+categories-expected-rows-for-fk=pk-join-condition)))
+
+(deftest ^:parallel join-expressions-lhs-col-rhs-expr-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:=
+      (mt/$ids venues $category_id)
+      [:+ 0 (mt/$ids categories &c.categories.id)]]
+     venues+categories-expected-rows-for-fk=pk-join-condition)))
+
+(deftest ^:parallel join-expressions-lhs-expr-rhs-col-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:=
+      [:+ 0 (mt/$ids venues $category_id)]
+      (mt/$ids categories &c.categories.id)]
+     venues+categories-expected-rows-for-fk=pk-join-condition)))
+
+(deftest ^:parallel join-expressions-lhs-and-rhs-expressions-without-cols-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:= [:+ 1 1] [:* 2 1]]
+     venues+categories-expected-rows-for-always-true-condition)))
+
+(deftest ^:parallel join-expressions-lhs-and-rhs-expressions-without-cols-with-false-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:= [:+ 2 1] [:* 2 1]]
+     venues+categories-expected-rows-for-always-false-condition)))
+
+(deftest ^:parallel join-expressions-lhs-and-rhs-literal-values-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:=
+      [:value 1 {:base_type :type/Integer}]
+      [:value 1 {:base_type :type/Integer}]]
+     venues+categories-expected-rows-for-always-true-condition)))
+
+(deftest ^:parallel join-expressions-lhs-and-rhs-unwrapped-literal-values-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:= true true]
+     venues+categories-expected-rows-for-always-true-condition)))
+
+(deftest ^:parallel join-expressions-lhs-and-rhs-unwrapped-literal-values-with-false-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:= true false]
+     venues+categories-expected-rows-for-always-false-condition)))
+
+(deftest ^:parallel join-expressions-lhs-and-rhs-non-trivial-expressions-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     ;; a wacky condition that validates lhs/rhs expression evaluation
+     [:=
+      [:+ 2 (mt/$ids venues $category_id)]
+      [:+ 1 (mt/$ids categories &c.categories.id)]]
+     [[1 "Red Medicine" "BBQ"]
+      [2 "Stout Burgers & Beers" "Café"]])))
+
+(deftest ^:parallel join-expressions-lhs-literal-rhs-col-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:=
+      [:value 19 {:base_type :type/Integer}]
+      (mt/$ids categories &c.categories.id)]
+     [[1 "Red Medicine" "Dim Sum"]
+      [2 "Stout Burgers & Beers" "Dim Sum"]])))
+
+(deftest ^:parallel join-expressions-lhs-col-rhs-literal-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:=
+      (mt/$ids venues $name)
+      [:value "Stout Burgers & Beers" {:base_type :type/Text}]]
+     [[1 "Red Medicine" nil]
+      [2 "Stout Burgers & Beers" "African"]])))
+
+(deftest ^:parallel join-expressions-lhs-and-rhs-expressions-with-function-calls-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:=
+      [:substring
+       (mt/$ids venues $name)
+       ;; The first +1 accounts for 1-based indexing. The second +1 accounts for the space character that follows
+       ;; "Stout". We could get the :length of "Stout ", but sqlserver's LEN function ignores trailing whitespace.
+       [:+ 1 [:+ 1 [:length "Stout"]]]
+       [:length "Burger"]]
+      [:substring
+       (mt/$ids categories &c.categories.name)
+       1
+       [:length "Burger"]]]
+     [[1 "Red Medicine" nil]
+      [2 "Stout Burgers & Beers" "Burger"]])))
+
+(deftest ^:parallel join-expressions-lhs-expression-with-multiple-cols-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:=
+      [:+
+       (mt/$ids venues $category_id)
+       (mt/$ids venues $price)]
+      (mt/$ids categories &c.categories.id)]
+     [[1 "Red Medicine" "Bar"]
+      [2 "Stout Burgers & Beers" "Café Sweets"]])))
+
+(deftest ^:parallel join-expressions-lhs-expr-rhs-col-with-operator-<-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:<
+      [:+ 1 (mt/$ids venues $price)]
+      (mt/$ids categories &c.categories.id)]
+     [[1 "Red Medicine" "BBQ"]
+      [1 "Red Medicine" "Bakery"]])))
+
+(deftest ^:parallel join-expressions-lhs-col-rhs-col-with-operator-!=-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-on-condition
+     [:!=
+      (mt/$ids venues $category_id)
+      (mt/$ids categories &c.categories.id)]
+     [[1 "Red Medicine" "African"]
+      [1 "Red Medicine" "American"]
+      [1 "Red Medicine" "Artisan"]
+      [1 "Red Medicine" "BBQ"]])))
+
+(defn- check-venues+categories-with-value-wrapped-args
+  [[op & args] expected-rows]
+  (check-venues+categories-on-condition
+   (into [op] (comp (map lib.expression/value)
+                    (map lib.convert/->legacy-MBQL))
+         args)
+   expected-rows))
+
+(deftest ^:parallel join-expressions-operator-<-always-true-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-with-value-wrapped-args
+     [:< 0 1]
+     venues+categories-expected-rows-for-always-true-condition)))
+
+(deftest ^:parallel join-expressions-operator-<-always-false-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-with-value-wrapped-args
+     [:< 1 0]
+     venues+categories-expected-rows-for-always-false-condition)))
+
+(deftest ^:parallel join-expressions-operator->-always-true-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-with-value-wrapped-args
+     [:> 1 0]
+     venues+categories-expected-rows-for-always-true-condition)))
+
+(deftest ^:parallel join-expressions-operator->-always-false-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-with-value-wrapped-args
+     [:> 0 1]
+     venues+categories-expected-rows-for-always-false-condition)))
+
+(deftest ^:parallel join-expressions-operator-<=-always-true-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-with-value-wrapped-args
+     [:<= 1 1]
+     venues+categories-expected-rows-for-always-true-condition)))
+
+(deftest ^:parallel join-expressions-operator-<=-always-false-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-with-value-wrapped-args
+     [:<= 2 1]
+     venues+categories-expected-rows-for-always-false-condition)))
+
+(deftest ^:parallel join-expressions-operator->=-always-true-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-with-value-wrapped-args
+     [:>= 1 1]
+     venues+categories-expected-rows-for-always-true-condition)))
+
+(deftest ^:parallel join-expressions-operator->=-always-false-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-with-value-wrapped-args
+     [:>= 1 2]
+     venues+categories-expected-rows-for-always-false-condition)))
+
+(deftest ^:parallel join-expressions-operator-=-always-true-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-with-value-wrapped-args
+     [:= 1 1]
+     venues+categories-expected-rows-for-always-true-condition)))
+
+(deftest ^:parallel join-expressions-operator-=-always-false-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+    (check-venues+categories-with-value-wrapped-args
+     [:= 0 1]
+     venues+categories-expected-rows-for-always-false-condition)))
+
+;; FIXME: QUE-1499 The sql driver does not compile the :!= clause
+#_(deftest ^:parallel join-expressions-operator-!=-always-true-condition-test
+    (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+      (check-venues+categories-with-value-wrapped-args
+       [:!= 0 1]
+       venues+categories-expected-rows-for-always-true-condition)))
+
+#_(deftest ^:parallel join-expressions-operator-!=-always-false-condition-test
+    (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
+      (check-venues+categories-with-value-wrapped-args
+       [:!= 1 1]
+       venues+categories-expected-rows-for-always-false-condition)))
+
+(deftest ^:parallel join-expressions-aggregations-and-breakouts-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions :basic-aggregations)
+    (doseq [{:keys [description condition]}
+            [{:description "products + orders with lhs and rhs columns"
+              :condition   [:=
+                            (mt/$ids products $id)
+                            (mt/$ids orders &o.orders.product_id)]}
+             {:description "products + orders with lhs and rhs expressions"
+              :condition   [:=
+                            [:+ 0 (mt/$ids products $id)]
+                            [:* 1 (mt/$ids orders &o.orders.product_id)]]}]]
+      (testing (str "\n" description "\n" condition)
+        (is (= [["Doohickey" 297271.47 14388.0]
+                ["Gadget" 406619.75 18865.0]
+                ["Gizmo" 383059.77 17367.0]]
+               (mt/formatted-rows
+                [str 2.0 2.0]
+                (mt/run-mbql-query products
+                  {:joins       [{:condition    condition
+                                  :source-table $$orders
+                                  :alias        "o"}]
+                   :breakout    [$category]
+                   :aggregation [[:sum &o.orders.total]
+                                 [:sum &o.orders.quantity]]
+                   :limit       3}))))))))
+
+(deftest ^:parallel join-expressions-inner-join-bucketed-dates-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :inner-join :expressions)
+    (testing "products + orders with month(products.created_at) = month(orders.created_at)"
+      (is (= [[1 5286  "Rustic Paper Wallet" "2017-07-19T19:44:56Z" "2017-07-28T13:58:43Z"]
+              [1 16048 "Rustic Paper Wallet" "2017-07-19T19:44:56Z" "2017-07-22T16:11:45Z"]
+              [2 2250  "Small Marble Shoes"  "2019-04-11T08:49:35Z" "2019-04-22T23:22:07Z"]]
+             (mt/formatted-rows
+              [int int str u.date/temporal-str->iso8601-str u.date/temporal-str->iso8601-str]
+              (mt/run-mbql-query products
+                {:joins       [{:condition    [:and
+                                               [:=
+                                                (mt/$ids products $id)
+                                                (mt/$ids orders &o.orders.product_id)]
+                                               [:=
+                                                (mt/$ids products !month.created_at)
+                                                (mt/$ids orders !month.&o.orders.created_at)]]
+                                :source-table $$orders
+                                :strategy     :inner-join
+                                :alias        "o"}]
+                 :fields      [$id &o.orders.id $title $created_at &o.orders.created_at]
+                 :order-by    [[:asc $id]
+                               [:asc &o.orders.id]]
+                 :limit       3})))))))
+
+(deftest ^:parallel join-expressions-inner-join-datetime-diff-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :inner-join :expressions :datetime-diff)
+    (testing "products + orders with dateTimeDiff(p.created_at, o.created_at) < 0 days"
+      (is (= [[1  448 "Rustic Paper Wallet" "2017-07-19T19:44:56Z" "2016-12-25T22:19:38Z"]
+              [1  493 "Rustic Paper Wallet" "2017-07-19T19:44:56Z" "2017-02-04T10:16:00Z"]
+              [1 1637 "Rustic Paper Wallet" "2017-07-19T19:44:56Z" "2017-02-16T06:03:39Z"]]
+             (mt/formatted-rows
+              [int int str u.date/temporal-str->iso8601-str u.date/temporal-str->iso8601-str]
+              (mt/run-mbql-query products
+                {:joins       [{:condition    [:and
+                                               [:=
+                                                (mt/$ids products $id)
+                                                (mt/$ids orders &o.orders.product_id)]
+                                               [:<
+                                                [:datetime-diff
+                                                 (mt/$ids products $created_at)
+                                                 (mt/$ids orders &o.orders.created_at)
+                                                 :day]
+                                                0]]
+                                :source-table $$orders
+                                :strategy     :inner-join
+                                :alias        "o"}]
+                 :fields      [$id &o.orders.id $title $created_at &o.orders.created_at]
+                 :order-by    [[:asc $id]
+                               [:asc &o.orders.id]]
+                 :limit       3})))))))


### PR DESCRIPTION
Closes QUE-1446

### Description

Add QP integration tests for custom expressions in join conditions including test cases for

- join condition operators from:  `[:= :> :< :>= :<= :!=]`
- LHS and RHS of the join condition from
   - `:value` literals
   - plain columns (`:field` references)
   - expressions without columns, e.g. `[:+ 1 2]`
   - expressions with 1 or multiple columns

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
