### PR TITLE
relax test, ordering can be nondeterministic

### DIFF
--- a/test/metabase/sync/analyze/classify_test.clj
+++ b/test/metabase/sync/analyze/classify_test.clj
@@ -122,8 +122,9 @@
                                    :table_id (u/the-id table)
                                    :semantic_type :type/Name)]
         (is (= 1 (count name-fields)))
-        ;; Should be the first name field encountered
-        (is (= "fullName" (:name (first name-fields))))))))
+
+        ;; Should be the first name field encountered, but we can't assume a specific ordering
+        (is (#{"lastName" "fullName" "firstName"} (:name (first name-fields))))))))
 
 ;; we either already incorrectly inferred multiple fields on a previous sync, or the user incorrectly set multiple fields.
 ;; let them sort it out rather than risk overriding their preferences


### PR DESCRIPTION
Test introduced in https://github.com/metabase/metabase/pull/60492 has been flaking, it encoded an ordering requirement that isn't necessarily satisfied due to non-determinism. 
The non-deterministic behavior is fine as per the requirments of [the original ticket](https://linear.app/metabase/issue/SEM-414/schema-sync-should-not-add-multiple-columns-with-the-entity-name-type)