### PR TITLE
Add height of 100vh to embed flow snippet

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
@@ -55,7 +55,7 @@ function getSnippet({
   // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
   return `<script src="${instanceUrl}/app/embed.js"></script>
 
-<div id="${SNIPPET_EMBED_TARGET}"></div>
+<div id="${SNIPPET_EMBED_TARGET}" style="height: 100vh"></div>
 
 <script>
   const { MetabaseEmbed } = window["metabase.embed"];


### PR DESCRIPTION
Closes EMB-614

Adds style="height: 100vh" to the snippet so that we have proper height by default. Right now there is no height so the embed is not visible by default.