### PR TITLE
Closes VIZ-1204 VIZ-1205 error state when removing columns and switching viz

### DIFF
--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
@@ -225,14 +225,20 @@ const funnelToCartesian = (
   const metrics = [metric].filter(isNotNull);
   const dimensions = [dimension].filter(isNotNull);
 
+  const isInRefs = (ref: string) =>
+    columnValuesMapping[ref] && columnValuesMapping[ref].length > 0;
+
   return {
     columns,
     columnValuesMapping,
     settings: {
       ...otherSettings,
-      "graph.metrics": metrics.length > 0 ? metrics : preservedMetrics,
+      "graph.metrics":
+        metrics.length > 0 ? metrics : preservedMetrics.filter(isInRefs),
       "graph.dimensions":
-        dimensions.length > 0 ? dimensions : preservedDimensions,
+        dimensions.length > 0
+          ? dimensions
+          : preservedDimensions.filter(isInRefs),
     },
   };
 };

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.ts
@@ -121,17 +121,20 @@ const pieToFunnel = (
 ) => {
   const {
     "pie.metric": metric,
-    "pie.dimension": dimension,
+    "pie.dimension": pieDimension,
     "card.title": cardTitle,
     ...otherSettings
   } = settings;
+
+  const dimension = Array.isArray(pieDimension)
+    ? pieDimension[0]
+    : pieDimension;
 
   return {
     columns,
     columnValuesMapping,
     settings: {
       ...otherSettings,
-      "card.title": cardTitle,
       "funnel.metric": metric,
       "funnel.dimension": dimension,
       "graph.metrics": [metric].filter(isNotNull) as string[],

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
@@ -254,6 +254,32 @@ describe("updateSettingsForDisplay", () => {
         },
       });
     });
+
+    it("should ignore preserved columns that have been removed in the meantime (VIZ-1204)", () => {
+      const preservedMetrics = ["COLUMN_1", "COLUMN_3"];
+      const preservedDimensions = ["COLUMN_2"];
+
+      const result = getUpdatedSettingsForDisplay(
+        columnValuesMapping,
+        columns,
+        {
+          "funnel.metric": "COLUMN_3",
+          "funnel.dimension": "COLUMN_2",
+          "graph.metrics": preservedMetrics,
+          "graph.dimensions": preservedDimensions,
+        },
+        "funnel",
+        "line",
+      );
+      expect(result).toEqual({
+        columnValuesMapping,
+        columns,
+        settings: {
+          "graph.metrics": ["COLUMN_3"],
+          "graph.dimensions": ["COLUMN_2"],
+        },
+      });
+    });
   });
 
   describe("funnel → pie", () => {

--- a/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-updated-settings-for-display.unit.spec.ts
@@ -305,6 +305,31 @@ describe("updateSettingsForDisplay", () => {
     });
   });
 
+  describe("pie → funnel", () => {
+    it("should work when a pie has an array of dimensions (VIZ-1205)", () => {
+      const result = getUpdatedSettingsForDisplay(
+        columnValuesMapping,
+        columns,
+        {
+          "pie.metric": "COLUMN_3",
+          "pie.dimension": ["COLUMN_2"],
+        },
+        "pie",
+        "funnel",
+      );
+      expect(result).toEqual({
+        columnValuesMapping,
+        columns,
+        settings: {
+          "funnel.metric": "COLUMN_3",
+          "funnel.dimension": "COLUMN_2",
+          "graph.metrics": ["COLUMN_3"],
+          "graph.dimensions": ["COLUMN_2"],
+        },
+      });
+    });
+  });
+
   describe("funnel made of scalars", () => {
     it("should reset state when changing to any other display type", () => {
       const cleanState = {


### PR DESCRIPTION
Closes [VIZ-1204: Empty states can break when switching viz types + removing columns](https://linear.app/metabase/issue/VIZ-1204/empty-states-can-break-when-switching-viz-types-removing-columns)
Closes [VIZ-1205: Ambiguous empty state / error for funnels](https://linear.app/metabase/issue/VIZ-1205/ambiguous-empty-state-error-for-funnels)

### Description

We try to preserve metrics/dimensions when switching back and forth between cartesian and non-cartesian, but when a column has been removed we need to sanitize those preserved columns, otherwise the target destination references a column that no longer is selected.

### How to verify

#### VIZ-1204
 1. Create and add to a dashboard a question "Orders, Count, Grouped by Product → Category" — a bar chart.
 2. Open it in the visualizer
 3. Switch to a funnel
 4. Remove a column
 5. Switch back to a bar chart

###### Expected result
<img width="1615" alt="image" src="https://github.com/user-attachments/assets/511c3700-e9b6-4bd3-bdc2-39cdcb2fe619" />


###### Result before this PR
<img width="1615" alt="image" src="https://github.com/user-attachments/assets/39b84a29-b7e2-40b0-aaec-48afbb918ac3" />

#### VIZ-1205
 1. Create and add a pie chart
 2. Edit it in the visualizer
 3. Switch to a funnel

###### Expected result
<img width="1611" alt="image" src="https://github.com/user-attachments/assets/ac8f753c-2d4c-4607-b911-71c8afae52cb" />


###### Result before this PR
<img width="1611" alt="image" src="https://github.com/user-attachments/assets/aefe169e-0557-4a61-8462-ea11e5d61223" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
