### PR TITLE
Ensure postgres downloads don't OOM

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -742,7 +742,7 @@
 
 (defn execute-reducible-query
   "Default impl of [[metabase.driver/execute-reducible-query]] for sql-jdbc drivers."
-  {:added "0.35.0", :arglists '([driver query context respond] [driver sql params max-rows context respond])}
+  {:added "0.35.0", :arglists '([driver query context respond])}
   [driver {{sql :query, params :params} :native, :as outer-query} _context respond]
   {:pre [(string? sql) (seq sql)]}
   (let [database (driver-api/database (driver-api/metadata-provider))

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -751,7 +751,6 @@
                         (inject-remark driver sql))
                    sql)
         max-rows (driver-api/determine-query-max-rows outer-query)]
-    #_(execute-reducible-query driver sql params max-rows context respond)
     (do-with-connection-with-options
      driver
      (driver-api/database (driver-api/metadata-provider))

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -395,7 +395,7 @@
           ;; todo (dan 7/11/25): fixing straightforward postgres oom on downloads in #60733, but seems like write? is
           ;; not set here. Note this is explicitly silent when `write?`. Lots of tests fail with autocommit false
           ;; there.
-          (and (-> options :download?) (= driver :postgres))
+          (and (-> options :download?) (isa? driver/hierarchy driver :postgres))
           (try
             (log/trace (pr-str '(.setAutoCommit conn false)))
             (.setAutoCommit conn false)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/60733

For performance reasons we set autocommit to true. this has an unfortunate consequence that the postgres driver does not honor batch sizes. We go through a lot of trouble to hook the streaming results of a query to the output stream of the download, but the postgres jdbc driver will realize all rows in memory.

A fast way forward is to set autocommit to false only when `write?` (previous condition) or when executing a postgres download, as reported in https://github.com/metabase/metabase/issues/60733.

How to test:
this is difficult. In CI we use

```clojure
  :ci
  {:jvm-opts ["-Xmx12g"
              "-Xms12g"
```

So hitting a query that would deterministically OOM the instance requires a lot more muscle than we realistically want to use.

I'm running the following tests locally:

```
  :small-ram
  {:jvm-opts ["-Xmx400m"
              "-Xms400m"
              "-Dci=TRUE"]}
```

```clojure
(defn- readable [bytes]
  (cond (nil? bytes)  "0 bytes"
        (zero? bytes) "0 bytes"
        :else
        (let [units ["b" "kb" "mb" "gb" "tb"]
              magnitude   1024.0]
          (loop [[unit & remaining] units
                current (double bytes)]
            (if (and (seq remaining) (> current magnitude))
              (recur remaining (/ current magnitude))
              (format "%.1f %s" current unit))))))

(defn- consume
  [^java.io.InputStream is]
  (let [arr (byte-array 8024)]
    (loop [c 0, gas 5000000]
      (let [r (java.io.InputStream/.read is arr 0 (alength arr))]
        (cond (zero? gas)
              (throw (ex-info "Ran out of gas" {}))
              (neg? r) c
              :else (recur (+ c r) (dec gas)))))))

(deftest large-csv-test
  (mt/test-driver :postgres
    (testing "Postgres can download csvs without holding the entire results in memory #(#60733)"
      (let [large-query "SELECT repeat('x', 2048) FROM generate_series(1, 1000000)"
            result (mt/user-real-request :crowberto :post 200 "dataset/csv"
                                         {:request-options {:as :stream}}
                                         {:query       (mt/native-query
                                                        {:query large-query})
                                          :format_rows true})
            size (consume result)]
        (is (> size 2000000000)
            (format "Only consumed %s but expected ~2gb" (readable size)))))))
```

and then

```
❯ time source pg.env && DRIVERS=postgres clojure -X:dev:test:small-ram :only metabase.driver.postgres-test/large-csv-test

Running QP tests against these drivers: #{:postgres}

LONG TEST in metabase.driver.postgres-test/large-csv-test
Test took 23.358 seconds seconds to run

Ran 1 tests in 32.825 seconds
2 assertions, 0 failures, 0 errors.
{:test 1, :pass 2, :fail 0, :error 0, :type :summary, :duration 32825.099875, :single-threaded 1}
Ran 0 tests in parallel, 1 single-threaded.
Finding and running tests took 40.7 s.
All tests passed.
Running after-run hooks...
```

Why not add these tests now?
We probably should write a full memory regression suite. This is a great candidate for a first one. But it seems silly to run a new CI job with just this one job. Push back if you think i'm wrong.

Another area of pushback:
I took the lazy way when determining if a driver should have autocommit set to false or not: i hardcoded it.

```clojure
(and (-> options :download?) (= driver :postgres))
```

The alternative is some method of a new driver multimethod or driver-supports?. The former feels a bit heavy-weight, the latter feels not quite right since this is almost a non-support and all other jdbc drivers do support it, presumably?

I'm quite open to pushback here and invite comments if you see a better way.