### PR TITLE
Closes VIZ-968 - PDF Exports of Pivot Tables contain Ugly Grey Blocks that overlap the Visualization

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.styled.tsx
@@ -99,6 +99,17 @@ const getColor = ({
   return color(theme.other.table.cell.textColor);
 };
 
+const borderRight = css`
+  &:after {
+    content: " ";
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    border-right: 1px solid var(--mb-color-border);
+  }
+`;
+
 export const PivotTableCell = styled.div<PivotTableCellProps>`
   flex: 1 0 auto;
   position: relative;
@@ -109,12 +120,12 @@ export const PivotTableCell = styled.div<PivotTableCellProps>`
   font-weight: ${(props) => (props.isBold ? "bold" : "normal")};
   cursor: ${(props) => (props.onClick ? "pointer" : "default")};
   color: ${getColor};
-  box-shadow: -1px 0 0 0 var(--mb-color-border) inset;
+  ${borderRight}
   border-bottom: 1px solid
     ${(props) =>
-      props.isBorderedHeader
-        ? "var(--mb-color-bg-dark)"
-        : "var(--mb-color-border)"};
+    props.isBorderedHeader
+      ? "var(--mb-color-bg-dark)"
+      : "var(--mb-color-border)"};
   background-color: ${getCellBackgroundColor};
   ${(props) =>
     props.hasTopBorder &&
@@ -136,7 +147,8 @@ interface PivotTableTopLeftCellsContainerProps {
 export const PivotTableTopLeftCellsContainer = styled.div<PivotTableTopLeftCellsContainerProps>`
   display: flex;
   align-items: flex-end;
-  box-shadow: -1px 0 0 0 var(--mb-color-border) inset;
+  position: relative;
+  ${borderRight}
   background-color: ${(props) =>
     getCellBackgroundColor({
       isEmphasized: true,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/57799
Closes VIZ-968

### Description

This fixes the issue by changing how pivot tables display their cells' right borders. Previously, they used to use an inset `box-shadow`, but html2canvas seems to have issues with box-shadows sometimes.

I replaced the `box-shadow` with an absolutely positioned `:after` pseudo-element. There are a few other ways we could fix this bug, but this seemed like the least risky and least changes (e.g. using `border-right` on the cells themselves would also work but would shift the content over 1px (and require loki updates)).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a pivot table
2. Add it to a dashboard*
4. Export it as PDF
5. Verify no grey boxes

\* - The issue was more reproducible if I made the pivot table the only dash card on the tab and made the table (not just the card) really wide.

### Demo

https://github.com/user-attachments/assets/d30b209f-a7f8-4c78-b8d7-9fcb37cc6f21

