### PR TITLE
Closes VIZ-1209 browser stalls when too many series in visualizer

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -97,6 +97,10 @@ export const getCartesianChartModel = (
     hiddenSeries,
     settings,
   );
+  // Limiting the number of series models to 100 to avoid performance issues
+  // with rendering large number of series in ECharts.
+  // We display an error message if there are more than 100 series models anyway.
+  unsortedSeriesModels.splice(101);
 
   const unsortedDataset = getJoinedCardsDataset(
     rawSeries,


### PR DESCRIPTION
Closes [VIZ-1209: Browser stalls when working with unaggregated data](https://linear.app/metabase/issue/VIZ-1209/browser-stalls-when-working-with-unaggregated-data)

### Description

We already prevent displaying more than 100 series in cartesian charts. This limits the number of series we handle to 101, so the error path still kicks in, but the model is much more manageable.

In the original bug, the FE code ends up dealing with a model of more than 2000 series, which makes everything (_everything_, even the settings UI) slow. Cropping that to 101 is an easy fix and at least no longer stalls the browser.

### How to verify

1. Make a new question that is a table of Orders
2. Put in in a card on a dashboard, open it in the visualizer: 
<img width="1446" alt="image" src="https://github.com/user-attachments/assets/74881d24-3684-4920-876d-6a0827514241" />

3. Deselect ID, then select Created At, and re-select ID

###### Expected result
You should see this, not an hour later:
<img width="1446" alt="image" src="https://github.com/user-attachments/assets/766429e9-92b6-4bf2-8dcf-7c4090a31fe3" />

###### Actual result
The browser hangs and eventually if you're lucky you see an error