### PR TITLE
Removes blue slow-loading card border

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.module.css
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.module.css
@@ -23,10 +23,6 @@
     background-color: var(--mb-color-bg-night);
   }
 
-  &.isUsuallySlow {
-    border-color: var(--slow-card-border-color);
-  }
-
   &.hasHiddenBackground {
     border: 0 !important;
     background: transparent !important;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -352,18 +352,15 @@ function DashCardInner({
             [S.hasHiddenBackground]: hasHiddenBackground,
             [S.shouldForceHiddenBackground]: shouldForceHiddenBackground,
             [S.isNightMode]: shouldRenderAsNightMode,
-            [S.isUsuallySlow]: isSlow === "usually-slow",
             [S.isEmbeddingSdk]: isEmbeddingSdk(),
           },
           className,
         )}
         style={(theme) => {
           const { border } = theme.other.dashboard.card;
-
-          return {
-            "--slow-card-border-color": theme.fn.themeColor("accent4"),
-            ...(border && { border }),
-          };
+          if (border) {
+            return { border };
+          }
         }}
         ref={cardRootRef}
       >


### PR DESCRIPTION
[Slack thread](https://metaboat.slack.com/archives/C064QMXEV9N/p1752588265516839?thread_ts=1752576773.438059&cid=C064QMXEV9N)

### Description

Removes the old blue slow-loading card border as it was deemed excessive now that we have the snail and skeletons.

### How to verify

**NOTE:** It's hard to _naturally_ show the blue border locally since it only shows up for actually slow-loading cards. I forced it to show up (and quickly) by making these changes.

<img width="488" height="316" alt="Screenshot 2025-07-15 at 11 28 23 AM" src="https://github.com/user-attachments/assets/333248e3-6584-40f0-8b17-a2968c688f18" />

1. Navigate to a dashboard
2. Wait for the slow-loading state to kick in
3. Verify no blue border

### Demo

**BEFORE**
<img width="1312" height="744" alt="before" src="https://github.com/user-attachments/assets/db210a9c-cf69-4c77-adef-c2a54f02cea2" />

**AFTER**
<img width="1312" height="744" alt="after" src="https://github.com/user-attachments/assets/03604efa-1a16-421e-b7de-d0f2c68ad577" />
