### PR TITLE
Resolve stacked modals (Add data modal + GdriveConnectionModal)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
@@ -75,6 +75,50 @@ const PanelWrapper = ({
   );
 };
 
+const ConnectionDetails = ({
+  onClose,
+  onDelete,
+  deleteError,
+  isDeleteInProgress,
+}: {
+  onClose: () => void;
+  onDelete: () => void;
+  deleteError?: string;
+  isDeleteInProgress: boolean;
+}) => {
+  const { title, bodyCopy, connectButtonText, disconnectButtonText } =
+    getDisconnectModalStrings({ reconnect: true });
+
+  return (
+    <PanelWrapper title={title} subtitle={bodyCopy}>
+      <Stack gap="sm" mt="sm">
+        <Button
+          variant="filled"
+          color="danger"
+          loading={isDeleteInProgress}
+          onClick={onDelete}
+          w={INNER_WIDTH}
+        >
+          {disconnectButtonText}
+        </Button>
+        <Button
+          variant="outline"
+          onClick={onClose}
+          disabled={isDeleteInProgress}
+          w={INNER_WIDTH}
+        >
+          {connectButtonText}
+        </Button>
+      </Stack>
+      {deleteError && (
+        <Text fz="sm" c="danger">
+          {deleteError}
+        </Text>
+      )}
+    </PanelWrapper>
+  );
+};
+
 export const GdriveAddDataPanel = () => {
   const [
     areConnectionDetailsShown,
@@ -140,36 +184,13 @@ export const GdriveAddDataPanel = () => {
   }
 
   if (areConnectionDetailsShown) {
-    const { title, bodyCopy, connectButtonText, disconnectButtonText } =
-      getDisconnectModalStrings({ reconnect: true });
-
     return (
-      <PanelWrapper title={title} subtitle={bodyCopy}>
-        <Stack gap="sm" mt="sm">
-          <Button
-            variant="filled"
-            color="danger"
-            loading={isDeletingFolderLink}
-            onClick={onDelete}
-            w={INNER_WIDTH}
-          >
-            {disconnectButtonText}
-          </Button>
-          <Button
-            variant="outline"
-            onClick={closeConnectionDetails}
-            disabled={isDeletingFolderLink}
-            w={INNER_WIDTH}
-          >
-            {connectButtonText}
-          </Button>
-        </Stack>
-        {deleteError && (
-          <Text fz="sm" c="danger">
-            {deleteError}
-          </Text>
-        )}
-      </PanelWrapper>
+      <ConnectionDetails
+        onClose={closeConnectionDetails}
+        isDeleteInProgress={isDeletingFolderLink}
+        onDelete={onDelete}
+        deleteError={deleteError}
+      />
     );
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
@@ -34,6 +34,7 @@ import {
 
 import { trackSheetConnectionClick } from "./analytics";
 import { getStatus, useDeleteGdriveFolderLink, useShowGdrive } from "./utils";
+import { getDisconnectModalStrings } from "./GdriveConnectionModal.strings";
 
 const PanelWrapper = ({
   title = t`Connect Google Sheets`,
@@ -140,11 +141,14 @@ export const GdriveAddDataPanel = ({
   }
 
   if (areConnectionDetailsShown) {
+    const { title, bodyCopy, connectButtonText, disconnectButtonText } =
+      getDisconnectModalStrings({ reconnect: true });
+
     return (
       <PanelWrapper
-        title={t`To add a new Google Drive folder, the existing one needs to be disconnected first`}
+        title={title}
         // eslint-disable-next-line no-literal-metabase-strings -- admin only string
-        subtitle={t`Only one folder can be synced with Metabase at a time. Your tables and Google Sheets will remain in place.`}
+        subtitle={bodyCopy}
       >
         <Button
           variant="filled"
@@ -153,7 +157,7 @@ export const GdriveAddDataPanel = ({
           onClick={onDelete}
           w={INNER_WIDTH}
         >
-          {t`Disconnect`}
+          {disconnectButtonText}
         </Button>
         <Button
           variant="outline"
@@ -161,7 +165,7 @@ export const GdriveAddDataPanel = ({
           disabled={isDeletingFolderLink}
           w={INNER_WIDTH}
         >
-          {t`Keep connected`}
+          {connectButtonText}
         </Button>
       </PanelWrapper>
     );

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
@@ -32,9 +32,9 @@ import {
   GdriveConnectionModal,
 } from "metabase-enterprise/google_drive";
 
+import { getDisconnectModalStrings } from "./GdriveConnectionModal.strings";
 import { trackSheetConnectionClick } from "./analytics";
 import { getStatus, useDeleteGdriveFolderLink, useShowGdrive } from "./utils";
-import { getDisconnectModalStrings } from "./GdriveConnectionModal.strings";
 
 const PanelWrapper = ({
   title = t`Connect Google Sheets`,
@@ -148,23 +148,25 @@ export const GdriveAddDataPanel = ({
         // eslint-disable-next-line no-literal-metabase-strings -- admin only string
         subtitle={bodyCopy}
       >
-        <Button
-          variant="filled"
-          color="danger"
-          loading={isDeletingFolderLink}
-          onClick={onDelete}
-          w={INNER_WIDTH}
-        >
-          {disconnectButtonText}
-        </Button>
-        <Button
-          variant="outline"
-          onClick={closeConnectionDetails}
-          disabled={isDeletingFolderLink}
-          w={INNER_WIDTH}
-        >
-          {connectButtonText}
-        </Button>
+        <Stack gap="sm" mt="sm">
+          <Button
+            variant="filled"
+            color="danger"
+            loading={isDeletingFolderLink}
+            onClick={onDelete}
+            w={INNER_WIDTH}
+          >
+            {disconnectButtonText}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={closeConnectionDetails}
+            disabled={isDeletingFolderLink}
+            w={INNER_WIDTH}
+          >
+            {connectButtonText}
+          </Button>
+        </Stack>
       </PanelWrapper>
     );
   }

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
@@ -75,18 +75,16 @@ const PanelWrapper = ({
   );
 };
 
-export const GdriveAddDataPanel = ({
-  onAddDataModalClose,
-}: {
-  onAddDataModalClose: () => void;
-}) => {
+export const GdriveAddDataPanel = () => {
   const [
     areConnectionDetailsShown,
     { open: showConnectionDetails, close: closeConnectionDetails },
   ] = useDisclosure(false);
 
-  const [isConnectionModalOpen, { open: openConnectionModal }] =
-    useDisclosure(false);
+  const [
+    isConnectionModalOpen,
+    { open: openConnectionModal, close: closeConnectionModal },
+  ] = useDisclosure(false);
 
   const {
     errorMessage: deleteError,
@@ -221,9 +219,7 @@ export const GdriveAddDataPanel = ({
   return (
     <PanelWrapper
       isModalOpen={isConnectionModalOpen}
-      // We are closing the parent (Add data) modal so we don't have to explicitly
-      // close the connection modal as well. It will be removed from DOM with its parent gone.
-      onModalClose={onAddDataModalClose}
+      onModalClose={closeConnectionModal}
     >
       <Button
         variant="filled"

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
@@ -88,14 +88,17 @@ export const GdriveAddDataPanel = ({
   const [isConnectionModalOpen, { open: openConnectionModal }] =
     useDisclosure(false);
 
-  const { errorMessage, isDeletingFolderLink, onDelete } =
-    useDeleteGdriveFolderLink({
-      onSuccess: () => {
-        // As soon as we disconnect, we want to show a new connection modal again
-        closeConnectionDetails();
-        openConnectionModal();
-      },
-    });
+  const {
+    errorMessage: deleteError,
+    isDeletingFolderLink,
+    onDelete,
+  } = useDeleteGdriveFolderLink({
+    onSuccess: () => {
+      // As soon as we disconnect, we want to show a new connection modal again
+      closeConnectionDetails();
+      openConnectionModal();
+    },
+  });
 
   const isAdmin = useSelector(getUserIsAdmin);
   const hasStorage = useHasTokenFeature("attached_dwh");
@@ -143,11 +146,7 @@ export const GdriveAddDataPanel = ({
       getDisconnectModalStrings({ reconnect: true });
 
     return (
-      <PanelWrapper
-        title={title}
-        // eslint-disable-next-line no-literal-metabase-strings -- admin only string
-        subtitle={bodyCopy}
-      >
+      <PanelWrapper title={title} subtitle={bodyCopy}>
         <Stack gap="sm" mt="sm">
           <Button
             variant="filled"
@@ -167,6 +166,11 @@ export const GdriveAddDataPanel = ({
             {connectButtonText}
           </Button>
         </Stack>
+        {deleteError && (
+          <Text fz="sm" c="danger">
+            {deleteError}
+          </Text>
+        )}
       </PanelWrapper>
     );
   }

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
@@ -85,10 +85,8 @@ export const GdriveAddDataPanel = ({
     { open: showConnectionDetails, close: closeConnectionDetails },
   ] = useDisclosure(false);
 
-  const [
-    isConnectionModalOpen,
-    { open: openConnectionModal, close: closeConnectionModal },
-  ] = useDisclosure(false);
+  const [isConnectionModalOpen, { open: openConnectionModal }] =
+    useDisclosure(false);
 
   const { errorMessage, isDeletingFolderLink, onDelete } =
     useDeleteGdriveFolderLink({
@@ -217,7 +215,9 @@ export const GdriveAddDataPanel = ({
   return (
     <PanelWrapper
       isModalOpen={isConnectionModalOpen}
-      onModalClose={closeConnectionModal}
+      // We are closing the parent (Add data) modal so we don't have to explicitly
+      // close the connection modal as well. It will be removed from DOM with its parent gone.
+      onModalClose={onAddDataModalClose}
     >
       <Button
         variant="filled"

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
@@ -54,10 +54,10 @@ const PanelWrapper = ({
 
   return (
     <>
-      <Stack gap="md" align="center" justify="center" pt="3rem">
+      <Stack gap="md" align="center" justify="center" pt="2.5rem">
         <Center component="img" src={illustration} w="3rem" />
         <Box component="header" ta="center" maw={CONTENT_MAX_WIDTH}>
-          <Title order={2} size="h4" mb="xs">
+          <Title order={2} size="h4" mb="sm">
             {title}
           </Title>
           <Text c="text-medium">{subtitle}</Text>

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.strings.ts
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.strings.ts
@@ -17,3 +17,19 @@ export const getStrings = (objectType: "file" | "folder") => {
     importText: t`Import folder`,
   };
 };
+
+export const getDisconnectModalStrings = ({
+  reconnect,
+}: {
+  reconnect: boolean;
+}) => {
+  return {
+    title: t`To add a new Google Drive folder, the existing one needs to be disconnected first`,
+    bodyCopy: reconnect
+      ? // eslint-disable-next-line no-literal-metabase-strings -- admin only string
+        t`Only one folder can be synced with Metabase at a time. Your tables and Google Sheets will remain in place.`
+      : t`Your existing tables and Google Sheets will remain in place but they will no longer be updated automatically.`,
+    connectButtonText: t`Keep connected`,
+    disconnectButtonText: t`Disconnect`,
+  };
+};

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -77,8 +77,8 @@ const ModalWrapper = ({
   children: React.ReactNode;
   onClose: () => void;
 }) => (
-  <Modal opened onClose={onClose} padding="xl" title={title}>
-    <Flex gap="md" pt="lg" direction="column">
+  <Modal opened onClose={onClose} padding="3rem" title={title} size="44rem">
+    <Flex gap="md" pt="xl" direction="column" justify="center">
       {children}
     </Flex>
   </Modal>

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -40,7 +40,7 @@ export function GdriveConnectionModal({
   reconnect,
 }: {
   isModalOpen: boolean;
-  onClose: () => void;
+  onClose: (success?: boolean) => void;
   reconnect: boolean;
 }) {
   const shouldShow = useShowGdrive();
@@ -94,7 +94,7 @@ function GoogleSheetsConnectModal({
   folderUrl,
   serviceAccountEmail,
 }: {
-  onClose: () => void;
+  onClose: (success?: boolean) => void;
   folderUrl: string | null;
   serviceAccountEmail: string;
 }) {
@@ -125,7 +125,7 @@ function GoogleSheetsConnectModal({
       .unwrap()
       .then(() => {
         dispatch(reloadSettings());
-        onClose();
+        onClose(true);
       })
       .catch((response) => {
         setErrorMessage(response?.data?.message ?? "Something went wrong");

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -4,7 +4,6 @@ import { c, t } from "ttag";
 
 import { reloadSettings } from "metabase/admin/settings/settings";
 import { skipToken, useGetUserQuery } from "metabase/api";
-import { getErrorMessage } from "metabase/api/utils";
 import { CopyButton } from "metabase/common/components/CopyButton";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import Markdown from "metabase/common/components/Markdown";
@@ -22,7 +21,6 @@ import {
   TextInput,
 } from "metabase/ui";
 import {
-  useDeleteGsheetsFolderLinkMutation,
   useGetGsheetsFolderQuery,
   useGetServiceAccountQuery,
   useSaveGsheetsFolderLinkMutation,
@@ -31,7 +29,7 @@ import {
 import Styles from "./Gdrive.module.css";
 import { getStrings } from "./GdriveConnectionModal.strings";
 import { trackSheetImportClick } from "./analytics";
-import { getStatus, useShowGdrive } from "./utils";
+import { getStatus, useDeleteGdriveFolderLink, useShowGdrive } from "./utils";
 
 export function GdriveConnectionModal({
   isModalOpen,
@@ -223,30 +221,14 @@ function GoogleSheetsDisconnectModal({
   onClose: () => void;
   reconnect: boolean;
 }) {
-  const [errorMessage, setErrorMessage] = useState("");
-
-  const [deleteFolderLink, { isLoading: isDeletingFolderLink }] =
-    useDeleteGsheetsFolderLinkMutation();
-
-  const onDelete = async () => {
-    setErrorMessage("");
-    await deleteFolderLink()
-      .unwrap()
-      .then(() => {
+  const { errorMessage, isDeletingFolderLink, onDelete } =
+    useDeleteGdriveFolderLink({
+      onSuccess: () => {
         if (!reconnect) {
           onClose();
         }
-      })
-      .catch((response: unknown) => {
-        setErrorMessage(
-          getErrorMessage(
-            response,
-            // eslint-disable-next-line no-literal-metabase-strings -- admin only ui
-            t`Please check that the folder is shared with the Metabase Service Account.`,
-          ),
-        );
-      });
-  };
+      },
+    });
 
   return (
     <ModalWrapper

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveConnectionModal.tsx
@@ -27,7 +27,10 @@ import {
 } from "metabase-enterprise/api";
 
 import Styles from "./Gdrive.module.css";
-import { getStrings } from "./GdriveConnectionModal.strings";
+import {
+  getDisconnectModalStrings,
+  getStrings,
+} from "./GdriveConnectionModal.strings";
 import { trackSheetImportClick } from "./analytics";
 import { getStatus, useDeleteGdriveFolderLink, useShowGdrive } from "./utils";
 
@@ -230,18 +233,15 @@ function GoogleSheetsDisconnectModal({
       },
     });
 
+  const { title, bodyCopy, connectButtonText, disconnectButtonText } =
+    getDisconnectModalStrings({ reconnect });
+
   return (
-    <ModalWrapper
-      onClose={onClose}
-      title={t`To add a new Google Drive folder, the existing one needs to be disconnected first`}
-    >
+    <ModalWrapper onClose={onClose} title={title}>
       <Stack gap="md">
         <DriveConnectionDisplay />
         <Text c="text-medium" pb="md">
-          {reconnect
-            ? // eslint-disable-next-line no-literal-metabase-strings -- admin only string
-              t`Only one folder can be synced with Metabase at a time. Your tables and Google Sheets will remain in place.`
-            : t`Your existing tables and Google Sheets will remain in place but they will no longer be updated automatically.`}
+          {bodyCopy}
         </Text>
         <Flex w="100%" gap="sm" justify="space-between">
           <Text c="error" ta="start">
@@ -253,7 +253,7 @@ function GoogleSheetsDisconnectModal({
               onClick={onClose}
               disabled={isDeletingFolderLink}
             >
-              {t`Keep connected`}
+              {connectButtonText}
             </Button>
             <Button
               variant="filled"
@@ -261,7 +261,7 @@ function GoogleSheetsDisconnectModal({
               loading={isDeletingFolderLink}
               onClick={onDelete}
             >
-              {t`Disconnect`}
+              {disconnectButtonText}
             </Button>
           </Flex>
         </Flex>

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/utils.tsx
@@ -1,10 +1,16 @@
+import { useState } from "react";
 import { P, match } from "ts-pattern";
+import { t } from "ttag";
 
 import { skipToken } from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
 import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { useGetServiceAccountQuery } from "metabase-enterprise/api";
+import {
+  useDeleteGsheetsFolderLinkMutation,
+  useGetServiceAccountQuery,
+} from "metabase-enterprise/api";
 import type { GdrivePayload } from "metabase-types/api";
 
 export type ErrorPayload =
@@ -43,3 +49,58 @@ export const getStatus = ({
     .with({ error: true }, () => "error")
     .with({ status: P.string.minLength(1) }, ({ status }) => status)
     .otherwise(() => "not-connected");
+
+/**
+ * Custom hook for deleting Google Drive folder links
+ *
+ * @param options - Optional callbacks for success and error handling
+ * @param options.onSuccess - Callback to execute on successful deletion
+ * @param options.onError - Callback to execute when an error occurs
+ *
+ * @returns Object containing:
+ *   - errorMessage: Current error message state
+ *   - isDeletingFolderLink: Loading state for the delete operation
+ *   - onDelete: Function to trigger the delete operation
+ *
+ * @example
+ * ```tsx
+ * const { errorMessage, isDeletingFolderLink, onDelete } = useDeleteGdriveFolderLink({
+ *   onSuccess: () => console.log('Folder deleted successfully'),
+ *   onError: (error) => console.error('Delete failed:', error),
+ * });
+ *
+ * const handleDelete = () => onDelete();
+ * ```
+ */
+export const useDeleteGdriveFolderLink = (options?: {
+  onSuccess?: () => void;
+  onError?: (error: string) => void;
+}) => {
+  const [errorMessage, setErrorMessage] = useState("");
+  const [deleteFolderLink, { isLoading: isDeletingFolderLink }] =
+    useDeleteGsheetsFolderLinkMutation();
+
+  const onDelete = async () => {
+    setErrorMessage("");
+    await deleteFolderLink()
+      .unwrap()
+      .then(() => {
+        options?.onSuccess?.();
+      })
+      .catch((response: unknown) => {
+        const error = getErrorMessage(
+          response,
+          // eslint-disable-next-line no-literal-metabase-strings -- admin only ui
+          t`Please check that the folder is shared with the Metabase Service Account.`,
+        );
+        setErrorMessage(error);
+        options?.onError?.(error);
+      });
+  };
+
+  return {
+    errorMessage,
+    isDeletingFolderLink,
+    onDelete,
+  };
+};

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
@@ -114,9 +114,7 @@ export const AddDataModal = ({ opened, onClose }: AddDataModalProps) => {
               <DatabasesPanel canSeeContent={isAdmin} />
             </Tabs.Panel>
             <Tabs.Panel value="gsheets" className={S.panel}>
-              <PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel
-                onAddDataModalClose={onClose}
-              />
+              <PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel />
             </Tabs.Panel>
           </Box>
         </Tabs>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
@@ -114,7 +114,9 @@ export const AddDataModal = ({ opened, onClose }: AddDataModalProps) => {
               <DatabasesPanel canSeeContent={isAdmin} />
             </Tabs.Panel>
             <Tabs.Panel value="gsheets" className={S.panel}>
-              <PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel />
+              <PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel
+                onAddDataModalClose={onClose}
+              />
             </Tabs.Panel>
           </Box>
         </Tabs>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
@@ -92,7 +92,7 @@ const AddDataEmptyState = ({
   upsell,
 }: EmptyStateProps) => {
   return (
-    <Stack gap="lg" align="center" justify="center" pt="3rem">
+    <Stack gap="lg" align="center" justify="center" pt="2.5rem">
       {illustration}
       <Box component="header" ta="center" maw={CONTENT_MAX_WIDTH}>
         <Title order={2} size="h4" mb="xs">

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -589,6 +589,10 @@ type GdriveConnectionModalProps = {
   reconnect: boolean;
 };
 
+type GdriveAddDataPanelProps = {
+  onAddDataModalClose: () => void;
+};
+
 export const PLUGIN_UPLOAD_MANAGEMENT = {
   FileUploadErrorModal: _FileUploadErrorModal,
   UploadManagementTable: PluginPlaceholder,
@@ -596,7 +600,8 @@ export const PLUGIN_UPLOAD_MANAGEMENT = {
   GdriveConnectionModal:
     PluginPlaceholder as ComponentType<GdriveConnectionModalProps>,
   GdriveDbMenu: PluginPlaceholder,
-  GdriveAddDataPanel: PluginPlaceholder,
+  GdriveAddDataPanel:
+    PluginPlaceholder as ComponentType<GdriveAddDataPanelProps>,
 };
 
 export const PLUGIN_IS_EE_BUILD = {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -589,10 +589,6 @@ type GdriveConnectionModalProps = {
   reconnect: boolean;
 };
 
-type GdriveAddDataPanelProps = {
-  onAddDataModalClose: () => void;
-};
-
 export const PLUGIN_UPLOAD_MANAGEMENT = {
   FileUploadErrorModal: _FileUploadErrorModal,
   UploadManagementTable: PluginPlaceholder,
@@ -600,8 +596,7 @@ export const PLUGIN_UPLOAD_MANAGEMENT = {
   GdriveConnectionModal:
     PluginPlaceholder as ComponentType<GdriveConnectionModalProps>,
   GdriveDbMenu: PluginPlaceholder,
-  GdriveAddDataPanel:
-    PluginPlaceholder as ComponentType<GdriveAddDataPanelProps>,
+  GdriveAddDataPanel: PluginPlaceholder,
 };
 
 export const PLUGIN_IS_EE_BUILD = {


### PR DESCRIPTION
Resolves PRG-78
Resolves PRG-79

Even though this touches seven files, the change itself is not that complex. I'm extracting the logic around the delete connection mutation into a custom hook in order to reuse it across the standalone modal and the inline connection details.

The rest is just renaming and accommodating the existing layout for that change.

### Why?
Stacked modals did not look very nice because the top-most modal was smaller than its parent. We decided to do two things about it:
1. `GoogleSheetsConnectModal` - increase its size slightly in order to cover the base modal
2. `GoogleSheetsDisconnectModal` - reuse the logic and some elements from and then create an inline version specially designed for the AddData modal, Gdrive panel.

#### Before
Stacked modals
![image](https://github.com/user-attachments/assets/7f2f3b9f-c8b1-40e2-a1fb-46f47b7906b1)

#### Now
Integral part of the existing modal
<img width="681" alt="image" src="https://github.com/user-attachments/assets/b7960747-ff50-4fe6-9f82-a29f28c0ff2b" />


