### PR TITLE
Fix PortalContainer to respect SDK styles

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkPortalContainer.tsx
@@ -1,6 +1,4 @@
-import ZIndex from "metabase/css/core/z-index.module.css";
 import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/config";
-import { Box } from "metabase/ui";
 
 import { PublicComponentStylesWrapper } from "./PublicComponentStylesWrapper";
 
@@ -11,14 +9,6 @@ import { PublicComponentStylesWrapper } from "./PublicComponentStylesWrapper";
  */
 export const PortalContainer = () => (
   <PublicComponentStylesWrapper>
-    <Box
-      id={EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}
-      className={ZIndex.Overlay}
-      // needed otherwise it will rendered "in place" and push the content below
-      pos="fixed"
-      left={0}
-      top={0}
-      w={"100%"}
-    ></Box>
+    <div id={EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}></div>
   </PublicComponentStylesWrapper>
 );


### PR DESCRIPTION
Fix PortalContainer to respect SDK styles.

Context https://metaboat.slack.com/archives/C063Q3F1HPF/p1751643058536579

`position: fixed` does not work well with `tether` package that positions LegacyPopover, so it is rendered in `body` instead of the `SDK popover portal root`.

We didn't have `position: fixed` since october 2024, so if we are ok we just remove it back to the state as it was between the october 2024 and today

