### PR TITLE
embedding setup: remove last fetch call and speed up e2e

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
@@ -242,43 +242,6 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
         ),
       );
 
-      cy.findByRole("tab", { name: 'A look at "Orders"' }).click();
-      /**
-       * There's a problem when changing tabs, sometimes Cypress seems to still get the old iframe body.
-       * So, it's be much more stable to wait for a brief moment before trying to get the new iframe body.
-       */
-      cy.wait(100);
-      H.getIframeBody().within(() => {
-        cy.findByText('A look at "Orders"').should("be.visible");
-      });
-      cy.findByRole("code").contains(
-        new RegExp(
-          `<iframe src="${Cypress.config("baseUrl")}/dashboard/\\d+" width="800px" height="500px" />`,
-        ),
-      );
-
-      cy.findByRole("tab", { name: 'A look at "Products"' }).click();
-      cy.wait(100);
-      H.getIframeBody().within(() => {
-        cy.findByText('A look at "Products"').should("be.visible");
-      });
-      cy.findByRole("code").contains(
-        new RegExp(
-          `<iframe src="${Cypress.config("baseUrl")}/dashboard/\\d+" width="800px" height="500px" />`,
-        ),
-      );
-
-      cy.findByRole("tab", { name: "Query Builder" }).click();
-      cy.wait(100);
-      H.getIframeBody().within(() => {
-        cy.findByText("Pick your starting data").should("be.visible");
-      });
-      cy.findByRole("code").contains(
-        new RegExp(
-          `<iframe src="${Cypress.config("baseUrl")}/question/new" width="800px" height="500px" />`,
-        ),
-      );
-
       cy.button("I see Metabase").click();
 
       cy.findByRole("heading", { name: "You're on your way!" }).should(
@@ -317,21 +280,35 @@ function sidebar() {
   return cy.findByRole("complementary");
 }
 
-function fillOutUserForm() {
-  cy.findByLabelText("First name").clear().type("Testy");
-  cy.findByLabelText("Last name").clear().type("McTestface");
-  cy.findByLabelText("Email").clear().type("testy@metabase.test");
-  cy.findByLabelText("Company or team name").clear().type("Epic Team");
+const TYPE_DELAY = 0;
 
-  cy.findByLabelText("Create a password").type("metabase123");
-  cy.findByLabelText("Confirm your password").type("metabase123");
+function fillOutUserForm() {
+  cy.findByLabelText("First name").clear().type("Testy", { delay: TYPE_DELAY });
+  cy.findByLabelText("Last name")
+    .clear()
+    .type("McTestface", { delay: TYPE_DELAY });
+  cy.findByLabelText("Email")
+    .clear()
+    .type("testy@metabase.test", { delay: TYPE_DELAY });
+  cy.findByLabelText("Company or team name")
+    .clear()
+    .type("Epic Team", { delay: TYPE_DELAY });
+
+  cy.findByLabelText("Create a password").type("metabase123", {
+    delay: TYPE_DELAY,
+  });
+  cy.findByLabelText("Confirm your password").type("metabase123", {
+    delay: TYPE_DELAY,
+  });
 }
 
 function fillOutDatabaseForm() {
-  cy.findByLabelText("Display name").type("Postgres Database");
-  cy.findByLabelText("Host").type("localhost");
-  cy.findByLabelText("Port").type("5404");
-  cy.findByLabelText("Database name").type("sample");
-  cy.findByLabelText("Username").type("metabase");
-  cy.findByLabelText("Password").type("metasample123");
+  cy.findByLabelText("Display name").type("Postgres Database", {
+    delay: TYPE_DELAY,
+  });
+  cy.findByLabelText("Host").type("localhost", { delay: TYPE_DELAY });
+  cy.findByLabelText("Port").type("5404", { delay: TYPE_DELAY });
+  cy.findByLabelText("Database name").type("sample", { delay: TYPE_DELAY });
+  cy.findByLabelText("Username").type("metabase", { delay: TYPE_DELAY });
+  cy.findByLabelText("Password").type("metasample123", { delay: TYPE_DELAY });
 }

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/EmbeddingSetupContext.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/EmbeddingSetupContext.tsx
@@ -44,7 +44,7 @@ type EmbeddingSetupContextType = {
   setError: (error: string) => void;
   selectedTables: Table[];
   setSelectedTables: (tables: Table[]) => void;
-  createdDashboard: Dashboard[];
+  createdDashboard2: Dashboard[];
   setCreatedDashboard: (dashboards: Dashboard[]) => void;
   stepKey: EmbeddingSetupStepKey;
   goToStep: (key: EmbeddingSetupStepKey) => void;
@@ -87,7 +87,7 @@ export const EmbeddingSetupProvider = ({
   const [processingStatus, setProcessingStatus] = useState("");
   const [error, setError] = useState("");
   const [selectedTables, setSelectedTables] = useState<Table[]>([]);
-  const [createdDashboard, setCreatedDashboard] = useState<Dashboard[]>([]);
+  const [createdDashboard2, setCreatedDashboard] = useState<Dashboard[]>([]);
   const [stepKey, goToStep] = useState<EmbeddingSetupStepKey>(STEPS[0].key);
 
   const stepIndex = getStepIndexByKey(stepKey);
@@ -130,7 +130,7 @@ export const EmbeddingSetupProvider = ({
         setError,
         selectedTables,
         setSelectedTables,
-        createdDashboard,
+        createdDashboard2,
         setCreatedDashboard,
         stepKey,
         goToStep,

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/EmbeddingSetupContext.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/EmbeddingSetupContext.tsx
@@ -10,7 +10,7 @@ import { trackSimpleEvent } from "metabase/lib/analytics";
 import { useSelector } from "metabase/lib/redux";
 import { getLocale } from "metabase/setup/selectors";
 import type { EmbeddingSetupClickEvent } from "metabase-types/analytics";
-import type { DashboardId, DatabaseData, Table } from "metabase-types/api";
+import type { Dashboard, DatabaseData, Table } from "metabase-types/api";
 
 import { DataConnectionStep } from "./steps/DataConnectionStep";
 import { DoneStep } from "./steps/DoneStep";
@@ -44,8 +44,8 @@ type EmbeddingSetupContextType = {
   setError: (error: string) => void;
   selectedTables: Table[];
   setSelectedTables: (tables: Table[]) => void;
-  createdDashboardIds: DashboardId[];
-  setCreatedDashboardIds: (ids: DashboardId[]) => void;
+  createdDashboard: Dashboard[];
+  setCreatedDashboard: (dashboards: Dashboard[]) => void;
   stepKey: EmbeddingSetupStepKey;
   goToStep: (key: EmbeddingSetupStepKey) => void;
   steps: StepDefinition[];
@@ -87,9 +87,7 @@ export const EmbeddingSetupProvider = ({
   const [processingStatus, setProcessingStatus] = useState("");
   const [error, setError] = useState("");
   const [selectedTables, setSelectedTables] = useState<Table[]>([]);
-  const [createdDashboardIds, setCreatedDashboardIds] = useState<DashboardId[]>(
-    [],
-  );
+  const [createdDashboard, setCreatedDashboard] = useState<Dashboard[]>([]);
   const [stepKey, goToStep] = useState<EmbeddingSetupStepKey>(STEPS[0].key);
 
   const stepIndex = getStepIndexByKey(stepKey);
@@ -132,8 +130,8 @@ export const EmbeddingSetupProvider = ({
         setError,
         selectedTables,
         setSelectedTables,
-        createdDashboardIds,
-        setCreatedDashboardIds,
+        createdDashboard,
+        setCreatedDashboard,
         stepKey,
         goToStep,
         steps: STEPS,

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/FinalStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/FinalStep.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { useAsync } from "react-use";
 import { t } from "ttag";
 
 import { CopyButton } from "metabase/common/components/CopyButton";
@@ -25,14 +24,7 @@ import type { StepProps } from "./embeddingSetupSteps";
 
 export const FinalStep = ({ nextStep }: StepProps) => {
   const { url: docsUrl } = useDocsUrl("embedding/interactive-embedding");
-  const { createdDashboardIds, trackEmbeddingSetupClick } = useEmbeddingSetup();
-
-  const { loading, value: dashboards } = useAsync(async () => {
-    const dashboardPromises = createdDashboardIds.map((id) =>
-      fetch(`/api/dashboard/${id}`).then((res) => res.json()),
-    );
-    return Promise.all(dashboardPromises);
-  }, [createdDashboardIds]);
+  const { createdDashboard, trackEmbeddingSetupClick } = useEmbeddingSetup();
 
   const getEmbedCode = (url: string) => {
     return `<iframe src="${url}" width="800px" height="500px" />`;
@@ -40,7 +32,7 @@ export const FinalStep = ({ nextStep }: StepProps) => {
 
   const tabs = useMemo(
     () => [
-      ...(dashboards ?? []).map((dashboard: Dashboard) => ({
+      ...createdDashboard.map((dashboard: Dashboard) => ({
         title: dashboard.name,
         url: `${window.location.origin}/dashboard/${dashboard.id}`,
       })),
@@ -49,18 +41,10 @@ export const FinalStep = ({ nextStep }: StepProps) => {
         url: `${window.location.origin}/question/new`,
       },
     ],
-    [dashboards],
+    [createdDashboard],
   );
 
-  if (loading) {
-    return (
-      <Center h="500px">
-        <Loader size="lg" />
-      </Center>
-    );
-  }
-
-  if (!dashboards || dashboards.length === 0) {
+  if (!createdDashboard || createdDashboard.length === 0) {
     return (
       <Center h="500px">
         <Text>{t`No dashboards found`}</Text>

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/FinalStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/FinalStep.tsx
@@ -24,7 +24,7 @@ import type { StepProps } from "./embeddingSetupSteps";
 
 export const FinalStep = ({ nextStep }: StepProps) => {
   const { url: docsUrl } = useDocsUrl("embedding/interactive-embedding");
-  const { createdDashboard, trackEmbeddingSetupClick } = useEmbeddingSetup();
+  const { createdDashboard2, trackEmbeddingSetupClick } = useEmbeddingSetup();
 
   const getEmbedCode = (url: string) => {
     return `<iframe src="${url}" width="800px" height="500px" />`;
@@ -32,7 +32,7 @@ export const FinalStep = ({ nextStep }: StepProps) => {
 
   const tabs = useMemo(
     () => [
-      ...createdDashboard.map((dashboard: Dashboard) => ({
+      ...createdDashboard2.map((dashboard: Dashboard) => ({
         title: dashboard.name,
         url: `${window.location.origin}/dashboard/${dashboard.id}`,
       })),
@@ -41,10 +41,10 @@ export const FinalStep = ({ nextStep }: StepProps) => {
         url: `${window.location.origin}/question/new`,
       },
     ],
-    [createdDashboard],
+    [createdDashboard2],
   );
 
-  if (!createdDashboard || createdDashboard.length === 0) {
+  if (!createdDashboard2 || createdDashboard2.length === 0) {
     return (
       <Center h="500px">
         <Text>{t`No dashboards found`}</Text>

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/ProcessingStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/ProcessingStep.tsx
@@ -7,7 +7,7 @@ import { useSaveDashboardMutation } from "metabase/api/dashboard";
 import { useUpdateSettingsMutation } from "metabase/api/settings";
 import { useSetting } from "metabase/common/hooks";
 import { Box, Loader, Stack, Text, Title } from "metabase/ui";
-import type { DashboardId } from "metabase-types/api";
+import type { Dashboard } from "metabase-types/api";
 
 import { useEmbeddingSetup } from "../EmbeddingSetupContext";
 
@@ -28,7 +28,7 @@ export const ProcessingStep = () => {
     selectedTables,
     processingStatus,
     setProcessingStatus,
-    setCreatedDashboardIds,
+    setCreatedDashboard,
   } = useEmbeddingSetup();
 
   const setupSettings = useCallback(async () => {
@@ -88,14 +88,14 @@ export const ProcessingStep = () => {
         );
 
         // Save the dashboards one at the time, to avoid creating multiple "Automatically Generated Dashboards" collections
-        const dashboardIds: DashboardId[] = [];
+        const dashboards: Dashboard[] = [];
         for (const dashboard of dashboardsContent) {
           const savedDashboard = await saveDashboard(dashboard).unwrap();
           setProcessingStep((prev) => prev + 1);
-          dashboardIds.push(savedDashboard.id);
+          dashboards.push(savedDashboard);
         }
 
-        setCreatedDashboardIds(dashboardIds);
+        setCreatedDashboard(dashboards);
 
         goToNextStep();
       } catch (err) {
@@ -108,7 +108,7 @@ export const ProcessingStep = () => {
     database?.id,
     selectedTables,
     setProcessingStatus,
-    setCreatedDashboardIds,
+    setCreatedDashboard,
     setupSettings,
     goToNextStep,
     createCard,


### PR DESCRIPTION
This closes EMB-487 by removing the last fetch call.

It also closes EMB-534 by speeding up the tests a bit, they were waiting a lot on the iframe loading, if one of the iframes loads, so should the others, it's not worth the cy.wait(100) + the actual time it takes to load.
It also makes the input faster by setting the type delay to 0