### PR TITLE
Fix drill thru with multi-series dashcards

### DIFF
--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -549,6 +549,99 @@ describe("scenarios > dashboard > title drill", () => {
       cy.get(elementAlias).should("have.attr", "href", href);
     }
   });
+
+  describe("multiple series", () => {
+    const question1Details = {
+      name: "Q1",
+      query: {
+        "source-table": PEOPLE_ID,
+        aggregation: [["count"]],
+        breakout: [["field", PEOPLE.CREATED_AT, { "temporal-unit": "year" }]],
+      },
+      display: "line",
+    };
+
+    const question2Details = {
+      name: "Q2",
+      query: {
+        "source-table": PEOPLE_ID,
+        aggregation: [["count"]],
+        breakout: [["field", PEOPLE.BIRTH_DATE, { "temporal-unit": "year" }]],
+      },
+      display: "line",
+    };
+
+    const dateParameter = {
+      id: "date",
+      name: "Date",
+      slug: "date",
+      type: "date/all-options",
+      default: "1970-01-01~2025-01-01",
+    };
+
+    const dashboardDetails = {
+      parameters: [dateParameter],
+    };
+
+    function createDashboard() {
+      H.createQuestionAndDashboard({
+        questionDetails: question1Details,
+        dashboardDetails,
+      }).then(({ body: { id, card_id, dashboard_id } }) => {
+        H.createQuestion(question2Details).then(
+          ({ body: { id: card_2_id } }) => {
+            cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+              dashcards: [
+                {
+                  id,
+                  card_id,
+                  series: [{ id: card_2_id }],
+                  row: 0,
+                  col: 0,
+                  size_x: 16,
+                  size_y: 8,
+                  parameter_mappings: [
+                    {
+                      parameter_id: dateParameter.id,
+                      card_id,
+                      target: ["dimension", ["field", PEOPLE.CREATED_AT, null]],
+                    },
+                    {
+                      parameter_id: dateParameter.id,
+                      card_id: card_2_id,
+                      target: ["dimension", ["field", PEOPLE.BIRTH_DATE, null]],
+                    },
+                  ],
+                },
+              ],
+            });
+          },
+        );
+        H.visitDashboard(dashboard_id);
+      });
+    }
+
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsNormalUser();
+    });
+
+    it("should use parameters mapped to each card for a multi-series dashcard", () => {
+      createDashboard();
+
+      cy.log("click on a dot in the second series and drill thru");
+      H.cartesianChartCircle().eq(20).click();
+      H.popover().findByText("See these People").click();
+
+      cy.log("make sure the parameter mapping for the second series was used");
+      H.queryBuilderFiltersPanel().within(() => {
+        cy.findByText("Birth Date is Jan 1, 1970 – Jan 1, 2025").should(
+          "be.visible",
+        );
+        cy.findByText(/Created At/).should("not.exist");
+      });
+    });
+  });
 });
 
 function checkFilterLabelAndValue(label, value) {

--- a/frontend/src/metabase/dashboard/actions/getNewCardUrl.ts
+++ b/frontend/src/metabase/dashboard/actions/getNewCardUrl.ts
@@ -42,9 +42,10 @@ export const getNewCardUrl = ({
 
   const previousQuestion = new Question(previousCard, metadata);
   const { isEditable } = Lib.queryDisplayInfo(previousQuestion.query());
-  const parametersMappedToCard = getParametersMappedToDashcard(
+  const parametersMappedToCard = getParametersMappedToCard(
     dashboard.parameters,
     dashcard,
+    previousCard,
   );
 
   let nextQuestion: Question | undefined = undefined;
@@ -80,14 +81,16 @@ export const getNewCardUrl = ({
   }
 };
 
-export function getParametersMappedToDashcard(
+export function getParametersMappedToCard(
   parameters: Dashboard["parameters"],
   dashcard: QuestionDashboardCard,
+  card: Card | VirtualCard,
 ): ParameterWithTarget[] {
   const { parameter_mappings } = dashcard;
   return (parameters || []).flatMap((parameter) => {
     const mapping = _.findWhere(parameter_mappings || [], {
       parameter_id: parameter.id,
+      card_id: card.id,
     });
 
     if (!mapping) {

--- a/frontend/src/metabase/dashboard/actions/getNewCardUrl.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/getNewCardUrl.unit.spec.ts
@@ -1,10 +1,11 @@
 import {
+  createMockCard,
   createMockDashboard,
   createMockDashboardCard,
   createMockParameter,
 } from "metabase-types/api/mocks";
 
-import { getParametersMappedToDashcard } from "./getNewCardUrl";
+import { getParametersMappedToCard } from "./getNewCardUrl";
 
 describe("getParametersMappedToDashcard", () => {
   const dashboard = createMockDashboard({
@@ -25,15 +26,23 @@ describe("getParametersMappedToDashcard", () => {
     ],
   });
 
+  const card1 = createMockCard({ id: 5 });
+  const card2 = createMockCard({ id: 6 });
+
   const dashcard = createMockDashboardCard({
     parameter_mappings: [
       {
-        card_id: 5,
+        card_id: card1.id,
         parameter_id: "foo",
         target: ["variable", ["template-tag", "abc"]],
       },
       {
-        card_id: 6,
+        card_id: card2.id,
+        parameter_id: "foo",
+        target: ["dimension", ["field", 123, null]],
+      },
+      {
+        card_id: card2.id,
         parameter_id: "bar",
         target: ["dimension", ["field", 123, null]],
       },
@@ -42,22 +51,34 @@ describe("getParametersMappedToDashcard", () => {
 
   const dashcardWithNoMappings = createMockDashboardCard();
 
-  it("should return the subset of the dashboard's parameters that are found in a given dashcard's parameter_mappings", () => {
-    expect(getParametersMappedToDashcard([], dashcard)).toEqual([]);
+  it("should return the subset of the dashboard's parameters for the current dashcard and card", () => {
+    expect(getParametersMappedToCard([], dashcard, card1)).toEqual([]);
+
     expect(
-      getParametersMappedToDashcard(
+      getParametersMappedToCard(
         dashboard.parameters,
         dashcardWithNoMappings,
+        card1,
       ),
     ).toEqual([]);
 
     expect(
-      getParametersMappedToDashcard(dashboard.parameters, dashcard),
+      getParametersMappedToCard(dashboard.parameters, dashcard, card1),
     ).toMatchObject([
       {
         id: "foo",
         type: "text",
         target: ["variable", ["template-tag", "abc"]],
+      },
+    ]);
+
+    expect(
+      getParametersMappedToCard(dashboard.parameters, dashcard, card2),
+    ).toMatchObject([
+      {
+        id: "foo",
+        type: "text",
+        target: ["dimension", ["field", 123, null]],
       },
       {
         id: "bar",


### PR DESCRIPTION
https://metaboat.slack.com/archives/C01LQQ2UW03/p1751902548668989

Before, we used the first parameter mapping in a dashcard for each parameter when doing drill thru. This creates issues when a parameter is mapped to different columns for each of dashcard's series. This PR fixes the issue by taking the `card_id` into account when doing drills.