### PR TITLE
Fix form key mapping

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/smtp-override/components/SMTPOverrideConnectionForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/smtp-override/components/SMTPOverrideConnectionForm.tsx
@@ -1,16 +1,11 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 
 import { BaseSMTPConnectionForm } from "metabase/admin/settings/components/Email/BaseSMTPConnectionForm";
 import { trackSMTPSetupSuccess } from "metabase/admin/settings/components/Email/analytics";
 import {
-  useGetAdminSettingsDetailsQuery,
-  useGetSettingsQuery,
-} from "metabase/api";
-import {
   useDeleteEmailSMTPOverrideSettingsMutation,
   useUpdateEmailSMTPOverrideSettingsMutation,
 } from "metabase-enterprise/api/smtp-override";
-import type { EmailSMTPOverrideSettings } from "metabase-types/api";
 
 export const SMTPOverrideConnectionForm = ({
   onClose,
@@ -21,49 +16,6 @@ export const SMTPOverrideConnectionForm = ({
     useUpdateEmailSMTPOverrideSettingsMutation();
   const [deleteCloudEmailSMTPSettings] =
     useDeleteEmailSMTPOverrideSettingsMutation();
-  const { data: settingValues } = useGetSettingsQuery();
-  const { data: settingsDetails } = useGetAdminSettingsDetailsQuery();
-
-  const mappedSettingValues = useMemo(
-    () => ({
-      host: settingValues?.["email-smtp-host-override"] ?? "",
-      port: settingValues?.["email-smtp-port-override"]
-        ? settingValues?.["email-smtp-port-override"] + ""
-        : "465",
-      security: settingValues?.["email-smtp-security-override"] ?? "ssl",
-      username: settingValues?.["email-smtp-username-override"] ?? "",
-      password: settingValues?.["email-smtp-password-override"] ?? "",
-    }),
-    [settingValues],
-  );
-
-  const mappedSettingsDetails = useMemo(
-    () => ({
-      host: settingsDetails?.["email-smtp-host-override"],
-      port: settingsDetails?.["email-smtp-port-override"],
-      security: settingsDetails?.["email-smtp-security-override"],
-      username: settingsDetails?.["email-smtp-username-override"],
-      password: settingsDetails?.["email-smtp-password-override"],
-    }),
-    [settingsDetails],
-  );
-
-  const handleUpdateMutation = useCallback(
-    (formData: any) => {
-      const emailSMTPData: EmailSMTPOverrideSettings = {
-        "email-smtp-host-override": formData.host,
-        "email-smtp-port-override": parseInt(
-          formData.port,
-        ) as EmailSMTPOverrideSettings["email-smtp-port-override"],
-        "email-smtp-security-override": formData.security,
-        "email-smtp-username-override": formData.username,
-        "email-smtp-password-override": formData.password,
-      };
-      return updateCloudEmailSMTPSettings(emailSMTPData);
-    },
-    [updateCloudEmailSMTPSettings],
-  );
-
   const handleTrackSuccess = useCallback(() => {
     trackSMTPSetupSuccess({ eventDetail: "cloud" });
   }, []);
@@ -71,13 +23,21 @@ export const SMTPOverrideConnectionForm = ({
   return (
     <BaseSMTPConnectionForm
       onClose={onClose}
-      settingValues={mappedSettingValues}
-      settingsDetails={mappedSettingsDetails}
       secureMode={true}
-      updateMutation={handleUpdateMutation}
+      updateMutation={updateCloudEmailSMTPSettings}
       deleteMutation={deleteCloudEmailSMTPSettings}
       dataTestId="smtp-override-connection-form"
       onTrackSuccess={handleTrackSuccess}
+      getFullFormKey={(shortFormKey) => {
+        const mapFormKeyToSettingKey = {
+          host: "email-smtp-host-override",
+          port: "email-smtp-port-override",
+          security: "email-smtp-security-override",
+          username: "email-smtp-username-override",
+          password: "email-smtp-password-override",
+        } as const;
+        return mapFormKeyToSettingKey[shortFormKey];
+      }}
     />
   );
 };

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -324,7 +324,7 @@ interface InstanceSettings {
   "email-reply-to": string[] | null;
   "email-smtp-host": string | null;
   "email-smtp-port": number | null;
-  "email-smtp-security": "none" | "ssl" | "tls" | "starttls";
+  "email-smtp-security": "none" | "ssl" | "tls" | "starttls" | null;
   "email-smtp-username": string | null;
   "email-smtp-password": string | null;
   "enable-embedding": boolean;

--- a/frontend/src/metabase/admin/settings/components/Email/SelfHostedSMTPConnectionForm.tsx
+++ b/frontend/src/metabase/admin/settings/components/Email/SelfHostedSMTPConnectionForm.tsx
@@ -1,14 +1,9 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 
-import {
-  useGetAdminSettingsDetailsQuery,
-  useGetSettingsQuery,
-} from "metabase/api";
 import {
   useDeleteEmailSMTPSettingsMutation,
   useUpdateEmailSMTPSettingsMutation,
 } from "metabase/api/email";
-import type { EmailSMTPSettings } from "metabase-types/api";
 
 import { BaseSMTPConnectionForm } from "./BaseSMTPConnectionForm";
 import { trackSMTPSetupSuccess } from "./analytics";
@@ -20,45 +15,6 @@ export const SelfHostedSMTPConnectionForm = ({
 }) => {
   const [updateEmailSMTPSettings] = useUpdateEmailSMTPSettingsMutation();
   const [deleteEmailSMTPSettings] = useDeleteEmailSMTPSettingsMutation();
-  const { data: settingValues } = useGetSettingsQuery();
-  const { data: settingsDetails } = useGetAdminSettingsDetailsQuery();
-
-  const mappedSettingValues = useMemo(
-    () => ({
-      host: settingValues?.["email-smtp-host"] ?? "",
-      port: settingValues?.["email-smtp-port"] ?? null,
-      security: settingValues?.["email-smtp-security"] ?? "none",
-      username: settingValues?.["email-smtp-username"] ?? "",
-      password: settingValues?.["email-smtp-password"] ?? "",
-    }),
-    [settingValues],
-  );
-
-  const mappedSettingsDetails = useMemo(
-    () => ({
-      host: settingsDetails?.["email-smtp-host"],
-      port: settingsDetails?.["email-smtp-port"],
-      security: settingsDetails?.["email-smtp-security"],
-      username: settingsDetails?.["email-smtp-username"],
-      password: settingsDetails?.["email-smtp-password"],
-    }),
-    [settingsDetails],
-  );
-
-  const handleUpdateMutation = useCallback(
-    (formData: any) => {
-      const emailSMTPData: EmailSMTPSettings = {
-        "email-smtp-host": formData.host,
-        "email-smtp-port": parseInt(formData.port),
-        "email-smtp-security": formData.security,
-        "email-smtp-username": formData.username,
-        "email-smtp-password": formData.password,
-      };
-      return updateEmailSMTPSettings(emailSMTPData);
-    },
-    [updateEmailSMTPSettings],
-  );
-
   const handleTrackSuccess = useCallback(() => {
     trackSMTPSetupSuccess({ eventDetail: "self-hosted" });
   }, []);
@@ -66,13 +22,21 @@ export const SelfHostedSMTPConnectionForm = ({
   return (
     <BaseSMTPConnectionForm
       onClose={onClose}
-      settingValues={mappedSettingValues}
-      settingsDetails={mappedSettingsDetails}
       secureMode={false}
-      updateMutation={handleUpdateMutation}
+      updateMutation={updateEmailSMTPSettings}
       deleteMutation={deleteEmailSMTPSettings}
       dataTestId="self-hosted-smtp-connection-form"
       onTrackSuccess={handleTrackSuccess}
+      getFullFormKey={(shortFormKey) => {
+        const mapFormKeyToSettingKey = {
+          host: "email-smtp-host",
+          port: "email-smtp-port",
+          security: "email-smtp-security",
+          username: "email-smtp-username",
+          password: "email-smtp-password",
+        } as const;
+        return mapFormKeyToSettingKey[shortFormKey];
+      }}
     />
   );
 };


### PR DESCRIPTION
This fixes form field error messages. I also added in a test to `BaseSMTPConnectionForm` to verify the fix

The problem was that the form had keys like 'port' | 'host' , but the errors generated by the api were full keys like 'email-smtp-port'

The way I solved this involved a bit of re-jigging. It's simplified some parts and complicated others. I chose to do all the mapping inside `BaseSMTPConnectionForm.tsx`, which makes that more complicated because it needs to call `getFullFormKey("port")` all over the place.

The other option I considered was adding a `mapErrorKeys` prop to `BaseSMTPConnectionForm` which would then allow the SelfHosted and Override forms to do the mapping there. This would keep `BaseSMTPConnectionForm` simpler. I'm open to opinions on it.

<img width="680" height="687" alt="Screenshot 2025-07-11 at 6 14 26 PM" src="https://github.com/user-attachments/assets/52213d2c-3133-4eba-bc95-63fddd2ae61f" />
