### PR TITLE
deactivate tenant users along with their tenants

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/tenants/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/core.clj
@@ -20,3 +20,10 @@
   (if (setting/get :use-tenants)
     #{"@tenant.slug"}
     #{}))
+
+(defenterprise tenant-is-active?
+  "Whether the tenant with this ID is active or not."
+  :feature :tenants
+  [tenant-id]
+  (or (nil? tenant-id)
+      (t2/exists? :model/Tenant :id tenant-id :is_active true)))

--- a/enterprise/frontend/src/metabase-enterprise/api/tenants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/tenants.ts
@@ -26,7 +26,7 @@ export const tenantsApi = EnterpriseApi.injectEndpoints({
     }),
     listTenants: builder.query<
       { data: Tenant[] },
-      { status: "active" | "deactivated" }
+      { status: "active" | "deactivated" | "all" }
     >({
       query: (params) => ({
         method: "GET",
@@ -42,7 +42,11 @@ export const tenantsApi = EnterpriseApi.injectEndpoints({
         body,
       }),
       invalidatesTags: (_, error, { id }) =>
-        invalidateTags(error, [listTag("tenant"), idTag("tenant", id)]),
+        invalidateTags(error, [
+          listTag("tenant"),
+          idTag("tenant", id),
+          listTag("user"),
+        ]),
     }),
   }),
 });

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/ReactivateExternalUserButton/ReactivateExternalUserButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/ReactivateExternalUserButton/ReactivateExternalUserButton.tsx
@@ -1,0 +1,28 @@
+import { t } from "ttag";
+
+import { ReactivateUserButton } from "metabase/admin/people/components/ReactivateUserButton";
+import { useListTenantsQuery } from "metabase-enterprise/api";
+import type { User } from "metabase-types/api";
+
+export const ReactivateExternalUserButton = ({ user }: { user: User }) => {
+  // This is set to all to avoid making another API request to the BE. <TenantDisplayName> should be
+  // Making the same API request, so we can leverage the cached result
+  const { data: tenants } = useListTenantsQuery({
+    status: "all",
+  });
+
+  const userTenantIsActive = Boolean(
+    tenants?.data.find((tenants) => tenants.id === user.tenant_id)?.is_active,
+  );
+  const tooltip = !userTenantIsActive
+    ? t`Cannot reactivate users on a disabled tenant`
+    : undefined;
+
+  return (
+    <ReactivateUserButton
+      user={user}
+      disabled={!userTenantIsActive}
+      tooltipLabel={tooltip}
+    />
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/ReactivateExternalUserButton/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/ReactivateExternalUserButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./ReactivateExternalUserButton";

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantDisplayName/TenantDisplayName.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantDisplayName/TenantDisplayName.tsx
@@ -6,7 +6,7 @@ import type { Tenant } from "metabase-types/api";
 
 export const TenantDisplayName = ({ id }: { id: Tenant["id"] }) => {
   const { data: tenants, isLoading } = useListTenantsQuery({
-    status: "active",
+    status: "all",
   });
 
   if (isLoading || !tenants) {

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -22,6 +22,7 @@ import * as Urls from "metabase-enterprise/urls";
 import { EditUserStrategyModal } from "./EditUserStrategyModal";
 import { EditUserStrategySettingsButton } from "./EditUserStrategySettingsButton";
 import { ExternalPeopleListingApp } from "./components/ExternalPeopleListingApp/ExternalPeopleListingApp";
+import { ReactivateExternalUserButton } from "./components/ReactivateExternalUserButton";
 import { TenantDisplayName } from "./components/TenantDisplayName";
 import { FormTenantWidget } from "./components/TenantFormWidget";
 import { EditTenantModal } from "./containers/EditTenantModal";
@@ -111,4 +112,5 @@ if (hasPremiumFeature("tenants")) {
   PLUGIN_TENANTS.isExternalUsersGroup = isExternalUsersGroup;
   PLUGIN_TENANTS.isExternalUser = isExternalUser;
   PLUGIN_TENANTS.isTenantCollection = isTenantCollection;
+  PLUGIN_TENANTS.ReactivateExternalUserButton = ReactivateExternalUserButton;
 }

--- a/frontend/src/metabase/admin/people/components/PeopleList.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleList.tsx
@@ -183,6 +183,7 @@ export const PeopleList = ({
               <th>{t`Email`}</th>
               {showDeactivated ? (
                 <Fragment>
+                  {external && <th>{t`Tenant`}</th>}
                   <th>{t`Deactivated`}</th>
                   <th />
                 </Fragment>

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
@@ -29,7 +29,7 @@ import type {
 import { userToColor } from "../colors";
 
 import { MembershipSelect } from "./MembershipSelect";
-import S from "./PeopleListRow.module.css";
+import { ReactivateUserButton } from "./ReactivateUserButton";
 
 const enablePasswordLoginKey = "enable-password-login";
 
@@ -93,16 +93,18 @@ export const PeopleListRow = ({
       <td>{user.email}</td>
       {showDeactivated ? (
         <Fragment>
+          {isExternal && (
+            <td>
+              <PLUGIN_TENANTS.TenantDisplayName id={user.tenant_id} />
+            </td>
+          )}
           <td>{dayjs(user.updated_at).fromNow()}</td>
           <td>
-            <Tooltip label={t`Reactivate this account`}>
-              <ForwardRefLink
-                to={Urls.reactivateUser(user)}
-                className={S.refreshLink}
-              >
-                <Icon name="refresh" size={20} />
-              </ForwardRefLink>
-            </Tooltip>
+            {isExternal ? (
+              <PLUGIN_TENANTS.ReactivateExternalUserButton user={user} />
+            ) : (
+              <ReactivateUserButton user={user} />
+            )}
           </td>
         </Fragment>
       ) : (

--- a/frontend/src/metabase/admin/people/components/ReactivateUserButton.module.css
+++ b/frontend/src/metabase/admin/people/components/ReactivateUserButton.module.css
@@ -6,4 +6,9 @@
   &:hover {
     color: var(--mb-color-brand);
   }
+
+  &.disabled:hover {
+    color: var(--mb-color-text-light);
+    cursor: unset;
+  }
 }

--- a/frontend/src/metabase/admin/people/components/ReactivateUserButton.tsx
+++ b/frontend/src/metabase/admin/people/components/ReactivateUserButton.tsx
@@ -1,0 +1,29 @@
+import cx from "classnames";
+import { t } from "ttag";
+
+import { ForwardRefLink } from "metabase/common/components/Link";
+import * as Urls from "metabase/lib/urls";
+import { Icon, Tooltip } from "metabase/ui";
+import type { User } from "metabase-types/api";
+
+import S from "./ReactivateUserButton.module.css";
+
+export const ReactivateUserButton = ({
+  user,
+  disabled = false,
+  tooltipLabel = t`Reactivate this account`,
+}: {
+  user: User;
+  disabled?: boolean;
+  tooltipLabel?: string;
+}) => (
+  <Tooltip label={tooltipLabel}>
+    <ForwardRefLink
+      to={Urls.reactivateUser(user)}
+      className={cx(S.refreshLink, { [S.disabled]: disabled })}
+      onClick={(e) => (disabled ? e.preventDefault() : true)}
+    >
+      <Icon name="refresh" size={20} />
+    </ForwardRefLink>
+  </Tooltip>
+);

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -785,4 +785,6 @@ export const PLUGIN_TENANTS = {
   isExternalUser: (_user?: Pick<User, "tenant_id">) => false,
   isTenantCollection: (_collection: Collection) => false,
   PeopleNav: null as React.ReactElement | null,
+  ReactivateExternalUserButton: ({ user: _user }: { user: User }) =>
+    null as React.ReactElement | null,
 };

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -302,6 +302,27 @@ databaseChangeLog:
       changes:
         - customChange:
             class: "metabase.app_db.custom_migrations.MoveExistingAtSymbolUserAttributes"
+
+
+  - changeSet:
+      id: v56.2025-07-07T07:13:58
+      author: johnswanson
+      comment: Mark users with `deactivated_with_tenant`
+      changes:
+        - addColumn:
+            tableName: core_user
+            columns:
+              - column:
+                  name: deactivated_with_tenant
+                  remarks: |
+                    if this user and its tenant are both deactivated, represents whether the user was deactivated
+                    *with* the tenant (in which case it should be reactivated when the tenant is reactivated)
+                    or was deactivated independently.
+                  type: ${boolean.type}
+                  constraints:
+                    nullable: true
+
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/tenants/core.clj
+++ b/src/metabase/tenants/core.clj
@@ -14,3 +14,10 @@
   metabase-enterprise.tenants.core
   []
   #{})
+
+(defenterprise tenant-is-active?
+  "OSS version of `tenant-is-active?`. Returns `true` only if you have no tenant, because no tenants are active on
+  OSS."
+  metabase-enterprise.tenants.core
+  [tenant-id]
+  (nil? tenant-id))


### PR DESCRIPTION
Tenant users from deactivated tenants were already prevented from logging in (we checked the activation status of their tenant) but for bookkeeping it's probably best to actually deactivate the users themselves along with their tenants, and reactivate them if the tenant is reactivated.

[ADM-1113: BE: Mark users from deactivated tenants as deactivated](https://linear.app/metabase/issue/ADM-1113/be-mark-users-from-deactivated-tenants-as-deactivated)