### PR TITLE
Update license text for airgap tokens

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import dayjs from "dayjs";
 import fetchMock from "fetch-mock";
 
 import {
@@ -70,6 +71,10 @@ const setup = async ({
 };
 
 describe("LicenseAndBilling", () => {
+  beforeEach(() => {
+    jest.spyOn(dayjs.prototype, "diff").mockReturnValue(27209);
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
@@ -17,6 +17,7 @@ import {
   createMockSettings,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
+import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import { getBillingInfoId } from "../BillingInfo/utils";
 
@@ -25,13 +26,16 @@ import { LicenseAndBillingSettings } from "./LicenseAndBillingSettings";
 const setup = async ({
   token = "token",
   is_env_setting = false,
+  airgapEnabled = false,
   features = {},
 }: {
   token?: string | null;
   is_env_setting?: boolean;
+  airgapEnabled?: boolean;
   features?: Partial<TokenFeatures> & { "metabase-store-managed"?: boolean };
 }) => {
   const settings = createMockSettings({
+    "airgap-enabled": airgapEnabled,
     "premium-embedding-token": token,
     "token-features": createMockTokenFeatures(features),
   });
@@ -43,6 +47,10 @@ const setup = async ({
       env_name: "MB_PREMIUM_EMBEDDING_TOKEN",
       value: token,
     },
+    {
+      key: "airgap-enabled",
+      value: airgapEnabled,
+    },
   ]);
 
   setupPropertiesEndpoints(settings);
@@ -52,7 +60,11 @@ const setup = async ({
   );
   setupUpdateSettingEndpoint();
 
-  renderWithProviders(<LicenseAndBillingSettings />);
+  renderWithProviders(<LicenseAndBillingSettings />, {
+    storeInitialState: {
+      settings: createMockSettingsState(settings),
+    },
+  });
 
   await screen.findByTestId("license-and-billing-content");
 };
@@ -254,6 +266,24 @@ describe("LicenseAndBilling", () => {
       screen.getByText(
         "Your license is active until Dec 31, 2099! Hope you’re enjoying it.",
       ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders settings for airgapped token", async () => {
+    await setup({ token: "valid", airgapEnabled: true });
+
+    expect(
+      await screen.findByText(
+        "To manage your billing preferences, please email",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("billing@metabase.com")).toHaveAttribute(
+      "href",
+      "mailto:billing@metabase.com",
+    );
+
+    expect(
+      screen.getByText("Your token expires in 27209 days."),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59362

Old:
![image](https://github.com/user-attachments/assets/3173f08e-6f29-4d16-bd7a-44b14c2e042e)

New:
<img width="860" alt="Screenshot 2025-07-03 at 2 23 02 PM" src="https://github.com/user-attachments/assets/20e69fa2-61e9-494e-939d-6595251bd6b3" />

How to test:
You can get the uberjar from the CI build process and generate an airgapped jar from it following these steps https://github.com/metabase/token_airgap_gen?tab=readme-ov-file#steps-to-generate-an-airgap-jar

@likeshumidity Just checking the copy here. I removed the 'If you already have a license, please enter it below' part because it didn't seem to make sense for airgapped instances?

