### PR TITLE
remove, once again, embedding team from codeowners in release branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # Before changing this file, make sure you have read how we use it:
 # https://www.notion.so/metabase/Pull-Request-Code-Review-Guide-374f05df889748b69d67af753f9bc9b8?pvs=4#36550c04ceab40b5a8b8bee6264b090c
 
-enterprise/frontend/src/embedding-sdk @metabase/embedding
-frontend/src/metabase/embedding-sdk @metabase/embedding
-frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embedding
-frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding
+# enterprise/frontend/src/embedding-sdk @metabase/embedding // disabled in release branch to avoid getting asked for a review on automatic backport
+# frontend/src/metabase/embedding-sdk @metabase/embedding // disabled in release branch to avoid getting asked for a review on automatic backport
+# frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion @metabase/embedding // disabled in release branch to avoid getting asked for a review on automatic backport
+# frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard @metabase/embedding // disabled in release branch to avoid getting asked for a review on automatic backport
 frontend/src/metabase/ui @metabase/core-frontend-admin-webapp
 # snowplow/* @metabase/data
 src/metabase/analytics/prometheus.clj @metabase/cloud-ops
@@ -144,8 +144,8 @@ docs/developers-guide # exclude from tech-writer ownership
 # src/metabase/eid_translation @metabase/core-backend-admin-webapp
 # test/metabase/eid_translation @metabase/core-backend-admin-webapp
 
-# src/metabase/embed @metabase/embedding
-# test/metabase/embed @metabase/embedding
+src/metabase/embed @metabase/embedding // disabled in release branch to avoid getting asked for a review on automatic backport
+test/metabase/embed @metabase/embedding // disabled in release branch to avoid getting asked for a review on automatic backport
 
 # src/metabase/events @metabase/devexp
 # test/metabase/events @metabase/devexp


### PR DESCRIPTION
Same thing as [chore: remove embedding team from codeowners on the release branch](https://github.com/metabase/metabase/pull/53368) and [remove embedding as  codeowners from the release branch of 54](https://github.com/metabase/metabase/pull/56912).
Codeowners in release branches automatically ask us for review on backports that have already been approved by the automatic bot, we don't need to waste time reviewing those.
