### PR TITLE
Prevent SDK issues going into Metabase release changelog

### DIFF
--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 
 import { graphql } from "@octokit/graphql";
-import _, { has } from "underscore";
+import _ from "underscore";
 
 import { hiddenLabels, nonUserFacingLabels } from "./constants";
 import {
@@ -26,7 +26,7 @@ import {
 
 function isBackport(pullRequest: Issue) {
   return (
-    pullRequest.title.includes("backport") || hasLabel(pullRequest, "backport")
+    pullRequest.title.includes("backport") || hasLabel(pullRequest, "was-backport")
   );
 }
 


### PR DESCRIPTION
closes EMB-602

See the [Slack thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1751911009433629?thread_ts=1751906670.129189&cid=C063Q3F1HPF).

There are many instances that confuse people because SDK items got into the core Metabase changelog. Since the SDK is released separately from Metabase and has its own changelogs. We shouldn't mix the two and create false expectations that at a specific MB version, the SDK fix is released.

It might be true that some fixes are BE, but most of the time (95%+) the fix is pure FE and shouldn't be included in the change log.