### PR TITLE
SEM-374 Improve searchability of Table Metadata Field Type section

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -1521,8 +1521,8 @@ describe("scenarios > admin > datamodel", () => {
 
           FieldSection.getSemanticTypeInput()
             .should("have.value", "Foreign Key")
-            .click();
-          H.popover().findByText("No semantic type").click();
+            // it should allow to just type to search
+            .type("no sema{downarrow}{enter}");
           cy.wait("@updateField");
           H.undoToast().should(
             "contain.text",
@@ -1575,8 +1575,8 @@ describe("scenarios > admin > datamodel", () => {
 
           FieldSection.getSemanticTypeFkTarget()
             .should("have.value", "")
-            .click();
-          H.popover().findByText("Products → ID").click();
+            // it should allow to just type to search
+            .type("products{downarrow}{enter}");
           cy.wait("@updateField");
           H.undoToast().should(
             "contain.text",
@@ -1750,8 +1750,8 @@ describe("scenarios > admin > datamodel", () => {
             .scrollIntoView()
             .should("be.visible")
             .and("have.value", "US Dollar")
-            .click();
-          H.popover().findByText("Canadian Dollar").click();
+            // it should allow to just type to search
+            .type("canadian{downarrow}{enter}");
           cy.wait("@updateField");
           verifyAndCloseToast("Semantic type of Tax updated");
 

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -1510,7 +1510,7 @@ describe("scenarios > admin > datamodel", () => {
 
     describe("Metadata", () => {
       describe("Semantic type", () => {
-        it("should allow to change the type to 'No semantic type'", () => {
+        it("should allow to change the type to 'No semantic type' (metabase#59052)", () => {
           H.DataModel.visit({
             databaseId: SAMPLE_DB_ID,
             schemaId: SAMPLE_DB_SCHEMA_ID,
@@ -1521,7 +1521,7 @@ describe("scenarios > admin > datamodel", () => {
 
           FieldSection.getSemanticTypeInput()
             .should("have.value", "Foreign Key")
-            // it should allow to just type to search
+            // it should allow to just type to search (metabase#59052)
             .type("no sema{downarrow}{enter}");
           cy.wait("@updateField");
           H.undoToast().should(
@@ -1548,7 +1548,7 @@ describe("scenarios > admin > datamodel", () => {
           );
         });
 
-        it("should allow to change the type to 'Foreign Key' and choose the target field", () => {
+        it("should allow to change the type to 'Foreign Key' and choose the target field (metabase#59052)", () => {
           H.DataModel.visit({
             databaseId: SAMPLE_DB_ID,
             schemaId: SAMPLE_DB_SCHEMA_ID,
@@ -1575,7 +1575,7 @@ describe("scenarios > admin > datamodel", () => {
 
           FieldSection.getSemanticTypeFkTarget()
             .should("have.value", "")
-            // it should allow to just type to search
+            // it should allow to just type to search (metabase#59052)
             .type("products{downarrow}{enter}");
           cy.wait("@updateField");
           H.undoToast().should(
@@ -1718,7 +1718,7 @@ describe("scenarios > admin > datamodel", () => {
           });
         });
 
-        it("should allow to change the type to 'Currency' and choose the currency", () => {
+        it("should allow to change the type to 'Currency' and choose the currency (metabase#59052)", () => {
           H.DataModel.visit({
             databaseId: SAMPLE_DB_ID,
             schemaId: SAMPLE_DB_SCHEMA_ID,
@@ -1750,7 +1750,7 @@ describe("scenarios > admin > datamodel", () => {
             .scrollIntoView()
             .should("be.visible")
             .and("have.value", "US Dollar")
-            // it should allow to just type to search
+            // it should allow to just type to search (metabase#59052)
             .type("canadian{downarrow}{enter}");
           cy.wait("@updateField");
           verifyAndCloseToast("Semantic type of Tax updated");

--- a/frontend/src/metabase/metadata/components/CurrencyPicker/CurrencyPicker.tsx
+++ b/frontend/src/metabase/metadata/components/CurrencyPicker/CurrencyPicker.tsx
@@ -1,3 +1,4 @@
+import type { FocusEvent } from "react";
 import { t } from "ttag";
 
 import { currency } from "cljs/metabase.util.currency";
@@ -25,8 +26,14 @@ export const CurrencyPicker = ({
   comboboxProps,
   value,
   onChange,
+  onFocus,
   ...props
 }: Props) => {
+  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
+    event.target.select();
+    onFocus?.(event);
+  };
+
   return (
     <Select
       comboboxProps={{
@@ -82,6 +89,7 @@ export const CurrencyPicker = ({
       searchable
       value={value}
       onChange={onChange}
+      onFocus={handleFocus}
       {...props}
     />
   );

--- a/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/FkTargetPicker/FkTargetPicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { type FocusEvent, useMemo } from "react";
 import { t } from "ttag";
 
 import {
@@ -32,6 +32,7 @@ export const FkTargetPicker = ({
   idFields,
   value,
   onChange,
+  onFocus,
   ...props
 }: Props) => {
   const { comparableIdFields, hasIdFields, data, optionsByFieldId } =
@@ -71,6 +72,11 @@ export const FkTargetPicker = ({
   const handleChange = (value: string) => {
     const fieldId = getFieldIdFromValue(value);
     onChange(fieldId);
+  };
+
+  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
+    event.target.select();
+    onFocus?.(event);
   };
 
   return (
@@ -140,6 +146,7 @@ export const FkTargetPicker = ({
       searchable
       value={stringifyValue(value)}
       onChange={handleChange}
+      onFocus={handleFocus}
       {...props}
     />
   );

--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.tsx
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { type FocusEvent, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -21,6 +21,7 @@ export const SemanticTypePicker = ({
   field,
   value,
   onChange,
+  onFocus,
   ...props
 }: Props) => {
   const data = useMemo(() => getData({ field, value }), [field, value]);
@@ -28,6 +29,11 @@ export const SemanticTypePicker = ({
   const handleChange = (value: string) => {
     const parsedValue = parseValue(value);
     onChange(parsedValue);
+  };
+
+  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
+    event.target.select();
+    onFocus?.(event);
   };
 
   return (
@@ -48,6 +54,7 @@ export const SemanticTypePicker = ({
       searchable
       value={stringifyValue(value)}
       onChange={handleChange}
+      onFocus={handleFocus}
       {...props}
     />
   );


### PR DESCRIPTION
Closes [SEM-374](https://linear.app/metabase/issue/SEM-374/improve-searchability-of-table-metadata-field-type-section)
Closes #59052

### Description

Auto-selects text on focus in Select inputs with search is enabled, to ease searchability:
- Semantic type picker
- Currency picker (under Semantic type picker)
- Foreign key picker (under Semantic type picker)

### How to verify

1. Admin > Table metadata > open a field
2. Focus semantic type picker

Value in semantic type picker is auto-selected and you can type to search.
Previously you'd have to clear the input value manually to start search.
