### PR TITLE
Allow configuring uploads for attached DWH

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -808,15 +808,41 @@
                                     (mt/user-http-request :rasta :post 403 execute-path
                                                           {:parameters {"id" 1}}))))))))))))))
 
+(defmacro with-all-users-as-settings-managers [& body]
+  `(try
+     (perms/grant-application-permissions! (perms-group/all-users) :setting)
+     (do ~@body)
+     (finally
+       (perms/revoke-application-permissions! (perms-group/all-users) :setting))))
+
 (deftest settings-managers-can-have-uploads-db-access-revoked
-  (perms/grant-application-permissions! (perms-group/all-users) :setting)
-  (testing "Upload DB can be set with the right permission"
-    (mt/with-all-users-data-perms-graph! {(mt/id) {:details :yes}}
-      (mt/user-http-request :rasta :put 204 "setting/" {:uploads-settings {:db_id (mt/id) :schema_name nil :table_prefix nil}})))
-  (testing "Upload DB cannot be set without the right permission"
-    (mt/with-all-users-data-perms-graph! {(mt/id) {:details :no}}
-      (mt/user-http-request :rasta :put 403 "setting/" {:uploads-settings {:db_id (mt/id) :schema_name nil :table_prefix nil}})))
-  (perms/revoke-application-permissions! (perms-group/all-users) :setting))
+  (mt/with-premium-features #{:advanced-permissions}
+    (with-all-users-as-settings-managers
+      (mt/user-http-request :crowberto :put 204 "setting/" {:uploads-settings {}})
+      (testing "Upload DB can be set with the right permission"
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:details :yes}}
+          (mt/user-http-request :rasta :put 204 "setting/" {:uploads-settings {:db_id (mt/id) :schema_name nil :table_prefix nil}})))
+      (testing "Upload DB cannot be set without the right permission"
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:details :no}}
+          (mt/user-http-request :rasta :put 403 "setting/" {:uploads-settings {:db_id (mt/id) :schema_name nil :table_prefix nil}}))))))
+
+(deftest settings-managers-can-enable-and-disable-uploads-on-dwh
+  (mt/with-premium-features #{:advanced-permissions}
+    (with-all-users-as-settings-managers
+      (mt/with-temp [:model/Database {db-id :id} {:is_attached_dwh true}
+                     :model/PermissionsGroup {group-id :id} {}
+                     :model/User {user-id :id} {}
+                     :model/PermissionsGroupMembership {} {:user_id user-id
+                                                           :group_id group-id}]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-restored-data-perms-for-groups! [group-id]
+            (testing "Can enable uploads on DWH"
+              (mt/user-http-request user-id :put 204 "setting/" {:uploads-settings {:db_id db-id :schema_name nil :table_prefix nil}}))
+            (testing "Can disable uploads on DWH"
+              (mt/user-http-request user-id :put 204 "setting/" {:uploads-settings {}}))
+            (testing "Admins can do this too"
+              (mt/user-http-request :crowberto :put 204 "setting/" {:uploads-settings {:db_id db-id :schema_name nil :table_prefix nil}})
+              (mt/user-http-request :crowberto :put 204 "setting/" {:uploads-settings {}}))))))))
 
 (deftest upload-csv-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads :schemas)

--- a/src/metabase/upload/settings.clj
+++ b/src/metabase/upload/settings.clj
@@ -11,6 +11,14 @@
   []
   (nil? @api/*current-user*))
 
+(defn- check-required-perms!
+  "Checks that we have the required permissions to change upload settings for this database."
+  [db-id]
+  (or (not-handling-api-request?)
+      (mi/can-write? :model/Database db-id)
+      (t2/select-one-fn :is_attached_dwh :model/Database db-id)
+      (api/throw-403)))
+
 (defsetting uploads-settings
   (deferred-tru "Upload settings")
   :encryption :when-encryption-key-set ; this doesn't really have an effect as this setting is not stored as a setting model
@@ -24,19 +32,15 @@
                    :schema_name  (:uploads_schema_name db)
                    :table_prefix (:uploads_table_prefix db)}))
   :setter     (fn [{:keys [db_id schema_name table_prefix]}]
-                (cond
-                  (nil? db_id)
+                (if (nil? db_id)
                   (t2/update! :model/Database :uploads_enabled true {:uploads_enabled      false
                                                                      :uploads_schema_name  nil
                                                                      :uploads_table_prefix nil})
-                  (or (not-handling-api-request?)
-                      (mi/can-write? :model/Database db_id)
-                      (t2/select-one-fn :is_attached_dwh :model/Database db_id))
-                  (t2/update! :model/Database db_id {:uploads_enabled      true
-                                                     :uploads_schema_name  schema_name
-                                                     :uploads_table_prefix table_prefix})
-                  :else
-                  (api/throw-403))))
+                  (do
+                    (check-required-perms! db_id)
+                    (t2/update! :model/Database db_id {:uploads_enabled      true
+                                                       :uploads_schema_name  schema_name
+                                                       :uploads_table_prefix table_prefix})))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Deprecated uploads settings begin

--- a/src/metabase/upload/settings.clj
+++ b/src/metabase/upload/settings.clj
@@ -30,7 +30,8 @@
                                                                      :uploads_schema_name  nil
                                                                      :uploads_table_prefix nil})
                   (or (not-handling-api-request?)
-                      (mi/can-write? :model/Database db_id))
+                      (mi/can-write? :model/Database db_id)
+                      (t2/select-one-fn :is_attached_dwh :model/Database db_id))
                   (t2/update! :model/Database db_id {:uploads_enabled      true
                                                      :uploads_schema_name  schema_name
                                                      :uploads_table_prefix table_prefix})

--- a/src/metabase/warehouses/api.clj
+++ b/src/metabase/warehouses/api.clj
@@ -1112,9 +1112,10 @@
   "Returns a list of all syncable schemas found for the database `id`."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  (let [db (get-database id {:exclude-uneditable-details? true})]
+  (let [db (get-database id)]
     (api/check-403 (or (:is_attached_dwh db)
-                       (mi/can-write? db)))
+                       (and (mi/can-write? db)
+                            (mi/can-read? db))))
     (->> db
          (driver/syncable-schemas (:engine db))
          (vec)

--- a/test/metabase/warehouses/api_test.clj
+++ b/test/metabase/warehouses/api_test.clj
@@ -1639,6 +1639,14 @@
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :get 403 (format "database/%d/syncable_schemas" (mt/id))))))))))
 
+(deftest get-syncable-schemas-checks-permissions-correctly
+  (testing "GET /api/database/:id/syncable_schemas"
+    (testing "Non-admins can get syncable schemas on the attached DWH"
+      (mt/with-temp [:model/Database {id :id} {:is_attached_dwh true}]
+        (with-redefs [driver/syncable-schemas (constantly #{"PUBLIC"})]
+          (is (= ["PUBLIC"]
+                 (mt/user-http-request :rasta :get 200 (format "database/%d/syncable_schemas" id)))))))))
+
 (deftest ^:parallel get-schemas-for-schemas-with-no-visible-tables
   (mt/with-temp
     [:model/Database {db-id :id} {}


### PR DESCRIPTION
Two changes required to allow this:

- first, for the setting itself, allow setting it if the database is writable OR an attached DWH.

- second, a similar change to make sure `syncable_schemas` is fetchable for the attached DWH.

Fixes #50109 and [ADM-119: You Can Turn Off CSV Uploads for "Metabase Cloud Storage" and Cannot Re-enable It](https://linear.app/metabase/issue/ADM-119/you-can-turn-off-csv-uploads-for-metabase-cloud-storage-and-cannot-re)

Demo in Cloud:

![attached-dwh](https://github.com/user-attachments/assets/c57b9474-d759-4263-8d41-de5902c301f7)
