### PR TITLE
feat: add audit log events for groups

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -766,6 +766,7 @@
            audit-app
            collections
            config
+           events
            models
            premium-features
            request

--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -249,3 +249,21 @@
 (methodical/defmethod events/publish-event! ::channel-event
   [topic event]
   (audit-log/record-event! topic event))
+
+(derive ::permissions-group-event ::event)
+(derive :event/group-create ::permissions-group-event)
+(derive :event/group-update ::permissions-group-event)
+(derive :event/group-delete ::permissions-group-event)
+
+(methodical/defmethod events/publish-event! ::permissions-group-event
+  [topic event]
+  (audit-log/record-event! topic event))
+
+(derive ::permissions-group-membership-event ::event)
+(derive :event/group-membership-create ::permissions-group-membership-event)
+(derive :event/group-membership-update ::permissions-group-membership-event)
+(derive :event/group-membership-delete ::permissions-group-membership-event)
+
+(methodical/defmethod events/publish-event! ::permissions-group-membership-event
+  [topic event]
+  (audit-log/record-event! topic event))

--- a/src/metabase/audit_app/models/audit_log.clj
+++ b/src/metabase/audit_app/models/audit_log.clj
@@ -91,6 +91,14 @@
     :password-reset-successful (select-keys entity [:token])
     {}))
 
+(defmethod model-details :model/PermissionsGroup
+  [permissions-group _event-type]
+  (select-keys permissions-group [:id :name :is_tenant_group :magic_group_type]))
+
+(defmethod model-details :model/PermissionsGroupMembership
+  [membership _event-type]
+  (select-keys membership [:id :user_id :group_id :is_group_manager]))
+
 (defmethod model-details :model/Notification
   [{:keys [subscriptions handlers] :as fully-hydrated-notification} _event-type]
   (merge

--- a/src/metabase/permissions/api.clj
+++ b/src/metabase/permissions/api.clj
@@ -8,6 +8,7 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as mdb]
+   [metabase.events.core :as events]
    [metabase.models.interface :as mi]
    [metabase.permissions.api.permission-graph :as api.permission-graph]
    [metabase.permissions.core :as perms]
@@ -183,8 +184,10 @@
    {:keys [name]} :- [:map
                       [:name ms/NonBlankString]]]
   (api/check-superuser)
-  (first (t2/insert-returning-instances! :model/PermissionsGroup
-                                         :name name)))
+  (u/prog1 (t2/insert-returning-instance! :model/PermissionsGroup
+                                          :name name)
+    (events/publish-event! :event/group-create {:object <>
+                                                :user-id api/*current-user-id*})))
 
 (api.macros/defendpoint :put "/group/:group-id"
   "Update the name of a `PermissionsGroup`."
@@ -194,18 +197,26 @@
    {:keys [name]} :- [:map
                       [:name ms/NonBlankString]]]
   (validation/check-manager-of-group group-id)
-  (api/check-404 (t2/exists? :model/PermissionsGroup :id group-id))
-  (t2/update! :model/PermissionsGroup group-id
-              {:name name})
-  ;; return the updated group
-  (t2/select-one :model/PermissionsGroup :id group-id))
+  (let [group (t2/select-one :model/PermissionsGroup :id group-id)]
+    (api/check-404 group)
+    (t2/update! :model/PermissionsGroup group-id
+                {:name name})
+    ;; return the updated group
+    (u/prog1 (t2/select-one :model/PermissionsGroup :id group-id)
+      (events/publish-event! :event/group-update
+                             {:user-id api/*current-user-id*
+                              :object <>
+                              :previous-object group}))))
 
 (api.macros/defendpoint :delete "/group/:group-id"
   "Delete a specific `PermissionsGroup`."
   [{:keys [group-id]} :- [:map
                           [:group-id ms/PositiveInt]]]
   (validation/check-manager-of-group group-id)
-  (t2/delete! :model/PermissionsGroup :id group-id)
+  (let [group (t2/select-one :model/PermissionsGroup :id group-id)]
+    (t2/delete! :model/PermissionsGroup :id group-id)
+    (events/publish-event! :event/group-delete {:object group
+                                                :user-id api/*current-user-id*}))
   api/generic-204-no-content)
 
 ;;; ------------------------------------------- Group Membership Endpoints -------------------------------------------


### PR DESCRIPTION
### Description

As part of the tenanting project we want to emit audit events when users join/leave tenant groups (or these groups are otherwise modified).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
