### PR TITLE
Fix MultiStageFilterPicker leaving the query with an empty stage

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -2229,7 +2229,6 @@ describe("cumulative count - issue 33330", () => {
     });
     cy.wait("@dataset");
 
-    H.queryBuilderHeader().findByLabelText("Show filters").click();
     cy.findByTestId("filter-pill").should("have.text", "Created At is today");
     cy.findAllByTestId("header-cell")
       .should("contain", "Created At: Month")

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.tsx
@@ -38,7 +38,7 @@ export function MultiStageFilterPicker({
     stageIndex: number,
     opts: FilterChangeOpts,
   ) => {
-    const newQuery = Lib.filter(query, stageIndex, filter);
+    const newQuery = Lib.dropEmptyStages(Lib.filter(query, stageIndex, filter));
     onChange(newQuery, opts);
   };
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/MultiStageFilterPicker/MultiStageFilterPicker.unit.spec.tsx
@@ -1,0 +1,72 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import * as Lib from "metabase-lib";
+import { createQueryWithClauses } from "metabase-lib/test-helpers";
+
+import { MultiStageFilterPicker } from "./MultiStageFilterPicker";
+
+type SetupOpts = {
+  query: Lib.Query;
+  canAppendStage?: boolean;
+};
+
+function setup({ query, canAppendStage = true }: SetupOpts) {
+  const onChange = jest.fn();
+  const onClose = jest.fn();
+
+  renderWithProviders(
+    <MultiStageFilterPicker
+      query={query}
+      canAppendStage={canAppendStage}
+      onChange={onChange}
+      onClose={onClose}
+    />,
+  );
+
+  const getNewQuery = (): Lib.Query => {
+    return onChange.mock.lastCall[0];
+  };
+
+  return { getNewQuery, onChange, onClose };
+}
+
+describe("MultiStageFilterPicker", () => {
+  it("should drop empty stages if there is no filter in a post-aggregation stage (metabase#57573)", async () => {
+    const { getNewQuery } = setup({
+      query: createQueryWithClauses({
+        aggregations: [{ operatorName: "count" }],
+        breakouts: [{ tableName: "PRODUCTS", columnName: "CATEGORY" }],
+      }),
+    });
+    expect(screen.getByText("Summaries")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("ID"));
+    await userEvent.type(screen.getByPlaceholderText("Enter an ID"), "10");
+    await userEvent.click(screen.getByRole("button", { name: "Apply filter" }));
+
+    const newQuery = getNewQuery();
+    expect(Lib.stageCount(newQuery)).toBe(1);
+    expect(Lib.filters(newQuery, 0)).toHaveLength(1);
+  });
+
+  it("should not drop the post-aggregation stage if there is a new filter", async () => {
+    const { getNewQuery } = setup({
+      query: createQueryWithClauses({
+        aggregations: [{ operatorName: "count" }],
+        breakouts: [{ tableName: "PRODUCTS", columnName: "CATEGORY" }],
+      }),
+    });
+    expect(screen.getByText("Summaries")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Summaries"));
+    await userEvent.click(screen.getByText("Count"));
+    await userEvent.type(screen.getByPlaceholderText("Min"), "10");
+    await userEvent.click(screen.getByRole("button", { name: "Apply filter" }));
+
+    const newQuery = getNewQuery();
+    expect(Lib.stageCount(newQuery)).toBe(2);
+    expect(Lib.filters(newQuery, 0)).toHaveLength(0);
+    expect(Lib.filters(newQuery, 1)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/57573

How to verify:
- New -> Question -> Orders
- Visualize
- Open the summarize sidebar -> Click on Category -> It should add an aggregation with a breakout
- Without closing the sidebar, click Filter -> ID -> Enter `1` -> `Apply filter`
- The summarize sidebar should not become blank

The reason why it was blank is that the `MultiStageFilterPicker` didn't remove an empty stage that it added to be able to add a post-aggregation filter.