### PR TITLE
Add repro for "Custom Expression can fail query when mixing numeric and string functions"

### DIFF
--- a/e2e/support/helpers/e2e-custom-column-helpers.ts
+++ b/e2e/support/helpers/e2e-custom-column-helpers.ts
@@ -1,3 +1,5 @@
+import { popover } from "e2e/support/helpers/e2e-ui-elements-helpers";
+
 export function expressionEditorWidget() {
   return cy.findByTestId("expression-editor");
 }
@@ -15,6 +17,7 @@ export function enterCustomColumnDetails({
   blur = true,
   format = false,
   allowFastSet = false,
+  clickDone = false,
 }: {
   formula: string;
 
@@ -41,6 +44,11 @@ export function enterCustomColumnDetails({
    *   This has some other side effects, like not triggering change handlers or not triggering autocomplte, so use it sparingly.
    */
   allowFastSet?: boolean;
+
+  /**
+   * set to true to click the done button after setting the detauls to save the custom column.
+   */
+  clickDone?: boolean;
 }) {
   CustomExpressionEditor.get().as("formula");
   CustomExpressionEditor.clear();
@@ -56,6 +64,10 @@ export function enterCustomColumnDetails({
 
   if (name) {
     cy.findByTestId("expression-name").clear().type(name).blur();
+  }
+
+  if (clickDone) {
+    popover().button("Done").click();
   }
 }
 

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -2057,3 +2057,25 @@ describe("Issue 58230", () => {
     H.popover().button("Done").should("be.enabled");
   });
 });
+
+describe("Issue 12938", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.openProductsTable({ mode: "notebook" });
+  });
+
+  it("should be possible to concat number with string (metabase#12938)", () => {
+    H.addCustomColumn();
+    H.enterCustomColumnDetails({
+      formula: "concat(floor([Rating]), [Title])",
+      name: "MyCustom",
+      clickDone: true,
+    });
+
+    H.visualize();
+    cy.get("main")
+      .findByText("There was a problem with your question")
+      .should("not.exist");
+  });
+});

--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -2078,4 +2078,18 @@ describe("Issue 12938", () => {
       .findByText("There was a problem with your question")
       .should("not.exist");
   });
+
+  it("should be possible to concat number with string (metabase#12938)", () => {
+    H.addCustomColumn();
+    H.enterCustomColumnDetails({
+      formula: 'concat(hour([Created At]), ":", minute([Created At]))',
+      name: "MyCustom",
+      clickDone: true,
+    });
+
+    H.visualize();
+    cy.get("main")
+      .findByText("There was a problem with your question")
+      .should("not.exist");
+  });
 });


### PR DESCRIPTION
Closes #12938

Issue was already fixed, this just adds the repro

Triple backport because the issue is fixed in 53, 54 and 55.