### PR TITLE
Closes VIZ-1216 bubble size well style 

### DIFF
--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.module.css
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.module.css
@@ -2,12 +2,12 @@
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) minmax(118px, auto);
   grid-template-rows: auto minmax(0, 1fr) minmax(auto, 42px);
   grid-template-areas:
-    "left main top-right"
-    "left main ."
-    "bottom-left bottom .";
+    ". . top"
+    "left main main"
+    "bottom-left bottom bottom";
   position: relative;
 }
 

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.tsx
@@ -137,7 +137,7 @@ export function VisualizationCanvas({ className }: VisualizationCanvasProps) {
           <HorizontalWell display={display} />
         </Box>
         {display === "scatter" && (
-          <Box style={{ gridArea: "top-right" }}>
+          <Box style={{ gridArea: "top" }}>
             <ScatterFloatingWell />
           </Box>
         )}

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/wells/ScatterFloatingWell/ScatterFloatingWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/wells/ScatterFloatingWell/ScatterFloatingWell.tsx
@@ -59,7 +59,7 @@ export function ScatterFloatingWell() {
           </Text>
         </WellItem>
       ) : (
-        <Text c="text-light">{t`Bubble size`}</Text>
+        <Text c="text-light" ta="center">{t`Bubble size`}</Text>
       )}
     </Box>
   );


### PR DESCRIPTION
Closes [VIZ-1216: Bubble size well for scatter charts is far removed from other stuff](https://linear.app/metabase/issue/VIZ-1216/bubble-size-well-for-scatter-charts-is-far-removed-from-other-stuff)

<img width="1549" alt="image" src="https://github.com/user-attachments/assets/e2e5bc47-c5cf-4c42-aa0d-9107ad5b413b" />
<img width="1549" alt="image" src="https://github.com/user-attachments/assets/df1f940b-51f3-49e0-9ea5-66612fd3b8be" />
