### PR TITLE
Allow overriding store-url in dev env

### DIFF
--- a/src/metabase/cloud_migration/settings.clj
+++ b/src/metabase/cloud_migration/settings.clj
@@ -22,23 +22,32 @@
     env-var-value
     config/is-dev?))
 
+(defn- store-url-default
+  "Returns the default store URL, with support for environment variable override in dev mode only."
+  []
+  (if-some [env-url (and config/is-dev? (config/config-str :mb-store-url))]
+    (str env-url)
+    (str "https://store" (when (default-to-staging?) ".staging") ".metabase.com")))
+
 ;;; TODO -- DEFAULT VALUES SHOULD NOT THE VALUE OF ANOTHER SETTING! BECAUSE GETTING SETTING VALUES REQUIRES THE APP DB
 ;;; TO BE SET UP!! AND IT IS NOT SET UP IMMEDIATELY ON LAUNCH!!
 
 (defsetting store-url
   (deferred-tru "Store URL.")
+  :type       :string
   :encryption :no
   ;; should be :internal, but FE doesn't get internal settings. -- Someone else
   ;;
   ;; OK, then no it shouldn't be internal at all, internal is literally for Settings that are only visible to backend
   ;; code. -- Cam
   :visibility :admin
-  :default    (str "https://store" (when (default-to-staging?) ".staging") ".metabase.com")
+  :default    (store-url-default)
   :doc        false
   :export?    false)
 
 (defsetting store-api-url
   (deferred-tru "Store API URL.")
+  :type       :string
   :encryption :no
   :visibility :internal
   :default    (str "https://store-api" (when (default-to-staging?) ".staging") ".metabase.com")


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-100/allow-setting-store-url-with-env-variable-in-dev-environment

### Description

It's useful to be able to set the store URL when working with feature branches. We were testing branches with various preview URLs of Store. 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Start Metabase with MB_STORE_URL env var
2. Take a look at the `store-url` value that is returned from `api/session/properties` endpoint. It should match the env var value.
