### PR TITLE
Fix couldn't click filters in dashboard edit mode with SDK

### DIFF
--- a/frontend/src/metabase/dashboard/components/CollapsibleDashboardParameterList/CollapsibleDashboardParameterList.tsx
+++ b/frontend/src/metabase/dashboard/components/CollapsibleDashboardParameterList/CollapsibleDashboardParameterList.tsx
@@ -57,10 +57,8 @@ export const CollapsibleDashboardParameterList = forwardRef<
               className={triggerClassName}
               aria-label={t`Show filters`}
               tooltipLabel={t`Show filters`}
-              onClick={(e) => {
-                // To avoid focusing the input when clicking the button
-                e.stopPropagation();
-              }}
+              onMouseDown={preventDragOrInputFocus}
+              onClick={preventDragOrInputFocus}
             >
               <Icon name="filter" />
               {parametersWithValues.length > 0 && (
@@ -104,3 +102,7 @@ export const CollapsibleDashboardParameterList = forwardRef<
     </>
   );
 });
+
+function preventDragOrInputFocus(e: React.MouseEvent) {
+  e.stopPropagation();
+}

--- a/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
+++ b/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
@@ -120,6 +120,12 @@ export const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
         gap="sm"
         className={className}
         ref={ref}
+        onMouseDown={(e) => {
+          if (isEditing) {
+            // Prevents clicking a filter in edit mode triggering card dragging
+            e.stopPropagation();
+          }
+        }}
       >
         {isSortable ? (
           <SortableList


### PR DESCRIPTION
Clicking a dashcard filter would most often trigger a dashcard drag event in SDK dashboards for some reason. Fixed by adding `event.stopPropagation()` on filter components

### To verify

1. Run `yarn dev-ee` with an enterprise token
2. Add filters to dashcards on the example dashboard (in the Examples collection)
3. [Enable SDK and enable JWT auth](https://github.com/metabase/metabase/blob/master/enterprise/frontend/src/embedding-sdk/dev.md#storybook)
4. `yarn storybook-embedding-sdk`
5. Open the `EditableDashboard` story
6. Open edit mode and try clicking filters, ensure all clicks open the parameter mapping flow