### PR TITLE
improve heading mapping ui empty state

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1040,7 +1040,7 @@ describe("scenarios > dashboard > parameters", () => {
       H.dashboardParameterSidebar().button("Remove").click();
 
       H.getDashboardCard(0).within(() => {
-        cy.findByText("Heading Text").should("exist");
+        cy.findByDisplayValue("Heading Text").should("exist");
         cy.findByText("Count").should("not.exist");
 
         H.filterWidget({ isEditing: true }).contains("Category").click();

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -3,6 +3,7 @@ import type { MouseEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
+import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { CollapsibleDashboardParameterList } from "metabase/dashboard/components/CollapsibleDashboardParameterList";
 import { DashCardParameterMapper } from "metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardParameterMapper";
 import { useDashboardContext } from "metabase/dashboard/context";
@@ -123,14 +124,20 @@ export function Heading({
 
   let leftContent: JSX.Element | null;
 
-  if (hasVariables && isEditingParameter) {
+  if (isEditingParameter) {
     leftContent = (
       <Box h="100%" style={{ overflow: "hidden" }}>
-        <DashCardParameterMapper
-          compact
-          dashcard={dashcard}
-          isMobile={isMobile}
-        />
+        {hasVariables ? (
+          <DashCardParameterMapper
+            compact
+            dashcard={dashcard}
+            isMobile={isMobile}
+          />
+        ) : (
+          <Flex h="100%" display="flex" align="center">
+            <Ellipsified>{t`You can connect widgets to {{ variables }} in heading cards.`}</Ellipsified>
+          </Flex>
+        )}
       </Box>
     );
   } else if (isPreviewing) {

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
@@ -283,7 +283,7 @@ describe("Text", () => {
         ).toBeInTheDocument();
       });
 
-      it("should not show mapping UI if a card doesn't have variables", () => {
+      it("should show an info message if a card doesn't have variables", () => {
         setup({
           isEditing: true,
           isEditingParameter: true,
@@ -297,6 +297,12 @@ describe("Text", () => {
         expect(
           screen.queryByTestId("parameter-mapper-container"),
         ).not.toBeInTheDocument();
+
+        expect(
+          screen.getByText(
+            "You can connect widgets to {{ variables }} in heading cards.",
+          ),
+        ).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
Closes [VIZ-1161](https://linear.app/metabase/issue/VIZ-1161/allow-editing-headers-when-filter-sidebar-is-open-or-make-it-clearer)

### Description

Adds a proper empty state to heading cards without variables when parameter mapping mode is enabled. As text cards, it shows a message that explains how to use variables: "You can connect widgets to {{ variables }} in heading cards."

### Demo

<img width="1132" alt="Screenshot 2025-07-02 at 7 21 31 PM" src="https://github.com/user-attachments/assets/2a9b2102-fef8-4aa5-bab5-3891bea1af22" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
