### PR TITLE
Make new iframe embed flow's parameter placeholder text contextual

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ParameterSettings/ParameterSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ParameterSettings/ParameterSettings.tsx
@@ -1,6 +1,6 @@
 import { useDebouncedCallback } from "@mantine/hooks";
 import { useCallback, useMemo } from "react";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import { Stack, Text, TextInput } from "metabase/ui";
 import { SET_INITIAL_PARAMETER_DEBOUNCE_MS } from "metabase-enterprise/embedding_iframe_sdk_setup/constants";
@@ -78,11 +78,17 @@ export const ParameterSettings = () => {
         {availableParameters.map((param) => {
           const defaultValue = parameterValues?.[param.slug] ?? undefined;
 
+          const placeholderValue = getParameterPlaceholder(param);
+
+          const placeholderText = c(
+            `the placeholder text containing examples of how a parameter string looks like. {0} contains the placeholder (e.g. "2025-11-05")`,
+          ).t`e.g. ${placeholderValue}`;
+
           return (
             <TextInput
               key={param.id}
               label={param.name}
-              placeholder={getParameterPlaceholder(param)}
+              placeholder={placeholderValue ? placeholderText : undefined}
               defaultValue={defaultValue}
               onChange={(e) =>
                 updateInitialParameterValue(param.slug, e.target.value)

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ParameterSettings/utils/parameter-placeholder.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ParameterSettings/utils/parameter-placeholder.ts
@@ -1,9 +1,40 @@
-import type { Parameter } from "metabase-types/api";
+import { match } from "ts-pattern";
+
+import type { Parameter, ParameterType } from "metabase-types/api";
 
 export const getParameterPlaceholder = (param: Parameter): string => {
+  // If the parameter has a list of default values.
   if (Array.isArray(param.default)) {
-    return param.default.join(", ");
+    return `${param.default.join(", ")}`;
   }
 
-  return param.name.toLowerCase();
+  // If the parameter has a single default value.
+  if (param.default != null) {
+    return String(param.default);
+  }
+
+  return getPlaceholderByParamType(param.type);
+};
+
+const getPlaceholderByParamType = (paramType: ParameterType): string => {
+  // parameter type format is "type/subtype", e.g. "date/range",
+  const [type, subtype] = paramType.split("/");
+
+  // see [enterprise/backend/src/metabase_enterprise/metabot_v3/query_analyzer/parameter_substitution.clj] for list of default values
+  return match({ type, subtype })
+    .with({ type: "date", subtype: "single" }, () => "2024-01-09")
+    .with({ type: "date", subtype: "range" }, () => "2023-01-09~2024-01-09")
+    .with({ type: "date", subtype: "relative" }, () => "past1years")
+    .with({ type: "date", subtype: "month-year" }, () => "2024-01")
+    .with({ type: "date", subtype: "quarter-year" }, () => "Q1-2024")
+    .with({ type: "date", subtype: "all-options" }, () => "2024-01-09")
+    .with({ type: "date" }, () => "2024-01-09")
+    .with({ type: "temporal-unit" }, () => "minute, hour, day, month, year")
+    .with({ type: "number", subtype: "between" }, () => "50 100")
+    .with({ type: "number" }, () => "1")
+    .with({ type: "string" }, () => "sample text")
+    .with({ type: "boolean" }, () => "true")
+    .with({ type: "category" }, () => "sample category")
+    .with({ type: "id" }, () => "1")
+    .otherwise(() => "");
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ParameterSettings/utils/parameter-placeholder.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ParameterSettings/utils/parameter-placeholder.unit.spec.ts
@@ -36,21 +36,157 @@ describe("getParameterPlaceholder", () => {
     });
   });
 
-  describe("when parameter has missing default", () => {
-    it("returns lowercased parameter name for null or undefined default", () => {
-      const nullDefault = createParameter({
-        name: "Category Filter",
+  describe("when parameter has a non-array default", () => {
+    it("returns the default value as string", () => {
+      const stringDefault = createParameter({
+        default: "default value",
+      });
+
+      expect(getParameterPlaceholder(stringDefault)).toBe("default value");
+
+      const numberDefault = createParameter({
+        default: 42,
+      });
+
+      expect(getParameterPlaceholder(numberDefault)).toBe("42");
+
+      const booleanDefault = createParameter({
+        default: true,
+      });
+
+      expect(getParameterPlaceholder(booleanDefault)).toBe("true");
+    });
+  });
+
+  describe("when parameter has no default", () => {
+    it("returns type-specific placeholder for string parameters", () => {
+      const stringParam = createParameter({
+        type: "string/=",
         default: null,
       });
 
-      expect(getParameterPlaceholder(nullDefault)).toBe("category filter");
+      expect(getParameterPlaceholder(stringParam)).toBe("sample text");
 
-      const undefinedDefault = createParameter({
-        name: "Date Range",
+      const stringContainsParam = createParameter({
+        type: "string/contains",
         default: undefined,
       });
 
-      expect(getParameterPlaceholder(undefinedDefault)).toBe("date range");
+      expect(getParameterPlaceholder(stringContainsParam)).toBe("sample text");
+    });
+
+    it("returns type-specific placeholder for number parameters", () => {
+      const numberParam = createParameter({
+        type: "number/=",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(numberParam)).toBe("1");
+
+      const numberBetweenParam = createParameter({
+        type: "number/between",
+        default: undefined,
+      });
+
+      expect(getParameterPlaceholder(numberBetweenParam)).toBe("50 100");
+    });
+
+    it("returns type-specific placeholder for date parameters", () => {
+      const dateSingleParam = createParameter({
+        type: "date/single",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(dateSingleParam)).toBe("2024-01-09");
+
+      const dateRangeParam = createParameter({
+        type: "date/range",
+        default: undefined,
+      });
+
+      expect(getParameterPlaceholder(dateRangeParam)).toBe(
+        "2023-01-09~2024-01-09",
+      );
+
+      const dateRelativeParam = createParameter({
+        type: "date/relative",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(dateRelativeParam)).toBe("past1years");
+
+      const dateMonthYearParam = createParameter({
+        type: "date/month-year",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(dateMonthYearParam)).toBe("2024-01");
+
+      const dateQuarterYearParam = createParameter({
+        type: "date/quarter-year",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(dateQuarterYearParam)).toBe("Q1-2024");
+
+      const dateAllOptionsParam = createParameter({
+        type: "date/all-options",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(dateAllOptionsParam)).toBe("2024-01-09");
+
+      const dateGenericParam = createParameter({
+        type: "date",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(dateGenericParam)).toBe("2024-01-09");
+    });
+
+    it("returns type-specific placeholder for boolean parameters", () => {
+      const booleanParam = createParameter({
+        type: "boolean/=",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(booleanParam)).toBe("true");
+    });
+
+    it("returns type-specific placeholder for temporal-unit parameters", () => {
+      const temporalUnitParam = createParameter({
+        type: "temporal-unit",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(temporalUnitParam)).toBe(
+        "minute, hour, day, month, year",
+      );
+    });
+
+    it("returns type-specific placeholder for category and id parameters", () => {
+      const categoryParam = createParameter({
+        type: "category",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(categoryParam)).toBe("sample category");
+
+      const idParam = createParameter({
+        type: "id",
+        default: undefined,
+      });
+
+      expect(getParameterPlaceholder(idParam)).toBe("1");
+    });
+
+    it("returns empty placeholder for unknown parameter types", () => {
+      const unknownParam = createParameter({
+        type: "unknown/unknown",
+        default: null,
+      });
+
+      expect(getParameterPlaceholder(unknownParam)).toBe("");
     });
   });
 });


### PR DESCRIPTION
Closes EMB-616

We should add a more informative parameter placeholder values that correspond to the placeholder's data type (e.g. we should show the "2025-11-05" date format hint for dates), so people get an idea of what they can put in. Right now, it shows the current parameter's name which isn't very helpful.

In the future, we should use the actual parameter value widget for this, but this is a super quick win.

### How to verify

- Click on "+ New" then "Embed"
- Dashboard should already be selected. Click "Next" two times until you see the "Behavior" menu.
- You should see the new placeholder texts for parameters.

### Demo

Before: Super generic placeholder text with just the parameter name. Not helpful at all.

<img width="2514" height="1760" alt="CleanShot 2568-07-16 at 00 07 18@2x" src="https://github.com/user-attachments/assets/b2df7edf-75bb-41f7-95d0-411040d3909c" />

After: Helpful placeholder texts by type.

<img width="2956" height="1762" alt="CleanShot 2568-07-16 at 00 05 34@2x" src="https://github.com/user-attachments/assets/71b77ee3-cb38-4a1e-b2d4-82b8317b3494" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - unit test
