### PR TITLE
Allow users to go back to dashboard from new dashboard question flow

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
@@ -17,12 +17,14 @@ import type {
   Parameter,
 } from "metabase-types/api";
 
+const DASHBOARD_NAME = "Embedding SDK Test Dashboard";
+
 describe("scenarios > embedding-sdk > editable-dashboard", () => {
   beforeEach(() => {
     signInAsAdminAndEnableEmbeddingSdk();
 
     H.createDashboard({
-      name: "Embedding SDK Test Dashboard",
+      name: DASHBOARD_NAME,
     }).then(({ body: dashboard }) => {
       cy.wrap(dashboard.id).as("dashboardId");
       cy.wrap(dashboard.entity_id).as("dashboardEntityId");
@@ -213,6 +215,14 @@ describe("scenarios > embedding-sdk > editable-dashboard", () => {
         cy.button("New Question").should("be.visible").click();
 
         cy.log("building the query");
+        H.popover().findByRole("link", { name: "Orders" }).click();
+        cy.button("Visualize").click();
+
+        cy.log("test going back to the dashboard from the visualization");
+        cy.button(`Back to ${DASHBOARD_NAME}`).should("be.visible").click();
+
+        cy.log("create a new question again");
+        cy.button("New Question").should("be.visible").click();
         H.popover().findByRole("link", { name: "Orders" }).click();
         /**
          * We need to visualize before we can save the question.

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/BackButton/BackButton.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/components/BackButton/BackButton.tsx
@@ -25,13 +25,18 @@ export type InteractiveQuestionBackButtonProps = Omit<
 export const BackButton = ({
   ...actionIconProps
 }: InteractiveQuestionBackButtonProps) => {
-  const { onNavigateBack } = useInteractiveQuestionContext();
+  const { onNavigateBack, backToDashboard } = useInteractiveQuestionContext();
 
   if (!onNavigateBack) {
     return null;
   }
 
   return (
-    <DashboardBackButton noLink onClick={onNavigateBack} {...actionIconProps} />
+    <DashboardBackButton
+      noLink
+      onClick={onNavigateBack}
+      dashboardOverride={backToDashboard}
+      {...actionIconProps}
+    />
   );
 };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
@@ -48,6 +48,7 @@ export const InteractiveQuestionProvider = ({
   withDownloads,
   variant,
   targetDashboardId,
+  backToDashboard,
 }: InteractiveQuestionProviderProps) => {
   const handleCreateQuestion = useCreateQuestion();
   const handleSaveQuestion = useSaveQuestion();
@@ -145,6 +146,7 @@ export const InteractiveQuestionProvider = ({
     withDownloads,
     variant,
     onRun,
+    backToDashboard,
   };
 
   useEffect(() => {

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
@@ -11,6 +11,7 @@ import type {
 } from "embedding-sdk/types/question";
 import type { Mode } from "metabase/visualizations/click-actions/Mode";
 import type Question from "metabase-lib/v1/Question";
+import type { DashboardId } from "metabase-types/api";
 import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-picker";
 
 type InteractiveQuestionConfig = {
@@ -69,6 +70,15 @@ type InteractiveQuestionConfig = {
    * A callback function that triggers when a user clicks the back button.
    */
   onNavigateBack?: () => void;
+
+  /**
+   * When provided, this dashboard will be used to navigate back to the dashboard from other view
+   * instead of the state from Redux in `qb.parentDashboard.dashboardId`
+   */
+  backToDashboard?: {
+    id: DashboardId;
+    name: string;
+  };
 };
 
 export type QuestionMockLocationParameters = {
@@ -95,6 +105,7 @@ export type InteractiveQuestionContextType = Omit<
     | "isSaveEnabled"
     | "targetCollection"
     | "withDownloads"
+    | "backToDashboard"
   > &
   Pick<InteractiveQuestionProviderProps, "variant"> & {
     plugins: InteractiveQuestionConfig["componentPlugins"] | null;

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -14,6 +14,7 @@ import { shouldRunCardQuery } from "embedding-sdk/lib/interactive-question";
 import type { SdkQuestionTitleProps } from "embedding-sdk/types/question";
 import { SaveQuestionModal } from "metabase/common/components/SaveQuestionModal";
 import { useLocale } from "metabase/common/hooks/use-locale";
+import CS from "metabase/css/core/index.css";
 import {
   Box,
   Button,
@@ -198,7 +199,11 @@ export const InteractiveQuestionDefaultView = ({
               {/* Vertical padding matches the visualization header above */}
               {/* If we don't conditionally render this button, it will be shown twice after visualizing the query once. */}
               {!queryResults && (
-                <Box px={{ base: "1rem", sm: "2rem" }} pt="md">
+                <Box
+                  px={{ base: "1rem", sm: "2rem" }}
+                  pt="md"
+                  className={CS.hideEmpty}
+                >
                   <InteractiveQuestion.BackButton />
                 </Box>
               )}

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -195,8 +195,8 @@ export const InteractiveQuestionDefaultView = ({
           {isEditorOpen ? (
             <>
               {/* Use the same horizontal padding as https://github.com/metabase/metabase/blob/98e2dcc7c8c7c9147f4a787cc7ed36eddde9c080/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.tsx#L48 */}
-              {/* Vertical padding matches the visualization header above*/}
-              {/* If we don't conditionally render this button, it will be shown twice after visualize the query once. */}
+              {/* Vertical padding matches the visualization header above */}
+              {/* If we don't conditionally render this button, it will be shown twice after visualizing the query once. */}
               {!queryResults && (
                 <Box px={{ base: "1rem", sm: "2rem" }} pt="md">
                   <InteractiveQuestion.BackButton />

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -193,7 +193,17 @@ export const InteractiveQuestionDefaultView = ({
       <Box className={InteractiveQuestionS.Main} p="sm" w="100%" h="100%">
         <Box className={InteractiveQuestionS.Content}>
           {isEditorOpen ? (
-            <InteractiveQuestion.Editor onApply={closeEditor} />
+            <>
+              {/* Use the same horizontal padding as https://github.com/metabase/metabase/blob/98e2dcc7c8c7c9147f4a787cc7ed36eddde9c080/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.tsx#L48 */}
+              {/* Vertical padding matches the visualization header above*/}
+              {/* If we don't conditionally render this button, it will be shown twice after visualize the query once. */}
+              {!queryResults && (
+                <Box px={{ base: "1rem", sm: "2rem" }} pt="md">
+                  <InteractiveQuestion.BackButton />
+                </Box>
+              )}
+              <InteractiveQuestion.Editor onApply={closeEditor} />
+            </>
           ) : (
             <InteractiveQuestion.QuestionVisualization height="100%" />
           )}

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.unit.spec.tsx
@@ -98,13 +98,7 @@ describe("EditableDashboard", () => {
 
   it("should allow to create a new question in addition to adding existing questions", async () => {
     await setup();
-    // These endpoints are used in the simple data picker
-    setupCollectionItemsEndpoint({
-      collection: createMockCollection(ROOT_COLLECTION),
-      collectionItems: [],
-    });
-    setupEmbeddingDataPickerDecisionEndpoints("flat");
-    setupSearchEndpoints([]);
+    setupSimpleDataPickerEndpoints();
 
     expect(screen.getByTestId("dashboard-header")).toBeInTheDocument();
 
@@ -124,4 +118,44 @@ describe("EditableDashboard", () => {
       await screen.findByRole("button", { name: "Pick your starting data" }),
     ).toBeInTheDocument();
   });
+
+  it("should allow to go back to the dashboard after seeing the query builder", async () => {
+    await setup();
+    setupSimpleDataPickerEndpoints();
+
+    expect(screen.getByTestId("dashboard-header")).toBeInTheDocument();
+
+    await userEvent.click(
+      within(screen.getByTestId("dashboard-header")).getByLabelText(
+        "Edit dashboard",
+      ),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add questions" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "New Question" }));
+
+    // We should be in the query builder
+    expect(
+      await screen.findByRole("button", { name: "Back to Test dashboard" }),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Back to Test dashboard" }),
+    );
+
+    // We should be back in the dashboard
+    expect(
+      screen.getByText("You're editing this dashboard."),
+    ).toBeInTheDocument();
+  });
 });
+
+function setupSimpleDataPickerEndpoints() {
+  // These endpoints are used in the simple data picker
+  setupCollectionItemsEndpoint({
+    collection: createMockCollection(ROOT_COLLECTION),
+    collectionItems: [],
+  });
+  setupEmbeddingDataPickerDecisionEndpoints("flat");
+  setupSearchEndpoints([]);
+}

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.unit.spec.tsx
@@ -120,7 +120,9 @@ describe("EditableDashboard", () => {
   });
 
   it("should allow to go back to the dashboard after seeing the query builder", async () => {
-    await setup();
+    await setup({
+      dashboardName: "Test dashboard",
+    });
     setupSimpleDataPickerEndpoints();
 
     expect(screen.getByTestId("dashboard-header")).toBeInTheDocument();

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.unit.spec.tsx
@@ -22,7 +22,9 @@ console.warn = () => {};
 
 describe("InteractiveDashboard", () => {
   it("should allow users to click the dashcard title", async () => {
-    await setup();
+    await setup({
+      dashboardName: "Test dashboard",
+    });
 
     expect(screen.getByTestId("legend-label")).toHaveAttribute(
       "data-is-clickable",
@@ -32,7 +34,7 @@ describe("InteractiveDashboard", () => {
     await userEvent.click(screen.getByTestId("legend-label"));
 
     expect(
-      await screen.findByLabelText("Back to Dashboard"),
+      await screen.findByLabelText("Back to Test dashboard"),
     ).toBeInTheDocument();
     expect(screen.getByText("Filter")).toBeInTheDocument();
     expect(screen.getByText("Group")).toBeInTheDocument();

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -290,6 +290,9 @@ const SdkDashboardInner = ({
               setRenderMode("dashboard");
               dashboardContextProviderRef.current?.refetchDashboard();
             }}
+            onNavigateBack={() => {
+              setRenderMode("dashboard");
+            }}
           />
         ))
         .exhaustive()}
@@ -324,6 +327,7 @@ function SdkDashboardParameterList(
 type DashboardQueryBuilderProps = {
   targetDashboardId: DashboardId;
   onCreate: (question: MetabaseQuestion) => void;
+  onNavigateBack: () => void;
 };
 
 /**
@@ -332,9 +336,21 @@ type DashboardQueryBuilderProps = {
 function DashboardQueryBuilder({
   targetDashboardId,
   onCreate,
+  onNavigateBack,
 }: DashboardQueryBuilderProps) {
   const dispatch = useSdkDispatch();
   const { dashboard } = useDashboardContext();
+
+  /**
+   * This won't happen at this point in time. As `DashboardQueryBuilder` is guaranteed to be rendered
+   * while under the dashboard context, after a dashboard has already been loaded.
+   *
+   * I added this condition just to satisfy TypeScript, so that below this, the dashboard value isn't null.
+   */
+  if (!dashboard) {
+    return null;
+  }
+
   return (
     <InteractiveQuestionProvider
       questionId="new"
@@ -345,6 +361,8 @@ function DashboardQueryBuilder({
           dispatch(setEditingDashboard(dashboard));
         }
       }}
+      onNavigateBack={onNavigateBack}
+      backToDashboard={dashboard}
     >
       <InteractiveQuestionDefaultView withResetButton withChartTypeSelector />
     </InteractiveQuestionProvider>

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -364,7 +364,12 @@ function DashboardQueryBuilder({
       onNavigateBack={onNavigateBack}
       backToDashboard={dashboard}
     >
-      <InteractiveQuestionDefaultView withResetButton withChartTypeSelector />
+      <InteractiveQuestionDefaultView
+        withResetButton
+        withChartTypeSelector
+        // The default value is 600px and it cuts off the "Visualize" button.
+        height="700px"
+      />
     </InteractiveQuestionProvider>
   );
 }

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/SdkDashboard.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/SdkDashboard.unit.spec.tsx
@@ -14,6 +14,7 @@ const setup = async (
     props?: Partial<SdkDashboardProps>;
     providerProps?: Partial<MetabaseProviderProps>;
     isLocaleLoading?: boolean;
+    dashboardName?: string;
   } = {},
 ) => {
   return setupSdkDashboard({
@@ -47,7 +48,7 @@ describe("SdkDashboard", () => {
   });
 
   it("should allow to navigate back to dashboard from a question", async () => {
-    await setup();
+    await setup({ dashboardName: "Test dashboard" });
 
     await userEvent.click(screen.getByText("Here is a card title"));
 
@@ -55,9 +56,9 @@ describe("SdkDashboard", () => {
       await screen.findByTestId("query-visualization-root"),
     ).toBeInTheDocument();
 
-    expect(screen.getByLabelText("Back to Dashboard")).toBeInTheDocument();
+    expect(screen.getByLabelText("Back to Test dashboard")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByLabelText("Back to Dashboard"));
+    await userEvent.click(screen.getByLabelText("Back to Test dashboard"));
 
     expect(await screen.findByTestId("dashboard-grid")).toBeInTheDocument();
 
@@ -68,7 +69,7 @@ describe("SdkDashboard", () => {
   });
 
   it("should allow to navigate back to dashboard from a question with empty results", async () => {
-    await setup();
+    await setup({ dashboardName: "Test dashboard" });
 
     await userEvent.click(screen.getByText("Here is a card title"));
 
@@ -76,7 +77,7 @@ describe("SdkDashboard", () => {
       await screen.findByTestId("query-visualization-root"),
     ).toBeInTheDocument();
 
-    expect(screen.getByLabelText("Back to Dashboard")).toBeInTheDocument();
+    expect(screen.getByLabelText("Back to Test dashboard")).toBeInTheDocument();
 
     await userEvent.click(screen.getByText("Back to previous results"));
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/setup.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/setup.tsx
@@ -108,6 +108,7 @@ export interface SetupSdkDashboardOptions {
   providerProps?: Partial<MetabaseProviderProps>;
   isLocaleLoading?: boolean;
   component: React.ComponentType<SdkDashboardProps>;
+  dashboardName?: string;
 }
 
 jest.mock("metabase/common/hooks/use-locale", () => ({
@@ -119,6 +120,7 @@ export const setupSdkDashboard = async ({
   providerProps = {},
   isLocaleLoading = false,
   component: Component,
+  dashboardName = "Dashboard",
 }: SetupSdkDashboardOptions) => {
   const useLocaleMock = useLocale as jest.Mock;
   useLocaleMock.mockReturnValue({ isLocaleLoading });
@@ -128,7 +130,7 @@ export const setupSdkDashboard = async ({
   const dashboardId = props?.dashboardId || TEST_DASHBOARD_ID;
   const dashboard = createMockDashboard({
     id: dashboardId,
-    name: "Test dashboard",
+    name: dashboardName,
     dashcards,
     tabs: dashboardTabs,
     parameters: [parameter],

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/setup.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/setup.tsx
@@ -128,6 +128,7 @@ export const setupSdkDashboard = async ({
   const dashboardId = props?.dashboardId || TEST_DASHBOARD_ID;
   const dashboard = createMockDashboard({
     id: dashboardId,
+    name: "Test dashboard",
     dashcards,
     tabs: dashboardTabs,
     parameters: [parameter],

--- a/frontend/src/metabase/css/core/hide.module.css
+++ b/frontend/src/metabase/css/core/hide.module.css
@@ -2,6 +2,10 @@
   display: none !important;
 }
 
+.hideEmpty:empty {
+  display: none;
+}
+
 .show {
   display: inherit;
 }

--- a/frontend/src/metabase/dashboard/context/context.tsx
+++ b/frontend/src/metabase/dashboard/context/context.tsx
@@ -213,16 +213,19 @@ const DashboardContextProviderInner = forwardRef(
       async (dashboardId: DashboardId, option: FetchOption = {}) => {
         const hasDashboardChanged = dashboardId !== previousDashboardId;
         const { forceRefetch } = option;
+        // When forcing a refetch, we want to clear the cache
+        const effectiveIsNavigatingBackToDashboard =
+          isNavigatingBackToDashboard && !forceRefetch;
         if (hasDashboardChanged || forceRefetch) {
           setError(null);
 
-          initialize({ clearCache: !isNavigatingBackToDashboard });
+          initialize({ clearCache: !effectiveIsNavigatingBackToDashboard });
           fetchDashboard({
             dashId: dashboardId,
             queryParams: parameterQueryParams,
             options: {
-              clearCache: !isNavigatingBackToDashboard,
-              preserveParameters: isNavigatingBackToDashboard,
+              clearCache: !effectiveIsNavigatingBackToDashboard,
+              preserveParameters: effectiveIsNavigatingBackToDashboard,
             },
           })
             .then((result) => {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/DashboardBackButton/DashboardBackButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/DashboardBackButton/DashboardBackButton.tsx
@@ -7,21 +7,28 @@ import * as Urls from "metabase/lib/urls";
 import { navigateBackToDashboard } from "metabase/query_builder/actions";
 import { getDashboard } from "metabase/query_builder/selectors";
 import { ActionIcon, type ActionIconProps, Icon, Tooltip } from "metabase/ui";
+import type { DashboardId } from "metabase-types/api";
 
 import DashboardBackButtonS from "./DashboardBackButton.module.css";
 
 export type DashboardBackButtonProps = {
   noLink?: boolean;
   onClick?: () => void;
+  dashboardOverride?: {
+    id: DashboardId;
+    name: string;
+  };
 } & ActionIconProps &
   HTMLAttributes<HTMLButtonElement>;
 
 export function DashboardBackButton({
   noLink,
   onClick,
+  dashboardOverride,
   ...actionIconProps
 }: DashboardBackButtonProps) {
-  const dashboard = useSelector(getDashboard);
+  const dashboardState = useSelector(getDashboard);
+  const dashboard = dashboardOverride ?? dashboardState;
   const dispatch = useDispatch();
 
   const handleClick = () => {

--- a/frontend/src/metabase/querying/notebook/components/DataStep/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/tests/enterprise.unit.spec.tsx
@@ -1,10 +1,9 @@
-// eslint-disable-next-line import/order -- We need to import this one first, as it mocks some modules, and importing other deps before that would break the tests
-import { type SetupOpts, setup as baseSetup } from "./setup";
-
 import userEvent from "@testing-library/user-event";
 
 import { fireEvent, screen } from "__support__/ui";
 import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
+
+import { type SetupOpts, setup as baseSetup } from "./setup";
 
 function setup(opts: SetupOpts = {}) {
   return baseSetup({

--- a/frontend/src/metabase/querying/notebook/components/DataStep/tests/setup.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/tests/setup.tsx
@@ -6,7 +6,6 @@ import {
 } from "__support__/server-mocks";
 import { renderWithProviders } from "__support__/ui";
 import { createMockModelResult } from "metabase/browse/models/test-utils";
-import * as envs from "metabase/env";
 import * as Lib from "metabase-lib";
 import { columnFinder } from "metabase-lib/test-helpers";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
@@ -15,16 +14,6 @@ import { createMockNotebookStep } from "../../../test-utils";
 import type { NotebookStep } from "../../../types";
 import { NotebookProvider } from "../../Notebook/context";
 import { DataStep } from "../DataStep";
-
-const mockedEnvs = envs as { isEmbeddingSdk: boolean };
-
-jest.mock("metabase/env", () => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("metabase/env"),
-    isEmbeddingSdk: false,
-  };
-});
 
 export interface SetupOpts {
   step?: NotebookStep;
@@ -38,8 +27,6 @@ export const setup = ({
   isEmbeddingSdk = false,
   hasEnterprisePlugins = false,
 }: SetupOpts = {}) => {
-  mockedEnvs.isEmbeddingSdk = isEmbeddingSdk;
-
   if (hasEnterprisePlugins) {
     setupEnterprisePlugins();
   }


### PR DESCRIPTION
closes EMB-560


### Description

Since the SDK can't operate on user URLs, the core dashboard doesn't have a way to go back to the dashboard when creating a new question. Without finishing the new question, users can still go back to the dashboard via the browser back button. With the SDK we can't do that. So, we need a back button for users for that.

### How to verify


1. Run BE e.g.
    ```sh
    clj -M:dev:ee:dev-start
    ```
1. Run storybook
    ```sh
    yarn storybook-embedding-sdk
    ```
1. Visit `EditableDashboard` story and test with the default example dashboard (ID=1) or modify this value locally to change it to any other dashboard ID you want
    https://github.com/metabase/metabase/blob/051b61bd256c2337880f1354e69cb6a4dca2dbbc/enterprise/frontend/src/embedding-sdk/test/storybook-id-args.ts#L77

### Demo

There are 2 places where users can choose to go back to the dashboard during the question creation flow. The reason there are 2 places is because we already have a back button after the visualization, but never before that.
1. Before visualizing the query
    ![image](https://github.com/user-attachments/assets/1514dd0a-200f-4118-9432-163443279312)
3. Atfer visualizing the query
    ![image](https://github.com/user-attachments/assets/f744446b-c8b5-4855-9de9-924429ee140c)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
