### PR TITLE
Fix issue where "official" icon is incorrectly small in dash cards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -251,7 +251,7 @@ function DashCardInner({
     const authorityLevel = dashcard.collection_authority_level;
     if (isRegularDashboard && !isRegularQuestion && authorityLevel) {
       const opts = PLUGIN_COLLECTIONS.AUTHORITY_LEVEL[authorityLevel];
-      const iconSize = 14;
+      const iconSize = 16;
       return {
         name: opts.icon,
         color: opts.color ? color(opts.color) : undefined,

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.styled.tsx
@@ -28,7 +28,8 @@ export const LegendLabel = styled(BaseLegendLabel)`
 `;
 
 export const LegendLabelIcon = styled(Icon)`
-  padding-right: 0.25rem;
+  flex-shrink: 0;
+  margin-right: 0.25rem;
 `;
 
 export const LegendDescriptionIcon = styled(


### PR DESCRIPTION
### Description

[Slack thread](https://metaboat.slack.com/archives/C064QMXEV9N/p1752180512220499)

* Increases the size of the "official" badge in dash card headers from 14px to 16px to match how icons are typically displayed.
* Changes padding -> margin so the spacing doesn't decrease the svg size
* Adds `flex-shrink: 0` so the icon doesn't ever look like an icon for ants

### How to verify

1. Mark a collection as Official and add a question to it
2. Add the question to a dashboard
3. Verify the Official badge shows up to the left of the dash card header at 16x16

### Demo

**BEFORE**
This issue has been around for a while. Here are small icons on v54.

<img width="1265" height="764" alt="v54" src="https://github.com/user-attachments/assets/2816c44a-3746-45c5-8100-d2b45895f0c4" />

We increased the font-size of dash card headers recently which made the issue more pronounced.

<img width="1265" height="764" alt="stats" src="https://github.com/user-attachments/assets/cfc2f98d-65e2-437a-a01e-e153157853f1" />

**AFTER**

<img width="1265" height="764" alt="after" src="https://github.com/user-attachments/assets/6da20d0a-09b5-417e-bd82-73bbd8199b57" />
