### PR TITLE
Add sqlite on demand in E2E tests

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -314,48 +314,6 @@ describe("snapshots", () => {
       },
     );
   }
-
-  // TODO: It'd be nice to have one file per snapshot.
-  // To do that we need to enforce execution order among them.
-  describe("withSqlite", () => {
-    it("withSqlite", () => {
-      restore("default");
-      cy.signInAsAdmin();
-
-      cy.request("POST", "/api/database", {
-        engine: "sqlite",
-        name: "sqlite",
-        details: { db: "./resources/sqlite-fixture.db" },
-        auto_run_queries: true,
-        is_full_sync: true,
-        schedules: {
-          cache_field_values: {
-            schedule_day: null,
-            schedule_frame: null,
-            schedule_hour: 0,
-            schedule_type: "daily",
-          },
-          metadata_sync: {
-            schedule_day: null,
-            schedule_frame: null,
-            schedule_hour: null,
-            schedule_type: "hourly",
-          },
-        },
-      }).then(({ body: { id } }) => {
-        cy.request("POST", `/api/database/${id}/sync_schema`);
-        cy.request("POST", `/api/database/${id}/rescan_values`);
-        cy.wait(1000); // wait for sync
-        snapshot("withSqlite");
-        // TODO: Temporary HACK that requires further investigation and a better solution.
-        // sqlite driver was messing with the sync of postres database in CY tests
-        // ("probably some weird race condition" @Damon)
-        // Deleting it here keeps snapshots intact, and enables for unobstructed postgres testing.
-        cy.request("DELETE", `/api/database/${id}`);
-        restore("blank");
-      });
-    });
-  });
 });
 
 function getDefaultInstanceData() {

--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -393,3 +393,31 @@ export function resyncDatabase({
   cy.request("POST", `/api/database/${dbId}/rescan_values`);
   waitForSyncToFinish({ iteration: 0, dbId, tableName, tableAlias });
 }
+
+export function addSqliteDatabase(name = "sqlite") {
+  cy.request("POST", "/api/database", {
+    engine: "sqlite",
+    name,
+    details: { db: "./resources/sqlite-fixture.db" },
+    auto_run_queries: true,
+    is_full_sync: true,
+    schedules: {
+      cache_field_values: {
+        schedule_day: null,
+        schedule_frame: null,
+        schedule_hour: 0,
+        schedule_type: "daily",
+      },
+      metadata_sync: {
+        schedule_day: null,
+        schedule_frame: null,
+        schedule_hour: null,
+        schedule_type: "hourly",
+      },
+    },
+  }).then(({ status, body }) => {
+    expect(status).to.equal(200);
+    assertOnDatabaseMetadata("sqlite");
+    cy.wrap(body.id).as("sqliteID");
+  });
+}

--- a/e2e/support/helpers/e2e-setup-helpers.js
+++ b/e2e/support/helpers/e2e-setup-helpers.js
@@ -11,7 +11,6 @@ export function snapshot(name) {
  * "setup" |
  * "without-models" |
  * "default" |
- * "withSqlite" |
  * "mongo-5" |
  * "postgres-12" |
  * "postgres-writable" |

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -2215,65 +2215,66 @@ describe("scenarios > admin > datamodel", () => {
         });
 
         it("should allow 'Custom mapping' null values", () => {
-          const databaseId = 2;
           const remappedNullValue = "nothin";
 
-          H.restore("withSqlite");
           cy.signInAsAdmin();
+          H.addSqliteDatabase();
 
-          H.withDatabase(
-            databaseId,
-            ({ NUMBER_WITH_NULLS: { NUM }, NUMBER_WITH_NULLS_ID }) => {
-              cy.request("GET", `/api/database/${databaseId}/schemas`).then(
-                ({ body }) => {
-                  const [schemaName] = body;
+          cy.get<number>("@sqliteID").then((databaseId) => {
+            H.withDatabase(
+              databaseId,
+              ({ NUMBER_WITH_NULLS: { NUM }, NUMBER_WITH_NULLS_ID }) => {
+                cy.request("GET", `/api/database/${databaseId}/schemas`).then(
+                  ({ body }) => {
+                    const [schemaName] = body;
 
-                  H.DataModel.visit({
-                    databaseId,
-                    schemaId: `${databaseId}:${schemaName}`,
-                    tableId: NUMBER_WITH_NULLS_ID,
-                    fieldId: NUM,
-                  });
-                },
-              );
+                    H.DataModel.visit({
+                      databaseId,
+                      schemaId: `${databaseId}:${schemaName}`,
+                      tableId: NUMBER_WITH_NULLS_ID,
+                      fieldId: NUM,
+                    });
+                  },
+                );
 
-              cy.log("Change `null` to custom mapping");
-              FieldSection.getDisplayValuesInput().scrollIntoView().click();
-              H.popover().findByText("Custom mapping").click();
-              cy.wait("@updateFieldValues");
-              H.undoToast().should(
-                "contain.text",
-                "Display values of Num updated",
-              );
-              H.undoToast().icon("close").click({
-                force: true, // it's behind a modal
-              });
-
-              H.modal()
-                .should("be.visible")
-                .within(() => {
-                  cy.findAllByPlaceholderText("Enter value")
-                    .filter("[value='null']")
-                    .clear()
-                    .type(remappedNullValue);
-                  cy.button("Save").click();
+                cy.log("Change `null` to custom mapping");
+                FieldSection.getDisplayValuesInput().scrollIntoView().click();
+                H.popover().findByText("Custom mapping").click();
+                cy.wait("@updateFieldValues");
+                H.undoToast().should(
+                  "contain.text",
+                  "Display values of Num updated",
+                );
+                H.undoToast().icon("close").click({
+                  force: true, // it's behind a modal
                 });
-              cy.wait("@updateFieldValues");
-              H.undoToast().should(
-                "contain.text",
-                "Display values of Num updated",
-              );
 
-              cy.log("Make sure custom mapping appears in QB");
-              H.openTable({
-                database: databaseId,
-                table: NUMBER_WITH_NULLS_ID,
-              });
-              cy.findAllByRole("gridcell", { name: remappedNullValue }).should(
-                "be.visible",
-              );
-            },
-          );
+                H.modal()
+                  .should("be.visible")
+                  .within(() => {
+                    cy.findAllByPlaceholderText("Enter value")
+                      .filter("[value='null']")
+                      .clear()
+                      .type(remappedNullValue);
+                    cy.button("Save").click();
+                  });
+                cy.wait("@updateFieldValues");
+                H.undoToast().should(
+                  "contain.text",
+                  "Display values of Num updated",
+                );
+
+                cy.log("Make sure custom mapping appears in QB");
+                H.openTable({
+                  database: databaseId,
+                  table: NUMBER_WITH_NULLS_ID,
+                });
+                cy.findAllByRole("gridcell", {
+                  name: remappedNullValue,
+                }).should("be.visible");
+              },
+            );
+          });
         });
 
         it("should correctly show remapped column value", () => {

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -41,30 +41,29 @@ describe("scenarios > home > homepage", () => {
 
     it("should display x-rays for a user database", () => {
       cy.signInAsAdmin();
+      H.addSqliteDatabase();
 
-      const dbId = 2;
+      cy.get("@sqliteID").then((dbId) => {
+        H.withDatabase(dbId, ({ NUMBER_WITH_NULLS: { NUM } }) => {
+          // we first set the semantic type of the num field to Category,
+          // else no X-rays would be computed
+          cy.request("PUT", `/api/field/${NUM}`, {
+            semantic_type: "type/Category",
+            has_field_values: "none",
+          });
 
-      H.restore("withSqlite");
+          cy.visit("/");
+          cy.wait("@getXrayCandidates");
 
-      H.withDatabase(dbId, ({ NUMBER_WITH_NULLS: { NUM } }) => {
-        // we first set the semantic type of the num field to Category,
-        // else no X-rays would be computed
-        cy.request("PUT", `/api/field/${NUM}`, {
-          semantic_type: "type/Category",
-          has_field_values: "none",
+          cy.findByText("Here are some explorations of");
+          cy.findAllByRole("link").contains("sqlite");
+
+          cy.findByText("Number With Nulls").click();
+
+          cy.wait("@getXrayDashboard");
+
+          cy.findByText("More X-rays");
         });
-
-        cy.visit("/");
-        cy.wait("@getXrayCandidates");
-
-        cy.findByText("Here are some explorations of");
-        cy.findAllByRole("link").contains("sqlite");
-
-        cy.findByText("Number With Nulls").click();
-
-        cy.wait("@getXrayDashboard");
-
-        cy.findByText("More X-rays");
       });
     });
 


### PR DESCRIPTION
I wanted to do this for sooooo long, but was convinced we "restore" `withSqlite` DB snapshot in way more tests. It was actually just two. Really doesn't make sense to have this step in the default snapshot creator because it runs for dozens of CI chunks, and it adds up.

It takes about three seconds to create this snapshot
<img width="487" height="54" alt="image" src="https://github.com/user-attachments/assets/167052df-9918-439e-81b6-a1263457ae3f" />
