### PR TITLE
Only bind ctrl-f to search on non-Mac machines

### DIFF
--- a/frontend/src/metabase/common/components/CodeMirror/utils.ts
+++ b/frontend/src/metabase/common/components/CodeMirror/utils.ts
@@ -24,6 +24,7 @@ import {
 import { getNonce } from "get-nonce";
 import { useMemo } from "react";
 
+import { isMac } from "metabase/lib/browser";
 import { isNotNull } from "metabase/lib/types";
 import { monospaceFontFamily } from "metabase/styled-components/theme";
 import { metabaseSyntaxHighlighting } from "metabase/ui/syntax";
@@ -163,11 +164,8 @@ function keyboardShortcuts({ onFormat }: { onFormat?: () => void }) {
             key: binding.key,
             scope: binding.scope,
             any(view, evt) {
-              if (
-                !evt.shiftKey &&
-                (evt.ctrlKey || evt.metaKey) &&
-                evt.key === "f"
-              ) {
+              const meta = isMac() ? evt.metaKey : evt.ctrlKey;
+              if (!evt.shiftKey && meta && evt.key === "f") {
                 return openSearchPanel(view);
               }
 


### PR DESCRIPTION
Fixes a keyboard shortcut issue in the codemirror editor.

Our check for the meta key was too liberal and it's also catching `ctrl-f` on Mac, where some users use it for other purposes (move the cursor forward).

No tests have been added since we don't test on Mac.
