### PR TITLE
[MBQL lib] Correctly parse new keys in JS column metadata to CLJS

### DIFF
--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -220,12 +220,18 @@
 
 (defmethod rename-key-fn :field
   [_object-type]
-  {:source          :lib/source
-   :unit            :metabase.lib.field/temporal-unit
-   :expression-name :lib/expression-name
-   :binning-info    :metabase.lib.field/binning
-   :dimensions      ::dimension
-   :values          ::field-values})
+  (merge
+    ;; Basic :foo -> :lib/foo mapping, since this is a common case
+   (into {} (map (juxt keyword #(keyword "lib" %)))
+         ["source" "expression-name" "breakout?"
+          "deduplicated-name" "original-name"
+          "desired-column-alias" "source-column-alias"])
+    ;; Custom remaps
+   {:unit              :metabase.lib.field/temporal-unit
+    :temporal-unit     :metabase.lib.field/temporal-unit
+    :binning-info      :metabase.lib.field/binning
+    :dimensions        ::dimension
+    :values            ::field-values}))
 
 (defn- parse-field-id
   [id]


### PR DESCRIPTION
### Description

Newly added keys like `:lib/breakout?` etc. get turned into JS keys
like `"breakout?"`, but `metabase.lib.js.metadata/parse-column` was
not parsing them correctly.

### How to verify

1. Create a query with an expression, multiple breakouts including one on the expression, and some aggregations.
2. Visualize as a pivot table
3. Click a pivot cell and choose "See these Orders" or similar (`underlying-records` drill)
4. Get a query error on master but it works with this PR.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
