### PR TITLE
Do not show error when snippet is active

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -209,6 +209,23 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     H.CustomExpressionEditor.type("Average([Price]){leftarrow}{leftarrow}");
     H.CustomExpressionEditor.helpText().should("not.exist");
   });
+
+  it("should not show an error when a snippet is still active", () => {
+    addCustomColumn();
+    H.CustomExpressionEditor.type("conca{tab}", {
+      delay: 50,
+    });
+    H.popover()
+      .findByText(/Unknown column/)
+      .should("not.exist");
+    H.CustomExpressionEditor.type("{tab}", {
+      focus: false,
+      delay: 50,
+    });
+    H.popover()
+      .findByText(/Unknown column/)
+      .should("be.visible");
+  });
 });
 
 const addCustomColumn = () => {

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -1,6 +1,10 @@
-import type { EditorState } from "@codemirror/state";
+import {
+  hasNextSnippetField,
+  hasPrevSnippetField,
+} from "@codemirror/autocomplete";
+import { EditorSelection, type EditorState } from "@codemirror/state";
 import { useDisclosure } from "@mantine/hooks";
-import { EditorSelection } from "@uiw/react-codemirror";
+import type { ViewUpdate } from "@uiw/react-codemirror";
 import cx from "classnames";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useMount } from "react-use";
@@ -146,6 +150,14 @@ export function Editor(props: EditorProps) {
     );
   }, []);
 
+  const [isSnippetActive, setIsSnippetActive] = useState(false);
+  const handleUpdate = useCallback((update: ViewUpdate) => {
+    const { state } = update;
+    setIsSnippetActive(
+      hasNextSnippetField(state) || hasPrevSnippetField(state),
+    );
+  }, []);
+
   return (
     <>
       <LayoutMain className={cx(S.wrapper, { [S.formatting]: isFormatting })}>
@@ -164,13 +176,16 @@ export function Editor(props: EditorProps) {
           width="100%"
           indentWithTab={false}
           autoFocus
+          onUpdate={handleUpdate}
           autoCorrect="off"
           tabIndex={0}
           onFormat={
-            error === null && isValidated ? formatExpression : undefined
+            error === null && isValidated && !isSnippetActive
+              ? formatExpression
+              : undefined
           }
         />
-        <Errors error={error} />
+        <Errors error={isSnippetActive ? null : error} />
 
         {source.trim() === "" && !isFormatting && error == null && (
           <Shortcuts shortcuts={shortcuts} className={S.shortcuts} />

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -1,7 +1,3 @@
-import {
-  hasNextSnippetField,
-  hasPrevSnippetField,
-} from "@codemirror/autocomplete";
 import { EditorSelection, type EditorState } from "@codemirror/state";
 import { useDisclosure } from "@mantine/hooks";
 import type { ViewUpdate } from "@uiw/react-codemirror";
@@ -41,6 +37,7 @@ import { Tooltip } from "./Tooltip";
 import { DEBOUNCE_VALIDATION_MS } from "./constants";
 import { useCustomTooltip } from "./custom-tooltip";
 import { useExtensions } from "./extensions";
+import { hasActiveSnippet } from "./utils";
 
 type EditorProps = {
   id?: string;
@@ -152,10 +149,7 @@ export function Editor(props: EditorProps) {
 
   const [isSnippetActive, setIsSnippetActive] = useState(false);
   const handleUpdate = useCallback((update: ViewUpdate) => {
-    const { state } = update;
-    setIsSnippetActive(
-      hasNextSnippetField(state) || hasPrevSnippetField(state),
-    );
+    setIsSnippetActive(hasActiveSnippet(update.state));
   }, []);
 
   return (

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/language.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/language.ts
@@ -9,6 +9,7 @@ import { parser } from "metabase-lib/v1/expressions/tokenizer/parser";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 
 import { DEBOUNCE_VALIDATION_MS } from "./constants";
+import { hasActiveSnippet } from "./utils";
 
 const expressionLanguage = LRLanguage.define({
   parser,
@@ -26,6 +27,10 @@ type LintOptions = {
 const lint = (options: LintOptions) =>
   linter(
     (view: EditorView): Diagnostic[] => {
+      if (hasActiveSnippet(view.state)) {
+        return [];
+      }
+
       const source = view.state.doc.toString();
       if (source === "") {
         return [];

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/utils.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/utils.ts
@@ -1,0 +1,9 @@
+import {
+  hasNextSnippetField,
+  hasPrevSnippetField,
+} from "@codemirror/autocomplete";
+import type { EditorState } from "@codemirror/state";
+
+export function hasActiveSnippet(state: EditorState) {
+  return hasNextSnippetField(state) || hasPrevSnippetField(state);
+}


### PR DESCRIPTION
This PR fixes a simple gripe of mine.

When a user types the name of a function in the expression editor and presses tab, they will see the snippet for that function. 

Because the snippet is a template, it will generate errors since it's not a valid expression.

This causes the user to see an error even though they typed nothing wrong.

This PR attempts to alleviate that by hiding the error when the snippet is still active.

### Before
<img width="757" alt="Screenshot 2025-07-03 at 15 56 42" src="https://github.com/user-attachments/assets/bef4fa98-81d3-46c0-a862-7344d0115806" />

### After
<img width="731" alt="Screenshot 2025-07-03 at 15 56 00" src="https://github.com/user-attachments/assets/598fc70b-02c5-4870-9ce1-971d323cc2c9" />
