### PR TITLE
feat(sdk): Add withDownloads to the static question

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.stories.tsx
@@ -6,6 +6,7 @@ import {
   questionIdArgType,
   questionIds,
 } from "embedding-sdk/test/storybook-id-args";
+import { Box } from "metabase/ui";
 
 import { StaticQuestion } from "./StaticQuestion";
 
@@ -22,11 +23,23 @@ export default {
   decorators: [CommonSdkStoryWrapper],
   argTypes: {
     questionId: questionIdArgType,
+    withDownloads: {
+      control: "boolean",
+      defaultValue: false,
+    },
+    withChartTypeSelector: {
+      control: "boolean",
+      defaultValue: false,
+    },
   },
 };
 
 const Template: StoryFn<StaticQuestionComponentProps> = (args) => {
-  return <StaticQuestion {...args} />;
+  return (
+    <Box p="md">
+      <StaticQuestion {...args} />
+    </Box>
+  );
 };
 
 export const Default = {
@@ -35,5 +48,7 @@ export const Default = {
   args: {
     questionId: QUESTION_ID,
     isSaveEnabled: true,
+    withDownloads: false,
+    withChartTypeSelector: false,
   },
 };

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
@@ -39,10 +39,12 @@ const StaticQuestionInner = ({
     withDownloads={withDownloads}
   >
     <Stack gap="sm">
-      <Group justify="space-between">
-        {withChartTypeSelector && <InteractiveQuestion.ChartTypeDropdown />}
-        {withDownloads && <InteractiveQuestion.DownloadWidgetDropdown />}
-      </Group>
+      {(withChartTypeSelector || withDownloads) && (
+        <Group justify="space-between">
+          {withChartTypeSelector && <InteractiveQuestion.ChartTypeDropdown />}
+          {withDownloads && <InteractiveQuestion.DownloadWidgetDropdown />}
+        </Group>
+      )}
       <InteractiveQuestion.QuestionVisualization
         height={height}
         width={width}

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
@@ -38,7 +38,7 @@ const StaticQuestionInner = ({
     initialSqlParameters={initialSqlParameters}
     withDownloads={withDownloads}
   >
-    <Stack gap="sm">
+    <Stack gap="sm" w="100%" h="100%">
       {(withChartTypeSelector || withDownloads) && (
         <Group justify="space-between">
           {withChartTypeSelector && <InteractiveQuestion.ChartTypeDropdown />}

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
@@ -4,6 +4,7 @@ import {
   type InteractiveQuestionProviderProps,
 } from "embedding-sdk/components/private/InteractiveQuestion/context";
 import { withPublicComponentWrapper } from "embedding-sdk/components/private/PublicComponentWrapper";
+import { Group, Stack } from "metabase/ui";
 
 import { InteractiveQuestion } from "../InteractiveQuestion";
 import type { InteractiveQuestionQuestionIdProps } from "../InteractiveQuestion/types";
@@ -15,7 +16,10 @@ import type { InteractiveQuestionQuestionIdProps } from "../InteractiveQuestion/
  */
 export type StaticQuestionProps = InteractiveQuestionQuestionIdProps & {
   withChartTypeSelector?: boolean;
-} & Pick<InteractiveQuestionProviderProps, "initialSqlParameters"> &
+} & Pick<
+    InteractiveQuestionProviderProps,
+    "initialSqlParameters" | "withDownloads"
+  > &
   FlexibleSizeProps;
 
 const StaticQuestionInner = ({
@@ -26,19 +30,26 @@ const StaticQuestionInner = ({
   className,
   style,
   initialSqlParameters,
+  withDownloads,
 }: StaticQuestionProps): JSX.Element | null => (
   <InteractiveQuestionProvider
     questionId={initialQuestionId}
     variant="static"
     initialSqlParameters={initialSqlParameters}
+    withDownloads={withDownloads}
   >
-    {withChartTypeSelector && <InteractiveQuestion.ChartTypeDropdown />}
-    <InteractiveQuestion.QuestionVisualization
-      height={height}
-      width={width}
-      className={className}
-      style={style}
-    />
+    <Stack gap="sm">
+      <Group justify="space-between">
+        {withChartTypeSelector && <InteractiveQuestion.ChartTypeDropdown />}
+        {withDownloads && <InteractiveQuestion.DownloadWidgetDropdown />}
+      </Group>
+      <InteractiveQuestion.QuestionVisualization
+        height={height}
+        width={width}
+        className={className}
+        style={style}
+      />
+    </Stack>
   </InteractiveQuestionProvider>
 );
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #54193
Closes EMB-195

---

_from copilot. it's longer than the code itself lol_

This pull request enhances the `StaticQuestion` component and its story in the embedding SDK by adding new features, improving layout, and updating type definitions. The changes primarily focus on introducing support for chart type selection and download options, as well as utilizing UI components for better styling.

### Enhancements to `StaticQuestion` Component:

* **Added support for chart type selection and download options**: Extended `StaticQuestionProps` to include `withChartTypeSelector` and `withDownloads` properties, enabling these features in the component. Updated the `InteractiveQuestionProvider` to pass `withDownloads` and added corresponding UI elements (`ChartTypeDropdown` and `DownloadWidgetDropdown`) within the layout. (`[[1]](diffhunk://#diff-fdb0f3de6fcdf7680fb7068ebfbf35b0ff4ade2b73388e506499a694628cc3feL18-R22)`, `[[2]](diffhunk://#diff-fdb0f3de6fcdf7680fb7068ebfbf35b0ff4ade2b73388e506499a694628cc3feR33-R52)`)

* **Improved layout with `Stack` and `Group` components**: Incorporated `Stack` and `Group` from `metabase/ui` to arrange elements with proper spacing and alignment, enhancing the visual structure of the component. (`[[1]](diffhunk://#diff-fdb0f3de6fcdf7680fb7068ebfbf35b0ff4ade2b73388e506499a694628cc3feR7)`, `[[2]](diffhunk://#diff-fdb0f3de6fcdf7680fb7068ebfbf35b0ff4ade2b73388e506499a694628cc3feR33-R52)`)

### Updates to `StaticQuestion` Story:

* **Added controls for new features**: Introduced `withDownloads` and `withChartTypeSelector` as configurable controls in the story, with default values set to `false`. This allows users to toggle these features in Storybook. (`[[1]](diffhunk://#diff-f25bd11639ac0992a068ccfdff135b32f01e3a11cf395d83a45aa55fe6c04fffR26-R42)`, `[[2]](diffhunk://#diff-f25bd11639ac0992a068ccfdff135b32f01e3a11cf395d83a45aa55fe6c04fffR51-R52)`)

* **Wrapped story template in `Box` for consistent padding**: Updated the story template to use the `Box` component with medium padding (`p="md"`), ensuring consistent spacing around the rendered component. (`[[1]](diffhunk://#diff-f25bd11639ac0992a068ccfdff135b32f01e3a11cf395d83a45aa55fe6c04fffR9)`, `[[2]](diffhunk://#diff-f25bd11639ac0992a068ccfdff135b32f01e3a11cf395d83a45aa55fe6c04fffR26-R42)`)