### PR TITLE
feat: tenant group api updates

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/tenants/permissions_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/permissions_api_test.clj
@@ -1,0 +1,35 @@
+(ns metabase-enterprise.tenants.permissions-api-test
+  "Tests for `/api/permissions` endpoints with EE features."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :test-users))
+
+(deftest create-group-test
+  (testing "POST /permissions/group"
+    (testing "creates tenant group when is_tenant_group is true (enterprise only)"
+      (mt/with-premium-features #{:tenants}
+        (mt/with-model-cleanup [:model/PermissionsGroup]
+          (mt/user-http-request :crowberto :post 200 "permissions/group" {:name "Tenants Group" :is_tenant_group true})
+          (let [group (t2/select-one :model/PermissionsGroup :name "Tenants Group")]
+            (is (some? group))
+            (is (true? (:is_tenant_group group)))))))
+
+    (testing "validates is_tenant_group parameter type"
+      (testing "rejects invalid type"
+        (is (= {:errors {:is_tenant_group "nullable boolean"}
+                :specific-errors {:is_tenant_group '("should be a boolean, received: \"invalid\"")}}
+               (mt/user-http-request :crowberto :post 400 "permissions/group" {:name "Invalid Group" :is_tenant_group "invalid"})))))))
+
+(deftest create-group-test-enterprise-features
+  (testing "POST /permissions/group enterprise feature enforcement"
+    (testing "allows creating tenant groups with tenants feature enabled"
+      (mt/with-premium-features #{:tenants}
+        (mt/with-model-cleanup [:model/PermissionsGroup]
+          (mt/user-http-request :crowberto :post 200 "permissions/group" {:name "Tenant Group EE" :is_tenant_group true})
+          (let [group (t2/select-one :model/PermissionsGroup :name "Tenant Group EE")]
+            (is (some? group))
+            (is (true? (:is_tenant_group group)))))))))

--- a/src/metabase/permissions/api.clj
+++ b/src/metabase/permissions/api.clj
@@ -172,7 +172,7 @@
   This API requires superuser or group manager of more than one group.
   Group manager is only available if `advanced-permissions` is enabled and returns only groups that user
   is manager of.
-  
+
   Optional query parameter `tenancy` can be used to filter groups:
   - `tenancy=external`: Returns only tenant groups (where `is_tenant_group = true`)
   - `tenancy=internal`: Returns only non-tenant groups (where `is_tenant_group = false`)

--- a/src/metabase/permissions/api.clj
+++ b/src/metabase/permissions/api.clj
@@ -207,11 +207,15 @@
   "Create a new `PermissionsGroup`."
   [_route-params
    _query-params
-   {:keys [name]} :- [:map
-                      [:name ms/NonBlankString]]]
+   {:keys [name is_tenant_group]} :- [:map
+                                      [:name ms/NonBlankString]
+                                      [:is_tenant_group {:optional true} [:maybe :boolean]]]]
   (api/check-superuser)
+  (when (and is_tenant_group (not (premium-features/enable-tenants?)))
+    (throw (premium-features/ee-feature-error (tru "Tenants"))))
   (first (t2/insert-returning-instances! :model/PermissionsGroup
-                                         :name name)))
+                                         :name name
+                                         :is_tenant_group (or is_tenant_group false))))
 
 (api.macros/defendpoint :put "/group/:group-id"
   "Update the name of a `PermissionsGroup`."

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -82,6 +82,7 @@
   add-user-to-groups!
   add-user-to-group!
   allow-changing-all-users-group-members
+  allow-changing-all-external-users-group-members
   fail-to-remove-last-admin-msg
   remove-user-from-group!
   remove-user-from-groups!

--- a/src/metabase/permissions/models/permissions_group_membership.clj
+++ b/src/metabase/permissions/models/permissions_group_membership.clj
@@ -82,6 +82,7 @@
 (t2/define-before-delete :model/PermissionsGroupMembership
   [{:keys [group_id user_id]}]
   (check-not-all-users-group group_id)
+  (check-not-all-external-users-group group_id)
   ;; Otherwise if this is the Admin group...
   (when (= group_id (:id (perms-group/admin)))
     ;; ...and this is the last membership, throw an exception

--- a/src/metabase/permissions/models/permissions_group_membership.clj
+++ b/src/metabase/permissions/models/permissions_group_membership.clj
@@ -22,11 +22,23 @@
   but enable it when adding or deleting users."
   false)
 
+(def ^:dynamic *allow-changing-all-external-users-group-members*
+  "Should we allow people to be added to or removed from the All External Users permissions group? By default, this is
+  `false`, but enable it when adding or deleting users."
+  false)
+
 (defmacro allow-changing-all-users-group-members
   "Allow people to be added to or removed from the All Users permissions group? By default, this is disallowed."
   {:style/indent 0}
   [& body]
   `(binding [*allow-changing-all-users-group-members* true]
+     ~@body))
+
+(defmacro allow-changing-all-external-users-group-members
+  "Allow users to be added to or removed from the All External Users permissions group? By default, this is disallowed."
+  {:style/indent 0}
+  [& body]
+  `(binding [*allow-changing-all-external-users-group-members* true]
      ~@body))
 
 (defn- check-not-all-users-group
@@ -35,6 +47,14 @@
   (when (= group-id (:id (perms-group/all-users)))
     (when-not *allow-changing-all-users-group-members*
       (throw (ex-info (tru "You cannot add or remove users to/from the ''All Users'' group.")
+                      {:status-code 400})))))
+
+(defn- check-not-all-external-users-group
+  "Throw an Exception if we're trying to add or remove a user to the All Users group."
+  [group-id]
+  (when (= group-id (:id (perms-group/all-external-users)))
+    (when-not *allow-changing-all-external-users-group-members*
+      (throw (ex-info (tru "You cannot add or remove users to/from the ''All External Users'' group.")
                       {:status-code 400})))))
 
 (defn- admin-count
@@ -147,6 +167,7 @@
           user-id->tenant? (t2/select-pk->fn (comp (complement nil?) :tenant_id)
                                              [:model/User :id :tenant_id]
                                              :id [:in user-ids])
+
           bad-user-group-pairs (->> (keys user-id-group-id->is-group-manager?)
                                     (keep (fn [[user-id group-id]]
                                             (when (not= (group-id->tenant? group-id)
@@ -156,10 +177,17 @@
                                                :user-is-tenant? (user-id->tenant? user-id)
                                                :group-is-tenant? (group-id->tenant? group-id)}))))
           _ (doseq [group-id group-ids]
-              (check-not-all-users-group group-id))
+              (check-not-all-users-group group-id)
+              (check-not-all-external-users-group group-id))
+          _ (doseq [[[user-id group-id] is-group-manager?] user-id-group-id->is-group-manager?]
+              (when (and is-group-manager? (user-id->tenant? user-id))
+                (throw (ex-info (tru "External users cannot be made group managers")
+                                {:bad-user-group-pair [user-id group-id]
+                                 :status-code 400}))))
           _ (when (seq bad-user-group-pairs)
               (throw (ex-info (tru "Cannot add non-tenant user to tenant-group or vice versa")
-                              {:bad-user-group-pairs bad-user-group-pairs})))
+                              {:bad-user-group-pairs bad-user-group-pairs
+                               :status-code 400})))
 
           new-admin-ids (->> user-id-group-id->is-group-manager?
                              keys

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -119,8 +119,9 @@
                                 (when (:tenant_id user) (perms/all-external-users-group))
                                 (when superuser? (perms/admin-group))])]
       (perms/allow-changing-all-users-group-members
-        (perms/without-is-superuser-sync-on-add-to-admin-group
-         (perms/add-user-to-groups! user-id (map u/the-id groups)))))))
+        (perms/allow-changing-all-external-users-group-members
+         (perms/without-is-superuser-sync-on-add-to-admin-group
+          (perms/add-user-to-groups! user-id (map u/the-id groups))))))))
 
 (t2/define-before-update :model/User
   [{:keys [id] :as user}]

--- a/test/metabase/permissions/api_test.clj
+++ b/test/metabase/permissions/api_test.clj
@@ -82,8 +82,8 @@
         (mt/with-temp [:model/PermissionsGroup regular-group {:name "Regular Group" :is_tenant_group false}
                        :model/PermissionsGroup tenant-group {:name "Tenant Group" :is_tenant_group true}]
           (let [all-groups (fetch-groups)
-                internal-groups #p (fetch-groups :tenancy "internal")
-                external-groups #p (fetch-groups :tenancy "external")
+                internal-groups (fetch-groups :tenancy "internal")
+                external-groups (fetch-groups :tenancy "external")
                 regular-id (:id regular-group)
                 tenant-id (:id tenant-group)]
 
@@ -128,17 +128,6 @@
 
     (testing "invalid tenancy value returns 400"
       (:status (mt/user-http-request :crowberto :get 400 "permissions/group" :tenancy "invalid")))))
-
-(deftest groups-list-limit-test
-  (testing "GET /api/permissions/group?limit=1&offset=1"
-    (testing "Limit and offset pagination have defaults"
-      (is (= (mt/user-http-request :crowberto :get 200 "permissions/group" :limit "1" :offset "0")
-             (mt/user-http-request :crowberto :get 200 "permissions/group" :limit "1")))
-      (is (= (mt/user-http-request :crowberto :get 200 "permissions/group" :offset "1" :limit 50)
-             (mt/user-http-request :crowberto :get 200 "permissions/group" :offset "1"))))
-    (testing "Limit and offset pagination works for permissions list"
-      (is (partial= [{:id (:id (perms-group/all-users)), :name "All Users"}]
-                    (mt/user-http-request :crowberto :get 200 "permissions/group" :limit "1" :offset "1"))))))
 
 (deftest fetch-group-test
   (testing "GET /permissions/group/:id"

--- a/test/metabase/users/api_test.clj
+++ b/test/metabase/users/api_test.clj
@@ -6,6 +6,7 @@
    [metabase.collections.models.collection :as collection]
    [metabase.config.core :as config]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.permissions.util :as perms-util]
    [metabase.test :as mt]
@@ -1342,3 +1343,85 @@
                              :previous {:first_name "John"
                                         :last_name "Cena"}}}
                  (mt/latest-audit-log-entry :user-update id))))))))
