### PR TITLE
Repro #55563 - Bigquery STRUCT types don't allow renaming in Admin -> Table Metadata

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -889,16 +889,18 @@ describe("scenarios > admin > datamodel", () => {
           .should("be.checked");
 
         H.openProductsTable();
-        assertTableHeader([
-          "ID",
-          "Ean",
-          "Title",
-          "Category",
-          "Vendor",
-          "Price",
-          "Rating",
-          "Created At",
-        ]);
+        H.assertTableData({
+          columns: [
+            "ID",
+            "Ean",
+            "Title",
+            "Category",
+            "Vendor",
+            "Price",
+            "Rating",
+            "Created At",
+          ],
+        });
       });
 
       it("should allow sorting fields alphabetically", () => {
@@ -919,16 +921,18 @@ describe("scenarios > admin > datamodel", () => {
           .should("be.checked");
 
         H.openProductsTable();
-        assertTableHeader([
-          "Category",
-          "Created At",
-          "Ean",
-          "ID",
-          "Price",
-          "Rating",
-          "Title",
-          "Vendor",
-        ]);
+        H.assertTableData({
+          columns: [
+            "Category",
+            "Created At",
+            "Ean",
+            "ID",
+            "Price",
+            "Rating",
+            "Title",
+            "Vendor",
+          ],
+        });
       });
 
       it("should allow sorting fields smartly", () => {
@@ -947,16 +951,18 @@ describe("scenarios > admin > datamodel", () => {
           .should("be.checked");
 
         H.openProductsTable();
-        assertTableHeader([
-          "ID",
-          "Created At",
-          "Category",
-          "Ean",
-          "Price",
-          "Rating",
-          "Title",
-          "Vendor",
-        ]);
+        H.assertTableData({
+          columns: [
+            "ID",
+            "Created At",
+            "Category",
+            "Ean",
+            "Price",
+            "Rating",
+            "Title",
+            "Vendor",
+          ],
+        });
       });
 
       it("should allow sorting fields in the custom order", () => {
@@ -989,16 +995,18 @@ describe("scenarios > admin > datamodel", () => {
           .should("be.checked");
 
         H.openProductsTable();
-        assertTableHeader([
-          "Ean",
-          "ID",
-          "Title",
-          "Category",
-          "Vendor",
-          "Price",
-          "Rating",
-          "Created At",
-        ]);
+        H.assertTableData({
+          columns: [
+            "Ean",
+            "ID",
+            "Title",
+            "Category",
+            "Vendor",
+            "Price",
+            "Rating",
+            "Created At",
+          ],
+        });
       });
 
       it("should allow switching to predefined order after drag & drop (metabase#56482)", () => {
@@ -2574,6 +2582,26 @@ describe("scenarios > admin > datamodel", () => {
           TablePicker.getTable("Many Data Types").click();
           TableSection.getField("Json → A").should("not.exist");
         });
+
+        it("should let you change the name of JSON-unfolded columns (metabase#55563)", () => {
+          // Go to field settings
+          H.DataModel.visit({ databaseId: WRITABLE_DB_ID });
+          TablePicker.getTable("Many Data Types").click();
+          TableSection.clickField("Json → A");
+
+          TableSection.getFieldNameInput("Json → A").clear().type("A").blur();
+          FieldSection.getPreviewButton().click();
+
+          FieldSection.getNameInput().should("have.value", "A");
+          FieldSection.get()
+            .findByTestId("name-prefix")
+            .should("be.visible")
+            .and("have.text", "Json:");
+          verifyTablePreview({
+            column: "A",
+            values: ["10", "10"],
+          });
+        });
       });
     });
 
@@ -2944,15 +2972,6 @@ function turnTableVisibilityOff(tableId: TableId) {
     visibility_type: "hidden",
   });
 }
-
-const assertTableHeader = (columns: string[]) => {
-  cy.findAllByTestId("header-cell").should("have.length", columns.length);
-
-  columns.forEach((column, index) => {
-    // eslint-disable-next-line no-unsafe-element-filtering
-    cy.findAllByTestId("header-cell").eq(index).should("have.text", column);
-  });
-};
 
 const setDataModelPermissions = ({
   tableIds = [],


### PR DESCRIPTION
Closes #55563
Closes [SEM-185](https://linear.app/metabase/issue/SEM-185/bigquery-struct-types-dont-allow-renaming-in-admin-table-metadata)

### Description

_Hiding whitespace changes recommended._

Just a repro. The issue has been fixed during the metadata editing project by using `field.display_name` directly as the input's `value`. Previously `field.displayName()` (from `metabase-lib/v1`) was used and it was adding an extra prefix which resulted in weird behavior.

This repro uses JSON database as we don't have BigQuery set up in e2e tests, but it should be equivalent.
