### PR TITLE
ask search bots to not index openapi docs

### DIFF
--- a/resources/openapi/index.html
+++ b/resources/openapi/index.html
@@ -2,9 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
     <title>Metabase API doc</title>
     <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700&display=swap" rel="stylesheet" />
   </head>
@@ -14,10 +13,7 @@
     }
   </style>
   <body>
-    <script
-      id="api-reference"
-      data-url="openapi.json"></script>
-
+    <script id="api-reference" data-url="openapi.json"></script>
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   </body>
 </html>


### PR DESCRIPTION
otherwise Google is trying to index every instance of Metabase docs
