### PR TITLE
Chars composition fix

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -156,6 +156,9 @@ export const MetabotChatEmbedding = ({
           // @ts-expect-error - undocumented API for mantine Textarea - leverages the prop from react-textarea-autosize's TextareaAutosize component
           onHeightChange={handleMaybeExpandInput}
           onKeyDown={(e) => {
+            if (e.nativeEvent.isComposing) {
+              return;
+            }
             if (e.key === "Enter") {
               // prevent event from inserting new line + interacting with other content
               e.preventDefault();

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -252,6 +252,9 @@ export const MetabotChat = () => {
               placeholder={t`Tell me to do something, or ask a question`}
               onChange={(e) => metabot.setPrompt(e.target.value)}
               onKeyDown={(e) => {
+                if (e.nativeEvent.isComposing) {
+                  return;
+                }
                 const isModifiedKeyPress =
                   e.shiftKey || e.ctrlKey || e.metaKey || e.altKey;
                 if (e.key === "Enter" && !isModifiedKeyPress) {

--- a/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
+++ b/frontend/src/metabase/common/components/AccordionList/AccordionList.tsx
@@ -286,6 +286,10 @@ export class AccordionList<
   };
 
   handleKeyDown = (event: KeyboardEvent) => {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
+
     const { cursor } = this.state;
     if (event.key === "ArrowUp") {
       event.preventDefault();

--- a/frontend/src/metabase/common/components/CollapseSection/CollapseSection.tsx
+++ b/frontend/src/metabase/common/components/CollapseSection/CollapseSection.tsx
@@ -43,6 +43,9 @@ const CollapseSection = ({
 
   const onKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
       if (e.key === "Enter") {
         toggle();
       }

--- a/frontend/src/metabase/common/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/common/components/EditableText/EditableText.tsx
@@ -103,6 +103,9 @@ const EditableText = forwardRef(function EditableText(
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.nativeEvent.isComposing) {
+        return;
+      }
       if (event.key === "Escape") {
         event.stopPropagation(); // don't close modal
         setInputValue(submitValue ?? "");

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
@@ -21,14 +21,17 @@ export const ButtonBar = ({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const handleEnter = (e: KeyboardEvent) => {
+    const handleKeyPress = (e: KeyboardEvent) => {
+      if (e.isComposing) {
+        return;
+      }
       if (canConfirm && e.key === "Enter") {
         onConfirm();
       }
     };
-    document.addEventListener("keypress", handleEnter);
+    document.addEventListener("keypress", handleKeyPress);
     return () => {
-      document.removeEventListener("keypress", handleEnter);
+      document.removeEventListener("keypress", handleKeyPress);
     };
   }, [canConfirm, onConfirm]);
 

--- a/frontend/src/metabase/common/components/SelectList/BaseSelectListItem.tsx
+++ b/frontend/src/metabase/common/components/SelectList/BaseSelectListItem.tsx
@@ -44,7 +44,9 @@ export function BaseSelectListItem({
       size={size}
       onClick={(event: MouseEvent) => onSelect(id, event)}
       onKeyDown={(event: KeyboardEvent) =>
-        event.key === "Enter" && onSelect(id, event)
+        event.key === "Enter" &&
+        !event.nativeEvent.isComposing &&
+        onSelect(id, event)
       }
       className={className}
       {...rest}

--- a/frontend/src/metabase/common/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/common/components/TabButton/TabButton.tsx
@@ -6,6 +6,7 @@ import styled from "@emotion/styled";
 import type {
   ChangeEventHandler,
   HTMLAttributes,
+  KeyboardEvent,
   KeyboardEventHandler,
   MouseEventHandler,
   Ref,
@@ -107,7 +108,10 @@ const _TabButton = forwardRef(function TabButton(
 
   const handleInputKeyPress: KeyboardEventHandler<HTMLInputElement> =
     useCallback(
-      (event: React.KeyboardEvent) => {
+      (event: KeyboardEvent) => {
+        if (event.nativeEvent.isComposing) {
+          return;
+        }
         if (event.key === "Enter" && typeof inputRef === "object") {
           inputRef?.current?.blur();
         }

--- a/frontend/src/metabase/common/components/TokenField/TokenField.tsx
+++ b/frontend/src/metabase/common/components/TokenField/TokenField.tsx
@@ -268,6 +268,9 @@ class _TokenField extends Component<TokenFieldProps, TokenFieldState> {
     if (this.props.onInputKeyDown) {
       this.props.onInputKeyDown(event);
     }
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
 
     const { key, keyCode } = event;
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperButton.tsx
@@ -173,6 +173,9 @@ export const DashCardCardParameterMapperButton = ({
             setIsDropdownVisible(true);
           }}
           onKeyDown={(e) => {
+            if (e.nativeEvent.isComposing) {
+              return;
+            }
             if (e.key === "Enter") {
               setIsDropdownVisible(true);
             }

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.tsx
@@ -120,6 +120,9 @@ const EngineSearch = ({
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
+      if (event.nativeEvent.isComposing) {
+        return;
+      }
       switch (event.key) {
         case "Enter":
           activeOption && onChange(activeOption.value);

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -1,6 +1,6 @@
 import type { LocationDescriptorObject } from "history";
 import { useKBar } from "kbar";
-import type { ChangeEvent, MouseEvent } from "react";
+import type { ChangeEvent, KeyboardEvent, MouseEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { withRouter } from "react-router";
 import { push } from "react-router-redux";
@@ -159,7 +159,10 @@ function SearchBarView({ location, onSearchActive, onSearchInactive }: Props) {
   }, [onChangeLocation, previousLocation, searchFilters, searchText]);
 
   const handleInputKeyPress = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: KeyboardEvent) => {
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
       if (e.key === "Enter" && hasSearchText) {
         goToSearchApp();
       }

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -1,6 +1,10 @@
 import type { LocationDescriptorObject } from "history";
 import { useKBar } from "kbar";
-import type { ChangeEvent, KeyboardEvent, MouseEvent } from "react";
+import type {
+  ChangeEvent,
+  MouseEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { withRouter } from "react-router";
 import { push } from "react-router-redux";
@@ -159,7 +163,7 @@ function SearchBarView({ location, onSearchActive, onSearchInactive }: Props) {
   }, [onChangeLocation, previousLocation, searchFilters, searchText]);
 
   const handleInputKeyPress = useCallback(
-    (e: KeyboardEvent) => {
+    (e: ReactKeyboardEvent) => {
       if (e.nativeEvent.isComposing) {
         return;
       }

--- a/frontend/src/metabase/palette/components/PaletteResultsList.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultsList.tsx
@@ -48,7 +48,6 @@ export const PaletteResultList: React.FC<PaletteResultListProps> = (props) => {
       if (event.isComposing) {
         return;
       }
-
       if (event.key === "ArrowUp" || (event.ctrlKey && event.key === "p")) {
         event.preventDefault();
         event.stopPropagation();

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.tsx
@@ -135,6 +135,9 @@ export const ListField = ({
   };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
     if (
       event.key === "Enter" &&
       filter.trim().length > 0 &&

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
@@ -125,6 +125,9 @@ const SingleSelectListField = ({
   };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
     if (
       event.key === "Enter" &&
       filter.trim().length > 0 &&

--- a/frontend/src/metabase/parameters/components/widgets/TextWidget/TextWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/TextWidget/TextWidget.tsx
@@ -80,6 +80,9 @@ export class TextWidget extends Component<TextWidgetProps, State> {
           }
         }}
         onKeyUp={(e) => {
+          if (e.nativeEvent.isComposing) {
+            return;
+          }
           const target = e.target as HTMLInputElement;
           if (e.key === "Escape") {
             target.blur();

--- a/frontend/src/metabase/query_builder/components/LimitPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/LimitPopover.jsx
@@ -16,6 +16,9 @@ const CustomRowLimit = ({ limit, onChangeLimit, onClose }) => {
       className={cx({ [cx(CS.textBrand, CS.borderBrand)]: limit != null })}
       placeholder={t`Pick a limit`}
       onKeyPress={(e) => {
+        if (e.nativeEvent.isComposing) {
+          return;
+        }
         if (e.key === "Enter") {
           const value = parseInt(e.target.value, 10);
           if (value > 0) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/completers.unit.spec.tsx
@@ -6,7 +6,7 @@ import { EditorState } from "@codemirror/state";
 import fetchMock from "fetch-mock";
 
 import { mockSettings } from "__support__/settings";
-import { act, renderWithProviders, waitFor } from "__support__/ui";
+import { renderWithProviders, waitFor } from "__support__/ui";
 import { isNotNull } from "metabase/lib/types";
 import type {
   AutocompleteMatchStyle,
@@ -43,27 +43,26 @@ function completer(
     storeInitialState: state,
   });
 
-  return (doc: string) =>
-    act(function () {
-      if (!completer) {
-        return null;
-      }
+  return (doc: string) => {
+    if (!completer) {
+      return null;
+    }
 
-      const cur = doc.indexOf("|");
-      if (cur === -1) {
-        throw new Error("Please use | to indicate the position of the cursor");
-      }
+    const cur = doc.indexOf("|");
+    if (cur === -1) {
+      throw new Error("Please use | to indicate the position of the cursor");
+    }
 
-      doc = doc.slice(0, cur) + doc.slice(cur + 1);
+    doc = doc.slice(0, cur) + doc.slice(cur + 1);
 
-      const state = EditorState.create({
-        doc,
-        selection: { anchor: cur },
-      });
-
-      const ctx = new CompletionContext(state, cur, false);
-      return completer(ctx);
+    const state = EditorState.create({
+      doc,
+      selection: { anchor: cur },
     });
+
+    const ctx = new CompletionContext(state, cur, false);
+    return completer(ctx);
+  };
 }
 
 describe("useSchemaCompletion", () => {

--- a/frontend/src/metabase/query_builder/components/expressions/CombineColumns/ColumnAndSeparatorRow/ColumnInput.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/CombineColumns/ColumnAndSeparatorRow/ColumnInput.tsx
@@ -60,6 +60,9 @@ export function ColumnInput({
   }
 
   function handleKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
     if (event.key === "Enter") {
       setOpen(true);
     }

--- a/frontend/src/metabase/query_builder/components/expressions/NameInput/NameInput.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/NameInput/NameInput.tsx
@@ -26,6 +26,9 @@ export function NameInput({
 
   const handleKeyDown = useCallback(
     (evt: KeyboardEvent<HTMLInputElement>) => {
+      if (evt.nativeEvent.isComposing) {
+        return;
+      }
       if (evt.key === "Enter") {
         onSubmit();
       }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.unit.spec.tsx
@@ -1,4 +1,5 @@
 import type { ComboboxItem, ComboboxItemGroup } from "@mantine/core";
+import { fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
@@ -463,5 +464,17 @@ describe("MultiAutocomplete", () => {
 
     await userEvent.type(input, "on");
     expect(getOption("One")).toBeInTheDocument();
+  });
+
+  it("should not submit the input value during a keyboard composition session (metabase#60630)", async () => {
+    const { input, onChange } = setup();
+    await userEvent.type(input, "foo");
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+    expect(input).toHaveValue("foo");
+    expect(onChange).toHaveBeenLastCalledWith(["foo"]);
+
+    fireEvent.keyDown(input, { key: "Enter", isComposing: false });
+    expect(input).toHaveValue("");
+    expect(onChange).toHaveBeenLastCalledWith(["foo"]);
   });
 });

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
@@ -145,6 +145,9 @@ export function useMultiAutocomplete({
   };
 
   const handleFieldKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
     if (
       event.key === "Enter" &&
       !event.nativeEvent.isComposing &&
@@ -242,6 +245,9 @@ export function useMultiAutocomplete({
   };
 
   const handleWindowKeydownCapture = (event: KeyboardEvent) => {
+    if (event.isComposing) {
+      return;
+    }
     if (event.key === "Escape" && combobox.dropdownOpened) {
       event.stopImmediatePropagation();
       combobox.closeDropdown();

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
@@ -147,6 +147,7 @@ export function useMultiAutocomplete({
   const handleFieldKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
     if (
       event.key === "Enter" &&
+      !event.nativeEvent.isComposing &&
       combobox.selectedOptionIndex < 0 &&
       fieldSelection.length > 0
     ) {

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/PeriodsAgoMenuOption.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/PeriodsAgoMenuOption.tsx
@@ -81,6 +81,9 @@ export function PeriodsAgoMenuOption({
 
   const handleInputEnter = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
       if (e.key === "Enter") {
         onChange({ type, value }, true);
       }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/60630

So it turns out that in almost every case, when we work with keyboard events, we need to ignore such events when `.isComposing` is true.

How to verify:
- Setup the Japanese keyboard
- New -> Question -> Products
- Filter -> Category -> Contains
- Type any Japanese character. Then hit the arrow down key. Select a character with arrow keys. Press `Enter`. The character should be selected but the value should not be submitted. 
- Add more characters like this
- Press Enter. It should submit the value, i.e. it should be added as a "pill".
- Press Enter again. It should submit the filter widget and add the filter to the query.