### PR TITLE
feat: add dashboard mode system for SdkDashboard

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/EditableDashboard/EditableDashboard.tsx
@@ -1,14 +1,4 @@
-import { DASHBOARD_EDITING_ACTIONS } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/constants";
-import { DASHBOARD_ACTION } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys";
-import type { MetabasePluginsConfig as InternalMetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
-import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
-import { EmbeddingSdkMode } from "metabase/visualizations/click-actions/modes/EmbeddingSdkMode";
-
-import {
-  SdkDashboard,
-  type SdkDashboardInnerProps,
-  type SdkDashboardProps,
-} from "../SdkDashboard";
+import { SdkDashboard, type SdkDashboardProps } from "../SdkDashboard";
 
 /**
  * @interface
@@ -25,31 +15,5 @@ export type EditableDashboardProps = SdkDashboardProps;
  * @param props
  */
 export const EditableDashboard = (props: EditableDashboardProps) => {
-  const dashboardActions: SdkDashboardInnerProps["dashboardActions"] = ({
-    isEditing,
-    downloadsEnabled,
-  }) =>
-    isEditing
-      ? DASHBOARD_EDITING_ACTIONS
-      : downloadsEnabled.pdf
-        ? [DASHBOARD_ACTION.EDIT_DASHBOARD, DASHBOARD_ACTION.DOWNLOAD_PDF]
-        : [DASHBOARD_ACTION.EDIT_DASHBOARD];
-
-  const getClickActionMode: SdkDashboardInnerProps["getClickActionMode"] = ({
-    question,
-  }) =>
-    getEmbeddingMode({
-      question,
-      queryMode: EmbeddingSdkMode,
-      plugins: props.drillThroughQuestionProps
-        ?.plugins as InternalMetabasePluginsConfig,
-    });
-
-  return (
-    <SdkDashboard
-      {...props}
-      getClickActionMode={getClickActionMode}
-      dashboardActions={dashboardActions}
-    />
-  );
+  return <SdkDashboard {...props} mode="editable" />;
 };

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
@@ -1,13 +1,3 @@
-import { useCallback } from "react";
-
-import { DashCardQuestionDownloadButton } from "metabase/dashboard/components/DashCard/DashCardQuestionDownloadButton";
-import { DASHBOARD_ACTION } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys";
-import { isQuestionCard } from "metabase/dashboard/utils";
-import type { MetabasePluginsConfig as InternalMetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
-import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
-import { EmbeddingSdkMode } from "metabase/visualizations/click-actions/modes/EmbeddingSdkMode";
-import type { ClickActionModeGetter } from "metabase/visualizations/types";
-
 import { SdkDashboard, type SdkDashboardProps } from "../SdkDashboard";
 
 /**
@@ -25,31 +15,5 @@ export type InteractiveDashboardProps = SdkDashboardProps;
  * @param props
  */
 export const InteractiveDashboard = (props: InteractiveDashboardProps) => {
-  const getClickActionMode: ClickActionModeGetter = useCallback(
-    ({ question }) =>
-      getEmbeddingMode({
-        question,
-        queryMode: EmbeddingSdkMode,
-        plugins: props.plugins as InternalMetabasePluginsConfig,
-      }),
-    [props.plugins],
-  );
-
-  return (
-    <SdkDashboard
-      {...props}
-      getClickActionMode={getClickActionMode}
-      dashboardActions={({ downloadsEnabled }) => {
-        return downloadsEnabled.pdf ? [DASHBOARD_ACTION.DOWNLOAD_PDF] : [];
-      }}
-      dashcardMenu={({ dashcard, result, downloadsEnabled }) =>
-        downloadsEnabled?.results &&
-        isQuestionCard(dashcard.card) &&
-        !!result?.data &&
-        !result?.error && (
-          <DashCardQuestionDownloadButton result={result} dashcard={dashcard} />
-        )
-      }
-    />
-  );
+  return <SdkDashboard {...props} mode="interactive" />;
 };

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -20,6 +20,7 @@ import {
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import type { DashboardEventHandlersProps } from "embedding-sdk/types/dashboard";
 import type { MetabasePluginsConfig } from "embedding-sdk/types/plugins";
+import type { DashboardMode } from "metabase/dashboard/types/dashboard-mode";
 import { useLocale } from "metabase/common/hooks/use-locale";
 import { setEditingDashboard, toggleSidebar } from "metabase/dashboard/actions";
 import { Dashboard } from "metabase/dashboard/components/Dashboard/Dashboard";
@@ -66,6 +67,12 @@ import { useCommonDashboardParams } from "./use-common-dashboard-params";
 export type SdkDashboardProps = PropsWithChildren<
   {
     /**
+     * Dashboard mode - defines what users can do with the dashboard.
+     * Can be a preset string ('editable', 'interactive', 'static') or a full configuration object.
+     */
+    mode?: DashboardMode;
+
+    /**
      * Additional mapper function to override or add drill-down menu. See the implementing custom actions section for more details.
      */
     plugins?: MetabasePluginsConfig;
@@ -99,6 +106,7 @@ export type SdkDashboardInnerProps = SdkDashboardProps &
       | "dashboardActions"
       | "dashcardMenu"
       | "navigateToNewCardFromDashboard"
+      | "dashboardMode"
     >
   >;
 
@@ -119,6 +127,7 @@ const SdkDashboardInner = ({
     plugins: plugins,
   },
   renderDrillThroughQuestion: AdHocQuestionView,
+  mode,
   dashboardActions,
   dashcardMenu = plugins?.dashboard?.dashboardCardMenu,
   getClickActionMode,
@@ -207,6 +216,7 @@ const SdkDashboardInner = ({
       getClickActionMode={getClickActionMode}
       dashcardMenu={dashcardMenu}
       dashboardActions={dashboardActions}
+      dashboardMode={mode}
       onAddQuestion={(dashboard) => {
         dispatch(setEditingDashboard(dashboard));
         dispatch(toggleSidebar(SIDEBAR_NAME.addQuestion));

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -102,10 +102,7 @@ export type SdkDashboardInnerProps = SdkDashboardProps &
   Partial<
     Pick<
       DashboardContextProps,
-      | "getClickActionMode"
-      | "dashboardActions"
       | "dashcardMenu"
-      | "navigateToNewCardFromDashboard"
       | "dashboardMode"
     >
   >;
@@ -128,10 +125,7 @@ const SdkDashboardInner = ({
   },
   renderDrillThroughQuestion: AdHocQuestionView,
   mode,
-  dashboardActions,
   dashcardMenu = plugins?.dashboard?.dashboardCardMenu,
-  getClickActionMode,
-  navigateToNewCardFromDashboard = undefined,
   className,
   style,
   children,
@@ -198,11 +192,6 @@ const SdkDashboardInner = ({
     <DashboardContextProvider
       dashboardId={dashboardId}
       parameterQueryParams={initialParameters}
-      navigateToNewCardFromDashboard={
-        navigateToNewCardFromDashboard !== undefined
-          ? navigateToNewCardFromDashboard
-          : onNavigateToNewCardFromDashboard
-      }
       downloadsEnabled={displayOptions.downloadsEnabled}
       background={displayOptions.background}
       bordered={displayOptions.bordered}
@@ -213,9 +202,7 @@ const SdkDashboardInner = ({
       onLoad={handleLoad}
       onLoadWithoutCards={handleLoadWithoutCards}
       onError={(error) => dispatch(setErrorPage(error))}
-      getClickActionMode={getClickActionMode}
       dashcardMenu={dashcardMenu}
-      dashboardActions={dashboardActions}
       dashboardMode={mode}
       onAddQuestion={(dashboard) => {
         dispatch(setEditingDashboard(dashboard));

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/StaticDashboard/StaticDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/StaticDashboard/StaticDashboard.tsx
@@ -1,10 +1,3 @@
-import { DashCardQuestionDownloadButton } from "metabase/dashboard/components/DashCard/DashCardQuestionDownloadButton";
-import { DASHBOARD_ACTION } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys";
-import { isQuestionCard } from "metabase/dashboard/utils";
-import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
-import type { ClickActionModeGetter } from "metabase/visualizations/types";
-
-import { StaticQuestionSdkMode } from "../../StaticQuestion/mode";
 import { SdkDashboard, type SdkDashboardProps } from "../SdkDashboard";
 
 /**
@@ -22,28 +15,5 @@ export type StaticDashboardProps = SdkDashboardProps;
  * @param props
  */
 export const StaticDashboard = (props: StaticDashboardProps) => {
-  const getClickActionMode: ClickActionModeGetter = ({ question }) =>
-    getEmbeddingMode({
-      question,
-      queryMode: StaticQuestionSdkMode,
-    });
-
-  return (
-    <SdkDashboard
-      {...props}
-      getClickActionMode={getClickActionMode}
-      dashboardActions={({ downloadsEnabled }) =>
-        downloadsEnabled.pdf ? [DASHBOARD_ACTION.DOWNLOAD_PDF] : []
-      }
-      navigateToNewCardFromDashboard={null}
-      dashcardMenu={({ dashcard, result }) =>
-        props.withDownloads &&
-        isQuestionCard(dashcard.card) &&
-        !!result?.data &&
-        !result?.error && (
-          <DashCardQuestionDownloadButton result={result} dashcard={dashcard} />
-        )
-      }
-    />
-  );
+  return <SdkDashboard {...props} mode="static" />;
 };

--- a/frontend/src/metabase/dashboard/context/context.tsx
+++ b/frontend/src/metabase/dashboard/context/context.tsx
@@ -21,7 +21,8 @@ import type { DashboardCardMenu } from "../components/DashCard/DashCardMenu/dash
 import type { NavigateToNewCardFromDashboardOpts } from "../components/DashCard/types";
 import type { DashboardActionKey } from "../components/DashboardHeader/DashboardHeaderButtonRow/types";
 import type { DashboardMode } from "../types/dashboard-mode";
-import { resolveDashboardBehaviors, type DashboardBehaviorInput } from "../utils/dashboard-mode-behavior";
+import { resolveDashboardBehaviors } from "../utils/dashboard-mode-behavior";
+import type { ClickActionModeGetter } from "metabase/visualizations/types/click-actions";
 import {
   useDashboardFullscreen,
   useDashboardRefreshPeriod,
@@ -85,9 +86,9 @@ export type DashboardContextReturned = DashboardContextOwnResult &
     fullscreenRef: ReturnType<typeof useDashboardFullscreen>["ref"];
   } & DashboardRefreshPeriodControls &
   EmbedThemeControls & {
-    navigateToNewCardFromDashboard: ((opts: any) => void) | null;
-    getClickActionMode: ((data: { question: any }) => any) | undefined;
-    dashboardActions: any[] | null;
+    navigateToNewCardFromDashboard: ((opts: NavigateToNewCardFromDashboardOpts) => void) | null;
+    getClickActionMode: ClickActionModeGetter | undefined;
+    dashboardActions: string[] | null;
   };
 
 export const DashboardContext = createContext<

--- a/frontend/src/metabase/dashboard/modes/index.ts
+++ b/frontend/src/metabase/dashboard/modes/index.ts
@@ -1,0 +1,18 @@
+export type {
+  DashboardMode,
+  DashboardModeConfig,
+  DashboardActionType,
+  DrillType,
+  ClickActionType,
+  NavigationConfig,
+  DashboardConfig,
+  QuestionConfig,
+  ResolvedDashboardMode,
+} from "../types/dashboard-mode";
+
+export {
+  resolveDashboardMode,
+  resolveDashboardActions,
+  resolveQuestionMode,
+  resolveNavigation,
+} from "../utils/dashboard-mode-resolver";

--- a/frontend/src/metabase/dashboard/types/dashboard-mode.ts
+++ b/frontend/src/metabase/dashboard/types/dashboard-mode.ts
@@ -1,0 +1,82 @@
+/**
+ * User-friendly dashboard mode configuration
+ * Defines what users can do with dashboards in terms they understand
+ */
+
+// Dashboard-level actions users can perform
+export type DashboardActionType =
+  | "edit"
+  | "download-pdf"
+  | "share"
+  | "refresh"
+  | "fullscreen"
+  | "info"
+  | "bookmark"
+  | "duplicate";
+
+// File formats users can download
+export type DownloadFormat = "pdf" | "csv" | "xlsx" | "json";
+
+// Drill types users can perform on charts (user-friendly names)
+export type DrillType =
+  | "column-filter"
+  | "column-extract"
+  | "distribution"
+  | "fk-details"
+  | "fk-filter"
+  | "pivot"
+  | "quick-filter"
+  | "sort"
+  | "summarize-column"
+  | "summarize-column-by-time"
+  | "underlying-records"
+  | "zoom-binning"
+  | "zoom-geographic"
+  | "zoom-timeseries";
+
+// Click actions users can perform on charts
+export type ClickActionType =
+  | "hide-column"
+  | "format-column"
+  | "extract-column"
+  | "combine-columns"
+  | "dashboard-click";
+
+// Navigation options for clicking through to questions
+export interface NavigationConfig {
+  enabled: boolean;
+  newTab?: boolean;
+  customHandler?: (questionId: number, filters?: any) => void;
+}
+
+// Dashboard-level configuration
+export interface DashboardConfig {
+  actions: DashboardActionType[];
+  downloads: DownloadFormat[];
+  editing: boolean;
+}
+
+// Question-level configuration (for charts within the dashboard)
+export interface QuestionConfig {
+  drilling: boolean | DrillType[];
+  clickActions: boolean | ClickActionType[];
+  navigation: boolean | NavigationConfig;
+  fallback?: "default" | "native-query";
+}
+
+// Full dashboard mode configuration
+export interface DashboardModeConfig {
+  name: string;
+  dashboard: DashboardConfig;
+  questions: QuestionConfig;
+}
+
+// Dashboard mode can be a string preset or full configuration
+export type DashboardMode = string | DashboardModeConfig;
+
+// Type for mode resolution result
+export interface ResolvedDashboardMode {
+  name: string;
+  dashboard: DashboardConfig;
+  questions: QuestionConfig;
+}

--- a/frontend/src/metabase/dashboard/utils/dashboard-mode-behavior.ts
+++ b/frontend/src/metabase/dashboard/utils/dashboard-mode-behavior.ts
@@ -7,30 +7,26 @@ import {
   resolveNavigation,
 } from "./dashboard-mode-resolver";
 
-export interface DashboardBehaviorOptions {
-  mode?: DashboardMode;
+export interface DashboardBehaviorInput {
+  dashboardMode?: DashboardMode;
   isEditing: boolean;
   downloadsEnabled: { pdf?: boolean; results?: boolean };
 }
 
-export interface DashboardBehaviors {
+export interface DashboardBehaviorOutput {
   dashboardActions: any[] | null;
-  navigateToNewCard: ((opts: any) => void) | null;
+  navigateToNewCardFromDashboard: ((opts: any) => void) | null;
   getClickActionMode: ((data: { question: any }) => any) | undefined;
 }
 
-export function resolveDashboardBehaviors(options: DashboardBehaviorOptions): DashboardBehaviors {
-  const { mode, isEditing, downloadsEnabled } = options;
+export function resolveDashboardBehaviors(input: DashboardBehaviorInput): DashboardBehaviorOutput {
+  const { dashboardMode, isEditing, downloadsEnabled } = input;
   
-  if (!mode) {
-    return {
-      dashboardActions: null,
-      navigateToNewCard: null,
-      getClickActionMode: undefined,
-    };
+  if (!dashboardMode) {
+    return createDefaultBehaviors();
   }
 
-  const resolvedMode = resolveDashboardMode(mode);
+  const resolvedMode = resolveDashboardMode(dashboardMode);
   
   return {
     dashboardActions: resolveDashboardActions({
@@ -38,8 +34,16 @@ export function resolveDashboardBehaviors(options: DashboardBehaviorOptions): Da
       editing: resolvedMode.dashboard.editing && isEditing,
       downloadsEnabled,
     }),
-    navigateToNewCard: resolveNavigation(resolvedMode.questions.navigation),
+    navigateToNewCardFromDashboard: resolveNavigation(resolvedMode.questions.navigation),
     getClickActionMode: buildClickActionMode(resolvedMode),
+  };
+}
+
+function createDefaultBehaviors(): DashboardBehaviorOutput {
+  return {
+    dashboardActions: null,
+    navigateToNewCardFromDashboard: null,
+    getClickActionMode: undefined,
   };
 }
 

--- a/frontend/src/metabase/dashboard/utils/dashboard-mode-behavior.ts
+++ b/frontend/src/metabase/dashboard/utils/dashboard-mode-behavior.ts
@@ -1,0 +1,54 @@
+import { Mode } from "metabase/visualizations/click-actions/Mode/Mode";
+import type { DashboardMode, DashboardModeConfig } from "../types/dashboard-mode";
+import {
+  resolveDashboardMode,
+  resolveDashboardActions,
+  resolveQuestionMode,
+  resolveNavigation,
+} from "./dashboard-mode-resolver";
+
+export interface DashboardBehaviorOptions {
+  mode?: DashboardMode;
+  isEditing: boolean;
+  downloadsEnabled: { pdf?: boolean; results?: boolean };
+}
+
+export interface DashboardBehaviors {
+  dashboardActions: any[] | null;
+  navigateToNewCard: ((opts: any) => void) | null;
+  getClickActionMode: ((data: { question: any }) => any) | undefined;
+}
+
+export function resolveDashboardBehaviors(options: DashboardBehaviorOptions): DashboardBehaviors {
+  const { mode, isEditing, downloadsEnabled } = options;
+  
+  if (!mode) {
+    return {
+      dashboardActions: null,
+      navigateToNewCard: null,
+      getClickActionMode: undefined,
+    };
+  }
+
+  const resolvedMode = resolveDashboardMode(mode);
+  
+  return {
+    dashboardActions: resolveDashboardActions({
+      actions: resolvedMode.dashboard.actions,
+      editing: resolvedMode.dashboard.editing && isEditing,
+      downloadsEnabled,
+    }),
+    navigateToNewCard: resolveNavigation(resolvedMode.questions.navigation),
+    getClickActionMode: buildClickActionMode(resolvedMode),
+  };
+}
+
+
+function buildClickActionMode(resolvedMode: DashboardModeConfig) {
+  return ({ question }: { question: any }) => {
+    const questionMode = resolveQuestionMode({
+      config: resolvedMode.questions,
+    });
+    return new Mode(question, questionMode, undefined);
+  };
+}

--- a/frontend/src/metabase/dashboard/utils/dashboard-mode-behavior.ts
+++ b/frontend/src/metabase/dashboard/utils/dashboard-mode-behavior.ts
@@ -1,5 +1,7 @@
 import { Mode } from "metabase/visualizations/click-actions/Mode/Mode";
+import type { ClickActionModeGetter } from "metabase/visualizations/types/click-actions";
 import type { DashboardMode, DashboardModeConfig } from "../types/dashboard-mode";
+import type { NavigateToNewCardFromDashboardOpts } from "../components/DashCard/types";
 import {
   resolveDashboardMode,
   resolveDashboardActions,
@@ -10,13 +12,13 @@ import {
 export interface DashboardBehaviorInput {
   dashboardMode?: DashboardMode;
   isEditing: boolean;
-  downloadsEnabled: { pdf?: boolean; results?: boolean };
+  downloadsEnabled: { pdf: boolean; results: boolean };
 }
 
 export interface DashboardBehaviorOutput {
-  dashboardActions: any[] | null;
-  navigateToNewCardFromDashboard: ((opts: any) => void) | null;
-  getClickActionMode: ((data: { question: any }) => any) | undefined;
+  dashboardActions: string[] | null;
+  navigateToNewCardFromDashboard: ((opts: NavigateToNewCardFromDashboardOpts) => void) | null;
+  getClickActionMode: ClickActionModeGetter | undefined;
 }
 
 export function resolveDashboardBehaviors(input: DashboardBehaviorInput): DashboardBehaviorOutput {
@@ -48,8 +50,8 @@ function createDefaultBehaviors(): DashboardBehaviorOutput {
 }
 
 
-function buildClickActionMode(resolvedMode: DashboardModeConfig) {
-  return ({ question }: { question: any }) => {
+function buildClickActionMode(resolvedMode: DashboardModeConfig): ClickActionModeGetter {
+  return ({ question }) => {
     const questionMode = resolveQuestionMode({
       config: resolvedMode.questions,
     });

--- a/frontend/src/metabase/dashboard/utils/dashboard-mode-resolver.ts
+++ b/frontend/src/metabase/dashboard/utils/dashboard-mode-resolver.ts
@@ -1,0 +1,241 @@
+import { DASHBOARD_ACTION } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys";
+import { DASHBOARD_EDITING_ACTIONS } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/constants";
+import { ColumnFormattingAction } from "metabase/visualizations/click-actions/actions/ColumnFormattingAction";
+import { CombineColumnsAction } from "metabase/visualizations/click-actions/actions/CombineColumnsAction";
+import { DashboardClickAction } from "metabase/visualizations/click-actions/actions/DashboardClickAction";
+import { ExtractColumnAction } from "metabase/visualizations/click-actions/actions/ExtractColumnAction";
+import { HideColumnAction } from "metabase/visualizations/click-actions/actions/HideColumnAction";
+import { NativeQueryClickFallback } from "metabase/visualizations/click-actions/actions/NativeQueryClickFallback";
+import { Mode } from "metabase/visualizations/click-actions/Mode/Mode";
+import type { QueryClickActionsMode } from "metabase/visualizations/types";
+import type { MetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
+
+import type {
+  DashboardMode,
+  DashboardModeConfig,
+  ResolvedDashboardMode,
+  DashboardActionType,
+  DrillType,
+  ClickActionType,
+} from "../types/dashboard-mode";
+
+// Maps user-friendly dashboard actions to internal action keys
+const DASHBOARD_ACTION_MAP: Record<DashboardActionType, string> = {
+  edit: DASHBOARD_ACTION.EDIT_DASHBOARD,
+  "download-pdf": DASHBOARD_ACTION.DOWNLOAD_PDF,
+  share: DASHBOARD_ACTION.DASHBOARD_SHARING,
+  refresh: DASHBOARD_ACTION.REFRESH_WIDGET,
+  fullscreen: DASHBOARD_ACTION.FULLSCREEN_TOGGLE,
+  info: DASHBOARD_ACTION.DASHBOARD_INFO,
+  bookmark: DASHBOARD_ACTION.DASHBOARD_BOOKMARK,
+  duplicate: DASHBOARD_ACTION.COPY_ANALYTICS_DASHBOARD,
+};
+
+// Maps user-friendly drill types to internal drill type strings
+const DRILL_TYPE_MAP: Record<DrillType, string> = {
+  "column-filter": "drill-thru/column-filter",
+  "column-extract": "drill-thru/column-extract",
+  distribution: "drill-thru/distribution",
+  "fk-details": "drill-thru/fk-details",
+  "fk-filter": "drill-thru/fk-filter",
+  pivot: "drill-thru/pivot",
+  "quick-filter": "drill-thru/quick-filter",
+  sort: "drill-thru/sort",
+  "summarize-column": "drill-thru/summarize-column",
+  "summarize-column-by-time": "drill-thru/summarize-column-by-time",
+  "underlying-records": "drill-thru/underlying-records",
+  "zoom-binning": "drill-thru/zoom-in.binning",
+  "zoom-geographic": "drill-thru/zoom-in.geographic",
+  "zoom-timeseries": "drill-thru/zoom-in.timeseries",
+};
+
+// Maps user-friendly click actions to internal action classes
+const CLICK_ACTION_MAP: Record<ClickActionType, any> = {
+  "hide-column": HideColumnAction,
+  "format-column": ColumnFormattingAction,
+  "extract-column": ExtractColumnAction,
+  "combine-columns": CombineColumnsAction,
+  "dashboard-click": DashboardClickAction,
+};
+
+/**
+ * Resolves a dashboard mode (string or config) to a full configuration
+ */
+export function resolveDashboardMode(
+  mode: DashboardMode,
+): ResolvedDashboardMode {
+  if (typeof mode === "string") {
+    // Handle preset modes
+    const presetConfig = PRESET_MODES[mode];
+    if (!presetConfig) {
+      throw new Error(`Unknown dashboard mode: ${mode}`);
+    }
+    return presetConfig;
+  }
+
+  // Handle full configuration
+  return {
+    name: mode.name,
+    dashboard: mode.dashboard,
+    questions: mode.questions,
+  };
+}
+
+/**
+ * Converts user-friendly dashboard actions to internal action keys
+ */
+export function resolveDashboardActions(
+  actions: DashboardActionType[],
+  editing: boolean,
+  downloadsEnabled: { pdf: boolean; results: boolean },
+): string[] {
+  // If editing is enabled, use editing actions
+  if (editing) {
+    return DASHBOARD_EDITING_ACTIONS;
+  }
+
+  // Otherwise, map user actions to internal keys
+  const resolvedActions = actions
+    .map((action) => DASHBOARD_ACTION_MAP[action])
+    .filter(Boolean);
+
+  // Auto-include download actions if enabled
+  if (
+    downloadsEnabled.pdf &&
+    !resolvedActions.includes(DASHBOARD_ACTION.DOWNLOAD_PDF)
+  ) {
+    resolvedActions.push(DASHBOARD_ACTION.DOWNLOAD_PDF);
+  }
+
+  return resolvedActions;
+}
+
+/**
+ * Creates a QueryClickActionsMode from user-friendly question config
+ */
+export function resolveQuestionMode(
+  config: ResolvedDashboardMode["questions"],
+  plugins?: MetabasePluginsConfig,
+): QueryClickActionsMode {
+  // Handle drilling configuration
+  let hasDrills = false;
+  let availableOnlyDrills: string[] | undefined;
+
+  if (config.drilling === true) {
+    hasDrills = true;
+  } else if (Array.isArray(config.drilling)) {
+    hasDrills = true;
+    availableOnlyDrills = config.drilling.map((drill) => DRILL_TYPE_MAP[drill]);
+  }
+
+  // Handle click actions
+  let clickActions: any[] = [];
+  if (config.clickActions === true) {
+    // Use all available click actions
+    clickActions = Object.values(CLICK_ACTION_MAP);
+  } else if (Array.isArray(config.clickActions)) {
+    clickActions = config.clickActions
+      .map((action) => CLICK_ACTION_MAP[action])
+      .filter(Boolean);
+  }
+
+  // Handle fallback
+  let fallback = undefined;
+  if (config.fallback === "native-query") {
+    fallback = NativeQueryClickFallback;
+  }
+
+  return {
+    name: "dashboard-mode",
+    hasDrills,
+    availableOnlyDrills,
+    clickActions,
+    fallback,
+  };
+}
+
+/**
+ * Creates a navigation handler from user-friendly navigation config
+ */
+export function resolveNavigation(
+  config: ResolvedDashboardMode["questions"]["navigation"],
+): ((opts: any) => void) | null {
+  if (config === false) {
+    return null;
+  }
+
+  if (config === true) {
+    // Default navigation behavior
+    return (opts) => {
+      console.log("Navigate to question:", opts);
+    };
+  }
+
+  if (typeof config === "object" && config.enabled) {
+    if (config.customHandler) {
+      return (opts) => config.customHandler!(opts.questionId, opts.filters);
+    }
+
+    // Default with new tab option
+    return (opts) => {
+      console.log("Navigate to question:", opts, "newTab:", config.newTab);
+    };
+  }
+
+  return null;
+}
+
+// Preset dashboard modes
+const PRESET_MODES: Record<string, ResolvedDashboardMode> = {
+  editable: {
+    name: "editable",
+    dashboard: {
+      actions: [
+        "edit",
+        "download-pdf",
+        "share",
+        "refresh",
+        "fullscreen",
+        "info",
+      ],
+      downloads: ["pdf", "csv", "xlsx"],
+      editing: true,
+    },
+    questions: {
+      drilling: true,
+      clickActions: true,
+      navigation: true,
+      fallback: "default",
+    },
+  },
+
+  interactive: {
+    name: "interactive",
+    dashboard: {
+      actions: ["download-pdf", "refresh", "fullscreen"],
+      downloads: ["pdf", "csv", "xlsx"],
+      editing: false,
+    },
+    questions: {
+      drilling: true,
+      clickActions: ["hide-column", "dashboard-click"],
+      navigation: true,
+      fallback: "default",
+    },
+  },
+
+  static: {
+    name: "static",
+    dashboard: {
+      actions: ["download-pdf"],
+      downloads: ["pdf"],
+      editing: false,
+    },
+    questions: {
+      drilling: false,
+      clickActions: false,
+      navigation: false,
+      fallback: "native-query",
+    },
+  },
+};

--- a/frontend/src/metabase/dashboard/utils/dashboard-mode-resolver.ts
+++ b/frontend/src/metabase/dashboard/utils/dashboard-mode-resolver.ts
@@ -84,7 +84,7 @@ export function resolveDashboardMode(
 interface ResolveActionsOptions {
   actions: DashboardActionType[];
   editing: boolean;
-  downloadsEnabled: { pdf?: boolean; results?: boolean };
+  downloadsEnabled: { pdf: boolean; results: boolean };
 }
 
 export function resolveDashboardActions(options: ResolveActionsOptions): string[] {
@@ -107,8 +107,10 @@ export function resolveDashboardActions(options: ResolveActionsOptions): string[
     resolvedActions.push(DASHBOARD_ACTION.DOWNLOAD_PDF);
   }
 
-  if (downloadsEnabled.results && !resolvedActions.includes("download-results")) {
-    resolvedActions.push("download-results");
+  if (downloadsEnabled.results) {
+    if (!resolvedActions.includes("download-results")) {
+      resolvedActions.push("download-results");
+    }
   }
 
   return resolvedActions;


### PR DESCRIPTION
Closes EMB-452

## Summary
- Introduces a new dashboard mode system for SdkDashboard components
- Replaces individual `navigateToNewCardFromDashboard` and `getClickActionMode` props with unified mode configuration
- Provides both simple preset modes and granular configuration options
- Uses user-friendly terminology with translation layer to internal Metabase types

## Key Features
- **Simple Presets**: "editable", "interactive", "static" modes for common use cases
- **Granular Control**: Full configuration objects for advanced customization
- **User-Friendly API**: Abstracts internal Metabase types behind readable terms
- **Backward Compatibility**: Existing prop-based API continues to work

## Implementation Details
- Created `DashboardMode` interface with dashboard and questions configuration
- Built mode resolver system to translate user config to internal behaviors
- Updated dashboard context to derive behaviors from mode configuration
- Simplified SDK dashboard variants to use preset mode strings
- Added comprehensive type definitions and translation maps

## Test Plan
- [ ] Verify EditableDashboard works with "editable" mode preset
- [ ] Verify InteractiveDashboard works with "interactive" mode preset  
- [ ] Verify StaticDashboard works with "static" mode preset
- [ ] Test custom mode configurations with granular options
- [ ] Confirm backward compatibility with existing prop-based usage
- [ ] Validate type safety and IntelliSense support