### PR TITLE
VIZ-1293 - Show max download rows text only when format is xlsx

### DIFF
--- a/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
@@ -203,9 +203,11 @@ export const QuestionDownloadWidget = ({
             mb="1rem"
           >{t`Your answer has a large number of rows so it could take a while to download.`}</Text>
 
-          <Text size="sm" c="text-medium">
-            {limitedDownloadSizeText}
-          </Text>
+          {format === "xlsx" && (
+            <Text size="sm" c="text-medium">
+              {limitedDownloadSizeText}
+            </Text>
+          )}
         </Box>
       )}
       <Button

--- a/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.unit.spec.tsx
@@ -208,4 +208,33 @@ describe("QuestionDownloadWidget", () => {
       screen.queryByLabelText("Keep the data pivoted"),
     ).not.toBeInTheDocument();
   });
+
+  it("should show maximum download size text only for xlsx format when results are truncated", async () => {
+    const truncatedResult = createMockDataset({
+      data: {
+        rows: [],
+        cols: [],
+        rows_truncated: 1000000,
+      },
+    });
+
+    setup({ result: truncatedResult });
+
+    // Initially on csv format - should not show the text
+    expect(
+      screen.queryByText(/maximum download size is 1 million rows/),
+    ).not.toBeInTheDocument();
+
+    // Switch to xlsx format - should show the text
+    await userEvent.click(screen.getByLabelText(".xlsx"));
+    expect(
+      screen.getByText(/maximum download size is 1 million rows/),
+    ).toBeInTheDocument();
+
+    // Switch back to csv format - should hide the text
+    await userEvent.click(screen.getByLabelText(".csv"));
+    expect(
+      screen.queryByText(/maximum download size is 1 million rows/),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Fixes #60769

Only show the max download 1 million rows text when xlsx is selected as that is an excel specific limitation