### PR TITLE
Avoid losing changes in the dashboard when creating a new dashboard question

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
@@ -328,5 +328,71 @@ describe("scenarios > embedding-sdk > editable-dashboard", () => {
         cy.findByText("You're editing this dashboard.").should("not.exist");
       });
     });
+
+    it("should allow to save unsaved changes before creating a dashboard question", () => {
+      cy.get("@dashboardId").then((dashboardId) => {
+        mountSdkContent(<EditableDashboard dashboardId={dashboardId} />);
+      });
+
+      const ADDED_QUESTION_NAME = "Orders";
+      const ADDED_QUESTION_NAME_2 = "Orders Model";
+      const ADDED_QUESTION_NAME_3 = "Products in a dashboard";
+
+      getSdkRoot().within(() => {
+        cy.button("Edit dashboard").should("be.visible").click();
+        cy.button("Add questions").should("be.visible").click();
+
+        cy.log("make the dashboard dirty");
+        cy.findByRole("menuitem", { name: ADDED_QUESTION_NAME }).click();
+        cy.button("New Question").should("be.visible").click();
+
+        cy.log("we should now see the save confirmation modal");
+        H.modal().within(() => {
+          cy.findByRole("heading", { name: "Save your changes?" }).should(
+            "be.visible",
+          );
+          cy.findByText(
+            "You’ll need to save your changes before leaving to create a new question.",
+          ).should("be.visible");
+
+          cy.button("Save changes").should("be.visible").click();
+        });
+
+        cy.log(
+          "go back to the dashboard should still land us in the edit mode with the dirty state saved",
+        );
+        cy.button(`Back to ${DASHBOARD_NAME}`).click();
+        H.getDashboardCard()
+          .findByText(ADDED_QUESTION_NAME)
+          .should("be.visible");
+
+        cy.log("make the dashboard dirty again");
+        cy.button("Add questions").should("be.visible").click();
+        cy.findByRole("menuitem", { name: ADDED_QUESTION_NAME_2 }).click();
+        cy.button("New Question").click();
+
+        H.modal().button("Save changes").click();
+
+        cy.log("we are back in the query builder");
+        H.popover().findByRole("link", { name: "Products" }).click();
+        cy.button("Save").click();
+
+        H.modal().within(() => {
+          cy.findByLabelText("Name").clear().type(ADDED_QUESTION_NAME_3);
+          cy.button("Save").click();
+        });
+
+        cy.log("we should see 3 dashcards in the dashboard now");
+        H.getDashboardCard()
+          .findByText(ADDED_QUESTION_NAME)
+          .should("be.visible");
+        H.getDashboardCard(1)
+          .findByText(ADDED_QUESTION_NAME_2)
+          .should("be.visible");
+        H.getDashboardCard(2)
+          .findByText(ADDED_QUESTION_NAME_3)
+          .should("be.visible");
+      });
+    });
   });
 });

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -27,8 +27,13 @@ import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import type { MetabaseQuestion } from "embedding-sdk/types";
 import type { DashboardEventHandlersProps } from "embedding-sdk/types/dashboard";
 import type { MetabasePluginsConfig } from "embedding-sdk/types/plugins";
+import { useConfirmation } from "metabase/common/hooks";
 import { useLocale } from "metabase/common/hooks/use-locale";
-import { setEditingDashboard, toggleSidebar } from "metabase/dashboard/actions";
+import {
+  setEditingDashboard,
+  toggleSidebar,
+  updateDashboardAndCards,
+} from "metabase/dashboard/actions";
 import { Dashboard } from "metabase/dashboard/components/Dashboard/Dashboard";
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 import {
@@ -37,11 +42,12 @@ import {
   type DashboardContextProviderHandle,
   useDashboardContext,
 } from "metabase/dashboard/context";
-import { getDashboardComplete } from "metabase/dashboard/selectors";
+import { getDashboardComplete, getIsDirty } from "metabase/dashboard/selectors";
 import { useSelector } from "metabase/lib/redux";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { useDashboardLoadHandlers } from "metabase/public/containers/PublicOrEmbeddedDashboard/use-dashboard-load-handlers";
 import { resetErrorPage, setErrorPage } from "metabase/redux/app";
+import { dismissAllUndo } from "metabase/redux/undo";
 import { getErrorPage } from "metabase/selectors/app";
 import type { DashboardId } from "metabase-types/api";
 
@@ -195,6 +201,9 @@ const SdkDashboardInner = ({
     }
   }, [dispatch, dashboardId]);
 
