### PR TITLE
Support configuring the query builder's `entityTypes`

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 
 import { CommonSdkStoryWrapper } from "embedding-sdk/test/CommonSdkStoryWrapper";
 import {
@@ -6,12 +6,18 @@ import {
   dashboardIds,
 } from "embedding-sdk/test/storybook-id-args";
 
+import type { InteractiveQuestionProps } from "../../InteractiveQuestion";
+
 import {
   EditableDashboard,
   type EditableDashboardProps,
 } from "./EditableDashboard";
 
 const DASHBOARD_ID = (window as any).DASHBOARD_ID || dashboardIds.numberId;
+
+type CustomArgs = {
+  "queryBuilderProps.entityTypes"?: InteractiveQuestionProps["entityTypes"];
+};
 
 const meta = {
   title: "EmbeddingSDK/EditableDashboard",
@@ -23,6 +29,16 @@ const meta = {
   argTypes: {
     // Core props
     dashboardId: dashboardIdArgType,
+
+    "queryBuilderProps.entityTypes": {
+      control: "check",
+      options: [
+        "model",
+        "table",
+        "question",
+      ] satisfies InteractiveQuestionProps["entityTypes"],
+      description: "`question` doesn't have effect on simple data picker",
+    },
 
     // Display options
     withTitle: {
@@ -135,18 +151,22 @@ const meta = {
       action: "onLoadWithoutCards",
     },
   },
-} satisfies Meta<typeof EditableDashboard>;
+  render: ({ "queryBuilderProps.entityTypes": entityTypes, ...args }) => {
+    return (
+      <EditableDashboard
+        {...args}
+        queryBuilderProps={{
+          entityTypes,
+        }}
+      />
+    );
+  },
+} satisfies Meta<EditableDashboardProps & CustomArgs>;
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const Template: StoryFn<EditableDashboardProps> = (args) => {
-  return <EditableDashboard {...args} />;
-};
-
 export const Default = {
-  render: Template,
-
   args: {
     dashboardId: DASHBOARD_ID,
   },

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryFn } from "@storybook/react";
+import type { Meta, StoryFn, StoryObj } from "@storybook/react";
 
 import { CommonSdkStoryWrapper } from "embedding-sdk/test/CommonSdkStoryWrapper";
 import {
@@ -13,7 +13,7 @@ import {
 
 const DASHBOARD_ID = (window as any).DASHBOARD_ID || dashboardIds.numberId;
 
-export default {
+const meta = {
   title: "EmbeddingSDK/EditableDashboard",
   component: EditableDashboard,
   parameters: {
@@ -135,7 +135,10 @@ export default {
       action: "onLoadWithoutCards",
     },
   },
-};
+} satisfies Meta<typeof EditableDashboard>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
 
 const Template: StoryFn<EditableDashboardProps> = (args) => {
   return <EditableDashboard {...args} />;
@@ -147,4 +150,4 @@ export const Default = {
   args: {
     dashboardId: DASHBOARD_ID,
   },
-};
+} satisfies Story;

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.tsx
@@ -5,6 +5,7 @@ import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/mode
 import { EmbeddingSdkMode } from "metabase/visualizations/click-actions/modes/EmbeddingSdkMode";
 
 import {
+  type EditableDashboardOwnProps,
   SdkDashboard,
   type SdkDashboardInnerProps,
   type SdkDashboardProps,
@@ -15,7 +16,8 @@ import {
  * @expand
  * @category Dashboard
  */
-export type EditableDashboardProps = SdkDashboardProps;
+export type EditableDashboardProps = SdkDashboardProps &
+  EditableDashboardOwnProps;
 
 /**
  * A dashboard component with the features available in the `InteractiveDashboard` component, as well as the ability to add and update questions, layout, and content within your dashboard.

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -112,6 +112,7 @@ type RenderMode = "dashboard" | "question" | "queryBuilder";
 
 /**
  * Despite being a prop for a specific component, to avoid circular dependencies, the type is defined here.
+ * @inline
  */
 export type EditableDashboardOwnProps = {
   /**

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -104,7 +104,8 @@ export type SdkDashboardProps = PropsWithChildren<
      */
     drillThroughQuestionProps?: DrillThroughQuestionProps;
   } & SdkDashboardDisplayProps &
-    DashboardEventHandlersProps
+    DashboardEventHandlersProps &
+    EditableDashboardOwnProps
 >;
 
 type RenderMode = "dashboard" | "question" | "queryBuilder";
@@ -128,8 +129,7 @@ export type SdkDashboardInnerProps = SdkDashboardProps &
       | "dashcardMenu"
       | "navigateToNewCardFromDashboard"
     >
-  > &
-  EditableDashboardOwnProps;
+  >;
 
 const SdkDashboardInner = ({
   dashboardId: dashboardIdProp,

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -62,7 +62,10 @@ import { resetErrorPage, setErrorPage } from "metabase/redux/app";
 import { getErrorPage } from "metabase/selectors/app";
 import type { DashboardId } from "metabase-types/api";
 
-import type { DrillThroughQuestionProps } from "../InteractiveQuestion";
+import type {
+  DrillThroughQuestionProps,
+  InteractiveQuestionProps,
+} from "../InteractiveQuestion";
 
 import {
   SdkDashboardStyledWrapper,
@@ -106,6 +109,16 @@ export type SdkDashboardProps = PropsWithChildren<
 
 type RenderMode = "dashboard" | "question" | "queryBuilder";
 
+/**
+ * Despite being a prop for a specific component, to avoid circular dependencies, the type is defined here.
+ */
+export type EditableDashboardOwnProps = {
+  /**
+   * Additional props to pass to the query builder rendered by `InteractiveQuestion` when creating a new dashboard question.
+   */
+  queryBuilderProps?: Pick<InteractiveQuestionProps, "entityTypes">;
+};
+
 export type SdkDashboardInnerProps = SdkDashboardProps &
   Partial<
     Pick<
@@ -115,7 +128,8 @@ export type SdkDashboardInnerProps = SdkDashboardProps &
       | "dashcardMenu"
       | "navigateToNewCardFromDashboard"
     >
-  >;
+  > &
+  EditableDashboardOwnProps;
 
 const SdkDashboardInner = ({
   dashboardId: dashboardIdProp,
@@ -141,6 +155,7 @@ const SdkDashboardInner = ({
   className,
   style,
   children,
+  queryBuilderProps,
 }: SdkDashboardInnerProps) => {
   const { handleLoad, handleLoadWithoutCards } = useDashboardLoadHandlers({
     onLoad,
@@ -293,6 +308,7 @@ const SdkDashboardInner = ({
             onNavigateBack={() => {
               setRenderMode("dashboard");
             }}
+            queryBuilderProps={queryBuilderProps}
           />
         ))
         .exhaustive()}
@@ -328,6 +344,7 @@ type DashboardQueryBuilderProps = {
   targetDashboardId: DashboardId;
   onCreate: (question: MetabaseQuestion) => void;
   onNavigateBack: () => void;
+  queryBuilderProps: EditableDashboardOwnProps["queryBuilderProps"];
 };
 
 /**
@@ -337,6 +354,7 @@ function DashboardQueryBuilder({
   targetDashboardId,
   onCreate,
   onNavigateBack,
+  queryBuilderProps,
 }: DashboardQueryBuilderProps) {
   const dispatch = useSdkDispatch();
   const { dashboard } = useDashboardContext();
@@ -363,6 +381,7 @@ function DashboardQueryBuilder({
       }}
       onNavigateBack={onNavigateBack}
       backToDashboard={dashboard}
+      entityTypes={queryBuilderProps?.entityTypes}
     >
       <InteractiveQuestionDefaultView
         withResetButton

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/setup.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/setup.tsx
@@ -198,8 +198,8 @@ export const setupSdkDashboard = async ({
     <Box h="500px">
       <Component
         dashboardId={dashboardId}
-        {...props}
         queryBuilderProps={queryBuilderProps}
+        {...props}
       />
     </Box>,
     {

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/setup.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/setup.tsx
@@ -44,6 +44,7 @@ import {
 } from "metabase-types/api/mocks/presets";
 import { createMockDashboardState } from "metabase-types/store/mocks";
 
+import type { EditableDashboardProps } from "../EditableDashboard";
 import type { SdkDashboardProps } from "../SdkDashboard";
 
 export const TEST_DASHBOARD_ID = 1;
@@ -109,6 +110,7 @@ export interface SetupSdkDashboardOptions {
   isLocaleLoading?: boolean;
   component: React.ComponentType<SdkDashboardProps>;
   dashboardName?: string;
+  queryBuilderProps?: EditableDashboardProps["queryBuilderProps"];
 }
 
 jest.mock("metabase/common/hooks/use-locale", () => ({
@@ -121,6 +123,7 @@ export const setupSdkDashboard = async ({
   isLocaleLoading = false,
   component: Component,
   dashboardName = "Dashboard",
+  queryBuilderProps,
 }: SetupSdkDashboardOptions) => {
   const useLocaleMock = useLocale as jest.Mock;
   useLocaleMock.mockReturnValue({ isLocaleLoading });
@@ -193,7 +196,11 @@ export const setupSdkDashboard = async ({
 
   renderWithSDKProviders(
     <Box h="500px">
-      <Component dashboardId={dashboardId} {...props} />
+      <Component
+        dashboardId={dashboardId}
+        {...props}
+        queryBuilderProps={queryBuilderProps}
+      />
     </Box>,
     {
       sdkProviderProps: {

--- a/enterprise/frontend/src/embedding-sdk/test/storybook-id-args.ts
+++ b/enterprise/frontend/src/embedding-sdk/test/storybook-id-args.ts
@@ -42,7 +42,7 @@ export const dashboardIdArgType = {
       [dashboardIds.wrongNumberId]: "Wrong Number ID",
     },
   },
-};
+} as const;
 
 export const collectionIds = generateIds(COLLECTION_ENTITY_ID);
 


### PR DESCRIPTION
closes EMB-561

### Description

We support `entityTypes` on the `InteractiveQuestion`, so we should do the same for the query builder rendered inside the `EditableDashboard` that will be rendered when creating a new dashboard question.

### How to verify

1. Run BE
1. Run storybook
    ```sh
    yarn storybook-embedding-sdk
    ```
1. Visit Editable dashboard story
1. Edita > Add Question > play around with `queryBuilderProps.entityTypes`.
1. The query builder should only contain the argument that is passed. Please note that `question` doesn't have any effect on the simple data picker, so it's treated as not passing it.

### Demo

![image](https://github.com/user-attachments/assets/0b34ea4d-0fec-44e3-aa8b-545781bc912a)
![image](https://github.com/user-attachments/assets/77aa4f6e-8742-45d6-81a6-e5e081739161)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
