### PR TITLE
Fix flaky SettingsPage test

### DIFF
--- a/frontend/src/metabase/admin/settings/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/tests/enterprise.unit.spec.tsx
@@ -37,10 +37,14 @@ describe("Admin Settings Routing - Enterprise without features", () => {
   describe("renders the common routes", () => {
     it.each(routes)(
       "renders the $name route",
-      async ({ path, testPattern }) => {
+      async ({ path, testPattern, role }) => {
         await setup({ isAdmin: true, initialRoute: path });
         await waitFor(() => {
-          expect(screen.queryAllByText(testPattern).length).toBeGreaterThan(0);
+          expect(
+            role
+              ? screen.getByRole(role, { name: testPattern })
+              : screen.getByText(testPattern),
+          ).toBeInTheDocument();
         });
       },
     );

--- a/frontend/src/metabase/admin/settings/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/tests/enterprise.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from "__support__/ui";
+import { screen, waitFor } from "__support__/ui";
 
 import {
   setup as baseSetup,
@@ -39,7 +39,9 @@ describe("Admin Settings Routing - Enterprise without features", () => {
       "renders the $name route",
       async ({ path, testPattern }) => {
         await setup({ isAdmin: true, initialRoute: path });
-        expect(await screen.findByText(testPattern)).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.queryAllByText(testPattern).length).toBeGreaterThan(0);
+        });
       },
     );
   });

--- a/frontend/src/metabase/admin/settings/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/tests/premium.unit.spec.tsx
@@ -42,10 +42,14 @@ describe("Admin Settings Routing - Enterprise with all features", () => {
   describe("renders all the routes", () => {
     it.each(routes)(
       "renders the $name route",
-      async ({ path, testPattern }) => {
+      async ({ path, testPattern, role }) => {
         await setup({ isAdmin: true, initialRoute: path });
         await waitFor(() => {
-          expect(screen.queryAllByText(testPattern).length).toBeGreaterThan(0);
+          expect(
+            role
+              ? screen.getByRole(role, { name: testPattern })
+              : screen.getByText(testPattern),
+          ).toBeInTheDocument();
         });
       },
     );

--- a/frontend/src/metabase/admin/settings/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/tests/premium.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from "__support__/ui";
+import { screen, waitFor } from "__support__/ui";
 
 import {
   setup as baseSetup,
@@ -44,7 +44,9 @@ describe("Admin Settings Routing - Enterprise with all features", () => {
       "renders the $name route",
       async ({ path, testPattern }) => {
         await setup({ isAdmin: true, initialRoute: path });
-        expect(await screen.findByText(testPattern)).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.queryAllByText(testPattern).length).toBeGreaterThan(0);
+        });
       },
     );
   });

--- a/frontend/src/metabase/admin/settings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/tests/setup.tsx
@@ -27,7 +27,10 @@ import {
 } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
-type RouteMap = Record<string, { path: string; testPattern: RegExp }>;
+type RouteMap = Record<
+  string,
+  { path: string; testPattern: RegExp; role?: string }
+>;
 
 export const ossRoutes: RouteMap = {
   root: { path: "", testPattern: /site name/i },
@@ -78,7 +81,7 @@ export const ossRoutes: RouteMap = {
 };
 
 export const enterpriseRoutes: RouteMap = {
-  license: { path: "/license", testPattern: /License/i },
+  license: { path: "/license", testPattern: /License/i, role: "heading" },
 };
 
 export const premiumRoutes: RouteMap = {
@@ -100,10 +103,11 @@ export const upsellRoutes: RouteMap = {
 };
 
 export const routeObjtoArray = (map: RouteMap) => {
-  return Object.entries(map).map(([name, { path, testPattern }]) => ({
+  return Object.entries(map).map(([name, { path, testPattern, role }]) => ({
     name,
     path,
     testPattern,
+    role,
   }));
 };
 

--- a/frontend/src/metabase/admin/settings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/tests/setup.tsx
@@ -27,7 +27,9 @@ import {
 } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
-export const ossRoutes = {
+type RouteMap = Record<string, { path: string; testPattern: RegExp }>;
+
+export const ossRoutes: RouteMap = {
   root: { path: "", testPattern: /site name/i },
   general: { path: "/general", testPattern: /site name/i },
   email: { path: "/email", testPattern: /SMTP/i },
@@ -74,8 +76,6 @@ export const ossRoutes = {
   },
   cloud: { path: "/cloud", testPattern: /Migrate to Metabase Cloud/i },
 };
-
-type RouteMap = Record<string, { path: string; testPattern: RegExp }>;
 
 export const enterpriseRoutes: RouteMap = {
   license: { path: "/license", testPattern: /License/i },


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-101/fix-flaky-unit-test-for-settingspage

The sighting https://github.com/metabase/metabase/actions/runs/16297550418/job/46025328831?pr=60850#step:6:1401

### Description

This test consistently fails if a timeout of 100 ms is introduced.
```ts
it.each(routes)(
  "renders the $name route",
  async ({ path, testPattern }) => {
    await setup({ isAdmin: true, initialRoute: path });
    await new Promise(resolve => setTimeout(resolve, 100));
    expect(screen.getByText(testPattern)).toBeInTheDocument();
  },
);
```

The License page has 4 texts matching selector.

```
Admin Settings Routing - Enterprise without features / renders the common routes / renders the license route
TestingLibraryElementError: Found multiple elements with the text: /License/i 
Here are the matching elements:


Ignored nodes: comments, script, style
<span
  class="m_1f6ac4c4 mb-mantine-NavLink-label"
>
  License
</span>


Ignored nodes: comments, script, style
<h1
  class="m_8a5d1357 mb-mantine-Title-root"
  data-order="1"
  style="--title-fw: var(--mantine-h1-font-weight); --title-lh: var(--mantine-h1-line-height); --title-fz: var(--mantine-h1-font-size);"
>
  License
</h1>


Ignored nodes: comments, script, style
<label
  class="mantine-focus-auto m_b6d8b162 mb-mantine-Text-root"
  color="var(--mb-color-text-primary)"
  data-size="md"
  for="license"
  style="--text-fz: var(--mantine-font-size-md); --text-lh: var(--mantine-line-height-md); --text-color: var(--mb-color-text-primary); font-weight: bold; display: inline-block;"
>
  License
</label>


Ignored nodes: comments, script, style
<div
  class="mantine-focus-auto m_b6d8b162 mb-mantine-Text-root"
  color="var(--mb-color-text-primary)"
  data-size="md"
  style="--text-fz: var(--mantine-font-size-md); --text-lh: var(--mantine-line-height-md); --text-color: var(--mb-color-text-primary); line-height: var(--mantine-line-height-xl); max-width: 38rem;"
>
  Bought a license to unlock advanced functionality? Please enter it below.
</div>
```

## Stress test results 

```bash
branch: prg-101-fix-flaky-unit-test-for-settingspage
spec: frontend/src/metabase/admin/settings/tests/enterprise.unit.spec.tsx
burn_in: 20
grep: ""

branch: prg-101-fix-flaky-unit-test-for-settingspage
spec: frontend/src/metabase/admin/settings/tests/premium.unit.spec.tsx
burn_in: 20
grep: "";
```