+  const { modalContent, show } = useConfirmation();
+  const isDashboardDirty = useSelector(getIsDirty);
+
   if (isLocaleLoading || isLoading) {
     return (
       <SdkDashboardStyledWrapper className={className} style={style}>
@@ -232,7 +241,28 @@ const SdkDashboardInner = ({
           : onNavigateToNewCardFromDashboard
       }
       onNewQuestion={() => {
-        setRenderMode("queryBuilder");
+        if (isDashboardDirty) {
+          show({
+            title: t`Save your changes?`,
+            message: t`You’ll need to save your changes before leaving to create a new question.`,
+            onConfirm: async () => {
+              /**
+               * Dispatch the same actions as in the DashboardLeaveConfirmationModal.
+               * @see {@link https://github.com/metabase/metabase/blob/4453fa8363eb37062a159f398050d050d91397a9/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx#L30-L34}
+               */
+              setRenderMode("queryBuilder");
+              dispatch(dismissAllUndo());
+              await dispatch(updateDashboardAndCards());
+              // After saving the dashboard, it will exit the editing mode.
+              dispatch(setEditingDashboard(dashboard));
+            },
+            confirmButtonProps: {
+              color: "brand",
+            },
+          });
+        } else {
+          setRenderMode("queryBuilder");
+        }
       }}
       downloadsEnabled={displayOptions.downloadsEnabled}
       background={displayOptions.background}
@@ -296,6 +326,7 @@ const SdkDashboardInner = ({
           />
         ))
         .exhaustive()}
+      {modalContent}
     </DashboardContextProvider>
   );
 };

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -245,6 +245,7 @@ const SdkDashboardInner = ({
           show({
             title: t`Save your changes?`,
             message: t`You’ll need to save your changes before leaving to create a new question.`,
+            confirmButtonText: t`Save changes`,
             onConfirm: async () => {
               /**
                * Dispatch the same actions as in the DashboardLeaveConfirmationModal.

--- a/frontend/src/metabase/common/hooks/use-confirmation.tsx
+++ b/frontend/src/metabase/common/hooks/use-confirmation.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
+import type { ButtonProps } from "metabase/ui";
 
 export type ConfirmationState = {
   title: string;
@@ -10,6 +11,7 @@ export type ConfirmationState = {
   onCancel?: () => void;
   confirmButtonText?: string;
   cancelButtonText?: string;
+  confirmButtonProps?: Omit<ButtonProps, "onClick" | "children">;
 };
 
 export const useConfirmation = () => {
@@ -35,6 +37,7 @@ export const useConfirmation = () => {
       title={confirmationState.title}
       message={confirmationState?.message}
       confirmButtonText={confirmationState.confirmButtonText}
+      confirmButtonProps={confirmationState.confirmButtonProps}
     />
   ) : null;
 
@@ -45,6 +48,7 @@ export const useConfirmation = () => {
     onCancel,
     confirmButtonText = t`Confirm`,
     cancelButtonText = t`Cancel`,
+    confirmButtonProps,
   }: ConfirmationState) =>
     setConfirmationState({
       title,
@@ -53,6 +57,7 @@ export const useConfirmation = () => {
       onCancel,
       confirmButtonText,
       cancelButtonText,
+      confirmButtonProps,
     });
 
   return { modalContent, show };


### PR DESCRIPTION
closes EMB-575

### Description
This PRs achieve the feature parity as the core dashboard. This allows users to still explore with their dashboard before clicking the `New Question` button. Before this PR, users would lose their unsaved changes due to the save confirmation being detected at the URL level, but in the SDK we couldn't rely on that. We need to hook the unsaved state into the SDK manually.

### How to verify
1. Run BE
1. Run storybook
    ```sh
    yarn storybook-embedding-sdk
    ```
1. Visit Editable dashboard story
1. Edit > Modify the dashboard e.g. add/remove cards, or add/remove filters.
1. Click "New Question" and we should see the confirmation modal now.
1. Going back now, or going back to the dashboard via saving a new question should land you back in the dashboard with edit mode on and all the unsaved changes saved.

### Demo
<img width="1254" height="790" alt="Screenshot 2025-07-12 at 12 37 56 PM" src="https://github.com/user-attachments/assets/dd078bee-4070-4661-a79e-fce60b8f4713" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

### Known issues
The modal position is a little weird right now. After https://github.com/metabase/metabase/issues/60894 is fixed it will look just right. Anyway, just ignore it for now. It's not from this feature.