### PR TITLE
tests: drop old testing library

### DIFF
--- a/frontend/src/metabase/actions/hooks/use-action-form/use-action-form.unit.spec.ts
+++ b/frontend/src/metabase/actions/hooks/use-action-form/use-action-form.unit.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react";
 
 import {
   createMockActionParameter,

--- a/frontend/src/metabase/common/hooks/use-list-keyboard-navigation/use-list-keyboard-navigation.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/use-list-keyboard-navigation/use-list-keyboard-navigation.unit.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react";
 
 import { fireEvent } from "__support__/ui";
 

--- a/frontend/src/metabase/common/hooks/use-list-select.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/use-list-select.unit.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 
 import { useListSelect } from "./use-list-select";
 

--- a/frontend/src/metabase/common/hooks/use-pagination.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/use-pagination.unit.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 
 import { usePagination } from "./use-pagination";
 

--- a/frontend/src/metabase/common/hooks/use-url-state/use-url-state.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/use-url-state/use-url-state.unit.spec.ts
@@ -1,6 +1,6 @@
 import type { Location } from "history";
 
-import { renderHookWithProviders, waitFor } from "__support__/ui";
+import { act, renderHookWithProviders, waitFor } from "__support__/ui";
 import { createMockLocation } from "metabase-types/store/mocks";
 
 import type { QueryParam } from "./types";
@@ -81,7 +81,11 @@ describe("useUrlState", () => {
     const location = createLocation("?name=abc&score=123");
     const { result, history } = setup({ location });
     const [_state, { patchUrlState }] = result.current;
-    patchUrlState({ score: 456 });
+
+    act(() => {
+      patchUrlState({ score: 456 });
+    });
+
     const [state] = result.current;
     expect(state).toEqual({ name: "abc", score: 456 });
     expect(history?.getCurrentLocation().search).toEqual("?name=abc&score=123");
@@ -96,7 +100,11 @@ describe("useUrlState", () => {
     const location = createLocation("?name=abc&score=123");
     const { result, history } = setup({ location });
     const [_state, { patchUrlState }] = result.current;
-    patchUrlState({ name: "xyz", score: 456 });
+
+    act(() => {
+      patchUrlState({ name: "xyz", score: 456 });
+    });
+
     const [state] = result.current;
     expect(state).toEqual({ name: "xyz", score: 456 });
     expect(history?.getCurrentLocation().search).toEqual("?name=abc&score=123");
@@ -111,7 +119,11 @@ describe("useUrlState", () => {
     const location = createLocation("?name=abc&score=123");
     const { result, history } = setup({ location });
     const [_state, { patchUrlState }] = result.current;
-    patchUrlState({ name: null, score: null });
+
+    act(() => {
+      patchUrlState({ name: null, score: null });
+    });
+
     const [state] = result.current;
     expect(state).toEqual({ name: null, score: null });
     expect(history?.getCurrentLocation().search).toEqual("?name=abc&score=123");

--- a/frontend/src/metabase/common/hooks/use-user-key-value.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-user-key-value.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 import fetchMock from "fetch-mock";
 
 import {

--- a/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
+++ b/frontend/src/metabase/nav/components/LicenseTokenMissingBanner/useLicenseTokenMissingBanner.unit.spec.ts
@@ -1,4 +1,4 @@
-import { act } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 import fetchMock from "fetch-mock";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";

--- a/frontend/src/metabase/querying/filters/hooks/use-boolean-filter/use-boolean-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-boolean-filter/use-boolean-filter.unit.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 
 import { createMockMetadata } from "__support__/metadata";
 import type { BooleanFilterValue } from "metabase/querying/filters/types";

--- a/frontend/src/metabase/querying/filters/hooks/use-coordinate-filter/use-coordinate-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-coordinate-filter/use-coordinate-filter.unit.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";

--- a/frontend/src/metabase/querying/filters/hooks/use-date-filter/use-date-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-date-filter/use-date-filter.unit.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react";
 
 import type { DatePickerValue } from "metabase/querying/filters/types";
 import * as Lib from "metabase-lib";

--- a/frontend/src/metabase/querying/filters/hooks/use-default-filter/use-default-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-default-filter/use-default-filter.unit.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";

--- a/frontend/src/metabase/querying/filters/hooks/use-number-filter/use-number-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-number-filter/use-number-filter.unit.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";

--- a/frontend/src/metabase/querying/filters/hooks/use-string-filter/use-string-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-string-filter/use-string-filter.unit.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";

--- a/frontend/src/metabase/querying/filters/hooks/use-time-filter/use-time-filter.unit.spec.ts
+++ b/frontend/src/metabase/querying/filters/hooks/use-time-filter/use-time-filter.unit.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react";
 
 import { createMockMetadata } from "__support__/metadata";
 import { checkNotNull } from "metabase/lib/types";

--- a/frontend/src/metabase/visualizations/echarts/tooltip/index.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/tooltip/index.unit.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react";
 import type { EChartsType } from "echarts/core";
 import type { MutableRefObject } from "react";
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -3,11 +3,11 @@ import type { Reducer, Store } from "@reduxjs/toolkit";
 import type { MatcherFunction } from "@testing-library/dom";
 import type { ByRoleMatcher, RenderHookOptions } from "@testing-library/react";
 import {
+  renderHook,
   screen,
   render as testingLibraryRender,
   waitFor,
 } from "@testing-library/react";
-import { renderHook } from "@testing-library/react-hooks/dom";
 import type { History } from "history";
 import { createMemoryHistory } from "history";
 import { KBarProvider } from "kbar";

--- a/package.json
+++ b/package.json
@@ -181,7 +181,6 @@
     "@testing-library/cypress": "^10.0.2",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
-    "@testing-library/react-hooks": "^8.0.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/babel__core": "^7.20.4",
     "@types/babel__preset-env": "^7.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,14 +4016,6 @@
     lodash "^4.17.21"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz#7d0164bffce4647f506039de0a97f6fcbd20f4bf"
-  integrity sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
-
 "@testing-library/react@^16.0.0":
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.0.0.tgz#0a1e0c7a3de25841c3591b8cb7fb0cf0c0a27321"
@@ -17624,13 +17616,6 @@ react-dropzone@^14.2.3:
     attr-accept "^2.2.2"
     file-selector "^0.6.0"
     prop-types "^15.8.1"
-
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^2.0.1:
   version "2.0.4"


### PR DESCRIPTION
`@testing-library/react-hooks` is not compatible with react 18, I noticed a deprecation warning in console.

<img width="880" alt="Screenshot 2025-07-07 at 16 34 48" src="https://github.com/user-attachments/assets/ae38e10e-78dd-4c42-8542-203676d4081c" />

### Additional info

https://github.com/testing-library/react-hooks-testing-library#a-note-about-react-18-support
https://github.com/testing-library/react-testing-library/pull/991