### PR TITLE
SEM-498 No focus state for the field item in table section

### DIFF
--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.module.css
@@ -1,11 +1,16 @@
 .card {
   box-shadow: 0 2px 4px 0 hsla(0, 0%, 0%, 0.05) !important;
+  overflow: visible; /* so that outline from focus state of inner <a /> is not cut off */
 
   &:hover {
     &:not(.active) {
       background-color: var(--mb-color-background-light) !important;
     }
   }
+}
+
+.link {
+  border-radius: inherit;
 }
 
 .icon {

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.tsx
@@ -111,6 +111,7 @@ export const FieldItem = ({ active, field, href, parent }: Props) => {
     >
       <Flex
         align="flex-start"
+        className={S.link}
         component={Link}
         direction="column"
         draggable={false} // this + onClick handler is required, otherwise interaction is broken on macOS


### PR DESCRIPTION
Closes [SEM-498](https://linear.app/metabase/issue/SEM-498/no-focus-state-for-the-field-item-in-table-section)

### Description

No tests because AFAIK it's not possible to assert outline visibility in Cypress.

### How to verify

1. Admin > Table metadata
2. Open a table
3. Focus name input of the first field
4. Hit <kbd>Tab</kbd> twice
5. Next field's outline should be visibile

### Demo

https://github.com/user-attachments/assets/71608125-af87-43d7-8867-f8b576e8b303
