### PR TITLE
audit events for tenants

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1301,6 +1301,7 @@
            config
            events
            models
+           notification
            permissions
            premium-features
            request
@@ -1791,6 +1792,7 @@
            settings
            sso
            system
+           tenants
            users
            util
            enterprise/scim}}
@@ -1813,6 +1815,8 @@
   {:team "Admin Webapp"
    :api #{}
    :uses #{api
+           audit-app
+           events
            models
            premium-features
            request

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -14,6 +14,7 @@
    [metabase.session.models.session :as session]
    [metabase.settings.core :as setting]
    [metabase.sso.core :as sso]
+   [metabase.tenants.core :as tenants]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru trs]]
    [metabase.util.malli :as mu]
@@ -35,7 +36,7 @@
 
         (and (nil? existing-tenant)
              (sso-settings/jwt-user-provisioning-enabled?))
-        (t2/insert-returning-pk! :model/Tenant {:slug tenant-slug :name tenant-slug})
+        (u/the-id (tenants/create-tenant! {:slug tenant-slug :name tenant-slug}))
 
         ;; possibilities here:
         ;; - we have an existing, active tenant - return its id

--- a/enterprise/backend/src/metabase_enterprise/tenants/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/core.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.tenants.core
   (:require
+   [metabase-enterprise.tenants.api :as api]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.settings.core :as setting]
    [toucan2.core :as t2]))
@@ -27,3 +28,9 @@
   [tenant-id]
   (or (nil? tenant-id)
       (t2/exists? :model/Tenant :id tenant-id :is_active true)))
+
+(defenterprise create-tenant!
+  "Creates a tenant"
+  :feature :tenants
+  [tenant]
+  (api/create-tenant! tenant))

--- a/enterprise/backend/src/metabase_enterprise/tenants/model.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/model.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.tenants.model
   (:require
+   [metabase.audit-app.core :as audit-app]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
@@ -7,6 +8,10 @@
    [toucan2.core :as t2]))
 
 (methodical/defmethod t2/table-name :model/Tenant [_model] :tenant)
+
+(defmethod audit-app/model-details :model/Tenant
+  [entity _event-type]
+  (select-keys entity [:name :slug :is_active]))
 
 (def Slug
   "The malli schema for a tenant's slug"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -521,16 +521,9 @@
                         (-> (mt/boolean-ids-and-timestamps new-user)
                             (dissoc :last_login))))
                  (testing "User Invite Event is logged."
-                   (is (= {:details  {:email      "newuser@metabase.com"
-                                      :first_name "New"
-                                      :last_name  "User"
-                                      :user_group_memberships [{:id 1}]
-                                      :sso_source "saml"}
-                           :model    "User"
-                           :model_id (:id new-user)
-                           :topic    :user-invited
-                           :user_id  nil}
-                          (mt/latest-audit-log-entry :user-invited (:id new-user))))))
+                   (is (= "newuser@metabase.com"
+                          (get-in (mt/latest-audit-log-entry :user-invited (:id new-user))
+                                  [:details :email])))))
                (testing "attributes"
                  (is (= (some-saml-attributes "newuser")
                         (saml-login-attributes "newuser@metabase.com"))))

--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -248,3 +248,11 @@
 (methodical/defmethod events/publish-event! ::channel-event
   [topic event]
   (audit-log/record-event! topic event))
+
+(derive ::tenant-event ::event)
+(derive :event/tenant-create ::tenant-event)
+(derive :event/tenant-update ::tenant-event)
+
+(methodical/defmethod events/publish-event! ::tenant-event
+  [topic event]
+  (audit-log/record-event! topic event))

--- a/src/metabase/audit_app/models/audit_log.clj
+++ b/src/metabase/audit_app/models/audit_log.clj
@@ -82,11 +82,11 @@
     :user-update               (select-keys (t2/hydrate entity :user_group_memberships)
                                             [:groups :first_name :last_name :email
                                              :invite_method :sso_source
-                                             :user_group_memberships])
+                                             :user_group_memberships :tenant_id])
     :user-invited              (select-keys (t2/hydrate entity :user_group_memberships)
                                             [:groups :first_name :last_name :email
                                              :invite_method :sso_source
-                                             :user_group_memberships])
+                                             :user_group_memberships :tenant_id])
     :password-reset-initiated  (select-keys entity [:token])
     :password-reset-successful (select-keys entity [:token])
     {}))

--- a/src/metabase/tenants/core.clj
+++ b/src/metabase/tenants/core.clj
@@ -21,3 +21,9 @@
   metabase-enterprise.tenants.core
   [tenant-id]
   (nil? tenant-id))
+
+(defenterprise create-tenant!
+  "Throws an exception in OSS because we can't create tenants there."
+  metabase-enterprise.tenants.core
+  [_tenant]
+  (throw (ex-info "Cannot create tenant in OSS." {})))


### PR DESCRIPTION
Pretty much what it says on the tin, audit events for:
- tenant creation, including via auto-provisioning
- tenant updates, including deactivation/reactivation
- user invites, activations, deactivations including `tenant_id`s

[ADM-917: Audit events for tenants](https://linear.app/metabase/issue/ADM-917/audit-events-for-tenants)