### PR TITLE
Remove broken `lib/aggregation-column`

### DIFF
--- a/frontend/src/metabase-lib/aggregation.ts
+++ b/frontend/src/metabase-lib/aggregation.ts
@@ -65,11 +65,3 @@ export function aggregationClause(
 ): AggregationClause {
   return ML.aggregation_clause(operator, column);
 }
-
-export function aggregationColumn(
-  query: Query,
-  stageIndex: number,
-  aggregation: AggregationClause,
-): ColumnMetadata | null {
-  return ML.aggregation_column(query, stageIndex, aggregation);
-}

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
@@ -147,6 +147,7 @@ export function useMultiAutocomplete({
   const handleFieldKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
     if (
       event.key === "Enter" &&
+      !event.nativeEvent.isComposing &&
       combobox.selectedOptionIndex < 0 &&
       fieldSelection.length > 0
     ) {

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/use-multi-autocomplete/use-multi-autocomplete.ts
@@ -147,7 +147,6 @@ export function useMultiAutocomplete({
   const handleFieldKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
     if (
       event.key === "Enter" &&
-      !event.nativeEvent.isComposing &&
       combobox.selectedOptionIndex < 0 &&
       fieldSelection.length > 0
     ) {

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -431,15 +431,3 @@
   (let [ags (aggregations query stage-number)]
     (when (> (clojure.core/count ags) index)
       (nth ags index))))
-
-(mu/defn aggregation-column :- [:maybe ::lib.schema.metadata/column]
-  "Returns the column consumed by this aggregation, eg. the column being summed.
-
-  Returns nil for aggregations like `[:count]` that don't specify a column."
-  [query                                         :- ::lib.schema/query
-   stage-number                                  :- :int
-   [_operator _opts column-ref :as _aggregation] :- ::lib.schema.aggregation/aggregation]
-  (when column-ref
-    (->> (lib.util/query-stage query stage-number)
-         (lib.metadata.calculation/visible-columns query stage-number)
-         (lib.equality/find-matching-column column-ref))))

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -86,7 +86,6 @@
  [lib.aggregation
   aggregate
   aggregation-clause
-  aggregation-column
   aggregation-ref
   aggregation-operator-columns
   aggregations

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -855,15 +855,6 @@
   [a-query stage-number]
   (to-array (lib.core/aggregations a-query stage-number)))
 
-(defn ^:export aggregation-column
-  "Given an `aggregation-clause` from [[aggregations]], returns the column corresponding to that aggregation.
-
-  Returns `nil` (JS `null`) if the aggregation is one like `:count` that doesn't have a column.
-
-  > **Code health:** Healthy"
-  [a-query stage-number aggregation-clause]
-  (lib.core/aggregation-column a-query stage-number aggregation-clause))
-
 (defn ^:export aggregation-clause
   "Returns a standalone aggregation clause for an `aggregation-operator` and a `column`.
 

--- a/test/metabase/lib/aggregation_test.cljc
+++ b/test/metabase/lib/aggregation_test.cljc
@@ -817,21 +817,6 @@
       1 [:count {}]
       2 nil)))
 
-(deftest ^:parallel aggregation-column-test
-  (let [query      (-> (lib.tu/venues-query)
-                       (lib/breakout  (meta/field-metadata :venues :category-id))
-                       (lib/aggregate (lib/count))
-                       (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
-        price      (m/find-first #(= (:name %) "PRICE") (lib/visible-columns query))
-        aggs       (lib/aggregations query)]
-    (is (= 2
-           (count aggs)))
-    (testing "aggregations like COUNT have no column"
-      (is (nil? (lib.aggregation/aggregation-column query -1 (first aggs)))))
-    (testing "aggregations like SUM return the column of interest"
-      (is (=? price
-              (lib.aggregation/aggregation-column query -1 (second aggs)))))))
-
 (deftest ^:parallel aggregation-operators-update-after-join
   (testing "available operators includes avg and sum once numeric fields are present (#31384)"
     (let [query (lib/query meta/metadata-provider (meta/table-metadata :categories))]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/48567

Aggregations are arbitrary expressions that can contain multiple columns. This API is broken.