### PR TITLE
SEM-483 For unfolded JSON subfields, the prefix gets cut aggressively

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -2649,7 +2649,6 @@ describe("scenarios > admin > datamodel", () => {
         });
 
         it("should let you change the name of JSON-unfolded columns (metabase#55563)", () => {
-          // Go to field settings
           H.DataModel.visit({ databaseId: WRITABLE_DB_ID });
           TablePicker.getTable("Many Data Types").click();
           TableSection.clickField("Json → A");
@@ -2666,6 +2665,36 @@ describe("scenarios > admin > datamodel", () => {
             column: "A",
             values: ["10", "10"],
           });
+        });
+
+        it("should smartly truncate prefix name", () => {
+          H.DataModel.visit({ databaseId: WRITABLE_DB_ID });
+          TablePicker.getTable("Many Data Types").click();
+          TableSection.clickField("Json → A");
+
+          cy.log("should not truncante short prefixes");
+          TableSection.getFieldNameInput("Json")
+            .clear()
+            .type("Quite long prefix")
+            .blur();
+          FieldSection.get()
+            .findByTestId("name-prefix")
+            .should("have.text", "Quite long prefix:")
+            .then((element) => {
+              H.assertIsNotEllipsified(element[0]);
+            });
+
+          cy.log("should truncante long prefixes");
+          TableSection.getFieldNameInput("Quite long prefix")
+            .clear()
+            .type("Legendarily long prefix")
+            .blur();
+          FieldSection.get()
+            .findByTestId("name-prefix")
+            .should("have.text", "Legendarily long prefix:")
+            .then((element) => {
+              H.assertIsEllipsified(element[0]);
+            });
         });
       });
     });

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -2668,6 +2668,8 @@ describe("scenarios > admin > datamodel", () => {
         });
 
         it("should smartly truncate prefix name", () => {
+          const shortPrefix = "Short prefix";
+          const longPrefix = "Legendarily long column prefix";
           H.DataModel.visit({ databaseId: WRITABLE_DB_ID });
           TablePicker.getTable("Many Data Types").click();
           TableSection.clickField("Json → A");
@@ -2675,26 +2677,60 @@ describe("scenarios > admin > datamodel", () => {
           cy.log("should not truncante short prefixes");
           TableSection.getFieldNameInput("Json")
             .clear()
-            .type("Quite long prefix")
+            .type(shortPrefix)
             .blur();
+
+          cy.log("in field section");
           FieldSection.get()
             .findByTestId("name-prefix")
-            .should("have.text", "Quite long prefix:")
+            .should("have.text", `${shortPrefix}:`)
             .then((element) => {
               H.assertIsNotEllipsified(element[0]);
             });
+          FieldSection.get().findByTestId("name-prefix").realHover();
+          H.tooltip().should("not.exist");
+
+          cy.log("in table section");
+          TableSection.getField("Json → D")
+            .findByTestId("name-prefix")
+            .should("have.text", `${shortPrefix}:`)
+            .then((element) => {
+              H.assertIsNotEllipsified(element[0]);
+            });
+          TableSection.getField("Json → D")
+            .findByTestId("name-prefix")
+            .realHover();
+          H.tooltip().should("not.exist");
 
           cy.log("should truncante long prefixes");
-          TableSection.getFieldNameInput("Quite long prefix")
+          TableSection.getFieldNameInput(shortPrefix)
             .clear()
-            .type("Legendarily long prefix")
+            .type(longPrefix)
             .blur();
+
+          cy.log("in field section");
           FieldSection.get()
             .findByTestId("name-prefix")
-            .should("have.text", "Legendarily long prefix:")
+            .should("have.text", `${longPrefix}:`)
             .then((element) => {
               H.assertIsEllipsified(element[0]);
             });
+          FieldSection.get()
+            .findByTestId("name-prefix")
+            .realHover({ scrollBehavior: "center" });
+          H.tooltip().should("be.visible").and("have.text", longPrefix);
+
+          // hide tooltip
+          FieldSection.getDescriptionInput().realHover();
+          H.tooltip().should("not.exist");
+
+          cy.log("in table section");
+          TableSection.getField("Json → D")
+            .scrollIntoView({ offset: { left: 0, top: -400 } })
+            .findByTestId("name-prefix")
+            .should("have.text", `${longPrefix}:`)
+            .realHover({ scrollBehavior: "center" });
+          H.tooltip().should("be.visible").and("have.text", longPrefix);
         });
       });
     });

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
@@ -5,6 +5,10 @@
   }
 }
 
