### PR TITLE
Fix join condition compilation on mongo when rhs is a literal value

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -858,9 +858,14 @@ function(bin) {
 (defmethod compile-filter :starts-with [[_ field v opts]] {$expr (str-match-pattern field opts "^" v nil)})
 (defmethod compile-filter :ends-with   [[_ field v opts]] {$expr (str-match-pattern field opts nil v "$")})
 
+(defn- rvalue-is-variable? [rvalue]
+  (and (string? rvalue)
+       (str/starts-with? rvalue "$$")))
+
 (defn- rvalue-is-field? [rvalue]
   (and (string? rvalue)
-       (str/starts-with? rvalue "$")))
+       (str/starts-with? rvalue "$")
+       (not (rvalue-is-variable? rvalue))))
 
 (defn- rvalue-can-be-compared-directly?
   "Whether `rvalue` is something simple that can be compared directly e.g.
@@ -873,6 +878,7 @@ function(bin) {
   [rvalue]
   (or (rvalue-is-field? rvalue)
       (and (not (map? rvalue))
+           (not (rvalue-is-variable? rvalue))
            (not (instance? java.util.regex.Pattern rvalue)))))
 
 (defn- filter-expr [operator field value]

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -1281,17 +1281,8 @@
      [[1 "Red Medicine" "Dim Sum"]
       [2 "Stout Burgers & Beers" "Dim Sum"]])))
 
-;; FIXME QUE-1500 Fix join condition compilation on mongo and remove this feature
-(defmethod driver/database-supports? [::driver/driver ::join-expressions-lhs-cols-rhs-literal]
-  [_driver _feature _database]
-  true)
-
-(defmethod driver/database-supports? [:mongo ::join-expressions-lhs-col-rhs-literal]
-  [_driver _feature _database]
-  false)
-
 (deftest ^:parallel join-expressions-lhs-col-rhs-literal-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions ::join-expressions-lhs-col-rhs-literal)
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join :expressions)
     (check-venues+categories-on-condition
      [:=
       (mt/$ids venues $name)


### PR DESCRIPTION
Closes QUE-1500

### Description

When compiling a join condition, columns from the source table get turned into `$let`-bound variables in the `$lookup` clause. These need to be compiled to an `$expr` in the `$lookup`'s `$match` clause and referenced via the `$$` variable prefix. These `$$variable` references were getting confused for `$field` references and therefore compiled to the more compact `$expr`-less field-matching form in `filter-expr`.

This PR updates `rvalue-is-field?` and `rvalue-can-be-compared-directly?` to distinguish `$field`s from `$$variables` and therefore to emit the required `$expr` wrapper when dealing with variable references.

Example compilation for input query from `metabase.query-processor-test.explicit-joins-test/join-expressions-lhs-col-rhs-literal-test`

**mbql query**

```Clojure
(mt/mbql-query venues
  {:joins       [{:condition    [:= $name
                                    [:value "Stout Burgers & Beers" {:base_type :type/Text}]]
                  :source-table $$categories
                  :alias        "c"
                  :fields       [&c.categories.name]}]
   :fields      [$id $name &c.categories.name]
   :order-by    [[:asc $id]
                 [:asc &c.categories.id]]
   :limit      3})
```

**before**

```Clojure
{"$lookup"
  {:from "categories",
   :let {"let_name___1" "$name"},
   :pipeline [{"$match" {"$let_name___1" "Stout Burgers & Beers"}}],
   :as "join_alias_c"}}
```

**after**

```Clojure
{"$lookup"
  {:from "categories",
   :let {"let_name___1" "$name"},
   :pipeline [{"$match" {"$expr" {"$eq" ["$$let_name___1" "Stout Burgers & Beers"]}}}],
   :as "join_alias_c"}}
```

### How to verify

See tests or (on a branch with join condition expressions)

1. New question -> Some Mongo DB dataset (e.g. test-data) -> venues
2. Join checkins on `venues.name = "Red Medicine"`

### Demo

![Screenshot 2025-07-03 at 11 43 55 AM](https://github.com/user-attachments/assets/e9cc2e82-3b90-4b72-982c-304f20ea3c53)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
