### PR TITLE
Closes VIZ-915 better remove all feature in tables

### DIFF
--- a/frontend/src/metabase/querying/fields/components/FieldPanel/FieldPanel.tsx
+++ b/frontend/src/metabase/querying/fields/components/FieldPanel/FieldPanel.tsx
@@ -78,26 +78,32 @@ export const FieldPanel = ({
                 onChange={() => handleGroupToggle(groupItem)}
               />
             </Box>
-            {groupItem.columnItems.map((columnItem, columnIndex) => (
-              <Box mb="1rem" key={columnIndex}>
-                <Checkbox
-                  label={
-                    <Flex ml="0.25rem" align="center">
-                      <Icon name={getColumnIcon(columnItem.column)} />
-                      <Text component="span" ml="0.5rem" lh="1rem" fw={400}>
-                        {columnItem.displayName}
-                      </Text>
-                    </Flex>
-                  }
-                  checked={columnItem.isSelected}
-                  disabled={columnItem.isDisabled}
-                  mb="1.5rem"
-                  size="xs"
-                  aria-label={columnItem.displayName}
-                  onChange={() => handleColumnToggle(columnItem)}
-                />
-              </Box>
-            ))}
+            {groupItem.columnItems.map((columnItem, columnIndex) => {
+              if (columnItem.isHidden) {
+                return null; // Skip hidden columns
+              }
+
+              return (
+                <Box mb="1rem" key={columnIndex}>
+                  <Checkbox
+                    label={
+                      <Flex ml="0.25rem" align="center">
+                        <Icon name={getColumnIcon(columnItem.column)} />
+                        <Text component="span" ml="0.5rem" lh="1rem" fw={400}>
+                          {columnItem.displayName}
+                        </Text>
+                      </Flex>
+                    }
+                    checked={columnItem.isSelected}
+                    disabled={columnItem.isDisabled}
+                    mb="1.5rem"
+                    size="xs"
+                    aria-label={columnItem.displayName}
+                    onChange={() => handleColumnToggle(columnItem)}
+                  />
+                </Box>
+              );
+            })}
           </div>
         );
       })}

--- a/frontend/src/metabase/querying/fields/components/FieldPanel/FieldPanel.unit.spec.tsx
+++ b/frontend/src/metabase/querying/fields/components/FieldPanel/FieldPanel.unit.spec.tsx
@@ -372,4 +372,48 @@ describe("QueryColumnPicker", () => {
     await userEvent.click(categoryColumn);
     expect(categoryColumn).toBeChecked();
   });
+
+  it("should add/remove all even when there is a search", async () => {
+    setup();
+
+    // search so we only see Orders columns
+    await userEvent.type(
+      screen.getByPlaceholderText("Search for a column…"),
+      "tal", // subtotal and total -> Orders only
+    );
+
+    // check that we only see the "Orders" group
+    expect(
+      screen.queryByRole("list", { name: "User" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("list", { name: "Products" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Orders" })).toBeInTheDocument();
+
+    // check that subtotal is there and checked
+    const subtotalColumn = screen.getByRole("checkbox", { name: "Subtotal" });
+    expect(subtotalColumn).toBeInTheDocument();
+    expect(subtotalColumn).toBeChecked();
+
+    // check that total is there and checked
+    const totalColumn = screen.getByRole("checkbox", { name: "Total" });
+    expect(totalColumn).toBeInTheDocument();
+    expect(totalColumn).toBeChecked();
+
+    // check that we have 3 checkboxes (Orders, Subtotal, Total)
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes.length).toBe(3);
+
+    // Get the "Remove all" checkbox for Orders group, which should be checked
+    // and click it to remove all columns in Orders group
+    const removeAll = screen.getByRole("checkbox", { name: "Orders" });
+    expect(removeAll).toBeInTheDocument();
+    expect(removeAll).toBeChecked();
+    await userEvent.click(removeAll);
+
+    // check that all visible columns are unchecked
+    expect(subtotalColumn).not.toBeChecked();
+    expect(totalColumn).not.toBeChecked();
+  });
 });

--- a/frontend/src/metabase/querying/fields/components/FieldPanel/types.ts
+++ b/frontend/src/metabase/querying/fields/components/FieldPanel/types.ts
@@ -5,6 +5,7 @@ export type ColumnItem = {
   displayName: string;
   isSelected: boolean;
   isDisabled: boolean;
+  isHidden?: boolean;
 };
 
 export type ColumnGroupItem = {

--- a/frontend/src/metabase/querying/fields/components/FieldPanel/utils.ts
+++ b/frontend/src/metabase/querying/fields/components/FieldPanel/utils.ts
@@ -116,11 +116,19 @@ export function searchColumnGroupItems(
   return groupItems
     .map((groupItem) => ({
       ...groupItem,
-      columnItems: groupItem.columnItems.filter((columnItem) =>
-        columnItem.displayName.toLowerCase().includes(searchString),
-      ),
+      columnItems: groupItem.columnItems.map((columnItem) => {
+        return {
+          ...columnItem,
+          isHidden: !columnItem.displayName
+            .toLowerCase()
+            .includes(searchString),
+        };
+      }),
     }))
-    .filter((groupItem) => groupItem.columnItems.length > 0);
+    .filter(
+      (groupItem) =>
+        groupItem.columnItems.filter((c) => !c.isHidden).length > 0,
+    );
 }
 
 export function toggleColumnInQuery(


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57327
Closes [VIZ-915: Remove all in chart settings acts weird while filtering columns](https://linear.app/metabase/issue/VIZ-915/remove-all-in-chart-settings-acts-weird-while-filtering-columns)

### Description

The FieldPanel had an asymmetry in its model: when searching, it wouldn't know about the columns that the search had excluded, yet toggling on or off an entire group would assume the toggled group model would contain all the columns to prevent ending up with zero selected columns.

This PR fixes that asymmetry by adding a "isHidden" property to the ColumnItem interface. Now groups always contain all their columns.


### Demo

###### Before

https://github.com/user-attachments/assets/42efbc7b-47cb-4c92-9926-6c9fa9c491e4



###### After

https://github.com/user-attachments/assets/69209b04-03dc-41bb-90cd-146283d369fd


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
