### PR TITLE
Allow toggling static question title in new iframe embed flow

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -211,6 +211,7 @@ H.describeWithSnowplow(suiteTitle, () => {
     cy.log("turn off title");
     getEmbedSidebar()
       .findByLabelText("Show chart title")
+      .should("be.checked")
       .click()
       .should("not.be.checked");
 
@@ -221,9 +222,45 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     H.getIframeBody().findByText("Orders, Count").should("not.exist");
 
+    cy.log("set drills to false");
+    getEmbedSidebar()
+      .findByLabelText("Allow users to drill through on data points")
+      .should("be.checked")
+      .click()
+      .should("not.be.checked");
+
+    cy.log("chart title state should remain unchecked");
+    getEmbedSidebar()
+      .findByLabelText("Show chart title")
+      .should("not.be.checked");
+
+    cy.log("chart title should remain hidden");
+    H.getIframeBody().findByText("Orders, Count").should("not.exist");
+
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
     codeBlock().should("contain", 'with-title="false"');
+
+    cy.log("go back to embed options step");
+    getEmbedSidebar().findByText("Back").click();
+
+    cy.log("show the chart title");
+    getEmbedSidebar()
+      .findByLabelText("Show chart title")
+      .should("not.be.checked")
+      .click()
+      .should("be.checked");
+
+    cy.log("chart title should be visible again");
+    H.getIframeBody().findByText("Orders, Count").should("be.visible");
+
+    H.expectUnstructuredSnowplowEvent(
+      {
+        event: "embed_wizard_option_changed",
+        event_detail: "withTitle",
+      },
+      2,
+    );
   });
 
   it("toggles save button for exploration", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
@@ -32,6 +32,24 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
     });
   });
 
+  it("shows a static question with isDrillThroughEnabled=false, withTitle=true", () => {
+    const frame = H.loadSdkIframeEmbedTestPage({
+      questionId: ORDERS_QUESTION_ID,
+      isDrillThroughEnabled: false,
+      withTitle: true,
+    });
+
+    cy.wait("@getCardQuery");
+
+    frame.within(() => {
+      cy.log("static question must contain title, but not toolbar");
+      cy.findByText("Orders").should("be.visible");
+      cy.findByTestId("interactive-question-result-toolbar").should(
+        "not.exist",
+      );
+    });
+  });
+
   it("shows a static dashboard using isDrillThroughEnabled=false, withTitle=false, withDownloads=true", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
       dashboardId: ORDERS_DASHBOARD_ID,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -120,6 +120,7 @@ const SdkIframeEmbedView = ({
           questionId={settings.questionId}
           height="100%"
           initialSqlParameters={settings.initialSqlParameters}
+          title={settings.withTitle}
           key={rerenderKey}
         />
       ),

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -3,7 +3,7 @@ import { useSearchParam } from "react-use";
 import _ from "underscore";
 
 import { useSetting } from "metabase/common/hooks";
-import { Box } from "metabase/ui";
+import { Card } from "metabase/ui";
 import type { MetabaseEmbed } from "metabase-enterprise/embedding_iframe_sdk/embed";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
@@ -84,8 +84,11 @@ export const SdkIframeEmbedPreview = () => {
   }, [settings, isIframeLoaded]);
 
   return (
-    <div>
-      <Box id="iframe-embed-container" data-iframe-loaded={isIframeLoaded} />
-    </div>
+    <Card
+      id="iframe-embed-container"
+      data-iframe-loaded={isIframeLoaded}
+      bg={settings.theme?.colors?.background}
+      h="100%"
+    />
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 
 import "react-resizable/css/styles.css";
 
-import { Box, Button, Card, Group, Stack } from "metabase/ui";
+import { Box, Button, Group } from "metabase/ui";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
 import { useSdkIframeEmbedNavigation } from "../hooks";
@@ -56,11 +56,7 @@ const SdkIframeEmbedSetupContent = () => {
       </SidebarResizer>
 
       <Box className={S.PreviewPanel}>
-        <Card p="md" h="100%">
-          <Stack h="100%">
-            <SdkIframeEmbedPreview />
-          </Stack>
-        </Card>
+        <SdkIframeEmbedPreview />
       </Box>
     </Box>
   );

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
@@ -122,7 +122,7 @@ export const SelectEmbedOptionsStep = () => {
           )}
         </Group>
 
-        {isDashboardOrInteractiveQuestion && (
+        {isQuestionOrDashboardEmbed && (
           <>
             <Divider mb="md" />
 


### PR DESCRIPTION
Closes EMB-617

### Description

We should allow showing and hiding question titles in static questions (questions with drill throughs disabled) in the new iframe embed's setup flow.

I also added a little padding, as StaticQuestion does not come with a padding by default.

### How to verify

- Go to "+ New" > "Embed"
- Select "Chart"
- Click "Next" twice to go to "Behavior" step
- Uncheck the drill-throughs checkbox
- Drills should now be disabled in the preview
- You should still be able to see the "Show chart title" checkbox.
- You should be able to show and hide the static question's title.

### Demo

Without chart title

<img width="2516" height="1758" alt="CleanShot 2568-07-16 at 02 25 54@2x" src="https://github.com/user-attachments/assets/a54a4815-2c59-4f45-8b83-b20f5645b864" />

With chart title

<img width="2518" height="1760" alt="CleanShot 2568-07-16 at 02 25 43@2x" src="https://github.com/user-attachments/assets/c80e2462-f038-4395-8fc2-5a771a946ef5" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
