### PR TITLE
Fix SQL Server connection failure when login and database users differ

### DIFF
--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -923,10 +923,11 @@
 
 (defmethod driver.sql/default-database-role :sqlserver
   [_driver database]
-  ;; Use a "role" (sqlserver user) if it exists, otherwise use
-  ;; the user if it can be impersonated (ie not the 'sa' user).
-  (let [{:keys [role user]} (:details database)]
-    (or role (when-not (= (u/lower-case-en user) "sa") user))))
+  ;; Use a "role" (sqlserver user) if it exists. Do not fall back to the user
+  ;; field automatically, as it represents the login user which may not be a 
+  ;; valid database user for impersonation (see issue #60665).
+  (let [{:keys [role]} (:details database)]
+    role))
 
 (defmethod driver.sql/set-role-statement :sqlserver
   [_driver role]

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -9,8 +9,8 @@
    [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]
-   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql :as driver.sql]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sqlserver :as sqlserver]
@@ -709,15 +709,15 @@
     (testing "returns role when explicitly configured"
       (let [database {:details {:user "login_user" :role "db_user"}}]
         (is (= "db_user" (driver.sql/default-database-role :sqlserver database)))))
-    
+
     (testing "returns nil when no role is configured"
       (let [database {:details {:user "login_user"}}]
         (is (nil? (driver.sql/default-database-role :sqlserver database)))))
-    
+
     (testing "returns nil even when user is 'sa'"
       (let [database {:details {:user "sa"}}]
         (is (nil? (driver.sql/default-database-role :sqlserver database)))))
-    
+
     (testing "ignores user field and only uses role field"
       (let [database {:details {:user "login_user" :role "impersonation_user"}}]
         (is (= "impersonation_user" (driver.sql/default-database-role :sqlserver database)))))))

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -10,6 +10,7 @@
    [metabase.driver :as driver]
    [metabase.driver.common :as driver.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sqlserver :as sqlserver]
@@ -702,3 +703,21 @@
 (deftest ^:parallel db-default-timezone-test
   (mt/test-driver :sqlserver
     (is (= "Z" (str (driver/db-default-timezone :sqlserver (mt/db)))))))
+
+(deftest ^:parallel default-database-role-test
+  (testing "SQL Server default database role handling"
+    (testing "returns role when explicitly configured"
+      (let [database {:details {:user "login_user" :role "db_user"}}]
+        (is (= "db_user" (driver.sql/default-database-role :sqlserver database)))))
+    
+    (testing "returns nil when no role is configured"
+      (let [database {:details {:user "login_user"}}]
+        (is (nil? (driver.sql/default-database-role :sqlserver database)))))
+    
+    (testing "returns nil even when user is 'sa'"
+      (let [database {:details {:user "sa"}}]
+        (is (nil? (driver.sql/default-database-role :sqlserver database)))))
+    
+    (testing "ignores user field and only uses role field"
+      (let [database {:details {:user "login_user" :role "impersonation_user"}}]
+        (is (= "impersonation_user" (driver.sql/default-database-role :sqlserver database)))))))


### PR DESCRIPTION
## Summary

Fixes #60665 - SQL Server connection fails when login user and database user have different names.

This resolves the issue where SQL Server connections would fail with the error "Cannot execute as the database principal because the principal 'X' does not exist" when the login user and database user have different names.

## Changes

- **Modified SQL Server driver impersonation logic**: Updated `default-database-role` method to only return explicitly configured roles instead of automatically falling back to the `user` field
- **Removed problematic fallback behavior**: The method no longer attempts impersonation with the login user when no explicit role is configured
- **Added comprehensive tests**: Created tests covering various scenarios including explicit roles, no roles, and different user configurations
- **Improved documentation**: Added clear comments explaining the fix and referencing the issue

## Root Cause

The original code automatically used the `user` field (login user) for impersonation when no explicit `role` was configured. This caused failures when:
1. The login user successfully authenticates to SQL Server
2. But the login user doesn't exist as a database principal 
3. The impersonation attempt fails with "principal does not exist"

## Solution

The fix ensures that impersonation only occurs when an explicit `role` is configured in the database connection details. This prevents the automatic fallback to invalid users while maintaining backward compatibility for properly configured connections.

## Test Plan

- [x] Unit tests pass for new default-database-role behavior
- [x] Code passes linting and formatting checks
- [x] Existing SQL Server driver tests continue to pass
- [x] Manual verification that connections work with explicit roles
- [x] Verification that connections don't attempt invalid impersonation

## Impact

- **Fixes blocking customer upgrades** from v55+
- **Maintains backward compatibility** for existing connections with proper `role` configuration
- **Eliminates confusing error messages** about non-existent principals
- **Requires explicit configuration** for impersonation, improving clarity

🤖 Generated with [Claude Code](https://claude.ai/code)