### PR TITLE
Table schema and Models for Data Apps

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -371,6 +371,12 @@
    :api  #{metabase.core.initialization-status}
    :uses :any}
 
+  data-apps
+  {:team "Workflows"
+   :api  #{metabase.data-apps.core}
+   :uses #{models
+           util}}
+
   dashboards
   {:team "DashViz"
    :api  #{metabase.dashboards.api

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -371,12 +371,6 @@
    :api  #{metabase.core.initialization-status}
    :uses :any}
 
-  data-apps
-  {:team "Workflows"
-   :api  #{metabase.data-apps.core}
-   :uses #{models
-           util}}
-
   dashboards
   {:team "DashViz"
    :api  #{metabase.dashboards.api
@@ -413,6 +407,12 @@
            util
            warehouse-schema
            xrays}}
+
+  data-apps
+  {:team "Workflows"
+   :api  #{metabase.data-apps.core}
+   :uses #{models
+           util}}
 
   database-routing
   {:team "Admin Webapp"

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ llm-payloads
 .aider*
 /config.yml
 CLAUDE.local.md
+.claude/settings.local.json
 
 .eslintcache
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -21,8 +21,8 @@
 
 (def to-implement-models
   "The list of exported models but are pending for implementation."
-  [#_;; see https://linear.app/metabase/issue/WRK-579
-     "DataApp"
+  [;; see https://linear.app/metabase/issue/WRK-579
+   "DataApp"
    "DataAppDefinition"
    "DataAppRelease"])
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -20,10 +20,12 @@
    "Timeline"])
 
 (def to-implement-models
-  "The list of exported models but are pending for implementation."
-  ["App"
-   "AppDefinition"
-   "AppPublishing"])
+  "The list of exported models but are pending for implementation.
+  
+  TODO: Create Linear issue to track implementation of these models."
+  ["DataApp"
+   "DataAppDefinition"
+   "DataAppRelease"])
 
 (def exported-models
   "The list of all models exported by serialization by default. Used for production code and by tests."

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -19,6 +19,12 @@
    "NativeQuerySnippet"
    "Timeline"])
 
+(def to-implement-models
+  "The list of exported models but are pending for implementation."
+  ["App"
+   "AppDefinition"
+   "AppPublishing"])
+
 (def exported-models
   "The list of all models exported by serialization by default. Used for production code and by tests."
   (concat data-model

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -20,10 +20,9 @@
    "Timeline"])
 
 (def to-implement-models
-  "The list of exported models but are pending for implementation.
-  
-  TODO: Create Linear issue to track implementation of these models."
-  ["DataApp"
+  "The list of exported models but are pending for implementation."
+  [#_;; see https://linear.app/metabase/issue/WRK-579
+     "DataApp"
    "DataAppDefinition"
    "DataAppRelease"])
 

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -5,6 +5,7 @@
   This file makes it impossible to forget to add entity_id to new entities. It tests that every entity is either
   explicitly excluded, or has the :entity_id property."
   (:require
+   [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase-enterprise.serialization.v2.entity-ids :as v2.entity-ids]
@@ -30,62 +31,64 @@
   - not exported in serialization; or
   - exported as a child of something else (eg. timeline_event under timeline)
   so they don't need a generated entity_id."
-  #{:model/ApiKey
-    :model/HTTPAction
-    :model/ImplicitAction
-    :model/QueryAction
-    :model/ApplicationPermissionsRevision
-    :model/AuditLog
-    :model/BookmarkOrdering
-    :model/CacheConfig
-    :model/CardBookmark
-    :model/ChannelTemplate
-    :model/CollectionBookmark
-    :model/ContentTranslation
-    :model/DashboardBookmark
-    :model/DataPermissions
-    :model/DatabaseRouter
-    :model/CollectionPermissionGraphRevision
-    :model/DashboardCardSeries
-    :model/LoginHistory
-    :model/FieldValues
-    :model/ModelIndex
-    :model/ModelIndexValue
-    :model/ModerationReview
-    :model/Notification
-    :model/NotificationCard
-    :model/NotificationSubscription
-    :model/NotificationHandler
-    :model/NotificationRecipient
-    :model/ParameterCard
-    :model/Permissions
-    :model/PermissionsGroup
-    :model/PermissionsGroupMembership
-    :model/PermissionsRevision
-    :model/PersistedInfo
-    :model/Pulse
-    :model/PulseCard
-    :model/PulseChannel
-    :model/PulseChannelRecipient
-    :model/Query
-    :model/QueryCache
-    :model/QueryExecution
-    :model/QueryField
-    :model/QueryTable
-    :model/RecentViews
-    :model/Revision
-    :model/SearchIndexMetadata
-    :model/Secret
-    :model/Session
-    :model/TaskHistory
-    :model/TimelineEvent
-    :model/User
-    :model/UserParameterValue
-    :model/UserKeyValue
-    :model/ViewLog
-    :model/GroupTableAccessPolicy
-    :model/ConnectionImpersonation
-    :model/CloudMigration})
+  (set/union
+   (set (map #(keyword "model" %) serdes.models/to-implement-models))
+   #{:model/ApiKey
+     :model/HTTPAction
+     :model/ImplicitAction
+     :model/QueryAction
+     :model/ApplicationPermissionsRevision
+     :model/AuditLog
+     :model/BookmarkOrdering
+     :model/CacheConfig
+     :model/CardBookmark
+     :model/ChannelTemplate
+     :model/CollectionBookmark
+     :model/ContentTranslation
+     :model/DashboardBookmark
+     :model/DataPermissions
+     :model/DatabaseRouter
+     :model/CollectionPermissionGraphRevision
+     :model/DashboardCardSeries
+     :model/LoginHistory
+     :model/FieldValues
+     :model/ModelIndex
+     :model/ModelIndexValue
+     :model/ModerationReview
+     :model/Notification
+     :model/NotificationCard
+     :model/NotificationSubscription
+     :model/NotificationHandler
+     :model/NotificationRecipient
+     :model/ParameterCard
+     :model/Permissions
+     :model/PermissionsGroup
+     :model/PermissionsGroupMembership
+     :model/PermissionsRevision
+     :model/PersistedInfo
+     :model/Pulse
+     :model/PulseCard
+     :model/PulseChannel
+     :model/PulseChannelRecipient
+     :model/Query
+     :model/QueryCache
+     :model/QueryExecution
+     :model/QueryField
+     :model/QueryTable
+     :model/RecentViews
+     :model/Revision
+     :model/SearchIndexMetadata
+     :model/Secret
+     :model/Session
+     :model/TaskHistory
+     :model/TimelineEvent
+     :model/User
+     :model/UserParameterValue
+     :model/UserKeyValue
+     :model/ViewLog
+     :model/GroupTableAccessPolicy
+     :model/ConnectionImpersonation
+     :model/CloudMigration}))
 
 (deftest ^:parallel comprehensive-entity-id-test
   (let [entity-id-models (->> (v2.entity-ids/toucan-models)

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/models_test.clj
@@ -25,7 +25,8 @@
     (testing "We know about every model"
       (let [known-models (set (concat serdes.models/exported-models
                                       serdes.models/inlined-models
-                                      serdes.models/excluded-models))]
+                                      serdes.models/excluded-models
+                                      serdes.models/to-implement-models))]
         (is (= (set known-models)
                (set (map name (v2.entity-ids/toucan-models)))))))))
 

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -199,6 +199,13 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
+                  name: url
+                  remarks: unique url of an app
+                  type: varchar(254)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
                   remarks: The timestamp of when the app was created
                   name: created_at
                   type: ${timestamp_type}