+.section {
+  width: auto;
+}
+
 .description {
   position: relative;
   top: -2px; /* Imitate collapsed borders. -1px does not seem to do the trick on Mac. */

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
@@ -1,5 +1,6 @@
 import { useElementSize } from "@mantine/hooks";
 
+import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { Box, Group, Icon, type IconName, Text, rem } from "metabase/ui";
 
 import { Input } from "./Input";
@@ -45,7 +46,11 @@ export const NameDescriptionInput = ({
         leftSection={
           <Group
             align="center"
+            c="text-light"
             gap={10}
+            flex="1"
+            fs="lg"
+            lh="normal"
             maw={rem(Math.floor(width / 2))}
             px={rem(10)}
             ref={sectionRef}
@@ -54,17 +59,16 @@ export const NameDescriptionInput = ({
             <Icon c="brand" flex="0 0 auto" name={nameIcon} size={20} />
 
             {namePrefix && (
-              <Text
-                c="text-light"
+              <Ellipsified
                 data-testid="name-prefix"
-                flex="1"
-                lh="normal"
-                lineClamp={1}
-                size="lg"
+                lines={1}
+                tooltip={namePrefix}
               >
-                {namePrefix}
-                {":"}
-              </Text>
+                <Text c="text-light" component="span" size="lg">
+                  {namePrefix}
+                  {":"}
+                </Text>
+              </Ellipsified>
             )}
           </Group>
         }

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
@@ -30,23 +30,25 @@ export const NameDescriptionInput = ({
   onNameChange,
 }: Props) => {
   const { ref, width } = useElementSize();
-  const leftSectionWidth = width > 0 ? width : 40;
+  const { ref: sectionRef, width: sectionWidth } = useElementSize();
+  const leftSectionWidth = sectionWidth > 0 ? sectionWidth : 40;
 
   return (
-    <Box>
+    <Box ref={ref}>
       <Input
         classNames={{
           input: S.nameInput,
           root: S.name,
+          section: S.section,
         }}
         fw="bold"
         leftSection={
           <Group
             align="center"
             gap={10}
-            maw={rem(140)}
+            maw={rem(Math.floor(width / 2))}
             px={rem(10)}
-            ref={ref}
+            ref={sectionRef}
             wrap="nowrap"
           >
             <Icon c="brand" flex="0 0 auto" name={nameIcon} size={20} />
@@ -82,7 +84,7 @@ export const NameDescriptionInput = ({
         styles={{
           section: {
             // limit the flicker when element is being measured for the first time
-            visibility: width === 0 ? "hidden" : undefined,
+            visibility: sectionWidth === 0 ? "hidden" : undefined,
           },
           input: {
             paddingLeft: leftSectionWidth,

--- a/frontend/src/metabase/metadata/components/SortableFieldItem/SortableFieldItem.tsx
+++ b/frontend/src/metabase/metadata/components/SortableFieldItem/SortableFieldItem.tsx
@@ -1,9 +1,10 @@
 import cx from "classnames";
 
+import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { Sortable } from "metabase/common/components/Sortable";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
-import { Card, Flex, Icon, Text, rem } from "metabase/ui";
+import { Box, Card, Flex, Icon, Text, rem } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { Field } from "metabase-types/api";
 
@@ -59,18 +60,18 @@ export const SortableFieldItem = ({
           <Icon className={S.icon} flex="0 0 auto" mr="sm" name={icon} />
 
           {parent && (
-            <Text
-              c="text-light"
+            <Box
               data-testid="name-prefix"
               flex="0 0 auto"
               lh="normal"
-              lineClamp={1}
               maw="50%"
               mr="xs"
             >
-              {parent.display_name}
-              {":"}
-            </Text>
+              <Ellipsified lines={1} tooltip={parent.display_name}>
+                {parent.display_name}
+                {":"}
+              </Ellipsified>
+            </Box>
           )}
 
           <Text flex="1" fw="bold" lh="normal" lineClamp={1}>

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.tsx
@@ -5,10 +5,11 @@ import { t } from "ttag";
 
 import { useUpdateFieldMutation } from "metabase/api";
 import EditableText from "metabase/common/components/EditableText";
+import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { useToast } from "metabase/common/hooks";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
-import { Box, Card, Flex, Group, Icon, Text, rem } from "metabase/ui";
+import { Box, Card, Flex, Group, Icon, rem } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { Field } from "metabase-types/api";
 
@@ -128,6 +129,7 @@ export const FieldItem = ({ active, field, href, parent }: Props) => {
       >
         <Group
           align="center"
+          c="text-light"
           flex="0 0 auto"
           gap={0}
           maw="100%"
@@ -137,20 +139,20 @@ export const FieldItem = ({ active, field, href, parent }: Props) => {
           <Icon className={S.icon} flex="0 0 auto" mr="sm" name={icon} />
 
           {parent && (
-            <Text
-              c="text-light"
+            <Box
               data-testid="name-prefix"
               flex="0 0 auto"
               lh="normal"
-              lineClamp={1}
               maw="50%"
               mb={rem(-4)}
               mr="xs"
               mt={rem(-3)}
             >
-              {parent.display_name}
-              {":"}
-            </Text>
+              <Ellipsified lines={1} tooltip={parent.display_name}>
+                {parent.display_name}
+                {":"}
+              </Ellipsified>
+            </Box>
           )}
 
           <Box


### PR DESCRIPTION
Closes [SEM-483](https://linear.app/metabase/issue/SEM-483/for-unfolded-json-subfields-the-prefix-gets-cut-aggressively)

### Description

Improves truncation of JSON-unfolded column prefixes.
Prefix now will now take up to 50% width of its container.
If it's longer than that, it will be truncated + have a tooltip.

### Demo

<img width="2552" height="1282" alt="image" src="https://github.com/user-attachments/assets/b22ba65d-d437-4d92-a31e-85a20f521bd2" />
