### PR TITLE
Rename source param name to content

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
@@ -33,7 +33,7 @@ export function InteractiveEmbeddingSettings() {
 
   return (
     <SettingsPageWrapper title={t`Interactive embedding`}>
-      <UpsellDevInstances source="embedding-page" />
+      <UpsellDevInstances location="embedding-page" />
       <SettingsSection>
         <EmbeddingToggle
           settingKey="enable-embedding-interactive"

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
@@ -163,7 +163,7 @@ export const GdriveAddDataPanel = ({
   if (!hasStorage) {
     return (
       <PanelWrapper subtitle={NO_STORAGE_SUBTITLE}>
-        <UpsellStorage source="add-data-modal-sheets" />
+        <UpsellStorage location="add-data-modal-sheets" />
       </PanelWrapper>
     );
   }

--- a/frontend/src/metabase/admin/people/components/PeopleNav.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleNav.tsx
@@ -30,7 +30,7 @@ export function PeopleNav() {
           icon="group"
         />
       </Stack>
-      {shouldNudge && <UpsellSSO source="people-groups-settings" />}
+      {shouldNudge && <UpsellSSO location="people-groups-settings" />}
     </AdminNavWrapper>
   );
 }

--- a/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyEditorForDatabases.tsx
@@ -164,7 +164,7 @@ const StrategyEditorForDatabases_Base = ({
             )}
           </Panel>
         </RoundedBox>
-        <UpsellCacheConfig source="performance-data_cache" />
+        <UpsellCacheConfig location="performance-data_cache" />
       </Flex>
     </SettingsPageWrapper>
   );

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditor.jsx
@@ -22,7 +22,7 @@ export const PermissionsEditor = ({ isLoading, error, ...contentProps }) => {
       <LoadingAndErrorWrapper loading={isLoading} error={error} noWrapper>
         <>
           <Box mx="xl" mb="md">
-            <UpsellPermissions source="settings-permissions" />
+            <UpsellPermissions location="settings-permissions" />
           </Box>
           <PermissionsEditorContent {...contentProps} />
         </>

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -106,7 +106,7 @@ export function EmbeddingSdkSettings() {
 
   return (
     <SettingsPageWrapper title={t`Embedding SDK`}>
-      <UpsellDevInstances source="embedding-page" />
+      <UpsellDevInstances location="embedding-page" />
       <SettingsSection>
         <EmbeddingToggle
           label={t`Enable Embedded analytics SDK for React`}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/StaticEmbeddingSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/StaticEmbeddingSettings.tsx
@@ -19,7 +19,7 @@ export function StaticEmbeddingSettings() {
 
   return (
     <SettingsPageWrapper title={t`Static embedding`}>
-      <UpsellDevInstances source="embedding-page" />
+      <UpsellDevInstances location="embedding-page" />
       <SettingsSection>
         <EmbeddingToggle
           settingKey="enable-embedding-static"

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/AuthenticationSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/AuthenticationSettingsPage.tsx
@@ -32,7 +32,7 @@ export function AuthenticationSettingsPage({ tab }: { tab: string }) {
           <ApiKeysAuthCard />
         </Stack>
         <Box style={{ flexShrink: 0 }}>
-          <UpsellSSO source="authentication-sidebar" />
+          <UpsellSSO location="authentication-sidebar" />
         </Box>
       </Flex>
     </SettingsPageWrapper>

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/EmailSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/EmailSettingsPage.tsx
@@ -86,7 +86,7 @@ export function EmailSettingsPage() {
           </SettingsSection>
         )}
         <Center>
-          <UpsellHostingBanner source="settings-email-migrate_to_cloud" />
+          <UpsellHostingBanner location="settings-email-migrate_to_cloud" />
         </Center>
       </SettingsPageWrapper>
       {showModal && <SMTPConnectionForm onClose={closeModal} />}

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/EmbeddingSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/EmbeddingSettingsPage.tsx
@@ -15,7 +15,7 @@ export function EmbeddingSettingsPage() {
       title={t`Embedding`}
       description={t`Embed dashboards, questions, or the entire Metabase app into your application. Integrate with your server code to create a secure environment, limited to specific users or organizations.`}
     >
-      <UpsellDevInstances source="embedding-page" />
+      <UpsellDevInstances location="embedding-page" />
       <StaticEmbeddingOptionCard />
       <InteractiveEmbeddingOptionCard />
       <EmbeddingSdkOptionCard />

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.tsx
@@ -82,7 +82,7 @@ export function GeneralSettingsPage() {
           inputType="textarea"
         />
       </SettingsSection>
-      <UpsellDevInstances source="settings-general" />
+      <UpsellDevInstances location="settings-general" />
     </SettingsPageWrapper>
   );
 }

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/UpdatesSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/UpdatesSettingsPage.tsx
@@ -63,7 +63,7 @@ export function UpdatesSettingsPage() {
           </div>
         )}
       </SettingsSection>
-      <UpsellHostingBanner source="settings-updates-migrate_to_cloud" />
+      <UpsellHostingBanner location="settings-updates-migrate_to_cloud" />
     </SettingsPageWrapper>
   );
 }

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/UploadSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/UploadSettingsPage.tsx
@@ -19,7 +19,7 @@ export function UploadSettingsPage() {
           <PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable />
         </SettingsSection>
         <Box>
-          <UpsellUploads source="settings-uploads" />
+          <UpsellUploads location="settings-uploads" />
         </Box>
       </Flex>
     </SettingsPageWrapper>

--- a/frontend/src/metabase/admin/tools/components/Help/Help.tsx
+++ b/frontend/src/metabase/admin/tools/components/Help/Help.tsx
@@ -121,7 +121,7 @@ export const Help = () => {
         />
       </Group>
 
-      <UpsellBetterSupport source="settings-troubleshooting" />
+      <UpsellBetterSupport location="settings-troubleshooting" />
 
       <SettingsSection
         title={t`Diagnostic info`}

--- a/frontend/src/metabase/admin/upsells/UpsellBetterSupport.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellBetterSupport.tsx
@@ -8,7 +8,7 @@ import { Text } from "metabase/ui";
 import { UpsellBanner } from "./components";
 import { UPGRADE_URL } from "./constants";
 
-export const UpsellBetterSupport = ({ source }: { source: string }) => {
+export const UpsellBetterSupport = ({ location }: { location: string }) => {
   const plan = useSelector((state) =>
     getPlan(getSetting(state, "token-features")),
   );
@@ -23,7 +23,7 @@ export const UpsellBetterSupport = ({ source }: { source: string }) => {
       campaign="better-hosting"
       buttonText={t`Try for free`}
       buttonLink={UPGRADE_URL}
-      source={source}
+      location={location}
     >
       <Text size="sm">
         {t`Unlimited support from success engineers whenever you need it with any paid plan.`}{" "}

--- a/frontend/src/metabase/admin/upsells/UpsellCacheConfig.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellCacheConfig.tsx
@@ -6,7 +6,7 @@ import { Box } from "metabase/ui";
 import { UpsellCard } from "./components";
 import { UPGRADE_URL } from "./constants";
 
-export const UpsellCacheConfig = ({ source }: { source: string }) => {
+export const UpsellCacheConfig = ({ location }: { location: string }) => {
   const hasCache = useHasTokenFeature("cache_granular_controls");
 
   if (hasCache) {
@@ -20,7 +20,7 @@ export const UpsellCacheConfig = ({ source }: { source: string }) => {
         campaign="cache-granular-controls"
         buttonText={t`Try Metabase Pro`}
         buttonLink={UPGRADE_URL}
-        source={source}
+        location={location}
       >
         {jt`Get granular caching controls for each database, dashboard, and query with ${(
           <strong key="label">{t`Metabase Pro.`}</strong>

--- a/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
@@ -6,9 +6,9 @@ import { Text } from "metabase/ui";
 
 import { UpsellBanner } from "./components";
 
-type SOURCE = "embedding-page" | "settings-general";
+type LOCATION = "embedding-page" | "settings-general";
 
-export function UpsellDevInstances({ source }: { source: SOURCE }) {
+export function UpsellDevInstances({ location }: { location: LOCATION }) {
   const isDevMode = useSetting("development-mode?");
 
   if (isDevMode) {
@@ -21,7 +21,7 @@ export function UpsellDevInstances({ source }: { source: SOURCE }) {
       campaign="dev_instances"
       buttonText={t`Set up`}
       buttonLink={getStoreUrl("account/new-dev-instance")}
-      source={source}
+      location={location}
       dismissible
     >
       <Text size="sm">

--- a/frontend/src/metabase/admin/upsells/UpsellHosting.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellHosting.tsx
@@ -10,7 +10,7 @@ import { UpsellBanner, UpsellCard } from "./components";
 const UPSELL_CARD_WIDTH = 202;
 const CLOUD_PAGE = "/admin/settings/cloud";
 
-export const UpsellHosting = ({ source }: { source: string }) => {
+export const UpsellHosting = ({ location }: { location: string }) => {
   const isHosted = useSelector(getIsHosted);
 
   if (isHosted) {
@@ -24,7 +24,7 @@ export const UpsellHosting = ({ source }: { source: string }) => {
       buttonText={t`Learn more`}
       internalLink={CLOUD_PAGE}
       illustrationSrc={RocketGlobeIllustrationSrc}
-      source={source}
+      location={location}
       maxWidth={UPSELL_CARD_WIDTH}
     >
       {jt`${(
@@ -34,7 +34,7 @@ export const UpsellHosting = ({ source }: { source: string }) => {
   );
 };
 
-export const UpsellHostingBanner = ({ source }: { source: string }) => {
+export const UpsellHostingBanner = ({ location }: { location: string }) => {
   const isHosted = useSelector(getIsHosted);
 
   if (isHosted) {
@@ -47,7 +47,7 @@ export const UpsellHostingBanner = ({ source }: { source: string }) => {
       campaign="hosting"
       buttonText={t`Learn more`}
       internalLink="/admin/settings/cloud"
-      source={source}
+      location={location}
     >
       {jt`${(
         <strong key="migrate">{t`Migrate to Metabase Cloud`}</strong>
@@ -56,7 +56,7 @@ export const UpsellHostingBanner = ({ source }: { source: string }) => {
   );
 };
 
-export const UpsellHostingUpdates = ({ source }: { source: string }) => {
+export const UpsellHostingUpdates = ({ location }: { location: string }) => {
   const isHosted = useSelector(getIsHosted);
 
   if (isHosted) {
@@ -70,7 +70,7 @@ export const UpsellHostingUpdates = ({ source }: { source: string }) => {
       buttonText={t`Learn more`}
       internalLink={CLOUD_PAGE}
       illustrationSrc={RocketGlobeIllustrationSrc}
-      source={source}
+      location={location}
       maxWidth={UPSELL_CARD_WIDTH}
     >
       {jt`${(

--- a/frontend/src/metabase/admin/upsells/UpsellMetabaseBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellMetabaseBanner.tsx
@@ -11,7 +11,7 @@ export function UpsellMetabaseBanner() {
       buttonLink={UPGRADE_URL}
       buttonText={t`Upgrade plan`}
       campaign="remove-mb-branding"
-      source="static-embed-settings-look-and-feel"
+      location="static-embed-settings-look-and-feel"
       fullWidth
     >
       {t`The “Powered by Metabase” banner appears on all static embeds created with your current version. Upgrade to remove it (and customize a lot more)`}

--- a/frontend/src/metabase/admin/upsells/UpsellPermissions.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellPermissions.tsx
@@ -5,7 +5,7 @@ import { useHasTokenFeature } from "metabase/common/hooks";
 import { UpsellBanner } from "./components";
 import { UPGRADE_URL } from "./constants";
 
-export const UpsellPermissions = ({ source }: { source: string }) => {
+export const UpsellPermissions = ({ location }: { location: string }) => {
   const hasAdvancedPermissions = useHasTokenFeature("advanced_permissions");
 
   if (hasAdvancedPermissions) {
@@ -17,7 +17,7 @@ export const UpsellPermissions = ({ source }: { source: string }) => {
       campaign="advanced-permissions"
       buttonText={t`Try for free`}
       buttonLink={UPGRADE_URL}
-      source={source}
+      location={location}
       title={t`Get advanced permissions`}
     >
       {t`Granular control down to the row- and column-level security. Manage advanced permissions per user group, or even at the database level.`}

--- a/frontend/src/metabase/admin/upsells/UpsellSSO.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellSSO.tsx
@@ -8,7 +8,7 @@ import { Box, List } from "metabase/ui";
 import { UpsellCard } from "./components";
 import { UPGRADE_URL } from "./constants";
 
-export const UpsellSSO = ({ source }: { source: string }) => {
+export const UpsellSSO = ({ location }: { location: string }) => {
   const tokenFeatures = useSelector((state) =>
     getSetting(state, "token-features"),
   );
@@ -26,7 +26,7 @@ export const UpsellSSO = ({ source }: { source: string }) => {
       campaign="sso"
       buttonText={t`Try Metabase Pro`}
       buttonLink={UPGRADE_URL}
-      source={source}
+      location={location}
       style={{ maxWidth: 242 }}
     >
       <Box px=".5rem">

--- a/frontend/src/metabase/admin/upsells/UpsellStorage.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellStorage.tsx
@@ -11,7 +11,7 @@ import { UpsellBanner } from "./components";
  */
 export const BUY_STORAGE_URL = getStoreUrl("account/storage");
 
-export const UpsellStorage = ({ source }: { source: string }) => {
+export const UpsellStorage = ({ location }: { location: string }) => {
   const isHosted = useSetting("is-hosted?");
   const hasStorage = useHasTokenFeature("attached_dwh");
 
@@ -24,7 +24,7 @@ export const UpsellStorage = ({ source }: { source: string }) => {
       campaign="storage"
       buttonText={t`Add`}
       buttonLink={BUY_STORAGE_URL}
-      source={source}
+      location={location}
       title={t`Add Metabase Storage`}
       large
     >

--- a/frontend/src/metabase/admin/upsells/UpsellUploads.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellUploads.tsx
@@ -7,7 +7,7 @@ import { getSetting } from "metabase/selectors/settings";
 import { UpsellCard } from "./components";
 import { UPGRADE_URL } from "./constants";
 
-export const UpsellUploads = ({ source }: { source: string }) => {
+export const UpsellUploads = ({ location }: { location: string }) => {
   const plan = useSelector((state) =>
     getPlan(getSetting(state, "token-features")),
   );
@@ -24,7 +24,7 @@ export const UpsellUploads = ({ source }: { source: string }) => {
       campaign="manage-uploads"
       buttonText={t`Try for free`}
       buttonLink={UPGRADE_URL}
-      source={source}
+      location={location}
     >
       {c("{0} is the string 'Upgrade to Metabase Pro'").jt`${(
         <strong key="upgrade">{t`Upgrade to Metabase Pro`}</strong>

--- a/frontend/src/metabase/admin/upsells/UpsellWhitelabel.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellWhitelabel.tsx
@@ -22,7 +22,11 @@ export const UpsellWhitelabel = ({ source }: { source: string }) => {
   // Even though getDocsUrl allows to pass utm params as one of the props,
   // the product requirement is to keep them in sync with the primary CTA.
   // That's why we're using useUpsellLink hook again here.
-  const url = useUpsellLink({ url: docsUrl, campaign: "whitelabel", source });
+  const url = useUpsellLink({
+    url: docsUrl,
+    campaign: "whitelabel",
+    location: source,
+  });
 
   if (isWhitelabeled) {
     return null;

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
@@ -56,7 +56,7 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
   buttonLink,
   internalLink,
   campaign,
-  source,
+  source: location,
   large,
   children,
   ...props
@@ -64,11 +64,11 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
   const url = useUpsellLink({
     url: buttonLink ?? UPGRADE_URL,
     campaign,
-    source,
+    location,
   });
 
   useMount(() => {
-    trackUpsellViewed({ source, campaign });
+    trackUpsellViewed({ location, campaign });
   });
 
   const { dismissible, onDismiss, ...domProps } =
@@ -100,7 +100,7 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
       <Flex align="center" gap="md">
         {buttonLink !== undefined ? (
           <ExternalLink
-            onClickCapture={() => trackUpsellClicked({ source, campaign })}
+            onClickCapture={() => trackUpsellClicked({ location, campaign })}
             href={url}
             className={S.UpsellCTALink}
           >
@@ -108,7 +108,7 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
           </ExternalLink>
         ) : (
           <Link
-            onClickCapture={() => trackUpsellClicked({ source, campaign })}
+            onClickCapture={() => trackUpsellClicked({ location, campaign })}
             to={internalLink}
             className={S.UpsellCTALink}
           >

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
@@ -40,7 +40,7 @@ type UpsellBannerPropsBase = {
   title: string;
   buttonText: string;
   campaign: string;
-  source: string;
+  location: string;
   large?: boolean;
   children: React.ReactNode;
   style?: React.CSSProperties;
@@ -56,7 +56,7 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
   buttonLink,
   internalLink,
   campaign,
-  source: location,
+  location,
   large,
   children,
   ...props

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.unit.spec.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.unit.spec.tsx
@@ -31,7 +31,7 @@ function setup({
       campaign={campaign}
       title={title}
       buttonText="Test button text"
-      source="test-source"
+      location="test-location"
       internalLink="test-internal-link"
       dismissible={dismissible}
     >

--- a/frontend/src/metabase/admin/upsells/components/UpsellBigCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBigCard.tsx
@@ -37,7 +37,7 @@ export const _UpsellBigCard: React.FC<UpsellBigCardProps> = ({
   campaign,
   illustrationSrc,
   onOpenModal,
-  source,
+  source: location,
   children,
   ...props
 }: UpsellBigCardProps) => {
@@ -47,11 +47,11 @@ export const _UpsellBigCard: React.FC<UpsellBigCardProps> = ({
     // there only because we cannot conditionally skip the hook.
     url: buttonLink ?? UPGRADE_URL,
     campaign,
-    source,
+    location,
   });
 
   useMount(() => {
-    trackUpsellViewed({ source, campaign });
+    trackUpsellViewed({ location, campaign });
   });
 
   return (
@@ -74,7 +74,7 @@ export const _UpsellBigCard: React.FC<UpsellBigCardProps> = ({
             <ExternalLink
               className={S.UpsellCTALink}
               href={url}
-              onClickCapture={() => trackUpsellClicked({ source, campaign })}
+              onClickCapture={() => trackUpsellClicked({ location, campaign })}
             >
               {buttonText}
             </ExternalLink>
@@ -82,7 +82,7 @@ export const _UpsellBigCard: React.FC<UpsellBigCardProps> = ({
             <Box
               component="button"
               className={S.UpsellCTALink}
-              onClickCapture={() => trackUpsellClicked({ source, campaign })}
+              onClickCapture={() => trackUpsellClicked({ location, campaign })}
               onClick={onOpenModal}
             >
               {buttonText}

--- a/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
@@ -50,7 +50,7 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
   buttonText,
   buttonLink,
   campaign,
-  source,
+  source: location,
   illustrationSrc,
   internalLink,
   children,
@@ -62,11 +62,11 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
   const url = useUpsellLink({
     url: buttonLink ?? UPGRADE_URL,
     campaign,
-    source,
+    location,
   });
 
   useMount(() => {
-    trackUpsellViewed({ source, campaign });
+    trackUpsellViewed({ location, campaign });
   });
 
   const gemSize = large ? "24px" : undefined;
@@ -99,7 +99,9 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
           <Box mx="md" mb="lg">
             {buttonLink !== undefined ? (
               <ExternalLink
-                onClickCapture={() => trackUpsellClicked({ source, campaign })}
+                onClickCapture={() =>
+                  trackUpsellClicked({ location, campaign })
+                }
                 href={url}
                 className={S.UpsellCTALink}
               >
@@ -107,7 +109,9 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
               </ExternalLink>
             ) : (
               <Link
-                onClickCapture={() => trackUpsellClicked({ source, campaign })}
+                onClickCapture={() =>
+                  trackUpsellClicked({ location, campaign })
+                }
                 to={internalLink}
                 className={S.UpsellCTALink}
               >

--- a/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
@@ -37,7 +37,7 @@ export type UpsellCardProps = {
   title: string;
   buttonText: string;
   campaign: string;
-  source: string;
+  location: string;
   illustrationSrc?: string;
   children: React.ReactNode;
   large?: boolean;
@@ -50,7 +50,7 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
   buttonText,
   buttonLink,
   campaign,
-  source: location,
+  location,
   illustrationSrc,
   internalLink,
   children,

--- a/frontend/src/metabase/admin/upsells/components/UpsellPill.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellPill.tsx
@@ -11,7 +11,7 @@ export function _UpsellPill({
   children,
   link,
   campaign,
-  source,
+  source: location,
 }: {
   children: React.ReactNode;
   link: string;
@@ -21,17 +21,17 @@ export function _UpsellPill({
   const url = useUpsellLink({
     url: link,
     campaign,
-    source,
+    location,
   });
 
   useMount(() => {
-    trackUpsellViewed({ source, campaign });
+    trackUpsellViewed({ location, campaign });
   });
 
   return (
     <ExternalLink
       href={url}
-      onClickCapture={() => trackUpsellClicked({ source, campaign })}
+      onClickCapture={() => trackUpsellClicked({ location, campaign })}
       data-testid="upsell-pill"
       className={S.UpsellPillComponent}
     >

--- a/frontend/src/metabase/admin/upsells/components/analytics.ts
+++ b/frontend/src/metabase/admin/upsells/components/analytics.ts
@@ -1,22 +1,25 @@
 import { trackSchemaEvent } from "metabase/lib/analytics";
 
 type UpsellEventProps = {
-  source: string;
+  location: string;
   campaign: string;
 };
 
-export const trackUpsellViewed = ({ source, campaign }: UpsellEventProps) => {
+export const trackUpsellViewed = ({ location, campaign }: UpsellEventProps) => {
   trackSchemaEvent("upsell", {
     event: "upsell_viewed",
     promoted_feature: campaign,
-    upsell_location: source,
+    upsell_location: location,
   });
 };
 
-export const trackUpsellClicked = ({ source, campaign }: UpsellEventProps) => {
+export const trackUpsellClicked = ({
+  location,
+  campaign,
+}: UpsellEventProps) => {
   trackSchemaEvent("upsell", {
     event: "upsell_clicked",
     promoted_feature: campaign,
-    upsell_location: source,
+    upsell_location: location,
   });
 };

--- a/frontend/src/metabase/admin/upsells/components/use-upsell-link.ts
+++ b/frontend/src/metabase/admin/upsells/components/use-upsell-link.ts
@@ -5,18 +5,18 @@ interface UpsellLinkProps {
   url: string;
   /* The name of the feature we're trying to sell */
   campaign: string;
-  /* The source component/view of the upsell notification */
-  source: string;
+  /* The location, specific component/view of the upsell notification */
+  location: string;
 }
 
 /**
  * We need to add extra anonymous information to upsell links to know where the user came from
  */
-export const useUpsellLink = ({ url, campaign, source }: UpsellLinkProps) => {
+export const useUpsellLink = ({ url, campaign, location }: UpsellLinkProps) => {
   return useUrlWithUtm(url, {
     utm_source: "product",
     utm_medium: "upsell",
     utm_campaign: campaign,
-    utm_content: source,
+    utm_content: location,
   });
 };

--- a/frontend/src/metabase/admin/upsells/components/use-upsell-link.unit.spec.tsx
+++ b/frontend/src/metabase/admin/upsells/components/use-upsell-link.unit.spec.tsx
@@ -11,11 +11,11 @@ import { useUpsellLink } from "./use-upsell-link";
 type TestComponentProps = {
   url: string;
   campaign: string;
-  source: string;
+  location: string;
 };
 
-const TestComponent = ({ url, campaign, source }: TestComponentProps) => {
-  const link = useUpsellLink({ url, campaign, source });
+const TestComponent = ({ url, campaign, location }: TestComponentProps) => {
+  const link = useUpsellLink({ url, campaign, location });
 
   return (
     <div>
@@ -35,7 +35,7 @@ const EEFeatures = Object.fromEntries(
 const setup = ({
   url,
   campaign,
-  source,
+  location,
   oss = true,
 }: TestComponentProps & { oss?: boolean }) => {
   const state = createMockState({
@@ -45,7 +45,7 @@ const setup = ({
   });
 
   return renderWithProviders(
-    <TestComponent url={url} campaign={campaign} source={source} />,
+    <TestComponent url={url} campaign={campaign} location={location} />,
     { storeInitialState: state },
   );
 };
@@ -55,14 +55,14 @@ describe("Upsells > useUpsellLink", () => {
     const props = {
       url: "https://www.metabase.com/",
       campaign: "test-campaign",
-      source: "test-source",
+      location: "test-location",
     };
     setup(props);
 
     const link = screen.getByText("Link");
     expect(link).toHaveAttribute(
       "href",
-      `${props.url}?utm_source=product&utm_medium=upsell&utm_campaign=${props.campaign}&utm_content=${props.source}&source_plan=oss`,
+      `${props.url}?utm_source=product&utm_medium=upsell&utm_campaign=${props.campaign}&utm_content=${props.location}&source_plan=oss`,
     );
   });
 
@@ -70,7 +70,7 @@ describe("Upsells > useUpsellLink", () => {
     const props = {
       url: "https://www.metabase.com",
       campaign: "test-campaign",
-      source: "test-source",
+      location: "test-location",
       oss: true,
     };
     setup(props);
@@ -86,7 +86,7 @@ describe("Upsells > useUpsellLink", () => {
     const props = {
       url: "https://www.metabase.com",
       campaign: "test-campaign",
-      source: "test-source",
+      location: "test-location",
       oss: false,
     };
     setup(props);

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/components/InsightsUpsellTab.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/components/InsightsUpsellTab.tsx
@@ -10,7 +10,7 @@ export const InsightsUpsellTab = ({
 }) => {
   return (
     <Flex justify="center">
-      <UpsellUsageAnalytics source={`${model}-sidesheet`} maxWidth={480} />
+      <UpsellUsageAnalytics location={`${model}-sidesheet`} maxWidth={480} />
     </Flex>
   );
 };

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/CSVPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/CSVPanel.tsx
@@ -41,7 +41,7 @@ export const CSVPanel = ({
           text: t`Enable uploads`,
           to: Urls.uploadsSettings(),
         }}
-        upsell={<UpsellStorage source="add-data-modal-csv" />}
+        upsell={<UpsellStorage location="add-data-modal-csv" />}
       />
     );
   }


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-84/refactor-useupselllink-to-use-sensible-argument-name

### Description

Rename `source` parameter to `content` to avoid confusion with `utm_source`