### PR TITLE
fix(sdk): fix popovers can't be rendered inside modals

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
@@ -1,30 +1,21 @@
 import styled from "@emotion/styled";
 
 import ZIndex from "metabase/css/core/z-index.module.css";
-import {
-  EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID,
-  EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID,
-} from "metabase/embedding-sdk/config";
+import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/config";
 
 import { PublicComponentStylesWrapper } from "./PublicComponentStylesWrapper";
 
 /**
  * This is the portal container used by popovers modals etc, it is wrapped with PublicComponentStylesWrapper
  * so that it has our styles applied.
- * Mantine components needs to have the defaultProps set to use `EMBEDDING_SDK_PORTAL_CONTAINER_ELEMENT_ID` as target for the portal
+ * Mantine components needs to have the defaultProps set to use `EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID` as target for the portal
  */
-export const FullPagePortalContainer = () => (
+export const PortalContainer = () => (
   <PublicComponentStylesWrapper>
     <FixedPosition
       className={ZIndex.Overlay}
-      id={EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID}
+      id={EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}
     ></FixedPosition>
-  </PublicComponentStylesWrapper>
-);
-
-export const PortalContainer = () => (
-  <PublicComponentStylesWrapper>
-    <div id={EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}></div>
   </PublicComponentStylesWrapper>
 );
 

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
@@ -1,7 +1,6 @@
-import styled from "@emotion/styled";
-
 import ZIndex from "metabase/css/core/z-index.module.css";
 import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/config";
+import { Box } from "metabase/ui";
 
 import { PublicComponentStylesWrapper } from "./PublicComponentStylesWrapper";
 
@@ -12,16 +11,14 @@ import { PublicComponentStylesWrapper } from "./PublicComponentStylesWrapper";
  */
 export const PortalContainer = () => (
   <PublicComponentStylesWrapper>
-    <FixedPosition
-      className={ZIndex.Overlay}
+    <Box
       id={EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}
-    ></FixedPosition>
+      className={ZIndex.Overlay}
+      // needed otherwise it will rendered "in place" and push the content below
+      pos="fixed"
+      left={0}
+      top={0}
+      w={"100%"}
+    ></Box>
   </PublicComponentStylesWrapper>
 );
-
-const FixedPosition = styled.div`
-  // needed otherwise it will rendered "in place" and push the content below
-  position: fixed;
-  left: 0;
-  top: 0;
-`;

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/index.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/index.tsx
@@ -1,6 +1,6 @@
 import { useSdkUsageProblem } from "embedding-sdk/hooks/private/use-sdk-usage-problem";
 import type { MetabaseAuthConfig } from "embedding-sdk/types";
-import { EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/config";
+import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/config";
 import { Box, Portal } from "metabase/ui";
 
 import { SdkUsageProblemBanner } from "./SdkUsageProblemBanner";
@@ -22,7 +22,7 @@ export const SdkUsageProblemDisplay = ({
   }
 
   return (
-    <Portal target={`#${EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID}`}>
+    <Portal target={`#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}`}>
       <Box pos="fixed" bottom="15px" left="15px" className={S.BannerContainer}>
         <SdkUsageProblemBanner problem={usageProblem} />
       </Box>

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -31,10 +31,7 @@ import { MetabotProvider } from "metabase-enterprise/metabot/context";
 import { SCOPED_CSS_RESET } from "../private/PublicComponentStylesWrapper";
 import { SdkContextProvider } from "../private/SdkContext";
 import { SdkFontsGlobalStyles } from "../private/SdkGlobalFontsStyles";
-import {
-  FullPagePortalContainer,
-  PortalContainer,
-} from "../private/SdkPortalContainer";
+import { PortalContainer } from "../private/SdkPortalContainer";
 import { SdkUsageProblemDisplay } from "../private/SdkUsageProblem";
 
 import "metabase/css/index.module.css";
@@ -156,7 +153,6 @@ export const MetabaseProviderInternal = ({
               allowConsoleLog={allowConsoleLog}
             />
             <PortalContainer />
-            <FullPagePortalContainer />
           </Box>
         </SdkThemeProvider>
       </EmotionCacheProvider>

--- a/frontend/src/metabase/embedding-sdk/config.ts
+++ b/frontend/src/metabase/embedding-sdk/config.ts
@@ -1,7 +1,5 @@
 export const EMBEDDING_SDK_ROOT_ELEMENT_ID = "metabase-sdk-root";
 export const EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID = "metabase-sdk-portal-root";
-export const EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID =
-  "metabase-sdk-full-page-portal-root";
 
 export const EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG = {
   /** Whether the iframe embedding auth flow should be used. */

--- a/frontend/src/metabase/embedding-sdk/theme/default-component-theme.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/default-component-theme.ts
@@ -1,10 +1,7 @@
 import { merge } from "icepick";
 
 import { OVERLAY_Z_INDEX } from "metabase/css/core/overlays/constants";
-import {
-  EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID,
-  EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID,
-} from "metabase/embedding-sdk/config";
+import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/config";
 import type { MetabaseComponentTheme } from "metabase/embedding-sdk/theme";
 import type { DeepPartial } from "metabase/embedding-sdk/types/utils";
 import type { MantineThemeOverride } from "metabase/ui";
@@ -155,7 +152,7 @@ export function getEmbeddingComponentOverrides(): MantineThemeOverride["componen
       defaultProps: {
         withinPortal: true,
         portalProps: {
-          target: `#${EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID}`,
+          target: `#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}`,
         },
       }, // satisfies Partial<ModalRootProps>,
     },
@@ -163,7 +160,7 @@ export function getEmbeddingComponentOverrides(): MantineThemeOverride["componen
       defaultProps: {
         withinPortal: true,
         portalProps: {
-          target: `#${EMBEDDING_SDK_FULL_PAGE_PORTAL_ROOT_ELEMENT_ID}`,
+          target: `#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}`,
         },
       }, // satisfies Partial<ModalProps>,
     },


### PR DESCRIPTION
closes EMB-582

### Backport reason
Let's only backport this to 55, if it's stable enough we could do 54, and 53 if needed.

### Description

So, this reverts https://github.com/metabase/metabase/pull/48256/commits/1a4d57468fc4a3fe70b6f43909274ef23064df0e, which is what I did in https://github.com/metabase/metabase/pull/48256.

The rationale for the commit is in this [Slack comment](https://metaboat.slack.com/archives/C063Q3F1HPF/p1727870437740469?thread_ts=1727862906.441629&cid=C063Q3F1HPF). So, I made that commit thinking it could make us not require the `z-index` fix, but in the end, we still need it. So I don't think we ever needed that commit at all.

### How to verify

Try to render a component that renders popovers inside modals when both are rendered in portals

### Demo
#### After
![image](https://github.com/user-attachments/assets/3f2df676-3172-4db6-929b-c142f52805b2)

#### Before (I shoudln't have drawn the red line since it basically hides the already-hard-to-see popover behind the modal)
![Screenshot 2025-07-03 at 2 31 54 PM](https://github.com/user-attachments/assets/f1cbacc3-43f3-47ac-88fa-742b34f22601)

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
