### PR TITLE
Remove Changelogs From Github

### DIFF
--- a/release/src/release-notes-templates.ts
+++ b/release/src/release-notes-templates.ts
@@ -17,6 +17,8 @@ JAR download: {{oss-download-url}}
 Docker image: {{ee-docker-tag}}
 JAR download: {{ee-download-url}}
 
+## Changelog
+
 [Full Changelog]({{changelog-url}})
 
 `;

--- a/release/src/release-notes-templates.ts
+++ b/release/src/release-notes-templates.ts
@@ -17,58 +17,40 @@ JAR download: {{oss-download-url}}
 Docker image: {{ee-docker-tag}}
 JAR download: {{ee-download-url}}
 
-## Changelog
-
-### Enhancements
-
-{{enhancements}}
-
-### Bug fixes
-
-{{bug-fixes}}
-
-### Already Fixed
-
-Issues confirmed to have been fixed in a previous release.
-
-{{already-fixed}}
-
-### Under the Hood
-
-{{under-the-hood}}
+[Full Changelog]({{changelog-url}})
 
 `;
 
 export const websiteChangelogTemplate = `
 ## Metabase {{version}}
 
-### Upgrading
+### Upgrading | {{generic-version}}
 
-#### Metabase Open Source
+#### Metabase Open Source | {{generic-version}}
 
 - Docker image: {{oss-docker-tag}}
-- JAR download: {{oss-download-url}}
+- [JAR download]({{oss-download-url}})
 
-#### Metabase Enterprise
+#### Metabase Enterprise | {{generic-version}}
 
 - Docker image: {{ee-docker-tag}}
-- JAR download: {{ee-download-url}}
+- [JAR download]({{ee-download-url}})
 
-### Enhancements
+### Enhancements | {{generic-version}}
 
 {{enhancements}}
 
-### Bug fixes
+### Bug fixes | {{generic-version}}
 
 {{bug-fixes}}
 
-### Already Fixed
+### Already Fixed | {{generic-version}}
 
 Issues confirmed to have been fixed in a previous release.
 
 {{already-fixed}}
 
-### Under the Hood
+### Under the Hood | {{generic-version}}
 
 {{under-the-hood}}
 

--- a/release/src/release-notes.ts
+++ b/release/src/release-notes.ts
@@ -9,6 +9,8 @@ import {
   getDotXVersion,
   getEnterpriseVersion,
   getGenericVersion,
+  getMajorVersion,
+  getMinorVersion,
   getOSSVersion,
   isEnterpriseVersion,
   isPreReleaseVersion,
@@ -59,6 +61,12 @@ export const getDownloadUrl = (version: string) => {
     isEnterpriseVersion(version) ? "enterprise/" : ""
   }${dotXVersion}/metabase.jar`;
 };
