### PR TITLE
Fix hover selector and add menu hover story

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.module.css
@@ -16,7 +16,7 @@
     color: var(--mb-color-text-light);
   }
 
-  &[data-hovered] {
+  &:hover {
     color: var(--mb-color-text-hover);
     background-color: var(--mb-color-background-hover);
 

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.stories.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.stories.tsx
@@ -61,7 +61,7 @@ const DefaultTemplate = (args: MenuProps) => (
         <Button variant="filled">Toggle menu</Button>
       </Menu.Target>
       <Menu.Dropdown>
-        <Menu.Item>Question</Menu.Item>
+        <Menu.Item id="menu-item-1">Question</Menu.Item>
         <Menu.Item>SQL query</Menu.Item>
         <Menu.Item>Dashboard</Menu.Item>
         <Menu.Item>Collection</Menu.Item>
@@ -159,4 +159,18 @@ export const Icons = {
 export const LabelsAndDividers = {
   render: LabelsAndDividersTemplate,
   name: "Labels and dividers",
+};
+
+export const HoverStates = {
+  render: DefaultTemplate,
+  name: "Hover states",
+  args: {
+    opened: true,
+  },
+  parameters: {
+    pseudo: {
+      hover: ["#menu-item-1"],
+      rootSelector: "body",
+    },
+  },
 };


### PR DESCRIPTION
Closes #60584

This hover state is broken after upgrading to Mantine v8.

<img width="608" alt="Screenshot 2025-07-08 at 10 01 40 PM" src="https://github.com/user-attachments/assets/5110d307-8001-49cc-b180-80cd4a543921" />


I was trying to add a Loki snapshot to capture hovers states, I can get it working visually in storybook with

```
export const HoverStates = {
  render: DefaultTemplate,
  name: "Hover states",
  args: {
    opened: true,
  },
  parameters: {
    pseudo: {
      hover: ["#menu-item-1"],
      rootSelector: "body",
    },
  },
};
```
But it doesn't work when I generate snapshots (the menu isn't open in the snapshot)
![chrome_laptop_Components_Overlays_Menu_Hover_states](https://github.com/user-attachments/assets/d02586d8-76c5-4a60-b947-44db1a7ac261)


Note: were we aware that all the Menu UI story snapshots look exactly the same as the above image, just a button?