### PR TITLE
Improve usage analytics without first/last name

### DIFF
--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -201,6 +201,36 @@ databaseChangeLog:
             path: instance_analytics_views/alerts/v3/h2-alerts.sql
             relativeToChangelogFile: true
 
+  - changeSet:
+      id: v56.2025-07-07T08:02:43
+      author: johnswanson
+      comment: improve full names in usage analytics - update view `v_users`
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/users/v3/postgres-users.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/users/v3/mysql-users.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/users/v3/h2-users.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/users/v2/postgres-users.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/users/v2/mysql-users.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/users/v2/h2-users.sql
+            relativeToChangelogFile: true
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/instance_analytics_views/users/v3/h2-users.sql
+++ b/resources/migrations/instance_analytics_views/users/v3/h2-users.sql
@@ -1,6 +1,3 @@
-DROP VIEW IF EXISTS v_users;
-
-
 CREATE OR REPLACE VIEW v_users AS
 SELECT id AS user_id,
        'user_' || id AS entity_qualified_id,

--- a/resources/migrations/instance_analytics_views/users/v3/h2-users.sql
+++ b/resources/migrations/instance_analytics_views/users/v3/h2-users.sql
@@ -1,0 +1,36 @@
+DROP VIEW IF EXISTS v_users;
+
+
+CREATE OR REPLACE VIEW v_users AS
+SELECT id AS user_id,
+       'user_' || id AS entity_qualified_id,
+       type,
+       CASE WHEN type = 'api-key' THEN null ELSE email END as email,
+       first_name,
+       last_name,
+       COALESCE(first_name || ' ' || last_name,
+                first_name,
+                last_name) AS full_name,
+       date_joined,
+       last_login,
+       updated_at,
+       is_superuser AS is_admin,
+       is_active,
+       sso_source,
+       locale
+FROM core_user
+UNION
+SELECT 0 AS user_id,
+       'user_0' AS entity_qualified_id,
+       'anonymous' as type,
+       NULL AS email,
+       'Anonymous' AS first_name,
+       'User' AS last_name,
+       'Anonymous User' AS full_name,
+       NULL AS date_joined,
+       NULL AS last_login,
+       NULL AS updated_at,
+       FALSE AS is_admin,
+                NULL AS is_active,
+                NULL AS sso_source,
+                NULL AS locale ;

--- a/resources/migrations/instance_analytics_views/users/v3/mysql-users.sql
+++ b/resources/migrations/instance_analytics_views/users/v3/mysql-users.sql
@@ -1,6 +1,3 @@
-DROP VIEW IF EXISTS v_users;
-
-
 CREATE OR REPLACE VIEW v_users AS
 SELECT id AS user_id,
        concat('user_', id) AS entity_qualified_id,

--- a/resources/migrations/instance_analytics_views/users/v3/mysql-users.sql
+++ b/resources/migrations/instance_analytics_views/users/v3/mysql-users.sql
@@ -1,0 +1,36 @@
+DROP VIEW IF EXISTS v_users;
+
+
+CREATE OR REPLACE VIEW v_users AS
+SELECT id AS user_id,
+       concat('user_', id) AS entity_qualified_id,
+       type,
+       CASE WHEN type = 'api-key' THEN null ELSE email END as email,
+       first_name,
+       last_name,
+       COALESCE(concat(first_name, ' ', last_name),
+                first_name,
+                last_name) as full_name,
+       date_joined,
+       last_login,
+       updated_at,
+       is_superuser AS is_admin,
+       is_active,
+       sso_source,
+       locale
+FROM core_user
+UNION
+SELECT 0 AS user_id,
+       'user_0' AS entity_qualified_id,
+       'anonymous' as type,
+       NULL AS email,
+       'External' AS first_name,
+       'User' AS last_name,
+       'External User' AS full_name,
+       NULL AS date_joined,
+       NULL AS last_login,
+       NULL AS updated_at,
+       FALSE AS is_admin,
+                NULL AS is_active,
+                NULL AS sso_source,
+                NULL AS locale ;

--- a/resources/migrations/instance_analytics_views/users/v3/postgres-users.sql
+++ b/resources/migrations/instance_analytics_views/users/v3/postgres-users.sql
@@ -1,0 +1,36 @@
+DROP VIEW IF EXISTS v_users;
+
+
+CREATE OR REPLACE VIEW v_users AS
+SELECT id AS user_id,
+       'user_' || id AS entity_qualified_id,
+       type,
+       CASE WHEN type = 'api-key' THEN null ELSE email END as email,
+       first_name,
+       last_name,
+       COALESCE(first_name || ' ' || last_name,
+                first_name,
+                last_name) AS full_name,
+       date_joined,
+       last_login,
+       updated_at,
+       is_superuser AS is_admin,
+       is_active,
+       sso_source,
+       locale
+FROM core_user
+UNION
+SELECT 0 AS user_id,
+       'user_0' AS entity_qualified_id,
+       'anonymous' as type,
+       NULL AS email,
+       'External' AS first_name,
+       'User' AS last_name,
+       'External User' AS full_name,
+       NULL AS date_joined,
+       NULL AS last_login,
+       NULL AS updated_at,
+       FALSE AS is_admin,
+                NULL AS is_active,
+                NULL AS sso_source,
+                NULL AS locale ;

--- a/resources/migrations/instance_analytics_views/users/v3/postgres-users.sql
+++ b/resources/migrations/instance_analytics_views/users/v3/postgres-users.sql
@@ -1,6 +1,3 @@
-DROP VIEW IF EXISTS v_users;
-
-
 CREATE OR REPLACE VIEW v_users AS
 SELECT id AS user_id,
        'user_' || id AS entity_qualified_id,


### PR DESCRIPTION
Users without a first or last name previously showed up in Usage Analytics as `null`. This change just uses either the full name (if both `first_name` and `last_name` are present), or whichever of those values is not `null`.

[ADM-826: Users with First Name only don't show up in Usage Analytics](https://linear.app/metabase/issue/ADM-826/users-with-first-name-only-dont-show-up-in-usage-analytics)

Fixes #58222 