### PR TITLE
Unreliable jobs & master runs all

### DIFF
--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -29,7 +29,7 @@ jobs:
 
   shared-tests-cljs:
     needs: files-changed
-    if: needs.files-changed.outputs.cljs == 'true'
+    if: github.ref_name == 'master' || needs.files-changed.outputs.cljs == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
           filters: .github/file-paths.yaml
   analyze:
     needs: files-changed
-    if: needs.files-changed.outputs.codeql == 'true'
+    if: github.ref_name == 'master' || needs.files-changed.outputs.codeql == 'true'
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository

--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -62,7 +62,7 @@ jobs:
     needs: [files-changed, get-build-requirements]
     if: |
       !cancelled() &&
-      needs.files-changed.outputs.e2e_embedding_sdk == 'true'
+      (github.ref_name == 'master' || needs.files-changed.outputs.e2e_embedding_sdk == 'true')
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     env:

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -26,7 +26,7 @@ jobs:
 
   cross-version-testing:
     needs: files-changed
-    if: ${{ needs.files-changed.outputs.e2e_cross_version == 'true' || github.event_name == 'schedule'}}
+    if: ${{ github.ref_name == 'master' || needs.files-changed.outputs.e2e_cross_version == 'true' || github.event_name == 'schedule'}}
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -149,7 +149,7 @@ jobs:
     needs: [files-changed, get-build-requirements, get-sample-apps-data]
     if: |
       !cancelled() &&
-      needs.files-changed.outputs.e2e_embedding_sdk_compatibility == 'true' &&
+      (github.ref_name == 'master' || needs.files-changed.outputs.e2e_embedding_sdk_compatibility == 'true') &&
       fromJSON(needs.get-sample-apps-data.outputs.matrix)[0] != null
     runs-on: ubuntu-22.04
     timeout-minutes: 25

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -140,32 +140,16 @@ jobs:
       tags: ${{ matrix.tags }}
       runner: ${{ matrix.runner }}
 
-  # run this separately to make it non-blocking
-  flaky-e2e-tests:
-    name: Flaky e2e Tests
-    uses: ./.github/workflows/e2e-test.yml
-    needs:
-      - build
-      - e2e-matrix-builder
-    # skip flaky test run if only e2e specs changed as an optimization
-    if: |
-      !cancelled() && needs.build.result == 'success' && needs.e2e-matrix-builder.outputs.isDefaultSpecPattern == 'true'
-    secrets: inherit
-    with:
-      name: Flaky
-      tags: "@flaky"
 
   e2e-tests-result:
     needs:
       - e2e-tests
-      - flaky-e2e-tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
     name: e2e-tests-result
     if: always() && !cancelled()
     env:
       E2E_TESTS_RESULT: ${{ needs.e2e-tests.result }}
-      FLAKY_E2E_TESTS_RESULT: ${{ needs.flaky-e2e-tests.result }}
     steps:
       - name: Stub
         if: ${{ needs.e2e-tests.result == 'skipped' }}
@@ -175,7 +159,6 @@ jobs:
         if: ${{ needs.e2e-tests.result != 'skipped' }}
         run: | # sh
           echo "E2E Tests: ${{ needs.e2e-tests.result }}"
-          echo "Flaky E2E Tests: ${{ needs.flaky-e2e-tests.result }}"
 
           if [ "${{ needs.e2e-tests.result }}" != "success" ]; then
             echo "E2E Tests failed"

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -34,7 +34,8 @@ jobs:
     needs: [files-changed]
     if: |
       !cancelled() &&
