### PR TITLE
docs: add H1 to securing-embeds.md

### DIFF
--- a/docs/embedding/securing-embeds.md
+++ b/docs/embedding/securing-embeds.md
@@ -3,6 +3,8 @@ title: Securing embedded Metabase
 summary: How to hide and protect sensitive data in different types of embeds.
 ---
 
+# Securing embedded Metabase
+
 {% include shared/in-page-promo.html %}
 
 ## Securing embeds with authentication and authorization


### PR DESCRIPTION
i forgot that in docs you need both title and h1 (whereas in Learn you don't need either of those)