### PR TITLE
Swap over to mysql's images for 8.0

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -348,7 +348,7 @@ jobs:
               enable-ssl-tests: 'false'
           - name: MySQL 8.0
             junit-name: be-tests-mysql-8-0-ee
-            image: cimg/mysql:8.0
+            image: mysql:8.0
             env:
               enable-ssl-tests: 'false'
           - name: MySQL Latest


### PR DESCRIPTION
Tests fail in CI which try to set timezones in mysql to "alias" types: 'US/Pacific', etc

manual backport of https://github.com/metabase/metabase/pull/60446
fixes https://github.com/metabase/metabase/issues/60426

don't want to wait for first to land. do these in parallel
```
❯ grep "Failed to set timezone" test-log_formatted.json | jq -r '.message'
Failed to set timezone 'US/Pacific' for :mysql database
Failed to set timezone 'US/Pacific' for :mysql database
Failed to set timezone 'US/Pacific' for :mysql database
Failed to set timezone 'US/Eastern' for :mysql database
Failed to set timezone 'US/Hawaii' for :mysql database
Failed to set timezone 'US/Pacific' for :mysql database
Failed to set timezone 'US/Pacific' for :mysql database
Failed to set timezone 'US/Eastern' for :mysql database
```

on mysql image from circle CI:

```
mysql> select now();
+---------------------+
| now()               |
+---------------------+
| 2025-07-03 02:00:48 |
+---------------------+
1 row in set (0.01 sec)

mysql> SET @@session.time_zone = "US/Pacific";
ERROR 1298 (HY000): Unknown or incorrect time zone: 'US/Pacific'
mysql> select now();
+---------------------+
| now()               |
+---------------------+
| 2025-07-03 02:10:25 |
+---------------------+
1 row in set (0.01 sec)
```

on mysql's official image for 8.0:

```
mysql> select now();
+---------------------+
| now()               |
+---------------------+
| 2025-07-03 13:51:36 |
+---------------------+
1 row in set (0.00 sec)

mysql> SET @@session.time_zone = "US/Pacific";
Query OK, 0 rows affected (0.00 sec)

mysql> select now();
+---------------------+
| now()               |
+---------------------+
| 2025-07-03 06:51:41 |
+---------------------+
1 row in set (0.01 sec)
```

This happened because circle ci bumped the base image to ubuntu 22 in https://github.com/CircleCI-Public/cimg-mysql/commit/511bd6378728aa20ae7b8108baa1dd2346f0c2d7 and this has different timezone information.

Here's timezone data in their 8.0.32 image

```
ls -l /usr/share/zoneinfo/US/Pacific
lrwxrwxrwx 1 root root 22 Feb 14 21:25 /usr/share/zoneinfo/US/Pacific -> ../America/Los_Angeles
```

and in 8.0.42 (alias to latest 8.0 at time of writing)

```
ls -l /usr/share/zoneinfo/US/Pacific
/usr/bin/ls: cannot access '/usr/share/zoneinfo/US/Pacific': No such file or directory
```

Mysql's official images still have these legacy timezone aliases