### PR TITLE
perf: Optimize remove-empty-clauses

### DIFF
--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -1050,57 +1050,54 @@
 ;;; |                                             REMOVING EMPTY CLAUSES                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(declare remove-empty-clauses)
+(declare remove-empty-clauses path->special-remove-empty-clauses-fn)
 
-(defn- remove-empty-clauses-in-map [m path]
-  (let [m (into (empty m) (for [[k v] m
-                                :let  [v (remove-empty-clauses v (conj path k))]
-                                :when (some? v)]
-                            [k v]))]
-    (when (seq m)
-      m)))
+(defn- remove-empty-clauses-in-map [m special-fns]
+  (not-empty (reduce-kv (fn [m k v]
+                          (let [v' (remove-empty-clauses v (get special-fns k))]
+                            (cond (nil? v') (dissoc m k)
+                                  (identical? v v') m
+                                  :else (assoc m k v'))))
+                        m m)))
 
-(defn- remove-empty-clauses-in-sequence* [xs path]
-  (let [xs (mapv #(remove-empty-clauses % (conj path ::sequence))
-                 xs)]
+(defn- remove-empty-clauses-in-sequence* [xs special-fns]
+  (let [special-fns (::sequence special-fns)
+        xs (#?(:clj perf/mapv :default mapv) #(remove-empty-clauses % special-fns) xs)]
     (when (some some? xs)
       xs)))
 
 (defmulti ^:private remove-empty-clauses-in-mbql-clause
-  {:arglists '([clause path])}
-  (fn [[tag] _path]
+  {:arglists '([clause special-fns])}
+  (fn [[tag] _special-fns]
     tag))
 
 (defmethod remove-empty-clauses-in-mbql-clause :default
-  [clause path]
-  (remove-empty-clauses-in-sequence* clause path))
+  [clause special-fns]
+  (remove-empty-clauses-in-sequence* clause special-fns))
 
 (defmethod remove-empty-clauses-in-mbql-clause :offset
-  [[_tag opts expr n] path]
-  [:offset opts (remove-empty-clauses expr (conj path :offset)) n])
+  [[_tag opts expr n] special-fns]
+  [:offset opts (remove-empty-clauses expr (:offset special-fns)) n])
 
-(defn- remove-empty-clauses-in-sequence [x path]
+(defn- remove-empty-clauses-in-sequence [x special-fns]
   (if (mbql-clause? x)
-    (remove-empty-clauses-in-mbql-clause x path)
-    (remove-empty-clauses-in-sequence* x path)))
+    (remove-empty-clauses-in-mbql-clause x special-fns)
+    (remove-empty-clauses-in-sequence* x special-fns)))
 
 (defn- remove-empty-clauses-in-join [join]
-  (remove-empty-clauses join [:query]))
+  (remove-empty-clauses join (:query path->special-remove-empty-clauses-fn)))
 
 (defn- remove-empty-clauses-in-source-query [{native? :native, :as source-query}]
   (if native?
-    (-> source-query
-        (set/rename-keys {:native :query})
-        (remove-empty-clauses [:native])
-        (set/rename-keys {:query :native}))
-    (remove-empty-clauses source-query [:query])))
+    source-query
+    (remove-empty-clauses source-query (:query path->special-remove-empty-clauses-fn))))
 
 (defn- remove-empty-clauses-in-parameter [parameter]
   (merge
    ;; don't remove `value: nil` from a parameter, the FE code (`haveParametersChanged`) is extremely dumb and will
    ;; consider the parameter to have changed and thus the query to be 'dirty' if we do this.
    (select-keys parameter [:value])
-   (remove-empty-clauses-in-map parameter [:parameters ::sequence])))
+   (remove-empty-clauses-in-map parameter (-> path->special-remove-empty-clauses-fn :parameters ::sequence))))
 
 (def ^:private path->special-remove-empty-clauses-fn
   {:native       identity
@@ -1114,21 +1111,21 @@
 (defn- remove-empty-clauses
   "Remove any empty or `nil` clauses in a query."
   ([query]
-   (remove-empty-clauses query []))
+   (remove-empty-clauses query path->special-remove-empty-clauses-fn))
 
-  ([x path]
+  ([x special-fns]
    (try
-     (let [special-fn (when (seq path)
-                        (get-in path->special-remove-empty-clauses-fn path))]
+     (let [special-fn (when (and special-fns (fn? special-fns))
+                        special-fns)]
        (cond
-         (fn? special-fn) (special-fn x)
+         special-fn       (special-fn x)
          (record? x)      x
-         (map? x)         (remove-empty-clauses-in-map x path)
-         (sequential? x)  (remove-empty-clauses-in-sequence x path)
+         (map? x)         (remove-empty-clauses-in-map x special-fns)
+         (sequential? x)  (remove-empty-clauses-in-sequence x special-fns)
          :else            x))
      (catch #?(:clj Throwable :cljs js/Error) e
        (throw (ex-info "Error removing empty clauses from form."
-                       {:form x, :path path}
+                       {:form x}
                        e))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This accounts for ~5% of the CPU side of pivot table processing. It's not a lot but most of the overhead there consists of such small inefficiencies that have to be addressed one by one.

The most impactful change here is removing the accumulation of `path` as `remove-empty-clauses`. Functionality-wise, this path was then used to look up special case functions in `path->special-remove-empty-clauses-fn` nested map. Instead of collecting path, the recursive functions now start from the top level `path->special-remove-empty-clauses-fn` and peel its layers away with the respective key on each level (walking the tree, basically). When we eventually get to the leaf node (a function object and not a submap), that is our special function. If we go into the non-existing key, the map becomes `nil` and stays nil for the rest of the recursive walk.

See more in-situ comments below.
