### PR TITLE
Fix Lib.isNumeric check 

### DIFF
--- a/frontend/src/metabase-lib/column_types.ts
+++ b/frontend/src/metabase-lib/column_types.ts
@@ -13,16 +13,11 @@ export const isTemporal: TypeFn = TYPES.temporal_QMARK_;
 export const isDateOrDateTime: TypeFn = TYPES.date_or_datetime_QMARK_;
 export const isDateWithoutTime: TypeFn = TYPES.date_without_time_QMARK_;
 export const isInteger: TypeFn = TYPES.integer_QMARK_;
+export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
 export const isString: TypeFn = TYPES.string_QMARK_;
 export const isStringLike: TypeFn = TYPES.string_like_QMARK_;
 export const isStringOrStringLike: TypeFn = TYPES.string_or_string_like_QMARK_;
 export const isTime: TypeFn = TYPES.time_QMARK_;
-
-// Checks for both effective and semantic types. This hack is required to
-// support numbers stored as strings in MySQL until there is a proper
-// coercion strategy. `isString` and `isNumeric` would be both `true` for such
-// columns; that's why `isNumeric` needs to be called first. See #44431.
-export const isNumeric: TypeFn = TYPES.numeric_QMARK_;
 
 // Semantic type checks. A semantic type can be assigned to a column with an
 // unrelated effective type. Do not imply any effective type when checking for a

--- a/frontend/src/metabase-lib/v1/types/constants.ts
+++ b/frontend/src/metabase-lib/v1/types/constants.ts
@@ -37,7 +37,6 @@ export const TYPE_HIERARCHIES = {
   [NUMBER]: {
     base: [TYPE.Number],
     effective: [TYPE.Number],
-    semantic: [TYPE.Number], // MySQL hack! See Lib.isNumeric
   },
   [INTEGER]: {
     base: [TYPE.Integer],

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.unit.spec.jsx
@@ -31,7 +31,7 @@ const setup = (funnelProps, visualizationSettings = {}) => {
             id: 2,
             name: "bar",
             display_name: "bar",
-            semantic_type: "type/Number",
+            effective_type: "type/Number",
           }),
         ],
         rows: [

--- a/src/metabase/lib/types/constants.cljc
+++ b/src/metabase/lib/types/constants.cljc
@@ -38,11 +38,7 @@
   "A front-end specific type hierarchy used by [[metabase.lib.types.isa/field-type?]].
   It is not meant to be used directly."
   {::temporal    {:effective-type [:type/Temporal]}
-   ;; Checks for both effective and semantic types. This hack is required to
-   ;; support numbers stored as strings in MySQL until there is a proper
-   ;; coercion strategy. See #44431.
-   ::number      {:effective-type [:type/Number]
-                  :semantic-type  [:type/Number]}
+   ::number      {:effective-type [:type/Number]}
    ::integer     {:effective-type [:type/Integer]}
    ::string      {:effective-type [:type/Text]}
    ::string_like {:effective-type [:type/TextLike]}

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -148,10 +148,12 @@
             (is (false? (pred (column negative))))))))))
 
 (deftest ^:parallel string?-test
-  #_{:clj-kondo/ignore [:equals-true]}
-  (are [exp column] (= exp (lib.types.isa/string? column))
-    true  {:effective-type :type/Text :semantic-type :type/SerializedJSON}
-    false {:effective-type :type/JSON :semantic-type :type/SerializedJSON}))
+  (is (true? (lib.types.isa/string? {:effective-type :type/Text :semantic-type :type/SerializedJSON})))
+  (is (false? (lib.types.isa/string? {:effective-type :type/JSON :semantic-type :type/SerializedJSON}))))
+
+(deftest ^:parallel numeric?-test
+  (is (true? (lib.types.isa/numeric? {:effective-type :type/Float :semantic-type :type/Price})))
+  (is (false? (lib.types.isa/numeric? {:effective-type :type/Text :semantic-type :type/Price}))))
 
 (deftest ^:parallel valid-filter-for?-test
   #_{:clj-kondo/ignore [:equals-true]}

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -101,7 +101,7 @@
             [{:pred #'lib.types.isa/temporal?,           :positive :type/Date,              :negative :type/CreationDate}
              {:pred #'lib.types.isa/temporal?,           :positive :type/DateTime,          :negative :type/City}
              {:pred #'lib.types.isa/numeric?,            :positive :type/Integer,           :negative :type/FK}
-             {:pred #'lib.types.isa/numeric?,            :positive :type/Price,             :negative :type/CreationDate}
+             {:pred #'lib.types.isa/numeric?,            :positive :type/Float,             :negative :type/Price}
              {:pred #'lib.types.isa/boolean?,            :positive :type/Boolean,           :negative :type/PK}
              {:pred #'lib.types.isa/string?,             :positive :type/Text,              :negative :type/URL}
              {:pred #'lib.types.isa/string-like?,        :positive :type/TextLike,          :negative :type/Address}
@@ -152,6 +152,7 @@
   (is (false? (lib.types.isa/string? {:effective-type :type/JSON :semantic-type :type/SerializedJSON}))))
 
 (deftest ^:parallel numeric?-test
+  (is (true? (lib.types.isa/numeric? {:effective-type :type/Float :semantic-type nil})))
   (is (true? (lib.types.isa/numeric? {:effective-type :type/Float :semantic-type :type/Price})))
   (is (false? (lib.types.isa/numeric? {:effective-type :type/Text :semantic-type :type/Price}))))
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/39855

We offer a coercion strategy for MySQL users now, and do not support overriding the effective type with the semantic type. Now, we need to drop the last piece of hack from the lib.