### PR TITLE
Fix permission check for SQL actions acting on another db

### DIFF
--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -323,7 +323,7 @@
                    ;; In the case of SQL actions, the query being executed might not act on the same database as that
                    ;; used by the model upon which the action is defined. In this case, the underlying model whose
                    ;; permissions we need to check will not be exposed by the metadata provider, so we need a fallback.
-                   #_(t2/select-one :model/Card :id card-id :database_id [:!= database-id])
+                   (t2/select-one :model/Card :id card-id :database_id [:!= database-id])
                    (throw (ex-info (tru "Card {0} does not exist." card-id)
                                    {:type    qp.error-type/invalid-query
                                     :card-id card-id})))]

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -320,6 +320,10 @@
     (let [card (or (some-> (lib.metadata.protocols/card (qp.store/metadata-provider) card-id)
                            (update-keys u/->snake_case_en)
                            (vary-meta assoc :type :model/Card))
+                   ;; In the case of SQL actions, the query being executed might not act on the same database as that
+                   ;; used by the model upon which the action is defined. In this case, the underlying model whose
+                   ;; permissions we need to check will not be exposed by the metadata provider, so we need a fallback.
+                   #_(t2/select-one :model/Card :id card-id :database_id [:!= database-id])
                    (throw (ex-info (tru "Card {0} does not exist." card-id)
                                    {:type    qp.error-type/invalid-query
                                     :card-id card-id})))]

--- a/test/metabase/actions/api_test.clj
+++ b/test/metabase/actions/api_test.clj
@@ -6,6 +6,7 @@
    [metabase.collections.models.collection :as collection]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.test.util :as tu]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
