### PR TITLE
Fix the "contact admin alert" when admin email is missing

### DIFF
--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -311,7 +311,7 @@ export type CustomGeoJSONMap = {
 export type CustomGeoJSONSetting = Record<string, CustomGeoJSONMap>;
 
 interface InstanceSettings {
-  "admin-email": string;
+  "admin-email": string | null;
   "email-from-name": string | null;
   "email-from-address": string | null;
   "email-reply-to": string[] | null;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
@@ -85,7 +85,7 @@ export const ContactAdminAlert = ({ reason }: { reason: ContactReason }) => {
       () =>
         t`To enable Google Sheets import, please contact your administrator.`,
     )
-    .exhaustive();
+    .otherwise(() => t`Please contact your administrator.`);
 
   return (
     <Alert icon={<Icon name="info_filled" />} maw={CONTENT_MAX_WIDTH}>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router";
-import { P, match } from "ts-pattern";
+import { match } from "ts-pattern";
 import { c, t } from "ttag";
 
 import { useSelector } from "metabase/lib/redux";
@@ -33,31 +33,33 @@ export const ContactAdminAlert = ({ reason }: { reason: ContactReason }) => {
   const adminEmail = useSelector((state) => getSetting(state, "admin-email"));
   const adminEmailElement = <b key="admin-email">{adminEmail}</b>;
 
-  const getAlertCopy = match({ reason, adminEmail })
+  const hasAdminEmail = !!adminEmail;
+
+  const getAlertCopy = match({ reason, hasAdminEmail })
     .with(
-      { reason: "add-database", adminEmail: P.when((email) => !!email) },
+      { reason: "add-database", hasAdminEmail: true },
       () =>
         c("{0} is admin's email address")
           .jt`To add a new database, please contact your administrator at ${adminEmailElement}.`,
     )
     .with(
-      { reason: "add-database", adminEmail: P.when((email) => !email) },
+      { reason: "add-database", hasAdminEmail: false },
       () => t`To add a new database, please contact your administrator.`,
     )
     .with(
-      { reason: "enable-csv-upload", adminEmail: P.when((email) => !!email) },
+      { reason: "enable-csv-upload", hasAdminEmail: true },
       () =>
         c("{0} is admin's email address")
           .jt`To enable CSV file upload, please contact your administrator at ${adminEmailElement}.`,
     )
     .with(
-      { reason: "enable-csv-upload", adminEmail: P.when((email) => !email) },
+      { reason: "enable-csv-upload", hasAdminEmail: false },
       () => t`To enable CSV file upload, please contact your administrator.`,
     )
     .with(
       {
         reason: "obtain-csv-upload-permission",
-        adminEmail: P.when((email) => !!email),
+        hasAdminEmail: true,
       },
       () =>
         c("{0} is admin's email address")
@@ -66,7 +68,7 @@ export const ContactAdminAlert = ({ reason }: { reason: ContactReason }) => {
     .with(
       {
         reason: "obtain-csv-upload-permission",
-        adminEmail: P.when((email) => !email),
+        hasAdminEmail: false,
       },
       () =>
         t`You are not permitted to upload CSV files. To get proper permissions, please contact your administrator.`,
@@ -74,18 +76,18 @@ export const ContactAdminAlert = ({ reason }: { reason: ContactReason }) => {
     .with(
       {
         reason: "enable-google-sheets",
-        adminEmail: P.when((email) => !!email),
+        hasAdminEmail: true,
       },
       () =>
         c("{0} is admin's email address")
           .jt`To enable Google Sheets import, please contact your administrator at ${adminEmailElement}.`,
     )
     .with(
-      { reason: "enable-google-sheets", adminEmail: P.when((email) => !email) },
+      { reason: "enable-google-sheets", hasAdminEmail: false },
       () =>
         t`To enable Google Sheets import, please contact your administrator.`,
     )
-    .otherwise(() => t`Please contact your administrator.`);
+    .exhaustive();
 
   return (
     <Alert icon={<Icon name="info_filled" />} maw={CONTENT_MAX_WIDTH}>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router";
-import { match } from "ts-pattern";
+import { P, match } from "ts-pattern";
 import { c, t } from "ttag";
 
 import { useSelector } from "metabase/lib/redux";
@@ -33,30 +33,57 @@ export const ContactAdminAlert = ({ reason }: { reason: ContactReason }) => {
   const adminEmail = useSelector((state) => getSetting(state, "admin-email"));
   const adminEmailElement = <b key="admin-email">{adminEmail}</b>;
 
-  const getAlertCopy = match(reason)
+  const getAlertCopy = match({ reason, adminEmail })
     .with(
-      "add-database",
+      { reason: "add-database", adminEmail: P.when((email) => !!email) },
       () =>
         c("{0} is admin's email address")
           .jt`To add a new database, please contact your administrator at ${adminEmailElement}.`,
     )
     .with(
-      "enable-csv-upload",
+      { reason: "add-database", adminEmail: P.when((email) => !email) },
+      () => t`To add a new database, please contact your administrator.`,
+    )
+    .with(
+      { reason: "enable-csv-upload", adminEmail: P.when((email) => !!email) },
       () =>
         c("{0} is admin's email address")
           .jt`To enable CSV file upload, please contact your administrator at ${adminEmailElement}.`,
     )
     .with(
-      "obtain-csv-upload-permission",
+      { reason: "enable-csv-upload", adminEmail: P.when((email) => !email) },
+      () => t`To enable CSV file upload, please contact your administrator.`,
+    )
+    .with(
+      {
+        reason: "obtain-csv-upload-permission",
+        adminEmail: P.when((email) => !!email),
+      },
       () =>
         c("{0} is admin's email address")
           .jt`You are not permitted to upload CSV files. To get proper permissions, please contact your administrator at ${adminEmailElement}.`,
     )
     .with(
-      "enable-google-sheets",
+      {
+        reason: "obtain-csv-upload-permission",
+        adminEmail: P.when((email) => !email),
+      },
+      () =>
+        t`You are not permitted to upload CSV files. To get proper permissions, please contact your administrator.`,
+    )
+    .with(
+      {
+        reason: "enable-google-sheets",
+        adminEmail: P.when((email) => !!email),
+      },
       () =>
         c("{0} is admin's email address")
           .jt`To enable Google Sheets import, please contact your administrator at ${adminEmailElement}.`,
+    )
+    .with(
+      { reason: "enable-google-sheets", adminEmail: P.when((email) => !email) },
+      () =>
+        t`To enable Google Sheets import, please contact your administrator.`,
     )
     .exhaustive();
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/common.unit.spec.tsx
@@ -106,9 +106,29 @@ describe("AddDataModal", () => {
       expect(alert).toBeInTheDocument();
       expect(
         within(alert).getByText(
-          /To add a new database, please contact your administrator/,
+          /To add a new database, please contact your administrator at.*\.$/,
         ),
       ).toBeInTheDocument();
+      expect(
+        within(alert).getByText("admin@metabase.test"),
+      ).toBeInTheDocument();
+    });
+
+    it("doesn't show admin email when there isn't one", async () => {
+      setup({ isAdmin: false, adminEmail: null });
+
+      await userEvent.click(screen.getByRole("tab", { name: /Database$/ }));
+
+      const alert = screen.getByRole("alert");
+      expect(alert).toBeInTheDocument();
+      expect(
+        within(alert).getByText(
+          "To add a new database, please contact your administrator.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        within(alert).queryByText("admin@metabase.test"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/setup.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/setup.tsx
@@ -32,6 +32,7 @@ interface SetupOpts {
   tokenFeatures?: Partial<TokenFeatures>;
   enableGoogleSheets?: boolean;
   status?: GdrivePayload["status"];
+  adminEmail?: string | null;
 }
 
 export const setup = ({
@@ -45,6 +46,7 @@ export const setup = ({
   tokenFeatures = {},
   enableGoogleSheets = false,
   status,
+  adminEmail = "admin@metabase.test",
 }: SetupOpts = {}) => {
   const user = {
     is_superuser: isAdmin,
@@ -78,6 +80,7 @@ export const setup = ({
       collections,
     }),
     settings: mockSettings({
+      "admin-email": adminEmail,
       "is-hosted?": isHosted,
       "show-google-sheets-integration": enableGoogleSheets,
       "token-features": createMockTokenFeatures(tokenFeatures),

--- a/frontend/src/metabase/query_builder/components/VisualizationError/components/AdminEmail/AdminEmail.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationError/components/AdminEmail/AdminEmail.unit.spec.tsx
@@ -6,7 +6,7 @@ import { createMockState } from "metabase-types/store/mocks";
 import { AdminEmail } from "./AdminEmail";
 
 interface SetupOpts {
-  adminEmail: string;
+  adminEmail: string | null;
 }
 
 const setup = ({ adminEmail }: SetupOpts) => {
@@ -32,8 +32,14 @@ describe("AdminEmail", () => {
     expect(link).toHaveAttribute("href", "mailto:admin@metabase.test");
   });
 
-  it("renders nothing when there's no admin email", () => {
+  it("renders nothing when email is an empty string (unlikely to ever happen)", () => {
     setup({ adminEmail: "" });
+
+    expect(screen.queryByText("admin@metabase.test")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when there's no admin email", () => {
+    setup({ adminEmail: null });
 
     expect(screen.queryByText("admin@metabase.test")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
Resolves PRG-89

When I introduced "Add data" modal, I didn't know that admin email can be null. Frontend type was wrong.

This PR fixes the type and adjusts empty states in the "Add data" modal to reflect this new condition.