### PR TITLE
VIZ-1294 - Convert static viz Gauge colors to hex

### DIFF
--- a/frontend/src/metabase/static-viz/components/Gauge/utils.tsx
+++ b/frontend/src/metabase/static-viz/components/Gauge/utils.tsx
@@ -1,4 +1,5 @@
 import type { PieArcDatum } from "@visx/shape/lib/shapes/Pie";
+import Color from "color";
 
 import type { NumberFormatOptions } from "metabase/static-viz/lib/numbers";
 import { measureTextWidth } from "metabase/static-viz/lib/text";
@@ -157,7 +158,8 @@ export function fixSwappedMinMax(segment: GaugeSegment): GaugeSegment {
 }
 
 export function colorGetter(pieArcDatum: PieArcDatum<GaugeSegment>) {
-  return pieArcDatum.data.color;
+  // Convert to hex due to Apache Batik limitations (SVG renderer for static viz)
+  return Color(pieArcDatum.data.color).hex();
 }
 
 /**


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60324
Resolves VIZ-1294

Convert color values in static viz Gauge component to hex so they play nicely with Apache Batik (e.g. can't support `hsla(...)`)