@@ -158,68 +159,82 @@
 
 (deftest action-model-db-disagree-test
   (let [cross-db-action (fn cross-db-action [model-id other-db-id]
-                          {:type :query
-                           :model_id model-id       ;; model against one-db
-                           :database_id other-db-id ;; action against test-data
-                           :name "cross db action"
+                          {:type        :query
+                           :model_id    model-id            ;; model against one-db
+                           :database_id other-db-id         ;; action against test-data
+                           :name        "cross db action"
                            :dataset_query
                            {:native
-                            {:query "update people
-                                       set source = {{source}}
-                                     where id = {{id}}",
-                             :template-tags {:source {:id "source",
-                                                      :name "source",
+                            {:query         "update people
+                                             set source = {{source}}
+                                             where id = {{id}}",
+                             :template-tags {:source {:id           "source",
+                                                      :name         "source",
                                                       :display-name "Source",
-                                                      :type "text"},
-                                             :id {:id "id",
-                                                  :name "id",
-                                                  :display-name "Id",
-                                                  :type "number"}}},
+                                                      :type         "text"},
+                                             :id     {:id           "id",
+                                                      :name         "id",
+                                                      :display-name "Id",
+                                                      :type         "number"}}},
                             :database other-db-id
-                            :type "native"}
-                           :parameters [{:id "id"
-                                         :slug "id"
-                                         :type :number
-                                         :target [:variable
-                                                  [:template-tag "id"]]}
-                                        {:id "source"
-                                         :slug "source"
-                                         :type :text
-                                         :required false
-                                         :target [:variable
-                                                  [:template-tag "source"]]}]})]
+                            :type     "native"}
+                           :parameters  [{:id     "id"
+                                          :slug   "id"
+                                          :type   :number
+                                          :target [:variable
+                                                   [:template-tag "id"]]}
+                                         {:id       "source"
+                                          :slug     "source"
+                                          :type     :text
+                                          :required false
+                                          :target   [:variable
+                                                     [:template-tag "source"]]}]})]
     (testing "when action's database and model's database disagree"
       (testing "Both dbs are checked for actions enabled at creation"
-        (mt/dataset time-test-data
+        (mt/dataset test-data
           (let [test-data-id (mt/id)]
-            (mt/dataset test-data
+            (mt/dataset time-test-data
               (mt/with-actions-enabled
                 (is (not= (mt/id) test-data-id))
-                (mt/with-temp [:model/Card model {:type :model
-                                                  :dataset_query
-                                                  (mt/native-query
-                                                    {:query "select * from checkins limit 1"})}]
-                  (let [action (cross-db-action (:id model) test-data-id)
+                (mt/with-temp [:model/Card model {:type          :model
+                                                  :dataset_query (mt/native-query {:query "select * from checkins limit 1"})}]
+                  (let [action   (cross-db-action (:id model) test-data-id)
                         response (mt/user-http-request :rasta :post 400 "action" action)]
                     (testing "Checks both databases for actions enabled"
                       (is (partial= {:message "Actions are not enabled."
-                                     :data {:database-id test-data-id}}
+                                     :data    {:database-id test-data-id}}
                                     response))))))))))
       (testing "When executing, both dbs are checked for enabled"
-        (mt/dataset time-test-data
+        (mt/dataset test-data
           (let [test-data-id (mt/id)]
             (mt/with-actions-test-data-and-actions-enabled
-              (mt/with-actions [{model-id :id} {:type :model
-                                                :dataset_query (mt/mbql-query categories)}
-                                {action-on-other-id :action-id} (cross-db-action model-id
-                                                                                 test-data-id)]
+              (mt/with-actions [{model-id :id} {:type :model, :dataset_query (mt/mbql-query categories)}
+                                {action-on-other-id :action-id} (cross-db-action model-id test-data-id)]
                 (is (partial= {:message "Actions are not enabled."
-                               :data {:database-id test-data-id}}
+                               :data    {:database-id test-data-id}}
                               (mt/user-http-request :rasta
                                                     :post 400
                                                     (format "action/%s/execute" action-on-other-id)
-                                                    ;; Twitter is the current value so effectively a no-op
-                                                    {:parameters {:id 1 :source "Twitter"}})))))))))))
+                                                   ;; Twitter is the current value so effectively a no-op
+                                                    {:parameters {:id 1 :source "Twitter"}})))))))
+        (testing "When actions are enabled on the other database"
+          (mt/dataset test-data
+            (let [test-data-id (mt/id)]
+              (mt/with-actions-enabled
+                (mt/with-temp [:model/Card model {:type          :model
+                                                  :dataset_query (mt/native-query {:query "select * from checkins limit 1"})
+                                                  :collection_id (:id (collection/user->personal-collection (mt/user->id :crowberto)))}]
+                  (let [action (cross-db-action (:id model) test-data-id)]
+                    (testing "Action creation should succeed when both databases have actions enabled"
+                      (is (= "You don't have permissions to do that." (mt/user-http-request :rasta :post 403 "action" action)))
+                      (is (=? {:name "cross db action"} (mt/user-http-request :crowberto :post 200 "action" action))))
+                    (testing "Action execution should succeed when both databases have actions enabled"
+                      (let [response (mt/user-http-request :crowberto :post "action" action)
+                            url      (format "action/%s/execute" (:id response))
+                            params   {:parameters {:id 1 :source "Twitter"}}]
+                        (is (=? {:message "You don't have permissions to do that."}
+                                (mt/user-http-request :rasta :post 403 url params)))
+                        (is (= {:rows-affected 1} (mt/user-http-request :crowberto :post 200 url params)))))))))))))))
 
 (deftest unified-action-create-test
   (mt/test-helpers-set-global-values!

--- a/test/metabase/actions/api_test.clj
+++ b/test/metabase/actions/api_test.clj
@@ -6,7 +6,6 @@
    [metabase.collections.models.collection :as collection]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [metabase.test.util :as tu]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]

--- a/test/metabase/actions/api_test.clj
+++ b/test/metabase/actions/api_test.clj
@@ -200,8 +200,7 @@
                                                   (mt/native-query
                                                     {:query "select * from checkins limit 1"})}]
                   (let [action (cross-db-action (:id model) test-data-id)
-                        response (mt/user-http-request :rasta :post 400 "action"
-                                                       action)]
+                        response (mt/user-http-request :rasta :post 400 "action" action)]
                     (testing "Checks both databases for actions enabled"
                       (is (partial= {:message "Actions are not enabled."
                                      :data {:database-id test-data-id}}
@@ -216,7 +215,7 @@
                                                                                  test-data-id)]
                 (is (partial= {:message "Actions are not enabled."
                                :data {:database-id test-data-id}}
-                              (mt/user-http-request :crowberto
+                              (mt/user-http-request :rasta
                                                     :post 400
                                                     (format "action/%s/execute" action-on-other-id)
                                                     ;; Twitter is the current value so effectively a no-op

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -290,8 +290,8 @@
 
 (defn do-with-actions-set!
   "Impl for [[with-actions-enabled]]."
-  [enable? thunk]
-  (tu/with-temp-vals-in-db :model/Database (data/id) {:settings {:database-enable-actions enable?}}
+  [db-id enable? thunk]
+  (tu/with-temp-vals-in-db :model/Database db-id {:settings {:database-enable-actions enable?}}
     (thunk)))
 
 ;;; TODO -- FIXME, rename this to `with-actions-enabled!` and remove the `:clj-kondo/ignore`
@@ -300,7 +300,7 @@
   "Execute `body` with Actions enabled for the current test Database."
   {:style/indent 0}
   [& body]
-  `(do-with-actions-set! true (fn [] ~@body)))
+  `(do-with-actions-set! (data/id) true (fn [] ~@body)))
 
 ;;; TODO -- FIXME, rename this to `with-actions-disabled!` and remove the `:clj-kondo/ignore`
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
@@ -308,7 +308,7 @@
   "Execute `body` with Actions disabled for the current test Database."
   {:style/indent 0}
   [& body]
-  `(do-with-actions-set! false (fn [] ~@body)))
+  `(do-with-actions-set! (data/id) false (fn [] ~@body)))
 
 ;;; TODO FIXME -- rename this to [[with-actions!]] and then remove the Kondo ignore comment below
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}


### PR DESCRIPTION
This fixes an issue where we'd get a "Card not found" error when trying to execute a SQL action which acts on a different database to that upon which the Model is defined.