### PR TITLE
Closes VIZ-1206 some settings are not preserved when changing to funnel

### DIFF
--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
@@ -97,10 +97,12 @@ const cartesianToFunnel = (
     "graph.metrics": metrics = [],
     "graph.dimensions": dimensions = [],
     "card.title": cardTitle,
+    ...otherSettings
   } = settings;
 
   return {
     settings: {
+      ...otherSettings,
       "card.title": cardTitle,
       "funnel.metric": metrics[0],
       "funnel.dimension": dimensions[0],
@@ -121,12 +123,14 @@ const pieToFunnel = (
     "pie.metric": metric,
     "pie.dimension": dimension,
     "card.title": cardTitle,
+    ...otherSettings
   } = settings;
 
   return {
     columns,
     columnValuesMapping,
     settings: {
+      ...otherSettings,
       "card.title": cardTitle,
       "funnel.metric": metric,
       "funnel.dimension": dimension,

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
@@ -78,6 +78,54 @@ describe("updateSettingsForDisplay", () => {
     expect(result).toBeUndefined();
   });
 
+  it("should preserve otherSettings such as goal line (VIZ-1206)", () => {
+    const settings = {
+      "graph.metrics": ["COLUMN_3"],
+      "graph.dimensions": ["COLUMN_1", "COLUMN_2"],
+      "card.title": "My viz",
+      "goal.line": 100,
+    };
+    const lineToPieResult = getUpdatedSettingsForDisplay(
+      columnValuesMapping,
+      columns,
+      settings,
+      "line",
+      "pie",
+    );
+
+    expect(lineToPieResult).toEqual({
+      columnValuesMapping,
+      columns,
+      settings: {
+        "card.title": "My viz",
+        "goal.line": 100,
+        "pie.metric": "COLUMN_3",
+        "pie.dimension": ["COLUMN_1", "COLUMN_2"],
+      },
+    });
+
+    const lineToFunnelResult = getUpdatedSettingsForDisplay(
+      columnValuesMapping,
+      columns,
+      settings,
+      "line",
+      "funnel",
+    );
+
+    expect(lineToFunnelResult).toEqual({
+      columnValuesMapping,
+      columns,
+      settings: {
+        "card.title": "My viz",
+        "funnel.dimension": "COLUMN_1",
+        "funnel.metric": "COLUMN_3",
+        "goal.line": 100,
+        "graph.dimensions": ["COLUMN_1", "COLUMN_2"],
+        "graph.metrics": ["COLUMN_3"],
+      },
+    });
+  });
+
   describe("cartesian → cartesian", () => {
     it("should keep current state", () => {
       const result = getUpdatedSettingsForDisplay(


### PR DESCRIPTION
Closes [VIZ-1206: Changing viz type to funnel can wipe some viz settings i.e. goal lines](https://linear.app/metabase/issue/VIZ-1206/changing-viz-type-to-funnel-can-wipe-some-viz-settings-ie-goal-lines)

### Description

Try to be more conservative with settings when switching viz type in visualizer


### Demo

https://www.loom.com/share/94f41a8071cc47b7aa0b2049569061a4


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
