### PR TITLE
simplify apply filters toast copy

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -89,7 +89,7 @@ describe(
           cy.button("Update filter").click();
         });
         H.assertTableRowsCount(53);
-        H.applyFilterToast().findByText("1 filter updated");
+        H.applyFilterToast().findByText("1 filter changed");
         H.applyFilterButton().click();
 
         cy.wait("@cardQuery");
@@ -154,7 +154,7 @@ describe(
       });
 
       H.applyFilterButton().should("be.visible");
-      H.applyFilterToast().findByText("1 filter added");
+      H.applyFilterToast().findByText("1 filter changed");
 
       cy.log("verify filter value is not saved");
 
@@ -173,7 +173,7 @@ describe(
       });
 
       H.applyFilterButton().should("be.visible");
-      H.applyFilterToast().findByText("1 filter added");
+      H.applyFilterToast().findByText("1 filter changed");
 
       H.cancelFilterButton().click();
       H.applyFilterToast().should("not.exist");

--- a/frontend/src/metabase/parameters/components/FilterApplyToast/utils.ts
+++ b/frontend/src/metabase/parameters/components/FilterApplyToast/utils.ts
@@ -9,9 +9,7 @@ export function getFilterChangeDescription(
   currentValues: Record<string, unknown>,
   draftValues: Record<string, unknown>,
 ): string {
-  let added = 0;
-  let removed = 0;
-  let updated = 0;
+  let changedCount = 0;
 
   const allParameterIds = _.union(
     Object.keys(currentValues),
@@ -26,42 +24,28 @@ export function getFilterChangeDescription(
     const isDraftEmpty = isParameterValueEmpty(draftValue);
 
     if (isCurrentEmpty && !isDraftEmpty) {
-      added++;
+      // Filter was added
+      changedCount++;
     } else if (!isCurrentEmpty && isDraftEmpty) {
-      removed++;
+      // Filter was removed
+      changedCount++;
     } else if (
       !isCurrentEmpty &&
       !isDraftEmpty &&
       !_.isEqual(currentValue, draftValue)
     ) {
-      updated++;
+      // Filter was updated
+      changedCount++;
     }
   }
 
-  const changes = [];
-  if (added > 0) {
-    changes.push(
-      ngettext(msgid`${added} filter added`, `${added} filters added`, added),
-    );
-  }
-  if (updated > 0) {
-    changes.push(
-      ngettext(
-        msgid`${updated} filter updated`,
-        `${updated} filters updated`,
-        updated,
-      ),
-    );
-  }
-  if (removed > 0) {
-    changes.push(
-      ngettext(
-        msgid`${removed} filter removed`,
-        `${removed} filters removed`,
-        removed,
-      ),
-    );
+  if (changedCount === 0) {
+    return "";
   }
 
-  return changes.join(", ");
+  return ngettext(
+    msgid`${changedCount} filter changed`,
+    `${changedCount} filters changed`,
+    changedCount,
+  );
 }

--- a/frontend/src/metabase/parameters/components/FilterApplyToast/utils.unit.spec.ts
+++ b/frontend/src/metabase/parameters/components/FilterApplyToast/utils.unit.spec.ts
@@ -6,7 +6,9 @@ describe("getFilterChangeDescription", () => {
       const current = {};
       const draft = { filter1: "value1" };
 
-      expect(getFilterChangeDescription(current, draft)).toBe("1 filter added");
+      expect(getFilterChangeDescription(current, draft)).toBe(
+        "1 filter changed",
+      );
     });
 
     it("should describe a single filter removed", () => {
@@ -14,7 +16,7 @@ describe("getFilterChangeDescription", () => {
       const draft = {};
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter removed",
+        "1 filter changed",
       );
     });
 
@@ -23,7 +25,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: "value2" };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter updated",
+        "1 filter changed",
       );
     });
   });
@@ -34,7 +36,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: "value1", filter2: "value2" };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "2 filters added",
+        "2 filters changed",
       );
     });
 
