### PR TITLE
QUE-1518: join picker custom search

### DIFF
--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -20,6 +20,7 @@ import S from "./QueryColumnPicker.module.css";
 
 export type ColumnListItem = Lib.ColumnDisplayInfo & {
   column: Lib.ColumnMetadata;
+  combinedDisplayName?: string;
 };
 
 export type QueryColumnPickerSection = BaseSection<ColumnListItem>;
@@ -47,6 +48,13 @@ export interface QueryColumnPickerProps {
   disableSearch?: boolean;
 }
 
+const SEARCH_PROP = [
+  "name",
+  "displayName",
+  "combinedDisplayName",
+  "longDisplayName",
+] as const;
+
 export function QueryColumnPicker({
   className,
   query,
@@ -72,14 +80,18 @@ export function QueryColumnPicker({
     const columnSections = columnGroups.map((group) => {
       const groupInfo = Lib.displayInfo(query, stageIndex, group);
 
-      const items = Lib.getColumnsFromColumnGroup(group).map((column) => ({
-        ...Lib.displayInfo(
+      const items = Lib.getColumnsFromColumnGroup(group).map((column) => {
+        const columnInfo = Lib.displayInfo(
           query,
           stageIndex,
           getColumnWithoutBucketing(column, hasTemporalBucketing, hasBinning),
-        ),
-        column,
-      }));
+        );
+        return {
+          ...columnInfo,
+          column,
+          combinedDisplayName: `${columnInfo.table?.displayName ?? ""} ${columnInfo.displayName}`,
+        };
+      });
 
       return {
         name: groupInfo.displayName,
@@ -223,7 +235,7 @@ export function QueryColumnPicker({
         }}
         maxHeight={Infinity}
         data-testid={dataTestId}
-        searchProp={["name", "displayName", "longDisplayName"]}
+        searchProp={SEARCH_PROP}
         // Compat with E2E tests around MLv1-based components
         // Prefer using a11y role selectors
         itemTestId="dimension-list-item"

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -20,6 +20,7 @@ import * as Lib from "metabase-lib";
 import {
   type DefinedClauseName,
   clausesForMode,
+  getClauseDefinition,
 } from "metabase-lib/v1/expressions";
 
 import { BucketPickerPopover } from "./BucketPickerPopover";
@@ -233,9 +234,19 @@ export function QueryColumnPicker({
     ],
   );
 
-  const handleSearchTextChange = useCallback((searchText: string) => {
-    setIsSearching(searchText !== "");
-  }, []);
+  const handleSearchTextChange = useCallback(
+    (searchText: string) => {
+      setIsSearching(searchText !== "");
+      if (searchText.trim().endsWith("(")) {
+        const name = searchText.trim().slice(0, -1);
+        const clause = getClauseDefinition(name);
+        if (clause) {
+          onSelectExpression?.(clause.name);
+        }
+      }
+    },
+    [onSelectExpression],
+  );
 
   const renderItemExtra = useCallback(
     (item: Item) => {

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionColumnPicker/JoinColumnDropdown/JoinColumnDropdown.module.css
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinConditionColumnPicker/JoinColumnDropdown/JoinColumnDropdown.module.css
@@ -1,5 +1,6 @@
 .JoinColumnPicker {
   color: var(--mb-color-brand);
+  overflow: visible;
 }
 
 .JoinCellItem {


### PR DESCRIPTION
Closes QUE-1518

Adds the custom expression and fuzzy searching logic to the join column picker too, since [Make joins with custom expressions](https://linear.app/metabase/project/make-joins-with-custom-expressions-4a9e57c1218e/overview) just landed.

I added the custom expression functionality to the `QueryColumnPicker` behind a flag and enabled it in the `JoinColumnPicker`. This is control coupling, but I figured it was better than reimplementing the `JoinColumnPicker`. 
