### PR TITLE
adjust inline filters popover position

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -409,6 +409,7 @@ export function DashCardVisualization({
             parameters={inlineParameters}
             isSortable={false}
             widgetsVariant="subtle"
+            widgetsPopoverPosition="bottom-end"
           />
         )}
         {!isEditing && (

--- a/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
@@ -16,7 +16,11 @@ import type { Parameter } from "metabase-types/api";
 export interface DashboardParameterListProps
   extends Pick<
     ComponentProps<typeof ParametersList>,
-    "widgetsVariant" | "widgetsWithinPortal" | "vertical" | "hasTestIdProps"
+    | "widgetsVariant"
+    | "widgetsWithinPortal"
+    | "widgetsPopoverPosition"
+    | "vertical"
+    | "hasTestIdProps"
   > {
   className?: string;
   parameters: Array<Parameter & { value: unknown }>;
@@ -33,6 +37,7 @@ export const DashboardParameterList = forwardRef<
     isSortable = true,
     widgetsVariant = "subtle",
     widgetsWithinPortal,
+    widgetsPopoverPosition,
     vertical,
     hasTestIdProps = true,
   },
@@ -51,6 +56,7 @@ export const DashboardParameterList = forwardRef<
 
   return (
     <ParametersList
+      ref={ref}
       className={cx(DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME, className)}
       parameters={parameters}
       editingParameter={editingParameter}
@@ -69,9 +75,9 @@ export const DashboardParameterList = forwardRef<
       enableParameterRequiredBehavior
       widgetsVariant={widgetsVariant}
       widgetsWithinPortal={widgetsWithinPortal}
+      widgetsPopoverPosition={widgetsPopoverPosition}
       vertical={vertical}
       hasTestIdProps={hasTestIdProps}
-      ref={ref}
     />
   );
 });

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.tsx
@@ -1,5 +1,10 @@
 import cx from "classnames";
-import { type PropsWithChildren, type ReactNode, useState } from "react";
+import {
+  type PropsWithChildren,
+  type ReactNode,
+  useMemo,
+  useState,
+} from "react";
 
 import { FieldSet } from "metabase/common/components/FieldSet";
 import { Sortable } from "metabase/common/components/Sortable";
@@ -17,7 +22,7 @@ import { ParameterValueWidget } from "../ParameterValueWidget";
 
 import S from "./ParameterWidget.module.css";
 
-type ParameterWidgetProps = PropsWithChildren<
+export type ParameterWidgetProps = PropsWithChildren<
   {
     parameter: UiParameter;
   } & Partial<
@@ -41,6 +46,7 @@ type ParameterWidgetProps = PropsWithChildren<
       withinPortal?: boolean;
       fullWidth?: boolean;
       hasTestId?: boolean;
+      popoverPosition: "bottom-start" | "bottom-end";
     } & Pick<DashboardFullscreenControls, "isFullscreen">
   >
 >;
@@ -64,6 +70,7 @@ export const ParameterWidget = ({
   dragHandle,
   variant = "default",
   withinPortal,
+  popoverPosition = "bottom-start",
   fullWidth,
   hasTestId = true,
 }: ParameterWidgetProps) => {
@@ -75,6 +82,16 @@ export const ParameterWidget = ({
   const maybeTranslatedParameterName = tc(parameter.name);
 
   const legend = fieldHasValueOrFocus ? maybeTranslatedParameterName : "";
+
+  const popoverOffset = useMemo(() => {
+    const crossAxisOffset = variant === "default" ? 16 : 0;
+    const mainAxis = variant === "default" ? 8 : 4;
+    return {
+      mainAxis,
+      crossAxis:
+        popoverPosition === "bottom-start" ? -crossAxisOffset : crossAxisOffset,
+    };
+  }, [popoverPosition, variant]);
 
   if (isEditing && setEditingParameter) {
     return (
@@ -119,10 +136,6 @@ export const ParameterWidget = ({
         })}
       >
         <ParameterValueWidget
-          offset={{
-            mainAxis: 8,
-            crossAxis: -16,
-          }}
           parameter={parameter}
           parameters={parameters}
           question={question}
@@ -140,6 +153,8 @@ export const ParameterWidget = ({
           variant={variant}
           withinPortal={withinPortal}
           prefix={legend ? legend + ":\u00a0" : undefined}
+          offset={popoverOffset}
+          position={popoverPosition}
         />
         {children}
       </Flex>
@@ -168,10 +183,6 @@ export const ParameterWidget = ({
         noPadding
       >
         <ParameterValueWidget
-          offset={{
-            mainAxis: 8,
-            crossAxis: -16,
-          }}
           parameter={parameter}
           parameters={parameters}
           question={question}
@@ -188,6 +199,8 @@ export const ParameterWidget = ({
           isSortable={isSortable && isEditing}
           variant={variant}
           withinPortal={withinPortal}
+          offset={popoverOffset}
+          position={popoverPosition}
         />
         {children}
       </FieldSet>

--- a/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
+++ b/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
@@ -42,6 +42,7 @@ export const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
       enableParameterRequiredBehavior,
       widgetsVariant = "default",
       widgetsWithinPortal,
+      widgetsPopoverPosition,
 
       hasTestIdProps = true,
     },
@@ -74,6 +75,7 @@ export const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
         variant={widgetsVariant}
         fullWidth={vertical}
         withinPortal={widgetsWithinPortal}
+        popoverPosition={widgetsPopoverPosition}
         className={cx({ [CS.mb2]: vertical })}
         isEditing={isEditing}
         isFullscreen={isFullscreen}

--- a/frontend/src/metabase/parameters/components/ParametersList/types.ts
+++ b/frontend/src/metabase/parameters/components/ParametersList/types.ts
@@ -6,6 +6,8 @@ import type {
 import type Question from "metabase-lib/v1/Question";
 import type { Dashboard, Parameter, ParameterId } from "metabase-types/api";
 
+import type { ParameterWidgetProps } from "../ParameterWidget";
+
 export type ParametersListProps = {
   parameters: Parameter[];
 } & Partial<
@@ -30,6 +32,7 @@ export type ParametersListProps = {
     enableParameterRequiredBehavior: boolean;
     widgetsVariant?: "default" | "subtle";
     widgetsWithinPortal?: boolean;
+    widgetsPopoverPosition: ParameterWidgetProps["popoverPosition"];
     layout?: "horizontal" | "vertical";
     hasTestIdProps?: boolean;
   } & Pick<DashboardFullscreenControls, "isFullscreen"> &

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -290,6 +290,7 @@ const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
     const parametersListCommonProps = {
       ...rest,
       isSortable: false,
+      widgetsPopoverPosition: "bottom-end" as const,
     };
 
     const renderContent = () => {


### PR DESCRIPTION
Closes [VIZ-1127](https://linear.app/metabase/issue/VIZ-1127/see-if-we-can-right-align-dropdown-contents-here)

### Description

Adjust inline filters popover position so it opens to the left as parameters are positioned right-to-left in heading and question cards.

### Demo

<img width="1131" alt="Screenshot 2025-07-02 at 9 17 35 PM" src="https://github.com/user-attachments/assets/3ced4e4b-17f0-41c2-a0c3-550aa8aee675" />

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR — visual change
