### PR TITLE
Tenant Groups UI

### DIFF
--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.js
@@ -91,6 +91,7 @@ describe("Tenants - management", () => {
     cy.visit("/admin/tenants");
 
     cy.location("pathname").should("eq", "/admin/people");
+    cy.visit("/admin/tenants");
 
     cy.findByRole("navigation", { name: "people-nav" })
       .findByRole("link", { name: /Groups/ })
@@ -258,11 +259,24 @@ describe("Tenants - management", () => {
     });
 
     cy.findByRole("navigation", { name: "people-nav" })
-      .findByRole("link", { name: /Groups/ })
+      .findAllByRole("link", { name: /Groups/ })
+      .should("have.length", 2)
+      .first()
       .click();
 
     cy.findByTestId("admin-content-table").within(() => {
-      cy.findByRole("link", { name: /All Internal Users/ }).should("exist");
+      cy.findByRole("link", { name: /All Internal Users/ }).should(
+        "be.visible",
+      );
+      cy.findByRole("link", { name: /All External Users/ }).should("not.exist");
+    });
+
+    cy.findByRole("navigation", { name: "people-nav" })
+      .findAllByRole("link", { name: /Tenant Groups/ })
+      .click();
+
+    cy.findByTestId("admin-content-table").within(() => {
+      cy.findByRole("link", { name: /All Internal Users/ }).should("not.exist");
       cy.findByRole("row", {
         name: `group-${ALL_EXTERNAL_USERS_GROUP_ID}-row`,
       }).within(() => {
@@ -273,7 +287,7 @@ describe("Tenants - management", () => {
         cy.findByRole("button", {
           name: "group-action-button",
         }).should("not.exist");
-        cy.findByRole("link", { name: /External Users/ }).click();
+        cy.findByRole("link", { name: /All External Users/ }).click();
       });
     });
 
@@ -283,9 +297,16 @@ describe("Tenants - management", () => {
   });
 
   it("should allow you to manage external user permissions once multi tenancy is enabled", () => {
-    const EXTERNAL_USER_GROUP_NAME = "External Users";
+    const EXTERNAL_USER_GROUP_NAME = "All External Users";
+    const TENANT_GROUP_NAME = "Favorite tenant users";
+
+    cy.request("POST", "/api/permissions/group", {
+      name: TENANT_GROUP_NAME,
+      is_tenant_group: true,
+    });
+
     cy.visit("/admin/permissions");
-    cy.findByRole("menuitem", { name: "Administrators" }).should("exist");
+    cy.findByRole("menuitem", { name: "Administrators" }).should("be.visible");
     cy.findByRole("menuitem", { name: EXTERNAL_USER_GROUP_NAME }).should(
       "not.exist",
     );
@@ -295,7 +316,8 @@ describe("Tenants - management", () => {
     });
 
     cy.reload();
-    cy.findByRole("menuitem", { name: "Administrators" }).should("exist");
+    cy.findByRole("menuitem", { name: "Administrators" }).should("be.visible");
+    cy.findByRole("menuitem", { name: TENANT_GROUP_NAME }).should("be.visible");
     cy.findByRole("menuitem", { name: EXTERNAL_USER_GROUP_NAME }).click();
 
     assertPermissionTableColumnsExist([
@@ -335,6 +357,11 @@ describe("Tenants - management", () => {
       .eq(4)
       .parent()
       .should("have.attr", "aria-disabled", "true");
+
+    hasGlobeIcon(EXTERNAL_USER_GROUP_NAME);
+    hasGlobeIcon(TENANT_GROUP_NAME);
+    lacksGlobeIcon("Administrators");
+    lacksGlobeIcon("All Internal Users");
   });
 
   it("should not show send email modal when creating tenant users when SMTP is configured", () => {
@@ -667,6 +694,86 @@ describe("tenant users", () => {
       .findByRole("link", { name: /trash/i })
       .should("not.exist");
   });
+
+  it("should create a tenant group and add users to it", () => {
+    const GROUP_NAME = "Favorites";
+    cy.intercept("POST", "/api/permissions/group").as("createGroup");
+    cy.intercept("POST", "/api/user").as("createUser");
+    cy.intercept("PUT", "/api/user/*").as("updateUser");
+    cy.visit("/admin/tenants/groups");
+
+    // FIXME shouldn't be necessary - caused by slow route guard
+    cy.findByTestId("admin-layout-sidebar")
+      .findByText(/Tenant Groups/)
+      .click();
+
+    cy.findByTestId("admin-layout-content")
+      .findByRole("heading", { name: /Tenant Groups/ })
+      .should("be.visible");
+
+    cy.button("Create a group").click();
+    cy.findByPlaceholderText(/something like/i).type(GROUP_NAME);
+    cy.findByRole("button", { name: "Add" }).click();
+    cy.wait("@createGroup");
+    cy.findByTestId("admin-content-table").findByText(GROUP_NAME);
+
+    cy.findByTestId("admin-layout-sidebar")
+      .findByText(/External Users/)
+      .click();
+
+    cy.log("put existing user in a group");
+    cy.findByTestId("admin-people-list-table")
+      .findAllByLabelText("ellipsis icon")
+      .first()
+      .click();
+    H.popover().findByText("Edit user").click();
+
+    H.modal().within(() => {
+      cy.findByText("Tenant Groups");
+      cy.findByText("All External Users").click();
+    });
+
+    H.popover().findByText(GROUP_NAME).click();
+
+    H.modal().within(() => {
+      cy.findByText("Tenant Groups").click(); // trigger blur
+      cy.findByText("2 other groups").should("be.visible");
+      cy.button("Update").click();
+    });
+
+    cy.wait("@updateUser").then(
+      ({ request: { body: reqBody }, response: { body: resBody } }) => {
+        expect(reqBody.user_group_memberships).to.have.length(2);
+        expect(resBody.user_group_memberships).to.have.length(2);
+      },
+    );
+
+    cy.log("add user in a group");
+    cy.button("Invite someone").click();
+
+    H.modal().within(() => {
+      cy.findByLabelText("First name").type("Misty");
+      cy.findByLabelText("Last name").type("Cerulean");
+      cy.findByLabelText(/Email/).type("misty@example.com");
+      cy.findByLabelText(/Tenant/).click();
+    });
+
+    H.popover().findByText(GIZMO_TENANT.name).click();
+    H.modal().findByText("All External Users").click();
+    H.popover().findByText(GROUP_NAME).click();
+
+    H.modal().within(() => {
+      cy.findByText("Tenant Groups").click(); // trigger blur
+      cy.findByText("2 other groups").should("be.visible");
+      cy.button("Create").click();
+    });
+    cy.wait("@createUser").then(
+      ({ request: { body: reqBody }, response: { body: resBody } }) => {
+        expect(reqBody.user_group_memberships).to.have.length(2);
+        expect(resBody.user_group_memberships).to.have.length(2);
+      },
+    );
+  });
 });
 
 const assertPermissionTableColumnsExist = (assertions) => {
@@ -685,6 +792,23 @@ const assertPermissionTableColumnsExist = (assertions) => {
   );
 };
 
+function hasGlobeIcon(groupName) {
+  cy.findByTestId("permission-table")
+    .findByText(groupName)
+    .parent()
+    .parent()
+    .icon("globe")
+    .should("be.visible");
+}
+
+function lacksGlobeIcon(groupName) {
+  cy.findByTestId("permission-table")
+    .findByText(groupName)
+    .parent()
+    .parent()
+    .icon("globe")
+    .should("not.exist");
+}
 const createUsers = () => {
   cy.request("GET", "/api/ee/tenant").then(({ body }) => {
     USERS.forEach((user) => {

--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.js
@@ -469,7 +469,7 @@ describe("Tenants - management", () => {
     });
 
     cy.findAllByRole("button", { name: /ellipsis/ })
-      .should("have.length", 2)
+      .should("have.length", 3)
       .last()
       .click();
     H.popover().findByText("Edit user").click();
@@ -482,7 +482,6 @@ describe("Tenants - management", () => {
         cy.findByText(key).should("be.visible");
         cy.findByDisplayValue(value).should("be.visible");
       });
-      cy.findByLabelText("close").click();
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/selectors.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/selectors.tsx
@@ -111,11 +111,12 @@ export const getApplicationPermissionEditor = createSelector(
     const entities = allGroups.map((group) => {
       const isAdmin = isAdminGroup(group);
       const isExternal =
-        !!externalUsersGroup && PLUGIN_TENANTS.isExternalUsersGroup(group);
+        !!externalUsersGroup && PLUGIN_TENANTS.isTenantGroup(group);
 
       return {
         id: group.id,
         name: getGroupNameLocalized(group),
+        icon: isExternal ? <PLUGIN_TENANTS.TenantGroupHintIcon /> : undefined,
         permissions: [
           getPermission(
             permissions,

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/ExternalGroupDetailApp/ExternalGroupDetailApp.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/ExternalGroupDetailApp/ExternalGroupDetailApp.tsx
@@ -1,0 +1,9 @@
+import { t } from "ttag";
+
+import { GroupDetailApp } from "metabase/admin/people/containers/GroupDetailApp";
+
+export const ExternalGroupDetailApp = (props: {
+  params: { groupId: number };
+}) => {
+  return <GroupDetailApp title={t`Tenant Groups`} {...props} />;
+};

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/ExternalGroupsListingApp/ExternalGroupsListingApp.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/ExternalGroupsListingApp/ExternalGroupsListingApp.tsx
@@ -1,0 +1,13 @@
+import { t } from "ttag";
+
+import { GroupsListingApp } from "metabase/admin/people/containers/GroupsListingApp";
+
+export const ExternalGroupsListingApp = () => {
+  return (
+    <GroupsListingApp
+      title={t`Tenant Groups`}
+      description={t`Use tenant groups to manage access for external users. Every tenant has access to these groups.`}
+      external
+    />
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantGroupHintIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantGroupHintIcon.tsx
@@ -1,0 +1,9 @@
+import { t } from "ttag";
+
+import { Icon, Tooltip } from "metabase/ui";
+
+export const TenantGroupHintIcon = () => (
+  <Tooltip label={t`This is a tenant group`}>
+    <Icon name="globe" c="text-medium" />
+  </Tooltip>
+);

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -2,7 +2,6 @@ import { Fragment } from "react";
 import { IndexRedirect, IndexRoute } from "react-router";
 import { t } from "ttag";
 
-import { PeopleNavItem } from "metabase/admin/people/components/PeopleNav";
 import { AdminPeopleApp } from "metabase/admin/people/containers/AdminPeopleApp";
 import { EditUserModal } from "metabase/admin/people/containers/EditUserModal";
 import { NewUserModal } from "metabase/admin/people/containers/NewUserModal";
@@ -15,12 +14,12 @@ import {
   PLUGIN_ADMIN_USER_MENU_ROUTES,
   PLUGIN_TENANTS,
 } from "metabase/plugins";
-import { Divider } from "metabase/ui";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
-import * as Urls from "metabase-enterprise/urls";
 
 import { EditUserStrategyModal } from "./EditUserStrategyModal";
 import { EditUserStrategySettingsButton } from "./EditUserStrategySettingsButton";
+import { ExternalGroupDetailApp } from "./components/ExternalGroupDetailApp/ExternalGroupDetailApp";
+import { ExternalGroupsListingApp } from "./components/ExternalGroupsListingApp/ExternalGroupsListingApp";
 import { ExternalPeopleListingApp } from "./components/ExternalPeopleListingApp/ExternalPeopleListingApp";
 import { ReactivateExternalUserButton } from "./components/ReactivateExternalUserButton";
 import { TenantDisplayName } from "./components/TenantDisplayName";
@@ -33,6 +32,7 @@ import {
   isExternalUser,
   isExternalUsersGroup,
   isTenantCollection,
+  isTenantGroup,
 } from "./utils/utils";
 
 if (hasPremiumFeature("tenants")) {
@@ -46,6 +46,10 @@ if (hasPremiumFeature("tenants")) {
         <IndexRoute component={TenantsListingApp} />
         <Route path="" component={TenantsListingApp}>
           <ModalRoute path="new" modal={NewTenantModal} noWrap />
+        </Route>
+        <Route path="groups">
+          <IndexRoute component={ExternalGroupsListingApp} />
+          <Route path=":groupId" component={ExternalGroupDetailApp} />
         </Route>
         <Route path="people" component={ExternalPeopleListingApp}>
           <ModalRoute
@@ -86,30 +90,13 @@ if (hasPremiumFeature("tenants")) {
     </>
   );
 
-  PLUGIN_TENANTS.PeopleNav = (
-    <>
-      <Divider my="sm" />
-      <PeopleNavItem
-        path={Urls.viewTenants()}
-        data-testid="nav-item"
-        label={t`Tenants`}
-        icon="globe"
-      />
-      <PeopleNavItem
-        path={Urls.viewTenantUsers()}
-        data-testid="nav-item"
-        label={t`External Users`}
-        icon="group"
-      />
-    </>
-  );
-
   PLUGIN_TENANTS.EditUserStrategySettingsButton =
     EditUserStrategySettingsButton;
 
   PLUGIN_TENANTS.FormTenantWidget = FormTenantWidget;
   PLUGIN_TENANTS.TenantDisplayName = TenantDisplayName;
   PLUGIN_TENANTS.isExternalUsersGroup = isExternalUsersGroup;
+  PLUGIN_TENANTS.isTenantGroup = isTenantGroup;
   PLUGIN_TENANTS.isExternalUser = isExternalUser;
   PLUGIN_TENANTS.isTenantCollection = isTenantCollection;
   PLUGIN_TENANTS.ReactivateExternalUserButton = ReactivateExternalUserButton;

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -24,6 +24,7 @@ import { ExternalPeopleListingApp } from "./components/ExternalPeopleListingApp/
 import { ReactivateExternalUserButton } from "./components/ReactivateExternalUserButton";
 import { TenantDisplayName } from "./components/TenantDisplayName";
 import { FormTenantWidget } from "./components/TenantFormWidget";
+import { TenantGroupHintIcon } from "./components/TenantGroupHintIcon";
 import { EditTenantModal } from "./containers/EditTenantModal";
 import { NewTenantModal } from "./containers/NewTenantModal";
 import { TenantActivationModal } from "./containers/TenantActivationModal";
@@ -100,4 +101,6 @@ if (hasPremiumFeature("tenants")) {
   PLUGIN_TENANTS.isExternalUser = isExternalUser;
   PLUGIN_TENANTS.isTenantCollection = isTenantCollection;
   PLUGIN_TENANTS.ReactivateExternalUserButton = ReactivateExternalUserButton;
+
+  PLUGIN_TENANTS.TenantGroupHintIcon = TenantGroupHintIcon;
 }

--- a/enterprise/frontend/src/metabase-enterprise/tenants/utils/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/utils/utils.ts
@@ -6,6 +6,10 @@ export const isExternalUsersGroup = (
   return group.magic_group_type === "all-external-users";
 };
 
+export const isTenantGroup = (group: Pick<Group, "is_tenant_group">) => {
+  return !!group.is_tenant_group;
+};
+
 export const isExternalUser = (user?: Pick<User, "tenant_id">) => {
   return user?.tenant_id !== null;
 };

--- a/enterprise/frontend/src/metabase-enterprise/urls.ts
+++ b/enterprise/frontend/src/metabase-enterprise/urls.ts
@@ -28,14 +28,6 @@ export function newMetabotConversation({ prompt }: { prompt: string }) {
   return `/metabot/new?q=${encodeURIComponent(prompt)}`;
 }
 
-export function viewTenants() {
-  return `/admin/tenants`;
-}
-
-export function viewTenantUsers() {
-  return `/admin/tenants`;
-}
-
 export function newTenant() {
   return `/admin/tenants/new`;
 }

--- a/frontend/src/metabase-types/api/group.ts
+++ b/frontend/src/metabase-types/api/group.ts
@@ -29,6 +29,7 @@ export type GroupInfo = {
     | "admin"
     | "all-external-users"
     | null;
+  is_tenant_group?: boolean;
 };
 
 export type Group = GroupInfo & {
@@ -40,6 +41,7 @@ export type GroupListQuery = GroupInfo;
 export type BaseGroupInfo = {
   id: GroupId;
   name: string;
+  is_tenant_group?: boolean;
 };
 
 export type ListUserMembershipsResponse = Record<User["id"], Membership[]>;

--- a/frontend/src/metabase/admin/people/components/GroupsListing.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.tsx
@@ -244,6 +244,12 @@ function GroupRow({
     !PLUGIN_TENANTS.isExternalUsersGroup(group);
   const editing = groupBeingEdited && groupBeingEdited.id === group.id;
 
+  const isTenantGroup = PLUGIN_TENANTS.isTenantGroup(group);
+
+  const membersLink = isTenantGroup
+    ? `/admin/tenants/groups/${group.id}`
+    : `/admin/people/groups/${group.id}`;
+
   return editing ? (
     <EditingGroupRow
       group={groupBeingEdited}
@@ -258,7 +264,7 @@ function GroupRow({
         <Flex
           component={Link}
           align="center"
-          to={"/admin/people/groups/" + group.id}
+          to={membersLink}
           className={CS.link}
           gap="md"
         >
@@ -378,6 +384,7 @@ interface GroupsListingProps {
   create: (group: { name: string }) => Promise<void>;
   update: (group: { id: number; name: string }) => Promise<void>;
   delete: (group: GroupInfo, groupCount: number) => Promise<void>;
+  description?: string;
 }
 
 export const GroupsListing = (props: GroupsListingProps) => {
@@ -512,7 +519,10 @@ export const GroupsListing = (props: GroupsListingProps) => {
           >{t`Create a group`}</Button>
         )
       }
-      description={t`You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed.`}
+      description={
+        props.description ??
+        t`You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed.`
+      }
     >
       <GroupsTable
         groups={filteredGroups}

--- a/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
+++ b/frontend/src/metabase/admin/people/components/MembershipSelect/MembershipSelect.tsx
@@ -17,7 +17,7 @@ import { GroupSummary } from "../GroupSummary";
 
 import S from "./MembershipSelect.module.css";
 
-const getGroupSections = (groups: GroupInfo[]) => {
+const getGroupSections = (groups: GroupInfo[], groupsTitle = t`Groups`) => {
   const defaultGroup = groups.find(
     (g) => isDefaultGroup(g) || PLUGIN_TENANTS.isExternalUsersGroup(g),
   );
@@ -33,7 +33,7 @@ const getGroupSections = (groups: GroupInfo[]) => {
   if (pinnedGroups.length > 0) {
     return [
       { groups: pinnedGroups },
-      { groups: regularGroups, header: t`Groups` },
+      { groups: regularGroups, header: groupsTitle },
     ];
   }
 
@@ -52,6 +52,7 @@ interface MembershipSelectProps {
   onRemove: (groupId: number) => void;
   onChange: (groupId: number, membershipData: Partial<Member>) => void;
   isConfirmModalOpen?: boolean;
+  groupsTitle?: string;
 }
 
 export const MembershipSelect = ({
@@ -63,12 +64,13 @@ export const MembershipSelect = ({
   isCurrentUser = false,
   isUserAdmin = false,
   emptyListMessage = t`No groups`,
+  groupsTitle = t`Groups`,
   isConfirmModalOpen,
 }: MembershipSelectProps) => {
   const [popoverOpened, { open: openPopover, toggle: togglePopover }] =
     useDisclosure();
   const selectedGroupIds = Array.from(memberships.keys());
-  const groupSections = getGroupSections(groups);
+  const groupSections = getGroupSections(groups, groupsTitle);
 
   const handleToggleMembership = (groupId: number) => {
     if (memberships.has(groupId)) {

--- a/frontend/src/metabase/admin/people/components/PeopleNav.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleNav.tsx
@@ -41,10 +41,16 @@ export function PeopleNav() {
               icon="globe"
             />
             <PeopleNavItem
+              path="/admin/tenants/groups"
+              data-testid="nav-item"
+              label={t`Tenant Groups`}
+              icon="group"
+            />
+            <PeopleNavItem
               path="/admin/tenants/people"
               data-testid="nav-item"
               label={t`External Users`}
-              icon="group"
+              icon="person"
             />
           </>
         )}

--- a/frontend/src/metabase/admin/people/containers/GroupDetailApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/GroupDetailApp.tsx
@@ -11,10 +11,16 @@ import { getUser } from "metabase/selectors/user";
 
 import { GroupDetail } from "../components/GroupDetail";
 
-export const GroupDetailApp = (props: any) => {
+export const GroupDetailApp = ({
+  params: { groupId },
+  title,
+}: {
+  params: { groupId: number };
+  title?: string;
+}) => {
   const currentUser = useSelector(getUser);
 
-  const getGroupReq = useGetPermissionsGroupQuery(props.params.groupId);
+  const getGroupReq = useGetPermissionsGroupQuery(groupId);
   const membershipsByUserReq = useListUserMembershipsQuery();
 
   const error = getGroupReq.error ?? membershipsByUserReq.error;
@@ -22,7 +28,7 @@ export const GroupDetailApp = (props: any) => {
     getGroupReq.isLoading ?? membershipsByUserReq.isLoading ?? !currentUser;
 
   return (
-    <SettingsPageWrapper title={t`Groups`}>
+    <SettingsPageWrapper title={title ?? t`Groups`}>
       <LoadingAndErrorWrapper error={error} loading={isLoading}>
         {currentUser && (
           <GroupDetail

--- a/frontend/src/metabase/admin/people/containers/GroupsListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/GroupsListingApp.tsx
@@ -1,4 +1,6 @@
+import { useMemo } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import {
   SettingsPageWrapper,
@@ -12,25 +14,42 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import { PLUGIN_GROUP_MANAGERS } from "metabase/plugins";
+import { PLUGIN_GROUP_MANAGERS, PLUGIN_TENANTS } from "metabase/plugins";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import type { Group } from "metabase-types/api";
 
 import { GroupsListing } from "../components/GroupsListing";
 
-export const GroupsListingApp = () => {
+export const GroupsListingApp = ({
+  external,
+  title,
+  description,
+}: {
+  external?: boolean;
+  title?: string;
+  description?: string;
+}) => {
   const dispatch = useDispatch();
   const isAdmin = useSelector(getUserIsAdmin);
 
   const { data, isLoading, error } = useListPermissionsGroupsQuery();
-  const groups = data ?? [];
+  const groups = useMemo(() => {
+    const [externalGroups, internalGroups] = _.partition(
+      data ?? [],
+      PLUGIN_TENANTS.isTenantGroup,
+    );
+    return external ? externalGroups : internalGroups;
+  }, [data, external]);
 
   const [createGroup] = useCreatePermissionsGroupMutation();
   const [updateGroup] = useUpdatePermissionsGroupMutation();
   const [deleteGroup] = useDeletePermissionsGroupMutation();
 
   const handleCreate = async (group: { name: string }) => {
-    await createGroup(group).unwrap();
+    await createGroup({
+      ...group,
+      is_tenant_group: external, // TODO, make the API accept this
+    }).unwrap();
   };
 
   const handleUpdate = async (group: { id: number; name: string }) => {
@@ -49,10 +68,11 @@ export const GroupsListingApp = () => {
   };
 
   return (
-    <SettingsPageWrapper title={t`Groups`}>
+    <SettingsPageWrapper title={title ?? t`Groups`}>
       <SettingsSection>
         <LoadingAndErrorWrapper error={error} loading={isLoading}>
           <GroupsListing
+            description={description}
             isAdmin={isAdmin}
             groups={groups}
             create={handleCreate}

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
@@ -42,7 +42,10 @@ export function PeopleListingApp({
     data: groups = [],
     isLoading,
     error,
-  } = useListPermissionsGroupsQuery(undefined, { skip: external });
+  } = useListPermissionsGroupsQuery(
+    { tenancy: "internal" },
+    { skip: external },
+  );
 
   const {
     query,

--- a/frontend/src/metabase/admin/people/forms/UserForm.tsx
+++ b/frontend/src/metabase/admin/people/forms/UserForm.tsx
@@ -75,7 +75,11 @@ export const UserForm = ({
             required
             mb="md"
           />
-          <FormGroupsWidget name="user_group_memberships" external={external} />
+          <FormGroupsWidget
+            name="user_group_memberships"
+            external={external}
+            title={external ? t`Tenant Groups` : t`Groups`}
+          />
           {external && (
             <PLUGIN_TENANTS.FormTenantWidget
               required

--- a/frontend/src/metabase/admin/people/forms/UserForm.tsx
+++ b/frontend/src/metabase/admin/people/forms/UserForm.tsx
@@ -75,7 +75,7 @@ export const UserForm = ({
             required
             mb="md"
           />
-          {!external && <FormGroupsWidget name="user_group_memberships" />}
+          <FormGroupsWidget name="user_group_memberships" external={external} />
           {external && (
             <PLUGIN_TENANTS.FormTenantWidget
               required

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.jsx
@@ -5,13 +5,12 @@ import { useRef, useState } from "react";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { Ellipsified } from "metabase/common/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
-import { Text, Tooltip } from "metabase/ui";
+import { Flex, Text, Tooltip } from "metabase/ui";
 
 import { PermissionsSelect } from "../PermissionsSelect";
 
 import {
   ColumnName,
-  EntityName,
   EntityNameLink,
   HintIcon,
   PermissionTableHeaderCell,
@@ -118,7 +117,10 @@ export function PermissionsTable({
                       {entityName}
                     </EntityNameLink>
                   ) : (
-                    <EntityName>{entityName}</EntityName>
+                    <Flex gap="xs" fw="bold">
+                      {entityName}
+                      {entity.icon}
+                    </Flex>
                   )}
                   {entity.callout && (
                     <Text c="text-secondary">{entity.callout}</Text>

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.tsx
@@ -80,10 +80,6 @@ export const PermissionsTableRow = styled.tr`
   border-bottom: ${({ theme }) => getTableBorder(theme)};
 `;
 
-export const EntityName = styled.span`
-  font-weight: 700;
-`;
-
 export const EntityNameLink = styled(Link)`
   display: inline;
   font-weight: 700;

--- a/frontend/src/metabase/admin/permissions/constants/messages.ts
+++ b/frontend/src/metabase/admin/permissions/constants/messages.ts
@@ -11,17 +11,17 @@ export const Messages = {
     return t`Change "No self-service (Deprecated)" View data access to enable custom Create queries permissions.`;
   },
   get EXTERNAL_USERS_NO_ACCESS_COLLECTION() {
-    return t`External Users can only access tenant collections`;
+    return t`External users can only access tenant collections`;
   },
   get EXTERNAL_USERS_NO_ACCESS_DATABASE() {
-    return t`External Users cannot manage database permissions`;
+    return t`External users cannot manage database permissions`;
   },
 
   get EXTERNAL_USERS_NO_ACCESS_SETTINGS() {
-    return t`External Users cannot have settings permissions`;
+    return t`External users cannot have settings permissions`;
   },
   get EXTERNAL_USERS_NO_ACCESS_MONITORING() {
-    return t`External Users cannot have monitioring permissions`;
+    return t`External users cannot have monitoring permissions`;
   },
 };
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.ts
@@ -44,7 +44,7 @@ export const getGroupsSidebar = createSelector(
     const externalGroupItems = externalGroups.map((group) => ({
       ...group,
       name: getGroupNameLocalized(group),
-      icon: "globe",
+      icon: group.magic_group_type ? "bolt" : "globe",
     }));
 
     const entityGroups = [

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/groups.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/groups.ts
@@ -15,7 +15,7 @@ export const getOrderedGroups = createSelector(
     const [pinnedGroups, unpinnedGroups] = _.partition(groups, isPinnedGroup);
     return [
       pinnedGroups,
-      ..._.partition(unpinnedGroups, PLUGIN_TENANTS.isExternalUsersGroup),
+      ..._.partition(unpinnedGroups, PLUGIN_TENANTS.isTenantGroup),
     ];
   },
 );

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
@@ -400,6 +400,8 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
         const isAdmin = isAdminGroup(group);
         const isExternal =
           !!externalUsersGroup && PLUGIN_TENANTS.isExternalUsersGroup(group);
+
+        const isTenantGroup = PLUGIN_TENANTS.isTenantGroup(group);
         let groupPermissions;
 
         if (tableId != null) {
@@ -450,6 +452,9 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
         return {
           id: group.id,
           name: group.name,
+          icon: isTenantGroup ? (
+            <PLUGIN_TENANTS.TenantGroupHintIcon />
+          ) : undefined,
           hint: isAdmin
             ? t`The Administrators group is special, and always has Unrestricted access.`
             : null,

--- a/frontend/src/metabase/api/permission.ts
+++ b/frontend/src/metabase/api/permission.ts
@@ -34,7 +34,10 @@ export const permissionApi = Api.injectEndpoints({
       providesTags: (group) =>
         group ? providePermissionsGroupTags(group) : [],
     }),
-    createPermissionsGroup: builder.mutation<BaseGroupInfo, { name: string }>({
+    createPermissionsGroup: builder.mutation<
+      BaseGroupInfo,
+      Pick<BaseGroupInfo, "name" | "is_tenant_group">
+    >({
       query: (body) => ({
         method: "POST",
         url: "/api/permissions/group",

--- a/frontend/src/metabase/api/permission.ts
+++ b/frontend/src/metabase/api/permission.ts
@@ -19,10 +19,14 @@ import {
 
 export const permissionApi = Api.injectEndpoints({
   endpoints: (builder) => ({
-    listPermissionsGroups: builder.query<GroupListQuery[], void>({
-      query: () => ({
+    listPermissionsGroups: builder.query<
+      GroupListQuery[],
+      { tenancy?: "external" | "internal" } | undefined
+    >({
+      query: (params) => ({
         method: "GET",
         url: "/api/permissions/group",
+        params,
       }),
       providesTags: (groups = []) => providePermissionsGroupListTags(groups),
     }),

--- a/frontend/src/metabase/forms/components/FormGroupsWidget/FormGroupsWidget.tsx
+++ b/frontend/src/metabase/forms/components/FormGroupsWidget/FormGroupsWidget.tsx
@@ -108,6 +108,7 @@ export const FormGroupsWidget = ({
         onAdd={handleAdd}
         onRemove={handleRemove}
         onChange={handleChange}
+        groupsTitle={title}
         isUserAdmin={isUserAdmin}
       />
     </FormField>

--- a/frontend/src/metabase/forms/components/FormGroupsWidget/FormGroupsWidget.tsx
+++ b/frontend/src/metabase/forms/components/FormGroupsWidget/FormGroupsWidget.tsx
@@ -1,5 +1,5 @@
 import { useField } from "formik";
-import type { HTMLAttributes } from "react";
+import { type HTMLAttributes, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -11,6 +11,7 @@ import type { GroupId, Member } from "metabase-types/api";
 
 interface FormGroupsWidgetProps extends HTMLAttributes<HTMLDivElement> {
   name: string;
+  external?: boolean;
 }
 
 export const FormGroupsWidget = ({
@@ -18,11 +19,19 @@ export const FormGroupsWidget = ({
   className,
   style,
   title = t`Groups`,
+  external,
 }: FormGroupsWidgetProps) => {
   const [{ value: formValue }, , { setValue }] =
     useField<{ id: GroupId; is_group_manager?: boolean }[]>(name);
 
-  const { data: groups, isLoading } = useListPermissionsGroupsQuery();
+  const { data, isLoading } = useListPermissionsGroupsQuery();
+
+  const groups = useMemo(() => {
+    if (external && data) {
+      return data?.filter((group) => group.is_tenant_group);
+    }
+    return data;
+  }, [data, external]);
 
   if (isLoading || !groups) {
     return null;

--- a/frontend/src/metabase/lib/groups.ts
+++ b/frontend/src/metabase/lib/groups.ts
@@ -10,7 +10,7 @@ const SPECIAL_GROUP_NAMES = new Map([
   // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
   ["Administrators", t`Administrators`],
   // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
-  ["All External Users", t`External Users`],
+  ["All External Users", t`All External Users`],
 ]);
 
 export function isDefaultGroup(group: Pick<GroupInfo, "magic_group_type">) {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -816,6 +816,7 @@ export const PLUGIN_TENANTS = {
   FormTenantWidget: (_props: any) => null as React.ReactElement | null,
   TenantDisplayName: (_props: any) => null as React.ReactElement | null,
   isExternalUsersGroup: (_group: Pick<Group, "magic_group_type">) => false,
+  isTenantGroup: (_group: Pick<Group, "is_tenant_group">) => false,
   isExternalUser: (_user?: Pick<User, "tenant_id">) => false,
   isTenantCollection: (_collection: Collection) => false,
   PeopleNav: null as React.ReactElement | null,

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -822,4 +822,5 @@ export const PLUGIN_TENANTS = {
   PeopleNav: null as React.ReactElement | null,
   ReactivateExternalUserButton: ({ user: _user }: { user: User }) =>
     null as React.ReactElement | null,
+  TenantGroupHintIcon: PluginPlaceholder,
 };


### PR DESCRIPTION
Closes ADM-779

### Description


Adds UI for
- adding and editing tenant groups
- assigning groups to tenant users
- not showing tenant groups in the main groups UI
- showing tenant groups together in permissions UI

<img width="1120" height="587" alt="Screenshot 2025-07-15 at 2 35 28 PM" src="https://github.com/user-attachments/assets/e186ab03-e848-49be-a80f-f54cc1c8695d" />

<img width="382" height="343" alt="Screenshot 2025-07-15 at 2 36 04 PM" src="https://github.com/user-attachments/assets/cbdab046-90f6-4a93-aed4-dd937495d119" />
<img width="1136" height="588" alt="Screenshot 2025-07-15 at 2 35 54 PM" src="https://github.com/user-attachments/assets/9a1b8e51-6051-40fc-897a-01b904136e01" />
<img width="1136" height="597" alt="Screenshot 2025-07-15 at 2 35 48 PM" src="https://github.com/user-attachments/assets/c11facec-f292-4012-b2f3-948e08d5e889" />



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
