### PR TITLE
Fix some minor Custom Expression editor annoyances

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -645,7 +645,7 @@ describe("issue 33439", () => {
       name: "Date",
     });
     H.popover().within(() => {
-      cy.findByText("Unsupported function convert-timezone");
+      cy.findByText("Unsupported function convertTimezone");
       cy.button("Done").should("be.disabled");
     });
   });

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
@@ -286,6 +286,26 @@ describe("diagnostics", () => {
       );
     });
 
+    it("should correctly pass along the position of the error", () => {
+      const metadata = createMockMetadata({
+        databases: [
+          createSampleDatabase({
+            id: 1,
+            features: ["left-join"],
+          }),
+        ],
+      });
+
+      const error = setup({
+        expression: `10 + percentile(1, 2)`,
+        expressionMode: "expression",
+        metadata,
+      });
+
+      expect(error?.pos).toBe(5);
+      expect(error?.len).toBe(10);
+    });
+
     it("should reject comparison operator with non-field operand", () => {
       expect(err("1 < 2")).toBe("Expecting field but found 1");
       expect(err("1 <= 2")).toBe("Expecting field but found 1");

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/diagnostics.unit.spec.ts
@@ -282,7 +282,7 @@ describe("diagnostics", () => {
       });
 
       expect(err(`percentile(1, 2)`, "expression", metadata)).toBe(
-        "Unsupported function percentile",
+        "Unsupported function Percentile",
       );
     });
 

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/check-supported-functions.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/expression/check-supported-functions.ts
@@ -36,7 +36,7 @@ export function checkSupportedFunctions({
       return;
     }
     if (!database?.hasFeature(clause.requiresFeature)) {
-      error(node, t`Unsupported function ${operator}`);
+      error(node, t`Unsupported function ${clause.displayName}`);
     }
   });
 }

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/utils.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/utils.ts
@@ -41,6 +41,9 @@ function position(x: Positionable):
   if ("node" in x) {
     return position(x.node);
   }
+  if ("token" in x && x.token) {
+    return { pos: x.token.pos, len: x.token.len };
+  }
   if ("pos" in x && "len" in x) {
     return { pos: x.pos, len: x.len };
   }

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/utils.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/utils.ts
@@ -30,7 +30,7 @@ type Positionable =
   | undefined
   | null;
 
-function position(x: Positionable):
+export function position(x: Positionable):
   | {
       pos?: number;
       len?: number;

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/utils.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/utils.ts
@@ -23,6 +23,7 @@ type Positionable =
   | Lib.ExpressionParts
   | Lib.ExpressionArg
   | { node?: Node }
+  | { token?: Token }
   | { pos: number; len: number }
   | Node
   | Token

--- a/frontend/src/metabase-lib/v1/expressions/diagnostics/utils.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/diagnostics/utils.unit.spec.ts
@@ -1,0 +1,38 @@
+import { CALL, Token } from "../pratt";
+
+import { position } from "./utils";
+
+describe("position", () => {
+  it("returns the correct position", () => {
+    const token = new Token({
+      type: CALL,
+      pos: 4,
+      length: 12,
+      text: "foo",
+    });
+    const node = {
+      type: CALL,
+      children: [],
+      parent: null,
+      token,
+      complete: true,
+    };
+    const parts = {
+      operator: "concat",
+      options: {},
+      args: [],
+      node,
+    };
+
+    const pos = { pos: 4, len: 12 };
+
+    expect(position(undefined)).toEqual(undefined);
+    expect(position(null)).toEqual(undefined);
+    expect(position({ node: undefined })).toEqual(undefined);
+    expect(position({ node })).toEqual(pos);
+    expect(position({ token })).toEqual(pos);
+    expect(position({ token: undefined })).toEqual(undefined);
+    expect(position(parts)).toEqual(pos);
+    expect(position(pos)).toEqual(pos);
+  });
+});

--- a/frontend/src/metabase/common/components/CodeMirror/CodeMirror.module.css
+++ b/frontend/src/metabase/common/components/CodeMirror/CodeMirror.module.css
@@ -14,14 +14,10 @@
       outline: none;
     }
 
-    .cm-scroller {
-      padding-top: 4px;
-      padding-bottom: 4px;
-    }
-
     .cm-content {
       color: var(--mb-color-text-dark);
       background: none;
+      padding-block: 8px;
     }
 
     .cm-line {

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.module.css
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.module.css
@@ -33,8 +33,8 @@
   margin-right: calc(28px + var(--mantine-spacing-sm));
 
   :global {
-    .cm-gutter {
-      background-color: var(--mb-color-bg-light);
+    .cm-gutters {
+      border-top-left-radius: var(--mantine-radius-sm);
     }
 
     .cm-tooltip-autocomplete {


### PR DESCRIPTION
Fixes some minor annoyances I've had with the custom expression editor.

1. Uses the display name for errors where applicable
  <table>
   <tr><th>before</th><td>
    <img width="336" height="55" alt="Screenshot 2025-07-11 at 10 31 06" src="https://github.com/user-attachments/assets/caa00152-ed03-4ed9-b305-fe9e67dafc8d" /></td></tr>
   <tr><th>after</th><td>
<img width="481" height="48" alt="Screenshot 2025-07-11 at 10 32 47" src="https://github.com/user-attachments/assets/a257ca7d-f12c-4ff1-9d09-b0cda7de29e0" />
</td></tr></table>
2. Fixes the location of errors in some cases 
  <table>
   <tr><th>before</th><td>
   
<img width="220" height="43" alt="Screenshot 2025-07-11 at 10 34 17" src="https://github.com/user-attachments/assets/1e300b6d-2ccf-4267-a84f-dded78331137" />


</td></tr>
   <tr><th>after</th><td>
<img width="184" height="46" alt="Screenshot 2025-07-11 at 10 33 39" src="https://github.com/user-attachments/assets/7b5d5621-c325-42ec-95b6-9b8e46e8cd5b" />
</td></tr></table>
3. Fixes the padding on the expression editor linenumber gutter
  <table>
   <tr><th>before</th><td>

<img width="114" height="50" alt="Screenshot 2025-07-11 at 10 35 08" src="https://github.com/user-attachments/assets/2c1b13e1-3219-4505-869e-680f512163d6" />


</td></tr>
   <tr><th>after</th><td>
<img width="84" height="42" alt="Screenshot 2025-07-11 at 10 35 25" src="https://github.com/user-attachments/assets/edc3ee28-9fde-40f6-a2a2-0392ff1a8038" />

</td></tr></table>
