### PR TITLE
Prg-95-migrate-upsellcard-to-the-new-upsell-flow

### DIFF
--- a/frontend/src/metabase/admin/upsells/UpsellCacheConfig.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellCacheConfig.tsx
@@ -1,12 +1,18 @@
 import { jt, t } from "ttag";
 
 import { useHasTokenFeature } from "metabase/common/hooks/use-has-token-feature";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 import { Box } from "metabase/ui";
 
 import { UpsellCard } from "./components";
 import { UPGRADE_URL } from "./constants";
 
 export const UpsellCacheConfig = ({ location }: { location: string }) => {
+  const campaign = "cache-granular-controls";
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
   const hasCache = useHasTokenFeature("cache_granular_controls");
 
   if (hasCache) {
@@ -17,10 +23,11 @@ export const UpsellCacheConfig = ({ location }: { location: string }) => {
     <Box>
       <UpsellCard
         title={t`Control your caching`}
-        campaign="cache-granular-controls"
+        campaign={campaign}
         buttonText={t`Try Metabase Pro`}
         buttonLink={UPGRADE_URL}
         location={location}
+        onClick={triggerUpsellFlow}
       >
         {jt`Get granular caching controls for each database, dashboard, and query with ${(
           <strong key="label">{t`Metabase Pro.`}</strong>

--- a/frontend/src/metabase/admin/upsells/UpsellMetabaseBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellMetabaseBanner.tsx
@@ -1,18 +1,26 @@
 import { t } from "ttag";
 
 import { UpsellCard } from "metabase/admin/upsells/components";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 
 import { UPGRADE_URL } from "./constants";
 
 export function UpsellMetabaseBanner() {
+  const campaign = "remove-mb-branding";
+  const location = "static-embed-settings-look-and-feel";
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
   return (
     <UpsellCard
       title={t`Removing the banner`}
       buttonLink={UPGRADE_URL}
       buttonText={t`Upgrade plan`}
-      campaign="remove-mb-branding"
-      location="static-embed-settings-look-and-feel"
+      campaign={campaign}
+      location={location}
       fullWidth
+      onClick={triggerUpsellFlow}
     >
       {t`The “Powered by Metabase” banner appears on all static embeds created with your current version. Upgrade to remove it (and customize a lot more)`}
     </UpsellCard>

--- a/frontend/src/metabase/admin/upsells/UpsellSSO.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellSSO.tsx
@@ -2,6 +2,7 @@ import { t } from "ttag";
 
 import { hasAnySsoFeature } from "metabase/common/utils/plan";
 import { useSelector } from "metabase/lib/redux";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 import { getSetting } from "metabase/selectors/settings";
 import { Box, List } from "metabase/ui";
 
@@ -9,6 +10,11 @@ import { UpsellCard } from "./components";
 import { UPGRADE_URL } from "./constants";
 
 export const UpsellSSO = ({ location }: { location: string }) => {
+  const campaign = "sso";
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
   const tokenFeatures = useSelector((state) =>
     getSetting(state, "token-features"),
   );
@@ -23,11 +29,12 @@ export const UpsellSSO = ({ location }: { location: string }) => {
   return (
     <UpsellCard
       title={t`Tired of manually managing people and groups?`}
-      campaign="sso"
+      campaign={campaign}
       buttonText={t`Try Metabase Pro`}
       buttonLink={UPGRADE_URL}
       location={location}
       style={{ maxWidth: 242 }}
+      onClick={triggerUpsellFlow}
     >
       <Box px=".5rem">
         {t`Metabase Pro and Enterprise plans include:`}

--- a/frontend/src/metabase/admin/upsells/UpsellUploads.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellUploads.tsx
@@ -2,12 +2,18 @@ import { c, t } from "ttag";
 
 import { getPlan } from "metabase/common/utils/plan";
 import { useSelector } from "metabase/lib/redux";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 import { getSetting } from "metabase/selectors/settings";
 
 import { UpsellCard } from "./components";
 import { UPGRADE_URL } from "./constants";
 
 export const UpsellUploads = ({ location }: { location: string }) => {
+  const campaign = "manage-uploads";
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
   const plan = useSelector((state) =>
     getPlan(getSetting(state, "token-features")),
   );
@@ -21,10 +27,11 @@ export const UpsellUploads = ({ location }: { location: string }) => {
   return (
     <UpsellCard
       title={t`Manage your uploads`}
-      campaign="manage-uploads"
+      campaign={campaign}
       buttonText={t`Try for free`}
       buttonLink={UPGRADE_URL}
       location={location}
+      onClick={triggerUpsellFlow}
     >
       {c("{0} is the string 'Upgrade to Metabase Pro'").jt`${(
         <strong key="upgrade">{t`Upgrade to Metabase Pro`}</strong>

--- a/frontend/src/metabase/admin/upsells/UpsellUsageAnalytics.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellUsageAnalytics.tsx
@@ -2,6 +2,7 @@ import { t } from "ttag";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useSelector } from "metabase/lib/redux";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 import { getDocsUrl } from "metabase/selectors/settings";
 import { Box, type BoxProps, Text } from "metabase/ui";
 
@@ -17,6 +18,12 @@ export const UpsellUsageAnalytics = (
       "children" | "title" | "buttonText" | "buttonLink" | "campaign"
     >,
 ) => {
+  const campaign = "usage_analytics";
+  const { location } = props;
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
   const usageAnalyticsUrl = useSelector((state) =>
     getDocsUrl(state, {
       page: "usage-and-performance-tools/usage-analytics",
@@ -29,9 +36,10 @@ export const UpsellUsageAnalytics = (
       title={t`See who’s doing what, when`}
       buttonText={t`Try for free`}
       buttonLink={UPGRADE_URL}
-      campaign="usage_analytics"
+      campaign={campaign}
       illustrationSrc={usageAnalyticsIllustrationSource}
       lh="1.5rem"
+      onClick={triggerUpsellFlow}
       {...props}
     >
       <Text lh="1.5rem" style={{ paddingInlineStart: "2rem" }}>

--- a/frontend/src/metabase/admin/upsells/components/UpsellCard.stories.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCard.stories.tsx
@@ -1,3 +1,5 @@
+import { action } from "@storybook/addon-actions";
+
 import { ReduxProvider } from "__support__/storybook";
 import { Flex } from "metabase/ui";
 
@@ -56,6 +58,11 @@ export default {
   component: _UpsellCard,
   args,
   argTypes,
+};
+
+export const WithOnClick = {
+  render: DefaultTemplate,
+  args: { ...args, onClick: action("clicked") },
 };
 
 export const WithImage = {

--- a/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
@@ -1,9 +1,18 @@
 import cx from "classnames";
 import { useMount } from "react-use";
+import { P, match } from "ts-pattern";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
 import Link from "metabase/common/components/Link";
-import { Box, Flex, Image, Stack, Text, Title } from "metabase/ui";
+import {
+  Box,
+  Flex,
+  Image,
+  Stack,
+  Text,
+  Title,
+  UnstyledButton,
+} from "metabase/ui";
 
 import { UPGRADE_URL } from "../constants";
 
@@ -42,6 +51,7 @@ export type UpsellCardProps = {
   children: React.ReactNode;
   large?: boolean;
   style?: React.CSSProperties;
+  onClick?: () => void;
 } & CardWidthProps &
   CardLinkProps;
 
@@ -57,6 +67,7 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
   fullWidth,
   maxWidth,
   large = false,
+  onClick,
   ...props
 }: UpsellCardProps) => {
   const url = useUpsellLink({
@@ -97,27 +108,62 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
             {children}
           </Text>
           <Box mx="md" mb="lg">
-            {buttonLink !== undefined ? (
-              <ExternalLink
-                onClickCapture={() =>
-                  trackUpsellClicked({ location, campaign })
-                }
-                href={url}
-                className={S.UpsellCTALink}
-              >
-                {buttonText}
-              </ExternalLink>
-            ) : (
-              <Link
-                onClickCapture={() =>
-                  trackUpsellClicked({ location, campaign })
-                }
-                to={internalLink}
-                className={S.UpsellCTALink}
-              >
-                {buttonText}
-              </Link>
-            )}
+            {match({ onClick, buttonLink, internalLink })
+              .with(
+                {
+                  onClick: P.nonNullable,
+                  buttonLink: P.any,
+                  internalLink: P.nullish,
+                },
+                (args) => (
+                  <UnstyledButton
+                    onClick={() => {
+                      trackUpsellClicked({ location, campaign });
+                      args.onClick();
+                    }}
+                    className={S.UpsellCTALink}
+                  >
+                    {buttonText}
+                  </UnstyledButton>
+                ),
+              )
+              .with(
+                {
+                  onClick: P.nullish,
+                  buttonLink: P.nonNullable,
+                  internalLink: P.nullish,
+                },
+                () => (
+                  <ExternalLink
+                    onClickCapture={() =>
+                      trackUpsellClicked({ location, campaign })
+                    }
+                    href={url}
+                    className={S.UpsellCTALink}
+                  >
+                    {buttonText}
+                  </ExternalLink>
+                ),
+              )
+              .with(
+                {
+                  onClick: P.any,
+                  buttonLink: P.any,
+                  internalLink: P.nonNullable,
+                },
+                (args) => (
+                  <Link
+                    onClickCapture={() =>
+                      trackUpsellClicked({ location, campaign })
+                    }
+                    to={args.internalLink}
+                    className={S.UpsellCTALink}
+                  >
+                    {buttonText}
+                  </Link>
+                ),
+              )
+              .otherwise(() => null)}
           </Box>
         </Stack>
       </Stack>


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-95/migrate-upsellcard-to-the-new-upsell-flow

### Description

- upsell card  updates to use onClick prop
- next batch of components migrated to the new upsell flow.