### PR TITLE
[qp] Use metabase.util.performance/postwalk instead of regular clojure.walk

### DIFF
--- a/src/metabase/lib/schema/util.cljc
+++ b/src/metabase/lib/schema/util.cljc
@@ -1,7 +1,8 @@
 (ns metabase.lib.schema.util
   (:refer-clojure :exclude [ref])
   (:require
-   [clojure.walk :as walk]
+   #?(:clj [metabase.util.performance :refer [postwalk]]
+      :default [clojure.walk :refer [postwalk]])
    [medley.core :as m]
    [metabase.lib.options :as lib.options]
    [metabase.util.malli :as mu]
@@ -117,7 +118,7 @@
 (defn remove-lib-uuids
   "Recursively remove all uuids from `x`."
   [x]
-  (walk/postwalk
+  (postwalk
    (fn [x]
      (cond-> x
        (map? x) (dissoc :lib/uuid)))

--- a/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
+++ b/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
@@ -2,7 +2,6 @@
   "Middlware that optimizes equality filter clauses against bucketed temporal fields. See docstring for
   `optimize-temporal-filters` for more details."
   (:require
-   [clojure.walk :as walk]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
@@ -13,7 +12,8 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :as perf]))
 
 (def ^:private optimizable-units
   #{:second :minute :hour :day :week :month :quarter :year})
@@ -346,7 +346,7 @@
   (if (not= query-type :query)
     query
     ;; walk query, looking for inner-query forms that have a `:filter` key
-    (walk/postwalk
+    (perf/postwalk
      (fn [form]
        (if-not (and (map? form) (seq (:filter form)))
          form

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -46,7 +46,6 @@
   If this clause is 'selected', this is the position the clause will appear in the results (i.e. the corresponding
   column index)."
   (:require
-   [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.legacy-mbql.schema :as mbql.s]
@@ -66,7 +65,8 @@
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :as perf]))
 
 (defn- prefix-field-alias
   "Generate a field alias by applying `prefix` to `field-alias`. This is used for automatically-generated aliases for
@@ -92,21 +92,22 @@
 ;; [[unique-alias-fn]] below.
 
 (defn- remove-namespaced-options [options]
-  (when options
-    (not-empty (into {}
-                     (remove (fn [[k _]]
-                               (qualified-keyword? k)))
-                     options))))
+  (not-empty
+   (reduce-kv (fn [m k _]
+                (if (qualified-keyword? k)
+                  (dissoc m k)
+                  m))
+              options options)))
 
 (defn normalize-clause
   "Normalize a `:field`/`:expression`/`:aggregation` clause by removing extra info so it can serve as a key for
   `:qp/refs`. This removes `:source-field` if it is present -- don't use the output of this for anything but internal
   key/distinct comparison purposes."
   [clause]
-  (lib.util.match/match-one clause
+  (lib.util.match/match-lite clause
     ;; optimization: don't need to rewrite a `:field` clause without any options
     [:field _ nil]
-    &match
+    clause
 
     [:field id-or-name opts]
     ;; this doesn't use [[mbql.u/update-field-options]] because this gets called a lot and the overhead actually adds up
@@ -128,7 +129,7 @@
       [:aggregation index])
 
     _
-    &match))
+    clause))
 
 (defn- selected-clauses
   "Get all the clauses that are returned by this level of the query as a map of normalized-clause -> index of that
@@ -614,7 +615,7 @@
                                                  lib.util/unique-name-generator)]
      (as-> query-or-inner-query $q
        ;; first escape all the join aliases
-       (walk/postwalk
+       (perf/postwalk
         (fn [form]
           (if (and (map? form)
                    (seq (:joins form)))
@@ -629,7 +630,7 @@
             form))
         $q)
        ;; then add alias info
-       (walk/postwalk
+       (perf/postwalk
         (fn [form]
           (if (and (map? form)
                    ((some-fn :source-query :source-table) form)


### PR DESCRIPTION
Each callsite has a small impact during pivot table generation (when the query is pre-processed) but they add up.
