### PR TITLE
[legacy-mbql] Optimize normalize-tokens

### DIFF
--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -81,7 +81,7 @@
 ;;; |                                                NORMALIZE TOKENS                                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(declare normalize-tokens)
+(declare normalize-tokens path->special-token-normalization-fn)
 
 (defmulti ^:private normalize-mbql-clause-tokens
   {:arglists '([mbql-clause])}
@@ -94,7 +94,7 @@
     (some? option) (conj option)))
 
 (defn- normalize-ref-opts [opts]
-  (let [opts (normalize-tokens opts :ignore-path)]
+  (let [opts (normalize-tokens opts nil)]
     (cond-> opts
       (:base-type opts)               (update :base-type keyword)
       (:effective-type opts)          (update :effective-type keyword)
@@ -126,7 +126,7 @@
   [[_ field strategy-name strategy-param]]
   (if strategy-param
     (conj (normalize-mbql-clause-tokens [:binning-strategy field strategy-name]) strategy-param)
-    [:binning-strategy (normalize-tokens field :ignore-path) (maybe-normalize-token strategy-name)]))
+    [:binning-strategy (normalize-tokens field nil) (maybe-normalize-token strategy-name)]))
 
 (defmethod normalize-mbql-clause-tokens :field
   [[_ id-or-name opts]]
@@ -148,17 +148,17 @@
   ;; normalize the unit, and `:as` (if present) tokens, and the Field."
   [[_ field as-or-unit maybe-unit]]
   (if maybe-unit
-    [:datetime-field (normalize-tokens field :ignore-path) :as (maybe-normalize-token maybe-unit)]
-    [:datetime-field (normalize-tokens field :ignore-path) (maybe-normalize-token as-or-unit)]))
+    [:datetime-field (normalize-tokens field nil) :as (maybe-normalize-token maybe-unit)]
+    [:datetime-field (normalize-tokens field nil) (maybe-normalize-token as-or-unit)]))
 
 (defmethod normalize-mbql-clause-tokens :time-interval
   ;; `time-interval`'s `unit` should get normalized, and `amount` if it's not an integer."
   [[_ field amount unit options]]
   (if options
     (conj (normalize-mbql-clause-tokens [:time-interval field amount unit])
-          (normalize-tokens options :ignore-path))
+          (normalize-tokens options nil))
     [:time-interval
-     (normalize-tokens field :ignore-path)
+     (normalize-tokens field nil)
      (if (integer? amount)
        amount
        (maybe-normalize-token amount))
@@ -166,7 +166,7 @@
 
 (defmethod normalize-mbql-clause-tokens :relative-time-interval
   [[_ col & [_value _bucket _offset-value _offset-bucket :as args]]]
-  (into [:relative-time-interval (normalize-tokens col :ignore-path)]
+  (into [:relative-time-interval (normalize-tokens col nil)]
         (map maybe-normalize-token)
         args))
 
@@ -186,18 +186,18 @@
 
 (defmethod normalize-mbql-clause-tokens :datetime-add
   [[_ field amount unit]]
-  [:datetime-add (normalize-tokens field :ignore-path) amount (maybe-normalize-token unit)])
+  [:datetime-add (normalize-tokens field nil) amount (maybe-normalize-token unit)])
 
 (defmethod normalize-mbql-clause-tokens :datetime-subtract
   [[_ field amount unit]]
-  [:datetime-subtract (normalize-tokens field :ignore-path) amount (maybe-normalize-token unit)])
+  [:datetime-subtract (normalize-tokens field nil) amount (maybe-normalize-token unit)])
 
 (defmethod normalize-mbql-clause-tokens :datetime
   [[_ field options]]
   (if (empty? options)
-    [:datetime (normalize-tokens field :ignore-path)]
-    [:datetime (normalize-tokens field :ignore-path)
-     (let [options (normalize-tokens options :ignore-path)]
+    [:datetime (normalize-tokens field nil)]
+    [:datetime (normalize-tokens field nil)
+     (let [options (normalize-tokens options nil)]
        (cond-> options
          (contains? options :mode)
          (update :mode lib.schema.expression.temporal/normalize-datetime-mode)))]))
@@ -205,31 +205,31 @@
 (defmethod normalize-mbql-clause-tokens :get-week
   [[_ field mode]]
   (if mode
-    [:get-week (normalize-tokens field :ignore-path) (maybe-normalize-token mode)]
-    [:get-week (normalize-tokens field :ignore-path)]))
+    [:get-week (normalize-tokens field nil) (maybe-normalize-token mode)]
+    [:get-week (normalize-tokens field nil)]))
 
 (defmethod normalize-mbql-clause-tokens :get-day-of-week
   [[_ field mode]]
   (if mode
-    [:get-day-of-week (normalize-tokens field :ignore-path) (maybe-normalize-token mode)]
-    [:get-day-of-week (normalize-tokens field :ignore-path)]))
+    [:get-day-of-week (normalize-tokens field nil) (maybe-normalize-token mode)]
+    [:get-day-of-week (normalize-tokens field nil)]))
 
 (defmethod normalize-mbql-clause-tokens :temporal-extract
   [[_ field unit mode]]
   (if mode
-    [:temporal-extract (normalize-tokens field :ignore-path) (maybe-normalize-token unit) (maybe-normalize-token mode)]
-    [:temporal-extract (normalize-tokens field :ignore-path) (maybe-normalize-token unit)]))
+    [:temporal-extract (normalize-tokens field nil) (maybe-normalize-token unit) (maybe-normalize-token mode)]
+    [:temporal-extract (normalize-tokens field nil) (maybe-normalize-token unit)]))
 
 (defmethod normalize-mbql-clause-tokens :datetime-diff
   [[_ x y unit]]
   [:datetime-diff
-   (normalize-tokens x :ignore-path)
-   (normalize-tokens y :ignore-path)
+   (normalize-tokens x nil)
+   (normalize-tokens y nil)
    (maybe-normalize-token unit)])
 
 (defmethod normalize-mbql-clause-tokens :during
   [[_ field value unit]]
-  [:during (normalize-tokens field :ignore-path) value (maybe-normalize-token unit)])
+  [:during (normalize-tokens field nil) value (maybe-normalize-token unit)])
 
 (defn- normalize-value-opts
   [opts]
@@ -252,13 +252,13 @@
   [[_tag opts expr n, :as clause]]
   {:pre [(= (count clause) 4)]}
   (let [opts (lib.normalize/normalize :metabase.lib.schema.common/options (or opts {}))]
-    [:offset opts (normalize-tokens expr :ignore-path) n]))
+    [:offset opts (normalize-tokens expr nil) n]))
 
 (defmethod normalize-mbql-clause-tokens :default
   ;; MBQL clauses by default are recursively normalized.
   ;; This includes the clause name (e.g. `[\"COUNT\" ...]` becomes `[:count ...]`) and args.
   [[clause-name & args]]
-  (into [(maybe-normalize-token clause-name)] (map #(normalize-tokens % :ignore-path)) args))
+  (into [(maybe-normalize-token clause-name)] (map #(normalize-tokens % nil)) args))
 
 (defn- aggregation-subclause?
   [x]
@@ -289,7 +289,7 @@
     (mapv normalize-ag-clause-tokens ag-clause)
 
     :else
-    (normalize-tokens ag-clause :ignore-path)))
+    (normalize-tokens ag-clause nil)))
 
 (defn- normalize-expressions-tokens
   "For expressions, we don't want to normalize the name of the expression; keep that as is, and make it a string;
@@ -297,7 +297,7 @@
   [expressions-clause]
   (into {} (for [[expression-name definition] expressions-clause]
              [(u/qualified-name expression-name)
-              (normalize-tokens definition :ignore-path)])))
+              (normalize-tokens definition nil)])))
 
 (defn- normalize-order-by-tokens
   "Normalize tokens in the order-by clause, which can have different syntax when using MBQL 95 or 98
@@ -321,7 +321,7 @@
        ;; if there's not a special transform function for the key in the map above, just wrap the key-value
        ;; pair in a dummy map and let [[normalize-tokens]] take care of it. Then unwrap
        (fn [v]
-         (-> (normalize-tokens {k v} :ignore-path)
+         (-> (normalize-tokens {k v} nil)
              (get k)))))
 
 (defn- normalize-template-tag-definition
@@ -363,22 +363,23 @@
     id                   (update :id u/qualified-name)
     ;; some things that get ran thru here, like dashcard param targets, do not have :type
     param-type           (update :type maybe-normalize-token)
-    target               (update :target #(normalize-tokens % :ignore-path))
-    values_source_config (update-in [:values_source_config :label_field] #(normalize-tokens % :ignore-path))
-    values_source_config (update-in [:values_source_config :value_field] #(normalize-tokens % :ignore-path))))
+    target               (update :target #(normalize-tokens % nil))
+    values_source_config (update-in [:values_source_config :label_field] #(normalize-tokens % nil))
+    values_source_config (update-in [:values_source_config :value_field] #(normalize-tokens % nil))))
 
 (defn- normalize-source-query [source-query]
   (let [{native? :native, :as source-query} (update-keys source-query maybe-normalize-token)]
     (if native?
       (-> source-query
           (set/rename-keys {:native :query})
-          (normalize-tokens [:native])
+          (normalize-tokens (:native path->special-token-normalization-fn))
           (set/rename-keys {:query :native}))
-      (normalize-tokens source-query [:query]))))
+      (normalize-tokens source-query (:query path->special-token-normalization-fn)))))
 
 (defn- normalize-join [join]
   ;; path in call to `normalize-tokens` is [:query] so it will normalize `:source-query` as appropriate
-  (let [{:keys [strategy fields], join-alias :alias, :as join} (normalize-tokens join :query)]
+  (let [{:keys [strategy fields], join-alias :alias, :as join}
+        (normalize-tokens join (:query path->special-token-normalization-fn))]
     (cond-> join
       strategy
       (update :strategy maybe-normalize-token)
@@ -483,47 +484,52 @@
 
   In some cases, dealing with the path isn't desirable, but we don't want to accidentally trigger normalization
   functions (such as accidentally normalizing the `:type` key in something other than the top-level of the query), so
-  by convention please pass `:ignore-path` to avoid accidentally triggering path functions."
-  [x & [path]]
-  (let [path       (if (keyword? path)
-                     [path]
-                     (vec path))
-        special-fn (when (seq path)
-                     (get-in path->special-token-normalization-fn path))]
-    (try
-      (cond
-        (fn? special-fn)
-        (special-fn x)
+  by convention please pass `nil` to avoid accidentally triggering special path functions."
+  ([x] (normalize-tokens x path->special-token-normalization-fn))
+  ([x special-fns]
+   (let [special-fn (when (and special-fns (fn? special-fns))
+                      special-fns)]
+     (try
+       (cond
+         special-fn
+         (special-fn x)
 
-        ;; Skip record types because this query is an `expanded` query, which is not going to play nice here. Hopefully we
-        ;; can remove expanded queries entirely soon.
-        (record? x)
-        x
+         ;; Skip record types because this query is an `expanded` query, which is not going to play nice here. Hopefully we
+         ;; can remove expanded queries entirely soon.
+         (record? x)
+         x
 
-        ;; maps should just get the keys normalized and then recursively call normalize-tokens on the values.
-        ;; Each recursive call appends to the keypath above so we can handle top-level clauses in a special way if needed
-        (map? x)
-        (into {} (for [[k v] x
-                       :let  [k (maybe-normalize-token k)]]
-                   [k (normalize-tokens v (conj (vec path) k))]))
+         ;; maps should just get the keys normalized and then recursively call normalize-tokens on the values.
+         ;; Each recursive call peels away one level from special-fns map so we can handle top-level clauses in a special way if needed
+         (map? x)
+         (reduce-kv (fn [m k v]
+                      (let [k' (maybe-normalize-token k)
+                            v' (normalize-tokens v (get special-fns k'))]
+                        (if (identical? k k')
+                          (if (identical? v v')
+                            m
+                            (assoc m k v'))
+                          (-> m (dissoc k) (assoc k' v')))))
+                    x x)
 
-        ;; MBQL clauses handled above because of special cases
-        (mbql-clause? x)
-        (normalize-mbql-clause-tokens x)
+         ;;          MBQL clauses handled above because of special cases
+         (mbql-clause? x)
+         (normalize-mbql-clause-tokens x)
 
-        ;; for non-mbql sequential collections (probably something like the subclauses of :order-by or something like
-        ;; that) recurse on all the args.
-        ;;
-        ;; To signify that we're recursing into a sequential collection, this appends `::sequence` to path
-        (sequential? x)
-        (mapv #(normalize-tokens % (conj (vec path) ::sequence)) x)
+         ;; for non-mbql sequential collections (probably something like the subclauses of :order-by or something like
+         ;; that) recurse on all the args.
+         ;;
+         ;; To signify that we're recursing into a sequential collection, this peels away `::sequence` from special-fns
+         (sequential? x)
+         (let [special-fns (::sequence special-fns)]
+           (mapv #(normalize-tokens % special-fns) x))
 
-        :else
-        x)
-      (catch #?(:clj Throwable :cljs js/Error) e
-        (throw (ex-info (i18n/tru "Error normalizing form: {0}" (ex-message e))
-                        {:form x, :path path, :special-fn special-fn}
-                        e))))))
+         :else
+         x)
+       (catch #?(:clj Throwable :cljs js/Error) e
+         (throw (ex-info (i18n/tru "Error normalizing form: {0}" (ex-message e))
+                         {:form x, :special-fn special-fn}
+                         e)))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  CANONICALIZE                                                  |
@@ -739,7 +745,7 @@
     [[_ clauses options]]
     (if options
       (conj (canonicalize-mbql-clause [tag clauses])
-            (normalize-tokens options :ignore-path))
+            (normalize-tokens options nil))
       [tag (vec (for [[pred expr] clauses]
                   [(canonicalize-mbql-clause pred) (canonicalize-mbql-clause expr)]))])))
 

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -31,7 +31,7 @@
   #_{:clj-kondo/ignore [:discouraged-var]}
   (-> (u/qualified-name token)
       str/lower-case
-      (str/replace #"_" "-")
+      (str/replace \_ \-)
       keyword))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/legacy_mbql/normalize_test.cljc
+++ b/test/metabase/legacy_mbql/normalize_test.cljc
@@ -1567,7 +1567,6 @@
             (t/is (some? cause))
             (t/is (re-find #"Error normalizing form:" (ex-message cause)))
             (t/is (= {:form       bad-query
-                      :path       []
                       :special-fn nil}
                      (ex-data cause)))))))))
 


### PR DESCRIPTION
The approach here is similar to what was used in https://github.com/metabase/metabase/pull/60461 - replace path accumulation with walking down the map immediately.