### PR TITLE
infer only one column to be entity name

### DIFF
--- a/src/metabase/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/analyze/fingerprint/fingerprinters.clj
@@ -23,7 +23,7 @@
 (set! *warn-on-reflection* true)
 
 (defn col-wise
-  "Apply reducing functinons `rfs` coll-wise to a seq of seqs."
+  "Apply reducing functions `rfs` coll-wise to a seq of seqs."
   [& rfs]
   (let [rfs (vec rfs)]
     (fn

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -108,10 +108,10 @@
   [table :- i/TableInstance]
   (when-let [fields (fields-to-classify table)]
     (let [table-id (:id table)
-          existing-name-field (t2/select :model/Field
-                                         :table_id table-id
-                                         :semantic_type :type/Name)
-          found-name (atom (seq existing-name-field))]
+          existing-name-field (t2/count :model/Field
+                                        :table_id table-id
+                                        :semantic_type :type/Name)
+          found-name (atom (pos? existing-name-field))]
       {:fields-classified (count fields)
        :fields-failed     (->> fields
                                (map (fn [field]

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -84,7 +84,7 @@
            would-be-name? (= (:semantic_type classified) :type/Name)
            ;; if it would be name and table already has a name field, don't classify as name (SEM-414)
            updated-field (if (and would-be-name? exists-name)
-                           field
+                           (assoc classified :semantic_type (:semantic_type field))
                            classified)]
        (when-not (= field updated-field)
          (save-model-updates! field updated-field))

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -108,23 +108,23 @@
   "Run various classifiers on the appropriate `fields` in a `table` that have not been previously analyzed. These do
   things like inferring (and setting) the semantic types and preview display status for Fields belonging to `table`."
   [table :- i/TableInstance]
-  (when-let [fields (fields-to-classify table)]
-    (let [table-id (:id table)
-          existing-name-field (t2/count :model/Field
-                                        :table_id table-id
-                                        :active true
-                                        :visibility_type [:not-in ["sensitive" "retired"]]
-                                        :semantic_type :type/Name)
-          found-name (atom (pos? existing-name-field))]
-      {:fields-classified (count fields)
-       :fields-failed     (->> fields
-                               (map (fn [field]
-                                      (let [result (classify! field {:exists-name @found-name})]
-                                        (when (= :type/Name (:semantic_type result))
-                                          (reset! found-name true))
-                                        result)))
-                               (filter (partial instance? Exception))
-                               count)})))
+  (let [table-id (:id table)]
+    (when-let [fields (fields-to-classify table)]
+      (let [existing-name-field (t2/count :model/Field
+                                          :table_id table-id
+                                          :active true
+                                          :visibility_type [:not-in ["sensitive" "retired"]]
+                                          :semantic_type :type/Name)
+            found-name (atom (pos? existing-name-field))]
+        {:fields-classified (count fields)
+         :fields-failed     (->> fields
+                                 (map (fn [field]
+                                        (let [result (classify! field {:exists-name @found-name})]
+                                          (when (= :type/Name (:semantic_type result))
+                                            (reset! found-name true))
+                                          result)))
+                                 (filter (partial instance? Exception))
+                                 count)}))))
 
 (mu/defn ^:always-validate classify-table!
   "Run various classifiers on the `table`. These do things like inferring (and setting) entitiy type of `table`."

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -144,16 +144,14 @@
   [database :- i/DatabaseInstance
    log-progress-fn]
   (let [tables (sync-util/reducible-sync-tables database)]
-    (transduce (map (fn [table]
-                      (let [result (classify-table! table)]
-                        (log-progress-fn "classify-tables" table)
-                        {:tables-classified (if result
-                                              1
-                                              0)
-                         :total-tables      1})))
-               (partial merge-with +)
-               {:tables-classified 0, :total-tables 0}
-               tables)))
+    (reduce (fn [acc table]
+              (let [result (classify-table! table)]
+                (log-progress-fn "classify-tables" table)
+                (-> acc
+                    (update :total-tables inc)
+                    (cond-> result (update :tables-classified inc)))))
+            {:tables-classified 0, :total-tables 0}
+            tables)))
 
 (mu/defn classify-fields-for-db!
   "Classify all fields found in a given database"

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -101,6 +101,7 @@
   (seq (apply t2/select :model/Field
               :table_id (u/the-id table)
               :active true
+              :visibility_type [:not-in ["sensitive" "retired"]]
               (reduce concat [] (sync.fingerprint/incomplete-analysis-kvs)))))
 
 (mu/defn classify-fields!
@@ -112,6 +113,7 @@
           existing-name-field (t2/count :model/Field
                                         :table_id table-id
                                         :active true
+                                        :visibility_type [:not-in ["sensitive" "retired"]]
                                         :semantic_type :type/Name)
           found-name (atom (pos? existing-name-field))]
       {:fields-classified (count fields)

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -100,6 +100,7 @@
   [table :- i/TableInstance]
   (seq (apply t2/select :model/Field
               :table_id (u/the-id table)
+              :active true
               (reduce concat [] (sync.fingerprint/incomplete-analysis-kvs)))))
 
 (mu/defn classify-fields!
@@ -110,6 +111,7 @@
     (let [table-id (:id table)
           existing-name-field (t2/count :model/Field
                                         :table_id table-id
+                                        :active true
                                         :semantic_type :type/Name)
           found-name (atom (pos? existing-name-field))]
       {:fields-classified (count fields)

--- a/test/metabase/sync/analyze/classify_test.clj
+++ b/test/metabase/sync/analyze/classify_test.clj
@@ -124,6 +124,9 @@
         ;; Should be the first name field encountered
         (is (= "fullName" (:name (first name-fields))))))))
 
+;; we either already incorrectly inferred multiple fields on a previous sync, or the user incorrectly set multiple fields.
+;; let them sort it out rather than risk overriding their preferences
+
 (deftest preserve-existing-name-fields-test
   (testing "On an existing table with 2 type/Name fields, they stay unchanged and adding more eligible  is a no-op"
     (mt/with-temp [:model/Database db {:engine :h2 :name "test-db"}

--- a/test/metabase/sync/analyze/classify_test.clj
+++ b/test/metabase/sync/analyze/classify_test.clj
@@ -115,7 +115,7 @@
                                    :fingerprint_version i/*latest-fingerprint-version*
                                    :last_analyzed       nil}]
 
-      (classify/classify-fields-for-db! db (constantly nil))
+      (classify/classify-fields! table)
 
       (let [name-fields (t2/select :model/Field
                                    :table_id (:id table)
@@ -139,8 +139,9 @@
                                    :table_id (:id table)
                                    :semantic_type :type/Name
                                    :last_analyzed :%now}
-
-                   :model/Field field {:name "middleName" :base_type :type/Text :table_id (u/the-id table)
+                   :model/Field field {:name "name"
+                                       :base_type :type/Text
+                                       :table_id (u/the-id table)
                                        :semantic_type       nil
                                        :fingerprint_version i/*latest-fingerprint-version*
                                        :last_analyzed       nil}]
@@ -179,7 +180,7 @@
                                    :table_id (u/the-id table)
                                    :semantic_type :type/Name
                                    :last_analyzed :%now}
-                   :model/Field _ {:name "displayName"
+                   :model/Field _ {:name "lastName"
                                    :base_type :type/Text
                                    :table_id (u/the-id table)
                                    :semantic_type nil


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #49783
Closes https://linear.app/metabase/issue/SEM-414/schema-sync-should-not-add-multiple-columns-with-the-entity-name-type


N.B.:
there still exists some situations where multiple columns for a table can be entity names:
- existing tables that have had multiple columns already inferred
- 1 column gets inferred as entity name, then gets disabled, another column then gets inferred, and the original column gets re-enabled
- a user manually sets multiple columns to be entity names

all those are considered out of scope for this particular ticket, and should be handled with user-guided input as part of the related feature request from the ticket:
>Related feature request: when multiple columns exist with this type, ideally we should issue a warning in the metadata editor: https://github.com/metabase/metabase/issues/49763 .