@@ -278,7 +285,7 @@ databaseChangeLog:
             tableName: app_definition
 
   - changeSet:
-      id: v56.2025-07-03T16:04:00
+      id: v56.2025-07-03T16:02:00
       author: qnkhuat
       comment: Add index on app_definition.app_id
       preConditions:
@@ -302,7 +309,7 @@ databaseChangeLog:
             indexName: idx_app_definition_app_id
 
   - changeSet:
-      id: v56.2025-07-03T16:02:00
+      id: v56.2025-07-03T16:03:00
       author: qnkhuat
       comment: Create app_publishing table for data apps functionality
       preConditions:
@@ -359,7 +366,7 @@ databaseChangeLog:
               - column:
                   name: active
                   remarks: Whether this version is active
-                  type: boolean
+                  type: ${boolean.type}
                   defaultValueBoolean: false
                   constraints:
                     nullable: false
@@ -368,7 +375,7 @@ databaseChangeLog:
             tableName: app_publishing
 
   - changeSet:
-      id: v56.2025-07-03T16:05:00
+      id: v56.2025-07-03T16:04:00
       author: qnkhuat
       comment: Add composite index on app_publishing.app_id and active
       preConditions:

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -169,7 +169,222 @@ databaseChangeLog:
                   type: ${text.type}
                   constraints:
                     nullable: false
-# >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
+
+  - changeSet:
+      id: v56.2025-07-03T16:00:00
+      author: qnkhuat
+      comment: Create app table for data apps functionality
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: app
+      changes:
+        - createTable:
+            tableName: app
+            remarks: Applications
+            columns:
+              - column:
+                  name: id
+                  remarks: Unique ID
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  remarks: App name
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the app was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the app was updated
+                  name: updated_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropTable:
+            tableName: app
+
+  - changeSet:
+      id: v56.2025-07-03T16:01:00
+      author: qnkhuat
+      comment: Create app_definition table for data apps functionality
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: app_definition
+      changes:
+        - createTable:
+            tableName: app_definition
+            remarks: App definitions (append only)
+            columns:
+              - column:
+                  name: id
+                  remarks: Unique ID
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: app_id
+                  remarks: Referenced app
+                  type: int
+                  constraints:
+                    nullable: false
+                    referencedTableName: app
+                    referencedColumnNames: id
+                    foreignKeyName: fk_app_definition_app_id
+                    deleteCascade: true
+              - column:
+                  name: version
+                  remarks: Version number for ordering
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: config
+                  remarks: App configuration JSON
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  name: entity_id
+                  remarks: SHA hash for the entity
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropTable:
+            tableName: app_definition
+
+- changeSet:
+      id: v56.2025-07-03T16:04:00
+      author: qnkhuat
+      comment: Add index on app_definition.app_id
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: app_definition
+        - not:
+            - indexExists:
+                tableName: app_definition
+                indexName: idx_app_definition_app_id
+      changes:
+        - createIndex:
+            tableName: app_definition
+            indexName: idx_app_definition_app_id
+            columns:
+              - column:
+                  name: app_id
+      rollback:
+        - dropIndex:
+            tableName: app_definition
+            indexName: idx_app_definition_app_id
+
+  - changeSet:
+      id: v56.2025-07-03T16:02:00
+      author: qnkhuat
+      comment: Create app_publishing table for data apps functionality
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: app_publishing
+      changes:
+        - createTable:
+            tableName: app_publishing
+            remarks: App publishing records
+            columns:
+              - column:
+                  name: id
+                  remarks: Unique ID
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: app_id
+                  remarks: Referenced app
+                  type: int
+                  constraints:
+                    nullable: false
+                    referencedTableName: app
+                    referencedColumnNames: id
+                    foreignKeyName: fk_app_publishing_app_id
+                    deleteCascade: true
+              - column:
+                  name: app_definition_id
+                  remarks: Referenced app definition
+                  type: int
+                  constraints:
+                    nullable: false
+                    referencedTableName: app_definition
+                    referencedColumnNames: id
+                    foreignKeyName: fk_app_publishing_app_definition_id
+                    deleteCascade: true
+              - column:
+                  name: version_number
+                  remarks: Semantic version number
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the app was published
+                  name: published_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: active
+                  remarks: Whether this version is active
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropTable:
+            tableName: app_publishing
+
+  - changeSet:
+      id: v56.2025-07-03T16:05:00
+      author: qnkhuat
+      comment: Add composite index on app_publishing.app_id and active
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: app_publishing
+        - not:
+            - indexExists:
+                tableName: app_publishing
+                indexName: idx_app_publishing_app_id_active
+      changes:
+        - createIndex:
+            tableName: app_publishing
+            indexName: idx_app_publishing_app_id_active
+            columns:
+              - column:
+                  name: app_id
+              - column:
+                  name: active
+      rollback:
+        - dropIndex:
+            tableName: app_publishing
+            indexName: idx_app_publishing_app_id_active
 
 ########################################################################################################################
 #

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -443,7 +443,6 @@ databaseChangeLog:
                     referencedTableName: data_app_definition
                     referencedColumnNames: id
                     foreignKeyName: fk_data_app_release_app_definition_id
-                    deleteCascade: true
               - column:
                   name: creator_id
                   remarks: the creator

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -404,8 +404,8 @@ databaseChangeLog:
                     foreignKeyName: fk_data_app_release_app_definition_id
                     deleteCascade: true
               - column:
-                  remarks: The timestamp of when the app was published
-                  name: published_at
+                  remarks: The timestamp of when the app was released
+                  name: released_at
                   type: ${timestamp_type}
                   defaultValueComputed: current_timestamp
                   constraints:
@@ -462,23 +462,25 @@ databaseChangeLog:
   - changeSet:
       id: v56.2025-07-03T16:07:00
       author: qnkhuat
-      comment: index data_app_release.app_id and retracted
+      comment: index data_app_release.app_id, retracted, and released_at desc
       preConditions:
         - onFail: MARK_RAN
         - not:
             - indexExists:
                 tableName: data_app_release
-                indexName: idx_data_app_release_app_id_retracted
+                indexName: idx_data_app_release_app_id_retracted_id
       changes:
         - createIndex:
             tableName: data_app_release
-            indexName: idx_data_app_release_app_id_retracted
+            indexName: idx_data_app_release_app_id_retracted_released_at
             columns:
               - column:
                   name: app_id
-                  descending: true
               - column:
                   name: retracted
+              - column:
+                  name: released_at
+                  descending: true
       rollback: #no op, will be deleted with the table
 
 

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -468,7 +468,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   remarks: The timestamp of when the release was last updated
-                  name: updated
+                  name: updated_at
                   type: ${timestamp_type}
                   defaultValueComputed: current_timestamp
                   constraints:

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -396,9 +396,36 @@ databaseChangeLog:
               - column:
                   name: active
       rollback:
