### PR TITLE
[malli] Don't instrument multimethods when instrumentation is disabled

### DIFF
--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -99,7 +99,7 @@
     (if-not instrument?
       `(def ~(vary-meta fn-name merge attr-map)
          ~docstring
-         ~(mu.fn/deparameterized-fn-form parsed cosmetic-name))
+         ~(mu.fn/deparameterized-fn-form parsed))
       `(def ~(vary-meta fn-name merge attr-map)
          ~docstring
          ~(macros/case

--- a/test/metabase/util/malli/defn_test.clj
+++ b/test/metabase/util/malli/defn_test.clj
@@ -175,7 +175,7 @@
       (mt/with-dynamic-fn-redefs [mu.fn/instrument-ns? (constantly false)]
         (let [expansion (macroexpand `(mu/defn ~'f :- :int [] "foo"))]
           (is (= '(def f
-                    "Inputs: []\n  Return: :int" (clojure.core/fn f [] "foo"))
+                    "Inputs: []\n  Return: :int" (clojure.core/fn [] "foo"))
                  (deanon-fn-names expansion))))))
     (testing "returns an instrumented fn"
       (mt/with-dynamic-fn-redefs [mu.fn/instrument-ns? (constantly true)]


### PR DESCRIPTION
Two commits here:
- Don't instrument multimethods when instrumentation is disabled – currently multimethods are instrumented regardless which causes a bit of prod overhead.
- Don't munge function names – no performance impact, helps with debugging and profiling.
