### PR TITLE
[Metabot] Only use visible timeline events when sending chart configs

### DIFF
--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.unit.spec.tsx
@@ -8,7 +8,7 @@ import type { ComputedVisualizationSettings } from "metabase/visualizations/type
 import Question from "metabase-lib/v1/Question";
 import type {
   RawSeries,
-  Timeline,
+  TimelineEvent,
   TransformedSeries,
 } from "metabase-types/api";
 import {
@@ -16,7 +16,6 @@ import {
   createMockColumn,
   createMockSettings,
   createMockSingleSeries,
-  createMockTimeline,
   createMockTimelineEvent,
   createMockTokenFeatures,
   createMockVisualizationSettings,
@@ -54,7 +53,7 @@ function createMockData(opts: {
   question: Question | undefined;
   series?: RawSeries | TransformedSeries;
   visualizationSettings?: ComputedVisualizationSettings;
-  timelines?: Timeline[];
+  timelineEvents?: TimelineEvent[];
 }) {
   const question = opts.question;
   const card = question?.card();
@@ -86,7 +85,7 @@ function createMockData(opts: {
       }),
     ],
     visualizationSettings: question?.settings() ?? {},
-    timelines: [],
+    timelineEvents: [],
     queryResult: undefined,
     ...opts,
   };
@@ -159,23 +158,24 @@ describe("registerQueryBuilderMetabotContextFn", () => {
         "graph.metrics": ["count"],
       }),
     });
-    const timelineEvents = [
-      createMockTimelineEvent({
-        name: "Third Event",
-        timestamp: "2025-07-13T00:00:00Z",
-      }),
-      createMockTimelineEvent({
-        name: "First Event",
-        timestamp: "2025-07-11T00:00:00Z",
-      }),
-      createMockTimelineEvent({
-        name: "Second Event",
-        description: "This happens second",
-        timestamp: "2025-07-12T00:00:00Z",
-      }),
-    ];
-    const timelines = [createMockTimeline({ events: timelineEvents })];
-    const data = createMockData({ question: new Question(card), timelines });
+    const data = createMockData({
+      question: new Question(card),
+      timelineEvents: [
+        createMockTimelineEvent({
+          name: "Third Event",
+          timestamp: "2025-07-13T00:00:00Z",
+        }),
+        createMockTimelineEvent({
+          name: "First Event",
+          timestamp: "2025-07-11T00:00:00Z",
+        }),
+        createMockTimelineEvent({
+          name: "Second Event",
+          description: "This happens second",
+          timestamp: "2025-07-12T00:00:00Z",
+        }),
+      ],
+    });
     const result = await registerQueryBuilderMetabotContextFn(data);
 
     const chartConfig = getChartConfig(result)!;

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -875,6 +875,7 @@ export const getVisibleTimelineEvents = createSelector(
     _.chain(timelines)
       .map((timeline) => timeline.events)
       .flatten()
+      .compact()
       .filter((event) => visibleTimelineEventIds.includes(event.id))
       .sortBy((event) => event.timestamp)
       .value(),


### PR DESCRIPTION
Closes [BOT-218](https://linear.app/metabase/issue/BOT-218/timestamps-passed-by-metabase-cannot-be-handled-by-ai-service)

### Description

TL:DR; Metabot was broken on our internal metabase instance today:
![image (7)](https://github.com/user-attachments/assets/ee92a757-cfba-4a66-98c3-02761e0b8809)
This was because a timeline event was added for the year 5, which between postgres + moment JS was generating a malformed ISO date string with a very odd offset when being sent to our AI Service (you can see in the screenshot). Unfortunately this event was breaking talking to metabot when viewing _any_ question.

To remedy this I've:
1. Removed the problematic timeline event. I've not spent any additional effort to support events this old since moment appears to be the main issue and we need to migrate off of it.
2. Updated the metabot logic to only use the visible timeline events. We shouldn't be sending unrelated data to the LLM.
3. Leverage moment methods directly as the TS types are wrong for a selector in a JS file.

### How to verify

- Check agent request context that it only contains timeline events rendered on your chart

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
