### PR TITLE
[Lib] Stop passing `:unique-name-fn` as an option

### DIFF
--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -24,7 +24,7 @@ const getEmbeddingSdkAppE2eConfig = async ({
   };
 
   const defaultConfig = {
-    browser: "chrome",
+    browser: "chromium",
     project,
     configFile: "e2e/support/cypress.config.js",
     config: {
@@ -75,7 +75,7 @@ const getHostAppE2eConfig = (suite) => ({
 const configs = {
   e2e: async () => {
     const defaultConfig = {
-      browser: "chrome",
+      browser: "chromium",
       configFile: "e2e/support/cypress.config.js",
       config: {
         baseUrl: getHost(),
@@ -103,7 +103,7 @@ const configs = {
     const { browser } = await parseArguments(args);
 
     const snapshotConfig = {
-      browser: browser ?? "chrome",
+      browser: browser ?? "chromium",
       configFile: "e2e/support/cypress-snapshots.config.js",
       config: {
         baseUrl: getHost(),
@@ -118,7 +118,7 @@ const configs = {
     const { browser } = await parseArguments(args);
 
     const sdkComponentConfig = {
-      browser: browser ?? "chrome",
+      browser: browser ?? "chromium",
       configFile: "e2e/support/cypress-embedding-sdk-component-test.config.js",
       config: {
         baseUrl: getHost(),

--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -24,7 +24,7 @@ const getEmbeddingSdkAppE2eConfig = async ({
   };
 
   const defaultConfig = {
-    browser: "chromium",
+    browser: "chrome",
     project,
     configFile: "e2e/support/cypress.config.js",
     config: {
@@ -75,7 +75,7 @@ const getHostAppE2eConfig = (suite) => ({
 const configs = {
   e2e: async () => {
     const defaultConfig = {
-      browser: "chromium",
+      browser: "chrome",
       configFile: "e2e/support/cypress.config.js",
       config: {
         baseUrl: getHost(),
@@ -103,7 +103,7 @@ const configs = {
     const { browser } = await parseArguments(args);
 
     const snapshotConfig = {
-      browser: browser ?? "chromium",
+      browser: browser ?? "chrome",
       configFile: "e2e/support/cypress-snapshots.config.js",
       config: {
         baseUrl: getHost(),
@@ -118,7 +118,7 @@ const configs = {
     const { browser } = await parseArguments(args);
 
     const sdkComponentConfig = {
-      browser: browser ?? "chromium",
+      browser: browser ?? "chrome",
       configFile: "e2e/support/cypress-embedding-sdk-component-test.config.js",
       config: {
         baseUrl: getHost(),

--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -37,7 +37,7 @@ const {
 } = USER_GROUPS;
 const { admin } = USERS;
 
-describe.skip("snapshots", () => {
+describe("snapshots", () => {
   describe("default", () => {
     it("default", () => {
       snapshot("blank");

--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -37,7 +37,7 @@ const {
 } = USER_GROUPS;
 const { admin } = USERS;
 
-describe("snapshots", () => {
+describe.skip("snapshots", () => {
   describe("default", () => {
     it("default", () => {
       snapshot("blank");

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -258,7 +258,7 @@ function assertTableDataForFilteredTemporalBreakouts() {
   H.assertQueryBuilderRowCount(3);
 }
 
-describe("scenarios > question > multiple column breakouts", () => {
+describe.only("scenarios > question > multiple column breakouts", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();
@@ -1446,7 +1446,7 @@ describe("scenarios > question > multiple column breakouts", () => {
     });
   });
 
-  describe("data source", () => {
+  describe.only("data source", () => {
     describe("notebook", () => {
       it("should be able to add filters for each source column", () => {
         function addDateBetweenFilter({
@@ -1781,8 +1781,8 @@ describe("scenarios > question > multiple column breakouts", () => {
       });
     });
 
-    describe("viz settings", () => {
-      it("should be able to toggle the fields that correspond to breakout columns in the source card", () => {
+    describe.only("viz settings", () => {
+      it.only("should be able to toggle the fields that correspond to breakout columns in the source card", () => {
         function toggleColumn(columnName: string, isVisible: boolean) {
           cy.findByTestId("chartsettings-sidebar").within(() => {
             cy.findAllByLabelText(columnName)

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -258,7 +258,7 @@ function assertTableDataForFilteredTemporalBreakouts() {
   H.assertQueryBuilderRowCount(3);
 }
 
-describe.only("scenarios > question > multiple column breakouts", () => {
+describe("scenarios > question > multiple column breakouts", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();
@@ -1446,7 +1446,7 @@ describe.only("scenarios > question > multiple column breakouts", () => {
     });
   });
 
-  describe.only("data source", () => {
+  describe("data source", () => {
     describe("notebook", () => {
       it("should be able to add filters for each source column", () => {
         function addDateBetweenFilter({
@@ -1781,8 +1781,8 @@ describe.only("scenarios > question > multiple column breakouts", () => {
       });
     });
 
-    describe.only("viz settings", () => {
-      it.only("should be able to toggle the fields that correspond to breakout columns in the source card", () => {
+    describe("viz settings", () => {
+      it("should be able to toggle the fields that correspond to breakout columns in the source card", () => {
         function toggleColumn(columnName: string, isVisible: boolean) {
           cy.findByTestId("chartsettings-sidebar").within(() => {
             cy.findAllByLabelText(columnName)

--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -60,8 +60,7 @@
         query
         stage-number
         (lib.util/query-stage query stage-number)
-        {:unique-name-fn                               (lib.util/unique-name-generator)
-         :include-joined?                              false
+        {:include-joined?                              false
          :include-expressions?                         false
          :include-implicitly-joinable?                 false
          :include-implicitly-joinable-for-source-card? false})

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -389,7 +389,7 @@
    {:metabase.lib.field/binning       :binning
     :metabase.lib.field/temporal-unit :temporal-unit}))
 
-(def ^:private field-ref-propagated-keys-for-non-inherited-colums
+(def ^:private field-ref-propagated-keys-for-non-inherited-columns
   "Keys that should get copied into `:field` ref options from column metadata ONLY when the column is not inherited.
 
     key-in-col-metadata => key-in-opts"
@@ -432,7 +432,7 @@
                                                               (:source-alias metadata))]
                                    {:join-alias source-alias})
                                  (when-not inherited-column?
-                                   (select-renamed-keys metadata field-ref-propagated-keys-for-non-inherited-colums)))
+                                   (select-renamed-keys metadata field-ref-propagated-keys-for-non-inherited-columns)))
         id-or-name        (or (lib.field.util/inherited-column-name metadata)
                               ((some-fn :id :lib/deduplicated-name :lib/original-name :name) metadata))]
     [:field options id-or-name]))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -491,7 +491,7 @@
     stage-number :- :int]
    (:fields (lib.util/query-stage query stage-number))))
 
-(mu/defn fieldable-columns :- [:sequential ::lib.schema.metadata/column]
+(mu/defn fieldable-columns :- ::lib.metadata.calculation/visible-columns
   "Return a sequence of column metadatas for columns that you can specify in the `:fields` of a query. This is
   basically just the columns returned by the source Table/Saved Question/Model or previous query stage.
 

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -89,6 +89,10 @@
 ;;; in [[lib.equality/find-matching-column]], but until I get around to that I'm keeping the old stuff around as a
 ;;; fallback using the `fallback-match-` prefix.
 
+(def ^:private ^:dynamic *recursive-column-resolution-by-name*
+  "Whether we're in a recursive call to [[resolve-column-name]] or not. Prevent infinite recursion (#32063)"
+  false)
+
 (mu/defn- fallback-match-field-name :- [:maybe ::lib.metadata.calculation/column-metadata-with-source]
   "Find the column with `column-name` in a sequence of `column-metadatas`."
   [column-name :- ::lib.schema.common/non-blank-string
@@ -152,10 +156,6 @@
               (fallback-match metadata-providerable field-ref cols))
           (cond-> *debug* (update ::debug.origin (fn [origin]
                                                    (list (list 'resolve-column-in-metadata field-ref :=> origin)))))))
-
-(def ^:private ^:dynamic *recursive-column-resolution-by-name*
-  "Whether we're in a recursive call to [[resolve-column-name]] or not. Prevent infinite recursion (#32063)"
-  false)
 
 (mu/defn- resolve-column-name :- [:maybe ::lib.metadata.calculation/column-metadata-with-source]
   "String column name: get metadata from the previous stage, if it exists, otherwise if this is the first stage and we

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -450,13 +450,13 @@
    ;; not from a join.
    ;;
    ;; resolve the field ID if we can.
-   (let [resolved-for-name (when (and (string? id-or-name)
-                                      (not *recursive-column-resolution-by-name*))
+   (let [resolved-for-name (when (string? id-or-name)
                              (or (resolve-column-name query stage-number field-ref)
                                  ;; if we can't resolve the column with this name we probably won't be able to
                                  ;; calculate much metadata -- assume it comes from the previous stage so we at least
                                  ;; have a value for `:lib/source`.
-                                 (log/warnf "Failed to resolve field ref with name %s in stage %d" (pr-str id-or-name) stage-number)
+                                 (when-not *recursive-column-resolution-by-name*
+                                   (log/warnf "Failed to resolve field ref with name %s in stage %d" (pr-str id-or-name) stage-number))
                                  {:lib/source :source/previous-stage}))
          field-id          (if (integer? id-or-name)
                              id-or-name

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -100,7 +100,7 @@
                         (cond-> *debug* (update ::debug.origin (fn [origin]
                                                                  (list (list 'resolve-column-name-in-metadata column-name :key k :=> origin)))))))
               resolution-keys)
-        (do
+        (when-not *recursive-column-resolution-by-name*
           ;; ideally we shouldn't hit this but if we do it's not the end of the world.
           (log/infof "Couldn't resolve column name %s."
                      (pr-str column-name))
@@ -450,7 +450,8 @@
    ;; not from a join.
    ;;
    ;; resolve the field ID if we can.
-   (let [resolved-for-name (when (string? id-or-name)
+   (let [resolved-for-name (when (and (string? id-or-name)
+                                      (not *recursive-column-resolution-by-name*))
                              (or (resolve-column-name query stage-number field-ref)
                                  ;; if we can't resolve the column with this name we probably won't be able to
                                  ;; calculate much metadata -- assume it comes from the previous stage so we at least

--- a/src/metabase/lib/field/util.cljc
+++ b/src/metabase/lib/field/util.cljc
@@ -30,11 +30,15 @@
       :name)
      column)))
 
-(mu/defn add-deduplicated-names :- [:sequential
-                                    [:merge
-                                     ::lib.schema.metadata/column
-                                     [:map
-                                      [:lib/deduplicated-name :string]]]]
+(mu/defn add-deduplicated-names :- [:or
+                                    ;; zero-arity: transducer
+                                    fn?
+                                    ;; one-arity
+                                    [:sequential
+                                     [:merge
+                                      ::lib.schema.metadata/column
+                                      [:map
+                                       [:lib/deduplicated-name :string]]]]]
   "Add `:lib/original-name` and `:lib/deduplicated-name` to columns if they don't already have them.
 
   The zero arity is a transducer version."

--- a/src/metabase/lib/field/util.cljc
+++ b/src/metabase/lib/field/util.cljc
@@ -48,7 +48,7 @@
             (let [original-name ((some-fn :lib/original-name :name) col)]
               (assoc col
                      :lib/original-name     original-name
-                     :lib/deduplicated-name (deduplicated-name-fn (:name col))))))))
+                     :lib/deduplicated-name (deduplicated-name-fn ((some-fn :lib/deduplicated-name :name) col))))))))
 
   ([cols :- [:sequential ::lib.schema.metadata/column]]
    (into []

--- a/src/metabase/lib/field/util.cljc
+++ b/src/metabase/lib/field/util.cljc
@@ -2,6 +2,8 @@
   "Some small field-related helper functions which are used from a few different namespaces."
   (:require
    [clojure.set :as set]
+   [metabase.lib.join.util :as lib.join.util]
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util :as lib.util]
@@ -28,6 +30,16 @@
       :name)
      column)))
 
+(defn add-deduplicated-names-xform
+  "Transducer version of [[add-deduplicated-names]]."
+  []
+  (let [deduplicated-name-fn (lib.util/non-truncating-unique-name-generator)]
+    (map (fn [col]
+           (let [original-name ((some-fn :lib/original-name :name) col)]
+             (assoc col
+                    :lib/original-name     original-name
+                    :lib/deduplicated-name (deduplicated-name-fn (:name col))))))))
+
 (mu/defn add-deduplicated-names :- [:sequential
                                     [:merge
                                      ::lib.schema.metadata/column
@@ -35,17 +47,25 @@
                                       [:lib/deduplicated-name :string]]]]
   "Add `:lib/original-name` and `:lib/deduplicated-name` to columns if they don't already have them."
   [cols :- [:sequential ::lib.schema.metadata/column]]
-  (let [deduplicated-name-fn (lib.util/non-truncating-unique-name-generator)]
-    (mapv (if (every? :lib/deduplicated-name cols)
-            ;; just double-check that they're deduplicated.
-            (fn [col]
-              (update col :lib/deduplicated-name deduplicated-name-fn))
-            (fn [col]
-              (let [original-name ((some-fn :lib/original-name :name) col)]
-                (assoc col
-                       :lib/original-name     original-name
-                       :lib/deduplicated-name (deduplicated-name-fn (:name col))))))
-          cols)))
+  (into []
+        (add-deduplicated-names-xform)
+        cols))
+
+(mu/defn add-source-and-desired-aliases-xform :- fn?
+  "Transducer to add `:lib/source-column-alias`, `:lib/desired-column-alias`, `:lib/original-name`, and
+  `:lib/deduplicated-name` to a sequence of columns.
+
+    (into [] (add-unique-names-xform) cols)"
+  [metadata-providerable :- ::lib.metadata.protocols/metadata-providerable]
+  (comp (add-deduplicated-names-xform)
+        (let [unique-name-fn (lib.util/unique-name-generator)]
+          (map (fn [col]
+                 (let [source-alias  ((some-fn :lib/source-column-alias :name) col)
+                       desired-alias (unique-name-fn
+                                      (lib.join.util/desired-alias metadata-providerable col))]
+                   (assoc col
+                          :lib/source-column-alias  source-alias
+                          :lib/desired-column-alias desired-alias)))))))
 
 (defn update-keys-for-col-from-previous-stage
   "For a column that came from a previous stage, change the keys for things that mean 'this happened in the current

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -8,6 +8,7 @@
    [metabase.lib.common :as lib.common]
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.equality :as lib.equality]
+   [metabase.lib.field.util :as lib.field.util]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.filter.operator :as lib.filter.operator]
    [metabase.lib.hierarchy :as lib.hierarchy]
@@ -266,20 +267,6 @@
            :display-name (lib.metadata.calculation/display-name query stage-number option)}
     default (assoc :default true)))
 
-(mu/defn- add-source-and-desired-aliases :- :map
-  [join           :- [:map
-                      [:alias
-                       {:error/message "Join must have an alias to determine column aliases!"}
-                       ::lib.schema.common/non-blank-string]]
-   unique-name-fn :- ::lib.metadata.calculation/unique-name-fn
-   col            :- :map]
-  (let [source-column-alias ((some-fn :lib/source-column-alias :name) col)]
-    (assoc col
-           :lib/source-column-alias  source-column-alias
-           :lib/desired-column-alias (unique-name-fn (lib.join.util/joined-field-desired-alias
-                                                      (:alias join)
-                                                      source-column-alias)))))
-
 (mu/defn- adjust-ident :- :map
   [join :- [:map
             [:ident
@@ -295,63 +282,60 @@
 ;;; things to get added to the parent stage `:fields`! See QUE-1380
 ;;;
 ;;; If you want just the stuff in `:fields`, use [[join-fields-to-add-to-parent-stage]] instead.
-(mu/defmethod lib.metadata.calculation/returned-columns-method :mbql/join :- [:maybe [:sequential ::lib.schema.metadata/column]]
-  [query
-   stage-number
-   {:keys [stages], join-alias :alias, :as join}
-   {:keys [unique-name-fn], :as options} :- [:map
-                                             [:unique-name-fn ::lib.metadata.calculation/unique-name-fn]]]
+(mu/defmethod lib.metadata.calculation/returned-columns-method :mbql/join :- [:maybe ::lib.metadata.calculation/returned-columns]
+  [query                                         :- ::lib.schema/query
+   stage-number                                  :- :int
+   {:keys [stages], join-alias :alias, :as join} :- ::lib.schema.join/join
+   options                                       :- [:maybe ::lib.metadata.calculation/returned-columns.options]]
   (let [join-query (assoc query :stages stages)
         cols       (lib.metadata.calculation/returned-columns
                     join-query -1 (lib.util/query-stage join-query -1)
-                    (assoc options
-                           ;; make sure we don't 'poison the well' by using our unique name function recursively.
-                           ;; Calling with zero args creates a 'fresh' generator. [[add-source-and-desired-aliases]]
-                           ;; will deduplicate them for reals.
-                           :unique-name-fn (unique-name-fn)))]
-    (mapv (fn [col]
-            (->> (column-from-join query stage-number col join-alias)
-                 (adjust-ident join)
-                 (add-source-and-desired-aliases join unique-name-fn)))
+                    options)]
+    (into []
+          (comp (map #(column-from-join query stage-number % join-alias))
+                (map #(adjust-ident join %))
+                (lib.field.util/add-source-and-desired-aliases-xform query))
           cols)))
 
-(mu/defn join-fields-to-add-to-parent-stage
+(mu/defn join-fields-to-add-to-parent-stage :- [:maybe [:sequential ::lib.metadata.calculation/column-metadata-with-source]]
   "The resolved `:fields` from a join, which we automatically append to the parent stage's `:fields`."
   [query
    stage-number
    {:keys [fields stages], join-alias :alias, :or {fields :none}, :as join}
-   {:keys [unique-name-fn], :as options} :- [:map
-                                             [:unique-name-fn ::lib.metadata.calculation/unique-name-fn]]]
+   options :- [:maybe ::lib.metadata.calculation/returned-columns.options]]
   (when-not (= fields :none)
-    (let [cols  (lib.metadata.calculation/returned-columns query stage-number join (assoc options :unique-name-fn (unique-name-fn)))
-          cols' (if (= fields :all)
-                  cols
-                  (for [field-ref fields
-                        :let [match (or (lib.equality/find-matching-column field-ref cols)
-                                        (log/warnf "Failed to find matching column in join %s for ref %s, found:\n%s"
-                                                   (pr-str join-alias)
-                                                   (pr-str field-ref)
-                                                   (u/pprint-to-str cols)))]
-                        :when match]
-                    (assoc match :lib/source-uuid (lib.options/uuid field-ref))))
+    (let [cols   (lib.metadata.calculation/returned-columns query stage-number join options)
+          cols'  (if (= fields :all)
+                   cols
+                   (for [field-ref fields
+                         :let      [match (or (lib.equality/find-matching-column field-ref cols)
+                                              (log/warnf "Failed to find matching column in join %s for ref %s, found:\n%s"
+                                                         (pr-str join-alias)
+                                                         (pr-str field-ref)
+                                                         (u/pprint-to-str cols)))]
+                         :when     match]
+                     (assoc match :lib/source-uuid (lib.options/uuid field-ref))))
           ;; If there was a `:fields` clause but none of them matched the `join-cols` then pretend it was `:fields :all`
           ;; instead. That can happen if a model gets reworked and an old join clause remembers the old fields.
-          cols' (if (empty? cols') cols cols')]
-      ;; add any remaps for the fields as needed.
-      (for [col (concat
-                 cols'
-                 (lib.metadata.calculation/remapped-columns
-                  (assoc query :stages stages)
-                  0 cols' (assoc options :unique-name-fn (unique-name-fn))))]
-        (->> (column-from-join query stage-number col join-alias)
-             (adjust-ident join)
-             (add-source-and-desired-aliases join unique-name-fn))))))
+          cols'  (if (empty? cols') cols cols')
+          ;; add any remaps for the fields as needed.
+          cols'' (concat
+                  cols'
+                  (lib.metadata.calculation/remapped-columns
+                   (assoc query :stages stages)
+                   0
+                   cols'
+                   options))]
+      (into []
+            (comp (map #(column-from-join query stage-number % join-alias))
+                  (map #(adjust-ident join %)))
+            cols''))))
 
 (defmethod lib.metadata.calculation/visible-columns-method :mbql/join
   [query stage-number join options]
   (lib.metadata.calculation/returned-columns query stage-number (assoc join :fields :all) options))
 
-(mu/defn all-joins-visible-columns :- ::lib.metadata.calculation/columns-with-unique-aliases
+(mu/defn all-joins-visible-columns :- ::lib.metadata.calculation/visible-columns
   "Convenience for calling [[lib.metadata.calculation/visible-columns]] on all of the joins in a query stage."
   [query          :- ::lib.schema/query
    stage-number   :- :int
@@ -361,15 +345,15 @@
                   (lib.metadata.calculation/visible-columns
                    query stage-number join
                    (-> options
-                       (select-keys [:unique-name-fn :include-remaps?]) ; WHY
+                       (select-keys [:include-remaps?]) ; WHY
                        (assoc :include-implicitly-joinable? false)))))
         (:joins (lib.util/query-stage query stage-number))))
 
-(mu/defn all-joins-fields-to-add-to-parent-stage :- ::lib.metadata.calculation/columns-with-unique-aliases
+(mu/defn all-joins-fields-to-add-to-parent-stage :- ::lib.metadata.calculation/returned-columns
   "Convenience for calling [[lib.metadata.calculation/returned-columns-method]] on all the joins in a query stage."
   [query        :- ::lib.schema/query
    stage-number :- :int
-   options      :- ::lib.metadata.calculation/returned-columns.options]
+   options      :- [:maybe ::lib.metadata.calculation/returned-columns.options]]
   (into []
         (mapcat (fn [join]
                   (join-fields-to-add-to-parent-stage query stage-number join options)))
@@ -968,17 +952,11 @@
 
 (defn- xform-add-join-alias [a-join]
   (let [join-alias (lib.join.util/current-join-alias a-join)]
-    (fn [xf]
-      (let [unique-name-fn (lib.util/unique-name-generator)]
-        (fn
-          ([] (xf))
-          ([result] (xf result))
-          ([result input]
-           (as-> input col
-             (with-join-alias col join-alias)
-             (assoc col :source-alias join-alias) ; TODO (Cam 6/25/25) -- remove `:source-alias` since it is busted
-             (add-source-and-desired-aliases a-join unique-name-fn col)
-             (xf result col))))))))
+    (map (fn [col]
+           (-> col
+               (with-join-alias join-alias)
+               ;; TODO (Cam 6/25/25) -- remove `:source-alias` since it is busted
+               (assoc :source-alias join-alias))))))
 
 (defn- xform-mark-selected-joinable-columns
   "Mark the column metadatas in `cols` as `:selected` if they appear in `a-join`'s `:fields`."
@@ -992,7 +970,9 @@
 (def ^:private xform-fix-source-for-joinable-columns
   (map #(assoc % :lib/source :source/joins)))
 
-(mu/defn joinable-columns :- [:sequential ::lib.schema.metadata/column]
+;;; TODO (Cam 7/8/25) -- this is a confusing name. `join-fieldable-columns` would be consistent
+;;; with [[metabase.lib.field/fieldable-columns]] and be less confusing
+(mu/defn joinable-columns :- ::lib.metadata.calculation/visible-columns
   "Return information about the fields that you can pass to [[with-join-fields]] when constructing a join against
   something [[Joinable]] (i.e., a Table or Card) or manipulating an existing join. When passing in a join, currently
   selected columns (those in the join's `:fields`) will include `:selected true` information."

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1386,6 +1386,9 @@
                    ;; Unique names are required by the FE for compatibility.
                    ;; This applies only for JS; Clojure usage should prefer `:lib/desired-column-alias` to `:name`, and
                    ;; that's already unique by construction.
+                   ;;
+                   ;; TODO (Cam 7/8/25) -- shouldn't this use `:lib/deduplicate-name` or something?? Shouldn't we do
+                   ;; this generally everywhere? (Also, we're already doing this in the `returned-columns-method`
                    (update :name unique-name-fn)))
          to-array)))
 

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -655,7 +655,12 @@
     (into []
           (mapcat (fn [{:keys [table-id], ::keys [fk-ident fk-field-id fk-field-name fk-join-alias]}]
                     (let [table-metadata (id->table table-id)
-                          ;; TODO (Cam 7/8/25) -- shouldn't we be forwarding the rest of the `options` as well?
+                          ;; Shouldn't we be forwarding the rest of the `options` as well? -- Cam
+                          ;;
+                          ;; I wouldn't say so. This is deliberately minimal, including only the core/default columns
+                          ;; for an implicit join. In practice since implicit joins are only to tables (or cards, in
+                          ;; the future) the other options (including joins, expressions, etc.) are not relevant. It's
+                          ;; always the table's columns, or the returned-columns of the card. -- Braden
                           options        {:include-implicitly-joinable? false}]
                       (for [field (visible-columns-method query stage-number table-metadata options)
                             :let  [ident (lib.metadata.ident/implicitly-joined-ident (:ident field) fk-ident)]]

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -23,7 +23,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
 
-(def DisplayNameStyle
+(mr/def ::display-name-style
   "Schema for valid values of `display-name-style` as passed to [[display-name-method]].
 
   * `:default`: normal style used for 99% of FE stuff. For example a column that comes from a joined table might return
@@ -52,7 +52,7 @@
   :hierarchy lib.hierarchy/hierarchy)
 
 (mu/defn ^:export display-name :- :string
-  "Calculate a nice human-friendly display name for something. See [[DisplayNameStyle]] for a the difference between
+  "Calculate a nice human-friendly display name for something. See [[::display-name-style]] for a the difference between
   different `style`s."
   ([query]
    (display-name query query))
@@ -66,7 +66,7 @@
   ([query        :- ::lib.schema/query
     stage-number :- :int
     x
-    style        :- DisplayNameStyle]
+    style        :- ::display-name-style]
    (or
     ;; if this is an MBQL clause with `:display-name` in the options map, then use that rather than calculating a name.
     ((some-fn :display-name :lib/expression-name) (lib.options/options x))

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -7,7 +7,6 @@
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.field.util :as lib.field.util]
    [metabase.lib.hierarchy :as lib.hierarchy]
-   [metabase.lib.join.util :as lib.join.util]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.ident :as lib.metadata.ident]
    [metabase.lib.options :as lib.options]
@@ -419,19 +418,22 @@
    [:map
     [:lib/source ::lib.schema.metadata/column.source]]])
 
-(mr/def ::columns-with-unique-aliases
-  "Schema for column metadata that should be returned by [[visible-columns]]. This is mostly used
-  to power metadata calculation for stages (see [[metabase.lib.stage]]."
+(mr/def ::returned-column
+  [:merge
+   ;; visible column is just the normal column metadata schema but also requires `:lib/source` and
+   ;; `:lib/source-column-alias`
+   [:ref ::visible-column]
+   [:map
+    [:lib/desired-column-alias ::lib.schema.metadata/desired-column-alias]]])
+
+(mr/def ::returned-columns
+  "Schema for column metadata that should be returned by [[returned-columns]] and implementations
+  of [[returned-columns-method]]."
   [:and
-   [:sequential
-    [:merge
-     [:ref ::column-metadata-with-source]
-     [:map
-      [:lib/source-column-alias  ::lib.schema.metadata/source-column-alias]
-      [:lib/desired-column-alias ::lib.schema.metadata/desired-column-alias]]]]
+   [:sequential ::returned-column]
    [:fn
     ;; should be dev-facing only, so don't need to i18n
-    {:error/message "Column :lib/desired-column-alias values must be distinct, regardless of case, for each stage!"
+    {:error/message "Column :lib/desired-column-alias values must be distinct for each stage!"
      :error/fn      (fn [{:keys [value]} _]
                       (str "Column :lib/desired-column-alias values must be distinct, got: "
                            (pr-str (mapv :lib/desired-column-alias value))))}
@@ -440,26 +442,14 @@
        (empty? columns)
        (apply distinct? (map :lib/desired-column-alias columns))))]])
 
-(mr/def ::unique-name-fn
-  "Stateful function with the signature
-
-    (f str) => unique-str
-
-  i.e. repeated calls with the same string should return different unique strings."
-  [:=>
-   [:cat :string] ; this is allowed to be a blank string.
-   ::lib.schema.common/non-blank-string])
-
 (mr/def ::returned-columns.options
   "Schema for options passed to [[returned-columns]] and [[returned-columns-method]]."
-  [:map
-   [:include-remaps? {:optional true, :default false} :boolean]
-   ;; has the signature (f str) => str
-   [:unique-name-fn {:optional true} ::unique-name-fn]])
-
-(mu/defn- default-returned-columns-options :- ::returned-columns.options
-  []
-  {:unique-name-fn (lib.util/unique-name-generator)})
+  [:and
+   [:map
+    [:include-remaps? {:optional true, :default false} :boolean]]
+   [:fn
+    {:error/message "unique-name-fn is no longer allowed as an option."}
+    (complement :unique-name-fn)]])
 
 (defmulti returned-columns-method
   "Impl for [[returned-columns]]."
@@ -494,12 +484,12 @@
   The value is used in [[metabase.lib.field.resolution/resolve-field-ref]]."
   false)
 
-(mu/defn returned-columns :- [:maybe ::columns-with-unique-aliases]
+(mu/defn returned-columns :- [:maybe ::returned-columns]
   "Return a sequence of metadata maps for all the columns expected to be 'returned' at a query, stage of the query, or
   join, and include the `:lib/source` of where they came from. This should only include columns that will be present
   in the results; DOES NOT include 'expected' columns that are not 'exported' to subsequent stages.
 
-  See [[ReturnedColumnsOptions]] for allowed options and [[default-returned-columns-options]] for default values."
+  See [[::returned-columns.options]] for allowed options."
   ([query]
    (returned-columns query (lib.util/query-stage query -1)))
 
@@ -513,9 +503,19 @@
     stage-number   :- :int
     x
     options        :- [:maybe ::returned-columns.options]]
-   (let [options (merge (default-returned-columns-options) options)]
-     (binding [*propagate-binning-and-bucketing* true]
-       (returned-columns-method query stage-number x options)))))
+   (binding [*propagate-binning-and-bucketing* true]
+     (returned-columns-method query stage-number x options))))
+
+(mr/def ::visible-column
+  [:merge
+   [:ref ::column-metadata-with-source]
+   [:map
+    [:lib/source-column-alias ::lib.schema.metadata/source-column-alias]]])
+
+(mr/def ::visible-columns
+  "Schema for column metadata that should be returned by [[visible-columns]] and implementations
+  of [[visible-columns-method]]."
+  [:sequential ::visible-column])
 
 (mr/def ::visible-columns.options
   "Schema for options passed to [[visible-columns]] and [[visible-columns-method]]."
@@ -530,23 +530,13 @@
 
 (mu/defn- default-visible-columns-options :- ::visible-columns.options
   []
-  (merge
-   (default-returned-columns-options)
-   {:include-joined?                              true
-    :include-expressions?                         true
-    :include-implicitly-joinable?                 true
-    :include-implicitly-joinable-for-source-card? true}))
+  {:include-joined?                              true
+   :include-expressions?                         true
+   :include-implicitly-joinable?                 true
+   :include-implicitly-joinable-for-source-card? true})
 
 (defmulti visible-columns-method
-  "Impl for [[visible-columns]].
-
-  This should mostly be similar to the implementation for [[metadata-method]], but needs to include
-  `:lib/source-column-alias` and `:lib/desired-column-alias`. `:lib/source-column-alias` should probably be the same
-  as `:name`; use the supplied `:unique-name-fn` from `options` with the signature `(f str) => str` to ensure
-  `:lib/desired-column-alias` is unique.
-
-  Also, columns that aren't 'projected' should be returned as well -- in other words, ignore `:fields`,
-  `:aggregations`, and `:breakouts`."
+  "Impl for [[visible-columns]]."
   {:arglists '([query stage-number x options])}
   (fn [_query _stage-number x _options]
     (lib.dispatch/dispatch-value x))
@@ -566,7 +556,7 @@
   [query _stage-number stage-number options]
   (visible-columns-method query stage-number (lib.util/query-stage query stage-number) options))
 
-(mu/defn visible-columns :- ::columns-with-unique-aliases
+(mu/defn visible-columns :- ::visible-columns
   "Return a sequence of columns that should be visible *within* a given stage of something, e.g. a query stage or a
   join query. This includes not just the columns that get returned (ones present in [[metadata]], but other columns
   that are 'reachable' in this stage of the query. E.g. in a query like
@@ -605,13 +595,12 @@
                                                       :target       x
                                                       :options      options})))))
 
-(mu/defn remapped-columns
+(mu/defn remapped-columns :- [:maybe ::visible-columns]
   "Given a seq of columns, return metadata for any remapped columns, if the `:include-remaps?` option is set."
-  [query :- map?
-   stage-number
-   source-cols
-   {:keys [include-remaps? unique-name-fn] :as _options} :- [:map
-                                                             [:unique-name-fn ::unique-name-fn]]]
+  [query                                  :- ::lib.schema/query
+   stage-number                           :- :int
+   source-cols                            :- [:maybe [:sequential ::lib.schema.metadata/column]]
+   {:keys [include-remaps?] :as _options} :- [:maybe ::returned-columns.options]]
   (when (and include-remaps?
              (lib.util/first-stage? query stage-number))
     (let [existing-ids (into #{} (keep :id) source-cols)]
@@ -620,12 +609,9 @@
             :when  (and remapped
                         (not (existing-ids (:id remapped))))]
         (assoc remapped
-               :lib/source               (:lib/source column) ;; TODO: What's the right source for a remap?
-               :lib/source-column-alias  (column-name query stage-number remapped)
-               :lib/hack-original-name   (or ((some-fn :lib/hack-original-name :name) column)
-                                             (:name remapped))
-               :lib/desired-column-alias (unique-name-fn (lib.join.util/desired-alias query remapped))
-               :ident                    (lib.metadata.ident/remap-ident (:ident remapped) (:ident column)))))))
+               :lib/source              (:lib/source column) ; TODO: What's the right source for a remap?
+               :lib/source-column-alias ((some-fn :lib/source-column-alias :name) remapped)
+               :ident                   (lib.metadata.ident/remap-ident (:ident remapped) (:ident column)))))))
 
 (mu/defn primary-keys :- [:sequential ::lib.schema.metadata/column]
   "Returns a list of primary keys for the source table of this query."
@@ -644,7 +630,7 @@
   Does not include columns from any Tables that are already explicitly joined.
 
   Does not include columns that would be implicitly joinable via multiple hops."
-  [query stage-number column-metadatas unique-name-fn]
+  [query stage-number column-metadatas]
   (let [remap-target-ids (into #{} (keep (comp :field-id :lib/external-remap)) column-metadatas)
         existing-table-ids (into #{} (comp (remove (comp remap-target-ids :id))
                                            (map :table-id))
@@ -669,22 +655,20 @@
     (into []
           (mapcat (fn [{:keys [table-id], ::keys [fk-ident fk-field-id fk-field-name fk-join-alias]}]
                     (let [table-metadata (id->table table-id)
-                          options        {:unique-name-fn               unique-name-fn
-                                          :include-implicitly-joinable? false}]
+                          ;; TODO (Cam 7/8/25) -- shouldn't we be forwarding the rest of the `options` as well?
+                          options        {:include-implicitly-joinable? false}]
                       (for [field (visible-columns-method query stage-number table-metadata options)
-                            :let  [ident (lib.metadata.ident/implicitly-joined-ident (:ident field) fk-ident)
-                                   field (m/assoc-some field
-                                                       :ident                    ident
-                                                       :fk-field-id              fk-field-id
-                                                       :fk-field-name            fk-field-name
-                                                       :fk-join-alias            fk-join-alias
-                                                       :lib/source               :source/implicitly-joinable
-                                                       :lib/source-column-alias  (:name field))]]
-                        (assoc field :lib/desired-column-alias (unique-name-fn
-                                                                (lib.join.util/desired-alias query field)))))))
+                            :let  [ident (lib.metadata.ident/implicitly-joined-ident (:ident field) fk-ident)]]
+                        (m/assoc-some field
+                                      :ident                    ident
+                                      :fk-field-id              fk-field-id
+                                      :fk-field-name            fk-field-name
+                                      :fk-join-alias            fk-join-alias
+                                      :lib/source               :source/implicitly-joinable
+                                      :lib/source-column-alias  (:name field))))))
           target-fields)))
 
-(mu/defn default-columns-for-stage :- ::columns-with-unique-aliases
+(mu/defn default-columns-for-stage :- ::returned-columns
   "Given a query and stage, returns the columns which would be selected by default.
 
   This is exactly [[lib.metadata.calculation/returned-columns]] filtered by the `:lib/source`.

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -315,8 +315,7 @@
                            query
                            -1
                            (lib.util/query-stage query -1)
-                           {:unique-name-fn  (lib.util/non-truncating-unique-name-generator)
-                            :include-remaps? (not (get-in query [:middleware :disable-remaps?]))}))
+                           {:include-remaps? (not (get-in query [:middleware :disable-remaps?]))}))
           ;; generate barebones cols if lib was unable to calculate metadata here.
           lib-cols (if (empty? lib-cols)
                      (mapv basic-native-col initial-cols)

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -706,7 +706,7 @@
 
     (lib.equality/matching-column-sets?
      query stage-number (:fields join)
-     (lib.join/join-fields-to-add-to-parent-stage query stage-number (assoc join :fields :all) {:unique-name-fn (lib.util/unique-name-generator)}))
+     (lib.join/join-fields-to-add-to-parent-stage query stage-number (assoc join :fields :all) nil))
     (assoc join :fields :all)
 
     :else join))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -48,17 +48,16 @@
                                   (lib.metadata.calculation/returned-columns query
                                                                              stage-number
                                                                              (lib.util/query-stage query stage-number)
-                                                                             (dissoc options :unique-name-fn))))
+                                                                             options)))
    query
    (range 0 (lib.util/canonical-stage-index query stage-number))))
 
-(mu/defn- existing-stage-metadata :- [:maybe ::lib.metadata.calculation/columns-with-unique-aliases]
+(mu/defn- existing-stage-metadata :- [:maybe ::lib.metadata.calculation/returned-columns]
   "Return existing stage metadata attached to a stage if is already present: return it as-is, but only if this is a
   native stage or a source-Card or a metric stage. If it's any other sort of stage then ignore the metadata, it's
   probably wrong; we can recalculate the correct metadata anyway."
   [query        :- ::lib.schema/query
-   stage-number :- :int
-   unique-name-fn :- ::lib.metadata.calculation/unique-name-fn]
+   stage-number :- :int]
   (let [{stage-type :lib/type, :keys [source-card] :as stage} (lib.util/query-stage query stage-number)]
     (or (::cached-metadata stage)
         (when-let [metadata (:lib/stage-metadata stage)]
@@ -68,86 +67,68 @@
                                 :mbql.stage/native :source/native
                                 :mbql.stage/mbql   :source/card)]
               (not-empty
-               (for [col (:columns metadata)]
-                 (-> (merge
-                      {:lib/source-column-alias  (:name col)
-                       :lib/desired-column-alias (:name col)}
-                      col
-                      {:lib/source source-type})
-                     (update :lib/desired-column-alias unique-name-fn))))))))))
+               (into []
+                     (comp (map #(assoc % :lib/source source-type))
+                           (lib.field.util/add-source-and-desired-aliases-xform query))
+                     (:columns metadata)))))))))
 
-(mu/defn- breakouts-columns :- [:maybe ::lib.metadata.calculation/columns-with-unique-aliases]
-  [query                                :- ::lib.schema/query
-   stage-number                         :- :int
-   {:keys [unique-name-fn] :as options} :- ::lib.metadata.calculation/returned-columns.options]
-  (let [cols (for [breakout (lib.breakout/breakouts-metadata query stage-number)]
-               (assoc breakout
-                      :lib/source-column-alias  ((some-fn :lib/source-column-alias :name) breakout)
-                      :lib/hack-original-name   ((some-fn :lib/hack-original-name :name) breakout)
-                      :lib/desired-column-alias (unique-name-fn (lib.join.util/desired-alias query breakout))))]
-    (not-empty (concat cols
-                       (lib.metadata.calculation/remapped-columns query stage-number cols options)))))
+(mu/defn- breakouts-columns :- [:maybe [:sequential ::lib.metadata.calculation/column-metadata-with-source]]
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   options      :- [:maybe ::lib.metadata.calculation/returned-columns.options]]
+  (let [cols (lib.breakout/breakouts-metadata query stage-number)]
+    (not-empty
+     (concat
+      cols
+      (lib.metadata.calculation/remapped-columns query stage-number cols options)))))
 
-(mu/defn- aggregations-columns :- [:maybe ::lib.metadata.calculation/columns-with-unique-aliases]
-  [query                    :- ::lib.schema/query
-   stage-number             :- :int
-   {:keys [unique-name-fn]} :- ::lib.metadata.calculation/returned-columns.options]
+(mu/defn- aggregations-columns :- [:maybe [:sequential ::lib.metadata.calculation/column-metadata-with-source]]
+  [query        :- ::lib.schema/query
+   stage-number :- :int]
   (not-empty
    (for [ag (lib.aggregation/aggregations-metadata query stage-number)]
-     (assoc ag
-            :lib/source               :source/aggregations
-            :lib/source-column-alias  (:name ag)
-            :lib/hack-original-name   ((some-fn :lib/hack-original-name :name) ag)
-            :lib/desired-column-alias (unique-name-fn (:name ag))))))
+     (assoc ag :lib/source :source/aggregations))))
 
 ;;; TODO -- maybe the bulk of this logic should be moved into [[metabase.lib.field]], like we did for breakouts and
 ;;; aggregations above.
-(mu/defn- fields-columns :- [:maybe ::lib.metadata.calculation/columns-with-unique-aliases]
-  [query                                :- ::lib.schema/query
-   stage-number                         :- :int
-   {:keys [unique-name-fn] :as options} :- ::lib.metadata.calculation/returned-columns.options]
+(mu/defn- fields-columns :- [:maybe [:sequential ::lib.metadata.calculation/column-metadata-with-source]]
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   options      :- [:maybe ::lib.metadata.calculation/returned-columns.options]]
   (when-let [{fields :fields} (lib.util/query-stage query stage-number)]
     (-> (for [[tag :as ref-clause] fields
-              :let                 [metadata (lib.metadata.calculation/metadata query stage-number ref-clause)]]
-          (merge metadata
-                 (when (= tag :expression)
-                   {:lib/source :source/expressions})
-                 {:lib/source-column-alias  (lib.metadata.calculation/column-name query stage-number metadata)
-                  :lib/desired-column-alias (unique-name-fn (lib.join.util/desired-alias query metadata))}))
+              :let                 [col (lib.metadata.calculation/metadata query stage-number ref-clause)]]
+          (cond-> col
+            (= tag :expression) (assoc :lib/source :source/expressions)))
         (as-> $cols (concat $cols (lib.metadata.calculation/remapped-columns query stage-number $cols options)))
         not-empty)))
 
-(mu/defn- summary-columns :- [:maybe ::lib.metadata.calculation/columns-with-unique-aliases]
+(mu/defn- summary-columns :- [:maybe [:sequential ::lib.metadata.calculation/column-metadata-with-source]]
   [query        :- ::lib.schema/query
    stage-number :- :int
-   options      :- ::lib.metadata.calculation/returned-columns.options]
+   options      :- [:maybe ::lib.metadata.calculation/returned-columns.options]]
   (not-empty
-   (into []
-         (mapcat (fn [f]
-                   (f query stage-number options)))
-         [breakouts-columns
-          aggregations-columns])))
+   (concat
+    (breakouts-columns query stage-number options)
+    (aggregations-columns query stage-number))))
 
-(mu/defn- previous-stage-metadata :- [:maybe ::lib.metadata.calculation/columns-with-unique-aliases]
+(mu/defn- previous-stage-metadata :- [:maybe ::lib.metadata.calculation/returned-columns]
   "Metadata for the previous stage, if there is one."
-  [query                                :- ::lib.schema/query
-   stage-number                         :- :int
-   {:keys [unique-name-fn] :as options} :- ::lib.metadata.calculation/returned-columns.options]
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   options      :- [:maybe ::lib.metadata.calculation/returned-columns.options]]
   (when-let [previous-stage-number (lib.util/previous-stage-number query stage-number)]
     (not-empty
-     (for [col  (lib.metadata.calculation/returned-columns query
-                                                           previous-stage-number
-                                                           (lib.util/query-stage query previous-stage-number)
-                                                           (dissoc options :unique-name-fn))
-           :let [source-alias (or ((some-fn :lib/desired-column-alias :lib/source-column-alias) col)
-                                  (lib.metadata.calculation/column-name query stage-number col))]]
-       (merge
-        (lib.field.util/update-keys-for-col-from-previous-stage col)
-        {:lib/source               :source/previous-stage
-         :lib/source-column-alias  source-alias
-         :lib/desired-column-alias (unique-name-fn source-alias)})))))
+     (into []
+           (comp (map lib.field.util/update-keys-for-col-from-previous-stage)
+                 (map #(assoc % :lib/source :source/previous-stage))
+                 (lib.field.util/add-source-and-desired-aliases-xform query))
+           (lib.metadata.calculation/returned-columns query
+                                                      previous-stage-number
+                                                      (lib.util/query-stage query previous-stage-number)
+                                                      options)))))
 
-(mu/defn- saved-question-visible-columns :- [:maybe ::lib.metadata.calculation/columns-with-unique-aliases]
+(mu/defn- saved-question-visible-columns :- [:maybe ::lib.metadata.calculation/visible-columns]
   "Metadata associated with a Saved Question, e.g. if we have a `:source-card`"
   [query          :- ::lib.schema/query
    stage-number   :- :int
@@ -157,7 +138,7 @@
     (when-let [card (lib.metadata/card query card-id)]
       (not-empty (lib.metadata.calculation/visible-columns query stage-number card options)))))
 
-(mu/defn- metric-metadata :- [:maybe ::lib.metadata.calculation/columns-with-unique-aliases]
+(mu/defn- metric-metadata :- [:maybe ::lib.metadata.calculation/returned-columns]
   [query         :- ::lib.schema/query
    _stage-number :- :int
    card          :- ::lib.schema.metadata/card
@@ -170,25 +151,21 @@
                 (lib.util/query-stage metric-query -1)
                 options))))
 
-(mu/defn- expressions-metadata :- [:maybe ::lib.metadata.calculation/columns-with-unique-aliases]
+(mu/defn- expressions-metadata :- [:maybe ::lib.metadata.calculation/visible-columns]
   [query                         :- ::lib.schema/query
    stage-number                  :- :int
-   unique-name-fn                :- ::lib.metadata.calculation/unique-name-fn
    {:keys [include-late-exprs?]} :- [:map [:include-late-exprs? {:optional true} :boolean]]]
   (not-empty
-   (for [[clause metadata] (map vector
-                                (:expressions (lib.util/query-stage query stage-number))
-                                (lib.expression/expressions-metadata query stage-number))
-          ;; Only include "late" expressions when required.
-          ;; "Late" expressions those like :offset which can't be used within the same query stage, like aggregations.
+   (for [[clause col] (map vector
+                           (:expressions (lib.util/query-stage query stage-number))
+                           (lib.expression/expressions-metadata query stage-number))
+         ;; Only include "late" expressions when required.
+         ;; "Late" expressions those like :offset which can't be used within the same query stage, like aggregations.
          :when (or include-late-exprs?
                    (not (lib.util.match/match-lite-recursive clause :offset clause)))]
-     (let [base-type (:base-type metadata)]
-       (-> (assoc metadata
-                  :lib/source               :source/expressions
-                  :lib/source-column-alias  (:name metadata)
-                  :lib/desired-column-alias (unique-name-fn (:name metadata)))
-           (u/assoc-default :effective-type (or base-type :type/*)))))))
+     (-> col
+         (assoc :lib/source :source/expressions, :lib/source-column-alias (:name col))
+         (u/assoc-default :effective-type (or (:base-type col) :type/*))))))
 
 ;;; Calculate the columns to return if `:aggregations`/`:breakout`/`:fields` are unspecified.
 ;;;
@@ -212,12 +189,11 @@
 ;;; PLUS
 ;;;
 ;;; 3. Columns added by joins at this stage
-(mu/defn- previous-stage-or-source-visible-columns :- ::lib.metadata.calculation/columns-with-unique-aliases
+(mu/defn- previous-stage-or-source-visible-columns :- ::lib.metadata.calculation/visible-columns
   "Return columns from the previous query stage or source Table/Card."
-  [query                                 :- ::lib.schema/query
-   stage-number                          :- :int
-   {:keys [unique-name-fn], :as options} :- ::lib.metadata.calculation/visible-columns.options]
-  {:pre [(fn? unique-name-fn)]}
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   options      :- ::lib.metadata.calculation/visible-columns.options]
   (let [{:keys [source-table source-card], :as this-stage} (lib.util/query-stage query stage-number)
         card          (some->> source-card (lib.metadata/card query))
         metric-based? (= (:type card) :metric)]
@@ -244,21 +220,19 @@
                  :let [source-column-alias ((some-fn :lib/source-column-alias :name) col)]]
              (assoc col
                     :lib/source               :source/native
-                    :lib/source-column-alias  source-column-alias
-                    :lib/desired-column-alias (unique-name-fn source-column-alias)))))))
+                    :lib/source-column-alias  source-column-alias))))))
 
-(mu/defn- existing-visible-columns :- ::lib.metadata.calculation/columns-with-unique-aliases
-  [query        :- ::lib.schema/query
-   stage-number :- :int
-   {:keys [unique-name-fn include-joined? include-expressions?]
-    :as options} :- ::lib.metadata.calculation/visible-columns.options]
+(mu/defn- existing-visible-columns :- ::lib.metadata.calculation/visible-columns
+  [query                                                       :- ::lib.schema/query
+   stage-number                                                :- :int
+   {:keys [include-joined? include-expressions?], :as options} :- ::lib.metadata.calculation/visible-columns.options]
   (let [source-columns (previous-stage-or-source-visible-columns query stage-number options)]
     (concat
      ;; 1: columns from the previous stage, source table or query
      source-columns
      ;; 2: expressions (aka calculated columns) added in this stage
      (when include-expressions?
-       (expressions-metadata query stage-number unique-name-fn {}))
+       (expressions-metadata query stage-number {}))
      ;; 3: remapped columns - which are only when requested with `:include-remaps?`, and only on the first stage.
      ;; (Otherwise they've already been added.)
      (lib.metadata.calculation/remapped-columns query stage-number source-columns options)
@@ -266,15 +240,18 @@
      (when include-joined?
        (lib.join/all-joins-visible-columns query stage-number options)))))
 
-(defmethod lib.metadata.calculation/visible-columns-method ::stage
-  [query stage-number _stage {:keys [unique-name-fn include-implicitly-joinable?], :as options}]
+(mu/defmethod lib.metadata.calculation/visible-columns-method ::stage :- ::lib.metadata.calculation/visible-columns
+  [query                                               :- ::lib.schema/query
+   stage-number                                        :- :int
+   _stage                                              :- ::lib.schema/stage
+   {:keys [include-implicitly-joinable?], :as options} :- ::lib.metadata.calculation/visible-columns.options]
   (let [query            (ensure-previous-stages-have-metadata query stage-number options)
         existing-columns (existing-visible-columns query stage-number options)]
     (->> (concat
           existing-columns
            ;; add implicitly joinable columns if desired
           (when include-implicitly-joinable?
-            (lib.metadata.calculation/implicitly-joinable-columns query stage-number existing-columns unique-name-fn)))
+            (lib.metadata.calculation/implicitly-joinable-columns query stage-number existing-columns)))
          vec)))
 
 (defn- add-cols-from-join-duplicate?
@@ -324,50 +301,53 @@
 ;;; Return results metadata about the expected columns in an MBQL query stage. If the query has
 ;;; aggregations/breakouts, then return those and the fields columns. Otherwise if there are fields columns return
 ;;; those and the joined columns. Otherwise return the defaults based on the source Table or previous stage + joins.
-(mu/defmethod lib.metadata.calculation/returned-columns-method ::stage :- [:sequential ::lib.schema.metadata/column]
-  [query stage-number _stage {:keys [include-remaps? unique-name-fn], :as options}]
+(mu/defmethod lib.metadata.calculation/returned-columns-method ::stage :- ::lib.metadata.calculation/returned-columns
+  [query                                  :- ::lib.schema/query
+   stage-number                           :- :int
+   _stage                                 :- ::lib.schema/stage
+   {:keys [include-remaps?], :as options} :- [:maybe ::lib.metadata.calculation/returned-columns.options]]
   (or
-   (existing-stage-metadata query stage-number unique-name-fn)
+   (existing-stage-metadata query stage-number)
    (let [query        (ensure-previous-stages-have-metadata query stage-number options)
          summary-cols (summary-columns query stage-number options)
-         field-cols   (fields-columns query stage-number options)]
-     ;; ... then calculate metadata for this stage
-     (-> (cond
-           summary-cols
-           (into summary-cols field-cols)
+         field-cols   (fields-columns query stage-number options)
+         ;; ... then calculate metadata for this stage
+         cols         (cond
+                        summary-cols
+                        (into summary-cols field-cols)
 
-           field-cols
-           (reduce
-            (fn [field-cols join]
-              (add-cols-from-join query stage-number options field-cols join))
-            ;; force generation of unique names before join columns
-            (doall field-cols)
-            (lib.join/joins query stage-number))
+                        field-cols
+                        (reduce
+                         (fn [field-cols join]
+                           (add-cols-from-join query stage-number options field-cols join))
+                         field-cols
+                         (lib.join/joins query stage-number))
 
-           :else
-           ;; there is no `:fields` or summary columns (aggregtions or breakouts) which means we return all the visible
-           ;; columns from the source or previous stage plus all the expressions. We return only the `:fields` from any
-           ;; joins
-           (let [;; we don't want to include all visible joined columns, so calculate that separately
-                 source-cols (previous-stage-or-source-visible-columns
-                              query stage-number
-                              {:include-implicitly-joinable? false
-                               :include-remaps?              (boolean include-remaps?)
-                               :unique-name-fn               unique-name-fn})]
-             (concat
-              source-cols
-              (expressions-metadata query stage-number unique-name-fn {:include-late-exprs? true})
-              (lib.metadata.calculation/remapped-columns query stage-number source-cols options)
-              (lib.join/all-joins-fields-to-add-to-parent-stage query stage-number options))))
-         lib.field.util/add-deduplicated-names
-         ;; we need to update `:name` to be the deduplicated name here, otherwise viz settings will break (see longer
-         ;; explanation in [[metabase.lib.stage-test/returned-columns-deduplicate-names-test]]). Only do this if this
-         ;; is the last stage of the query, just like the QP does! Otherwise we might accidentally break something
-         ;; else that incorrectly relies on the notoriously unreliable `:name` key.
-         (as-> cols (cond->> cols
-                      (lib.util/last-stage? query stage-number)
-                      (map (fn [col]
-                             (assoc col :name (:lib/deduplicated-name col))))))))))
+                        :else
+                        ;; there is no `:fields` or summary columns (aggregtions or breakouts) which means we return
+                        ;; all the visible columns from the source or previous stage plus all the expressions. We
+                        ;; return only the `:fields` from any joins
+                        (let [;; we don't want to include all visible joined columns, so calculate that separately
+                              source-cols (previous-stage-or-source-visible-columns
+                                           query stage-number
+                                           {:include-implicitly-joinable? false
+                                            :include-remaps?              (boolean include-remaps?)})]
+                          (concat
+                           source-cols
+                           (expressions-metadata query stage-number {:include-late-exprs? true})
+                           (lib.metadata.calculation/remapped-columns query stage-number source-cols options)
+                           (lib.join/all-joins-fields-to-add-to-parent-stage query stage-number options))))]
+     (into []
+           (comp (lib.field.util/add-source-and-desired-aliases-xform query)
+                 ;; we need to update `:name` to be the deduplicated name here, otherwise viz settings will break (see
+                 ;; longer explanation in [[metabase.lib.stage-test/returned-columns-deduplicate-names-test]]). Only
+                 ;; do this if this is the last stage of the query, just like the QP does! Otherwise we might
+                 ;; accidentally break something else that incorrectly relies on the notoriously unreliable `:name`
+                 ;; key.
+                 (if (lib.util/last-stage? query stage-number)
+                   (map #(assoc % :name (:lib/deduplicated-name %)))
+                   identity))
+           cols))))
 
 (defmethod lib.metadata.calculation/display-name-method :mbql.stage/native
   [_query _stage-number _stage _style]

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -314,7 +314,7 @@
          ;; ... then calculate metadata for this stage
          cols         (cond
                         summary-cols
-                        (into summary-cols field-cols)
+                        (concat summary-cols field-cols)
 
                         field-cols
                         (reduce

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -76,47 +76,41 @@
                 :id                       (meta/id :venues :id)
                 :table-id                 (meta/id :venues)
                 :base-type                :type/BigInteger
-                :lib/source-column-alias  "ID"
-                :lib/desired-column-alias "ID"}
+                :lib/source-column-alias  "ID"}
                {:lib/type                 :metadata/column
                 :name                     "NAME"
                 :display-name             "Name"
                 :id                       (meta/id :venues :name)
                 :table-id                 (meta/id :venues)
                 :base-type                :type/Text
-                :lib/source-column-alias  "NAME"
-                :lib/desired-column-alias "NAME"}
+                :lib/source-column-alias  "NAME"}
                {:lib/type                 :metadata/column
                 :name                     "CATEGORY_ID"
                 :display-name             "Category ID"
                 :id                       (meta/id :venues :category-id)
                 :table-id                 (meta/id :venues)
-                :lib/source-column-alias  "CATEGORY_ID"
-                :lib/desired-column-alias "CATEGORY_ID"}
+                :lib/source-column-alias  "CATEGORY_ID"}
                {:lib/type                 :metadata/column
                 :name                     "LATITUDE"
                 :display-name             "Latitude"
                 :id                       (meta/id :venues :latitude)
                 :table-id                 (meta/id :venues)
                 :base-type                :type/Float
-                :lib/source-column-alias  "LATITUDE"
-                :lib/desired-column-alias "LATITUDE"}
+                :lib/source-column-alias  "LATITUDE"}
                {:lib/type                 :metadata/column
                 :name                     "LONGITUDE"
                 :display-name             "Longitude"
                 :id                       (meta/id :venues :longitude)
                 :table-id                 (meta/id :venues)
                 :base-type                :type/Float
-                :lib/source-column-alias  "LONGITUDE"
-                :lib/desired-column-alias "LONGITUDE"}
+                :lib/source-column-alias  "LONGITUDE"}
                {:lib/type                 :metadata/column
                 :name                     "PRICE"
                 :display-name             "Price"
                 :id                       (meta/id :venues :price)
                 :table-id                 (meta/id :venues)
                 :base-type                :type/Integer
-                :lib/source-column-alias  "PRICE"
-                :lib/desired-column-alias "PRICE"}
+                :lib/source-column-alias  "PRICE"}
                {:lib/type                 :metadata/column
                 :name                     "ID"
                 :display-name             "ID"
@@ -124,7 +118,7 @@
                 :table-id                 (meta/id :categories)
                 :base-type                :type/BigInteger
                 :lib/source-column-alias  "ID"
-                :lib/desired-column-alias "CATEGORIES__via__CATEGORY_ID__ID"}
+                :fk-field-id              (meta/id :venues :category-id)}
                {:lib/type                 :metadata/column
                 :name                     "NAME"
                 :display-name             "Name"
@@ -132,7 +126,7 @@
                 :table-id                 (meta/id :categories)
                 :base-type                :type/Text
                 :lib/source-column-alias  "NAME"
-                :lib/desired-column-alias "CATEGORIES__via__CATEGORY_ID__NAME"}]
+                :fk-field-id              (meta/id :venues :category-id)}]
               (lib/breakoutable-columns query))))))
 
 (deftest ^:parallel breakoutable-expressions-test
@@ -281,35 +275,30 @@
           :let [query (@varr)]]
     (testing (str (pr-str varr) \newline (lib.util/format "Query =\n%s" (u/pprint-to-str query)))
       (let [columns (lib/breakoutable-columns query)]
-        (is (=? [{:name                     "USER_ID"
-                  :display-name             "User ID"
-                  :base-type                :type/Integer
-                  :lib/source               :source/card
-                  :lib/desired-column-alias "USER_ID"}
-                 {:name                     "count"
-                  :display-name             "Count"
-                  :base-type                :type/Integer
-                  :lib/source               :source/card
-                  :lib/desired-column-alias "count"}
+        (is (=? [{:name         "USER_ID"
+                  :display-name "User ID"
+                  :base-type    :type/Integer
+                  :lib/source   :source/card}
+                 {:name         "count"
+                  :display-name "Count"
+                  :base-type    :type/Integer
+                  :lib/source   :source/card}
                  ;; Implicitly joinable columns
-                 {:name                     "ID"
-                  :display-name             "ID"
-                  :base-type                :type/BigInteger
-                  :lib/source               :source/implicitly-joinable
-                  :lib/desired-column-alias "USERS__via__USER_ID__ID"
-                  :fk-field-id              (meta/id :checkins :user-id)}
-                 {:name                     "NAME"
-                  :display-name             "Name"
-                  :base-type                :type/Text
-                  :lib/source               :source/implicitly-joinable
-                  :lib/desired-column-alias "USERS__via__USER_ID__NAME"
-                  :fk-field-id              (meta/id :checkins :user-id)}
-                 {:name                     "LAST_LOGIN"
-                  :display-name             "Last Login"
-                  :base-type                :type/DateTime
-                  :lib/source               :source/implicitly-joinable
-                  :lib/desired-column-alias "USERS__via__USER_ID__LAST_LOGIN"
-                  :fk-field-id              (meta/id :checkins :user-id)}]
+                 {:name         "ID"
+                  :display-name "ID"
+                  :base-type    :type/BigInteger
+                  :lib/source   :source/implicitly-joinable
+                  :fk-field-id  (meta/id :checkins :user-id)}
+                 {:name         "NAME"
+                  :display-name "Name"
+                  :base-type    :type/Text
+                  :lib/source   :source/implicitly-joinable
+                  :fk-field-id  (meta/id :checkins :user-id)}
+                 {:name         "LAST_LOGIN"
+                  :display-name "Last Login"
+                  :base-type    :type/DateTime
+                  :lib/source   :source/implicitly-joinable
+                  :fk-field-id  (meta/id :checkins :user-id)}]
                 columns))
         (testing `lib/display-info
           (is (=? [{:name                   "USER_ID"

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -5,6 +5,7 @@
    [metabase.lib.column-group :as lib.column-group]
    [metabase.lib.core :as lib]
    [metabase.lib.equality :as lib.equality]
+   [metabase.lib.field.util :as lib.field.util]
    [metabase.lib.join :as lib.join]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -353,7 +354,11 @@
                                                                 (meta/field-metadata :orders :id))])
                                        (lib/with-join-fields (for [field [:id :tax]]
                                                                (lib/ref (meta/field-metadata :orders field)))))))
-        columns      (lib/visible-columns query)
+        ;; [[lib/visible-columns]] no longer returns desired column alias (since it's a function of which columns get
+        ;; returned), however I don't feel like completely reworking this test so I'm just going to add them here.
+        columns      (into []
+                           (lib.field.util/add-source-and-desired-aliases-xform query)
+                           (lib/visible-columns query))
         marked       (lib.equality/mark-selected-columns query -1 columns (lib/returned-columns query))
         user-cols    ["ID" "ADDRESS" "EMAIL" "PASSWORD" "NAME" "CITY" "LONGITUDE"
                       "STATE" "SOURCE" "BIRTH_DATE" "ZIP" "LATITUDE" "CREATED_AT"]
@@ -400,7 +405,9 @@
                                                (first (lib/join-condition-rhs-columns query card nil nil)))])
 
           query (lib/join query clause)
-          cols (lib/visible-columns query)
+          cols (into []
+                     (lib.field.util/add-source-and-desired-aliases-xform query)
+                     (lib/visible-columns query))
           [_ _ _ product-1 _ product-2 :as groups] (lib/group-columns cols)]
       (is (=? [{:display-name "Mock Orders Card"
                 :is-from-join false,

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -307,7 +307,7 @@
                   (lib/expression "b" 2))
         expressionable-expressions-for-position (fn [pos]
                                                   (some->> (lib/expressionable-columns query pos)
-                                                           (map :lib/desired-column-alias)))]
+                                                           (map :lib/source-column-alias)))]
     ;; Because of (the second problem in) #44584, the expression-position argument is ignored,
     ;; so the first two calls behave the same as the last two.
     (is (= ["ID" "NAME" "a" "b"] (expressionable-expressions-for-position 0)))

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -6,6 +6,7 @@
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.expression :as lib.expression]
+   [metabase.lib.field.util :as lib.field.util]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.filter.operator :as lib.filter.operator]
    [metabase.lib.options :as lib.options]
@@ -258,7 +259,10 @@
             "Venues__PRICE"
             "CATEGORIES__via__CATEGORY_ID__via__Venues__ID"
             "CATEGORIES__via__CATEGORY_ID__via__Venues__NAME"]
-           (map :lib/desired-column-alias columns)))
+           (into []
+                 (comp (lib.field.util/add-source-and-desired-aliases-xform query)
+                       (map :lib/desired-column-alias))
+                 columns)))
     (testing "Operators are attached to proper columns"
       (is (=? {"ID" pk-operators,
                "NAME" text-operators,
@@ -907,7 +911,7 @@
                                     {:column-type :type/Boolean :v true}
                                     {:column-type :type/Coordinate :v 1}}
           [query desired] (matrix/test-queries column-type)]
-    (let [col (matrix/find-first desired (lib/filterable-columns query))
+    (let [col (matrix/find-first query desired (lib/filterable-columns query))
           query' (lib/filter query (lib/= col v))
           parts (lib/expression-parts query' (first (lib/filters query')))]
       (is (=? (lib.filter.operator/filter-operators {:lib/type :metadata/column :name "expected" :base-type column-type})

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -1258,14 +1258,12 @@
                     :source-alias                 "Cat"
                     :lib/source                   :source/joins
                     :lib/source-column-alias      "ID"
-                    :lib/desired-column-alias     "Cat__ID"
                     :selected?                    id-selected?}
                    {:name                         "NAME"
                     :metabase.lib.join/join-alias "Cat"
                     :source-alias                 "Cat"
                     :lib/source                   :source/joins
                     :lib/source-column-alias      "NAME"
-                    :lib/desired-column-alias     "Cat__NAME"
                     :selected?                    name-selected?}]
                   cols))
           (testing `lib/display-info
@@ -1662,7 +1660,7 @@
               {:id (meta/id :orders :tax),     :display-name "Card → Tax" #_"Tax"}
               {:id (meta/id :products :vendor) :display-name "Card → Vendor"}]
              (map #(select-keys % [:id :display-name])
-                  (lib.join/join-fields-to-add-to-parent-stage query -1 join {:unique-name-fn (lib.util/unique-name-generator)})))))))
+                  (lib.join/join-fields-to-add-to-parent-stage query -1 join {})))))))
 
 (deftest ^:parallel remapping-in-joins-test
   (testing "explicitly joined columns with remaps are added after their join"
@@ -1724,7 +1722,7 @@
                 ["sum"   "Orders__sum"   "sum"   "Orders → Sum of Quantity"]]
                (map (juxt :name :lib/desired-column-alias :lib/source-column-alias :display-name)
                     (lib.join/join-fields-to-add-to-parent-stage
-                     query -1 join {:unique-name-fn (lib.util/unique-name-generator), :include-remaps? true}))))))))
+                     query -1 join {:include-remaps? true}))))))))
 
 (deftest ^:parallel remapping-in-joins-test-3
   (testing "join-fields-to-add-to-parent-stage should include remapped columns"
@@ -1741,12 +1739,12 @@
                     :fields   [$title $category]}))
           join (first (lib/joins query -1))]
       (binding [lib.metadata.calculation/*display-name-style* :long]
-        (is (= [["PRODUCT_ID" "Orders__PRODUCT_ID" "PRODUCT_ID" "Orders → Product ID"]
+        (is (= [["PRODUCT_ID" "Orders" "PRODUCT_ID" "Orders → Product ID"]
                 ;; should get added because it is a remap
-                ["TITLE"      "Orders__TITLE"      "TITLE"      "Orders → Title"]]
-               (map (juxt :name :lib/desired-column-alias :lib/source-column-alias :display-name)
+                ["TITLE"      "Orders" "TITLE"      "Orders → Title"]]
+               (map (juxt :name :metabase.lib.join/join-alias :lib/source-column-alias :display-name)
                     (lib.join/join-fields-to-add-to-parent-stage
-                     query -1 join {:unique-name-fn (lib.util/unique-name-generator), :include-remaps? true}))))))))
+                     query -1 join {:include-remaps? true}))))))))
 
 (deftest ^:parallel remapping-in-joins-duplicates-test
   (testing "Remapped columns in joined source queries should not append duplicates (QUE-1410)"
@@ -1771,7 +1769,7 @@
                 ["TITLE"      "Orders__TITLE"      "TITLE"      "Orders → Title"]]
                (map (juxt :name :lib/desired-column-alias :lib/source-column-alias :display-name)
                     (lib.join/join-fields-to-add-to-parent-stage
-                     query -1 join {:unique-name-fn (lib.util/unique-name-generator), :include-remaps? true}))))))))
+                     query -1 join {:include-remaps? true}))))))))
 
 (deftest ^:parallel calculate-sane-join-aliases-test
   (testing "Don't strip ID for names like 'X → ID'"

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
+   [metabase.lib.field.util :as lib.field.util]
    [metabase.lib.js :as lib.js]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.options :as lib.options]
@@ -465,7 +466,10 @@
 
     (testing "fingerprint is included in display-info"
       (let [query      (lib/query meta/metadata-provider (meta/table-metadata :orders))
-            by-dca     (m/index-by :lib/desired-column-alias (lib/visible-columns query))
+            by-dca     (m/index-by :lib/desired-column-alias
+                                   (into []
+                                         (lib.field.util/add-source-and-desired-aliases-xform query)
+                                         (lib/visible-columns query)))
             discount   (by-dca "DISCOUNT")
             vendor     (by-dca "PRODUCTS__via__PRODUCT_ID__VENDOR")
             created-at (by-dca "CREATED_AT")]

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -4,6 +4,7 @@
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
+   [metabase.lib.field.util :as lib.field.util]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.ident :as lib.metadata.ident]
@@ -82,6 +83,15 @@
                  :long-display-name "join → Unknown Field"}
                 (lib/display-info query [:field {:join-alias "join"} field-id])))))))
 
+(defn- visible-columns-with-desired-aliases
+  "[[lib/visible-columns]] no longer includes `:lib/desired-column-alias` (which never really made sense because desired
+  column alias is a function of the columns that are RETURNED) but since so many tests were written to look at it this
+  function is around to make those tests continue to work without extensive rewrites."
+  [query]
+  (into []
+        (lib.field.util/add-source-and-desired-aliases-xform query)
+        (lib/visible-columns query)))
+
 (deftest ^:parallel visible-columns-test
   (testing "Include all visible columns, not just projected ones (#31233)"
     (is (= ["ID"
@@ -100,10 +110,14 @@
                                      (meta/field-metadata :venues :category-id)
                                      (lib/with-join-alias (meta/field-metadata :categories :id) "Categories"))])
                                   (lib/with-join-fields [(lib/with-join-alias (meta/field-metadata :categories :name) "Categories")])))
-                    lib/visible-columns)))))
+                    visible-columns-with-desired-aliases))))))
+
+(deftest ^:parallel visible-columns-test-2
   (testing "nil has no visible columns (#31366)"
     (is (empty? (-> (lib.tu/venues-query)
-                    (lib/visible-columns nil)))))
+                    (lib/visible-columns nil))))))
+
+(deftest ^:parallel visible-columns-test-3
   (testing "Include multiple implicitly joinable columns pointing to the same table and field (##33451)"
     (is (= ["id"
             "created_by"
@@ -113,13 +127,47 @@
             "ic_accounts__via__updated_by__id"
             "ic_accounts__via__updated_by__name"]
            (->> (lib/query meta/metadata-provider (meta/table-metadata :ic/reports))
-                lib/visible-columns
-                (map :lib/desired-column-alias)))))
+                visible-columns-with-desired-aliases
+                (map :lib/desired-column-alias))))))
+
+(deftest ^:parallel visible-columns-test-4
   (testing "multiple aggregations"
-    (lib.metadata.calculation/visible-columns
-     (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-         (lib/aggregate (lib/count))
-         (lib/aggregate (lib/sum (meta/field-metadata :orders :quantity)))))))
+    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                    (lib/aggregate (lib/count))
+                    (lib/aggregate (lib/sum (meta/field-metadata :orders :quantity))))]
+      (is (= [["Orders"   "ID"]
+              ["Orders"   "User ID"]
+              ["Orders"   "Product ID"]
+              ["Orders"   "Subtotal"]
+              ["Orders"   "Tax"]
+              ["Orders"   "Total"]
+              ["Orders"   "Discount"]
+              ["Orders"   "Created At"]
+              ["Orders"   "Quantity"]
+              ["People"   "User → ID"]
+              ["People"   "User → Address"]
+              ["People"   "User → Email"]
+              ["People"   "User → Password"]
+              ["People"   "User → Name"]
+              ["People"   "User → City"]
+              ["People"   "User → Longitude"]
+              ["People"   "User → State"]
+              ["People"   "User → Source"]
+              ["People"   "User → Birth Date"]
+              ["People"   "User → Zip"]
+              ["People"   "User → Latitude"]
+              ["People"   "User → Created At"]
+              ["Products" "Product → ID"]
+              ["Products" "Product → Ean"]
+              ["Products" "Product → Title"]
+              ["Products" "Product → Category"]
+              ["Products" "Product → Vendor"]
+              ["Products" "Product → Price"]
+              ["Products" "Product → Rating"]
+              ["Products" "Product → Created At"]]
+             (map #(-> (lib/display-info query -1 %)
+                       ((juxt (comp :long-display-name :table) :long-display-name)))
+                  (lib.metadata.calculation/visible-columns query)))))))
 
 (deftest ^:parallel source-cards-test
   (testing "with :source-card"
@@ -679,9 +727,8 @@
   `expected-cols` should be a list of tuples of [:lib/desired-column-alias :lib/source] for the expected columns."
   [query expected-cols]
   (is (= expected-cols
-         (->> query
-              lib/visible-columns
-              (map (juxt :lib/desired-column-alias :lib/source))))))
+         (map (juxt :lib/desired-column-alias :lib/source)
+              (visible-columns-with-desired-aliases query)))))
 
 (deftest ^:parallel visible-columns-orders+people-card-test
   (testing "single-card orders+people join (#34743)"

--- a/test/metabase/lib/metadata/result_metadata_test.cljc
+++ b/test/metabase/lib/metadata/result_metadata_test.cljc
@@ -922,7 +922,6 @@
                   :unit                                       :year
                   :lib/deduplicated-name                      "CREATED_AT"
                   :lib/desired-column-alias                   "CREATED_AT"
-                  :lib/hack-original-name                     "CREATED_AT"
                   :lib/original-display-name                  "Created At"
                   :lib/original-name                          "CREATED_AT"
                   :lib/source                                 :source/previous-stage

--- a/test/metabase/lib/metadata/result_metadata_test.cljc
+++ b/test/metabase/lib/metadata/result_metadata_test.cljc
@@ -1046,3 +1046,24 @@
             "Count"
             "Sum of Total" "Average of Quantity"]
            (map :display-name (result-metadata/returned-columns query))))))
+
+(deftest ^:parallel return-correct-deduplicated-names-test
+  (testing "Deduplicated names from previous stage should be preserved even when excluding certain fields"
+    ;; e.g. a field called CREATED_AT_2 in the previous stage should continue to be called that. See ;; see
+    ;; https://metaboat.slack.com/archives/C0645JP1W81/p1750961267171999
+    (let [query (-> (lib/query
+                     meta/metadata-provider
+                     (lib.tu.macros/mbql-query orders
+                       {:source-query {:source-table $$orders
+                                       :aggregation  [[:count]]
+                                       :breakout     [[:field %created-at {:base-type :type/DateTime, :temporal-unit :year}]
+                                                      [:field %created-at {:base-type :type/DateTime, :temporal-unit :month}]]}
+                        :filter       [:>
+                                       [:field "count" {:base-type :type/Integer}]
+                                       0]}))
+                    lib/append-stage
+                    lib/append-stage
+                    (as-> query (lib/remove-field query -1 (first (lib/fieldable-columns query -1)))))]
+      (is (=? [{:name "CREATED_AT_2", :display-name "Created At: Month", :field-ref [:field "CREATED_AT_2" {}]}
+               {:name "count", :display-name "Count", :field-ref [:field "count" {}]}]
+              (result-metadata/returned-columns query))))))

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -237,69 +237,63 @@
 (deftest ^:parallel orderable-columns-test
   (let [query (lib.tu/venues-query)]
     (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
-      (is (=? [{:lib/type                 :metadata/column
-                :name                     "ID"
-                :display-name             "ID"
-                :id                       (meta/id :venues :id)
-                :table-id                 (meta/id :venues)
-                :base-type                :type/BigInteger
-                :lib/source-column-alias  "ID"
-                :lib/desired-column-alias "ID"}
-               {:lib/type                 :metadata/column
-                :name                     "NAME"
-                :display-name             "Name"
-                :id                       (meta/id :venues :name)
-                :table-id                 (meta/id :venues)
-                :base-type                :type/Text
-                :lib/source-column-alias  "NAME"
-                :lib/desired-column-alias "NAME"}
-               {:lib/type                 :metadata/column
-                :name                     "CATEGORY_ID"
-                :display-name             "Category ID"
-                :id                       (meta/id :venues :category-id)
-                :table-id                 (meta/id :venues)
-                :lib/source-column-alias  "CATEGORY_ID"
-                :lib/desired-column-alias "CATEGORY_ID"}
-               {:lib/type                 :metadata/column
-                :name                     "LATITUDE"
-                :display-name             "Latitude"
-                :id                       (meta/id :venues :latitude)
-                :table-id                 (meta/id :venues)
-                :base-type                :type/Float
-                :lib/source-column-alias  "LATITUDE"
-                :lib/desired-column-alias "LATITUDE"}
-               {:lib/type                 :metadata/column
-                :name                     "LONGITUDE"
-                :display-name             "Longitude"
-                :id                       (meta/id :venues :longitude)
-                :table-id                 (meta/id :venues)
-                :base-type                :type/Float
-                :lib/source-column-alias  "LONGITUDE"
-                :lib/desired-column-alias "LONGITUDE"}
-               {:lib/type                 :metadata/column
-                :name                     "PRICE"
-                :display-name             "Price"
-                :id                       (meta/id :venues :price)
-                :table-id                 (meta/id :venues)
-                :base-type                :type/Integer
-                :lib/source-column-alias  "PRICE"
-                :lib/desired-column-alias "PRICE"}
-               {:lib/type                 :metadata/column
-                :name                     "ID"
-                :display-name             "ID"
-                :id                       (meta/id :categories :id)
-                :table-id                 (meta/id :categories)
-                :base-type                :type/BigInteger
-                :lib/source-column-alias  "ID"
-                :lib/desired-column-alias "CATEGORIES__via__CATEGORY_ID__ID"}
-               {:lib/type                 :metadata/column
-                :name                     "NAME"
-                :display-name             "Name"
-                :id                       (meta/id :categories :name)
-                :table-id                 (meta/id :categories)
-                :base-type                :type/Text
-                :lib/source-column-alias  "NAME"
-                :lib/desired-column-alias "CATEGORIES__via__CATEGORY_ID__NAME"}]
+      (is (=? [{:lib/type                :metadata/column
+                :name                    "ID"
+                :display-name            "ID"
+                :id                      (meta/id :venues :id)
+                :table-id                (meta/id :venues)
+                :base-type               :type/BigInteger
+                :lib/source-column-alias "ID"}
+               {:lib/type                :metadata/column
+                :name                    "NAME"
+                :display-name            "Name"
+                :id                      (meta/id :venues :name)
+                :table-id                (meta/id :venues)
+                :base-type               :type/Text
+                :lib/source-column-alias "NAME"}
+               {:lib/type                :metadata/column
+                :name                    "CATEGORY_ID"
+                :display-name            "Category ID"
+                :id                      (meta/id :venues :category-id)
+                :table-id                (meta/id :venues)
+                :lib/source-column-alias "CATEGORY_ID"}
+               {:lib/type                :metadata/column
+                :name                    "LATITUDE"
+                :display-name            "Latitude"
+                :id                      (meta/id :venues :latitude)
+                :table-id                (meta/id :venues)
+                :base-type               :type/Float
+                :lib/source-column-alias "LATITUDE"}
+               {:lib/type                :metadata/column
+                :name                    "LONGITUDE"
+                :display-name            "Longitude"
+                :id                      (meta/id :venues :longitude)
+                :table-id                (meta/id :venues)
+                :base-type               :type/Float
+                :lib/source-column-alias "LONGITUDE"}
+               {:lib/type                :metadata/column
+                :name                    "PRICE"
+                :display-name            "Price"
+                :id                      (meta/id :venues :price)
+                :table-id                (meta/id :venues)
+                :base-type               :type/Integer
+                :lib/source-column-alias "PRICE"}
+               {:lib/type                :metadata/column
+                :name                    "ID"
+                :display-name            "ID"
+                :id                      (meta/id :categories :id)
+                :table-id                (meta/id :categories)
+                :base-type               :type/BigInteger
+                :lib/source-column-alias "ID"
+                :fk-field-id             (meta/id :venues :category-id)}
+               {:lib/type                :metadata/column
+                :name                    "NAME"
+                :display-name            "Name"
+                :id                      (meta/id :categories :name)
+                :table-id                (meta/id :categories)
+                :base-type               :type/Text
+                :lib/source-column-alias "NAME"
+                :fk-field-id             (meta/id :venues :category-id)}]
               (lib/orderable-columns query))))))
 
 (deftest ^:parallel orderable-expressions-test
@@ -379,31 +373,26 @@
       (is (=? [{:name                     "USER_ID"
                 :display-name             "User ID"
                 :base-type                :type/Integer
-                :lib/source               :source/card
-                :lib/desired-column-alias "USER_ID"}
+                :lib/source               :source/card}
                {:name                     "count"
                 :display-name             "Count"
                 :base-type                :type/Integer
-                :lib/source               :source/card
-                :lib/desired-column-alias "count"}
+                :lib/source               :source/card}
                ;; Implicitly joinable columns
                {:name                     "ID"
                 :display-name             "ID"
                 :base-type                :type/BigInteger
                 :lib/source               :source/implicitly-joinable
-                :lib/desired-column-alias "USERS__via__USER_ID__ID"
                 :fk-field-id              (meta/id :checkins :user-id)}
                {:name                     "NAME"
                 :display-name             "Name"
                 :base-type                :type/Text
                 :lib/source               :source/implicitly-joinable
-                :lib/desired-column-alias "USERS__via__USER_ID__NAME"
                 :fk-field-id              (meta/id :checkins :user-id)}
                {:name                     "LAST_LOGIN"
                 :display-name             "Last Login"
                 :base-type                :type/DateTime
                 :lib/source               :source/implicitly-joinable
-                :lib/desired-column-alias "USERS__via__USER_ID__LAST_LOGIN"
                 :fk-field-id              (meta/id :checkins :user-id)}]
               (lib/orderable-columns query)))
       (testing `lib/display-info

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
+   [metabase.lib.field.util :as lib.field.util]
    [metabase.lib.join :as lib.join]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.options :as lib.options]
@@ -1737,7 +1738,10 @@
                      (lib/join (meta/table-metadata :products))
                      (lib/aggregate (lib/count))
                      (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal))))
-          cols   (m/index-by :lib/desired-column-alias (lib/breakoutable-columns base1))
+          cols   (m/index-by :lib/desired-column-alias
+                             (into []
+                                   (lib.field.util/add-source-and-desired-aliases-xform base1)
+                                   (lib/breakoutable-columns base1)))
           base2  (-> base1
                      (lib/breakout (get cols "Products__CATEGORY"))           ; Explicitly joined
                      (lib/breakout (get cols "PEOPLE__via__USER_ID__SOURCE")) ; Implicitly joined
@@ -1761,7 +1765,11 @@
                                         (lib/join (meta/table-metadata :products))
                                         (lib/aggregate (lib/count))
                                         (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal))))
-          cols                      (m/index-by :lib/desired-column-alias (lib/breakoutable-columns base1))
+          cols                      (m/index-by
+                                     :lib/desired-column-alias
+                                     (into []
+                                           (lib.field.util/add-source-and-desired-aliases-xform base1)
+                                           (lib/breakoutable-columns base1)))
           base2                     (-> base1
                                         (lib/breakout (get cols "Products__CATEGORY"))             ; Explicitly joined
                                         (lib/breakout (get cols "PEOPLE__via__USER_ID__SOURCE"))   ; Implicitly joined

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -795,20 +795,21 @@
                (map :display-name (lib/returned-columns query))))))))
 
 (deftest ^:parallel expressions-with-aggregations-and-breakouts-returned-columns-test
-  (let [query (lib/query
-               meta/metadata-provider
-               (lib.tu.macros/mbql-query orders
-                 {:aggregation [[:count] [:sum $orders.quantity]]
-                  :breakout    [$orders.user-id->people.state
-                                $orders.user-id->people.source
-                                $orders.product-id->products.category]
-                  :expressions {:test-expr [:ltrim "wheeee"]}
-                  :fields      [[:expression "test-expr"]]}))]
-    (is (= ["User → State"              ; from breakouts
-            "User → Source"             ; from breakouts
-            "Product → Category"        ; from breakouts
-            "Count"                     ; from aggregations
-            "Sum of Quantity"           ; from aggregations
-            "test-expr"]                ; from expressions/fields ???
-           (binding [lib.metadata.calculation/*display-name-style* :long]
-             (mapv :display-name (lib/returned-columns query)))))))
+  (testing "expressions in :fields should be returned AFTER breakouts and aggregations"
+    (let [query (lib/query
+                 meta/metadata-provider
+                 (lib.tu.macros/mbql-query orders
+                   {:aggregation [[:count] [:sum $orders.quantity]]
+                    :breakout    [$orders.user-id->people.state
+                                  $orders.user-id->people.source
+                                  $orders.product-id->products.category]
+                    :expressions {:test-expr [:ltrim "wheeee"]}
+                    :fields      [[:expression "test-expr"]]}))]
+      (is (= ["User → State"              ; from breakouts
+              "User → Source"             ; from breakouts
+              "Product → Category"        ; from breakouts
+              "Count"                     ; from aggregations
+              "Sum of Quantity"           ; from aggregations
+              "test-expr"]                ; from expressions/fields ???
+             (binding [lib.metadata.calculation/*display-name-style* :long]
+               (mapv :display-name (lib/returned-columns query))))))))

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -813,3 +813,34 @@
               "test-expr"]                ; from expressions/fields ???
              (binding [lib.metadata.calculation/*display-name-style* :long]
                (mapv :display-name (lib/returned-columns query))))))))
+
+(deftest ^:parallel return-correct-deduplicated-names-test
+  (testing "Deduplicated names from previous stage should be preserved even when excluding certain fields"
+    ;; e.g. a field called CREATED_AT_2 in the previous stage should continue to be called that. See ;; see
+    ;; https://metaboat.slack.com/archives/C0645JP1W81/p1750961267171999
+    (let [query (-> (lib/query
+                     meta/metadata-provider
+                     (lib.tu.macros/mbql-query orders
+                       {:source-query {:source-table $$orders
+                                       :aggregation  [[:count]]
+                                       :breakout     [[:field %created-at {:base-type :type/DateTime, :temporal-unit :year}]
+                                                      [:field %created-at {:base-type :type/DateTime, :temporal-unit :month}]]}
+                        :filter       [:>
+                                       [:field "count" {:base-type :type/Integer}]
+                                       0]}))
+                    lib/append-stage
+                    lib/append-stage
+                    (as-> query (lib/remove-field query -1 (first (lib/fieldable-columns query -1)))))]
+      (is (=? [{:name                     "CREATED_AT_2"
+                :lib/original-name        "CREATED_AT"
+                :lib/deduplicated-name    "CREATED_AT_2"
+                :lib/source-column-alias  "CREATED_AT_2"
+                :lib/desired-column-alias "CREATED_AT_2"
+                :display-name             "Created At: Month"}
+               {:name                     "count"
+                :lib/original-name        "count"
+                :lib/deduplicated-name    "count"
+                :lib/source-column-alias  "count"
+                :lib/desired-column-alias "count"
+                :display-name             "Count"}]
+              (lib/returned-columns query))))))

--- a/test/metabase/lib/test_util/metadata_providers/mock.cljc
+++ b/test/metabase/lib/test_util/metadata_providers/mock.cljc
@@ -6,6 +6,7 @@
    [clojure.test :refer [deftest is]]
    [malli.core :as mc]
    [malli.transform :as mtx]
+   [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols :as metadata.protocols]
    [metabase.lib.normalize :as lib.normalize]
@@ -158,8 +159,8 @@
   ([m]
    (-> m
        ->mock-metadata
-       (update :fields #(for [field %]
-                          (u/assoc-default field :ident (u/generate-nano-id))))
+       (m/update-existing :fields #(for [field %]
+                                     (u/assoc-default field :ident (u/generate-nano-id))))
        ->MockMetadataProvider))
 
   ([parent-metadata-provider mock-metadata]

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -38,54 +38,44 @@
                                           orderable-columns))]
     (testing "effective type"
       (is (=? [{:name "NAME"
-                :lib/desired-column-alias "NAME"
                 :semantic-type :type/Name
                 :effective-type :type/Text}
                {:name "NAME"
-                :lib/desired-column-alias "CATEGORIES__via__CATEGORY_ID__NAME"
                 :semantic-type :type/Name
                 :effective-type :type/Text}]
               (columns-of-type :type/Text))))
     (testing "semantic type"
       (is (=? [{:name "ID"
-                :lib/desired-column-alias "ID"
                 :semantic-type :type/PK
                 :effective-type :type/BigInteger}
                {:name "CATEGORY_ID"
-                :lib/desired-column-alias "CATEGORY_ID"
                 :semantic-type :type/FK
                 :effective-type :type/Integer}
                {:name "ID"
-                :lib/desired-column-alias "CATEGORIES__via__CATEGORY_ID__ID"
+                :fk-field-id (meta/id :venues :category-id)
                 :semantic-type :type/PK
                 :effective-type :type/BigInteger}]
               (columns-of-type :Relation/*))))
-    (testing "experssions"
+    (testing "expressions"
       (is (=? [{:name "ID"
-                :lib/desired-column-alias "ID"
                 :semantic-type :type/PK
                 :effective-type :type/BigInteger}
                {:name "CATEGORY_ID"
-                :lib/desired-column-alias "CATEGORY_ID"
                 :semantic-type :type/FK
                 :effective-type :type/Integer}
                {:name "LATITUDE"
-                :lib/desired-column-alias "LATITUDE"
                 :semantic-type :type/Latitude
                 :effective-type :type/Float}
                {:name "LONGITUDE"
-                :lib/desired-column-alias "LONGITUDE"
                 :semantic-type :type/Longitude
                 :effective-type :type/Float}
                {:name "PRICE"
-                :lib/desired-column-alias "PRICE"
                 :semantic-type :type/Category
                 :effective-type :type/Integer}
                {:name "myadd"
-                :lib/desired-column-alias "myadd"
                 :effective-type :type/Integer}
                {:name "ID"
-                :lib/desired-column-alias "CATEGORIES__via__CATEGORY_ID__ID"
+                :fk-field-id (meta/id :venues :category-id)
                 :semantic-type :type/PK
                 :effective-type :type/BigInteger}]
               (filter lib.types.isa/numeric? orderable-columns))))))

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -19,7 +19,7 @@
    [metabase.query-processor.api :as api.dataset]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
-   [metabase.query-processor.pivot.test-util :as api.pivots]
+   [metabase.query-processor.pivot.test-util :as qp.pivot.test-util]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.query-processor.util :as qp.util]
    [metabase.test :as mt]
@@ -659,11 +659,11 @@
         (is (not (str/includes? (:error res) "\n\tat ")))))))
 
 (deftest ^:parallel pivot-dataset-test
-  (mt/test-drivers (api.pivots/applicable-drivers)
+  (mt/test-drivers (qp.pivot.test-util/applicable-drivers)
     (mt/dataset test-data
       (testing "POST /api/dataset/pivot"
         (testing "Run a pivot table"
-          (let [result (mt/user-http-request :crowberto :post 202 "dataset/pivot" (api.pivots/pivot-query))
+          (let [result (mt/user-http-request :crowberto :post 202 "dataset/pivot" (qp.pivot.test-util/pivot-query))
                 rows   (mt/rows result)]
             (is (= 1144 (:row_count result)))
             (is (= "completed" (:status result)))
@@ -676,7 +676,7 @@
 ;; historical test: don't do this going forward
 #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
 (deftest ^:parallel pivot-dataset-with-added-expression-test
-  (mt/test-drivers (api.pivots/applicable-drivers)
+  (mt/test-drivers (qp.pivot.test-util/applicable-drivers)
     (mt/dataset test-data
       (testing "POST /api/dataset/pivot"
         ;; this only works on a handful of databases -- most of them don't allow you to ask for a Field that isn't in
@@ -685,7 +685,7 @@
           (testing "with an added expression"
             ;; the added expression is coming back in this query because it is explicitly included in `:fields` -- see
             ;; comments on [[metabase.query-processor.pivot-test/pivots-should-not-return-expressions-test]].
-            (let [query  (-> (api.pivots/pivot-query)
+            (let [query  (-> (qp.pivot.test-util/pivot-query)
                              (assoc-in [:query :fields] [[:expression "test-expr"]])
                              (assoc-in [:query :expressions] {:test-expr [:ltrim "wheeee"]}))
                   result (mt/user-http-request :crowberto :post 202 "dataset/pivot" query)
@@ -711,10 +711,10 @@
               (is (= [nil nil nil 7 18760 69540 "wheeee"] (last rows))))))))))
 
 (deftest ^:parallel pivot-dataset-row-totals-disabled-test
-  (mt/test-drivers (api.pivots/applicable-drivers)
+  (mt/test-drivers (qp.pivot.test-util/applicable-drivers)
     (mt/dataset test-data
       (testing "POST /api/dataset/pivot with row totals disabled"
-        (let [query (merge (api.pivots/pivot-query true)
+        (let [query (merge (qp.pivot.test-util/pivot-query true)
                            {:show_row_totals false
                             :show_column_totals true})
               result (mt/user-http-request :crowberto :post 202 "dataset/pivot" query)
@@ -729,10 +729,10 @@
                       vec))))))))
 
 (deftest ^:parallel pivot-dataset-column-totals-disabled-test
-  (mt/test-drivers (api.pivots/applicable-drivers)
+  (mt/test-drivers (qp.pivot.test-util/applicable-drivers)
     (mt/dataset test-data
       (testing "POST /api/dataset/pivot with column totals disabled"
-        (let [query (merge (api.pivots/pivot-query true)
+        (let [query (merge (qp.pivot.test-util/pivot-query true)
                            {:show_row_totals true
                             :show_column_totals false})
               result (mt/user-http-request :crowberto :post 202 "dataset/pivot" query)
@@ -747,10 +747,10 @@
                       vec))))))))
 
 (deftest ^:parallel pivot-dataset-both-totals-disabled-test
-  (mt/test-drivers (api.pivots/applicable-drivers)
+  (mt/test-drivers (qp.pivot.test-util/applicable-drivers)
     (mt/dataset test-data
       (testing "POST /api/dataset/pivot with row and column totals disabled"
-        (let [query (merge (api.pivots/pivot-query true)
+        (let [query (merge (qp.pivot.test-util/pivot-query true)
                            {:show_row_totals false
                             :show_column_totals false})
               result (mt/user-http-request :crowberto :post 202 "dataset/pivot" query)
@@ -765,11 +765,11 @@
                       vec))))))))
 
 (deftest ^:parallel pivot-filter-dataset-test
-  (mt/test-drivers (api.pivots/applicable-drivers)
+  (mt/test-drivers (qp.pivot.test-util/applicable-drivers)
     (mt/dataset test-data
       (testing "POST /api/dataset/pivot"
         (testing "Run a pivot table"
-          (let [result (mt/user-http-request :crowberto :post 202 "dataset/pivot" (api.pivots/filters-query))
+          (let [result (mt/user-http-request :crowberto :post 202 "dataset/pivot" (qp.pivot.test-util/filters-query))
                 rows   (mt/rows result)]
             (is (= 140 (:row_count result)))
             (is (= "completed" (:status result)))
@@ -782,11 +782,11 @@
             (is (= [nil nil 3 7562] (last rows)))))))))
 
 (deftest ^:parallel pivot-parameter-dataset-test
-  (mt/test-drivers (api.pivots/applicable-drivers)
+  (mt/test-drivers (qp.pivot.test-util/applicable-drivers)
     (mt/dataset test-data
       (testing "POST /api/dataset/pivot"
         (testing "Run a pivot table"
-          (let [result (mt/user-http-request :crowberto :post 202 "dataset/pivot" (api.pivots/parameters-query))
+          (let [result (mt/user-http-request :crowberto :post 202 "dataset/pivot" (qp.pivot.test-util/parameters-query))
                 rows   (mt/rows result)]
             (is (= 137 (:row_count result)))
             (is (= "completed" (:status result)))

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -15,7 +15,7 @@
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.query-processor :as qp]
    [metabase.query-processor.pivot :as qp.pivot]
-   [metabase.query-processor.pivot.test-util :as api.pivots]
+   [metabase.query-processor.pivot.test-util :as qp.pivot.test-util]
    [metabase.test :as mt]
    [metabase.test.data :as data]
    [metabase.util :as u]
@@ -141,7 +141,7 @@
                                                                {:pivot-rows :pivot_rows, :pivot-cols :pivot_cols})))))))
 
 (deftest ^:parallel generate-queries-test
-  (mt/test-drivers (api.pivots/applicable-drivers)
+  (mt/test-drivers (qp.pivot.test-util/applicable-drivers)
     (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (mt/id))
           query             (lib/query
                              metadata-provider
@@ -204,8 +204,8 @@
 
 (deftest ^:parallel pivot-options-test
   (testing "`pivot-options` correctly generates pivot-rows and pivot-cols from a card's viz settings"
-    (let [query         (api.pivots/pivot-query false)
-          viz-settings  (:visualization_settings (api.pivots/pivot-card))
+    (let [query         (qp.pivot.test-util/pivot-query false)
+          viz-settings  (:visualization_settings (qp.pivot.test-util/pivot-card))
           pivot-options {:pivot-rows [1 0], :pivot-cols [2] :pivot-measures nil :column-sort-order {}}]
       (let [actual-pivot-options (#'qp.pivot/pivot-options query viz-settings)]
         (is (= (assoc pivot-options :show-row-totals true :show-column-totals true)
@@ -415,7 +415,7 @@
        set))
 
 (deftest ^:parallel return-correct-columns-test
-  (let [results (qp.pivot/run-pivot-query (api.pivots/pivot-query))
+  (let [results (qp.pivot/run-pivot-query (qp.pivot.test-util/pivot-query))
         rows    (mt/rows results)]
     (testing "Columns should come back in the expected order"
       (is (= ["User → State"
@@ -459,14 +459,14 @@
               ([] 0)
               ([acc] acc)
               ([acc _] (inc acc))))]
-    (is (= (count (mt/rows (qp.pivot/run-pivot-query (api.pivots/pivot-query))))
-           (qp.pivot/run-pivot-query (api.pivots/pivot-query) rff)))))
+    (is (= (count (mt/rows (qp.pivot/run-pivot-query (qp.pivot.test-util/pivot-query))))
+           (qp.pivot/run-pivot-query (qp.pivot.test-util/pivot-query) rff)))))
 
 (deftest ^:parallel parameters-query-test
   (mt/dataset test-data
     (is (=? {:status    :completed
              :row_count 137}
-            (qp.pivot/run-pivot-query (api.pivots/parameters-query))))))
+            (qp.pivot/run-pivot-query (qp.pivot.test-util/parameters-query))))))
 
 (defn- clean-pivot-results [results]
   (let [no-uuid #(cond-> (dissoc % :lib/source_uuid)

--- a/test/metabase/query_processor_test/model_test.clj
+++ b/test/metabase/query_processor_test/model_test.clj
@@ -74,7 +74,11 @@
                                           (lib/with-join-fields :all))))))]
       (is (= ["Reviews → Created At: Month"
               "Average of Rating"
-              "Products+Reviews Summary - Reviews → Created At: Month → Created At: Month"
+              ;; the 'correct' display name here seems to change any time we touch anything. Some previous values:
+              #_"Products+Reviews Summary - Reviews → Created At: Month → Reviews → Created At: Month"
+              #_"Products+Reviews Summary - Reviews → Created At: Month → Created At"
+              #_"Products+Reviews Summary - Reviews → Created At: Month → Created At: Month"
+              "Products+Reviews Summary - Reviews → Created At: Month → Created At"
               "Products+Reviews Summary - Reviews → Created At: Month → Sum of Price"]
              (->> (qp/process-query question)
                   mt/cols


### PR DESCRIPTION
Resolves QUE-1494
Resolves QUE-1497

Prerequisite work to the caching improvements in #60590 (issue #60284) 

I was originally going to do this as part of #60590 but decided to split it out into a separate PR so debugging test failures was more straightforward.

- Eliminate `unique-name-fn` as an option passed around between functions; it is now created only in the places it is needed (e.g. `returned-columns-method` for a stage). Actually desired column aliases are now consistently calculated in a single place by `metabase.lib.field.util/add-source-and-desired-aliases-xform`. This simplifies metadata calculation code a lot and makes it a lot easier to follow. Also since a stateful function is no longer passed around it makes caching metadata much easier.
- `visible-columns` is no longer guaranteed to include `:lib/desired-column-alias` since `desired-column-alias` is a function of the `returned-columns` in a query stage 