### PR TITLE
create markdrown card

### DIFF
--- a/frontend/src/metabase-types/api/visualization.ts
+++ b/frontend/src/metabase-types/api/visualization.ts
@@ -5,6 +5,7 @@ export const virtualCardDisplayTypes = [
   "placeholder",
   "text",
   "iframe",
+  "markdowncard",
 ] as const;
 
 export type VirtualCardDisplay = (typeof virtualCardDisplayTypes)[number];
@@ -30,6 +31,7 @@ const cardDisplayTypes = [
   "progress",
   "funnel",
   "object",
+  "markdown",
   "map",
   "scatter",
   "waterfall",

--- a/frontend/src/metabase/visualizations/components/MarkdownDetail.jsx
+++ b/frontend/src/metabase/visualizations/components/MarkdownDetail.jsx
@@ -1,0 +1,108 @@
+import React, { useMemo } from "react";
+import Markdown from "metabase/core/components/Markdown";
+import ObjectDetail from "./ObjectDetail";
+
+export default function MarkdownDetail({ series, settings, ...props }) {
+  const [{ data }] = series;
+  const template = settings["markdown.template"];
+
+  const renderedMarkdown = useMemo(() => {
+    if (!template) {
+      return null;
+    }
+
+    try {
+      const { cols, rows } = data;
+      
+      // Create template data with basic info
+      const templateData = {
+        title: "Data Table",
+        row_count: rows.length,
+        col_count: cols.length,
+      };
+
+      // Add column values from first row if available
+      if (rows.length > 0) {
+        cols.forEach((col, index) => {
+          const value = rows[0][index];
+          // Add both original name (lowercase) and version with spaces replaced by underscores
+          const originalName = col.name.toLowerCase();
+          const spacelessName = col.name.toLowerCase().replace(/\s+/g, '_');
+          
+          templateData[originalName] = value;
+          templateData[spacelessName] = value;
+        });
+      }
+
+      // Simple template variable processing
+      const processed = template.replace(
+        /{{([^}]+)}}/g,
+        (_whole, variableName) => {
+          const name = variableName.toLowerCase().trim();
+          const value = templateData[name];
+          return value !== undefined ? String(value) : "";
+        }
+      );
+
+      return processed;
+    } catch (error) {
+      return `**Template Error:** ${error.message}`;
+    }
+  }, [data, template, settings]);
+
+  if (template && renderedMarkdown) {
+    return (
+      <div style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
+        <Markdown>{renderedMarkdown}</Markdown>
+      </div>
+    );
+  }
+
+  // Show empty state with instructions if no template
+  if (!template || template.trim() === "") {
+    return (
+      <div style={{ 
+        padding: "2rem", 
+        height: "100%", 
+        display: "flex", 
+        flexDirection: "column", 
+        justifyContent: "center", 
+        alignItems: "center",
+        textAlign: "center",
+        color: "#666"
+      }}>
+        <div style={{ maxWidth: "400px" }}>
+          <h3 style={{ marginBottom: "1rem", color: "#333" }}>Create a Markdown Template</h3>
+          <p style={{ marginBottom: "1.5rem", lineHeight: "1.5" }}>
+            Use the <strong>Markdown Template</strong> field in the Display settings to create a custom view of your data.
+          </p>
+          <div style={{ 
+            backgroundColor: "#f8f9fa", 
+            padding: "1rem", 
+            borderRadius: "4px", 
+            marginBottom: "1.5rem",
+            fontFamily: "monospace",
+            fontSize: "13px",
+            textAlign: "left"
+          }}>
+            <div style={{ marginBottom: "0.5rem", fontWeight: "bold" }}>Example template:</div>
+            <div>
+              # My Data Report<br/>
+              <br/>
+              **Total Records:** {`{{row_count}}`}<br/>
+              **Columns:** {`{{col_count}}`}<br/>
+              <br/>
+              Use column references from the settings below.
+            </div>
+          </div>
+          <p style={{ fontSize: "14px", color: "#888" }}>
+            Check the column settings below to see the available variable names for your data.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Fall back to regular ObjectDetail if template exists but didn't render
+  return <ObjectDetail series={series} settings={settings} {...props} />;
+}

--- a/frontend/src/metabase/visualizations/components/MarkdownTemplateWidget.jsx
+++ b/frontend/src/metabase/visualizations/components/MarkdownTemplateWidget.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { t } from "ttag";
+
+export default function MarkdownTemplateWidget({ value, onChange, placeholder }) {
+  return (
+    <div>
+      <textarea
+        value={value || ""}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder || t`Enter your markdown template using {{variable_name}} syntax...`}
+        style={{
+          width: "100%",
+          minHeight: "120px",
+          padding: "8px",
+          border: "1px solid #ccc",
+          borderRadius: "4px",
+          fontFamily: "monospace",
+          fontSize: "13px",
+          lineHeight: "1.4",
+          resize: "vertical",
+        }}
+        rows={6}
+      />
+    </div>
+  );
+}

--- a/frontend/src/metabase/visualizations/register.js
+++ b/frontend/src/metabase/visualizations/register.js
@@ -16,6 +16,7 @@ import { LineChart } from "./visualizations/LineChart";
 import { LinkViz } from "./visualizations/LinkViz";
 import { Map } from "./visualizations/Map";
 import ObjectDetail from "./visualizations/ObjectDetail";
+import MarkdownDetail from "./visualizations/MarkdownDetail";
 import { PieChart } from "./visualizations/PieChart";
 import PivotTable from "./visualizations/PivotTable";
 import Progress from "./visualizations/Progress";
@@ -45,6 +46,7 @@ export default function () {
   registerVisualization(Map);
   registerVisualization(Funnel);
   registerVisualization(ObjectDetail);
+  registerVisualization(MarkdownDetail);
   registerVisualization(PivotTable);
   registerVisualization(SankeyChart);
 

--- a/frontend/src/metabase/visualizations/shared/utils/sizes.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/sizes.ts
@@ -40,6 +40,7 @@ export const MOBILE_HEIGHT_BY_DISPLAY_TYPE: Record<
   action: 1,
   link: 1,
   text: (desktopHeight) => Math.max(2, desktopHeight),
+  markdowncard: (desktopHeight) => Math.max(3, desktopHeight),
   heading: 2,
   scalar: 4,
 };

--- a/frontend/src/metabase/visualizations/visualizations/MarkdownDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/MarkdownDetail.jsx
@@ -1,0 +1,70 @@
+import { t } from "ttag";
+
+import { displayNameForColumn } from "metabase/lib/formatting";
+import MarkdownDetail from "metabase/visualizations/components/MarkdownDetail";
+import MarkdownTemplateWidget from "metabase/visualizations/components/MarkdownTemplateWidget";
+import {
+  columnSettings,
+  tableColumnSettings,
+} from "metabase/visualizations/lib/settings/column";
+import {
+  getDefaultSize,
+  getMinSize,
+} from "metabase/visualizations/shared/utils/sizes";
+
+const MarkdownDetailProperties = {
+  getUiName() {
+    return t`Markdown`;
+  },
+  identifier: "markdown",
+  iconName: "document",
+  get noun() {
+    return t`markdown`;
+  },
+  minSize: getMinSize("markdown"),
+  defaultSize: getDefaultSize("markdown"),
+  hidden: false,
+  canSavePng: false,
+  disableClickBehavior: true,
+  settings: {
+    "markdown.template": {
+      section: t`Display`,
+      title: t`Markdown Template`,
+      widget: MarkdownTemplateWidget,
+      default: `# Data Summary
+
+**Rows:** {{row_count}}
+**Columns:** {{col_count}}
+
+**Available Variables:**
+- {{title}} - Table title
+- {{row_count}} - Number of rows  
+- {{col_count}} - Number of columns
+- Column values from first row available by column name`,
+      placeholder: t`Enter your markdown template using {{variable_name}} syntax...`,
+    },
+    ...columnSettings({ hidden: true }),
+    ...tableColumnSettings,
+  },
+  columnSettings: (column) => {
+    const settings = {
+      column_title: {
+        title: t`Column Reference`,
+        widget: "input",
+        getDefault: (column) => column.name.toLowerCase().replace(/\s+/g, '_'),
+      },
+      click_behavior: {},
+
+      // Makes sure `column_settings` doesn't omit these settings,
+      // so they can be used for formatting
+      view_as: { hidden: true },
+      link_text: { hidden: true },
+      link_url: { hidden: true },
+    };
+
+    return settings;
+  },
+  isSensible: () => true,
+};
+
+export default Object.assign(MarkdownDetail, MarkdownDetailProperties);

--- a/src/metabase/dashboards/constants.cljc
+++ b/src/metabase/dashboards/constants.cljc
@@ -30,7 +30,9 @@
    :object      {:min {:width 4 :height 3} :default {:width 12 :height 9}}
    :row         {:min {:width 4 :height 3} :default {:width 12 :height 6}}
    :heading     {:min {:width 1 :height 1} :default {:width GRID_WIDTH :height 1}}
-   :text        {:min {:width 1 :height 1} :default {:width 12 :height 3}}})
+   :text        {:min {:width 1 :height 1} :default {:width 12 :height 3}}
+   :markdowncard {:min {:width 4 :height 3} :default {:width 12 :height 6}}
+   :markdown    {:min {:width 4 :height 3} :default {:width 12 :height 9}}})
 
 #?(:cljs (def ^:export CARD_SIZE_DEFAULTS_JSON
            "Default card sizes per visualization type as a json object suitable for the FE"


### PR DESCRIPTION
### Description

A new viz, "Markdown Cards" allows the user to write markdown and reference values from a result set.
This is something ive always wanted as a feature, just happy to spend some time making it a thing/

In the dashboard:
![image](https://github.com/user-attachments/assets/1b3f34a0-7589-46e5-8683-f96e1076eb7b)

In edit:
![image](https://github.com/user-attachments/assets/367ba01e-76b7-4300-abb2-0a1e26242018)
![image](https://github.com/user-attachments/assets/68f14d40-6d65-4f19-a01a-e6e47609754a)


Empty state:
![image](https://github.com/user-attachments/assets/6440dd94-4ad0-42e1-a80c-5e31f376559b)


# Disclaimer
Still in a POC just wanted to see if this is something I should keep going on....

# Process

Basically copied the flow of a detail card then implemented new component. There is a text area to write metabase version of jinja. This gets rendered in a detail card.
I had to force column names into snake_case to help with parsing.

Pretty basic implmentation as a POC. still needs tests and love.


### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> select markdown view


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
