### PR TITLE
Add the metabase-browser custom element to Embed JS

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
@@ -14,9 +14,9 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     H.prepareSdkIframeEmbedTest({ withTokenFeatures: true });
   });
 
-  describe("<metabase-manage-content> (read-only mode)", () => {
+  describe("<metabase-browser> (read-only mode)", () => {
     it("should show a collection browser with collection items", () => {
-      setupEmbed('<metabase-manage-content initial-collection="root" />');
+      setupEmbed('<metabase-browser initial-collection="root" />');
 
       H.getSimpleEmbedIframeContent()
         .should("contain", "Name")
@@ -26,7 +26,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     });
 
     it("should navigate to question when clicking on a question item", () => {
-      setupEmbed('<metabase-manage-content initial-collection="root" />');
+      setupEmbed('<metabase-browser initial-collection="root" />');
 
       H.getSimpleEmbedIframeContent()
         .findByText("Orders")
@@ -40,7 +40,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     });
 
     it("should show New Exploration button and open data picker when clicked", () => {
-      setupEmbed('<metabase-manage-content initial-collection="root" />');
+      setupEmbed('<metabase-browser initial-collection="root" />');
 
       H.getSimpleEmbedIframeContent()
         .findByText("New Exploration")
@@ -54,7 +54,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should pass through collection-visible-columns parameter", () => {
       setupEmbed(`
-        <metabase-manage-content
+        <metabase-browser
           initial-collection="root"
           collection-visible-columns='["type", "name"]'
         />
@@ -68,7 +68,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should pass through collection-page-size parameter", () => {
       setupEmbed(`
-        <metabase-manage-content
+        <metabase-browser
           initial-collection="root"
           collection-page-size="5"
         />
@@ -82,7 +82,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should hide New Exploration button when with-new-question is false", () => {
       setupEmbed(`
-        <metabase-manage-content
+        <metabase-browser
           initial-collection="root"
           with-new-question="false"
         />
@@ -94,10 +94,10 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     });
   });
 
-  describe("<metabase-manage-content> (curate mode)", () => {
+  describe("<metabase-browser> (read-write mode)", () => {
     it("should show New Dashboard button and open modal when clicked", () => {
       setupEmbed(
-        '<metabase-manage-content initial-collection="root" read-only="false" />',
+        '<metabase-browser initial-collection="root" read-only="false" />',
       );
 
       H.getSimpleEmbedIframeContent()
@@ -113,7 +113,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should show New Exploration button and open data picker when clicked", () => {
       setupEmbed(
-        '<metabase-manage-content initial-collection="root" read-only="false" />',
+        '<metabase-browser initial-collection="root" read-only="false" />',
       );
 
       H.getSimpleEmbedIframeContent()
@@ -129,7 +129,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should show Save button and save modal without entity picker when creating a new question", () => {
       setupEmbed(
-        '<metabase-manage-content initial-collection="root" read-only="false" />',
+        '<metabase-browser initial-collection="root" read-only="false" />',
       );
 
       H.getSimpleEmbedIframeContent().findByText("New Exploration").click();
@@ -154,7 +154,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should hide New Dashboard button when with-new-dashboard is false", () => {
       setupEmbed(`
-        <metabase-manage-content
+        <metabase-browser
           initial-collection="root"
           read-only="false"
           with-new-dashboard="false"
@@ -168,7 +168,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should hide New Exploration button when with-new-question is false", () => {
       setupEmbed(`
-        <metabase-manage-content
+        <metabase-browser
           initial-collection="root"
           read-only="false"
           with-new-question="false"
@@ -182,7 +182,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should pass through data-picker-entity-types parameter", () => {
       setupEmbed(`
-        <metabase-manage-content
+        <metabase-browser
           initial-collection="root"
           read-only="false"
           data-picker-entity-types='["table"]'
@@ -204,7 +204,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
   describe("breadcrumb navigation", () => {
     it("should show breadcrumbs when navigating between content", () => {
-      setupEmbed('<metabase-manage-content initial-collection="root" />');
+      setupEmbed('<metabase-browser initial-collection="root" />');
 
       cy.log("should show initial breadcrumb");
       H.getSimpleEmbedIframeContent()

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
@@ -209,6 +209,70 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         .should("not.exist");
     });
 
+    it("should create a dashboard in a new collection", () => {
+      setupEmbed(
+        '<metabase-browser initial-collection="root" read-only="false" />',
+      );
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("New Dashboard")
+        .should("be.visible")
+        .click();
+
+      H.getSimpleEmbedIframeContent().within(() => {
+        cy.findByRole("dialog").within(() => {
+          cy.findByPlaceholderText("What is the name of your dashboard?").type(
+            "Foo Bar Dashboard",
+          );
+
+          cy.log("open the collection picker");
+          cy.findByText("Our analytics").click();
+        });
+
+        cy.findByText("Collections").click();
+        cy.findByText("New collection").click();
+
+        cy.findAllByRole("dialog")
+          .eq(2)
+          .within(() => {
+            cy.findByPlaceholderText("My new collection").type(
+              "Foo Collection",
+            );
+            cy.findByText("Create").click();
+          });
+
+        cy.findByText("Select").click();
+
+        cy.log("create new dashboard");
+        cy.findByRole("dialog").within(() => {
+          cy.findByText("Create").click();
+        });
+      });
+
+      cy.log("dashboard is created and shows empty state");
+      H.getSimpleEmbedIframeContent()
+        .findByText("This dashboard is empty")
+        .should("be.visible");
+
+      cy.log("breadcrumbs show the new collection");
+      H.getSimpleEmbedIframeContent()
+        .findByTestId("sdk-breadcrumbs")
+        .findByText("Foo Collection")
+        .should("be.visible");
+
+      cy.log("breadcrumbs show the new dashboard");
+      H.getSimpleEmbedIframeContent()
+        .findByTestId("sdk-breadcrumbs")
+        .findByText("Foo Bar Dashboard")
+        .should("be.visible");
+
+      cy.log("dashboard title is visible in header");
+      H.getSimpleEmbedIframeContent()
+        .findByTestId("dashboard-header")
+        .findByText("Foo Bar Dashboard")
+        .should("be.visible");
+    });
+
     it("should hide New Exploration button when with-new-question is false", () => {
       setupEmbed(`
         <metabase-browser

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
@@ -111,6 +111,49 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         .should("be.visible");
     });
 
+    it("should update breadcrumbs when creating dashboard in different collection", () => {
+      setupEmbed(
+        '<metabase-browser initial-collection="root" read-only="false" />',
+      );
+
+      cy.log("verify initial breadcrumb");
+      H.getSimpleEmbedIframeContent()
+        .findByText("Our analytics")
+        .should("be.visible");
+
+      H.getSimpleEmbedIframeContent().findByText("New Dashboard").click();
+
+      H.getSimpleEmbedIframeContent().within(() => {
+        cy.log("change collection to save dashboard in");
+        cy.findByRole("dialog").within(() => {
+          cy.findByText("Which collection should this go in?").should(
+            "be.visible",
+          );
+
+          cy.findByText("Our analytics").click();
+        });
+
+        cy.findByText("First collection", { timeout: 20_000 }).click();
+        cy.findByText("Select").click();
+
+        cy.log("create the dashboard");
+        cy.findByRole("dialog").within(() => {
+          cy.findByPlaceholderText("What is the name of your dashboard?").type(
+            "Test Dashboard",
+          );
+          cy.findByText("Create").click();
+        });
+      });
+
+      cy.log(
+        "verify breadcrumbs are updated to reflect the selected collection",
+      );
+      H.getSimpleEmbedIframeContent()
+        .findByTestId("sdk-breadcrumbs")
+        .findByText("First collection")
+        .should("be.visible");
+    });
+
     it("should show New Exploration button and open data picker when clicked", () => {
       setupEmbed(
         '<metabase-browser initial-collection="root" read-only="false" />',

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
@@ -14,9 +14,9 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     H.prepareSdkIframeEmbedTest({ withTokenFeatures: true });
   });
 
-  describe("<metabase-view-content>", () => {
+  describe("<metabase-manage-content> (read-only mode)", () => {
     it("should show a collection browser with collection items", () => {
-      setupEmbed('<metabase-view-content initial-collection="root" />');
+      setupEmbed('<metabase-manage-content initial-collection="root" />');
 
       H.getSimpleEmbedIframeContent()
         .should("contain", "Name")
@@ -26,7 +26,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     });
 
     it("should navigate to question when clicking on a question item", () => {
-      setupEmbed('<metabase-view-content initial-collection="root" />');
+      setupEmbed('<metabase-manage-content initial-collection="root" />');
 
       H.getSimpleEmbedIframeContent()
         .findByText("Orders")
@@ -40,7 +40,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     });
 
     it("should show New Exploration button and open data picker when clicked", () => {
-      setupEmbed('<metabase-view-content initial-collection="root" />');
+      setupEmbed('<metabase-manage-content initial-collection="root" />');
 
       H.getSimpleEmbedIframeContent()
         .findByText("New Exploration")
@@ -54,7 +54,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should pass through collection-visible-columns parameter", () => {
       setupEmbed(`
-        <metabase-view-content
+        <metabase-manage-content
           initial-collection="root"
           collection-visible-columns='["type", "name"]'
         />
@@ -68,7 +68,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should pass through collection-page-size parameter", () => {
       setupEmbed(`
-        <metabase-view-content
+        <metabase-manage-content
           initial-collection="root"
           collection-page-size="5"
         />
@@ -82,7 +82,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should hide New Exploration button when with-new-question is false", () => {
       setupEmbed(`
-        <metabase-view-content
+        <metabase-manage-content
           initial-collection="root"
           with-new-question="false"
         />
@@ -94,9 +94,11 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     });
   });
 
-  describe("<metabase-curate-content>", () => {
+  describe("<metabase-manage-content> (curate mode)", () => {
     it("should show New Dashboard button and open modal when clicked", () => {
-      setupEmbed('<metabase-curate-content initial-collection="root" />');
+      setupEmbed(
+        '<metabase-manage-content initial-collection="root" read-only="false" />',
+      );
 
       H.getSimpleEmbedIframeContent()
         .findByText("New Dashboard")
@@ -110,7 +112,9 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     });
 
     it("should show New Exploration button and open data picker when clicked", () => {
-      setupEmbed('<metabase-curate-content initial-collection="root" />');
+      setupEmbed(
+        '<metabase-manage-content initial-collection="root" read-only="false" />',
+      );
 
       H.getSimpleEmbedIframeContent()
         .findByText("New Exploration")
@@ -124,7 +128,9 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     });
 
     it("should show Save button and save modal without entity picker when creating a new question", () => {
-      setupEmbed('<metabase-curate-content initial-collection="root" />');
+      setupEmbed(
+        '<metabase-manage-content initial-collection="root" read-only="false" />',
+      );
 
       H.getSimpleEmbedIframeContent().findByText("New Exploration").click();
 
@@ -148,8 +154,9 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should hide New Dashboard button when with-new-dashboard is false", () => {
       setupEmbed(`
-        <metabase-curate-content
+        <metabase-manage-content
           initial-collection="root"
+          read-only="false"
           with-new-dashboard="false"
         />
       `);
@@ -161,8 +168,9 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should hide New Exploration button when with-new-question is false", () => {
       setupEmbed(`
-        <metabase-curate-content
+        <metabase-manage-content
           initial-collection="root"
+          read-only="false"
           with-new-question="false"
         />
       `);
@@ -174,8 +182,9 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
     it("should pass through data-picker-entity-types parameter", () => {
       setupEmbed(`
-        <metabase-curate-content
+        <metabase-manage-content
           initial-collection="root"
+          read-only="false"
           data-picker-entity-types='["table"]'
         />
       `);
@@ -195,7 +204,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
   describe("breadcrumb navigation", () => {
     it("should show breadcrumbs when navigating between content", () => {
-      setupEmbed('<metabase-view-content initial-collection="root" />');
+      setupEmbed('<metabase-manage-content initial-collection="root" />');
 
       cy.log("should show initial breadcrumb");
       H.getSimpleEmbedIframeContent()

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
@@ -37,11 +37,6 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
       H.getSimpleEmbedIframeContent()
         .findByTestId("query-visualization-root")
         .should("be.visible");
-
-      H.getSimpleEmbedIframeContent()
-        .findByText("Orders")
-        .should("be.visible")
-        .click();
     });
 
     it("should show New Exploration button and open data picker when clicked", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
@@ -33,7 +33,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         .should("be.visible")
         .click();
 
-      cy.log("Should show question view");
+      cy.log("should show question view");
       H.getSimpleEmbedIframeContent()
         .findByTestId("query-visualization-root")
         .should("be.visible");
@@ -63,18 +63,21 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
       H.getSimpleEmbedIframeContent().should("contain", "Name");
       H.getSimpleEmbedIframeContent().should("contain", "Type");
       H.getSimpleEmbedIframeContent().should("not.contain", "Last edited by");
+      H.getSimpleEmbedIframeContent().should("not.contain", "Last edited at");
     });
 
     it("should pass through collection-page-size parameter", () => {
       setupEmbed(`
         <metabase-view-content
           initial-collection="root"
-          collection-page-size="10"
+          collection-page-size="5"
         />
       `);
 
-      cy.log("Should show collection browser");
-      H.getSimpleEmbedIframeContent().should("contain", "Name");
+      cy.log("should show exactly 5 collection entries");
+      H.getSimpleEmbedIframeContent()
+        .findAllByTestId("collection-entry-type")
+        .should("have.length", 5);
     });
 
     it("should hide New Exploration button when with-new-question is false", () => {
@@ -100,7 +103,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         .should("be.visible")
         .click();
 
-      cy.log("Should show create dashboard modal");
+      cy.log("should show create dashboard modal");
       H.getSimpleEmbedIframeContent()
         .findByText("New dashboard")
         .should("be.visible");
@@ -114,7 +117,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         .should("be.visible")
         .click();
 
-      cy.log("Should show data picker");
+      cy.log("should show data picker");
       H.getSimpleEmbedIframeContent()
         .findByText("Pick your starting data")
         .should("be.visible");
@@ -125,16 +128,16 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
       H.getSimpleEmbedIframeContent().findByText("New Exploration").click();
 
-      cy.log("Select data model");
+      cy.log("select data model");
       H.getSimpleEmbedIframeContent().findByText("Orders").click();
 
-      cy.log("Should show Save button");
+      cy.log("should show Save button");
       H.getSimpleEmbedIframeContent()
         .findByText("Save")
         .should("be.visible")
         .click();
 
-      cy.log("Should show save modal without entity picker");
+      cy.log("should show save modal without entity picker");
       H.getSimpleEmbedIframeContent().within(() => {
         cy.findByRole("dialog").within(() => {
           cy.findByText("Save new question").should("be.visible");
@@ -179,12 +182,12 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
 
       H.getSimpleEmbedIframeContent().findByText("New Exploration").click();
 
-      cy.log("Should show data picker with limited entity types");
+      cy.log("should show data picker with limited entity types");
       H.getSimpleEmbedIframeContent()
         .findByText("Pick your starting data")
         .should("be.visible");
 
-      cy.log("Should show Orders table but not Orders model");
+      cy.log("should show Orders table but not Orders model");
       H.getSimpleEmbedIframeContent().should("contain", "Orders");
       H.getSimpleEmbedIframeContent().should("not.contain", "Orders model");
     });
@@ -194,19 +197,19 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
     it("should show breadcrumbs when navigating between content", () => {
       setupEmbed('<metabase-view-content initial-collection="root" />');
 
-      cy.log("Should show initial breadcrumb");
+      cy.log("should show initial breadcrumb");
       H.getSimpleEmbedIframeContent()
         .findByText("Our analytics")
         .should("be.visible");
 
       H.getSimpleEmbedIframeContent().findAllByText("Orders").first().click();
 
-      cy.log("Should show breadcrumb for the question");
+      cy.log("should show breadcrumb for the question");
       H.getSimpleEmbedIframeContent().should("contain", "Orders");
 
       H.getSimpleEmbedIframeContent().findByText("Our analytics").click();
 
-      cy.log("Should be back at collection browser");
+      cy.log("should be back at collection browser");
       H.getSimpleEmbedIframeContent().should("contain", "Name");
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
@@ -37,6 +37,11 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
       H.getSimpleEmbedIframeContent()
         .findByTestId("query-visualization-root")
         .should("be.visible");
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("Orders")
+        .should("be.visible")
+        .click();
     });
 
     it("should show New Exploration button and open data picker when clicked", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
@@ -1,0 +1,213 @@
+const { H } = cy;
+
+const setupEmbed = (elementHtml: string) => {
+  H.visitCustomHtmlPage(`
+    ${H.getNewEmbedScriptTag()}
+    ${H.getNewEmbedConfigurationScript({})}
+    ${elementHtml}
+  `);
+};
+
+describe("scenarios > embedding > sdk iframe embedding > view and curate content", () => {
+  beforeEach(() => {
+    cy.signInAsAdmin();
+    H.prepareSdkIframeEmbedTest({ withTokenFeatures: true });
+  });
+
+  describe("<metabase-view-content>", () => {
+    it("should show a collection browser with collection items", () => {
+      setupEmbed('<metabase-view-content initial-collection="root" />');
+
+      H.getSimpleEmbedIframeContent()
+        .should("contain", "Name")
+        .findAllByText("Orders")
+        .first()
+        .should("be.visible");
+    });
+
+    it("should navigate to question when clicking on a question item", () => {
+      setupEmbed('<metabase-view-content initial-collection="root" />');
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("Orders")
+        .should("be.visible")
+        .click();
+
+      cy.log("Should show question view");
+      H.getSimpleEmbedIframeContent()
+        .findByTestId("query-visualization-root")
+        .should("be.visible");
+    });
+
+    it("should show New Exploration button and open data picker when clicked", () => {
+      setupEmbed('<metabase-view-content initial-collection="root" />');
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("New Exploration")
+        .should("be.visible")
+        .click();
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("Pick your starting data")
+        .should("be.visible");
+    });
+
+    it("should pass through collection-visible-columns parameter", () => {
+      setupEmbed(`
+        <metabase-view-content
+          initial-collection="root"
+          collection-visible-columns='["type", "name"]'
+        />
+      `);
+
+      H.getSimpleEmbedIframeContent().should("contain", "Name");
+      H.getSimpleEmbedIframeContent().should("contain", "Type");
+      H.getSimpleEmbedIframeContent().should("not.contain", "Last edited by");
+    });
+
+    it("should pass through collection-page-size parameter", () => {
+      setupEmbed(`
+        <metabase-view-content
+          initial-collection="root"
+          collection-page-size="10"
+        />
+      `);
+
+      cy.log("Should show collection browser");
+      H.getSimpleEmbedIframeContent().should("contain", "Name");
+    });
+
+    it("should hide New Exploration button when with-new-question is false", () => {
+      setupEmbed(`
+        <metabase-view-content
+          initial-collection="root"
+          with-new-question="false"
+        />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("New Exploration")
+        .should("not.exist");
+    });
+  });
+
+  describe("<metabase-curate-content>", () => {
+    it("should show New Dashboard button and open modal when clicked", () => {
+      setupEmbed('<metabase-curate-content initial-collection="root" />');
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("New Dashboard")
+        .should("be.visible")
+        .click();
+
+      cy.log("Should show create dashboard modal");
+      H.getSimpleEmbedIframeContent()
+        .findByText("New dashboard")
+        .should("be.visible");
+    });
+
+    it("should show New Exploration button and open data picker when clicked", () => {
+      setupEmbed('<metabase-curate-content initial-collection="root" />');
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("New Exploration")
+        .should("be.visible")
+        .click();
+
+      cy.log("Should show data picker");
+      H.getSimpleEmbedIframeContent()
+        .findByText("Pick your starting data")
+        .should("be.visible");
+    });
+
+    it("should show Save button and save modal without entity picker when creating a new question", () => {
+      setupEmbed('<metabase-curate-content initial-collection="root" />');
+
+      H.getSimpleEmbedIframeContent().findByText("New Exploration").click();
+
+      cy.log("Select data model");
+      H.getSimpleEmbedIframeContent().findByText("Orders").click();
+
+      cy.log("Should show Save button");
+      H.getSimpleEmbedIframeContent()
+        .findByText("Save")
+        .should("be.visible")
+        .click();
+
+      cy.log("Should show save modal without entity picker");
+      H.getSimpleEmbedIframeContent().within(() => {
+        cy.findByRole("dialog").within(() => {
+          cy.findByText("Save new question").should("be.visible");
+          cy.findByText("Where do you want to save this?").should("not.exist");
+        });
+      });
+    });
+
+    it("should hide New Dashboard button when with-new-dashboard is false", () => {
+      setupEmbed(`
+        <metabase-curate-content
+          initial-collection="root"
+          with-new-dashboard="false"
+        />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("New Dashboard")
+        .should("not.exist");
+    });
+
+    it("should hide New Exploration button when with-new-question is false", () => {
+      setupEmbed(`
+        <metabase-curate-content
+          initial-collection="root"
+          with-new-question="false"
+        />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("New Exploration")
+        .should("not.exist");
+    });
+
+    it("should pass through data-picker-entity-types parameter", () => {
+      setupEmbed(`
+        <metabase-curate-content
+          initial-collection="root"
+          data-picker-entity-types='["table"]'
+        />
+      `);
+
+      H.getSimpleEmbedIframeContent().findByText("New Exploration").click();
+
+      cy.log("Should show data picker with limited entity types");
+      H.getSimpleEmbedIframeContent()
+        .findByText("Pick your starting data")
+        .should("be.visible");
+
+      cy.log("Should show Orders table but not Orders model");
+      H.getSimpleEmbedIframeContent().should("contain", "Orders");
+      H.getSimpleEmbedIframeContent().should("not.contain", "Orders model");
+    });
+  });
+
+  describe("breadcrumb navigation", () => {
+    it("should show breadcrumbs when navigating between content", () => {
+      setupEmbed('<metabase-view-content initial-collection="root" />');
+
+      cy.log("Should show initial breadcrumb");
+      H.getSimpleEmbedIframeContent()
+        .findByText("Our analytics")
+        .should("be.visible");
+
+      H.getSimpleEmbedIframeContent().findAllByText("Orders").first().click();
+
+      cy.log("Should show breadcrumb for the question");
+      H.getSimpleEmbedIframeContent().should("contain", "Orders");
+
+      H.getSimpleEmbedIframeContent().findByText("Our analytics").click();
+
+      cy.log("Should be back at collection browser");
+      H.getSimpleEmbedIframeContent().should("contain", "Name");
+    });
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkBreadcrumbs/SdkBreadcrumbs.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkBreadcrumbs/SdkBreadcrumbs.tsx
@@ -32,7 +32,7 @@ export const SdkBreadcrumbs = ({
 
   return (
     <PublicComponentStylesWrapper className={className} style={style}>
-      <Flex align="center">
+      <Flex align="center" data-testid="sdk-breadcrumbs">
         {breadcrumbs.map((breadcrumb, index) => (
           <Fragment key={breadcrumb.id}>
             <Badge

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useState } from "react";
+import { P, match } from "ts-pattern";
+import { t } from "ttag";
+
+import {
+  CollectionBrowser,
+  CreateDashboardModal,
+  EditableDashboard,
+  InteractiveDashboard,
+  InteractiveQuestion,
+  type SdkCollectionId,
+} from "embedding-sdk";
+import { SdkBreadcrumbs } from "embedding-sdk/components/private/SdkBreadcrumbs";
+import { useSdkBreadcrumbs } from "embedding-sdk/hooks/private/use-sdk-breadcrumb";
+import type { SdkBreadcrumbItemType } from "embedding-sdk/types/breadcrumb";
+import { Button, Group, Stack } from "metabase/ui";
+
+import type { SdkIframeEmbedSettings } from "../types/embed";
+
+interface ViewContentProps {
+  settings: SdkIframeEmbedSettings & {
+    componentName: "metabase-view-content" | "metabase-curate-content";
+  };
+}
+
+type ContentManagerView =
+  | { type: "collection"; id: SdkCollectionId }
+  | { type: "dashboard"; id: number | string }
+  | { type: "question" | "metric" | "model"; id: number | string }
+  | { type: "exploration" }
+  | { type: "create-dashboard" };
+
+export function ContentManager({ settings }: ViewContentProps) {
+  const { componentName, initialCollection } = settings;
+
+  const isReadOnly = componentName === "metabase-view-content";
+
+  const { breadcrumbs, currentLocation } = useSdkBreadcrumbs();
+
+  const [currentView, setCurrentView] = useState<ContentManagerView>({
+    type: "collection",
+    id: initialCollection,
+  });
+
+  // Use the last collection in the breadcrumb as the target for new questions.
+  const targetCollection = useMemo(() => {
+    const fallback = { type: "collection", id: initialCollection };
+
+    return (
+      breadcrumbs.findLast((item) => item.type === "collection") ?? fallback
+    );
+  }, [breadcrumbs, initialCollection]);
+
+  // If a user clicks on a collection breadcrumb, switch the view.
+  useEffect(() => {
+    if (currentLocation?.type === "collection") {
+      setCurrentView({ type: currentLocation.type, id: currentLocation.id });
+    }
+  }, [currentLocation]);
+
+  return match(currentView)
+    .with({ type: "exploration" }, () => (
+      <Stack h="100%">
+        <SdkBreadcrumbs />
+
+        <InteractiveQuestion
+          questionId="new"
+          height="100%"
+          withDownloads
+          isSaveEnabled={!isReadOnly}
+          entityTypes={settings.dataPickerEntityTypes}
+          targetCollection={targetCollection.id}
+        />
+      </Stack>
+    ))
+    .with({ type: "create-dashboard" }, () => (
+      <Stack h="100%">
+        <CreateDashboardModal
+          onCreate={(dashboard) =>
+            setCurrentView({ type: "dashboard", id: dashboard.id })
+          }
+          onClose={() =>
+            setCurrentView({ type: "collection", id: targetCollection.id })
+          }
+          initialCollectionId={targetCollection.id}
+        />
+      </Stack>
+    ))
+    .with({ type: "dashboard", id: P.nonNullable }, ({ id }) => (
+      <Stack h="100%">
+        <SdkBreadcrumbs />
+
+        {isReadOnly ? (
+          <InteractiveDashboard dashboardId={id} withDownloads />
+        ) : (
+          <EditableDashboard withCardTitle dashboardId={id} />
+        )}
+      </Stack>
+    ))
+    .with(
+      { type: P.union("question", "metric", "model"), id: P.nonNullable },
+      ({ id }) => (
+        <Stack h="100%">
+          <SdkBreadcrumbs />
+
+          <InteractiveQuestion
+            questionId={id}
+            height="100%"
+            withDownloads
+            isSaveEnabled={!isReadOnly}
+            targetCollection={targetCollection.id}
+          />
+        </Stack>
+      ),
+    )
+    .with({ type: "collection" }, (view) => (
+      <Stack px="lg" py="xl" maw="60rem" mx="auto">
+        <Group justify="space-between" align="center" gap="sm">
+          <SdkBreadcrumbs />
+
+          <Group>
+            {(settings.withNewQuestion ?? true) && (
+              <Button
+                justify="center"
+                onClick={() => setCurrentView({ type: "exploration" })}
+              >
+                {t`New Exploration`}
+              </Button>
+            )}
+
+            {!isReadOnly && (settings.withNewDashboard ?? true) && (
+              <Button
+                justify="center"
+                onClick={() => setCurrentView({ type: "create-dashboard" })}
+              >
+                {t`New Dashboard`}
+              </Button>
+            )}
+          </Group>
+        </Group>
+
+        <CollectionBrowser
+          collectionId={view.id}
+          visibleColumns={settings.collectionVisibleColumns}
+          visibleEntityTypes={settings.collectionEntityTypes}
+          pageSize={settings.collectionPageSize}
+          onClick={(item) => {
+            const type = match<string, SdkBreadcrumbItemType>(item.model)
+              .with("card", () => "question")
+              .with("dataset", () => "model")
+              .otherwise((model) => model as SdkBreadcrumbItemType);
+
+            setCurrentView({ type, id: item.id });
+          }}
+        />
+      </Stack>
+    ));
+}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
@@ -35,7 +35,7 @@ export function ContentManager({ settings }: ViewContentProps) {
 
   const isReadOnly = componentName === "metabase-view-content";
 
-  const { breadcrumbs, currentLocation } = useSdkBreadcrumbs();
+  const { breadcrumbs, currentLocation, reportLocation } = useSdkBreadcrumbs();
 
   const [currentView, setCurrentView] = useState<ContentManagerView>({
     type: "collection",
@@ -121,24 +121,33 @@ export function ContentManager({ settings }: ViewContentProps) {
 
           setCurrentView({ type, id: item.id });
         }}
+        style={{ overflowY: "scroll" }}
       />
     ))
     .otherwise(() => null);
 
   return (
-    <Stack px="lg" py="xl" maw="60rem" mx="auto" h="100%">
+    <Stack px="xl" py="lg" h="100%" style={{ overflowY: "hidden" }}>
       {/* Fixes the height to avoid layout shift when hiding buttons */}
-      <Group justify="space-between" align="center" gap="sm" h="2.5rem">
-        <Group>
+      <Group justify="space-between" align="center" gap="sm">
+        <Group h="2.5rem">
           <SdkBreadcrumbs />
         </Group>
 
         {currentView.type === "collection" && (
-          <Group>
+          <Group gap="sm">
             {(settings.withNewQuestion ?? true) && (
               <Button
                 justify="center"
-                onClick={() => setCurrentView({ type: "exploration" })}
+                onClick={() => {
+                  setCurrentView({ type: "exploration" });
+
+                  reportLocation({
+                    type: "question",
+                    id: "new",
+                    name: "New Exploration",
+                  });
+                }}
               >
                 {t`New Exploration`}
               </Button>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
@@ -19,7 +19,7 @@ import type { SdkIframeEmbedSettings } from "../types/embed";
 
 interface ContentManagerProps {
   settings: SdkIframeEmbedSettings & {
-    componentName: "metabase-view-content" | "metabase-curate-content";
+    componentName: "metabase-manage-content";
   };
 }
 
@@ -31,9 +31,9 @@ type ContentManagerView =
   | { type: "create-dashboard" };
 
 export function ContentManager({ settings }: ContentManagerProps) {
-  const { componentName, initialCollection } = settings;
+  const { initialCollection } = settings;
 
-  const isReadOnly = componentName === "metabase-view-content";
+  const isReadOnly = settings.readOnly ?? true;
 
   const { breadcrumbs, currentLocation, reportLocation } = useSdkBreadcrumbs();
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { P, match } from "ts-pattern";
 import { t } from "ttag";
+import _ from "underscore";
 
 import { SdkBreadcrumbs } from "embedding-sdk/components/private/SdkBreadcrumbs";
 import {
@@ -44,10 +45,13 @@ export function ContentManager({ settings }: ContentManagerProps) {
 
   // Use the last collection in the breadcrumb as the target for saving new questions.
   const targetCollection = useMemo(() => {
-    return (
-      breadcrumbs.findLast((item) => item.type === "collection")?.id ??
-      initialCollection
+    const collectionBreadcrumbs = breadcrumbs.filter(
+      (item) => item.type === "collection",
     );
+
+    const lastCollectionItem = _.last(collectionBreadcrumbs);
+
+    return lastCollectionItem?.id ?? initialCollection;
   }, [breadcrumbs, initialCollection]);
 
   // If a user clicks on a collection breadcrumb, switch the view.

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
@@ -81,9 +81,18 @@ export function ContentManager({ settings }: ViewContentProps) {
     ))
     .with({ type: "dashboard", id: P.nonNullable }, ({ id }) => {
       return isReadOnly ? (
-        <InteractiveDashboard dashboardId={id} withDownloads />
+        <InteractiveDashboard
+          dashboardId={id}
+          withDownloads
+          style={{ height: "100%" }}
+          drillThroughQuestionProps={{ isSaveEnabled: false }}
+        />
       ) : (
-        <EditableDashboard withCardTitle dashboardId={id} />
+        <EditableDashboard
+          withCardTitle
+          dashboardId={id}
+          style={{ height: "100%" }}
+        />
       );
     })
     .with(

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
@@ -42,12 +42,11 @@ export function ContentManager({ settings }: ViewContentProps) {
     id: initialCollection,
   });
 
-  // Use the last collection in the breadcrumb as the target for new questions.
+  // Use the last collection in the breadcrumb as the target for saving new questions.
   const targetCollection = useMemo(() => {
-    const fallback = { type: "collection", id: initialCollection };
-
     return (
-      breadcrumbs.findLast((item) => item.type === "collection") ?? fallback
+      breadcrumbs.findLast((item) => item.type === "collection")?.id ??
+      initialCollection
     );
   }, [breadcrumbs, initialCollection]);
 
@@ -66,7 +65,7 @@ export function ContentManager({ settings }: ViewContentProps) {
         withDownloads
         isSaveEnabled={!isReadOnly}
         entityTypes={settings.dataPickerEntityTypes}
-        targetCollection={targetCollection.id}
+        targetCollection={targetCollection}
       />
     ))
     .with({ type: "create-dashboard" }, () => (
@@ -75,9 +74,9 @@ export function ContentManager({ settings }: ViewContentProps) {
           setCurrentView({ type: "dashboard", id: dashboard.id })
         }
         onClose={() =>
-          setCurrentView({ type: "collection", id: targetCollection.id })
+          setCurrentView({ type: "collection", id: targetCollection })
         }
-        initialCollectionId={targetCollection.id}
+        initialCollectionId={targetCollection}
       />
     ))
     .with({ type: "dashboard", id: P.nonNullable }, ({ id }) => {
@@ -95,7 +94,7 @@ export function ContentManager({ settings }: ViewContentProps) {
           height="100%"
           withDownloads
           isSaveEnabled={!isReadOnly}
-          targetCollection={targetCollection.id}
+          targetCollection={targetCollection}
         />
       ),
     )
@@ -118,7 +117,7 @@ export function ContentManager({ settings }: ViewContentProps) {
     .otherwise(() => null);
 
   return (
-    <Stack px="lg" py="xl" maw="60rem" mx="auto">
+    <Stack px="lg" py="xl" maw="60rem" mx="auto" h="100%">
       {/* Fixes the height to avoid layout shift when hiding buttons */}
       <Group justify="space-between" align="center" gap="sm" h="2.5rem">
         <Group>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
@@ -17,7 +17,7 @@ import { Button, Group, Stack } from "metabase/ui";
 
 import type { SdkIframeEmbedSettings } from "../types/embed";
 
-interface ViewContentProps {
+interface ContentManagerProps {
   settings: SdkIframeEmbedSettings & {
     componentName: "metabase-view-content" | "metabase-curate-content";
   };
@@ -30,7 +30,7 @@ type ContentManagerView =
   | { type: "exploration" }
   | { type: "create-dashboard" };
 
-export function ContentManager({ settings }: ViewContentProps) {
+export function ContentManager({ settings }: ContentManagerProps) {
   const { componentName, initialCollection } = settings;
 
   const isReadOnly = componentName === "metabase-view-content";
@@ -117,7 +117,7 @@ export function ContentManager({ settings }: ViewContentProps) {
           const type = match<string, SdkBreadcrumbItemType>(item.model)
             .with("card", () => "question")
             .with("dataset", () => "model")
-            .otherwise((model) => model as SdkBreadcrumbItemType);
+            .otherwise((model) => model);
 
           setCurrentView({ type, id: item.id });
         }}
@@ -125,6 +125,11 @@ export function ContentManager({ settings }: ViewContentProps) {
       />
     ))
     .otherwise(() => null);
+
+  const handleNewExploration = () => {
+    setCurrentView({ type: "exploration" });
+    reportLocation({ type: "question", id: "new", name: "New Exploration" });
+  };
 
   return (
     <Stack px="xl" py="lg" h="100%" style={{ overflowY: "hidden" }}>
@@ -137,18 +142,7 @@ export function ContentManager({ settings }: ViewContentProps) {
         {currentView.type === "collection" && (
           <Group gap="sm">
             {(settings.withNewQuestion ?? true) && (
-              <Button
-                justify="center"
-                onClick={() => {
-                  setCurrentView({ type: "exploration" });
-
-                  reportLocation({
-                    type: "question",
-                    id: "new",
-                    name: "New Exploration",
-                  });
-                }}
-              >
+              <Button justify="center" onClick={handleNewExploration}>
                 {t`New Exploration`}
               </Button>
             )}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
@@ -117,7 +117,7 @@ export function ContentManager({ settings }: ContentManagerProps) {
           const type = match<string, SdkBreadcrumbItemType>(item.model)
             .with("card", () => "question")
             .with("dataset", () => "model")
-            .otherwise((model) => model);
+            .otherwise((model) => model as SdkBreadcrumbItemType);
 
           setCurrentView({ type, id: item.id });
         }}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/ContentManager.tsx
@@ -20,7 +20,7 @@ import type { SdkIframeEmbedSettings } from "../types/embed";
 
 interface ContentManagerProps {
   settings: SdkIframeEmbedSettings & {
-    componentName: "metabase-manage-content";
+    componentName: "metabase-browser";
   };
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
@@ -74,9 +74,18 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
     ))
     .with({ type: "create-dashboard" }, () => (
       <CreateDashboardModal
-        onCreate={(dashboard) =>
-          setCurrentView({ type: "dashboard", id: dashboard.id })
-        }
+        onCreate={(dashboard) => {
+          // Update the breadcrumbs to reflect the collection where the dashboard was saved
+          if (dashboard.collection) {
+            reportLocation({
+              type: "collection",
+              id: dashboard.collection.id,
+              name: dashboard.collection.name,
+            });
+          }
+
+          setCurrentView({ type: "dashboard", id: dashboard.id });
+        }}
         onClose={() =>
           setCurrentView({ type: "collection", id: targetCollection })
         }

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
@@ -18,27 +18,27 @@ import { Button, Group, Stack } from "metabase/ui";
 
 import type { SdkIframeEmbedSettings } from "../types/embed";
 
-interface ContentManagerProps {
+interface MetabaseBrowserProps {
   settings: SdkIframeEmbedSettings & {
     componentName: "metabase-browser";
   };
 }
 
-type ContentManagerView =
+type MetabaseBrowserView =
   | { type: "collection"; id: SdkCollectionId }
   | { type: "dashboard"; id: number | string }
   | { type: "question" | "metric" | "model"; id: number | string }
   | { type: "exploration" }
   | { type: "create-dashboard" };
 
-export function ContentManager({ settings }: ContentManagerProps) {
+export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
   const { initialCollection } = settings;
 
   const isReadOnly = settings.readOnly ?? true;
 
   const { breadcrumbs, currentLocation, reportLocation } = useSdkBreadcrumbs();
 
-  const [currentView, setCurrentView] = useState<ContentManagerView>({
+  const [currentView, setCurrentView] = useState<MetabaseBrowserView>({
     type: "collection",
     id: initialCollection,
   });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
@@ -4,13 +4,13 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { SdkBreadcrumbs } from "embedding-sdk/components/private/SdkBreadcrumbs";
+import { CollectionBrowser } from "embedding-sdk/components/public/CollectionBrowser";
+import { CreateDashboardModal } from "embedding-sdk/components/public/CreateDashboardModal";
+import { InteractiveQuestion } from "embedding-sdk/components/public/InteractiveQuestion";
 import {
-  CollectionBrowser,
-  CreateDashboardModal,
   EditableDashboard,
   InteractiveDashboard,
-  InteractiveQuestion,
-} from "embedding-sdk/components/public";
+} from "embedding-sdk/components/public/dashboard";
 import { useSdkBreadcrumbs } from "embedding-sdk/hooks/private/use-sdk-breadcrumb";
 import type { SdkCollectionId } from "embedding-sdk/types";
 import type { SdkBreadcrumbItemType } from "embedding-sdk/types/breadcrumb";

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
@@ -112,7 +112,13 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
         />
       );
 
-      return <Group h="100%">{dashboardView}</Group>;
+      // The overflow-scroll is needed otherwise the editable
+      // dashboard header gets scrolled out of view.
+      return (
+        <Group h="100%" style={{ overflowY: "scroll" }}>
+          {dashboardView}
+        </Group>
+      );
     })
     .with(
       { type: P.union("question", "metric", "model"), id: P.nonNullable },

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
@@ -88,7 +88,11 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
             });
           }
 
-          setCurrentView({ type: "dashboard", id: dashboard.id });
+          // On the next tick, update the current view.
+          // This is needed for when we create new collections.
+          setTimeout(() => {
+            setCurrentView({ type: "dashboard", id: dashboard.id });
+          }, 0);
         }}
         onClose={() =>
           setCurrentView({ type: "collection", id: targetCollection })

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -18,7 +18,7 @@ import { useParamRerenderKey } from "../hooks/use-param-rerender-key";
 import { useSdkIframeEmbedEventBus } from "../hooks/use-sdk-iframe-embed-event-bus";
 import type { SdkIframeEmbedSettings } from "../types/embed";
 
-import { ContentManager } from "./ContentManager";
+import { MetabaseBrowser } from "./MetabaseBrowser";
 import {
   SdkIframeApiKeyInProductionError,
   SdkIframeExistingUserSessionInProductionError,
@@ -90,7 +90,7 @@ const SdkIframeEmbedView = ({
       },
       (settings) => (
         <SdkBreadcrumbsProvider>
-          <ContentManager settings={settings} />
+          <MetabaseBrowser settings={settings} />
         </SdkBreadcrumbsProvider>
       ),
     )

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -86,10 +86,7 @@ const SdkIframeEmbedView = ({
   return match(settings)
     .with(
       {
-        componentName: P.union(
-          "metabase-curate-content",
-          "metabase-view-content",
-        ),
+        componentName: "metabase-manage-content",
       },
       (settings) => (
         <SdkBreadcrumbsProvider>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -86,7 +86,7 @@ const SdkIframeEmbedView = ({
   return match(settings)
     .with(
       {
-        componentName: "metabase-manage-content",
+        componentName: "metabase-browser",
       },
       (settings) => (
         <SdkBreadcrumbsProvider>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -487,19 +487,16 @@ const MetabaseQuestionElement = createCustomElement("metabase-question", [
   "entity-types",
 ]);
 
-const MetabaseManageContentElement = createCustomElement(
-  "metabase-manage-content",
-  [
-    "initial-collection",
-    "collection-visible-columns",
-    "collection-page-size",
-    "collection-entity-types",
-    "data-picker-entity-types",
-    "with-new-question",
-    "with-new-dashboard",
-    "read-only",
-  ],
-);
+const MetabaseManageContentElement = createCustomElement("metabase-browser", [
+  "initial-collection",
+  "collection-visible-columns",
+  "collection-page-size",
+  "collection-entity-types",
+  "data-picker-entity-types",
+  "with-new-question",
+  "with-new-dashboard",
+  "read-only",
+]);
 
 // Expose the old API that's still used in the tests, we'll probably remove this api unless customers prefer it
 if (typeof window !== "undefined") {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -487,20 +487,8 @@ const MetabaseQuestionElement = createCustomElement("metabase-question", [
   "entity-types",
 ]);
 
-const MetabaseViewContentElement = createCustomElement(
-  "metabase-view-content",
-  [
-    "initial-collection",
-    "collection-visible-columns",
-    "collection-page-size",
-    "collection-entity-types",
-    "data-picker-entity-types",
-    "with-new-question",
-  ],
-);
-
-const MetabaseCurateContentElement = createCustomElement(
-  "metabase-curate-content",
+const MetabaseManageContentElement = createCustomElement(
+  "metabase-manage-content",
   [
     "initial-collection",
     "collection-visible-columns",
@@ -509,6 +497,7 @@ const MetabaseCurateContentElement = createCustomElement(
     "data-picker-entity-types",
     "with-new-question",
     "with-new-dashboard",
+    "read-only",
   ],
 );
 
@@ -522,6 +511,5 @@ if (typeof window !== "undefined") {
 export {
   MetabaseDashboardElement,
   MetabaseQuestionElement,
-  MetabaseViewContentElement,
-  MetabaseCurateContentElement,
+  MetabaseManageContentElement,
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -288,6 +288,7 @@ export abstract class MetabaseEmbedElement extends HTMLElement {
     this._iframe.style.width = "100%";
     this._iframe.style.height = "100%";
     this._iframe.style.border = "none";
+    this._iframe.style.minHeight = "600px";
 
     this._iframe.setAttribute("data-metabase-embed", "true");
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -487,6 +487,31 @@ const MetabaseQuestionElement = createCustomElement("metabase-question", [
   "entity-types",
 ]);
 
+const MetabaseViewContentElement = createCustomElement(
+  "metabase-view-content",
+  [
+    "initial-collection",
+    "collection-visible-columns",
+    "collection-page-size",
+    "collection-entity-types",
+    "data-picker-entity-types",
+    "with-new-question",
+  ],
+);
+
+const MetabaseCurateContentElement = createCustomElement(
+  "metabase-curate-content",
+  [
+    "initial-collection",
+    "collection-visible-columns",
+    "collection-page-size",
+    "collection-entity-types",
+    "data-picker-entity-types",
+    "with-new-question",
+    "with-new-dashboard",
+  ],
+);
+
 // Expose the old API that's still used in the tests, we'll probably remove this api unless customers prefer it
 if (typeof window !== "undefined") {
   (window as any)["metabase.embed"] = {
@@ -494,4 +519,9 @@ if (typeof window !== "undefined") {
   };
 }
 
-export { MetabaseDashboardElement, MetabaseQuestionElement };
+export {
+  MetabaseDashboardElement,
+  MetabaseQuestionElement,
+  MetabaseViewContentElement,
+  MetabaseCurateContentElement,
+};

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -96,7 +96,7 @@ export interface BrowserEmbedOptions {
   /** Whether the content manager is in read-only mode. Defaults to true. */
   readOnly?: boolean;
 
-  /** Which collections to show on the collection browser */
+  /** Which columns to show on the collection browser */
   collectionVisibleColumns?: CollectionBrowserListColumns[];
 
   /** How many items to show per page in the collection browser */

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -1,4 +1,6 @@
 import type {
+  CollectionBrowserListColumns,
+  EmbeddingEntityType,
   EntityTypeFilterKeys,
   MetabaseTheme,
   SqlParameterValues,
@@ -85,24 +87,40 @@ export interface ExplorationEmbedOptions {
   questionId?: never;
 }
 
-export interface CurateContentEmbedOptions {
-  template: "curate-content";
+/** Shared properties between the content manager templates. */
+export interface ContentManagerCommonEmbedOptions {
   initialCollection: CollectionId;
 
-  entityTypes?: CollectionBrowserEntityTypes[];
+  /** Which collections to show on the collection browser */
+  collectionVisibleColumns?: CollectionBrowserListColumns[];
+
+  /** How many items to show per page in the collection browser */
+  collectionPageSize?: number;
+
+  /** Which entities to show on the collection browser */
+  collectionEntityTypes?: CollectionBrowserEntityTypes[];
+
+  /** Which entities to show on the question's data picker */
+  dataPickerEntityTypes?: EmbeddingEntityType[];
+
+  /** Whether to show the "New Exploration" button. Defaults to true. */
+  withNewQuestion?: boolean;
 
   questionId?: never;
   dashboardId?: never;
 }
 
-export interface ViewContentEmbedOptions {
-  template: "view-content";
-  initialCollection: CollectionId;
+export interface CurateContentEmbedOptions
+  extends ContentManagerCommonEmbedOptions {
+  componentName: "metabase-curate-content";
 
-  entityTypes?: CollectionBrowserEntityTypes[];
+  /** Whether to show the "New Dashboard" button. Defaults to true. */
+  withNewDashboard?: boolean;
+}
 
-  questionId?: never;
-  dashboardId?: never;
+export interface ViewContentEmbedOptions
+  extends ContentManagerCommonEmbedOptions {
+  componentName: "metabase-view-content";
 }
 
 type CollectionBrowserEntityTypes =
@@ -128,9 +146,9 @@ export type SdkIframeEmbedBaseSettings = {
 export type SdkIframeEmbedTemplateSettings =
   | DashboardEmbedOptions
   | QuestionEmbedOptions
-  | ExplorationEmbedOptions;
-// | CurateContentEmbedOptions
-// | ViewContentEmbedOptions;
+  | ExplorationEmbedOptions
+  | CurateContentEmbedOptions
+  | ViewContentEmbedOptions;
 
 /** Settings used by the sdk embed route */
 export type SdkIframeEmbedSettings = SdkIframeEmbedBaseSettings &

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -87,9 +87,14 @@ export interface ExplorationEmbedOptions {
   questionId?: never;
 }
 
-/** Shared properties between the content manager templates. */
-export interface ContentManagerCommonEmbedOptions {
+export interface ManageContentEmbedOptions {
+  componentName: "metabase-manage-content";
+
+  /** Which collection to start from? */
   initialCollection: CollectionId;
+
+  /** Whether the content manager is in read-only mode. Defaults to true. */
+  readOnly?: boolean;
 
   /** Which collections to show on the collection browser */
   collectionVisibleColumns?: CollectionBrowserListColumns[];
@@ -106,22 +111,12 @@ export interface ContentManagerCommonEmbedOptions {
   /** Whether to show the "New Exploration" button. Defaults to true. */
   withNewQuestion?: boolean;
 
+  /** Whether to show the "New Dashboard" button. Defaults to true. Only applies when readOnly is false. */
+  withNewDashboard?: boolean;
+
   template?: never;
   questionId?: never;
   dashboardId?: never;
-}
-
-export interface CurateContentEmbedOptions
-  extends ContentManagerCommonEmbedOptions {
-  componentName: "metabase-curate-content";
-
-  /** Whether to show the "New Dashboard" button. Defaults to true. */
-  withNewDashboard?: boolean;
-}
-
-export interface ViewContentEmbedOptions
-  extends ContentManagerCommonEmbedOptions {
-  componentName: "metabase-view-content";
 }
 
 type CollectionBrowserEntityTypes =
@@ -148,8 +143,7 @@ export type SdkIframeEmbedTemplateSettings =
   | DashboardEmbedOptions
   | QuestionEmbedOptions
   | ExplorationEmbedOptions
-  | CurateContentEmbedOptions
-  | ViewContentEmbedOptions;
+  | ManageContentEmbedOptions;
 
 /** Settings used by the sdk embed route */
 export type SdkIframeEmbedSettings = SdkIframeEmbedBaseSettings &
@@ -165,5 +159,4 @@ export type SdkIframeEmbedSettingKey =
   | keyof DashboardEmbedOptions
   | keyof QuestionEmbedOptions
   | keyof ExplorationEmbedOptions
-  | keyof CurateContentEmbedOptions
-  | keyof ViewContentEmbedOptions;
+  | keyof ManageContentEmbedOptions;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -88,7 +88,7 @@ export interface ExplorationEmbedOptions {
 }
 
 export interface ManageContentEmbedOptions {
-  componentName: "metabase-manage-content";
+  componentName: "metabase-browser";
 
   /** Which collection to start from? */
   initialCollection: CollectionId;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -106,6 +106,7 @@ export interface ContentManagerCommonEmbedOptions {
   /** Whether to show the "New Exploration" button. Defaults to true. */
   withNewQuestion?: boolean;
 
+  template?: never;
   questionId?: never;
   dashboardId?: never;
 }

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -87,7 +87,7 @@ export interface ExplorationEmbedOptions {
   questionId?: never;
 }
 
-export interface ManageContentEmbedOptions {
+export interface BrowserEmbedOptions {
   componentName: "metabase-browser";
 
   /** Which collection to start from? */
@@ -143,7 +143,7 @@ export type SdkIframeEmbedTemplateSettings =
   | DashboardEmbedOptions
   | QuestionEmbedOptions
   | ExplorationEmbedOptions
-  | ManageContentEmbedOptions;
+  | BrowserEmbedOptions;
 
 /** Settings used by the sdk embed route */
 export type SdkIframeEmbedSettings = SdkIframeEmbedBaseSettings &
@@ -159,4 +159,4 @@ export type SdkIframeEmbedSettingKey =
   | keyof DashboardEmbedOptions
   | keyof QuestionEmbedOptions
   | keyof ExplorationEmbedOptions
-  | keyof ManageContentEmbedOptions;
+  | keyof BrowserEmbedOptions;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -129,7 +129,8 @@ export const SdkIframeEmbedPreview = () => {
               : undefined,
           }),
         )
-        .otherwise(() => null)}
+        .with({ componentName: "metabase-browser" }, () => null)
+        .exhaustive()}
     </Card>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -129,7 +129,7 @@ export const SdkIframeEmbedPreview = () => {
               : undefined,
           }),
         )
-        .exhaustive()}
+        .otherwise(() => null)}
     </Card>
   );
 };


### PR DESCRIPTION
Closes EMB-605

Adds a single custom element that renders the collection browser, and allows you to do read-only operations (by default, or `read-only="true"`) or do read-write operations (with `read-only="false"`)

- Collection browser with configurable columns and page size  
- Navigate to questions/dashboards
- "New Exploration" button for ad-hoc queries
- Breadcrumb navigation

With `read-only="false"`
- All of the above, plus:
- "New Dashboard" button to create new dashboards
- Save questions directly to the target collection without collection picker, based on the top-level collection you are in.

## Custom element attributes

- `initial-collection: CollectionId` (required) - what collection to start from? example: `root`
- `read-only: boolean` (optional, defaults to `true`) - whether to enable editing
- `collection-visible-columns: CollectionBrowserListColumns[]` - what columns should be visible? example: `['name']`
- `collection-page-size: number` - how many items to show at a time in a collection
- `collection-entity-types: CollectionBrowserEntityTypes[]` - what entity types should be visible in the collection?
- `data-picker-entity-types: EmbeddingEntityType[]` - what entity types should be visible in the data picker?
- `with-new-question: boolean` (default: true) - should we show the "New Question" menu?
- `with-new-dashboard: boolean` (default: true) - should we show the "New Dashboard" menu?

## How to test

Use this HTML code snippet. I personally served it from a Python server using `python3 -m http.server 4567`, but you can use any web server you like to serve this HTML.

You can use the above custom element attributes and play around with it. If you are not sure about the syntax, look at the Cypress E2E test.

```html
<script defer src="http://localhost:3000/app/embed.js"></script>

<style>
body {
  margin: 0;
}
</style>

<script>
function defineMetabaseConfig(config) {
  window.metabaseConfig = config;
}
</script>

<script>
  defineMetabaseConfig({
    "instanceUrl": "http://localhost:3000",
    "useExistingUserSession": true,
  });
</script>

<div>
  <metabase-browser
    initial-collection="root"
    collection-visible-columns="['type', 'name']"
  ></metabase-browser>
</div>


```

## Screenshots

Collection Browser

<img width="2246" height="1604" alt="CleanShot 2568-08-19 at 00 47 35@2x" src="https://github.com/user-attachments/assets/8d45c38c-7d98-438c-b10f-4879af0daef7" />

Viewing Dashboards

<img width="2240" height="1608" alt="CleanShot 2568-08-19 at 00 48 36@2x" src="https://github.com/user-attachments/assets/449dadac-5629-4f7f-bcb4-c829603026b6" />

Editing Dashboards

<img width="2248" height="1606" alt="CleanShot 2568-08-19 at 00 48 49@2x" src="https://github.com/user-attachments/assets/54a705ae-c21e-4a43-887b-6cb69c49448f" />

Viewing Questions

<img width="2250" height="1606" alt="CleanShot 2568-08-19 at 00 49 05@2x" src="https://github.com/user-attachments/assets/09d4f3b2-4a38-46f6-90db-527405cf4e47" />

New Custom Exploration

<img width="2252" height="1604" alt="CleanShot 2568-08-19 at 00 48 17@2x" src="https://github.com/user-attachments/assets/1d4cefb4-084b-48d6-999b-49615507383f" />