-      (needs.files-changed.outputs.e2e_embedding_sdk == 'true' ||
+      (github.ref_name == 'master' ||
+      needs.files-changed.outputs.e2e_embedding_sdk == 'true' ||
       needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' ||
       needs.files-changed.outputs.embedding_documentation == 'true')
     runs-on: ubuntu-22.04
@@ -58,7 +59,7 @@ jobs:
   embedding-sdk-cli-snippets-type-check:
     needs: [files-changed, build]
     if: |
-      needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' &&
+      (github.ref_name == 'master' || needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true') &&
       needs.build.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
@@ -77,7 +78,7 @@ jobs:
   embedding-sdk-docs-snippets-type-check:
     needs: [files-changed, build]
     if: |
-      needs.files-changed.outputs.embedding_documentation == 'true' &&
+      (github.ref_name == 'master' || needs.files-changed.outputs.embedding_documentation == 'true') &&
       needs.build.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
@@ -96,7 +97,7 @@ jobs:
   embedding-sdk-api-documentation-generation-validation:
     needs: [files-changed, build]
     if: |
-      needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true' &&
+      (github.ref_name == 'master' || needs.files-changed.outputs.frontend_embedding_sdk_sources == 'true') &&
       needs.build.result == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 20

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -29,7 +29,7 @@ jobs:
 
   verify-i18n-files:
     needs: files-changed
-    if: needs.files-changed.outputs.i18n == 'true'
+    if: github.ref_name == 'master' || needs.files-changed.outputs.i18n == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:

--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -22,7 +22,7 @@ jobs:
 
   visual-test:
     needs: files-changed
-    if: needs.files-changed.outputs.frontend_ci == 'true' || needs.files-changed.outputs.frontend_sources == 'true' || needs.files-changed.outputs.frontend_loki_ci == 'true'
+    if: github.ref_name == 'master' || needs.files-changed.outputs.frontend_ci == 'true' || needs.files-changed.outputs.frontend_sources == 'true' || needs.files-changed.outputs.frontend_loki_ci == 'true'
     runs-on: ubuntu-latest
     services:
       docker:

--- a/.github/workflows/presto-kerberos-integration-test.yml
+++ b/.github/workflows/presto-kerberos-integration-test.yml
@@ -33,7 +33,7 @@ jobs:
 
   run-presto-kerberos-test:
     needs: files-changed
-    if: needs.files-changed.outputs.backend_presto_kerberos == 'true'
+    if: github.ref_name == 'master' || needs.files-changed.outputs.backend_presto_kerberos == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
   release-type-check:
     needs: files-changed
-    if: needs.files-changed.outputs.release_source == 'true'
+    if: github.ref_name == 'master' || needs.files-changed.outputs.release_source == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   release-tests-unit:
     needs: files-changed
-    if: needs.files-changed.outputs.release_source == 'true'
+    if: github.ref_name == 'master' || needs.files-changed.outputs.release_source == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -57,7 +57,7 @@ jobs:
 
   release-test-build:
     needs: files-changed
-    if: needs.files-changed.outputs.release_source == 'true'
+    if: github.ref_name == 'master' || needs.files-changed.outputs.release_source == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -69,38 +69,38 @@ jobs:
     uses: ./.github/workflows/backend.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.backend_all != 'true' && needs.static-viz-files-changed.outputs.static_viz != 'true' }}
+      skip: ${{ github.ref_name != 'master' && needs.files-changed.outputs.backend_all != 'true' && needs.static-viz-files-changed.outputs.static_viz != 'true' }}
 
   app-db-tests:
     needs: files-changed
     uses: ./.github/workflows/app-db.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.backend_all != 'true' }}
+      skip: ${{ github.ref_name != 'master' && needs.files-changed.outputs.backend_all != 'true' }}
 
   driver-tests:
     needs: files-changed
     uses: ./.github/workflows/drivers.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.backend_all != 'true' }}
+      skip: ${{ github.ref_name != 'master' && needs.files-changed.outputs.backend_all != 'true' }}
 
   frontend-tests:
     needs: files-changed
     uses: ./.github/workflows/frontend.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.frontend_all != 'true' }}
-      skip-lint: ${{ needs.files-changed.outputs.frontend_all != 'true' && needs.files-changed.outputs.e2e_specs != 'true' }}
+      skip: ${{ github.ref_name != 'master' && needs.files-changed.outputs.frontend_all != 'true' }}
+      skip-lint: ${{ github.ref_name != 'master' && needs.files-changed.outputs.frontend_all != 'true' && needs.files-changed.outputs.e2e_specs != 'true' }}
 
   e2e-tests:
     needs: files-changed
     uses: ./.github/workflows/e2e-tests.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.e2e_all != 'true' }}
+      skip: ${{ github.ref_name != 'master' && needs.files-changed.outputs.e2e_all != 'true' }}
       # here we pass result from files-changed, which is a list of files, comma separated
       # e.g. e2e/test/scenarios/onboarding/command-palette.cy.spec.js,e2e/test/scenarios/question/document-title.cy.spec.js
       # e2e_all_files includes all changes which trigger all e2e tests, if the list of changes files is included in the
       # list of changed specs files, then only specs are changed and we can run only those specs
