### PR TITLE
docs(sdk): Remove beta message from the SDK readme after GA

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -2,8 +2,6 @@
 
 ![Metabase logo](https://raw.githubusercontent.com/metabase/metabase/refs/heads/master/docs/images/metabase-logo.svg)
 
-> This SDK is in public beta and actively being developed. You can expect some changes to the API, especially during the beta. The SDK currently only works with a Metabase 1.51 or higher.
-
 With Metabase's Embedded analytics SDK, you can embed individual [Metabase](https://www.metabase.com/) components with React (like standalone charts, dashboards, the query builder, and more). You can manage access and interactivity per component, and you have advanced customization for seamless styling.
 
 [Learn more](https://www.metabase.com/docs/latest/embedding/sdk/introduction).


### PR DESCRIPTION
closes EMB-598


Triple backport should bring this back to 53 which is our first GA considering the timeline of [this doc](https://www.notion.so/metabase/Re-evaluation-of-GA-blockers-SDK-18269354c90180918897d47c689351c1), and the [53 changelog](https://github.com/metabase/metabase/blob/release-x.53.x/enterprise/frontend/src/embedding-sdk/CHANGELOG.md).