+
+(deftest create-user-tenant-group-restrictions-test
+  (testing "POST /api/user with tenant groups"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Tenant {tenant-id :id} {:name "Test Tenant" :slug "test"}
+                       :model/PermissionsGroup {tenant-group-id :id} {:name "Tenant Group"
+                                                                      :is_tenant_group true}
+                       :model/PermissionsGroup {normal-group-id :id} {:name "Normal Group"
+                                                                      :is_tenant_group false}]
+          (testing "external users cannot be added to non-tenant groups via POST"
+            (with-temp-user-email! [email]
+              (is (=? {:message "Cannot add non-tenant user to tenant-group or vice versa"}
+                      (mt/user-http-request :crowberto :post 400 "user"
+                                            {:first_name "External"
+                                             :last_name "User"
+                                             :email email
+                                             :tenant_id tenant-id
+                                             :user_group_memberships [{:id (u/the-id (perms/all-external-users-group))}
+                                                                      {:id normal-group-id}]})))))
+
+          (testing "internal users cannot be added to tenant groups via POST"
+            (with-temp-user-email! [email]
+              (is (=? {:message "Cannot add non-tenant user to tenant-group or vice versa"}
+                      (mt/user-http-request :crowberto :post 400 "user"
+                                            {:first_name "Internal"
+                                             :last_name "User"
+                                             :email email
+                                             :user_group_memberships [{:id (u/the-id (perms/all-users-group))}
+                                                                      {:id tenant-group-id}]}))))))))))
+
+(deftest update-user-tenant-group-restrictions-test
+  (testing "PUT /api/user/:id with tenant groups"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Tenant {tenant-id :id} {:name "Test Tenant" :slug "test"}
+                       :model/PermissionsGroup {tenant-group-id :id} {:name "Tenant Group"
+                                                                      :is_tenant_group true}
+                       :model/PermissionsGroup {normal-group-id :id} {:name "Normal Group"
+                                                                      :is_tenant_group false}]
+
+          (testing "external users cannot be added to non-tenant groups via PUT"
+            (mt/with-temp [:model/User {external-user-id :id} {:tenant_id tenant-id}]
+              (is (=? {:message "Cannot add non-tenant user to tenant-group or vice versa"}
+                      (mt/user-http-request :crowberto :put 400 (str "user/" external-user-id)
+                                            {:user_group_memberships [{:id (u/the-id (perms/all-external-users-group))}
+                                                                      {:id normal-group-id}]})))))
+
+          (testing "internal users cannot be added to tenant groups via PUT"
+            (mt/with-temp [:model/User {internal-user-id :id} {}]
+              (is (=? {:message "Cannot add non-tenant user to tenant-group or vice versa"}
+                      (mt/user-http-request :crowberto :put 400 (str "user/" internal-user-id)
+                                            {:user_group_memberships [{:id (u/the-id (perms/all-users-group))}
+                                                                      {:id tenant-group-id}]}))))))))))
+
+(deftest external-user-group-manager-restrictions-test
+  (testing "External users cannot be made group managers"
+    (mt/with-premium-features #{:tenants :advanced-permissions}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Tenant {tenant-id :id} {:name "Test Tenant" :slug "test"}
+                       :model/PermissionsGroup {tenant-group-id :id} {:name "Tenant Group"
+                                                                      :is_tenant_group true}]
+
+          (testing "cannot create external user as group manager via POST"
+            (with-temp-user-email! [email]
+              ;; This test is expected to fail until group manager restrictions are implemented
+              (is (=? {:message "External users cannot be made group managers"}
+                      (mt/user-http-request :crowberto :post 400 "user"
+                                            {:first_name "External"
+                                             :last_name "Manager"
+                                             :email email
+                                             :tenant_id tenant-id
+                                             :user_group_memberships [{:id tenant-group-id
+                                                                       :is_group_manager true}]})))))
+
+          (testing "cannot make external user group manager via PUT"
+            (mt/with-temp [:model/User {external-user-id :id} {:tenant_id tenant-id}]
+              ;; This test is expected to fail until group manager restrictions are implemented
+              (is (=? {:message "External users cannot be made group managers"}
+                      (mt/user-http-request :crowberto :put 400 (str "user/" external-user-id)
+                                            {:user_group_memberships [{:id tenant-group-id
+                                                                       :is_group_manager true}]}))))))))))


### PR DESCRIPTION
### Description

Updates the groups api to allow us to interact with Tenant groups. Adds tests that verify tenant group membership invariants are enforced and adds a new invariant preventing tenant users from being made group managers. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
