### PR TITLE
Pin tj-actions/changed-files to avoid ambiguous version resolution

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Get changed PNG files
       id: changed-files
-      uses: tj-actions/changed-files@v41
+      uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
       with:
         files: |
           docs/**/*.png


### PR DESCRIPTION
We were already using a version of tj-actions/changed-files that was not vulnerable to [CVE-2023-51664](https://www.cve.org/CVERecord?id=CVE-2023-51664), and verified no secrets were leaked in our workflow logs.

However, the action was referenced by a tag (`@v41`), which could resolve to different SHAs depending on timing. This PR pins it explicitly to commit [ed68ef8](https://github.com/tj-actions/changed-files/commit/ed68ef82c095e0d48ec87eccea555d944a631a4c) (v46), the latest known-safe version, to eliminate ambiguity and ensure future safety.