### PR TITLE
VIZ-1298 - Prevent Link settings onChange when no changes

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingLinkUrlInput.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingLinkUrlInput.tsx
@@ -54,7 +54,9 @@ const ChartSettingLinkUrlInput = ({
 
   const handleBlur = () => {
     setIsFocused(false);
-    onChange(focusedValue);
+    if (focusedValue !== (value ?? "")) {
+      onChange(focusedValue);
+    }
   };
 
   return (

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingLinkUrlInput.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingLinkUrlInput.unit.spec.tsx
@@ -150,4 +150,19 @@ describe("ChartSettingLinkUrlInput", () => {
     expect(input).toHaveValue("");
     expect(onChange).toHaveBeenCalledTimes(1);
   });
+
+  it("should not call onChange when focusing and blurring without making changes", async () => {
+    const { input, onChange } = setup({
+      value: "existing value",
+    });
+
+    // Trigger focus and onBlur without making changes
+    await userEvent.click(input);
+    expect(input).toHaveFocus();
+    act(() => {
+      input.blur();
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60841
Resolves VIZ-1298

Conditionally trigger onChange in the "Display as" "Link" input text setting fields for link url and link text only when the updated value is different.