### PR TITLE
Reduce flakiness in new iframe embed locale test

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -16,9 +16,16 @@ export const getEmbedSidebar = () => cy.findByRole("complementary");
 export const getRecentItemCards = () =>
   cy.findAllByTestId("embed-recent-item-card");
 
-export const visitNewEmbedPage = () => {
+export const visitNewEmbedPage = ({ locale }: { locale?: string } = {}) => {
   cy.intercept("GET", "/api/dashboard/*").as("dashboard");
-  cy.visit("/embed-iframe");
+
+  const params = new URLSearchParams();
+
+  if (locale) {
+    params.append("locale", locale);
+  }
+
+  cy.visit("/embed-iframe?" + params);
   cy.wait("@dashboard");
 
   cy.get("#iframe-embed-container").should(

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -28,11 +28,10 @@ export const visitNewEmbedPage = ({ locale }: { locale?: string } = {}) => {
   cy.visit("/embed-iframe?" + params);
   cy.wait("@dashboard");
 
-  cy.get("#iframe-embed-container").should(
-    "have.attr",
-    "data-iframe-loaded",
-    "true",
-  );
+  cy.get("#iframe-embed-container", {
+    // we are loading lots of JS, so on a slow connection it will take a long while.
+    timeout: 20000,
+  }).should("have.attr", "data-iframe-loaded", "true");
 };
 
 export const assertRecentItemName = (

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -125,8 +125,7 @@ H.describeWithSnowplow(suiteTitle, () => {
   });
 
   it("localizes the iframe preview when ?locale is passed", () => {
-    cy.visit("/embed-iframe?locale=fr");
-    cy.wait("@dashboard");
+    visitNewEmbedPage({ locale: "fr" });
 
     // TODO: update this test once "Exploration" is localized in french.
     getEmbedSidebar().findByText("Exploration").click();


### PR DESCRIPTION
Uses the `visitNewEmbedPage` helper which asserts that the iframe-embed-container is fully loaded before continuing. Also, this adds timeouts for the preview loaded assertion. This should reduce the 10% flakiness rate. ([see trunk](https://app.trunk.io/metabase/flaky-tests?repo=metabase/metabase&sortIndex=2&statuses=Flaky,Broken&filter=sdk+iframe+embed+setup))

<img width="2168" height="220" alt="CleanShot 2568-07-15 at 18 25 27@2x" src="https://github.com/user-attachments/assets/7de8f1d8-322e-4eca-ae8c-d07ec6f34178" />

Stress Test Run (3): https://github.com/metabase/metabase/actions/runs/16313997032