### PR TITLE
Do not update new iframe embed flow preview if the same resource is chosen

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -83,6 +83,24 @@ H.describeWithSnowplow(suiteTitle, () => {
     H.getIframeBody().within(() => {
       cy.findByText(SECOND_DASHBOARD_NAME).should("be.visible");
     });
+
+    cy.log("select the same the dashboard again");
+    getEmbedSidebar().within(() => {
+      cy.findByText(SECOND_DASHBOARD_NAME).click();
+      cy.findByText(SECOND_DASHBOARD_NAME).click();
+    });
+
+    cy.get("@secondDashboardId").then((secondDashboardId) => {
+      cy.log("only a single snowplow event should be sent");
+      H.expectUnstructuredSnowplowEvent(
+        {
+          event: "embed_wizard_resource_selected",
+          target_id: secondDashboardId,
+          event_detail: "dashboard",
+        },
+        1,
+      );
+    });
   });
 
   it("can select a recent question to embed", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/user-settings-persistence.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/user-settings-persistence.cy.spec.ts
@@ -29,8 +29,6 @@ describe("scenarios > embedding > sdk iframe embed setup > user settings persist
       resourceName: DASHBOARD_NAME,
     });
 
-    cy.wait("@persistSettings");
-
     cy.log("1. set embed settings to non-default values");
     getEmbedSidebar().within(() => {
       cy.findByLabelText("Allow downloads")
@@ -132,8 +130,6 @@ describe("scenarios > embedding > sdk iframe embed setup > user settings persist
       resourceName: DASHBOARD_NAME,
     });
 
-    cy.wait("@persistSettings");
-
     cy.log("1. change brand color to red");
     cy.findByLabelText("#509EE3").click();
 
@@ -166,8 +162,6 @@ describe("scenarios > embedding > sdk iframe embed setup > user settings persist
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
     });
-
-    cy.wait("@persistSettings");
 
     cy.log("1. select sso auth method");
     getEmbedSidebar().within(() => {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceStep.tsx
@@ -45,6 +45,14 @@ export const SelectEmbedResourceStep = () => {
     experience: SdkIframeEmbedSetupExperience,
     id: string | number,
   ) => {
+    // Do not update if the selected item is already selected.
+    if (
+      (experience === "dashboard" && settings.dashboardId === id) ||
+      (experience === "chart" && settings.questionId === id)
+    ) {
+      return;
+    }
+
     trackEmbedWizardResourceSelected(Number(id), experience);
 
     if (experience === "dashboard") {


### PR DESCRIPTION
Closes EMB-618

We should not reload the embed preview when clicking on the same card in the new iframe embedding's embed flow. In addition, we should not send the snowplow events multiple times if they select the same dashboard or question as before.

### How to verify

- There should be multiple resources in your activity log already.
- Go to /embed-iframe (or "+ New > Embed")
- Click on "Chart"
- Click on "Dashboard"
- Click "Next"
- Click on the card of current dashboard you've selected (e.g. "E-commerce Insights")
- Click on the card of current dashboard again for good measure.
- The embed should not be reloaded.
- The snowplow event embed_wizard_resource_selected should not be fired, as you are still selecting the **same** dashboard.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
