### PR TITLE
Closes VIZ-1283 overflow in visualizer modal

### DIFF
--- a/frontend/src/metabase/visualizer/components/VisualizerModal/VisualizerModal.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizerModal/VisualizerModal.tsx
@@ -64,6 +64,11 @@ export function VisualizerModal({
         withCloseButton={false}
         onClose={onModalClose}
         padding={0}
+        styles={{
+          content: {
+            overflow: "hidden",
+          },
+        }}
       >
         {open && (
           <Visualizer


### PR DESCRIPTION
Closes [VIZ-1283: Fix overflow in Visualizer modal](https://linear.app/metabase/issue/VIZ-1283/fix-overflow-in-visualizer-modal).

This issue was caused by the migration to Mantine v8.

![Kapture 2025-07-09 at 14 52 18](https://github.com/user-attachments/assets/c6456b1a-14b9-4fa8-8dab-4540e214f0bc)
