### PR TITLE
SEM-486 Empty state when there's no data to preview and it's legit

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -2709,87 +2709,112 @@ describe("scenarios > admin > datamodel", () => {
   });
 
   describe("Preview section", () => {
-    it("should allow closing the preview with Esc key", () => {
-      H.DataModel.visit({
-        databaseId: SAMPLE_DB_ID,
-        schemaId: SAMPLE_DB_SCHEMA_ID,
-        tableId: ORDERS_ID,
-        fieldId: ORDERS.PRODUCT_ID,
+    describe("Esc key", () => {
+      it("should allow closing the preview with Esc key", () => {
+        H.DataModel.visit({
+          databaseId: SAMPLE_DB_ID,
+          schemaId: SAMPLE_DB_SCHEMA_ID,
+          tableId: ORDERS_ID,
+          fieldId: ORDERS.PRODUCT_ID,
+        });
+
+        PreviewSection.get().should("not.exist");
+
+        FieldSection.getPreviewButton().click();
+        FieldSection.getPreviewButton().should("not.exist");
+        PreviewSection.get().should("be.visible");
+
+        cy.realPress("Escape");
+        PreviewSection.get().should("not.exist");
+        FieldSection.getPreviewButton().should("be.visible");
       });
 
-      PreviewSection.get().should("not.exist");
+      it("should not close the preview when hitting Esc key while modal is open", () => {
+        H.DataModel.visit({
+          databaseId: SAMPLE_DB_ID,
+          schemaId: SAMPLE_DB_SCHEMA_ID,
+          tableId: ORDERS_ID,
+          fieldId: ORDERS.PRODUCT_ID,
+        });
 
-      FieldSection.getPreviewButton().click();
-      FieldSection.getPreviewButton().should("not.exist");
-      PreviewSection.get().should("be.visible");
+        FieldSection.getPreviewButton().click();
+        PreviewSection.get().should("be.visible");
 
-      cy.realPress("Escape");
-      PreviewSection.get().should("not.exist");
-      FieldSection.getPreviewButton().should("be.visible");
+        TableSection.getSyncOptionsButton().click();
+        H.modal().should("be.visible");
+
+        cy.realPress("Escape");
+        H.modal().should("not.exist");
+        PreviewSection.get().should("be.visible");
+
+        FieldSection.getFieldValuesButton().click();
+        H.modal().should("be.visible");
+
+        cy.realPress("Escape");
+        H.modal().should("not.exist");
+        PreviewSection.get().should("be.visible");
+      });
+
+      it("should not close the preview when hitting Esc key while popover is open", () => {
+        H.DataModel.visit({
+          databaseId: SAMPLE_DB_ID,
+          schemaId: SAMPLE_DB_SCHEMA_ID,
+          tableId: ORDERS_ID,
+          fieldId: ORDERS.PRODUCT_ID,
+        });
+
+        FieldSection.getPreviewButton().click();
+        PreviewSection.get().should("be.visible");
+
+        FieldSection.getSemanticTypeInput().click();
+        H.popover().should("be.visible");
+
+        cy.realPress("Escape");
+        H.popover({ skipVisibilityCheck: true }).should("not.be.visible");
+        PreviewSection.get().should("be.visible");
+      });
+
+      it("should not close the preview when hitting Esc key while command palette is open", () => {
+        H.DataModel.visit({
+          databaseId: SAMPLE_DB_ID,
+          schemaId: SAMPLE_DB_SCHEMA_ID,
+          tableId: ORDERS_ID,
+          fieldId: ORDERS.PRODUCT_ID,
+        });
+
+        FieldSection.getPreviewButton().click();
+        PreviewSection.get().should("be.visible");
+
+        H.openCommandPalette();
+        H.commandPalette().should("be.visible");
+
+        cy.realPress("Escape");
+        H.commandPalette().should("not.exist");
+        PreviewSection.get().should("be.visible");
+      });
     });
 
-    it("should not close the preview when hitting Esc key while modal is open", () => {
-      H.DataModel.visit({
-        databaseId: SAMPLE_DB_ID,
-        schemaId: SAMPLE_DB_SCHEMA_ID,
-        tableId: ORDERS_ID,
-        fieldId: ORDERS.PRODUCT_ID,
+    describe("Empty states", { tags: "@external" }, () => {
+      beforeEach(() => {
+        H.restore("postgres-writable");
+        H.resetTestTable({ type: "postgres", table: "multi_schema" });
+        H.resyncDatabase({ dbId: WRITABLE_DB_ID });
+        H.queryWritableDB('delete from "Domestic"."Animals"');
       });
 
-      FieldSection.getPreviewButton().click();
-      PreviewSection.get().should("be.visible");
+      it("should show empty state when there is no data", () => {
+        H.DataModel.visit();
 
-      TableSection.getSyncOptionsButton().click();
-      H.modal().should("be.visible");
+        TablePicker.getDatabase("Writable Postgres12").click();
+        TablePicker.getSchema("Domestic").click();
+        TablePicker.getTable("Animals").click();
+        TableSection.clickField("Name");
+        FieldSection.getPreviewButton().click();
 
-      cy.realPress("Escape");
-      H.modal().should("not.exist");
-      PreviewSection.get().should("be.visible");
-
-      FieldSection.getFieldValuesButton().click();
-      H.modal().should("be.visible");
-
-      cy.realPress("Escape");
-      H.modal().should("not.exist");
-      PreviewSection.get().should("be.visible");
-    });
-
-    it("should not close the preview when hitting Esc key while popover is open", () => {
-      H.DataModel.visit({
-        databaseId: SAMPLE_DB_ID,
-        schemaId: SAMPLE_DB_SCHEMA_ID,
-        tableId: ORDERS_ID,
-        fieldId: ORDERS.PRODUCT_ID,
+        PreviewSection.get().findByText("No data to show").should("be.visible");
+        PreviewSection.getPreviewTypeInput().findByText("Detail").click();
+        PreviewSection.get().findByText("No data to show").should("be.visible");
       });
-
-      FieldSection.getPreviewButton().click();
-      PreviewSection.get().should("be.visible");
-
-      FieldSection.getSemanticTypeInput().click();
-      H.popover().should("be.visible");
-
-      cy.realPress("Escape");
-      H.popover({ skipVisibilityCheck: true }).should("not.be.visible");
-      PreviewSection.get().should("be.visible");
-    });
-
-    it("should not close the preview when hitting Esc key while command palette is open", () => {
-      H.DataModel.visit({
-        databaseId: SAMPLE_DB_ID,
-        schemaId: SAMPLE_DB_SCHEMA_ID,
-        tableId: ORDERS_ID,
-        fieldId: ORDERS.PRODUCT_ID,
-      });
-
-      FieldSection.getPreviewButton().click();
-      PreviewSection.get().should("be.visible");
-
-      H.openCommandPalette();
-      H.commandPalette().should("be.visible");
-
-      cy.realPress("Escape");
-      H.commandPalette().should("not.exist");
-      PreviewSection.get().should("be.visible");
     });
   });
 

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/ObjectDetailPreview.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/ObjectDetailPreview.tsx
@@ -41,10 +41,6 @@ const ObjectDetailPreviewBase = ({
     tableId,
   });
 
-  if (error) {
-    return <Error message={error} />;
-  }
-
   const data = rawSeries?.[0]?.data;
   const zoomedRow = data?.rows[0];
 
@@ -58,10 +54,14 @@ const ObjectDetailPreviewBase = ({
     );
   }
 
+  if (error) {
+    return <Error message={error} />;
+  }
+
   if (!data || !zoomedRow) {
     return (
       <Stack h="100%" justify="center" p="md">
-        <EmptyState title={t`No data to show.`} />
+        <EmptyState title={t`No data to show`} />
       </Stack>
     );
   }

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
@@ -4,6 +4,7 @@ import _ from "underscore";
 
 import { useGetAdhocQueryQuery } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
+import EmptyState from "metabase/common/components/EmptyState";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
 import { Repeat, Skeleton, Stack } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -34,6 +35,7 @@ interface Props {
 
 const TablePreviewBase = (props: Props) => {
   const { error, isFetching, rawSeries } = useDataSample(props);
+  const data = rawSeries?.[0]?.data?.rows;
 
   if (isFetching) {
     return (
@@ -49,6 +51,14 @@ const TablePreviewBase = (props: Props) => {
 
   if (error) {
     return <Error message={error} />;
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <Stack h="100%" justify="center" p="md">
+        <EmptyState title={t`No data to show`} />
+      </Stack>
+    );
   }
 
   return (

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/TablePicker.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/TablePicker.tsx
@@ -98,7 +98,7 @@ function Tree({
   }, [databaseId, schemaName, tree, toggle, isExpanded, onChange]);
 
   if (isEmpty) {
-    return <EmptyState title={t`No data to show.`} />;
+    return <EmptyState title={t`No data to show`} />;
   }
 
   return (


### PR DESCRIPTION
Closes [SEM-486](https://linear.app/metabase/issue/SEM-486/empty-state-when-theres-no-data-to-preview-and-its-legit)

### Description

_Hiding whitespace changes recommended._

### How to verify

1. Have a table with no data
2. Open any field from that table in Admin > Table metadata
3. Open table preview

There should be "No data to show" message.

4. Open detail preview

There should be "No data to show" message.
