### PR TITLE
Closes VIZ-1215 more space for pie wells

### DIFF
--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/VisualizationCanvas.tsx
@@ -106,7 +106,7 @@ export function VisualizationCanvas({ className }: VisualizationCanvasProps) {
           <Visualization
             rawSeries={rawSeries}
             // TableInteractive crashes when trying to use metabase-lib
-            isDashboard={display === "table"}
+            isDashboard
           />
         </Box>
 

--- a/frontend/src/metabase/visualizer/components/VisualizationCanvas/wells/VerticalWell/PieVerticalWell.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationCanvas/wells/VerticalWell/PieVerticalWell.tsx
@@ -137,7 +137,7 @@ export const WellBox = forwardRef<HTMLDivElement, WellBoxProps>(
           [S.isActive]: isHighlighted,
         })}
         mih="120px"
-        w="150px"
+        w="250px"
         ref={ref}
       >
         {children}


### PR DESCRIPTION
Closes [VIZ-1215: Column pills in pie chart wells aren’t long enough in many cases](https://linear.app/metabase/issue/VIZ-1215/column-pills-in-pie-chart-wells-arent-long-enough-in-many-cases)

### Description

###### Before
![image](https://github.com/user-attachments/assets/be46c0c4-ec43-42cb-ae41-dcc31b2b316b)
###### After
![image](https://github.com/user-attachments/assets/6cacadcc-60e0-4aac-872e-f6dc4c550198)