@@ -43,7 +45,7 @@ describe("getFilterChangeDescription", () => {
       const draft = {};
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "2 filters removed",
+        "2 filters changed",
       );
     });
 
@@ -52,7 +54,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: "newValue1", filter2: "newValue2" };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "2 filters updated",
+        "2 filters changed",
       );
     });
   });
@@ -63,7 +65,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: "newValue1", filter2: "value2" };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter added, 1 filter updated",
+        "2 filters changed",
       );
     });
 
@@ -72,7 +74,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter2: "value2" };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter added, 1 filter removed",
+        "2 filters changed",
       );
     });
 
@@ -81,7 +83,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: "newValue1" };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter updated, 1 filter removed",
+        "2 filters changed",
       );
     });
 
@@ -90,7 +92,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: "newValue1", filter3: "value3" };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter added, 1 filter updated, 1 filter removed",
+        "3 filters changed",
       );
     });
   });
@@ -100,21 +102,27 @@ describe("getFilterChangeDescription", () => {
       const current = { filter1: null };
       const draft = { filter1: "value1" };
 
-      expect(getFilterChangeDescription(current, draft)).toBe("1 filter added");
+      expect(getFilterChangeDescription(current, draft)).toBe(
+        "1 filter changed",
+      );
     });
 
     it("should treat undefined as empty", () => {
       const current = { filter1: undefined };
       const draft = { filter1: "value1" };
 
-      expect(getFilterChangeDescription(current, draft)).toBe("1 filter added");
+      expect(getFilterChangeDescription(current, draft)).toBe(
+        "1 filter changed",
+      );
     });
 
     it("should treat empty array as empty", () => {
       const current = { filter1: [] };
       const draft = { filter1: ["value1"] };
 
-      expect(getFilterChangeDescription(current, draft)).toBe("1 filter added");
+      expect(getFilterChangeDescription(current, draft)).toBe(
+        "1 filter changed",
+      );
     });
 
     it("should not treat non-empty array as empty", () => {
@@ -122,7 +130,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: ["value2"] };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter updated",
+        "1 filter changed",
       );
     });
 
@@ -131,7 +139,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: null };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter removed",
+        "1 filter changed",
       );
     });
 
@@ -140,7 +148,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: [] };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter removed",
+        "1 filter changed",
       );
     });
   });
@@ -151,7 +159,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: ["a", "c"] };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter updated",
+        "1 filter changed",
       );
     });
 
@@ -160,7 +168,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: ["b", "a"] };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter updated",
+        "1 filter changed",
       );
     });
 
@@ -178,7 +186,7 @@ describe("getFilterChangeDescription", () => {
       const draft = { filter1: { key: "value2" } };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "1 filter updated",
+        "1 filter changed",
       );
     });
 
@@ -229,7 +237,7 @@ describe("getFilterChangeDescription", () => {
       };
 
       expect(getFilterChangeDescription(current, draft)).toBe(
-        "3 filters added, 1 filter updated, 1 filter removed",
+        "5 filters changed",
       );
     });
   });


### PR DESCRIPTION
Closes [VIZ-1260](https://linear.app/metabase/issue/VIZ-1260/simplified-copy-for-apply-filters-toast)

### Description

Simplifies the manual Apply Filter Toast copy. Previously, we showed how many filters were added, removed, updated which could produce long text like `3 filters added, 1 filter updated, 1 filter removed` but now we show just `5 filters changed`.

### How to verify

- Open a dashboard in view mode -> click on "..." -> Edit Settings -> disable auto-apply
- Try changing any filter values on the dashboard
- Ensure it shows the new simplified copy

### Demo

<img width="1078" alt="Screenshot 2025-07-09 at 10 22 34 PM" src="https://github.com/user-attachments/assets/55057244-1c43-458d-9c55-cf6708b7f26e" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
