### PR TITLE
Fix positioning of the Mantine Modal in SDK

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -375,6 +375,24 @@ describe("scenarios > embedding-sdk > styles", () => {
       // TODO: good place for a visual regression test
     });
 
+    it("mantine modals should render with proper position", () => {
+      cy.mount(
+        <div style={{ paddingLeft: "9999px" }}>
+          <MetabaseProvider authConfig={DEFAULT_SDK_AUTH_PROVIDER_CONFIG}>
+            <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />
+          </MetabaseProvider>
+        </div>,
+      );
+
+      getSdkRoot().within(() => {
+        cy.findByText("Summarize").click();
+        cy.findByText("Count of rows").click();
+        cy.findByText("Save").click();
+
+        cy.findByText("Save question").should("be.visible");
+      });
+    });
+
     describe("popover/tooltips/overlays styles", () => {
       beforeEach(() => {
         signInAsAdminAndEnableEmbeddingSdk();
@@ -423,7 +441,7 @@ describe("scenarios > embedding-sdk > styles", () => {
         );
       });
 
-      it.skip("should render legacy Popover with our styles", () => {
+      it("should render legacy Popover with our styles", () => {
         cy.get("@dashboardId").then((dashboardId) => {
           mountSdkContent(<EditableDashboard dashboardId={dashboardId} />, {
             sdkProviderProps: {

--- a/frontend/src/metabase/ui/components/overlays/Modal/Modal.config.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/Modal.config.tsx
@@ -3,6 +3,7 @@ import cx from "classnames";
 import { t } from "ttag";
 
 import Animation from "metabase/css/core/animation.module.css";
+import Layout from "metabase/css/core/layout.module.css";
 import ZIndex from "metabase/css/core/z-index.module.css";
 
 export const DEFAULT_MODAL_Z_INDEX = 200;
@@ -20,7 +21,7 @@ export const modalOverrides = {
       title: Styles.title,
       overlay: cx(Styles.overlay, ZIndex.Overlay, Animation.fadeIn),
       content: cx(Styles.content, ZIndex.Overlay, Animation.popInFromBottom),
-      inner: cx(ZIndex.Overlay, Animation.popInFromBottom),
+      inner: cx(ZIndex.Overlay, Layout.left, Animation.popInFromBottom),
       header: Styles.header,
       close: Styles.ModalCloseButton,
     },


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60894
Closes https://linear.app/metabase/issue/GIT-7618/sdk-modal-pop-isnt-centered-when-the-sdk-component-isnt-rendered-at

We removed `position: fixed` from Modal portal container, but the Mantine Modal.Inner still has the `position: fixed`. But for some reason it does not have `left: 0` so if parent elements have offsets (padding), offsets affect the Modal position.

The fix adds `left: 0` to Modal.Inner. Also a test is added.