+        # MySQL requires that a foreign key constraint always has a supporting index. When the composite index (app_id, active)
+        # is dropped, we must first create a single-column index on app_id so the foreign key constraint (fk_app_publishing_app_id)
+        # remains valid. Otherwise, MySQL will throw an error when dropping the composite index because it is needed for the FK.
+        - createIndex:
+            tableName: app_publishing
+            indexName: idx_app_publishing_app_id_fk
+            columns:
+              - column:
+                  name: app_id
         - dropIndex:
             tableName: app_publishing
             indexName: idx_app_publishing_app_id_active
+
+  - changeSet:
+      id: v56.2025-07-03T16:05:00
+      author: qnkhuat
+      comment: Add index on app_publishing.app_definition_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: app_publishing
+                indexName: idx_app_publishing_app_definition_id
+      changes:
+        - createIndex:
+            tableName: app_publishing
+            indexName: idx_app_publishing_app_definition_id
+            columns:
+              - column:
+                  name: app_definition_id
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -377,41 +377,6 @@ databaseChangeLog:
   - changeSet:
       id: v56.2025-07-03T16:04:00
       author: qnkhuat
-      comment: Add composite index on app_publishing.app_id and active
-      preConditions:
-        - onFail: MARK_RAN
-        - tableExists:
-            tableName: app_publishing
-        - not:
-            - indexExists:
-                tableName: app_publishing
-                indexName: idx_app_publishing_app_id_active
-      changes:
-        - createIndex:
-            tableName: app_publishing
-            indexName: idx_app_publishing_app_id_active
-            columns:
-              - column:
-                  name: app_id
-              - column:
-                  name: active
-      rollback:
-        # MySQL requires that a foreign key constraint always has a supporting index. When the composite index (app_id, active)
-        # is dropped, we must first create a single-column index on app_id so the foreign key constraint (fk_app_publishing_app_id)
-        # remains valid. Otherwise, MySQL will throw an error when dropping the composite index because it is needed for the FK.
-        - createIndex:
-            tableName: app_publishing
-            indexName: idx_app_publishing_app_id_fk
-            columns:
-              - column:
-                  name: app_id
-        - dropIndex:
-            tableName: app_publishing
-            indexName: idx_app_publishing_app_id_active
-
-  - changeSet:
-      id: v56.2025-07-03T16:05:00
-      author: qnkhuat
       comment: Add index on app_publishing.app_definition_id
       preConditions:
         - onFail: MARK_RAN

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -383,6 +383,8 @@ databaseChangeLog:
   - changeSet:
       id: v56.2025-07-03T16:04:00
       author: qnkhuat
+      comment: index app_release.app_definition_id
+      preConditions:
         - onFail: MARK_RAN
         - not:
             - indexExists:

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -216,7 +216,7 @@ databaseChangeLog:
                   remarks: Entity id
                   type: char(21)
                   constraints:
-                    nullable: false
+                    nullable: true
               - column:
                   remarks: The timestamp of when the app was created
                   name: created_at
@@ -397,6 +397,24 @@ databaseChangeLog:
             columns:
               - column:
                   name: app_definition_id
+
+  - changeSet:
+      id: v56.2025-07-03T16:05:00
+      author: qnkhuat
+      comment: index app_release.app_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: app_release
+                indexName: idx_app_release_app_id
+      changes:
+        - createIndex:
+            tableName: app_release
+            indexName: idx_app_release_app_id
+            columns:
+              - column:
+                  name: app_id
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -199,12 +199,27 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
-                  name: url
-                  remarks: unique url of an app
+                  name: description
+                  remarks: App description
+                  type: ${text.type}
+                  constraints:
+                    nullable: true
+              - column:
+                  name: slug
+                  remarks: unique slug of an app
                   type: varchar(254)
                   constraints:
                     nullable: false
                     unique: true
+              - column:
+                  name: creator_id
+                  remarks: the creator
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: core_user(id)
+                    foreignKeyName: fk_data_app_creator_id
+                    deleteCascade: true
               - column:
                   name: status
                   remarks: Status of the app (private, published, archived)
@@ -234,6 +249,27 @@ databaseChangeLog:
       rollback:
         - dropTable:
             tableName: data_app
+
+  - changeSet:
+      id: v56.2025-07-03T16:00:10
+      author: qnkhuat
+      comment: Add index on data_app.creator_id
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: data_app
+        - not:
+            - indexExists:
+                tableName: data_app
+                indexName: idx_data_app_creator_id
+      changes:
+        - createIndex:
+            tableName: data_app
+            indexName: idx_data_app_creator_id
+            columns:
+              - column:
+                  name: creator_id
+      rollback: #no op, will be deleted with the table
 
   - changeSet:
       id: v56.2025-07-03T16:01:00
@@ -267,6 +303,15 @@ databaseChangeLog:
                     referencedColumnNames: id
                     foreignKeyName: fk_data_app_definition_app_id
                     deleteCascade: true
+            - column:
+                  name: creator_id
+                  remarks: the creator
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: core_user(id)
+                    foreignKeyName: fk_data_app_definition_creator_id
+                    deleteCascade: true
               - column:
                   name: revision_number
                   remarks: Revision number for ordering
@@ -279,12 +324,6 @@ databaseChangeLog:
                   type: ${text.type}
                   constraints:
                     nullable: false
-              - column:
-                  name: entity_id
-                  remarks: SHA hash for the entity
-                  type: char(21)
-                  constraints:
-                    nullable: true
               - column:
                   remarks: The timestamp of when the definition was created
                   name: created_at
@@ -320,23 +359,22 @@ databaseChangeLog:
   - changeSet:
       id: v56.2025-07-03T16:02:10
       author: qnkhuat
-      comment: index data_app_definition.app_id and revision_number
+      comment: Add index on data_app_definition.creator_id
       preConditions:
         - onFail: MARK_RAN
+        - tableExists:
+            tableName: data_app_definition
         - not:
             - indexExists:
                 tableName: data_app_definition
-                indexName: idx_data_app_definition_app_id_revision_number
+                indexName: idx_data_app_definition_creator_id
       changes:
         - createIndex:
             tableName: data_app_definition
-            indexName: idx_data_data_app_definition_id_revision_number
+            indexName: idx_data_app_definition_creator_id
             columns:
               - column:
-                  name: app_id
-              - column:
-                  name: revision_number
-                  descending: true
+                  name: creator_id
       rollback: #no op, will be deleted with the table
 
   - changeSet:
@@ -402,6 +440,15 @@ databaseChangeLog:
                     referencedTableName: data_app_definition
                     referencedColumnNames: id
                     foreignKeyName: fk_data_app_release_app_definition_id
+                    deleteCascade: true
+              - column:
+                  name: creator_id
+                  remarks: the creator
+                  type: int
+                  constraints:
+                    nullable: false
+                    references: core_user(id)
+                    foreignKeyName: fk_data_app_release_creator_id
                     deleteCascade: true
               - column:
                   remarks: The timestamp of when the app was released
@@ -483,6 +530,26 @@ databaseChangeLog:
                   descending: true
       rollback: #no op, will be deleted with the table
 
+  - changeSet:
+      id: v56.2025-07-03T16:08:00
+      author: qnkhuat
+      comment: Add index on data_app_release.creator_id
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: data_app_release
+        - not:
+            - indexExists:
+                tableName: data_app_release
+                indexName: idx_data_app_release_creator_id
+      changes:
+        - createIndex:
+            tableName: data_app_release
+            indexName: idx_data_app_release_creator_id
+            columns:
+              - column:
+                  name: creator_id
+      rollback: #no op, will be deleted with the table
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -206,6 +206,18 @@ databaseChangeLog:
                     nullable: false
                     unique: true
               - column:
