### PR TITLE
Accept `access_token` as well as `jwt` in SSO

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -137,9 +137,10 @@
             (str return-to-param redirect))))))
 
 (defmethod sso.i/sso-get :jwt
-  [{{:keys [jwt redirect]} :params, :as request}]
+  [{{:keys [jwt access_token redirect]} :params, :as request}]
   (premium-features/assert-has-feature :sso-jwt (tru "JWT-based authentication"))
-  (let [jwt-data (when jwt (session-data jwt request))
+  (let [jwt (or jwt access_token)
+        jwt-data (when jwt (session-data jwt request))
         is-sdk? (sso-utils/is-embedding-sdk-header? request)]
     (cond
       (and is-sdk? (not (embed.settings/enable-embedding-sdk))) (throw-embedding-disabled)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #43468
Fixes [ADM-232: Accept access_token property along jwt in JWT SSO](https://linear.app/metabase/issue/ADM-232/accept-access-token-property-along-jwt-in-jwt-sso)