### PR TITLE
Optimize writable QA DB snapshot creation process

### DIFF
--- a/e2e/snapshot-creators/qa-db.cy.snap.js
+++ b/e2e/snapshot-creators/qa-db.cy.snap.js
@@ -20,33 +20,15 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
       addPostgresDatabase();
       snapshot("postgres-12");
 
-      setupWritableDB("postgres");
-      cy.get("@postgresID").then((id) => {
-        cy.log("**-- Enabling actions --**");
-        cy.request("PUT", `/api/database/${id}`, {
-          details: {
-            dbname: "writable_db",
-          },
-          settings: { "database-enable-actions": true },
-        });
-      });
+      convertToWritable("postgres");
       snapshot("postgres-writable");
+
       restoreAndAuthenticate();
 
       addMySQLDatabase({});
       snapshot("mysql-8");
 
-      setupWritableDB("mysql");
-      cy.get("@mysqlID").then((id) => {
-        cy.log("**-- Enabling actions --**");
-        cy.request("PUT", `/api/database/${id}`, {
-          details: {
-            dbname: "writable_db",
-            user: "root",
-          },
-          settings: { "database-enable-actions": true },
-        });
-      });
+      convertToWritable("mysql");
       snapshot("mysql-writable");
     }
     restore("blank");
@@ -56,4 +38,28 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
 function restoreAndAuthenticate() {
   restore("default");
   cy.signInAsAdmin();
+}
+
+/**
+ * Takes the existing postgres or mysql database, creates a new database with the
+ * name `writable_db` if it doesn't exist already, and then alters the connection
+ * details to point to that new database.
+ *
+ * @param {"postgres" | "mysql"} engine
+ */
+function convertToWritable(engine) {
+  setupWritableDB(engine);
+
+  const idAlias = `@${engine}ID`;
+
+  cy.get(idAlias).then((id) => {
+    cy.log("**-- Enabling actions --**");
+    cy.request("PUT", `/api/database/${id}`, {
+      details: {
+        dbname: "writable_db",
+        ...(engine === "mysql" ? { user: "root" } : {}),
+      },
+      settings: { "database-enable-actions": true },
+    });
+  });
 }

--- a/e2e/snapshot-creators/qa-db.cy.snap.js
+++ b/e2e/snapshot-creators/qa-db.cy.snap.js
@@ -16,8 +16,6 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
     if (Cypress.env("QA_DB_MONGO") === true) {
       addMongoDatabase();
       snapshot("mongo-5");
-
-      restoreAndAuthenticate();
     } else {
       addPostgresDatabase();
       snapshot("postgres-12");
@@ -32,21 +30,25 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
           settings: { "database-enable-actions": true },
         });
       });
-      // restoreAndAuthenticate();
-      // addPostgresDatabase("Writable Postgres12", true);
       snapshot("postgres-writable");
       restoreAndAuthenticate();
 
       addMySQLDatabase({});
       snapshot("mysql-8");
-      restoreAndAuthenticate();
 
       setupWritableDB("mysql");
-      addMySQLDatabase({ displayName: "Writable MySQL8", writable: true });
+      cy.get("@mysqlID").then((id) => {
+        cy.log("**-- Enabling actions --**");
+        cy.request("PUT", `/api/database/${id}`, {
+          details: {
+            dbname: "writable_db",
+            user: "root",
+          },
+          settings: { "database-enable-actions": true },
+        });
+      });
       snapshot("mysql-writable");
-      restoreAndAuthenticate();
     }
-
     restore("blank");
   });
 });

--- a/e2e/snapshot-creators/qa-db.cy.snap.js
+++ b/e2e/snapshot-creators/qa-db.cy.snap.js
@@ -8,21 +8,22 @@ import {
 } from "e2e/support/helpers";
 
 describe("qa databases snapshots", { tags: "@external" }, () => {
-  beforeEach(() => {
-    restoreAndAuthenticate();
-  });
-
   it("creates snapshots for supported qa databases", () => {
     if (Cypress.env("QA_DB_MONGO") === true) {
+      restoreAndAuthenticate();
       addMongoDatabase();
       snapshot("mongo-5");
     } else {
+      // Postgres
+      restoreAndAuthenticate();
+
       addPostgresDatabase();
       snapshot("postgres-12");
 
       convertToWritable("postgres");
       snapshot("postgres-writable");
 
+      // MySQL
       restoreAndAuthenticate();
 
       addMySQLDatabase({});
@@ -31,6 +32,7 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
       convertToWritable("mysql");
       snapshot("mysql-writable");
     }
+
     restore("blank");
   });
 });

