### PR TITLE
fix css issues in the Native Query Editor 

### DIFF
--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -23,24 +23,31 @@ describe("issue 9357", () => {
     cy.signInAsAdmin();
   });
 
-  it("should reorder template tags by drag and drop (metabase#9357)", () => {
-    H.startNewNativeQuestion();
-    SQLFilter.enterParameterizedQuery(
-      "{{firstparameter}} {{nextparameter}} {{lastparameter}}",
-    );
+  it(
+    "should reorder template tags by drag and drop (metabase#9357)",
+    { viewportWidth: 1280, viewportHeight: 800 },
+    () => {
+      H.startNewNativeQuestion();
+      SQLFilter.enterParameterizedQuery(
+        "{{firstparameter}} {{nextparameter}} {{lastparameter}}",
+      );
 
-    // Drag the firstparameter to last position
-    H.moveDnDKitElement(cy.get("fieldset").findAllByRole("listitem").first(), {
-      horizontal: 430,
-    });
+      // Drag the firstparameter to last position
+      H.moveDnDKitElement(
+        cy.get("fieldset").findAllByRole("listitem").first(),
+        {
+          horizontal: 430,
+        },
+      );
 
-    // Ensure they're in the right order
-    cy.findAllByText("Variable name").parent().as("variableField");
+      // Ensure they're in the right order
+      cy.findAllByText("Variable name").parent().as("variableField");
 
-    cy.get("@variableField").first().findByText("nextparameter");
+      cy.get("@variableField").first().findByText("nextparameter");
 
-    cy.get("@variableField").eq(1).findByText("firstparameter");
-  });
+      cy.get("@variableField").eq(1).findByText("firstparameter");
+    },
+  );
 });
 
 describe("issue 11480", () => {

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -25,7 +25,7 @@ describe("issue 9357", () => {
 
   it(
     "should reorder template tags by drag and drop (metabase#9357)",
-    { viewportWidth: 1280, viewportHeight: 800 },
+    { viewportWidth: 800, viewportHeight: 600 },
     () => {
       H.startNewNativeQuestion();
       SQLFilter.enterParameterizedQuery(
@@ -36,7 +36,7 @@ describe("issue 9357", () => {
       H.moveDnDKitElement(
         cy.get("fieldset").findAllByRole("listitem").first(),
         {
-          horizontal: 430,
+          vertical: 50,
         },
       );
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
@@ -90,7 +90,7 @@ export function DatabaseTrigger({ database }: { database: Database }) {
   return database ? (
     <span
       className={cx(CS.textWrap, CS.noDecoration)}
-      data-testid="selected-database1"
+      data-testid="selected-database"
     >
       {database.name}
     </span>

--- a/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
-import { Box, Icon, Text } from "metabase/ui";
+import { Box, Flex, Icon, Text } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type Field from "metabase-lib/v1/metadata/Field";
 import type Table from "metabase-lib/v1/metadata/Table";
@@ -40,18 +40,24 @@ export function Trigger({
   }
 
   return (
-    <span
+    <Flex
+      align="center"
       className={
         className ||
         cx(CS.px2, CS.py2, CS.textBold, CS.cursorPointer, CS.textDefault)
       }
+      data-testid="trigger"
       style={style}
     >
       {children}
       {showDropdownIcon && (
-        <Icon className={CS.ml1} name="chevrondown" size={iconSize} />
+        <Icon
+          className={cx(CS.ml1, CS.flexNoShrink)}
+          name="chevrondown"
+          size={iconSize}
+        />
       )}
-    </span>
+    </Flex>
   );
 }
 
@@ -83,7 +89,7 @@ export function DatabaseTrigger({ database }: { database: Database }) {
   return database ? (
     <span
       className={cx(CS.textWrap, CS.noDecoration)}
-      data-testid="selected-database"
+      data-testid="selected-database1"
     >
       {database.name}
     </span>

--- a/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
@@ -41,6 +41,7 @@ export function Trigger({
 
   return (
     <Flex
+      component="span"
       align="center"
       className={
         className ||

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorTopBar/NativeQueryEditorTopBar.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorTopBar/NativeQueryEditorTopBar.tsx
@@ -138,7 +138,7 @@ const NativeQueryEditorTopBar = (props: NativeQueryEditorTopBarProps) => {
           enableParameterRequiredBehavior
         />
       )}
-      <Flex ml="auto" gap="lg" mr="lg" align="center" h="55px">
+      <Flex ml="auto" gap="lg" mr="lg" align="center" h="55px" pl="md">
         {isNativeEditorOpen && hasEditingSidebar && !readOnly && (
           <NativeQueryEditorActionButtons
             features={sidebarFeatures}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58995

### Description

This ~~MR~~ PR fixes the CSS issues described in: https://github.com/metabase/metabase/issues/58995

### How to verify

Same as how to reproduce in the issue:

1. Open the native query editor
2. Open the viz sidebar — important because when it's closed you hit https://github.com/metabase/metabase/issues/58994 instead
3. Narrow the screen width and verify that the chevron does not jump and the buttons look nice


### Demo

https://www.loom.com/share/35549e462b2a4d0581a96b3e27e3081f?sid=8db7766c-ef34-4429-990d-ee639f45e9f5 

https://github.com/user-attachments/assets/fca7bd80-f2b2-4275-83aa-8d25e4b53922




### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
