### PR TITLE
SEM-433 Empty table preview of columns with hidden visibility

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -1842,11 +1842,10 @@ describe("scenarios > admin > datamodel", () => {
           cy.log("verify preview");
           TableSection.clickField("Tax");
           FieldSection.getPreviewButton().click();
-
-          // TODO: assert table preview shows empty state
-          // https://linear.app/metabase/issue/SEM-433/empty-table-preview-of-columns-with-hidden-visibility
-          // Currently works incorrectly because of metabase#60487
-
+          PreviewSection.get()
+            .findByText("This field is hidden")
+            .should("be.visible");
+          cy.get("@dataset.all").should("have.length", 0);
           PreviewSection.getPreviewTypeInput().findByText("Detail").click();
           cy.wait("@dataset");
           PreviewSection.get().findByText("Tax").should("not.exist");
@@ -1889,11 +1888,10 @@ describe("scenarios > admin > datamodel", () => {
           cy.log("verify preview");
           TableSection.clickField("Tax");
           FieldSection.getPreviewButton().click();
-          cy.wait("@dataset");
-          // TODO: https://linear.app/metabase/issue/SEM-433/empty-table-preview-of-columns-with-hidden-visibility
           PreviewSection.get()
-            .findByText("Every field is hidden right now")
+            .findByText("This field is hidden")
             .should("be.visible");
+          cy.get("@dataset.all").should("have.length", 0);
           verifyObjectDetailPreview({
             index: 4,
             row: ["Tax", "2.07"],

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/TablePreview.tsx
@@ -38,7 +38,11 @@ const TablePreviewBase = (props: Props) => {
   const { error, isFetching, rawSeries } = useDataSample(props);
 
   if (isFieldHidden(field)) {
-    return <EmptyState message={t`This field is hidden`} />;
+    return (
+      <Stack h="100%" justify="center" p="md">
+        <EmptyState message={t`This field is hidden`} />
+      </Stack>
+    );
   }
 
   if (isFetching) {


### PR DESCRIPTION
Closes [SEM-433](https://linear.app/metabase/issue/SEM-433/empty-table-preview-of-columns-with-hidden-visibility)

### Description

Shows "This field is hidden message" in field table preview when field's visibility is "Do not include" or "Only in detail views".

### How to verify

1. Admin > Table metadata
2. Open field
3. Open preview
4. Change field's visibility to "Do not include" or "Only in detail views"

### Demo

<img width="1837" height="1437" alt="image" src="https://github.com/user-attachments/assets/d96ada5e-2af7-48b1-a222-06d9a6010e25" />
