### PR TITLE
Fix can't save SDK question to a different tab

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
@@ -415,17 +415,20 @@ describe("scenarios > embedding-sdk > editable-dashboard", () => {
           cy.log(
             "we should see 2 dash cards in the the first tab, and the 3rd one in the second tab",
           );
+          cy.log(
+            'we should be on the "Tab 2" tab, because we saved the question there',
+          );
+          H.getDashboardCard()
+            .findByText(ADDED_QUESTION_NAME_3)
+            .should("be.visible");
+
+          // 1st tab
+          H.goToTab("Tab 1");
           H.getDashboardCard()
             .findByText(ADDED_QUESTION_NAME)
             .should("be.visible");
           H.getDashboardCard(1)
             .findByText(ADDED_QUESTION_NAME_2)
-            .should("be.visible");
-
-          // 2nd tab
-          H.goToTab("Tab 2");
-          H.getDashboardCard()
-            .findByText(ADDED_QUESTION_NAME_3)
             .should("be.visible");
         });
       });

--- a/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
@@ -309,6 +309,10 @@ describe("scenarios > embedding-sdk > editable-dashboard", () => {
             "be.visible",
           );
           cy.findByLabelText("Name").clear().type("Orders in a dashboard");
+          // Dashboard without tabs should not show the tab selector
+          cy.findByLabelText("Which tab should this go on?").should(
+            "not.exist",
+          );
           cy.button("Save").click();
         });
 
@@ -329,69 +333,101 @@ describe("scenarios > embedding-sdk > editable-dashboard", () => {
       });
     });
 
