### PR TITLE
Closes VIZ-974 column formatting for BigInts

### DIFF
--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -337,6 +337,13 @@ function abs(a: number | bigint) {
   return a < 0 ? -a : a;
 }
 
+/**
+ * Multiplies two numbers, handling bigints and floats safely.
+ */
 function multiply(a: number | bigint, b: number) {
-  return typeof a === "bigint" ? a * BigInt(b) : a * b;
+  if (typeof a === "bigint" && Number.isInteger(b)) {
+    return a * BigInt(b);
+  } else {
+    return Number(a) * b;
+  }
 }

--- a/frontend/src/metabase/lib/formatting/numbers.unit.spec.ts
+++ b/frontend/src/metabase/lib/formatting/numbers.unit.spec.ts
@@ -62,3 +62,33 @@ describe("formatNumber", () => {
     ).toEqual("1.000015e+0");
   });
 });
+
+describe("formatNumber with scale (multiply function)", () => {
+  it("should multiply regular numbers with scale", () => {
+    expect(formatNumber(5, { scale: 3 })).toBe("15");
+    expect(formatNumber(2.5, { scale: 4 })).toBe("10");
+  });
+
+  it("should multiply bigint with integer scale", () => {
+    expect(formatNumber(BigInt(5), { scale: 3 })).toBe("15");
+    expect(formatNumber(BigInt(100), { scale: 7 })).toBe("700");
+  });
+
+  it("should convert bigint to number when scaling with float", () => {
+    expect(formatNumber(BigInt(5), { scale: 2.5 })).toBe("12.5");
+    expect(formatNumber(BigInt(10), { scale: 1.5 })).toBe("15");
+  });
+
+  it("should handle edge cases with scale", () => {
+    expect(formatNumber(0, { scale: 5 })).toBe("0");
+    expect(formatNumber(BigInt(0), { scale: 3 })).toBe("0");
+    expect(formatNumber(BigInt(5), { scale: 0 })).toBe("0");
+    expect(formatNumber(BigInt(5), { scale: 0.5 })).toBe("2.5");
+  });
+
+  it("should handle negative numbers with scale", () => {
+    expect(formatNumber(-5, { scale: 3 })).toBe("-15");
+    expect(formatNumber(BigInt(-5), { scale: 3 })).toBe("-15");
+    expect(formatNumber(BigInt(-5), { scale: 2.5 })).toBe("-12.5");
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57884
Closes [VIZ-974: Column Formatting: The number 1e-18 cannot be converted to a BigInt because it is not an integer](https://linear.app/metabase/issue/VIZ-974/column-formatting-the-number-1e-18-cannot-be-converted-to-a-bigint)

### Description

This fixes issues in formatting for BigInts.

Thanks @adamJLev for the issue and the fix, I've made this PR so it gets tested and merged more seamlessly.

### How to verify

 - Make a new SQL question: `SELECT 100000000000000000`
 - Visualize it as a table
 - In formatting, set "Multiply by a number" to `1e-18`

##### Before

https://github.com/user-attachments/assets/e10b253b-e76d-4633-9671-c48dea376725



##### After


https://github.com/user-attachments/assets/cf0d5d98-57b5-46d0-bc0a-c760308f6ca6



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
