### PR TITLE
fix wrong implementation of MB_DOWNLOAD_ROW_LIMIT

### DIFF
--- a/src/metabase/query_processor/settings.clj
+++ b/src/metabase/query_processor/settings.clj
@@ -54,7 +54,7 @@
   absolute-max-results)
 
 (defsetting download-row-limit
-  (deferred-tru "Row limit in file exports excluding the header. Enforces 1048575 excluding header as minimum. xlsx downloads are inherently limited to 1048575 rows even if this limit is higher.")
+  (deferred-tru "Row limit in file exports excluding the header. Enforces 1048575 excluding header as maximum. xlsx downloads are inherently limited to 1048575 rows even if this limit is higher.")
   :visibility :internal
   :export?    true
   :type       :positive-integer
@@ -62,4 +62,4 @@
                 (let [limit (setting/get-value-of-type :positive-integer :download-row-limit)]
                   (if (nil? limit)
                     limit
-                    (max limit *minimum-download-row-limit*)))))
+                    (min limit *minimum-download-row-limit*)))))


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/60753

### Description

minor fix the implementation:
> Row limit in file exports excluding the header. Enforces 1048575 excluding header as minimum. xlsx downloads are inherently limited to 1048575 rows even if this limit is higher.

This statement contains a logical contradiction. Let me break down the inconsistency:

1. **"Enforces 1048575 excluding header as minimum"** - This implies 1,048,575 is the **minimum** limit
2. **"xlsx downloads are inherently limited to 1048575 rows"** - This implies 1,048,575 is the **maximum** limit

In practical, 1,048,575 should be the **maximum** limit


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
