### PR TITLE
fix: reject dictionary locales not defined by mb

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -27,7 +27,7 @@
 (defn- collect-locale-error
   "Returns an error message if a row does not have a valid locale."
   [_state index {:keys [locale]}]
-  (when (not (i18n/available-locale? locale))
+  (when (not (i18n/included-locale? locale))
     (tru "Row {0}: Invalid locale: {1}" (adjust-index index) locale)))
 
 (defn- collect-duplication-error

--- a/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
@@ -36,26 +36,37 @@
               {:locale "de" :msgid "Thank you" :msgstr "Danke"}]
              (:translations result))))))
 
-(deftest ^:parallel process-rows-validation-test
+(deftest ^:parallel process-rows-invalid-locale-test
   (testing "Invalid locale generates error"
     (let [rows [["invalidlocale" "Hello" "Hola"]]
           result (#'dictionary/process-rows rows)]
       (is (= 1 (count (:errors result))))
-      (is (re-find #"Row 2.*Invalid locale" (first (:errors result))))))
+      (is (re-find #"Row 2.*Invalid locale" (first (:errors result)))))))
 
+(deftest ^:parallel process-rows-undefined-locale-test
+  (testing "Invalid locale generates error"
+    ;; Esperanto is not a locale metabase is available in
+    (let [rows [["eo" "Hello" "Hola"]]
+          result (#'dictionary/process-rows rows)]
+      (is (= 1 (count (:errors result))))
+      (is (re-find #"Row 2.*Invalid locale" (first (:errors result)))))))
+
+(deftest ^:parallel process-rows-duplicate-keys-test
   (testing "Duplicate translation keys generate error"
     (let [rows [["fr" "Hello" "Bonjour"]
                 ["fr" "Hello" "Salut"]]  ; Same locale+msgid
           result (#'dictionary/process-rows rows)]
       (is (= 1 (count (:errors result))))
-      (is (re-find #"Row 3.*Hello.*fr.*earlier" (first (:errors result))))))
+      (is (re-find #"Row 3.*Hello.*fr.*earlier" (first (:errors result)))))))
 
+(deftest ^:parallel process-rows-wrong-columns-test
   (testing "Wrong number of columns generates error"
     (let [rows [["fr" "Hello" "Bonjour" "extra"]]
           result (#'dictionary/process-rows rows)]
       (is (= 1 (count (:errors result))))
-      (is (re-find #"Row 2.*Invalid format.*3 columns" (first (:errors result))))))
+      (is (re-find #"Row 2.*Invalid format.*3 columns" (first (:errors result)))))))
 
+(deftest ^:parallel process-rows-multiple-errors-test
   (testing "Multiple errors are collected"
     (let [rows [["invalid" "Hello" "Hola" "extra"]  ; Invalid locale + extra column
                 ["fr" "Hello" "Bonjour"]

--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -67,6 +67,14 @@
     ;; because the locale is normalized before saving (metabase#15657, metabase#16654)
     [(normalized-locale-string locale-name) (.getDisplayName (locale locale-name))]))
 
+(def ^:private included-locales
+  (delay (set (map normalized-locale-string (i18n.impl/available-locale-names)))))
+
+(defn included-locale?
+  "Returns true is this is a locale included in locales.clj instead of just one available on the JVM."
+  [locale]
+  (contains? @included-locales locale))
+
 (defn- translate-site-locale
   "Translate a string with the System locale."
   [format-string args pluralization-opts]


### PR DESCRIPTION
### Description

If a locale is not defined for metabase we should not allow content-translation dictionaries to uploaded with it. Since these locales can't be used anyway it results in a confusing user experience.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
