### PR TITLE
Prg-91-migrate-upsell-components-to-support-ee-upsell-flow

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/license/index.js
@@ -1,5 +1,8 @@
 import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 
 import { LicenseAndBillingSettings } from "./components/LicenseAndBillingSettings";
+import { useUpsellFlow } from "./use-upsell-flow";
 
 PLUGIN_ADMIN_SETTINGS.LicenseAndBillingSettings = LicenseAndBillingSettings;
+
+PLUGIN_ADMIN_SETTINGS.useUpsellFlow = useUpsellFlow;

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup.tsx
@@ -5,6 +5,7 @@ import {
   setupCollectionPermissionsGraphEndpoint,
   setupCollectionsEndpoints,
   setupGroupsEndpoint,
+  setupTokenStatusEndpoint,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
@@ -134,6 +135,8 @@ export function setup({
     collections,
     rootCollection,
   });
+
+  setupTokenStatusEndpoint(true);
 
   setupCollectionPermissionsGraphEndpoint(permissionsGraph);
   setupGroupsEndpoint(permissionGroups);

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
@@ -3,6 +3,7 @@ import {
   findRequests,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
+  setupTokenStatusEndpoint,
   setupUpdateSettingEndpoint,
   setupUpdateSettingsEndpoint,
   setupUserKeyValueEndpoints,
@@ -46,6 +47,7 @@ export async function setup({
 
   if (hasEnterprisePlugins) {
     setupEnterprisePlugins();
+    setupTokenStatusEndpoint(true);
   }
 
   setupPropertiesEndpoints(settings);
@@ -64,7 +66,7 @@ export async function setup({
 
   await waitFor(async () => {
     const gets = await findRequests("GET");
-    expect(gets).toHaveLength(3);
+    expect(gets).toHaveLength(hasEnterprisePlugins ? 4 : 3);
   });
 
   await screen.findByText("Embedding SDK");

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
@@ -66,7 +66,16 @@ export async function setup({
 
   await waitFor(async () => {
     const gets = await findRequests("GET");
-    expect(gets).toHaveLength(hasEnterprisePlugins ? 4 : 3);
+    expect(gets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          url: expect.stringContaining("/api/setting"),
+        }),
+        expect.objectContaining({
+          url: expect.stringContaining("/api/session/properties"),
+        }),
+      ]),
+    );
   });
 
   await screen.findByText("Embedding SDK");

--- a/frontend/src/metabase/admin/upsells/UpsellBetterSupport.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellBetterSupport.tsx
@@ -2,6 +2,7 @@ import { c, t } from "ttag";
 
 import { getPlan } from "metabase/common/utils/plan";
 import { useSelector } from "metabase/lib/redux";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 import { getSetting } from "metabase/selectors/settings";
 import { Text } from "metabase/ui";
 
@@ -9,6 +10,12 @@ import { UpsellBanner } from "./components";
 import { UPGRADE_URL } from "./constants";
 
 export const UpsellBetterSupport = ({ location }: { location: string }) => {
+  const campaign = "better-hosting";
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
+
   const plan = useSelector((state) =>
     getPlan(getSetting(state, "token-features")),
   );
@@ -20,10 +27,11 @@ export const UpsellBetterSupport = ({ location }: { location: string }) => {
   return (
     <UpsellBanner
       title={t`Get expert help`}
-      campaign="better-hosting"
+      campaign={campaign}
       buttonText={t`Try for free`}
       buttonLink={UPGRADE_URL}
       location={location}
+      onClick={triggerUpsellFlow}
     >
       <Text size="sm">
         {t`Unlimited support from success engineers whenever you need it with any paid plan.`}{" "}

--- a/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { useSetting } from "metabase/common/hooks";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 import { getStoreUrl } from "metabase/selectors/settings";
 import { Text } from "metabase/ui";
 
@@ -10,6 +11,11 @@ type LOCATION = "embedding-page" | "settings-general";
 
 export function UpsellDevInstances({ location }: { location: LOCATION }) {
   const isDevMode = useSetting("development-mode?");
+  const campaign = "dev_instances";
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
 
   if (isDevMode) {
     return null;
@@ -18,11 +24,12 @@ export function UpsellDevInstances({ location }: { location: LOCATION }) {
   return (
     <UpsellBanner
       title={t`Get a development instance`}
-      campaign="dev_instances"
+      campaign={campaign}
       buttonText={t`Set up`}
       buttonLink={getStoreUrl("account/new-dev-instance")}
       location={location}
       dismissible
+      onClick={triggerUpsellFlow}
     >
       <Text size="sm">
         {t`Test out code in staging in a separate Metabase instance before deploying to production.`}

--- a/frontend/src/metabase/admin/upsells/UpsellPermissions.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellPermissions.tsx
@@ -1,11 +1,18 @@
 import { t } from "ttag";
 
 import { useHasTokenFeature } from "metabase/common/hooks";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 
 import { UpsellBanner } from "./components";
 import { UPGRADE_URL } from "./constants";
 
 export const UpsellPermissions = ({ location }: { location: string }) => {
+  const campaign = "advanced-permissions";
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
+
   const hasAdvancedPermissions = useHasTokenFeature("advanced_permissions");
 
   if (hasAdvancedPermissions) {
@@ -19,6 +26,7 @@ export const UpsellPermissions = ({ location }: { location: string }) => {
       buttonLink={UPGRADE_URL}
       location={location}
       title={t`Get advanced permissions`}
+      onClick={triggerUpsellFlow}
     >
       {t`Granular control down to the row- and column-level security. Manage advanced permissions per user group, or even at the database level.`}
     </UpsellBanner>

--- a/frontend/src/metabase/admin/upsells/UpsellStorage.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellStorage.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 import { getStoreUrl } from "metabase/selectors/settings";
 import { List } from "metabase/ui";
 
@@ -12,6 +13,12 @@ import { UpsellBanner } from "./components";
 export const BUY_STORAGE_URL = getStoreUrl("account/storage");
 
 export const UpsellStorage = ({ location }: { location: string }) => {
+  const campaign = "storage";
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
+
   const isHosted = useSetting("is-hosted?");
   const hasStorage = useHasTokenFeature("attached_dwh");
 
@@ -27,6 +34,7 @@ export const UpsellStorage = ({ location }: { location: string }) => {
       location={location}
       title={t`Add Metabase Storage`}
       large
+      onClick={triggerUpsellFlow}
     >
       <List
         mt="xs"

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.stories.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.stories.tsx
@@ -83,6 +83,16 @@ export const Secondary = {
   render: SecondaryTemplate,
 };
 
+export const WithOnClick = {
+  render: (args: UpsellBannerProps) => (
+    <ReduxProvider>
+      <Box>
+        <_UpsellBanner {...args} onClick={action("clicked")} />
+      </Box>
+    </ReduxProvider>
+  ),
+};
+
 export const Dismissible = {
   render: (args: UpsellBannerProps) => (
     <ReduxProvider>

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.stories.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.stories.tsx
@@ -83,6 +83,15 @@ export const Secondary = {
   render: SecondaryTemplate,
 };
 
+export const WithInternalLink = {
+  render: DefaultTemplate,
+  args: {
+    ...args,
+    internalLink: "/internal-link",
+    buttonText: "Internal link text",
+  },
+};
+
 export const WithOnClick = {
   render: (args: UpsellBannerProps) => (
     <ReduxProvider>

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
@@ -44,6 +44,7 @@ type UpsellBannerPropsBase = {
   large?: boolean;
   children: React.ReactNode;
   style?: React.CSSProperties;
+  onClick?: () => void;
 };
 
 export type UpsellBannerProps =
@@ -59,6 +60,7 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
   location,
   large,
   children,
+  onClick,
   ...props
 }: UpsellBannerProps) => {
   const url = useUpsellLink({
@@ -98,7 +100,18 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
       </Flex>
 
       <Flex align="center" gap="md">
-        {buttonLink !== undefined ? (
+        {onClick !== undefined && (
+          <UnstyledButton
+            onClick={() => {
+              trackUpsellClicked({ location, campaign });
+              onClick();
+            }}
+            className={S.UpsellCTALink}
+          >
+            {buttonText}
+          </UnstyledButton>
+        )}
+        {buttonLink !== undefined && onClick === undefined && (
           <ExternalLink
             onClickCapture={() => trackUpsellClicked({ location, campaign })}
             href={url}
@@ -106,7 +119,8 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
           >
             {buttonText}
           </ExternalLink>
-        ) : (
+        )}
+        {internalLink !== undefined && onClick === undefined && (
           <Link
             onClickCapture={() => trackUpsellClicked({ location, campaign })}
             to={internalLink}

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import { useMount } from "react-use";
+import { P, match } from "ts-pattern";
 import { t } from "ttag";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
@@ -100,35 +101,62 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
       </Flex>
 
       <Flex align="center" gap="md">
-        {onClick !== undefined && (
-          <UnstyledButton
-            onClick={() => {
-              trackUpsellClicked({ location, campaign });
-              onClick();
-            }}
-            className={S.UpsellCTALink}
-          >
-            {buttonText}
-          </UnstyledButton>
-        )}
-        {buttonLink !== undefined && onClick === undefined && (
-          <ExternalLink
-            onClickCapture={() => trackUpsellClicked({ location, campaign })}
-            href={url}
-            className={S.UpsellCTALink}
-          >
-            {buttonText}
-          </ExternalLink>
-        )}
-        {internalLink !== undefined && onClick === undefined && (
-          <Link
-            onClickCapture={() => trackUpsellClicked({ location, campaign })}
-            to={internalLink}
-            className={S.UpsellCTALink}
-          >
-            {buttonText}
-          </Link>
-        )}
+        {match({ onClick, buttonLink, internalLink })
+          .with(
+            {
+              onClick: P.nonNullable,
+              buttonLink: P.any,
+              internalLink: P.nullish,
+            },
+            (args) => (
+              <UnstyledButton
+                onClick={() => {
+                  trackUpsellClicked({ location, campaign });
+                  args.onClick();
+                }}
+                className={S.UpsellCTALink}
+              >
+                {buttonText}
+              </UnstyledButton>
+            ),
+          )
+          .with(
+            {
+              onClick: P.any,
+              buttonLink: P.nonNullable,
+              internalLink: P.nullish,
+            },
+            () => (
+              <ExternalLink
+                onClickCapture={() =>
+                  trackUpsellClicked({ location, campaign })
+                }
+                href={url}
+                className={S.UpsellCTALink}
+              >
+                {buttonText}
+              </ExternalLink>
+            ),
+          )
+          .with(
+            {
+              onClick: P.any,
+              buttonLink: P.any,
+              internalLink: P.nonNullable,
+            },
+            (args) => (
+              <Link
+                onClickCapture={() =>
+                  trackUpsellClicked({ location, campaign })
+                }
+                to={args.internalLink}
+                className={S.UpsellCTALink}
+              >
+                {buttonText}
+              </Link>
+            ),
+          )
+          .otherwise(() => null)}
 
         {dismissible && (
           <UnstyledButton

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
@@ -22,12 +22,8 @@ describe("Add data modal (Starter: hosted instance without the attached DWH)", (
       ).toBeInTheDocument();
       expect(screen.getByText("Upload CSV files")).toBeInTheDocument();
       expect(screen.getByText("Sync with Google Sheets")).toBeInTheDocument();
-      const upsellLink = screen.getByRole("link", { name: "Add" });
+      const upsellLink = screen.getByRole("button", { name: "Add" });
       expect(upsellLink).toBeInTheDocument();
-      expect(upsellLink).toHaveAttribute(
-        "href",
-        "https://store.metabase.com/account/storage?utm_source=product&utm_medium=upsell&utm_campaign=storage&utm_content=add-data-modal-sheets&source_plan=starter",
-      );
     });
 
     it("should render a 'contact admin prompt' for non-admin", async () => {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/setup.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/setup.tsx
@@ -4,6 +4,7 @@ import {
   setupGdriveGetFolderEndpoint,
   setupGdrivePostFolderEndpoint,
   setupGdriveServiceAccountEndpoint,
+  setupTokenStatusEndpoint,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
@@ -86,12 +87,14 @@ export const setup = ({
         schema_name: "uploads",
         table_prefix: "uploaded_",
       },
+      "store-url": "https://store.metabase.com",
     }),
   });
 
   if (hasEnterprisePlugins) {
     setupEnterprisePlugins();
   }
+  setupTokenStatusEndpoint(true);
 
   setupDatabaseListEndpoint(databases);
 

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -122,6 +122,14 @@ export const PLUGIN_WHITELABEL = {
 export const PLUGIN_ADMIN_SETTINGS = {
   InteractiveEmbeddingSettings: NotFoundPlaceholder,
   LicenseAndBillingSettings: PluginPlaceholder,
+  useUpsellFlow: (_props: {
+    campaign: string;
+    location: string;
+  }): {
+    triggerUpsellFlow: (() => void) | undefined;
+  } => ({
+    triggerUpsellFlow: undefined,
+  }),
 };
 
 // admin permissions


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-91/migrate-upsellbanner-components-to-support-ee-upsell-flow

### Description

- Added `useUpsell` as premium plugin in the way discussed and [decided in the document](https://www.notion.so/metabase/OSS-Upsells-migration-to-EE-versions-22c69354c9018016a337f8ac57075838?source=copy_link)
- I've added `onClick` support to UpselBanner
- Added new upsell flow to all UpsellBanner based upsells that have `buttonLink`

### Follow-up tickets
- https://linear.app/metabase/issue/PRG-96/migrate-upsellbigcard-to-new-upsell-flow
- https://linear.app/metabase/issue/PRG-95/migrate-upsellcard-to-the-new-upsell-flow
- https://linear.app/metabase/issue/PRG-97/migrate-upsellpill-to-the-new-upsell-flow

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