-    it("should allow to save unsaved changes before creating a dashboard question", () => {
-      cy.get("@dashboardId").then((dashboardId) => {
-        mountSdkContent(<EditableDashboard dashboardId={dashboardId} />);
+    describe("with dashboard with tabs", () => {
+      const DASHBOARD_WITH_TABS_NAME = "Dashboard With tabs";
+
+      beforeEach(() => {
+        cy.signInAsAdmin();
+        H.createDashboardWithTabs({
+          name: DASHBOARD_WITH_TABS_NAME,
+          tabs: [
+            { name: "Tab 1", id: 1 },
+            { name: "Tab 2", id: 2 },
+          ],
+        }).then(({ id: dashboardId }) => {
+          cy.wrap(dashboardId).as("dashboardWithTabsId");
+        });
+        cy.signOut();
       });
 
-      const ADDED_QUESTION_NAME = "Orders";
-      const ADDED_QUESTION_NAME_2 = "Orders Model";
-      const ADDED_QUESTION_NAME_3 = "Products in a dashboard";
+      it("should allow to save unsaved changes before creating a dashboard question", () => {
+        cy.get("@dashboardWithTabsId").then((dashboardId) => {
+          mountSdkContent(<EditableDashboard dashboardId={dashboardId} />);
+        });
 
-      getSdkRoot().within(() => {
-        cy.button("Edit dashboard").should("be.visible").click();
-        cy.button("Add questions").should("be.visible").click();
+        const ADDED_QUESTION_NAME = "Orders";
+        const ADDED_QUESTION_NAME_2 = "Orders Model";
+        const ADDED_QUESTION_NAME_3 = "Products in a dashboard";
 
-        cy.log("make the dashboard dirty");
-        cy.findByRole("menuitem", { name: ADDED_QUESTION_NAME }).click();
-        cy.button("New Question").should("be.visible").click();
+        getSdkRoot().within(() => {
+          cy.button("Edit dashboard").should("be.visible").click();
+          cy.button("Add questions").should("be.visible").click();
 
-        cy.log("we should now see the save confirmation modal");
-        H.modal().within(() => {
-          cy.findByRole("heading", { name: "Save your changes?" }).should(
-            "be.visible",
+          cy.log("make the dashboard dirty");
+          cy.findByRole("menuitem", { name: ADDED_QUESTION_NAME }).click();
+          cy.button("New Question").should("be.visible").click();
+
+          cy.log("we should now see the save confirmation modal");
+          H.modal().within(() => {
+            cy.findByRole("heading", { name: "Save your changes?" }).should(
+              "be.visible",
+            );
+            cy.findByText(
+              "You’ll need to save your changes before leaving to create a new question.",
+            ).should("be.visible");
+
+            cy.button("Save changes").should("be.visible").click();
+          });
+
+          cy.log(
+            "go back to the dashboard should still land us in the edit mode with the dirty state saved",
           );
-          cy.findByText(
-            "You’ll need to save your changes before leaving to create a new question.",
-          ).should("be.visible");
+          cy.button(`Back to ${DASHBOARD_WITH_TABS_NAME}`).click();
+          H.getDashboardCard()
+            .findByText(ADDED_QUESTION_NAME)
+            .should("be.visible");
 
-          cy.button("Save changes").should("be.visible").click();
-        });
+          cy.log("make the dashboard dirty again");
+          cy.button("Add questions").should("be.visible").click();
+          cy.findByRole("menuitem", { name: ADDED_QUESTION_NAME_2 }).click();
+          cy.button("New Question").click();
 
-        cy.log(
-          "go back to the dashboard should still land us in the edit mode with the dirty state saved",
-        );
-        cy.button(`Back to ${DASHBOARD_NAME}`).click();
-        H.getDashboardCard()
-          .findByText(ADDED_QUESTION_NAME)
-          .should("be.visible");
+          H.modal().button("Save changes").click();
 
-        cy.log("make the dashboard dirty again");
-        cy.button("Add questions").should("be.visible").click();
-        cy.findByRole("menuitem", { name: ADDED_QUESTION_NAME_2 }).click();
-        cy.button("New Question").click();
-
-        H.modal().button("Save changes").click();
-
-        cy.log("we are back in the query builder");
-        H.popover().findByRole("link", { name: "Products" }).click();
-        cy.button("Save").click();
-
-        H.modal().within(() => {
-          cy.findByLabelText("Name").clear().type(ADDED_QUESTION_NAME_3);
+          cy.log("we are back in the query builder");
+          H.popover().findByRole("link", { name: "Products" }).click();
           cy.button("Save").click();
-        });
 
-        cy.log("we should see 3 dashcards in the dashboard now");
-        H.getDashboardCard()
-          .findByText(ADDED_QUESTION_NAME)
-          .should("be.visible");
-        H.getDashboardCard(1)
-          .findByText(ADDED_QUESTION_NAME_2)
-          .should("be.visible");
-        H.getDashboardCard(2)
-          .findByText(ADDED_QUESTION_NAME_3)
-          .should("be.visible");
+          H.modal().within(() => {
+            cy.findByLabelText("Name").clear().type(ADDED_QUESTION_NAME_3);
+            // Test saving a question to a different tab
+            cy.findByLabelText("Which tab should this go on?")
+              .should("be.visible")
+              .and("have.value", "Tab 1")
+              .click();
+          });
+
+          // The popover is rendered in the portal root, so we need to call this outside `H.modal()`
+          H.popover().findByRole("option", { name: "Tab 2" }).click();
+          cy.log("save the question to the dashboard");
+          H.modal().button("Save").click();
+
+          cy.log(
+            "we should see 2 dash cards in the the first tab, and the 3rd one in the second tab",
+          );
+          H.getDashboardCard()
+            .findByText(ADDED_QUESTION_NAME)
+            .should("be.visible");
+          H.getDashboardCard(1)
+            .findByText(ADDED_QUESTION_NAME_2)
+            .should("be.visible");
+
+          // 2nd tab
+          H.goToTab("Tab 2");
+          H.getDashboardCard()
+            .findByText(ADDED_QUESTION_NAME_3)
+            .should("be.visible");
+        });
       });
     });
   });

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
@@ -73,7 +73,10 @@ export const InteractiveQuestionProvider = ({
     options?: OnCreateOptions,
   ): Promise<Question> => {
     if (isSaveEnabled) {
-      const saveContext = { isNewQuestion: true };
+      const saveContext = {
+        isNewQuestion: true,
+        dashboardTabId: options?.dashboardTabId,
+      };
       const sdkQuestion = transformSdkQuestion(question);
 
       await onBeforeSave?.(sdkQuestion, saveContext);

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
@@ -70,7 +70,7 @@ export const InteractiveQuestionProvider = ({
 
   const handleCreate = async (
     question: Question,
-    options: OnCreateOptions,
+    options?: OnCreateOptions,
   ): Promise<Question> => {
     if (isSaveEnabled) {
       const saveContext = { isNewQuestion: true };

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/InteractiveQuestionProvider.tsx
@@ -7,7 +7,10 @@ import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import { getPlugins } from "embedding-sdk/store/selectors";
 import type { MetabasePluginsConfig } from "embedding-sdk/types/plugins";
 import type { MetabasePluginsConfig as InternalMetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
-import { useCreateQuestion } from "metabase/query_builder/containers/use-create-question";
+import {
+  type OnCreateOptions,
+  useCreateQuestion,
+} from "metabase/query_builder/containers/use-create-question";
 import { useSaveQuestion } from "metabase/query_builder/containers/use-save-question";
 import { setEntityTypes } from "metabase/redux/embedding-data-picker";
 import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
@@ -65,14 +68,17 @@ export const InteractiveQuestionProvider = ({
     }
   };
 
-  const handleCreate = async (question: Question): Promise<Question> => {
+  const handleCreate = async (
+    question: Question,
+    options: OnCreateOptions,
+  ): Promise<Question> => {
     if (isSaveEnabled) {
       const saveContext = { isNewQuestion: true };
       const sdkQuestion = transformSdkQuestion(question);
 
       await onBeforeSave?.(sdkQuestion, saveContext);
 
-      const createdQuestion = await handleCreateQuestion(question);
+      const createdQuestion = await handleCreateQuestion(question, options);
       onSave?.(transformSdkQuestion(createdQuestion), saveContext);
 
       // Set the latest saved question object to update the question title.

--- a/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/private/InteractiveQuestion/context/types.ts
@@ -58,7 +58,7 @@ type InteractiveQuestionConfig = {
    */
   onSave?: (
     question: MetabaseQuestion,
-    context: { isNewQuestion: boolean },
+    context: { isNewQuestion: boolean; dashboardTabId?: number | undefined },
   ) => void;
 
   /**

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -376,8 +376,7 @@ function DashboardQueryBuilder({
   onNavigateBack,
   queryBuilderProps,
 }: DashboardQueryBuilderProps) {
-  const dispatch = useSdkDispatch();
-  const { dashboard } = useDashboardContext();
+  const { dashboard, selectTab, setEditingDashboard } = useDashboardContext();
 
   /**
    * This won't happen at this point in time. As `DashboardQueryBuilder` is guaranteed to be rendered
@@ -393,10 +392,13 @@ function DashboardQueryBuilder({
     <InteractiveQuestionProvider
       questionId="new"
       targetDashboardId={targetDashboardId}
-      onSave={(question, { isNewQuestion }) => {
+      onSave={(question, { isNewQuestion, dashboardTabId }) => {
         if (isNewQuestion) {
           onCreate(question);
-          dispatch(setEditingDashboard(dashboard));
+          if (dashboardTabId) {
+            selectTab({ tabId: dashboardTabId });
+          }
+          setEditingDashboard(dashboard);
         }
       }}
       onNavigateBack={onNavigateBack}

--- a/frontend/src/metabase/query_builder/containers/use-create-question.ts
+++ b/frontend/src/metabase/query_builder/containers/use-create-question.ts
@@ -11,7 +11,7 @@ import type { DashboardTabId } from "metabase-types/api";
 
 import { updateUrl } from "../actions/url";
 
-type OnCreateOptions = { dashboardTabId?: DashboardTabId | undefined };
+export type OnCreateOptions = { dashboardTabId?: DashboardTabId | undefined };
 
 interface UseCreateQuestionParams {
   scheduleCallback?: ScheduleCallback;


### PR DESCRIPTION
Closes EMB-609

> [!note]
> Despite the PR saying "Fix" it's only the issue that was created within the project, so it's a part of the feature, because previously we couldn't even save a dashboard question on the SDK in the first place.

### Description
This PR does 2 things:
1. We couldn't save an SDK question to a different dashboard tab. We missed passing an additional `options` to the `onCreate` handler. So it fixes that.
2. Another problem is when navigating back to the dashboard from saving a question. We need to show the tab that the user saved the new question to. This PR also addresses this.

### How to verify
0. Run BE
1. Run storybook
    ```sh
    yarn storybook-embedding-sdk
    ```
3. Visit `EditableDashboard` story
4. Now you should see the example dashboard. Try to save a new question to a new dashboard.
5. Edit > Add questions > New Question > build question and click Save > Select the tab that's not the first one.
6. Save > You should be brought back to the tab you selected to, with the new question added.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
