### PR TITLE
fix: handle headerless translations csv

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/dictionary.clj
@@ -142,12 +142,13 @@
          (catch Exception e
            (let [error-message (.getMessage ^Exception e)
                  ;; report line number 1 indexed
-                 line-no (inc i)]
-             (throw (ex-info
-                     (tru "Error Parsing CSV at Row {0}: {1}" line-no error-message)
-                     {:status-code http-status-unprocessable
-                      :line line-no}
-                     e)))))))))
+                 line-no (inc i)
+                 error-message (tru "Error Parsing CSV at Row {0}: {1}" line-no error-message)]
+             (throw (ex-info error-message
+                             {:status-code http-status-unprocessable
+                              :errors [error-message]
+                              :line line-no}
+                             e)))))))))
 
 (defn read-and-import-csv!
   "Read CSV and catch error if the CSV is invalid."

--- a/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_translation/routes.clj
@@ -66,8 +66,7 @@
                       {:status-code http-status-content-too-large})))
     (when-not (instance? java.io.File file)
       (throw (ex-info (tru "No file provided") {:status-code 400})))
-    (let [[_header & rows] (dictionary/read-csv file)]
-      (dictionary/import-translations! rows))
+    (dictionary/read-and-import-csv! file)
     {:success true}))
 
 (api.macros/defendpoint :get "/dictionary/:token"

--- a/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/dictionary_test.clj
@@ -103,22 +103,43 @@
     (is (= 3 (#'dictionary/adjust-index 1)) "Second row becomes row 3")
     (is (= 10 (#'dictionary/adjust-index 8)) "Ninth row becomes row 10")))
 
-(deftest ^:parallel read-csv-test
-  (testing "Reads valid CSV without error"
-    (let [file (.getBytes "Language,String,Translation")]
-      (is (=
-           [["Language" "String" "Translation"]]
-           (dictionary/read-csv file)))))
-  (testing "Reads CSV with invalid header row and throws informative error"
-    (let [file (.getBytes "Language,String,\"Translation\"X")] ; character outside quotation marks
-      (is (thrown-with-msg?
-           Exception #"Header row.*CSV error.*unexpected character.*X"
-           (dictionary/read-csv file)))))
-  (testing "Reads CSV with invalid data row and throws informative error"
-    (let [file (.getBytes "Language,String,Translation\nde,Title,Titel\nde,Vendor,\"Anbieter\"X")] ; character outside quotation marks
-      (is (thrown-with-msg?
-           Exception #"Row 2.*CSV error.*unexpected character.*X"
-           (dictionary/read-csv file))))))
+(deftest read-and-import-csv!-test
+  (mt/with-premium-features #{:content-translation}
+    (testing "Reads valid CSV without error"
+      (let [file (.getBytes "Language,String,Translation")]
+        (is (nil? (dictionary/read-and-import-csv! file)))))
+    (testing "Reads CSV with invalid header row and throws informative error"
+      (let [file (.getBytes "Language,String,\"Translation\"X")] ; character outside quotation marks
+        (is (thrown-with-msg?
+             Exception #"Header row.*CSV error.*unexpected character.*X"
+             (dictionary/read-and-import-csv! file)))))
+    (testing "Reads CSV with invalid data row and throws informative error"
+      (let [file (.getBytes "Language,String,Translation\nde,Title,Titel\nde,Vendor,\"Anbieter\"X")] ; character outside quotation marks
+        (is (thrown-with-msg?
+             Exception #"Row 2.*CSV error.*unexpected character.*X"
+             (dictionary/read-and-import-csv! file)))))))
+
+(deftest read-and-import-csv-with-and-without-header-test
+  (ct-utils/with-clean-translations!
+    (testing "CSV with header row is imported correctly"
+      (mt/with-premium-features #{:content-translation}
+        (let [csv-with-header "Language,String,Translation\nes,Hello,Hola\nfr,Goodbye,Au revoir"
+              file (.getBytes csv-with-header)]
+          (dictionary/read-and-import-csv! file)
+          (is (= 2 (count-translations)))
+          (let [translations (get-translations)]
+            (is (some #(and (= (:locale %) "es") (= (:msgid %) "Hello") (= (:msgstr %) "Hola")) translations))
+            (is (some #(and (= (:locale %) "fr") (= (:msgid %) "Goodbye") (= (:msgstr %) "Au revoir")) translations))))))
+
+    (testing "CSV without header row is imported correctly"
+      (mt/with-premium-features #{:content-translation}
+        (let [csv-without-header "de,Thank you,Danke\nit,Good morning,Buongiorno"
+              file (.getBytes csv-without-header)]
+          (dictionary/read-and-import-csv! file)
+          (is (= 2 (count-translations)))
+          (let [translations (get-translations)]
+            (is (some #(and (= (:locale %) "de") (= (:msgid %) "Thank you") (= (:msgstr %) "Danke")) translations))
+            (is (some #(and (= (:locale %) "it") (= (:msgid %) "Good morning") (= (:msgstr %) "Buongiorno")) translations))))))))
 
 (deftest ^:parallel format-row-test
   (testing "Format function standardizes locale"
@@ -147,7 +168,7 @@
                     ["fr" "Goodbye" "Au revoir"]
                     ["de" "Thank you" "Danke"]
                     ["pt-br" "Thank you" "Obrigado"]]]
-          (dictionary/import-translations! rows)
+          (#'dictionary/import-translations! rows)
           (is (= 4 (count-translations)) "All translations should be imported")
 
           (let [translations (get-translations)]
@@ -170,7 +191,7 @@
                     ["en" "Whitespace" "   "] ; Unusable
                     ["en" "Commas" ",,,"]     ; Unusable
                     ["fr" "Good" "Bien"]]]     ; Usable
-          (dictionary/import-translations! rows)
+          (#'dictionary/import-translations! rows)
           (is (= 2 (count-translations)) "Only usable translations should be imported")
           (let [translations (get-translations)]
             (is (some #(= (:msgstr %) "Hola") translations))
@@ -190,14 +211,14 @@
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
                #"The file could not be uploaded due to the following error"
-               (dictionary/import-translations! invalid-rows))))))
+               (#'dictionary/import-translations! invalid-rows))))))
     (testing "Import fails when one row has too many fields"
       (mt/with-premium-features #{:content-translation}
         (let [invalid-rows [["en" "Test" "Translation" "extra"]]]
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
                #"The file could not be uploaded due to the following error"
-               (dictionary/import-translations! invalid-rows))))))
+               (#'dictionary/import-translations! invalid-rows))))))
     (testing "Import fails when two rows have the same msgid and the same standardized locale"
       (mt/with-premium-features #{:content-translation}
         (let [invalid-rows [["pt-br" "Test" "Translation"]
@@ -205,7 +226,7 @@
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
                #"The file could not be uploaded due to the following error"
-               (dictionary/import-translations! invalid-rows))))))
+               (#'dictionary/import-translations! invalid-rows))))))
     (testing "Multiple error messages can be returned"
       (mt/with-premium-features #{:content-translation}
         (let [invalid-rows [["invalidlocale" "Hello" "Hola"]
@@ -213,7 +234,7 @@
                             ["en" "Test" "Translation1"]
                             ["en" "Test" "Translation2"]]]
           (try
-            (dictionary/import-translations! invalid-rows)
+            (#'dictionary/import-translations! invalid-rows)
             (is false "Should have thrown exception")
             (catch Exception e
               (let [data (ex-data e)]
@@ -226,12 +247,12 @@
       (mt/with-premium-features #{:content-translation}
         ;; First import
         (let [initial-rows [["it" "Hello" "Buongiorno"]]]
-          (dictionary/import-translations! initial-rows)
+          (#'dictionary/import-translations! initial-rows)
           (is (= 1 (count-translations))))
         ;; Second import should replace all
         (let [new-rows [["de" "Thank you" "Danke"]
                         ["es" "Good morning" "Buenos días"]]]
-          (dictionary/import-translations! new-rows)
+          (#'dictionary/import-translations! new-rows)
           (is (= 2 (count-translations)))
           (let [translations (get-translations)]
             (is (not (some #(= (:locale %) "fr") translations)) "Old translations should be gone")

--- a/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_translation/routes_test.clj
@@ -97,7 +97,7 @@
     (testing "admin sees useful error when uploaded file has invalid csv"
       (ct-utils/with-clean-translations!
         (mt/with-premium-features #{:content-translation}
-          (is (=? {:errors ["Row 3: CSV error (unexpected character: !)"]}
+          (is (=? {:errors ["Error Parsing CSV at Row 4: CSV error (unexpected character: !)"]}
                   (mt/user-http-request :crowberto :post 422 "ee/content-translation/upload-dictionary"
                                         {:request-options {:headers {"content-type" "multipart/form-data"}}}
                                         {:file invalid-csv}))))))


### PR DESCRIPTION
### Description

Allows a content translation csv to be uploaded without a header row.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
