### PR TITLE
Disable workaround for #57596

### DIFF
--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -328,7 +328,7 @@
                             :dashboard-id           dashboard-id
                             :visualization-settings merged-viz}
                      (and (= (:type card) :model)
-                          (not= :table-editable (:display card))
+                          #_(not= :table-editable (:display card))
                           (seq (:result_metadata card)))
                      (assoc :metadata/model-metadata (:result_metadata card)))]
     (when (seq parameters)


### PR DESCRIPTION
Removes workaround for [the issue](https://github.com/metabase/metabase/issues/57596) connecting dashboard filters to FK walking fields on a model.
