### PR TITLE
Add repro for "Custom column of convertTimezone dissapears if the timezone is entered incorrectly"

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -2280,3 +2280,24 @@ describe("Issue 26512", () => {
     });
   });
 });
+
+describe("Issue 38498", { tags: "@external" }, () => {
+  beforeEach(() => {
+    H.restore("postgres-12");
+    cy.signInAsAdmin();
+
+    H.startNewQuestion();
+    H.entityPickerModal().within(() => {
+      cy.findByText("QA Postgres12").click();
+      cy.findByText("Orders").click();
+    });
+  });
+
+  it("should not be possible to use convertTimezone with an invalid timezone (metabse#38498)", () => {
+    H.addCustomColumn();
+    H.CustomExpressionEditor.type(
+      'convertTimezone([Created At], "Asia/Ho_Chi_Mihn", "UTC")',
+    );
+    H.popover().findByText("Types are incompatible.").should("be.visible");
+  });
+});


### PR DESCRIPTION
Closes #38498

The issue was fixed by disallowing invalid timezones being entered.

This PR just adds a repro for the issue.

Double backport since this was fixed in 54 and 55.