### PR TITLE
Can fetch field values for custom filter fields

### DIFF
--- a/src/metabase/parameters/params.clj
+++ b/src/metabase/parameters/params.clj
@@ -71,18 +71,20 @@
   "Parse a Card parameter `target` form, which looks something like `[:dimension [:field-id 100]]`, and return the Field
   ID it references (if any)."
   [target card]
-  (let [target (mbql.normalize/normalize target)]
-    (let [[_ dimension] target
-          field-form    (if (mbql.u/is-clause? :template-tag dimension)
-                          (template-tag->field-form dimension card)
-                          dimension)]
-      ;; Being extra safe here since we've got many reports on this cause loading dashboard to fail
-      ;; for unknown reasons. See #8917
-      (when field-form
-        (try
-          (mbql.u/unwrap-field-or-expression-clause field-form)
-          (catch Exception e
-            (log/error e "Failed unwrap field form" field-form)))))))
+  (let [target (mbql.normalize/normalize target)
+        [_ dimension] target
+        field-form    (if (mbql.u/is-clause? :template-tag dimension)
+                        (template-tag->field-form dimension card)
+                        dimension)]
+    ;; Being extra safe here since we've got many reports on this cause loading dashboard to fail
+    ;; for unknown reasons. See #8917
+    (cond
+      field-form (try
+                   (mbql.u/unwrap-field-or-expression-clause field-form)
+                   (catch Exception e
+                     (log/error e "Failed unwrap field form" field-form)))
+
+      (mbql.u/is-clause? :dimension target) (log/error "Could not find matching field clause for target:" target))))
 
 (defn- pk-fields
   "Return the `fields` that are PK Fields."

--- a/src/metabase/parameters/params.clj
+++ b/src/metabase/parameters/params.clj
@@ -72,19 +72,17 @@
   ID it references (if any)."
   [target card]
   (let [target (mbql.normalize/normalize target)]
-    (when (mbql.u/is-clause? :dimension target)
-      (let [[_ dimension] target
-            field-form    (if (mbql.u/is-clause? :template-tag dimension)
-                            (template-tag->field-form dimension card)
-                            dimension)]
-        ;; Being extra safe here since we've got many reports on this cause loading dashboard to fail
-        ;; for unknown reasons. See #8917
-        (if field-form
-          (try
-            (mbql.u/unwrap-field-or-expression-clause field-form)
-            (catch Exception e
-              (log/error e "Failed unwrap field form" field-form)))
-          (log/error "Could not find matching field clause for target:" target))))))
+    (let [[_ dimension] target
+          field-form    (if (mbql.u/is-clause? :template-tag dimension)
+                          (template-tag->field-form dimension card)
+                          dimension)]
+      ;; Being extra safe here since we've got many reports on this cause loading dashboard to fail
+      ;; for unknown reasons. See #8917
+      (when field-form
+        (try
+          (mbql.u/unwrap-field-or-expression-clause field-form)
+          (catch Exception e
+            (log/error e "Failed unwrap field form" field-form)))))))
 
 (defn- pk-fields
   "Return the `fields` that are PK Fields."


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-1475/field-values-support-enhanced-native-filters

### Description

Allows the card and dashboard /values routes to fetch field values for a custom filter.  I think this covers every relevant case, because unsaved cards seem to just ask for the field values for a specific field (instead of specifying a parameter).  That said, I wouldn't be at all surprised if it turns out that I missed a case once we start actually hooking up the frontend.

### How to verify

Tests pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
