### PR TITLE
SEM-503 + SEM-504 + SEM-509 + SEM-510 Micro UI/UX improvements

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -3199,7 +3199,7 @@ function verifyFieldSectionEmptyState() {
     .should("be.visible");
   H.DataModel.get()
     .findByText(
-      "Select a field to edit it. Then change the display name, semantic type or filtering behavior.",
+      "Select a field to edit its name, description, formatting, and more.",
     )
     .should("be.visible");
 }

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
@@ -22,6 +22,7 @@
 }
 
 .descriptionInput {
+  line-height: var(--mantine-line-height-lg);
   border-start-start-radius: 0;
   border-start-end-radius: 0;
   border-end-start-radius: var(--mantine-radius-md);

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.module.css
@@ -15,6 +15,8 @@
 }
 
 .nameInput {
+  border-start-start-radius: var(--mantine-radius-md);
+  border-start-end-radius: var(--mantine-radius-md);
   border-end-start-radius: 0;
   border-end-end-radius: 0;
 }
@@ -22,4 +24,6 @@
 .descriptionInput {
   border-start-start-radius: 0;
   border-start-end-radius: 0;
+  border-end-start-radius: var(--mantine-radius-md);
+  border-end-end-radius: var(--mantine-radius-md);
 }

--- a/frontend/src/metabase/metadata/components/SortableFieldItem/SortableFieldItem.module.css
+++ b/frontend/src/metabase/metadata/components/SortableFieldItem/SortableFieldItem.module.css
@@ -3,6 +3,10 @@
   border-radius: var(--default-border-radius);
 }
 
+.active {
+  border-color: var(--mb-color-brand) !important;
+}
+
 .card {
   box-shadow: 0 2px 4px 0 hsla(0, 0%, 0%, 0.05) !important;
 

--- a/frontend/src/metabase/metadata/components/SortableFieldItem/SortableFieldItem.tsx
+++ b/frontend/src/metabase/metadata/components/SortableFieldItem/SortableFieldItem.tsx
@@ -30,7 +30,9 @@ export const SortableFieldItem = ({
 
   return (
     <Sortable
-      className={S.sortableField}
+      className={cx(S.sortableField, {
+        [S.active]: active,
+      })}
       disabled={disabled}
       draggingStyle={{ opacity: 0.5 }}
       id={id}

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -236,7 +236,7 @@ export const DataModel = ({ children, location, params }: Props) => {
                   }
                   message={
                     table
-                      ? t`Select a field to edit it. Then change the display name, semantic type or filtering behavior.`
+                      ? t`Select a field to edit its name, description, formatting, and more.`
                       : t`Browse your databases to find the table you’d like to edit.`
                   }
                 />

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.module.css
@@ -9,6 +9,10 @@
   }
 }
 
+.active {
+  border-color: var(--mb-color-brand) !important;
+}
+
 .link {
   border-radius: inherit;
 }

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.module.css
@@ -48,6 +48,10 @@
   }
 }
 
+.description {
+  line-height: var(--mantine-line-height-lg) !important;
+}
+
 .name {
   line-clamp: 1;
   -webkit-line-clamp: 1;

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.tsx
@@ -176,7 +176,7 @@ export const FieldItem = ({ active, field, href, parent }: Props) => {
         </Group>
 
         <Box
-          className={S.input}
+          className={cx(S.input, S.description)}
           // TODO: fix EditableText or use something else
           // https://linear.app/metabase/issue/SEM-429/data-model-inline-field-namedescription-inputs
           component={EditableText}


### PR DESCRIPTION
Closes [SEM-503](https://linear.app/metabase/issue/SEM-503/add-blue-border-to-selected-field)
Closes [SEM-504](https://linear.app/metabase/issue/SEM-504/border-radius-of-tablefield-name-and-description-boxes-should-match)
Closes [SEM-509](https://linear.app/metabase/issue/SEM-509/improve-microcopy-for-table-and-field-editing-instructions)
Closes [SEM-510](https://linear.app/metabase/issue/SEM-510/field-descriptions-could-use-paragraph-text-style-with-greater-line)

### Description

- adds blue border around selected field ([SEM-503](https://linear.app/metabase/issue/SEM-503/add-blue-border-to-selected-field))
- updates border-radius of name/description input to match other panes ([SEM-504](https://linear.app/metabase/issue/SEM-504/border-radius-of-tablefield-name-and-description-boxes-should-match))
- updates copy in empty state ([SEM-509](https://linear.app/metabase/issue/SEM-509/improve-microcopy-for-table-and-field-editing-instructions))
- updates line-height in description inputs ([SEM-510](https://linear.app/metabase/issue/SEM-510/field-descriptions-could-use-paragraph-text-style-with-greater-line))
