### PR TITLE
feat(sdk): add onBreadcrumbClick to CollectionBrowser

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from "@storybook/addon-actions";
 import type { StoryFn } from "@storybook/react";
 import type { ComponentProps } from "react";
 
@@ -28,6 +29,7 @@ export const Default = {
 
   args: {
     collectionId: COLLECTION_ID,
+    onBreadcrumbClick: action("onBreadcrumbClick"),
   },
 };
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.tsx
@@ -9,6 +9,7 @@ import { useTranslatedCollectionId } from "embedding-sdk/hooks/private/use-trans
 import { getCollectionIdSlugFromReference } from "embedding-sdk/store/collections";
 import { useSdkSelector } from "embedding-sdk/store/use-sdk-selector";
 import type {
+  MetabaseCollection,
   MetabaseCollectionItem,
   SdkCollectionId,
 } from "embedding-sdk/types/collection";
@@ -91,11 +92,17 @@ export type CollectionBrowserProps = {
    * A function to call when an item is clicked.
    */
   onClick?: (item: MetabaseCollectionItem) => void;
+
+  /**
+   * A function to call when a breadcrumb is clicked.
+   */
+  onBreadcrumbClick?: (collection: MetabaseCollection) => void;
 } & CommonStylingProps;
 
 export const CollectionBrowserInner = ({
   collectionId = "personal",
   onClick,
+  onBreadcrumbClick,
   pageSize = COLLECTION_PAGE_SIZE,
   visibleEntityTypes = [...USER_FACING_ENTITY_NAMES],
   EmptyContentComponent = null,
@@ -127,6 +134,12 @@ export const CollectionBrowserInner = ({
   };
 
   const onClickBreadcrumbItem = (item: CollectionEssentials) => {
+    onBreadcrumbClick?.({
+      id: item.id,
+      name: item.name,
+      description: null,
+    });
+
     setCurrentCollectionId(item.id);
   };
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
@@ -105,6 +105,11 @@ describe("CollectionBrowser", () => {
 
     breadcrumb.click();
     expect(onBreadcrumbClick).toHaveBeenCalledTimes(1);
+    expect(onBreadcrumbClick).toHaveBeenCalledWith({
+      id: "root",
+      name: "Our analytics",
+      description: null,
+    });
   });
 });
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
@@ -93,6 +93,19 @@ describe("CollectionBrowser", () => {
 
     expect(columnNames).toStrictEqual(["Type", "Name"]);
   });
+
+  it("should call onBreadcrumbClick when a breadcrumb is clicked", async () => {
+    const onBreadcrumbClick = jest.fn();
+
+    await setup({ props: { onBreadcrumbClick } });
+
+    const breadcrumb = await screen.findByText("Our analytics");
+    expect(breadcrumb).toBeInTheDocument();
+    expect(onBreadcrumbClick).not.toHaveBeenCalled();
+
+    breadcrumb.click();
+    expect(onBreadcrumbClick).toHaveBeenCalledTimes(1);
+  });
 });
 
 async function setup({


### PR DESCRIPTION
Closes EMB-606

We want to expose `onBreadcrumbClick` to the `CollectionBrowser` component, as that allows embedders to track where we currently are in terms of collection browsing.

This is blocking for [the view-content and curate-content templates](https://github.com/metabase/metabase/pull/60828) to track the current collection for use when creating new questions/dashboards in the collection, and to allow returning back to the collection.

### How to verify

Render the following snippet:

```tsx
<CollectionBrowser collectionId="root" onBreadcrumbClick={console.log} />
```

Click on the "Our analytics" breadcrumb. It should trigger the `onBreadcrumbClick` handler.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
