### PR TITLE
ADM-1154 make form text inputs non-bold

### DIFF
--- a/frontend/src/metabase/forms/components/FormTextInput/FormTextInput.tsx
+++ b/frontend/src/metabase/forms/components/FormTextInput/FormTextInput.tsx
@@ -58,11 +58,6 @@ export const FormTextInput = forwardRef(function FormTextInput(
 
   return (
     <TextInput
-      styles={{
-        input: {
-          fontWeight: "bold",
-        },
-      }}
       {...props}
       ref={ref}
       name={name}

--- a/frontend/src/metabase/forms/components/FormTextarea/FormTextarea.tsx
+++ b/frontend/src/metabase/forms/components/FormTextarea/FormTextarea.tsx
@@ -50,9 +50,6 @@ export const FormTextarea = forwardRef(function FormTextarea(
       onBlur={handleBlur}
       styles={{
         ...(props.styles ?? {}),
-        input: {
-          fontWeight: "bold",
-        },
       }}
     />
   );


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #54481
Some of our form inputs where bolded, but the Figma designs (and confirmed by design) show them as non-bold

https://storybook.metabase.com/?path=/docs/components-inputs-textarea--default

https://storybook.metabase.com/?path=/story/components-inputs-textinput--default


| Before | After |
|--------|-------|
| <img width="780" alt="Screenshot 2025-07-09 at 11 06 34 AM" src="https://github.com/user-attachments/assets/98224420-9a15-4600-b3be-cac2093816e5" /> | <img width="780" alt="Screenshot 2025-07-09 at 11 06 15 AM" src="https://github.com/user-attachments/assets/eb9e2cca-4c30-4efe-bc5b-978e7816bc09" /> |
| <img width="869" alt="Screenshot 2025-07-09 at 11 06 53 AM" src="https://github.com/user-attachments/assets/105362ad-ede8-4818-a941-b24a757ce9e0" /> | <img width="869" alt="Screenshot 2025-07-09 at 11 07 07 AM" src="https://github.com/user-attachments/assets/53a68cac-0039-494c-9362-14c7280cdd97" /> |