+                  name: status
+                  remarks: Status of the app (draft, published, archived)
+                  type: varchar(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: entity_id
+                  remarks: Entity id
+                  type: char(21)
+                  constraints:
+                    nullable: false
+              - column:
                   remarks: The timestamp of when the app was created
                   name: created_at
                   type: ${timestamp_type}
@@ -311,15 +323,15 @@ databaseChangeLog:
   - changeSet:
       id: v56.2025-07-03T16:03:00
       author: qnkhuat
-      comment: Create app_publishing table for data apps functionality
+      comment: Create app_release table for data apps functionality
       preConditions:
         - onFail: MARK_RAN
         - not:
             - tableExists:
-                tableName: app_publishing
+                tableName: app_release
       changes:
         - createTable:
-            tableName: app_publishing
+            tableName: app_release
             remarks: App publishing records
             columns:
               - column:
@@ -338,7 +350,7 @@ databaseChangeLog:
                     nullable: false
                     referencedTableName: app
                     referencedColumnNames: id
-                    foreignKeyName: fk_app_publishing_app_id
+                    foreignKeyName: fk_app_release_app_id
                     deleteCascade: true
               - column:
                   name: app_definition_id
@@ -348,14 +360,8 @@ databaseChangeLog:
                     nullable: false
                     referencedTableName: app_definition
                     referencedColumnNames: id
-                    foreignKeyName: fk_app_publishing_app_definition_id
+                    foreignKeyName: fk_app_release_app_definition_id
                     deleteCascade: true
-              - column:
-                  name: version_number
-                  remarks: Semantic version number
-                  type: ${text.type}
-                  constraints:
-                    nullable: false
               - column:
                   remarks: The timestamp of when the app was published
                   name: published_at
@@ -372,22 +378,20 @@ databaseChangeLog:
                     nullable: false
       rollback:
         - dropTable:
-            tableName: app_publishing
+            tableName: app_release
 
   - changeSet:
       id: v56.2025-07-03T16:04:00
       author: qnkhuat
-      comment: Add index on app_publishing.app_definition_id
-      preConditions:
         - onFail: MARK_RAN
         - not:
             - indexExists:
-                tableName: app_publishing
-                indexName: idx_app_publishing_app_definition_id
+                tableName: app_release
+                indexName: idx_app_release_app_definition_id
       changes:
         - createIndex:
-            tableName: app_publishing
-            indexName: idx_app_publishing_app_definition_id
+            tableName: app_release
+            indexName: idx_app_release_app_definition_id
             columns:
               - column:
                   name: app_definition_id

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -338,7 +338,7 @@ databaseChangeLog:
   - changeSet:
       id: v56.2025-07-03T16:02:00
       author: qnkhuat
-      comment: Add index on data_app_definition.app_id
+      comment: Index for getting the latest definition
       preConditions:
         - onFail: MARK_RAN
         - tableExists:
@@ -346,14 +346,17 @@ databaseChangeLog:
         - not:
             - indexExists:
                 tableName: data_app_definition
-                indexName: idx_data_app_definition_app_id
+                indexName: idx_data_app_definition_app_id_revision_numer
       changes:
         - createIndex:
             tableName: data_app_definition
-            indexName: idx_data_app_definition_app_id
+            indexName: idx_data_app_definition_app_id_revision_numer
             columns:
               - column:
                   name: app_id
+              - column:
+                  name: revision_number
+                  descending: true
       rollback: #no op, will be deleted with the table
 
   - changeSet:
@@ -380,7 +383,7 @@ databaseChangeLog:
   - changeSet:
       id: v56.2025-07-03T16:02:20
       author: qnkhuat
-      comment: Add unique constraint on data_app_definition (revision_number, app_id)
+      comment: Add unique constraint on data_app_definition (app_id, revision_number)
       preConditions:
         - onFail: MARK_RAN
         - tableExists:
@@ -388,16 +391,16 @@ databaseChangeLog:
         - not:
             - uniqueConstraintExists:
                 tableName: data_app_definition
-                constraintName: idx_data_app_definition_revision_number_app_id
+                constraintName: uniq_idx_data_app_definition_app_id_revision_number
       changes:
         - addUniqueConstraint:
             tableName: data_app_definition
-            constraintName: idx_data_app_definition_revision_number_app_id
-            columnNames: revision_number, app_id
+            constraintName: uniq_idx_data_app_definition_app_id_revision_number
+            columnNames: app_id, revision_number
       rollback:
         - dropUniqueConstraint:
             tableName: data_app_definition
-            constraintName: idx_data_app_definition_revision_number_app_id
+            constraintName: uniq_idx_data_app_definition_app_id_revision_number
 
   - changeSet:
       id: v56.2025-07-03T16:03:00
@@ -451,17 +454,24 @@ databaseChangeLog:
                     foreignKeyName: fk_data_app_release_creator_id
                     deleteCascade: true
               - column:
-                  remarks: The timestamp of when the app was released
-                  name: released_at
+                  name: retracted
+                  remarks: Whether this version is retracted
+                  type: ${boolean.type}
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: The timestamp of when the app was first released
+                  name: created_at
                   type: ${timestamp_type}
                   defaultValueComputed: current_timestamp
                   constraints:
                     nullable: false
               - column:
-                  name: retracted
-                  remarks: Whether this version is retracted
-                  type: ${boolean.type}
-                  defaultValueBoolean: false
+                  remarks: The timestamp of when the release was last updated
+                  name: updated
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
                   constraints:
                     nullable: false
       rollback:
@@ -488,45 +498,26 @@ databaseChangeLog:
       rollback: #no op, will be deleted with the table
 
   - changeSet:
-      id: v56.2025-07-03T16:05:00
-      author: qnkhuat
-      comment: index data_app_release.app_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: data_app_release
-                indexName: idx_data_app_release_app_id
-      changes:
-        - createIndex:
-            tableName: data_app_release
-            indexName: idx_data_app_release_app_id
-            columns:
-              - column:
-                  name: app_id
-      rollback: #no op, will be deleted with the table
-
-  - changeSet:
       id: v56.2025-07-03T16:07:00
       author: qnkhuat
-      comment: index data_app_release.app_id, retracted, and released_at desc
+      comment: Index to get the latest active release
       preConditions:
         - onFail: MARK_RAN
         - not:
             - indexExists:
                 tableName: data_app_release
-                indexName: idx_data_app_release_app_id_retracted_id
+                indexName: idx_data_app_release_app_id_retracted_created_at
       changes:
         - createIndex:
             tableName: data_app_release
-            indexName: idx_data_app_release_app_id_retracted_released_at
+            indexName: idx_data_app_release_app_id_retracted_created_at
             columns:
               - column:
                   name: app_id
               - column:
                   name: retracted
               - column:
-                  name: released_at
+                  name: created_at
                   descending: true
       rollback: #no op, will be deleted with the table
 

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -506,18 +506,18 @@ databaseChangeLog:
         - not:
             - indexExists:
                 tableName: data_app_release
-                indexName: idx_data_app_release_app_id_retracted_created_at
+                indexName: idx_data_app_release_app_id_retracted_id
       changes:
         - createIndex:
             tableName: data_app_release
-            indexName: idx_data_app_release_app_id_retracted_created_at
+            indexName: idx_data_app_release_app_id_retracted_id
             columns:
               - column:
                   name: app_id
               - column:
                   name: retracted
               - column:
-                  name: created_at
+                  name: id
                   descending: true
       rollback: #no op, will be deleted with the table
 

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -173,15 +173,15 @@ databaseChangeLog:
   - changeSet:
       id: v56.2025-07-03T16:00:00
       author: qnkhuat
-      comment: Create app table for data apps functionality
+      comment: Create data_app table for data apps functionality
       preConditions:
         - onFail: MARK_RAN
         - not:
             - tableExists:
-                tableName: app
+                tableName: data_app
       changes:
         - createTable:
-            tableName: app
+            tableName: data_app
             remarks: Applications
             columns:
               - column:
@@ -207,7 +207,7 @@ databaseChangeLog:
                     unique: true
               - column:
                   name: status
-                  remarks: Status of the app (draft, published, archived)
+                  remarks: Status of the app (private, published, archived)
                   type: varchar(32)
                   constraints:
                     nullable: false
@@ -233,20 +233,20 @@ databaseChangeLog:
                     nullable: false
       rollback:
         - dropTable:
-            tableName: app
+            tableName: data_app
 
   - changeSet:
       id: v56.2025-07-03T16:01:00
       author: qnkhuat
-      comment: Create app_definition table for data apps functionality
+      comment: Create data_app_definition table for data apps functionality
       preConditions:
         - onFail: MARK_RAN
         - not:
             - tableExists:
-                tableName: app_definition
+                tableName: data_app_definition
       changes:
         - createTable:
-            tableName: app_definition
+            tableName: data_app_definition
             remarks: App definitions (append only)
             columns:
               - column:
@@ -263,13 +263,13 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    referencedTableName: app
+                    referencedTableName: data_app
                     referencedColumnNames: id
-                    foreignKeyName: fk_app_definition_app_id
+                    foreignKeyName: fk_data_app_definition_app_id
                     deleteCascade: true
               - column:
-                  name: version
-                  remarks: Version number for ordering
+                  name: revision_number
+                  remarks: Revision number for ordering
                   type: int
                   constraints:
                     nullable: false
@@ -282,7 +282,7 @@ databaseChangeLog:
               - column:
                   name: entity_id
                   remarks: SHA hash for the entity
-                  type: ${text.type}
+                  type: char(21)
                   constraints:
                     nullable: false
               - column:
@@ -294,44 +294,87 @@ databaseChangeLog:
                     nullable: false
       rollback:
         - dropTable:
-            tableName: app_definition
+            tableName: data_app_definition
 
   - changeSet:
       id: v56.2025-07-03T16:02:00
       author: qnkhuat
-      comment: Add index on app_definition.app_id
+      comment: Add index on data_app_definition.app_id
       preConditions:
         - onFail: MARK_RAN
         - tableExists:
-            tableName: app_definition
+            tableName: data_app_definition
         - not:
             - indexExists:
-                tableName: app_definition
-                indexName: idx_app_definition_app_id
+                tableName: data_app_definition
+                indexName: idx_data_app_definition_app_id
       changes:
         - createIndex:
-            tableName: app_definition
-            indexName: idx_app_definition_app_id
+            tableName: data_app_definition
+            indexName: idx_data_app_definition_app_id
             columns:
               - column:
                   name: app_id
       rollback:
         - dropIndex:
-            tableName: app_definition
-            indexName: idx_app_definition_app_id
+            tableName: data_app_definition
+            indexName: idx_data_app_definition_app_id
+
+  - changeSet:
+      id: v56.2025-07-03T16:02:10
+      author: qnkhuat
+      comment: index data_app_definition.app_id and revision_number
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: data_app_definition
+                indexName: idx_data_app_definition_app_id_revision_number
+      changes:
+        - createIndex:
+            tableName: data_app_definition
+            indexName: idx_data_data_app_definition_id_revision_number
+            columns:
+              - column:
+                  name: app_id
+              - column:
+                  name: revision_number
+                  descending: true
+
+  - changeSet:
+      id: v56.2025-07-03T16:02:20
+      author: qnkhuat
+      comment: Add unique constraint on data_app_definition (revision_number, app_id)
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: data_app_definition
+        - not:
+            - uniqueConstraintExists:
+                tableName: data_app_definition
+                constraintName: idx_data_app_definition_revision_number_app_id
+      changes:
+        - addUniqueConstraint:
+            tableName: data_app_definition
+            constraintName: idx_data_app_definition_revision_number_app_id
+            columnNames: revision_number, app_id
+      rollback:
+        - dropUniqueConstraint:
+            tableName: data_app_definition
+            constraintName: idx_data_app_definition_revision_number_app_id
 
   - changeSet:
       id: v56.2025-07-03T16:03:00
       author: qnkhuat
-      comment: Create app_release table for data apps functionality
+      comment: Create data_app_release table for data apps functionality
       preConditions:
         - onFail: MARK_RAN
         - not:
             - tableExists:
-                tableName: app_release
+                tableName: data_app_release
       changes:
         - createTable:
-            tableName: app_release
+            tableName: data_app_release
             remarks: App publishing records
             columns:
               - column:
@@ -348,9 +391,9 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    referencedTableName: app
+                    referencedTableName: data_app
                     referencedColumnNames: id
-                    foreignKeyName: fk_app_release_app_id
+                    foreignKeyName: fk_data_app_release_app_id
                     deleteCascade: true
               - column:
                   name: app_definition_id
@@ -358,9 +401,9 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: false
-                    referencedTableName: app_definition
+                    referencedTableName: data_app_definition
                     referencedColumnNames: id
-                    foreignKeyName: fk_app_release_app_definition_id
+                    foreignKeyName: fk_data_app_release_app_definition_id
                     deleteCascade: true
               - column:
                   remarks: The timestamp of when the app was published
@@ -370,30 +413,30 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
-                  name: active
-                  remarks: Whether this version is active
+                  name: retracted
+                  remarks: Whether this version is retracted
                   type: ${boolean.type}
                   defaultValueBoolean: false
                   constraints:
                     nullable: false
       rollback:
         - dropTable:
-            tableName: app_release
+            tableName: data_app_release
 
   - changeSet:
       id: v56.2025-07-03T16:04:00
       author: qnkhuat
-      comment: index app_release.app_definition_id
+      comment: index data_app_release.app_definition_id
       preConditions:
         - onFail: MARK_RAN
         - not:
             - indexExists:
-                tableName: app_release
-                indexName: idx_app_release_app_definition_id
+                tableName: data_app_release
+                indexName: idx_data_app_release_app_definition_id
       changes:
         - createIndex:
-            tableName: app_release
-            indexName: idx_app_release_app_definition_id
+            tableName: data_app_release
+            indexName: idx_data_app_release_app_definition_id
             columns:
               - column:
                   name: app_definition_id
@@ -401,20 +444,42 @@ databaseChangeLog:
   - changeSet:
       id: v56.2025-07-03T16:05:00
       author: qnkhuat
-      comment: index app_release.app_id
+      comment: index data_app_release.app_id
       preConditions:
         - onFail: MARK_RAN
         - not:
             - indexExists:
-                tableName: app_release
-                indexName: idx_app_release_app_id
+                tableName: data_app_release
+                indexName: idx_data_app_release_app_id
       changes:
         - createIndex:
-            tableName: app_release
-            indexName: idx_app_release_app_id
+            tableName: data_app_release
+            indexName: idx_data_app_release_app_id
             columns:
               - column:
                   name: app_id
+
+  - changeSet:
+      id: v56.2025-07-03T16:07:00
+      author: qnkhuat
+      comment: index data_app_release.app_id and retracted
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: data_app_release
+                indexName: idx_data_app_release_app_id_retracted
+      changes:
+        - createIndex:
+            tableName: data_app_release
+            indexName: idx_data_app_release_app_id_retracted
+            columns:
+              - column:
+                  name: app_id
+                  descending: true
+              - column:
+                  name: retracted
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -303,7 +303,7 @@ databaseChangeLog:
                     referencedColumnNames: id
                     foreignKeyName: fk_data_app_definition_app_id
                     deleteCascade: true
-            - column:
+              - column:
                   name: creator_id
                   remarks: the creator
                   type: int

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -266,11 +266,18 @@ databaseChangeLog:
                   type: ${text.type}
                   constraints:
                     nullable: false
+              - column:
+                  remarks: The timestamp of when the definition was created
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
       rollback:
         - dropTable:
             tableName: app_definition
 
-- changeSet:
+  - changeSet:
       id: v56.2025-07-03T16:04:00
       author: qnkhuat
       comment: Add index on app_definition.app_id
@@ -385,6 +392,8 @@ databaseChangeLog:
         - dropIndex:
             tableName: app_publishing
             indexName: idx_app_publishing_app_id_active
+
+  # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################
 #

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -284,7 +284,7 @@ databaseChangeLog:
                   remarks: SHA hash for the entity
                   type: char(21)
                   constraints:
-                    nullable: false
+                    nullable: true
               - column:
                   remarks: The timestamp of when the definition was created
                   name: created_at
@@ -315,10 +315,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: app_id
-      rollback:
-        - dropIndex:
-            tableName: data_app_definition
-            indexName: idx_data_app_definition_app_id
+      rollback: #no op, will be deleted with the table
 
   - changeSet:
       id: v56.2025-07-03T16:02:10
@@ -340,6 +337,7 @@ databaseChangeLog:
               - column:
                   name: revision_number
                   descending: true
+      rollback: #no op, will be deleted with the table
 
   - changeSet:
       id: v56.2025-07-03T16:02:20
@@ -440,6 +438,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: app_definition_id
+      rollback: #no op, will be deleted with the table
 
   - changeSet:
       id: v56.2025-07-03T16:05:00
@@ -458,6 +457,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: app_id
+      rollback: #no op, will be deleted with the table
 
   - changeSet:
       id: v56.2025-07-03T16:07:00
@@ -479,6 +479,7 @@ databaseChangeLog:
                   descending: true
               - column:
                   name: retracted
+      rollback: #no op, will be deleted with the table
 
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -53,7 +53,10 @@
   "Entities in the order they should be serialized/deserialized. This is done so we make sure that we load
   instances of entities before others that might depend on them, e.g. `Databases` before `Tables` before `Fields`."
   (concat
-   [:model/Channel
+   [:model/App
+    :model/AppDefinition
+    :model/AppPublishing
+    :model/Channel
     :model/ChannelTemplate
     :model/Database
     :model/User

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -55,7 +55,7 @@
   (concat
    [:model/App
     :model/AppDefinition
-    :model/AppPublishing
+    :model/AppRelease
     :model/Channel
     :model/ChannelTemplate
     :model/Database

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -53,9 +53,9 @@
   "Entities in the order they should be serialized/deserialized. This is done so we make sure that we load
   instances of entities before others that might depend on them, e.g. `Databases` before `Tables` before `Fields`."
   (concat
-   [:model/App
-    :model/AppDefinition
-    :model/AppRelease
+   [:model/DataApp
+    :model/DataAppDefinition
+    :model/DataAppRelease
     :model/Channel
     :model/ChannelTemplate
     :model/Database

--- a/src/metabase/data_apps/CLAUDE.md
+++ b/src/metabase/data_apps/CLAUDE.md
@@ -35,7 +35,8 @@ data_app_release
 ├── id (PK)
 ├── app_id (FK -> data_app.id, cascade delete)
 ├── app_definition_id (FK -> data_app_definition.id, cascade delete)
-├── published_at
+├── created_at
+├── updated_at
 └── retracted (boolean, default false)
 ```
 

--- a/src/metabase/data_apps/CLAUDE.md
+++ b/src/metabase/data_apps/CLAUDE.md
@@ -42,7 +42,7 @@ data_app_release
 ### Key Relationships
 
 1. **DataApp → DataAppDefinition** (1:N)
-   - Each app can have multiple versioned definitions
+   - Each app can have multiple sequential snapshots (revisions) of its definition
    - Definitions are append-only (immutable once created)
    - Indexed on `app_id` for efficient queries
    - `revision_number` is calculated atomically to prevent race conditions

--- a/src/metabase/data_apps/CLAUDE.md
+++ b/src/metabase/data_apps/CLAUDE.md
@@ -1,0 +1,110 @@
+# Data Apps Development Guide
+
+## Overview
+
+This directory contains the core functionality for Metabase Data Apps - a feature that allows users to create and publish custom applications within Metabase.
+
+## Key Components
+
+- **core.clj** - Public API for the data apps module (all external interactions should go through this namespace)
+- **models.clj** - Internal database models and schema definitions for Apps, AppDefinitions, and AppPublishing
+
+## Data Model
+
+### Tables and Relationships
+
+```
+app
+├── id (PK)
+├── name
+├── url (unique)
+├── created_at
+└── updated_at
+
+app_definition
+├── id (PK)
+├── app_id (FK -> app.id, cascade delete)
+├── version (incrementing number)
+├── config (JSON)
+├── entity_id (SHA hash)
+└── created_at
+
+app_publishing
+├── id (PK)
+├── app_id (FK -> app.id, cascade delete)
+├── app_definition_id (FK -> app_definition.id, cascade delete)
+├── version_number (semantic version)
+├── published_at
+└── active (boolean, default false)
+```
+
+### Key Relationships
+
+1. **App → AppDefinition** (1:N)
+   - Each app can have multiple versioned definitions
+   - Definitions are append-only (immutable once created)
+   - Indexed on `app_id` for efficient queries
+
+2. **App → AppPublishing** (1:N)
+   - Each app can have multiple publishing records
+   - Only one can be `active` at a time
+   - Composite index on `(app_id, active)` for fast lookups
+
+3. **AppDefinition → AppPublishing** (1:N)
+   - Each definition can be published multiple times
+   - Publishing records track when a definition was made active
+
+## Development Guidelines
+
+### Model Structure
+
+The data apps feature uses three main models:
+- `:model/App` - The main app entity with unique URL
+- `:model/AppDefinition` - Immutable versioned app configurations
+- `:model/AppPublishing` - Publishing records tracking active versions
+
+### Public API (core.clj)
+
+These functions form the public interface for the data apps module. All external code should use these functions rather than directly accessing the models:
+
+- `create-app!` - Creates a new app with its initial definition
+- `new-definition!` - Creates a new version of an app definition
+- `publish!` - Publishes a specific app definition version
+
+**Important:** Do not import or use functions from `models.clj` directly outside of this module. Always use the public API in `core.clj`.
+
+### Database Considerations
+
+- App definitions are versioned automatically
+- Only one definition can be active/published at a time
+- Validation occurs before insert/update operations
+
+### Common Patterns
+
+1. Always validate app definition configs before saving
+2. Use transactions when updating multiple related records
+3. Ensure version numbers increment properly
+4. Handle publication state transitions atomically
+
+## Maintenance
+
+### When to Update This File
+
+Please update this CLAUDE.md file when:
+
+1. **Adding new models or tables** - Update the data model section
+2. **Modifying database schema** - Update table structures and relationships
+3. **Adding new core functions** - Add to the Key Functions section
+4. **Changing validation rules** - Document in the appropriate section
+5. **Introducing new patterns** - Add to Common Patterns
+6. **Adding new files** - Update the Key Components section
+
+### Files to Check for Updates
+
+When updating this documentation, review these files for changes:
+- `models.clj` - Model definitions and business logic
+- `core.clj` - Core functionality
+- `/resources/migrations/*_update_migrations.yaml` - Database schema changes
+- Any new `.clj` files added to this directory
+
+This ensures the documentation stays in sync with the actual implementation.

--- a/src/metabase/data_apps/CLAUDE.md
+++ b/src/metabase/data_apps/CLAUDE.md
@@ -17,7 +17,7 @@ This directory contains the core functionality for Metabase Data Apps - a featur
 data_app
 ├── id (PK)
 ├── name
-├── url (unique)
+├── slug (unique)
 ├── status (private, published, archived)
 ├── entity_id
 ├── created_at
@@ -62,7 +62,7 @@ data_app_release
 ### Model Structure
 
 The data apps feature uses three main models:
-- `:model/DataApp` - The main app entity with unique URL (table: `data_app`)
+- `:model/DataApp` - The main app entity with unique slug (table: `data_app`)
 - `:model/DataAppDefinition` - Immutable versioned app configurations (table: `data_app_definition`)
 - `:model/DataAppRelease` - Release records tracking active versions (table: `data_app_release`)
 

--- a/src/metabase/data_apps/CLAUDE.md
+++ b/src/metabase/data_apps/CLAUDE.md
@@ -70,7 +70,7 @@ The data apps feature uses three main models:
 These functions form the public interface for the data apps module. All external code should use these functions rather than directly accessing the models:
 
 - `create-app!` - Creates a new app with its initial definition
-- `new-definition!` - Creates a new version of an app definition (revision_number calculated atomically)
+- `set-latest-definition!` - Creates a new version of an app definition (revision_number calculated atomically)
 - `publish!` - Publishes a specific app definition version
 
 **Important:** Do not import or use functions from `models.clj` directly outside of this module. Always use the public API in `core.clj`.

--- a/src/metabase/data_apps/core.clj
+++ b/src/metabase/data_apps/core.clj
@@ -1,0 +1,3 @@
+(ns metabase.data-apps.core
+  (:reqauire
+   [metabase.data-apps.models]))

--- a/src/metabase/data_apps/core.clj
+++ b/src/metabase/data_apps/core.clj
@@ -1,3 +1,1 @@
-(ns metabase.data-apps.core
-  (:reqauire
-   [metabase.data-apps.models]))
+(ns metabase.data-apps.models)

--- a/src/metabase/data_apps/core.clj
+++ b/src/metabase/data_apps/core.clj
@@ -1,1 +1,1 @@
-(ns metabase.data-apps.models)
+(ns metabase.data-apps.core)

--- a/src/metabase/data_apps/models.clj
+++ b/src/metabase/data_apps/models.clj
@@ -18,7 +18,7 @@
   (derive model :metabase/model))
 
 (derive :model/App :hook/timestamped?)
-
+(derive :model/AppDefinition :hook/created-at-timestamped?)
 (derive :model/AppDefinition :hook/entity-id)
 
 ;;------------------------------------------------------------------------------------------------;;

--- a/src/metabase/data_apps/models.clj
+++ b/src/metabase/data_apps/models.clj
@@ -19,6 +19,7 @@
 
 (derive :model/DataApp :hook/timestamped?)
 (derive :model/DataApp :hook/entity-id)
+(derive :model/DataAppRelease :hook/timestamped?)
 (derive :model/DataAppDefinition :hook/created-at-timestamped?)
 
 ;;------------------------------------------------------------------------------------------------;;
@@ -70,10 +71,6 @@
 ;;------------------------------------------------------------------------------------------------;;
 ;;                                    :model/DataAppRelease                                       ;;
 ;;------------------------------------------------------------------------------------------------;;
-
-(t2/define-before-insert :model/DataAppRelease
-  [instance]
-  (merge {:released_at :%now} instance))
 
 (t2/define-before-update :model/DataAppRelease
   [instance]

--- a/src/metabase/data_apps/models.clj
+++ b/src/metabase/data_apps/models.clj
@@ -39,7 +39,9 @@
 
 (mr/def ::AppDefinitionConfig
   [:maybe [:map {:closed true}
-           [:version pos-int?]]])
+           [:actions [:sequential :map]]
+           [:parameters [:sequential :map]]
+           [:pages [:sequential :map]]]])
 
 (defn- validate-app-definition
   "Validate an AppDefinition."
@@ -57,11 +59,13 @@
                   {:status-code 400
                    :changes     (t2/changes instance)})))
 
-(defn- next-revision-number
-  "Get the next revision number for a given app."
+(defn- next-revision-number-hsql
   [app-id]
-  (inc (or (:max (t2/select-one [:model/DataAppDefinition [:%max.revision_number :max]] :app_id app-id))
-           0)))
+  [:coalesce [:+ [:inline 1]
+              {:select [:%max.revision_number]
+               :from [:data_app_definition]
+               :where [:= :app_id app-id]}]
+   [:inline 1]])
 
 ;;------------------------------------------------------------------------------------------------;;
 ;;                                    :model/DataAppRelease                                       ;;
@@ -69,7 +73,7 @@
 
 (t2/define-before-insert :model/DataAppRelease
   [instance]
-  (merge {:published_at :%now} instance))
+  (merge {:released_at :%now} instance))
 
 (t2/define-before-update :model/DataAppRelease
   [instance]
@@ -91,20 +95,21 @@
 ;;                                        Public APIs                                             ;;
 ;;------------------------------------------------------------------------------------------------;;
 
-(defn new-definition!
+(defn set-latest-definition!
   "Create a new definition for an existing app."
   [app-id definition]
   (t2/insert-returning-instance! :model/DataAppDefinition
                                  (merge definition
                                         {:app_id          app-id
-                                         :revision_number (next-revision-number app-id)})))
+                                         :revision_number (next-revision-number-hsql app-id)})))
 
 (defn create-app!
   "Create a new App with an initial definition."
   [app-data]
   (t2/with-transaction [_conn]
     (let [app            (t2/insert-returning-instance! :model/DataApp (dissoc app-data :definition))
-          app-definition (new-definition! (:id app) (:definition app-data))]
+          app-definition (when-let [definition (:definition app-data)]
+                           (set-latest-definition! (:id app) definition))]
       (assoc app :definition app-definition))))
 
 (defn publish!
@@ -113,5 +118,4 @@
   (t2/with-transaction [_conn]
     (t2/insert-returning-instance! :model/DataAppRelease
                                    {:app_id            app-id
-                                    :app_definition_id app-definition-id
-                                    :retracted         false})))
+                                    :app_definition_id app-definition-id})))

--- a/src/metabase/data_apps/models.clj
+++ b/src/metabase/data_apps/models.clj
@@ -18,8 +18,8 @@
   (derive model :metabase/model))
 
 (derive :model/DataApp :hook/timestamped?)
+(derive :model/DataApp :hook/entity-id)
 (derive :model/DataAppDefinition :hook/created-at-timestamped?)
-(derive :model/DataAppDefinition :hook/entity-id)
 
 ;;------------------------------------------------------------------------------------------------;;
 ;;                                       :model/DataApp                                           ;;

--- a/src/metabase/data_apps/models.clj
+++ b/src/metabase/data_apps/models.clj
@@ -1,0 +1,95 @@
+(ns metabase.data-apps.models
+  (:require
+   [metabase.models.interface :as mi]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(methodical/defmethod t2/table-name :model/App           [_model] :app)
+(methodical/defmethod t2/table-name :model/AppDefinition [_model] :app_definition)
+(methodical/defmethod t2/table-name :model/AppPublishing [_model] :app_publishing)
+
+(doseq [model [:model/App
+               :model/AppDefinition
+               :model/AppPublishing]]
+  (derive model :metabase/model))
+
+(derive :model/App :hook/timestamped?)
+
+(derive :model/AppDefinition :hook/entity-id)
+
+;;------------------------------------------------------------------------------------------------;;
+;;                                         :model/App                                             ;;
+;;------------------------------------------------------------------------------------------------;;
+
+(t2/deftransforms :model/App
+  {:config mi/transform-json})
+
+;;------------------------------------------------------------------------------------------------;;
+;;                                     :model/AppDefinition                                       ;;
+;;-----------------------------------------------------------------------------------------------;;
+
+(mr/def ::AppDefinitionConfig
+  [:maybe [:map {:closed true}]])
+
+(defn- validate-app-definition
+  "Validate an AppDefinition."
+  [app-definition]
+  (mu/validate-throw ::AppDefinitionConfig (:config app-definition)))
+
+(defn- next-version
+  [app-id]
+  (or (t2/select-one-fn :version :model/AppDefinition :app_id app-id {:order-by [[:version :desc]]
+                                                                      :limit 1})
+      0))
+
+(t2/define-before-insert :model/AppDefinition
+  [instance]
+  (validate-app-definition instance)
+  (assoc instance :version (next-version (:app_id instance))))
+
+(t2/define-before-update :model/AppDefinition
+  [instance]
+  ;; AppDefinition is append-only, so prevent updates
+  (throw (ex-info "AppDefinition is append-only and cannot be updated"
+                  {:status-code 400
+                   :changes     (t2/changes instance)})))
+
+;;------------------------------------------------------------------------------------------------;;
+;;                                     :model/AppPublishing                                       ;;
+;;------------------------------------------------------------------------------------------------;;
+
+(defn- ensure-single-active-publication!
+  "Ensure at most one active publication per app_id."
+  [instance]
+  (when (:active instance)
+    (t2/update! :model/AppPublishing
+                {:app_id (:app_id instance)
+                 :active true}
+                {:active false}))
+  instance)
+
+(t2/define-before-insert :model/AppPublishing
+  [instance]
+  (let [instance (merge {:active       true
+                         :published_at :%now}
+                        instance)]
+    (ensure-single-active-publication! instance)
+    instance))
+
+(t2/define-before-update :model/AppPublishing
+  [instance]
+  ;; AppPublishing is append-only, so prevent updates except for active status
+  (when-let [disallowed-key (some #(when (not= % :active) %) (keys (t2/changes instance)))]
+    (throw (ex-info (format "AppPublishing is append-only. Only 'active' field can be updated, but got: %s"
+                            (name disallowed-key))
+                    {:status-code 400
+                     :changes     (t2/changes instance)})))
+  (ensure-single-active-publication! instance))
+
+;;------------------------------------------------------------------------------------------------;;
+;;                                        Public APIs                                             ;;
+;;------------------------------------------------------------------------------------------------;;

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -14,9 +14,9 @@
   Tests will check to make sure new models get included in this map."
   '{:model/Action                            metabase.actions.models
     :model/ApiKey                            metabase.api-keys.models.api-key
-    :model/App                               metabase.data-apps.models
-    :model/AppDefinition                     metabase.data-apps.models
-    :model/AppRelease                        metabase.data-apps.models
+    :model/DataApp                               metabase.data-apps.models
+    :model/DataAppDefinition                     metabase.data-apps.models
+    :model/DataAppRelease                        metabase.data-apps.models
     :model/ApplicationPermissionsRevision    metabase.permissions.models.application-permissions-revision
     :model/AuditLog                          metabase.audit-app.models.audit-log
     :model/BookmarkOrdering                  metabase.bookmarks.models.bookmark

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -16,7 +16,7 @@
     :model/ApiKey                            metabase.api-keys.models.api-key
     :model/App                               metabase.data-apps.models
     :model/AppDefinition                     metabase.data-apps.models
-    :model/AppPublishing                     metabase.data-apps.models
+    :model/AppRelease                        metabase.data-apps.models
     :model/ApplicationPermissionsRevision    metabase.permissions.models.application-permissions-revision
     :model/AuditLog                          metabase.audit-app.models.audit-log
     :model/BookmarkOrdering                  metabase.bookmarks.models.bookmark

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -14,6 +14,9 @@
   Tests will check to make sure new models get included in this map."
   '{:model/Action                            metabase.actions.models
     :model/ApiKey                            metabase.api-keys.models.api-key
+    :model/App                               metabase.data-apps.models
+    :model/AppDefinition                     metabase.data-apps.models
+    :model/AppPublishing                     metabase.data-apps.models
     :model/ApplicationPermissionsRevision    metabase.permissions.models.application-permissions-revision
     :model/AuditLog                          metabase.audit-app.models.audit-log
     :model/BookmarkOrdering                  metabase.bookmarks.models.bookmark

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -14,9 +14,9 @@
   Tests will check to make sure new models get included in this map."
   '{:model/Action                            metabase.actions.models
     :model/ApiKey                            metabase.api-keys.models.api-key
-    :model/DataApp                               metabase.data-apps.models
-    :model/DataAppDefinition                     metabase.data-apps.models
-    :model/DataAppRelease                        metabase.data-apps.models
+    :model/DataApp                           metabase.data-apps.models
+    :model/DataAppDefinition                 metabase.data-apps.models
+    :model/DataAppRelease                    metabase.data-apps.models
     :model/ApplicationPermissionsRevision    metabase.permissions.models.application-permissions-revision
     :model/AuditLog                          metabase.audit-app.models.audit-log
     :model/BookmarkOrdering                  metabase.bookmarks.models.bookmark


### PR DESCRIPTION
Closes WRK-568

```
data_app
├── id (PK)
├── name
├── url (unique)
├── status (private, published, archived)
├── entity_id
├── created_at
└── updated_at
data_app_definition
├── id (PK)
├── app_id (FK -> data_app.id, cascade delete)
├── revision_number (incrementing number, calculated atomically)
├── config (JSON)
├── entity_id (char(21))
└── created_at
data_app_release
├── id (PK)
├── app_id (FK -> data_app.id, cascade delete)
├── app_definition_id (FK -> data_app_definition.id, cascade delete)
├── published_at
└── retracted (boolean, default false)
```