--- a/e2e/snapshot-creators/qa-db.cy.snap.js
+++ b/e2e/snapshot-creators/qa-db.cy.snap.js
@@ -57,6 +57,7 @@ function convertToWritable(engine) {
   cy.get(idAlias).then((id) => {
     cy.log("**-- Enabling actions --**");
     cy.request("PUT", `/api/database/${id}`, {
+      name: engine === "postgres" ? "Writable Postgres12" : "Writable MySQL8",
       details: {
         dbname: "writable_db",
         ...(engine === "mysql" ? { user: "root" } : {}),

--- a/e2e/snapshot-creators/qa-db.cy.snap.js
+++ b/e2e/snapshot-creators/qa-db.cy.snap.js
@@ -21,10 +21,19 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
     } else {
       addPostgresDatabase();
       snapshot("postgres-12");
-      restoreAndAuthenticate();
 
       setupWritableDB("postgres");
-      addPostgresDatabase("Writable Postgres12", true);
+      cy.get("@postgresID").then((id) => {
+        cy.log("**-- Enabling actions --**");
+        cy.request("PUT", `/api/database/${id}`, {
+          details: {
+            dbname: "writable_db",
+          },
+          settings: { "database-enable-actions": true },
+        });
+      });
+      // restoreAndAuthenticate();
+      // addPostgresDatabase("Writable Postgres12", true);
       snapshot("postgres-writable");
       restoreAndAuthenticate();
 

--- a/e2e/snapshot-creators/qa-db.cy.snap.js
+++ b/e2e/snapshot-creators/qa-db.cy.snap.js
@@ -16,34 +16,25 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
     if (Cypress.env("QA_DB_MONGO") === true) {
       addMongoDatabase();
       snapshot("mongo-5");
-      deleteDatabase("mongoID");
 
       restoreAndAuthenticate();
     } else {
       addPostgresDatabase();
       snapshot("postgres-12");
-      deleteDatabase("postgresID");
-
       restoreAndAuthenticate();
 
       setupWritableDB("postgres");
       addPostgresDatabase("Writable Postgres12", true);
       snapshot("postgres-writable");
-      deleteDatabase("postgresID");
-
       restoreAndAuthenticate();
 
       addMySQLDatabase({});
       snapshot("mysql-8");
-      deleteDatabase("mysqlID");
-
       restoreAndAuthenticate();
 
       setupWritableDB("mysql");
       addMySQLDatabase({ displayName: "Writable MySQL8", writable: true });
       snapshot("mysql-writable");
-      deleteDatabase("mysqlID");
-
       restoreAndAuthenticate();
     }
 
@@ -54,10 +45,4 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
 function restoreAndAuthenticate() {
   restore("default");
   cy.signInAsAdmin();
-}
-
-function deleteDatabase(idAlias) {
-  cy.get("@" + idAlias).then((id) => {
-    return cy.request("DELETE", `/api/database/${id}`);
-  });
 }

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -85,6 +85,7 @@ H.describeWithSnowplow(
       cy.findByRole("link", { name: "Table Metadata" }).click();
 
       H.DataModel.TablePicker.getDatabase("Writable Postgres12").click();
+      H.DataModel.TablePicker.getSchema(EMPTY_SCHEMA_NAME).click();
       H.DataModel.TablePicker.getTables().should("have.length", 1);
       H.DataModel.TablePicker.getTable("Dog Breeds").should("be.visible");
     });

--- a/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
+++ b/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
@@ -119,7 +119,7 @@ export const Onboarding = () => {
     });
   };
 
-  // Scroll the last opened item into view when the user navigates back go this page
+  // Scroll the last opened item into view when the user navigates back to this page
   useEffect(() => {
     if (isValidItemKey(lastItemOpened)) {
       const item = itemRefs[lastItemOpened].current;


### PR DESCRIPTION
🏎️  This PR should shave off ~10 seconds from the E2E snapshot creation process (making it 15-20% faster). 🏎️ 

There were a few things we were doing related to the "writable" databases that I think are superfluous.

First, deleting a database before we restore the "default" snapshot. That one is just a blind mirror of a [hotfix from 5-6 years ago](https://github.com/metabase/metabase/pull/60888/files#diff-3bba924aa231cd18371d6e6aa058ac423f2c238b134aaeb21ba7f35052c1db97L350) that we had to do for sqlite but never knew or understood why - it just seemed to work. It's not needed for postgres/mysql.

The fact that we're deleting a database that already synced, only to add it back and wait for the connection + sync again is wasteful. That's basically the same connection with slightly different details. One important bit here is that we use NodeJS (via Knex) to set up the writable DB:
1. query DB to see if the `writable_db` schema exists
2. add it if it doesn't

But then what's left to change is not that much, actually.
We have to update the:
1. (display) name of the database 
2. name of the actual database (from `sample` to `writable_db`)
3. (only in case of MySQL to update the user from `metabase` to `root`), and finally
4. enable actions

> [!IMPORTANT]
> There is one caveat, though! This means that our writable databases will now have TWO schemas: (1) public and (2) writable_db! I don't think this is bad to begin with, and it might even prove useful because we rarely (if ever?) test databases with more than one schema. IIRC, we had to mock that in the past.
> 
> There is only one test that is failing because of this. It has inflexible assertion, but the functionality it is testing is still working as intended. This test is easy to update.
>
> Alternatively, we can delete the `public` schema although I don't see a very good reason to do that.