-      specs: ${{ needs.files-changed.outputs.e2e_all_files == needs.files-changed.outputs.e2e_specs_files && needs.files-changed.outputs.e2e_specs_files || '' }}
+      specs: ${{ github.ref_name == 'master' && '' || (needs.files-changed.outputs.e2e_all_files == needs.files-changed.outputs.e2e_specs_files && needs.files-changed.outputs.e2e_specs_files || '') }}

--- a/.github/workflows/snowplow.yml
+++ b/.github/workflows/snowplow.yml
@@ -23,7 +23,7 @@ jobs:
 
   lint:
     needs: files-changed
-    if: needs.files-changed.outputs.snowplow == 'true'
+    if: github.ref_name == 'master' || needs.files-changed.outputs.snowplow == 'true'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/unreliable.yml
+++ b/.github/workflows/unreliable.yml
@@ -1,0 +1,62 @@
+# This CI workflow contains jobs that are too unreliable to run on CI on every commit.
+# It runs daily, when manually dispatching the workflow on the GH website, and on
+# PRs that have the `run-unreliable-ci`
+#
+# Unreliable jobs are CI jobs that fail often enough that a red CI badge needs someone to
+# manually check it before determining if the commit is really breaking something.
+# Red CI should mean the commit broke something and we need to fix it.
+#
+# Use these 2 stats questions to determine if a job is unreliable:
+# - more than 5% on https://stats.metabase.com/question/23726-failure-rate-on-master
+# - more than 25 on https://stats.metabase.com/question/18090-most-re-run-workflows
+
+name: Unreliable Tests
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: '0 2 * * *'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+jobs:
+  build:
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-unreliable-ci')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    env:
+      MB_EDITION: ee
+      INTERACTIVE: false
+      SKIP_LICENSES: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: uberjar
+          java-version: 21
+
+      - name: Build uberjar with ./bin/build.sh
+        timeout-minutes: 10
+        run: ./bin/build.sh
+        shell: bash
+
+      - name: Prepare uberjar artifact
+        uses: ./.github/actions/prepare-uberjar-artifact
+        with:
+          name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+
+  flaky-e2e-tests:
+    name: Flaky e2e Tests
+    uses: ./.github/workflows/e2e-test.yml
+    needs:
+      - build
+    secrets: inherit
+    with:
+      name: Flaky
+      tags: "@flaky"

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -25,7 +25,7 @@ jobs:
 
   yaml-linter:
     runs-on: ubuntu-22.04
-    if: needs.files-changed.outputs.yaml == 'true'
+    if: github.ref_name == 'master' || needs.files-changed.outputs.yaml == 'true'
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The goal of this PR is to increase confidence in the CI badge on master commits.
Commits with a green badge should mean that they are safe to branch off of.
Commits with a red badge should mean that something is broken and needs to be fixed.

The changes in this PR try to achieve this goal in two ways:


## Unreliable jobs

The first way is to reduce "false reds" by providing a home for unreliable CI jobs in `.github/workflows/unreliable.yml`.
This workflow does not run on every commit, instead it runs on a schedule, on PRs with the `run-unreliable-ci` label, and on manual dispatch.

Unreliable jobs interact badly with each other. 2 jobs that fail 5% of the time means CI now fails ~10% of the time (0.95*0.95=0.9025). With 5 of those jobs, CI fails ~23% of the time.

Unreliable jobs are CI jobs that fail often enough that a red CI badge needs someone to manually check it before determining if the commit is really breaking something or not.

Use these 2 stats questions to determine if a job is unreliable:
- more than 5% on https://stats.metabase.com/question/23726-failure-rate-on-master
- more than 25 on https://stats.metabase.com/question/18090-most-re-run-workflows


## Master runs all

The second way is to reduce "false greens" by not skipping jobs on master.

Our CI skips jobs based on the files changed, which is very useful to avoid tests whose inputs have not changed.
But this means that looking at master commits you cannot know if any given commit is really green or not, because it did not run all the tests.
So if you branch your changes off that commit, and change different files than it changed, you can get different CI results.

Skipping tests on master also makes it harder to determine which tests are unreliable.
Weeks that have mostly FE PRs merged will surface unreliable FE tests and hide BE ones, and vice versa.

