### PR TITLE
Boolean variables in native queries

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-boolean.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-boolean.cy.spec.ts
@@ -1,3 +1,5 @@
+const { H } = cy;
+
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type {
@@ -9,8 +11,6 @@ import {
   createMockDashboardCard,
   createMockParameter,
 } from "metabase-types/api/mocks";
-
-const { H } = cy;
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -29,7 +29,7 @@ export function openTypePickerFromDefaultFilterType() {
 /**
  * Sets the SQL filter type.
  *
- * @param {("Text"|"Number"|"Date"|"Field Filter")} filterType
+ * @param {("Text"|"Number"|"Date"|"Boolean"|"Field Filter")} filterType
  *
  * @example
  * chooseType("Date");

--- a/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/click-behavior.ts
@@ -240,6 +240,7 @@ function getTargetsForVariables(legacyNativeQuery: NativeQuery): Target[] {
           text: TYPE.Text,
           number: TYPE.Number,
           date: TYPE.Temporal,
+          boolean: TYPE.Boolean,
         }[type]
       : undefined;
 

--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
@@ -139,6 +139,8 @@ function tagFilterForParameter(
       return (tag) => tag.type === "number";
     case "string":
       return (tag) => tag.type === "text";
+    case "boolean":
+      return (tag) => tag.type === "boolean";
     case "temporal-unit":
       return (tag) => tag.type === "temporal-unit";
   }

--- a/frontend/src/metabase-lib/v1/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/template-tags.ts
@@ -21,13 +21,15 @@ function getParameterType(tag: TemplateTag) {
     return "date/single";
   }
   // @ts-expect-error -- preserving preexisting incorrect types (for now)
-  if (type === "string") {
+  if (type === "string" || type === "text") {
     return "string/=";
   }
   if (type === "number") {
     return "number/=";
   }
-
+  if (type === "boolean") {
+    return "boolean/=";
+  }
   if (type === "temporal-unit") {
     return "temporal-unit";
   }

--- a/frontend/src/metabase-lib/v1/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/v1/queries/NativeQuery.ts
@@ -276,7 +276,14 @@ export default class NativeQuery {
 
   variableTemplateTags(): TemplateTag[] {
     return this.templateTags().filter((t) =>
-      ["dimension", "text", "number", "date", "temporal-unit"].includes(t.type),
+      [
+        "dimension",
+        "text",
+        "number",
+        "date",
+        "boolean",
+        "temporal-unit",
+      ].includes(t.type),
     );
   }
 

--- a/frontend/src/metabase-lib/v1/variables/TemplateTagVariable/constants.ts
+++ b/frontend/src/metabase-lib/v1/variables/TemplateTagVariable/constants.ts
@@ -7,6 +7,7 @@ export const VARIABLE_ICONS: Record<TemplateTagType, IconName | null> = {
   text: "string",
   number: "int",
   date: "calendar",
+  boolean: "io",
   dimension: null,
   "temporal-unit": "clock",
   card: null,

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -191,6 +191,7 @@ export type TemplateTagType =
   | "text"
   | "number"
   | "date"
+  | "boolean"
   | "temporal-unit" // e.g. for mb.time_grouping()
   | "dimension"
   | "snippet";

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -15,6 +15,7 @@ import type Question from "metabase-lib/v1/Question";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import { getQueryType } from "metabase-lib/v1/parameters/utils/parameter-source";
 import {
+  isBooleanParameter,
   isDateParameter,
   isStringParameter,
   isTemporalUnitParameter,
@@ -337,7 +338,11 @@ export const ParameterValueWidget = ({
 function hasNoPopover(parameter: UiParameter) {
   // This is needed because isTextWidget check isn't complete,
   // and returns true for dates too.
-  if (isDateParameter(parameter) || isTemporalUnitParameter(parameter)) {
+  if (
+    isDateParameter(parameter) ||
+    isTemporalUnitParameter(parameter) ||
+    isBooleanParameter(parameter)
+  ) {
     return false;
   }
   return isTextWidget(parameter);

--- a/frontend/src/metabase/parameters/utils/formatting.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.ts
@@ -58,7 +58,7 @@ export function formatParameterValue(
   if (isFieldFilterParameter(parameter)) {
     // skip formatting field filter parameters mapped to native query variables
     if (parameter.hasVariableTemplateTagTarget) {
-      return value;
+      return String(value);
     }
 
     // format using the parameter's first targeted field

--- a/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/formatting.unit.spec.ts
@@ -129,7 +129,7 @@ describe("metabase/parameters/utils/formatting", () => {
       {
         type: "number/>=",
         value: 1.111111111111,
-        expected: 1.111111111111,
+        expected: "1.111111111111",
         fields: [],
         hasVariableTemplateTagTarget: true,
       },

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/VariableTypeSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/VariableTypeSelect.tsx
@@ -25,6 +25,12 @@ const OPTIONS: Array<{ value: TemplateTagType; label: string }> = [
     },
   },
   {
+    value: "boolean",
+    get label() {
+      return t`Boolean`;
+    },
+  },
+  {
     value: "dimension",
     get label() {
       return t`Field Filter`;

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -728,7 +728,7 @@ describe("Question", () => {
           name: "Bar",
           slug: "bar",
           target: ["variable", ["template-tag", "bar"]],
-          type: "category",
+          type: "string/=",
           value: null,
         },
       ]);

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -319,6 +319,10 @@
   [tag params]
   (param-value-for-raw-value-tag tag params))
 
+(defmethod parse-tag :boolean
+  [tag params]
+  (param-value-for-raw-value-tag tag params))
+
 ;;; Parsing Values
 
 (mu/defn- parse-number :- number?

--- a/src/metabase/lib/schema/parameter.cljc
+++ b/src/metabase/lib/schema/parameter.cljc
@@ -70,8 +70,7 @@
    :text    {:type :string,  :allowed-for #{:text :string/= :id :category
                                             :location/city :location/state :location/zip_code :location/country}}
    :date    {:type :date,    :allowed-for #{:date :date/single :date/all-options :id :category}}
-   ;; I don't think `:boolean` is actually used on the FE at all.
-   :boolean {:type :boolean, :allowed-for #{:boolean :id :category}}
+   :boolean {:type :boolean, :allowed-for #{:boolean :id :category :boolean/=}}
 
    ;; as far as I can tell this is basically just an alias for `:date`... I'm not sure what the difference is TBH
    :date/single {:type :date, :allowed-for #{:date :date/single :date/all-options :id :category}}
@@ -138,7 +137,7 @@
    :string/does-not-contain {:type :string, :operator :variadic, :options-fn variadic-opts-first, :allowed-for #{:string/does-not-contain}}
    :string/ends-with        {:type :string, :operator :variadic, :options-fn variadic-opts-first, :allowed-for #{:string/ends-with}}
    :string/starts-with      {:type :string, :operator :variadic, :options-fn variadic-opts-first, :allowed-for #{:string/starts-with}}
-   :boolean/=               {:type :boolean, :operator :variadic, :allowed-for #{:boolean/=}}})
+   :boolean/=               {:type :boolean, :operator :variadic, :allowed-for #{:boolean :boolean/=}}})
 
 (mr/def ::type
   (into [:enum {:error/message    "valid parameter type"

--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -21,7 +21,7 @@
 (mr/def ::type
   [:enum
    {:decode/normalize common/normalize-keyword}
-   :snippet :card :dimension :number :text :date :temporal-unit])
+   :snippet :card :dimension :number :text :date :boolean :temporal-unit])
 
 (mr/def ::name
   [:ref

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -381,7 +381,7 @@
                              :value  [1 2]}]}))))))
 
 (deftest ^:parallel native-with-boolean-params-test
-  (testing "Make sure we can convert a parameterized query to a native query"
+  (testing "Make sure we can convert a parameterized query with boolean params to a native query"
     (doseq [value [false true]]
       (let [query {:type       :native
                    :native     {:query         "SELECT CASE WHEN {{x}} = {{x}} THEN 1 ELSE 0 END"

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -380,6 +380,21 @@
                              :target [:dimension [:template-tag "price"]]
                              :value  [1 2]}]}))))))
 
+(deftest ^:parallel native-with-boolean-params-test
+  (testing "Make sure we can convert a parameterized query to a native query with boolean params"
+    (doseq [value [false true]]
+      (let [query {:type       :native
+                   :native     {:query         "SELECT CASE WHEN {{x}} = {{x}} THEN 1 ELSE 0 END"
+                                :template-tags {"x"
+                                                {:name         "x"
+                                                 :display-name "X"
+                                                 :type         :boolean}}}
+                   :database   (mt/id)
+                   :parameters [{:type   :boolean/=
+                                 :target [:variable [:template-tag "x"]]
+                                 :value  [value]}]}]
+        (is (= [[1]] (mt/rows (qp/process-query query))))))))
+
 (defmethod driver/database-supports? [::driver/driver ::get-parameter-count]
   [_driver _feature _database]
   true)

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -381,7 +381,7 @@
                              :value  [1 2]}]}))))))
 
 (deftest ^:parallel native-with-boolean-params-test
-  (testing "Make sure we can convert a parameterized query to a native query with boolean params"
+  (testing "Make sure we can convert a parameterized query to a native query"
     (doseq [value [false true]]
       (let [query {:type       :native
                    :native     {:query         "SELECT CASE WHEN {{x}} = {{x}} THEN 1 ELSE 0 END"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/20230

How to verify:
- New -> SQL query
- `select id from products [[where category = (case when {{boolean}} then 'Gadget' else 'Widget' end)]]`
- Change the type for `boolean` to be `Boolean`
- Set the parameter value and run the query
- Try setting the default value
- Try adding this question to a dashboard and connecting a Boolean parameter to it.

<img width="1264" height="629" alt="Screenshot 2025-07-16 at 12 07 54" src="https://github.com/user-attachments/assets/ba1905a0-004c-4e16-8aeb-0bf14557482e" />
