### PR TITLE
skip e2e-cross-version-for-breaking-changes.yml as cypress crashes

### DIFF
--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -157,15 +157,16 @@ jobs:
     uses: ./.github/workflows/e2e-component-tests-embedding-sdk-cross-version.yml
     secrets: inherit
 
+  # Temporarily skipped because the cypress runner crashes
   # See `bin/backward-compatibility-test.js` for the documentation of this workflow.
-  cross-version-for-breaking-changes:
-    # run on: every pr that targets a release branch, it does NOT run for pr targeting master
-    if: ${{ github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-x.') }}
-    uses: ./.github/workflows/e2e-cross-version-for-breaking-changes.yml
-    secrets: inherit
-    with:
-      fe-ref: ${{ github.base_ref }}
-      be-ref: ${{ github.head_ref }}
+  # cross-version-for-breaking-changes:
+  #   # run on: every pr that targets a release branch, it does NOT run for pr targeting master
+  #   if: ${{ github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-x.') }}
+  #   uses: ./.github/workflows/e2e-cross-version-for-breaking-changes.yml
+  #   secrets: inherit
+  #   with:
+  #     fe-ref: ${{ github.base_ref }}
+  #     be-ref: ${{ github.head_ref }}
 
   embedding-sdk-tests-result:
     needs:


### PR DESCRIPTION
We got reports of this failing because of the runner crashing, we're going to temporarily skip them
https://metaboat.slack.com/archives/C063Q3F1HPF/p1752144668723169

Triple backport as these thests are in the release branch of 53