### PR TITLE
Add metabase window name

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
+++ b/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
@@ -8,6 +8,7 @@ import { useSelector } from "metabase/lib/redux";
 import { useLicense } from "metabase-enterprise/settings/hooks/use-license";
 
 const NOTIFICATION_TIMEOUT = 30_000;
+const METABASE_INSTANCE_WINDOW_NAME = "metabase-instance";
 
 /**
  * This hook allows to create an upsell flow that listens to the events from the Store tab
@@ -57,6 +58,12 @@ export function useUpsellFlow({
   }
 
   useEffect(() => {
+    const { name } = window;
+    // Setting window name allows Store to move the focus back to the named window
+    if (name !== METABASE_INSTANCE_WINDOW_NAME) {
+      window.name = METABASE_INSTANCE_WINDOW_NAME;
+    }
+
     const listener = createListener({
       updateToken,
       storeOrigin,
@@ -65,6 +72,7 @@ export function useUpsellFlow({
     window.addEventListener("message", listener);
 
     return () => {
+      window.name = name;
       window.removeEventListener("message", listener);
     };
   }, [updateToken, storeOrigin]);


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-98/add-window-name-to-allow-focusing-back-to-instance-window

### Description

Focus can be moved back to the MB Instance tab by specifying [window name](https://github.com/metabase/infra-frontend/pull/1528/files#diff-6c102dd14c001ccd1a717f38c165deb9ffa79158f90df12c1efd93b186454eddR87) as the `window.open` `target` parameter.