### PR TITLE
increase the timeout of toast messages

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
+++ b/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
@@ -25,12 +25,12 @@ export function useUpsellFlow({
   const storeUrl = useStoreUrl("checkout/upgrade/self-hosted");
   const storeOrigin = new URL(storeUrl).origin;
   const { updateToken, tokenStatus, error } = useLicense(() => {
+    sendToast({
+      message: t`License activated successfully`,
+      icon: "check_filled",
+      timeout: NOTIFICATION_TIMEOUT,
+    });
     if (storeWindowRef.current) {
-      sendToast({
-        message: t`License activated successfully`,
-        icon: "check_filled",
-        timeout: NOTIFICATION_TIMEOUT,
-      });
       sendMessageTokenActivation(true, storeWindowRef.current, storeOrigin);
     }
   });

--- a/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
+++ b/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
@@ -7,6 +7,8 @@ import { useSetting, useStoreUrl, useToast } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { useLicense } from "metabase-enterprise/settings/hooks/use-license";
 
+const NOTIFICATION_TIMEOUT = 30_000;
+
 /**
  * This hook allows to create an upsell flow that listens to the events from the Store tab
  *   and sends back results of token activation to the Store
@@ -27,6 +29,7 @@ export function useUpsellFlow({
       sendToast({
         message: t`License activated successfully`,
         icon: "check_filled",
+        timeout: NOTIFICATION_TIMEOUT,
       });
       sendMessageTokenActivation(true, storeWindowRef.current, storeOrigin);
     }
@@ -70,7 +73,9 @@ export function useUpsellFlow({
     if (error && storeWindowRef.current) {
       sendMessageTokenActivation(false, storeWindowRef.current, storeOrigin);
       sendToast({
+        icon: "warning",
         message: error,
+        timeout: NOTIFICATION_TIMEOUT,
       });
     }
   }, [tokenStatus, error, sendToast, storeOrigin]);


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-99/increase-the-timeout-of-toast-messages

### Description

The default timeout of 5 seconds is not enough in this flow were users are performing actions in the other tab, and then coming back to the instance tab with toast message feedback. We agreed to increase it to 30 seconds.
