### PR TITLE
fix question caching key in dashboard selectors

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -147,7 +147,7 @@ export type VirtualCard = Partial<
   Omit<Card, "name" | "dataset_query" | "visualization_settings" | "display">
 > & {
   name: null;
-  dataset_query: Record<string, never>;
+  dataset_query?: Record<string, never>; // Some old virtual cards have dataset_query equal to {}
   display: VirtualCardDisplay;
   visualization_settings: VisualizationSettings;
 };

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -143,12 +143,12 @@ function DashCardActionsPanelInner({
   }
 
   const canAddFilter = useMemo(() => {
-    if (!dashcard || question == null || !supportsInlineParameters(dashcard)) {
+    if (!dashcard || !supportsInlineParameters(dashcard)) {
       return false;
     }
 
     return isQuestionDashCard(dashcard)
-      ? canEditQuestion(question)
+      ? question != null && canEditQuestion(question)
       : isHeadingDashCard(dashcard);
   }, [dashcard, question]);
 

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -506,11 +506,8 @@ export const getQuestionByCard = createCachedSelector(
     return isQuestionCard(card) ? new Question(card, metadata) : undefined;
   },
 )((_state, props) => {
-  // Sometime card doesn't have an id.
-  // In that case, we use the stringified version of the card as a cache key.
-  // That's nless than ideal, but it avoids flooding the console with warnings
-  // and it's still better than using `undefined` as a cache key.
-  return props.card.id ?? JSON.stringify(props.card).slice(0, 50);
+  // Virtual cards don't have an ID and should not return a question so we use "virtual" as a cache key for all of them
+  return props.card.id == null ? "virtual" : props.card.id;
 });
 
 export const getDashcardParameterMappingOptions = createCachedSelector(

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -83,7 +83,10 @@ export function expandInlineCard(card?: Card | VirtualCard) {
 }
 
 export function isQuestionCard(card: Card | VirtualCard) {
-  return card.dataset_query != null;
+  // Some old virtual cards have dataset_query equal to {} so we need to check for null and empty object
+  return (
+    card.dataset_query != null && Object.keys(card.dataset_query).length > 0
+  );
 }
 
 export function isQuestionDashCard(
@@ -418,7 +421,6 @@ export function createDashCard(
 export function createVirtualCard(display: VirtualCardDisplay): VirtualCard {
   return {
     name: null,
-    dataset_query: {},
     display,
     visualization_settings: {},
     archived: false,


### PR DESCRIPTION
Closes [VIZ-1229](https://linear.app/metabase/issue/VIZ-1229/fix-question-caching-selector-for-cards-without-ids)

### Description

Fixes [question cache key](https://github.com/metabase/metabase/pull/60476/files#diff-42bcfa1d90a1dea044b01f469bcda0e502bbd35c2a028fa621f434eb0f1b5ca4L513) in dashboard selectors which implicitly led to occasional collisions on virtual cards although it was harmless.

While fixing this, I noticed that our code contradicts about virtual cards (text, heading, actions). `isQuestionCard` assumed that lack of `dataset_query` property tells the card is not a question but a virutal card, however, all virtual cards set `dataset_query` to an empty object. Because of this we considered virtual cards to be question cards and created Question instances for them which is not expected [here](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx#L61).

### How to verify

CI should be green
