### PR TITLE
Preview native query with snippet

### DIFF
--- a/e2e/test/scenarios/native/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets.cy.spec.js
@@ -169,6 +169,22 @@ describe("scenarios > question > snippets", () => {
     H.rightSidebar().icon("close").click();
     H.rightSidebar().findByText("snippet 2").should("be.visible");
   });
+
+  it("should be possible to preview a query that has a snippet in it (metabase#60534)", () => {
+    cy.request("POST", "/api/native-query-snippet", {
+      content: "'foo'",
+      name: "Foo",
+      collection_id: null,
+    });
+
+    H.startNewNativeQuestion();
+    cy.icon("snippet").click();
+    H.NativeEditor.type("select {{snippet: Foo}}");
+    cy.findByTestId("native-query-top-bar")
+      .findByLabelText("Preview the query")
+      .click();
+    H.modal().findByText("select 'foo'").should("be.visible");
+  });
 });
 
 describe("scenarios > question > snippets (OSS)", { tags: "@OSS" }, () => {

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.tsx
@@ -45,9 +45,14 @@ interface PreviewQueryButtonOpts {
 PreviewQueryButton.shouldRender = ({ question }: PreviewQueryButtonOpts) => {
   const { isNative } = Lib.queryDisplayInfo(question.query());
 
-  return (
-    isNative &&
-    question.canRun() &&
-    (question.legacyNativeQuery() as NativeQuery).hasVariableTemplateTags()
-  );
+  if (!isNative) {
+    return false;
+  }
+
+  const nativeQuestion = question.legacyNativeQuery() as NativeQuery;
+
+  const hasVariableTemplateTags = nativeQuestion.hasVariableTemplateTags();
+  const hasSnippets = nativeQuestion.hasSnippets();
+
+  return question.canRun() && (hasVariableTemplateTags || hasSnippets);
 };


### PR DESCRIPTION
Closes #60534

### To verify

1. New -> Native query
2. Create a snippet named `Foo` with value `'foobar'`
3. In the editor, type: `SELECT {{snippet: Foo}}`
4. There should be an eye icon in the toolbar, click it
5. The modal should contain `SELECT 'foobar'`


- [x] Test have been added