### PR TITLE
Removes many console NPE warnings

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -47,6 +47,7 @@ import {
 import ChartSkeleton from "metabase/visualizations/components/skeletons/ChartSkeleton";
 import { extendCardWithDashcardSettings } from "metabase/visualizations/lib/settings/typed-utils";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import {
   createDataSource,
   isVisualizerDashboardCard,
@@ -164,6 +165,26 @@ const DashCardLoadingView = ({
   );
 };
 
+/**
+ * This populates the `data` field of each series with an empty
+ * object if it doesn't already have one. This is useful to compute
+ * the visualization settings correctly before data is loaded.
+ *
+ * @param series the series to sanitize
+ */
+function sanitizeSeriesData(series: RawSeries | { card: Card }[]) {
+  return series.map((s) => {
+    if ("data" in s) {
+      // If the series already has data, we're good
+      return s;
+    }
+
+    return {
+      ...s,
+      data: { cols: [], rows: [] },
+    };
+  });
+}
 interface DashCardVisualizationProps {
   dashcard: DashboardCard;
   series: Series;
@@ -477,7 +498,9 @@ export function DashCardVisualization({
   );
 
   const cardTitle = useMemo(() => {
-    const settings = getComputedSettingsForSeries(series);
+    const settings = getComputedSettingsForSeries(
+      sanitizeSeriesData(series),
+    ) as ComputedVisualizationSettings;
     return settings["card.title"] ?? series?.[0].card.name ?? "";
   }, [series]);
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -162,53 +162,56 @@ export const getCardSeriesModels = (
 
   // Charts without breakout have one series per selected metric column.
   if (!hasBreakout) {
-    return columns.metrics.map((metric) => {
-      const vizSettingsKey = getSeriesVizSettingsKey(
-        metric.column,
-        hasMultipleCards,
-        isFirstCard,
-        columns.metrics.length,
-        null,
-        card.name,
-      );
-      const legacySeriesSettingsObjectKey =
-        createLegacySeriesObjectKey(vizSettingsKey);
-
-      const customName = settings[SERIES_SETTING_KEY]?.[vizSettingsKey]?.title;
-      const tooltipName = customName ?? metric.column.display_name;
-      const name =
-        customName ??
-        getDefaultSeriesName(
-          metric.column.display_name,
+    return columns.metrics
+      .filter((m) => !!m.column)
+      .map((metric) => {
+        const vizSettingsKey = getSeriesVizSettingsKey(
+          metric.column,
           hasMultipleCards,
+          isFirstCard,
           columns.metrics.length,
-          false,
+          null,
           card.name,
         );
+        const legacySeriesSettingsObjectKey =
+          createLegacySeriesObjectKey(vizSettingsKey);
 
-      const color = getHexColor(
-        settings?.[SERIES_COLORS_SETTING_KEY]?.[vizSettingsKey],
-      );
+        const customName =
+          settings[SERIES_SETTING_KEY]?.[vizSettingsKey]?.title;
+        const tooltipName = customName ?? metric.column.display_name;
+        const name =
+          customName ??
+          getDefaultSeriesName(
+            metric.column.display_name,
+            hasMultipleCards,
+            columns.metrics.length,
+            false,
+            card.name,
+          );
 
-      const dataKey = getDatasetKey(metric.column, cardId);
+        const color = getHexColor(
+          settings?.[SERIES_COLORS_SETTING_KEY]?.[vizSettingsKey],
+        );
 
-      return {
-        name,
-        tooltipName,
-        color,
-        visible: !hiddenSeries.includes(dataKey),
-        cardId,
-        column: metric.column,
-        columnIndex: metric.index,
-        dataKey,
-        vizSettingsKey,
-        legacySeriesSettingsObjectKey,
-        bubbleSizeDataKey:
-          hasBubbleSize && columns.bubbleSize != null
-            ? getDatasetKey(columns.bubbleSize.column, cardId)
-            : undefined,
-      };
-    });
+        const dataKey = getDatasetKey(metric.column, cardId);
+
+        return {
+          name,
+          tooltipName,
+          color,
+          visible: !hiddenSeries.includes(dataKey),
+          cardId,
+          column: metric.column,
+          columnIndex: metric.index,
+          dataKey,
+          vizSettingsKey,
+          legacySeriesSettingsObjectKey,
+          bubbleSizeDataKey:
+            hasBubbleSize && columns.bubbleSize != null
+              ? getDatasetKey(columns.bubbleSize.column, cardId)
+              : undefined,
+        };
+      });
   }
 
   // Charts with breakout have one series per a unique breakout value. They can have only one metric in such cases.

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -647,7 +647,7 @@ export const GRAPH_AXIS_SETTINGS = {
         },
       ],
       vizSettings,
-    ) => getDefaultIsHistogram(cols[0]),
+    ) => cols[0] && getDefaultIsHistogram(cols[0]),
   },
   "graph.x_axis.scale": {
     get section() {


### PR DESCRIPTION
Closes _nothing_

### Description

This sanitizes the series we pass to get the computed settings, so it doesn't flood the console with warnings.