### PR TITLE
Allow to save question even before visualizing it

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -71,6 +71,37 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
     getSdkRoot().contains("My Orders");
   });
 
+  it("can create a question without visualizing it first (EMB-584)", () => {
+    cy.signOut();
+    mockAuthProviderAndJwtSignIn();
+
+    mountSdkContent(
+      <Flex p="xl">
+        <InteractiveQuestion questionId="new" />
+      </Flex>,
+    );
+
+    getSdkRoot().within(() => {
+      cy.findByText("New question").should("be.visible");
+      cy.button("Save").should("not.exist");
+    });
+
+    popover().findByRole("link", { name: "Orders" }).click();
+
+    getSdkRoot().button("Save").should("be.visible").click();
+
+    const expectedQuestionName = "Orders question";
+    modal().within(() => {
+      cy.findByRole("heading", { name: "Save new question" }).should(
+        "be.visible",
+      );
+      cy.findByLabelText("Name").clear().type(expectedQuestionName);
+      cy.button("Save").click();
+    });
+
+    getSdkRoot().findByText(expectedQuestionName).should("be.visible");
+  });
+
   it("can save a question in a dashboard", () => {
     createQuestion({
       name: "Total Orders",

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -114,9 +114,7 @@ export const InteractiveQuestionDefaultView = ({
   }
 
   const showSaveButton =
-    shouldShowSaveButton({ question, originalQuestion }) &&
-    isSaveEnabled &&
-    !isSaveModalOpen;
+    shouldShowSaveButton({ question, originalQuestion }) && isSaveEnabled;
 
   return (
     <FlexibleSizeComponent
@@ -125,22 +123,19 @@ export const InteractiveQuestionDefaultView = ({
       className={cx(InteractiveQuestionS.Container, className)}
       style={style}
     >
-      {queryResults && (
-        <Stack className={InteractiveQuestionS.TopBar} gap="sm" p="md">
-          <Group justify="space-between" align="flex-end">
-            <Group gap="xs">
-              <Box mr="sm">
-                <InteractiveQuestion.BackButton />
-              </Box>
-              <DefaultViewTitle
-                title={title}
-                withResetButton={withResetButton}
-              />
-            </Group>
-            {showSaveButton && (
-              <InteractiveQuestion.SaveButton onClick={openSaveModal} />
-            )}
+      <Stack className={InteractiveQuestionS.TopBar} gap="sm" p="md">
+        <Group justify="space-between" align="flex-end">
+          <Group gap="xs">
+            <Box mr="sm">
+              <InteractiveQuestion.BackButton />
+            </Box>
+            <DefaultViewTitle title={title} withResetButton={withResetButton} />
           </Group>
+          {showSaveButton && (
+            <InteractiveQuestion.SaveButton onClick={openSaveModal} />
+          )}
+        </Group>
+        {queryResults && (
           <Group
             justify="space-between"
             p="sm"
@@ -188,8 +183,8 @@ export const InteractiveQuestionDefaultView = ({
               />
             </Group>
           </Group>
-        </Stack>
-      )}
+        )}
+      </Stack>
 
       <Box className={InteractiveQuestionS.Main} p="sm" w="100%" h="100%">
         <Box className={InteractiveQuestionS.Content}>

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestionDefaultView/InteractiveQuestionDefaultView.tsx
@@ -14,7 +14,6 @@ import { shouldRunCardQuery } from "embedding-sdk/lib/interactive-question";
 import type { SdkQuestionTitleProps } from "embedding-sdk/types/question";
 import { SaveQuestionModal } from "metabase/common/components/SaveQuestionModal";
 import { useLocale } from "metabase/common/hooks/use-locale";
-import CS from "metabase/css/core/index.css";
 import {
   Box,
   Button,
@@ -189,21 +188,7 @@ export const InteractiveQuestionDefaultView = ({
       <Box className={InteractiveQuestionS.Main} p="sm" w="100%" h="100%">
         <Box className={InteractiveQuestionS.Content}>
           {isEditorOpen ? (
-            <>
-              {/* Use the same horizontal padding as https://github.com/metabase/metabase/blob/98e2dcc7c8c7c9147f4a787cc7ed36eddde9c080/frontend/src/metabase/querying/notebook/components/Notebook/Notebook.tsx#L48 */}
-              {/* Vertical padding matches the visualization header above */}
-              {/* If we don't conditionally render this button, it will be shown twice after visualizing the query once. */}
-              {!queryResults && (
-                <Box
-                  px={{ base: "1rem", sm: "2rem" }}
-                  pt="md"
-                  className={CS.hideEmpty}
-                >
-                  <InteractiveQuestion.BackButton />
-                </Box>
-              )}
-              <InteractiveQuestion.Editor onApply={closeEditor} />
-            </>
+            <InteractiveQuestion.Editor onApply={closeEditor} />
           ) : (
             <InteractiveQuestion.QuestionVisualization height="100%" />
           )}


### PR DESCRIPTION
closes EMB-584

### Description

We allow to save question wihout requiring users to visualize the query before on the core app. I couldn't see why don't do the same on the SDK.

### How to verify
1. Run BE
1. Run storybook
    ```sh
    yarn storybook-embedding-sdk
    ```
1. Visit Editable dashboard story
1. Edit > Add cards > New Question
2. Build the query, but do not click "Visualize" yet
3. The "Save" button should be visible and clickable.

### Demo

![image](https://github.com/user-attachments/assets/158b958d-a322-4a43-88bf-b4c80489af88)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
