### PR TITLE
Enable cljs dev tools when not hot reloading too

### DIFF
--- a/frontend/src/metabase/dev.js
+++ b/frontend/src/metabase/dev.js
@@ -2,7 +2,7 @@ if (
   // eslint-disable-next-line no-undef
   process.env.ENABLE_CLJS_HOT_RELOAD === "true" ||
   // eslint-disable-next-line no-undef
-  process.env.NODE_ENV === "development"
+  process.env.ENABLE_CLJS_DEV_TOOLS === "true"
 ) {
   import("cljs/metabase.util.devtools");
 }

--- a/frontend/src/metabase/dev.js
+++ b/frontend/src/metabase/dev.js
@@ -1,4 +1,8 @@
-// eslint-disable-next-line no-undef
-if (process.env.ENABLE_CLJS_HOT_RELOAD === "true") {
+if (
+  // eslint-disable-next-line no-undef
+  process.env.ENABLE_CLJS_HOT_RELOAD === "true" ||
+  // eslint-disable-next-line no-undef
+  process.env.NODE_ENV === "development"
+) {
   import("cljs/metabase.util.devtools");
 }


### PR DESCRIPTION
Currently, we only enable the cljs dev tools when `process.env.ENABLE_CLJS_HOT_RELOAD` is enabled (ie. in `yarn dev-hot-be` or `yarn dev-ee-hot-be`).

This PR makes it so that the cljs dev tools are loaded for `yarn dev` and `yarn dev-ee` as well, or whenever `ENABLE_CLJS_DEV_TOOLS=true`.