### PR TITLE
SEM-444 Remove the "Add filter" button from the filter preview

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -1959,9 +1959,10 @@ describe("scenarios > admin > datamodel", () => {
           TableSection.clickField("Quantity");
           FieldSection.getPreviewButton().click();
           PreviewSection.getPreviewTypeInput().findByText("Filtering").click();
-          PreviewSection.get()
-            .findByPlaceholderText("Enter a number")
-            .should("be.visible");
+          PreviewSection.get().within(() => {
+            cy.findByPlaceholderText("Enter a number").should("be.visible");
+            cy.button(/Add filter/).should("not.exist");
+          });
 
           cy.reload();
           FieldSection.getFilteringInput()
@@ -1989,12 +1990,11 @@ describe("scenarios > admin > datamodel", () => {
           TableSection.clickField("Quantity");
           FieldSection.getPreviewButton().click();
           PreviewSection.getPreviewTypeInput().findByText("Filtering").click();
-          PreviewSection.get()
-            .findByPlaceholderText("Min")
-            .should("be.visible");
-          PreviewSection.get()
-            .findByPlaceholderText("Max")
-            .should("be.visible");
+          PreviewSection.get().within(() => {
+            cy.findByPlaceholderText("Min").should("be.visible");
+            cy.findByPlaceholderText("Max").should("be.visible");
+            cy.button(/Add filter/).should("not.exist");
+          });
 
           cy.reload();
           FieldSection.getFilteringInput()
@@ -2025,9 +2025,10 @@ describe("scenarios > admin > datamodel", () => {
           TableSection.clickField("Quantity");
           FieldSection.getPreviewButton().click();
           PreviewSection.getPreviewTypeInput().findByText("Filtering").click();
-          PreviewSection.get()
-            .findByPlaceholderText("Search the list")
-            .should("be.visible");
+          PreviewSection.get().within(() => {
+            cy.findByPlaceholderText("Search the list").should("be.visible");
+            cy.button(/Add filter/).should("not.exist");
+          });
 
           cy.reload();
           FieldSection.getFilteringInput()

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/FilteringPreview.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/FilteringPreview.tsx
@@ -34,6 +34,7 @@ const FilteringPreviewBase = ({ databaseId, fieldId, table }: Props) => {
       column={column}
       query={query}
       stageIndex={STAGE_INDEX}
+      withSubmitButton={false}
       onChange={_.noop}
     />
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -18,6 +18,7 @@ export function BooleanFilterPicker({
   filter,
   isNew,
   withAddButton,
+  withSubmitButton,
   onBack,
   onChange,
 }: FilterPickerWidgetProps) {
@@ -64,6 +65,7 @@ export function BooleanFilterPicker({
         isNew={isNew}
         isValid
         withAddButton={withAddButton}
+        withSubmitButton={withSubmitButton}
         onAddButtonClick={handleAddButtonClick}
       />
     </Box>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
@@ -37,6 +37,7 @@ function setup({
       filter={filter}
       isNew={!filter}
       withAddButton={withAddButton}
+      withSubmitButton
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -27,6 +27,7 @@ export function CoordinateFilterPicker({
   filter,
   isNew,
   withAddButton,
+  withSubmitButton,
   onChange,
   onBack,
 }: FilterPickerWidgetProps) {
@@ -119,6 +120,7 @@ export function CoordinateFilterPicker({
           isNew={isNew}
           isValid={isValid}
           withAddButton={withAddButton}
+          withSubmitButton={withSubmitButton}
           onAddButtonClick={handleAddButtonClick}
         />
       </Box>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
@@ -65,6 +65,7 @@ function setup({
       filter={filter}
       isNew={!filter}
       withAddButton={withAddButton}
+      withSubmitButton
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -16,6 +16,7 @@ export function DateFilterPicker({
   filter,
   isNew,
   withAddButton,
+  withSubmitButton,
   onChange,
   onBack,
 }: FilterPickerWidgetProps) {
@@ -45,14 +46,20 @@ export function DateFilterPicker({
         value={value}
         availableOperators={availableOperators}
         availableUnits={availableUnits}
-        renderSubmitButton={({ value, isDisabled }) => (
-          <FilterSubmitButton
-            isNew={isNew}
-            isDisabled={isDisabled}
-            withAddButton={withAddButton}
-            onAddButtonClick={() => handleAddButtonClick(value)}
-          />
-        )}
+        renderSubmitButton={({ value, isDisabled }) => {
+          if (!withSubmitButton) {
+            return null;
+          }
+
+          return (
+            <FilterSubmitButton
+              isNew={isNew}
+              isDisabled={isDisabled}
+              withAddButton={withAddButton}
+              onAddButtonClick={() => handleAddButtonClick(value)}
+            />
+          );
+        }}
         renderBackButton={() =>
           onBack ? (
             <PopoverBackButton p="sm" onClick={onBack}>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
@@ -44,6 +44,7 @@ function setup({
       filter={filter}
       isNew={isNew}
       withAddButton={withAddButton}
+      withSubmitButton
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
@@ -17,6 +17,7 @@ export function DefaultFilterPicker({
   filter,
   isNew,
   withAddButton,
+  withSubmitButton,
   onBack,
   onChange,
 }: FilterPickerWidgetProps) {
@@ -88,6 +89,7 @@ export function DefaultFilterPicker({
           isNew={isNew}
           isValid
           withAddButton={withAddButton}
+          withSubmitButton={withSubmitButton}
           onAddButtonClick={handleAddButtonClick}
         />
       </div>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
@@ -38,6 +38,7 @@ function setup({
       filter={filter}
       isNew={!filter}
       withAddButton={withAddButton}
+      withSubmitButton
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
@@ -16,6 +16,7 @@ interface FilterPickerBodyProps {
   filter?: Lib.Filterable;
   isNew?: boolean;
   withAddButton?: boolean;
+  withSubmitButton?: boolean;
   onChange: (filter: Lib.ExpressionClause, opts: FilterChangeOpts) => void;
   onBack?: () => void;
 }
@@ -27,6 +28,7 @@ export function FilterPickerBody({
   filter,
   isNew = filter == null,
   withAddButton = false,
+  withSubmitButton = true,
   onChange,
   onBack,
 }: FilterPickerBodyProps) {
@@ -43,6 +45,7 @@ export function FilterPickerBody({
       filter={filter}
       isNew={isNew}
       withAddButton={withAddButton}
+      withSubmitButton={withSubmitButton}
       onChange={onChange}
       onBack={onBack}
     />

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.unit.spec.tsx
@@ -123,6 +123,7 @@ function setup({
       filter={filter}
       isNew={isNew}
       withAddButton={withAddButton}
+      withSubmitButton
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerFooter/FilterPickerFooter.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerFooter/FilterPickerFooter.tsx
@@ -11,6 +11,7 @@ interface FilterPickerFooterProps {
   isNew: boolean;
   isValid: boolean;
   withAddButton: boolean;
+  withSubmitButton: boolean;
   children?: ReactNode;
   onAddButtonClick: () => void;
 }
@@ -18,19 +19,27 @@ interface FilterPickerFooterProps {
 export function FilterPickerFooter({
   isNew,
   isValid,
-  withAddButton = false,
+  withAddButton,
+  withSubmitButton,
   children,
   onAddButtonClick,
 }: FilterPickerFooterProps) {
+  if (!isValidElement(children) && !withSubmitButton) {
+    return null;
+  }
+
   return (
     <Flex className={S.FilterFooterRoot} p="md" justify="space-between">
       {isValidElement(children) ? children : <Box />}
-      <FilterSubmitButton
-        isNew={isNew}
-        isDisabled={!isValid}
-        withAddButton={withAddButton}
-        onAddButtonClick={onAddButtonClick}
-      />
+
+      {withSubmitButton && (
+        <FilterSubmitButton
+          isNew={isNew}
+          isDisabled={!isValid}
+          withAddButton={withAddButton}
+          onAddButtonClick={onAddButtonClick}
+        />
+      )}
     </Flex>
   );
 }

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -25,6 +25,7 @@ export function NumberFilterPicker({
   filter,
   isNew,
   withAddButton,
+  withSubmitButton,
   onChange,
   onBack,
 }: FilterPickerWidgetProps) {
@@ -103,6 +104,7 @@ export function NumberFilterPicker({
           isNew={isNew}
           isValid={isValid}
           withAddButton={withAddButton}
+          withSubmitButton={withSubmitButton}
           onAddButtonClick={handleAddButtonClick}
         />
       </div>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -66,6 +66,7 @@ function setup({
       filter={filter}
       isNew={!filter}
       withAddButton={withAddButton}
+      withSubmitButton
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -23,6 +23,7 @@ export function StringFilterPicker({
   filter,
   isNew,
   withAddButton,
+  withSubmitButton,
   onChange,
   onBack,
 }: FilterPickerWidgetProps) {
@@ -101,6 +102,7 @@ export function StringFilterPicker({
           isNew={isNew}
           isValid={isValid}
           withAddButton={withAddButton}
+          withSubmitButton={withSubmitButton}
           onAddButtonClick={handleAddButtonClick}
         >
           {type === "partial" && (

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -65,6 +65,7 @@ function setup({
       filter={filter}
       isNew={!filter}
       withAddButton={withAddButton}
+      withSubmitButton
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -22,6 +22,7 @@ export function TimeFilterPicker({
   filter,
   isNew,
   withAddButton,
+  withSubmitButton,
   onChange,
   onBack,
 }: FilterPickerWidgetProps) {
@@ -98,6 +99,7 @@ export function TimeFilterPicker({
           isNew={isNew}
           isValid
           withAddButton={withAddButton}
+          withSubmitButton={withSubmitButton}
           onAddButtonClick={handleAddButtonClick}
         />
       </Box>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -56,6 +56,7 @@ function setup({
       filter={filter}
       isNew={!filter}
       withAddButton={withAddButton}
+      withSubmitButton
       onChange={onChange}
       onBack={onBack}
     />,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
@@ -8,6 +8,7 @@ export type FilterPickerWidgetProps = {
   filter?: Lib.Filterable;
   isNew: boolean;
   withAddButton: boolean;
+  withSubmitButton: boolean;
   onChange: (filter: Lib.ExpressionClause, opts: FilterChangeOpts) => void;
   onBack?: () => void;
 };


### PR DESCRIPTION
Closes [SEM-444](https://linear.app/metabase/issue/SEM-444/remove-the-add-filter-button-from-the-filter-preview)

### Description

Adds `withSubmitButton` prop to `FilterPickerWidgetProps` and `FilterPickerBody`.
It defaults to `true`. It's `false` in 1 case: field filtering preview in Admin > Table metadata page.
`FilterPickerFooter` is now smart to not render itself when it does not have any children (because of its `border-top`).

### How to verify

1. Admin > Table metadata
2. Open a field
3. Open preview
4. Open filtering preview

There should be no submit button.
If there's nothing else in the filter picker footer, the footer should not be rendered.
Filter picker footer should still be rendered e.g. for date pickers, because of the "Add time" button (see demo screenshot below).

### Demo

<img width="2855" height="1363" alt="image" src="https://github.com/user-attachments/assets/5d432f8e-8fff-4e06-bc74-e9aa29c2b9db" />