+
+export const getChangelogUrl = (version: string ) => {
+  const majorVersion = getMajorVersion(version);
+  const minorVersion = getMinorVersion(version);
+  return `https://www.metabase.com/changelog/${majorVersion}#metabase-${majorVersion}${minorVersion}`
+}
 
 export const getReleaseTitle = (version: string) => {
   return `Metabase ${getGenericVersion(version)}`;
@@ -213,7 +221,9 @@ export const generateReleaseNotes = ({
     .replace("{{ee-docker-tag}}", getDockerTag(eeVersion))
     .replace("{{ee-download-url}}", getDownloadUrl(eeVersion))
     .replace("{{oss-docker-tag}}", getDockerTag(ossVersion))
-    .replace("{{oss-download-url}}", getDownloadUrl(ossVersion));
+    .replace("{{oss-download-url}}", getDownloadUrl(ossVersion))
+    .replaceAll("{{generic-version}}", getGenericVersion(version))
+    .replace("{{changelog-url}}", getChangelogUrl(ossVersion));
 };
 
 export async function publishRelease({

--- a/release/src/release-notes.unit.spec.ts
+++ b/release/src/release-notes.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   categorizeIssues,
   generateReleaseNotes,
+  getChangelogUrl,
   getReleaseTitle,
   getWebsiteChangelog,
   markdownIssueLinks,
@@ -72,25 +73,21 @@ describe("Release Notes", () => {
     it("should generate release notes", () => {
       const notes = generateReleaseNotes({
         version: "v1.2.3",
-        template: githubReleaseTemplate,
+        template: websiteChangelogTemplate,
         issues,
       });
 
       expect(notes).toContain(
-        "Get the most out of Metabase"
-      );
-
-      expect(notes).toContain(
-        "### Enhancements\n\n**Querying**\n\n- Feature Issue (#2)",
+        "### Enhancements | 2.3\n\n**Querying**\n\n- Feature Issue (#2)",
       );
       expect(notes).toContain(
-        "### Bug fixes\n\n**Embedding**\n\n- Bug Issue (#1)",
+        "### Bug fixes | 2.3\n\n**Embedding**\n\n- Bug Issue (#1)",
       );
       expect(notes).toContain(
-        "### Already Fixed\n\nIssues confirmed to have been fixed in a previous release.\n\n**Embedding**\n\n- Issue Already Fixed (#3)",
+        "### Already Fixed | 2.3\n\nIssues confirmed to have been fixed in a previous release.\n\n**Embedding**\n\n- Issue Already Fixed (#3)",
       );
       expect(notes).toContain(
-        "### Under the Hood\n\n**Administration**\n\n- Issue That Users Don't Care About (#4)",
+        "### Under the Hood | 2.3\n\n**Administration**\n\n- Issue That Users Don't Care About (#4)",
       );
 
       expect(notes).toContain("metabase/metabase-enterprise:v1.2.3.x");
@@ -106,21 +103,12 @@ describe("Release Notes", () => {
     it("should generate release notes from alternative templates", () => {
       const notes = generateReleaseNotes({
         version: "v1.2.3",
-        template: websiteChangelogTemplate,
+        template: githubReleaseTemplate,
         issues,
       });
 
       expect(notes).toContain(
-        "### Enhancements\n\n**Querying**\n\n- Feature Issue (#2)",
-      );
-      expect(notes).toContain(
-        "### Bug fixes\n\n**Embedding**\n\n- Bug Issue (#1)",
-      );
-      expect(notes).toContain(
-        "### Already Fixed\n\nIssues confirmed to have been fixed in a previous release.\n\n**Embedding**\n\n- Issue Already Fixed (#3)",
-      );
-      expect(notes).toContain(
-        "### Under the Hood\n\n**Administration**\n\n- Issue That Users Don't Care About (#4)",
+        "https://www.metabase.com/changelog/"
       );
 
       expect(notes).toContain("metabase/metabase-enterprise:v1.2.3.x");
@@ -497,5 +485,18 @@ describe("Release Notes", () => {
       expect(notes).toContain("- Issue That Users Don't Care About ([#4](https://github.com/metabase/metabase/issues/4))");
     });
 
+  });
+
+  it.each([
+    ["v0.53.2", "53#metabase-532"],
+    ["v1.53.0", "53#metabase-530"],
+    ["v1.57.16", "57#metabase-5716"],
+    ["v1.59.0.4-beta", "59#metabase-590"],
+    ["v1.60.0", "60#metabase-600"],
+    ["v0.32.0", "32#metabase-320"],
+    ["v0.444.1", "444#metabase-4441"],
+
+  ])("getChangelogUrl: %s -> %s", (input, expected)=> {
+    expect(getChangelogUrl(input)).toEqual(`https://www.metabase.com/changelog/${expected}`);
   });
 });

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -1,3 +1,5 @@
+import { get } from "underscore";
+
 import type { GithubProps, Tag } from "./types";
 
 // https://regexr.com/7l1ip
@@ -70,17 +72,23 @@ export const isEnterpriseVersion = (versionString: string): boolean => {
 export const isPreReleaseVersion = (version: string) =>
   isValidVersionString(version) && /rc|alpha|beta/i.test(version);
 
-export const getMajorVersion = (versionString: string) =>
-  versionString
+const getVersionParts = (versionString: string) => {
+  const parts = versionString
     .replace(/^[^\.]+\./, "")
     .replace(/-rc\d+/i, "")
-    .split(".")[0];
+    .split(".");
+  return {
+    major: Number(parts[0]),
+    minor: Number(parts[1]) || 0,
+    patch: Number(parts[2]),
+  };
+};
+
+export const getMajorVersion = (versionString: string) =>
+  getVersionParts(versionString).major.toString();
 
 export const getMinorVersion = (versionString: string) =>
-  versionString
-    .replace(/^[^\.]+\./, "")
-    .replace(/-rc\d+/i, "")
-    .split(".")?.[1] || "0";
+  getVersionParts(versionString).minor.toString();
 
 export const isReleaseBranch = (branchName: string) => {
   return branchName.startsWith("release-x.");

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -1,5 +1,3 @@
-import { get } from "underscore";
-
 import type { GithubProps, Tag } from "./types";
 
 // https://regexr.com/7l1ip
@@ -78,17 +76,17 @@ const getVersionParts = (versionString: string) => {
     .replace(/-rc\d+/i, "")
     .split(".");
   return {
-    major: Number(parts[0]),
-    minor: Number(parts[1]) || 0,
-    patch: Number(parts[2]),
+    major: parts[0],
+    minor: parts[1] || "0",
+    patch: parts[2],
   };
 };
 
 export const getMajorVersion = (versionString: string) =>
-  getVersionParts(versionString).major.toString();
+  getVersionParts(versionString).major;
 
 export const getMinorVersion = (versionString: string) =>
-  getVersionParts(versionString).minor.toString();
+  getVersionParts(versionString).minor;
 
 export const isReleaseBranch = (branchName: string) => {
   return branchName.startsWith("release-x.");

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -76,6 +76,12 @@ export const getMajorVersion = (versionString: string) =>
     .replace(/-rc\d+/i, "")
     .split(".")[0];
 
+export const getMinorVersion = (versionString: string) =>
+  versionString
+    .replace(/^[^\.]+\./, "")
+    .replace(/-rc\d+/i, "")
+    .split(".")?.[1] || "0";
+
 export const isReleaseBranch = (branchName: string) => {
   return branchName.startsWith("release-x.");
 };

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -8,8 +8,10 @@ import {
   getExtraTagsForVersion,
   getGenericVersion,
   getLastReleaseFromTags,
+  getMajorVersion,
   getMajorVersionNumberFromReleaseBranch,
   getMilestoneName,
+  getMinorVersion,
   getNextVersions,
   getOSSVersion,
   getReleaseBranch,
@@ -799,5 +801,25 @@ describe("version-helpers", () => {
 
       expect(filteredTags).toEqual(createTags(["0.55.0", "0.55.0-nightly"]));
     });
+  });
+
+  describe("getMajorVersion", () => {
+    it.each([
+      ["v0.52.3", "52"],
+      ["v1.52", "52"],
+      ["v1.43.2.1", "43"]
+    ])("%s -> %s" , (input, expected) => {
+      expect(getMajorVersion(input)).toBe(expected);
+    })
+  });
+
+  describe("getMinorVersion", () => {
+    it.each([
+      ["v0.52.3", "3"],
+      ["v1.52", "0"],
+      ["v1.43.2.1", "2"]
+    ])("%s -> %s" , (input, expected) => {
+      expect(getMinorVersion(input)).toBe(expected);
+    })
   });
 });

--- a/release/src/version-info.ts
+++ b/release/src/version-info.ts
@@ -1,5 +1,4 @@
 import fetch from "node-fetch";
-import _ from "underscore";
 
 import { getMilestoneIssues } from "./github";
 import type {


### PR DESCRIPTION
closes DEV-94

### Description

Replaces changelogs in github with a link to the website changelog page.

Updates changelog template to make @alexyarosh's life easier. 


- [x] Tests have been added/updated to cover changes in this PR
- [x] Run a [test release](https://github.com/iethree/metabase/releases/tag/v0.51.89) on my fork
