### PR TITLE
Run tests for merge queue

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,7 @@ on:
       - "release-**"
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 jobs:
   files-changed:


### PR DESCRIPTION
Triggers all jobs in run-tests in the merge queue.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions