### PR TITLE
Send correct model metadata on model creation

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -603,3 +603,7 @@ export function repeatAssertion(assertFn, timeout = 4000, interval = 400) {
 export function mapPinIcon() {
   return cy.get(".leaflet-marker-icon");
 }
+
+export function waitForLoaderToBeRemoved() {
+  cy.findByTestId("loading-indicator").should("not.exist");
+}

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -44,6 +44,7 @@ describe("scenarios > models metadata", () => {
 
       H.popover().findByTextEnsureVisible("Edit metadata").click();
       cy.url().should("include", "/metadata");
+      H.waitForLoaderToBeRemoved();
 
       H.openColumnOptions("Subtotal");
       H.renameColumn("Subtotal", "Pre-tax");
@@ -63,6 +64,7 @@ describe("scenarios > models metadata", () => {
 
     it("allows for canceling changes, back navigation (metabase#55162)", () => {
       H.openQuestionActions("Edit metadata");
+      H.waitForLoaderToBeRemoved();
 
       H.openColumnOptions("Subtotal");
       H.renameColumn("Subtotal", "Pre-tax");
@@ -77,6 +79,7 @@ describe("scenarios > models metadata", () => {
 
       // Ensure back navigation works correctly metabase#55162
       H.openQuestionActions("Edit metadata");
+      H.waitForLoaderToBeRemoved();
       cy.go("back");
       cy.get("@questionId").then((id) => {
         cy.location("pathname").should("equal", `/model/${id}-gui-model`);
@@ -86,6 +89,7 @@ describe("scenarios > models metadata", () => {
     it("clears custom metadata when a model is turned back into a question", () => {
       H.openQuestionActions();
       H.popover().findByTextEnsureVisible("Edit metadata").click();
+      H.waitForLoaderToBeRemoved();
 
       H.openColumnOptions("Subtotal");
       H.renameColumn("Subtotal", "Pre-tax");
@@ -135,6 +139,7 @@ describe("scenarios > models metadata", () => {
 
     H.popover().findByTextEnsureVisible("Edit metadata").click();
     cy.url().should("include", "/metadata");
+    H.waitForLoaderToBeRemoved();
 
     H.openColumnOptions("SUBTOTAL");
 
@@ -171,6 +176,7 @@ describe("scenarios > models metadata", () => {
     );
     H.openQuestionActions();
     H.popover().findByTextEnsureVisible("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
     H.openColumnOptions("USER_ID");
     H.setColumnType("No semantic type", "Foreign Key");
     H.sidebar().findByPlaceholderText("Select a target").click();
@@ -234,6 +240,7 @@ describe("scenarios > models metadata", () => {
 
     H.openQuestionActions();
     H.popover().findByTextEnsureVisible("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
 
     cy.log("Revision 2");
     H.openColumnOptions("TAX");
@@ -288,6 +295,7 @@ describe("scenarios > models metadata", () => {
     H.openQuestionActions();
     H.popover().findByTextEnsureVisible("Edit metadata").click();
     cy.url().should("include", "/metadata");
+    H.waitForLoaderToBeRemoved();
 
     cy.log("wait for the hint, otherwise scroll into view doesn't work ");
     cy.findByTestId("tab-hint-toast").should("be.visible");
@@ -462,6 +470,7 @@ describe("scenarios > models metadata", () => {
 
       H.openQuestionActions();
       H.popover().findByTextEnsureVisible("Edit metadata").click();
+      H.waitForLoaderToBeRemoved();
 
       cy.findAllByTestId("header-cell")
         .contains(/^Vendor$/)

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -75,6 +75,7 @@ describe("issue 29943", () => {
 
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
 
     reorderTotalAndCustomColumns();
     cy.button("Save changes").click();
@@ -82,6 +83,7 @@ describe("issue 29943", () => {
 
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
 
     assertColumnSelected(0, "ID");
 
@@ -151,6 +153,8 @@ describe("issue 35711", () => {
 
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
+
     reorderTaxAndTotalColumns();
     assertNoError();
 
@@ -189,6 +193,7 @@ describe("issues 25884 and 34349", () => {
 
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
 
     cy.findByLabelText("Description").should("have.text", ID_DESCRIPTION);
 
@@ -220,6 +225,7 @@ describe("issue 23103", () => {
 
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
 
     cy.findAllByTestId("header-cell").contains("CATEGORY").click();
     cy.findAllByTestId("select-button").contains("None").click();
@@ -602,6 +608,7 @@ describe("issue 33427", () => {
 
     cy.findByLabelText("Move, trash, and more…").click();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
 
     H.openColumnOptions("CREATED_BY");
     H.mapColumnTo({ table: "Products", column: "Title" });
@@ -655,6 +662,7 @@ describe("issue 25113", () => {
   it("should not mistakenly override model column metadata with raw field metadata (metabase#25113)", () => {
     H.createQuestion(modelDetails, { visitQuestion: true });
     H.openQuestionActions("Edit metadata");
+    H.waitForLoaderToBeRemoved();
     H.openColumnOptions("ID");
     H.renameColumn("ID", "ID renamed");
     H.saveMetadataChanges();
@@ -706,6 +714,7 @@ describe("issue 39749", () => {
     cy.log("edit metadata");
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
     H.tableHeaderClick("Count");
     cy.findByLabelText("Description").type("A");
     H.tableHeaderClick("Sum of Total");
@@ -720,6 +729,7 @@ describe("issue 39749", () => {
     cy.log("verify that the description was updated successfully");
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
     H.tableHeaderClick("Count");
     cy.findByLabelText("Description").should("have.text", "A");
     H.tableHeaderClick("Sum of Total");
@@ -807,6 +817,7 @@ describe("issue 25885", () => {
     );
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
     setColumnName("ID", "ID1");
     setColumnName("Orders → ID", "ID2");
     setColumnName("Orders_2 → ID", "ID3");
@@ -851,6 +862,7 @@ describe("issue 33844", () => {
     cy.log("make the column visible in table views");
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
     H.tableHeaderClick("ID");
     cy.findByLabelText("Detail views only").should("be.checked");
     cy.findByLabelText("Table and details views").click();
@@ -880,6 +892,7 @@ describe("issue 33844", () => {
     cy.wait("@dataset");
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
     testModelMetadata(false);
   });
 });
@@ -898,6 +911,7 @@ describe("issue 45924", () => {
     cy.wait("@dataset");
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
     H.tableHeaderClick("ID");
     cy.findByLabelText("Display name").clear().type("ID1");
     cy.findByTestId("dataset-edit-bar").findByText("Query").click();
@@ -962,6 +976,7 @@ describe("issue 39993", () => {
     );
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
     cy.log("drag & drop the custom column 100 px to the left");
     H.moveDnDKitElement(H.tableHeaderColumn(columnName), { horizontal: -100 });
     cy.button("Save changes").click();
@@ -1471,6 +1486,7 @@ describe("issue 20624", () => {
     cy.log("rename the column using the model's metadata");
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
     H.tableHeaderClick("Vendor");
     cy.findByLabelText("Display name").clear().type("Retailer");
     cy.button("Save changes").should("be.enabled").click();
@@ -1502,6 +1518,7 @@ describe("issue 37300", () => {
   it("should show the table headers even when there are no results (metabase/metabase#37300)", () => {
     H.openQuestionActions();
     H.popover().findByText("Edit metadata").click();
+    H.waitForLoaderToBeRemoved();
 
     H.main().within(() => {
       cy.findByText("ID").should("be.visible");
@@ -1540,6 +1557,7 @@ describe("issue 32037", () => {
 
   it("should show unsaved changes modal and allow to discard changes when editing model's metadata (metabase#32037)", () => {
     H.openQuestionActions("Edit metadata");
+    H.waitForLoaderToBeRemoved();
     cy.button("Save changes").should("be.disabled");
     cy.findByLabelText("Description").type("123").blur();
     cy.button("Save changes").should("be.enabled");
@@ -1587,6 +1605,7 @@ describe("issue 51925", () => {
   it('should allow to set "Display as Link" options independently for each column (metabase#51925)', () => {
     H.visitModel(ORDERS_MODEL_ID);
     H.openQuestionActions("Edit metadata");
+    H.waitForLoaderToBeRemoved();
     H.tableInteractive().findByText("User ID").click();
     H.rightSidebar().within(() => {
       setLinkDisplayType();
@@ -1694,6 +1713,7 @@ describe("issue 57557", () => {
       cy.findByText("Edit query definition").should("not.exist");
       cy.findByText("Edit metadata").click();
     });
+    H.waitForLoaderToBeRemoved();
     cy.findByTestId("editor-tabs-query").should("be.disabled");
     cy.findByTestId("editor-tabs-metadata").should("be.checked");
   });
@@ -1730,11 +1750,10 @@ describe("issue 56775", () => {
   });
 });
 
-describe.skip("issue 57359", () => {
+describe("issue 57359", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();
-    cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("PUT", "/api/card/*").as("updateCard");
   });
 
@@ -1754,16 +1773,15 @@ describe.skip("issue 57359", () => {
     H.openQuestionActions("Turn into a model");
     H.modal().button("Turn this into a model").click();
     cy.wait("@updateCard");
-    cy.wait("@dataset");
 
     cy.log("edit query metadata");
     H.openQuestionActions("Edit metadata");
+    H.waitForLoaderToBeRemoved();
     H.openColumnOptions("Product ID");
     H.renameColumn("Product ID", "Product ID2");
     H.saveMetadataChanges();
 
-    cy.log("make sure the query can run");
-    cy.wait("@dataset");
+    cy.log("make sure the query is run successfully");
     H.tableInteractive().should("be.visible");
   });
 });

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -1168,6 +1168,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       );
 
       H.openQuestionActions("Edit metadata");
+      H.waitForLoaderToBeRemoved();
       H.datasetEditBar().findByRole("button", { name: "Cancel" }).click();
 
       cy.location("pathname").should(
@@ -1176,6 +1177,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       );
 
       H.openQuestionActions("Edit metadata");
+      H.waitForLoaderToBeRemoved();
 
       cy.go("back");
       cy.location("pathname").should(

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -13,6 +13,7 @@ import * as Urls from "metabase/lib/urls";
 import { copy } from "metabase/lib/utils";
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { openUrl } from "metabase/redux/app";
+import { getMetadata } from "metabase/selectors/metadata";
 import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/utils";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
@@ -217,18 +218,24 @@ export const apiCreateQuestion = (
 
     // Saving a card, locks in the current display as though it had been
     // selected in the UI.
-    const card = createdQuestion.lockDisplay().card();
-    dispatch({ type: API_CREATE_QUESTION, payload: card });
+    const createdCard = createdQuestion.lockDisplay().card();
+    dispatch({ type: API_CREATE_QUESTION, payload: createdCard });
 
-    await dispatch(loadMetadataForCard(card));
+    await dispatch(loadMetadataForCard(createdCard));
+    const createdQuestionWithMetadata = new Question(
+      createdCard,
+      getMetadata(getState()),
+    );
 
     const isModel = question.type() === "model";
     const isMetric = question.type() === "metric";
     if (isModel || isMetric) {
-      dispatch(runQuestionQuery());
+      const composedQuestion =
+        createdQuestionWithMetadata.composeQuestionAdhoc();
+      dispatch(runQuestionQuery({ overrideWithQuestion: composedQuestion }));
     }
 
-    return createdQuestion;
+    return createdQuestionWithMetadata;
   };
 };
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
@@ -3,7 +3,7 @@ import cx from "classnames";
 import { merge } from "icepick";
 import PropTypes from "prop-types";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { usePrevious } from "react-use";
+import { useMount, usePrevious } from "react-use";
 import { t } from "ttag";
 
 import { useListModelIndexesQuery } from "metabase/api";
@@ -247,6 +247,12 @@ const _DatasetEditorInner = (props) => {
 
   const [focusedFieldName, setFocusedFieldName] = useState();
 
+  useMount(() => {
+    if (Lib.canRun(question.query(), question.type())) {
+      runDirtyQuestionQuery();
+    }
+  });
+
   const focusedFieldIndex = useMemo(() => {
     if (!focusedFieldName) {
       return -1;
@@ -320,8 +326,8 @@ const _DatasetEditorInner = (props) => {
   const handleCancelEdit = () => {
     closeModal();
     cancelQuestionChanges();
-    runDirtyQuestionQuery();
     setQueryBuilderMode("view");
+    runDirtyQuestionQuery();
   };
 
   const handleCancelClick = () => {

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
@@ -248,7 +248,7 @@ const _DatasetEditorInner = (props) => {
   const [focusedFieldName, setFocusedFieldName] = useState();
 
   useMount(() => {
-    if (Lib.canRun(question.query(), question.type())) {
+    if (question.isSaved() && Lib.canRun(question.query(), question.type())) {
       runQuestionQuery();
     }
   });

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.jsx
@@ -249,7 +249,7 @@ const _DatasetEditorInner = (props) => {
 
   useMount(() => {
     if (Lib.canRun(question.query(), question.type())) {
-      runDirtyQuestionQuery();
+      runQuestionQuery();
     }
   });
 

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -123,7 +123,7 @@ export const TEST_MODEL_CARD = createMockCard({
     },
   },
   type: "model",
-  display: "scalar",
+  display: "table",
   description: "Test description",
 });
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -400,86 +400,21 @@ export const getRowIndexToPKMap = createSelector(
   },
 );
 
-function areLegacyQueriesEqual(queryA, queryB, tableMetadata) {
-  return Lib.areLegacyQueriesEqual(
-    queryA,
-    queryB,
-    tableMetadata?.fields.map(({ id }) => id),
-  );
-}
-
-// Models or metrics may be composed via the `composeQuestion` method.
-// A composed entity should be treated as the equivalent to its original form.
-// We need to handle scenarios where both the `lastRunQuestion` and the `currentQuestion` are
-// in either form.
-function areComposedEntitiesEquivalent({
-  originalQuestion,
-  lastRunQuestion,
-  currentQuestion,
-  tableMetadata,
-}) {
-  const isQuestion = originalQuestion?.type() === "question";
-  if (!originalQuestion || !lastRunQuestion || !currentQuestion || isQuestion) {
-    return false;
-  }
-
-  const composedOriginal = originalQuestion.composeQuestionAdhoc();
-
-  const isLastRunComposed = areLegacyQueriesEqual(
-    lastRunQuestion.datasetQuery(),
-    composedOriginal.datasetQuery(),
-    tableMetadata,
-  );
-  const isCurrentComposed = areLegacyQueriesEqual(
-    currentQuestion.datasetQuery(),
-    composedOriginal.datasetQuery(),
-    tableMetadata,
-  );
-
-  const isLastRunEquivalentToCurrent =
-    isLastRunComposed &&
-    areLegacyQueriesEqual(
-      currentQuestion.datasetQuery(),
-      originalQuestion.datasetQuery(),
-      tableMetadata,
-    );
-
-  const isCurrentEquivalentToLastRun =
-    isCurrentComposed &&
-    areLegacyQueriesEqual(
-      lastRunQuestion.datasetQuery(),
-      originalQuestion.datasetQuery(),
-      tableMetadata,
-    );
-
-  return isLastRunEquivalentToCurrent || isCurrentEquivalentToLastRun;
-}
-
 export function areQueriesEquivalent({
-  originalQuestion,
   lastRunQuestion,
   currentQuestion,
   tableMetadata,
 }) {
-  return (
-    areLegacyQueriesEqual(
-      lastRunQuestion?.datasetQuery(),
-      currentQuestion?.datasetQuery(),
-      tableMetadata,
-    ) ||
-    areComposedEntitiesEquivalent({
-      originalQuestion,
-      lastRunQuestion,
-      currentQuestion,
-      tableMetadata,
-    })
+  return Lib.areLegacyQueriesEqual(
+    lastRunQuestion?.datasetQuery(),
+    currentQuestion?.datasetQuery(),
+    tableMetadata?.fields.map(({ id }) => id),
   );
 }
 
 export const getIsResultDirty = createSelector(
   [
     getQuestion,
-    getOriginalQuestion,
     getLastRunQuestion,
     getLastRunParameterValues,
     getNextRunParameterValues,
@@ -487,7 +422,6 @@ export const getIsResultDirty = createSelector(
   ],
   (
     question,
-    originalQuestion,
     lastRunQuestion,
     lastParameters,
     nextParameters,
@@ -501,7 +435,6 @@ export const getIsResultDirty = createSelector(
       haveParametersChanged ||
       (isEditable &&
         !areQueriesEquivalent({
-          originalQuestion,
           lastRunQuestion,
           currentQuestion: question,
           tableMetadata,

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -400,21 +400,86 @@ export const getRowIndexToPKMap = createSelector(
   },
 );
 
-export function areQueriesEquivalent({
+function areLegacyQueriesEqual(queryA, queryB, tableMetadata) {
+  return Lib.areLegacyQueriesEqual(
+    queryA,
+    queryB,
+    tableMetadata?.fields.map(({ id }) => id),
+  );
+}
+
+// Models or metrics may be composed via the `composeQuestion` method.
+// A composed entity should be treated as the equivalent to its original form.
+// We need to handle scenarios where both the `lastRunQuestion` and the `currentQuestion` are
+// in either form.
+function areComposedEntitiesEquivalent({
+  originalQuestion,
   lastRunQuestion,
   currentQuestion,
   tableMetadata,
 }) {
-  return Lib.areLegacyQueriesEqual(
-    lastRunQuestion?.datasetQuery(),
-    currentQuestion?.datasetQuery(),
-    tableMetadata?.fields.map(({ id }) => id),
+  const isQuestion = originalQuestion?.type() === "question";
+  if (!originalQuestion || !lastRunQuestion || !currentQuestion || isQuestion) {
+    return false;
+  }
+
+  const composedOriginal = originalQuestion.composeQuestionAdhoc();
+
+  const isLastRunComposed = areLegacyQueriesEqual(
+    lastRunQuestion.datasetQuery(),
+    composedOriginal.datasetQuery(),
+    tableMetadata,
+  );
+  const isCurrentComposed = areLegacyQueriesEqual(
+    currentQuestion.datasetQuery(),
+    composedOriginal.datasetQuery(),
+    tableMetadata,
+  );
+
+  const isLastRunEquivalentToCurrent =
+    isLastRunComposed &&
+    areLegacyQueriesEqual(
+      currentQuestion.datasetQuery(),
+      originalQuestion.datasetQuery(),
+      tableMetadata,
+    );
+
+  const isCurrentEquivalentToLastRun =
+    isCurrentComposed &&
+    areLegacyQueriesEqual(
+      lastRunQuestion.datasetQuery(),
+      originalQuestion.datasetQuery(),
+      tableMetadata,
+    );
+
+  return isLastRunEquivalentToCurrent || isCurrentEquivalentToLastRun;
+}
+
+export function areQueriesEquivalent({
+  originalQuestion,
+  lastRunQuestion,
+  currentQuestion,
+  tableMetadata,
+}) {
+  return (
+    areLegacyQueriesEqual(
+      lastRunQuestion?.datasetQuery(),
+      currentQuestion?.datasetQuery(),
+      tableMetadata,
+    ) ||
+    areComposedEntitiesEquivalent({
+      originalQuestion,
+      lastRunQuestion,
+      currentQuestion,
+      tableMetadata,
+    })
   );
 }
 
 export const getIsResultDirty = createSelector(
   [
     getQuestion,
+    getOriginalQuestion,
     getLastRunQuestion,
     getLastRunParameterValues,
     getNextRunParameterValues,
@@ -422,6 +487,7 @@ export const getIsResultDirty = createSelector(
   ],
   (
     question,
+    originalQuestion,
     lastRunQuestion,
     lastParameters,
     nextParameters,
@@ -435,6 +501,7 @@ export const getIsResultDirty = createSelector(
       haveParametersChanged ||
       (isEditable &&
         !areQueriesEquivalent({
+          originalQuestion,
           lastRunQuestion,
           currentQuestion: question,
           tableMetadata,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/57359

Previously, the model editor worked with incorrect metadata in some cases:
1. When it was opened, it used metadata for the ad-hoc question built on top of the model, not the model itself. Now we re-run the actual model query when opening the model editor to get correct metadata for the inner query, and not the ad-hoc query.
2. When a new model was saved, we ran the model query and not the ad-hoc query based on the model, leading to incorrect metadata being used later. Now we create an ad-hoc query after the model was created and run it instead.