### PR TITLE
Closes VIZ-1311 - Slow loading dashcards with no average query duration shows 0

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -91,6 +91,17 @@ const DashCardLoadingView = ({
   expectedDuration,
   display,
 }: LoadingViewProps & { display?: CardDisplayType }) => {
+  const getMessage = () => {
+    if (isSlow === "usually-fast") {
+      return t`This usually loads immediately, but is currently taking longer.`;
+    }
+    if (expectedDuration) {
+      jt`This usually takes an average of ${(
+        <span className={CS.textNoWrap}>{duration(expectedDuration)}</span>
+      )}, but is currently taking longer.`;
+    }
+  };
+
   return (
     <div
       data-testid="loading-indicator"
@@ -122,15 +133,7 @@ const DashCardLoadingView = ({
               <HoverCard.Dropdown ml={-8} className={EmbedFrameS.dropdown}>
                 <div className={cx(CS.p2, CS.textCentered)}>
                   <Text fw="bold">{t`Waiting for your data`}</Text>
-                  <Text lh="1.5">
-                    {isSlow === "usually-slow"
-                      ? jt`This usually takes an average of ${(
-                          <span className={CS.textNoWrap}>
-                            {duration(expectedDuration ?? 0)}
-                          </span>
-                        )}, but is currently taking longer.`
-                      : t`This usually loads immediately, but is currently taking longer.`}
-                  </Text>
+                  <Text lh="1.5">{getMessage()} </Text>
                 </div>
               </HoverCard.Dropdown>
             </HoverCard>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from "react";
 import { jt, t } from "ttag";
 import _ from "underscore";
 
+import { useLearnUrl } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { useClickBehaviorData } from "metabase/dashboard/hooks";
@@ -21,7 +22,6 @@ import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { getSetting } from "metabase/selectors/settings";
-import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import {
   Box,
   Button,
@@ -92,7 +92,9 @@ const DashCardLoadingView = ({
   expectedDuration,
   display,
 }: LoadingViewProps & { display?: CardDisplayType }) => {
-  const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+  const { url, showMetabaseLinks } = useLearnUrl(
+    "metabase-basics/administration/administration-and-operation/making-dashboards-faster",
+  );
   const getPreamble = () => {
     if (isSlow === "usually-fast") {
       return t`This usually loads immediately, but is currently taking longer.`;
@@ -146,7 +148,7 @@ const DashCardLoadingView = ({
                       size="compact-md"
                       rightSection={<Icon name="external" />}
                       component="a"
-                      href="https://www.metabase.com/learn/metabase-basics/administration/administration-and-operation/making-dashboards-faster"
+                      href={url}
                       target="_blank"
                       rel="noreferrer"
                     >

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from "react";
 import { jt, t } from "ttag";
 import _ from "underscore";
 
+import ExternalLink from "metabase/common/components/ExternalLink/ExternalLink";
 import { useLearnUrl } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import { useDashboardContext } from "metabase/dashboard/context";
@@ -147,10 +148,8 @@ const DashCardLoadingView = ({
                       variant="subtle"
                       size="compact-md"
                       rightSection={<Icon name="external" />}
-                      component="a"
+                      component={ExternalLink}
                       href={url}
-                      target="_blank"
-                      rel="noreferrer"
                     >
                       {t`Making dashboards faster`}
                     </Button>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -21,6 +21,7 @@ import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { getSetting } from "metabase/selectors/settings";
+import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import {
   Box,
   Button,
@@ -91,14 +92,15 @@ const DashCardLoadingView = ({
   expectedDuration,
   display,
 }: LoadingViewProps & { display?: CardDisplayType }) => {
-  const getMessage = () => {
+  const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+  const getPreamble = () => {
     if (isSlow === "usually-fast") {
       return t`This usually loads immediately, but is currently taking longer.`;
     }
     if (expectedDuration) {
-      jt`This usually takes an average of ${(
+      return jt`This usually takes around ${(
         <span className={CS.textNoWrap}>{duration(expectedDuration)}</span>
-      )}, but is currently taking longer.`;
+      )}.`;
     }
   };
 
@@ -133,7 +135,24 @@ const DashCardLoadingView = ({
               <HoverCard.Dropdown ml={-8} className={EmbedFrameS.dropdown}>
                 <div className={cx(CS.p2, CS.textCentered)}>
                   <Text fw="bold">{t`Waiting for your data`}</Text>
-                  <Text lh="1.5">{getMessage()} </Text>
+                  <Text lh="1.5" mt={4}>
+                    {getPreamble()}{" "}
+                    {t`You can use caching to speed up question loading.`}
+                  </Text>
+                  {showMetabaseLinks && (
+                    <Button
+                      mt={12}
+                      variant="subtle"
+                      size="compact-md"
+                      rightSection={<Icon name="external" />}
+                      component="a"
+                      href="https://www.metabase.com/learn/metabase-basics/administration/administration-and-operation/making-dashboards-faster"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {t`Making dashboards faster`}
+                    </Button>
+                  )}
                 </div>
               </HoverCard.Dropdown>
             </HoverCard>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/60988
Closes VIZ-1311

### Description

1. Adds "You can use caching" message to slow-loading hover card
2. Adds "Making dashboards faster" link to hover card (not shown if white-labeled)
3. Removes "usually loads immediately/takes around x seconds" message for when we don't have an average yet

### How to verify

It's difficult to trigger this state naturally so here are some changes you can make locally to trigger it.

<img width="469" height="408" alt="Screenshot 2025-07-15 at 5 37 40 PM" src="https://github.com/user-attachments/assets/c6f3b9b9-1cb8-4aea-83e1-8ca8d455fae3" />

1. Navigate to a dashboard
2. Trigger the slow-loading (snail) state
3. Hover over a snail for a card with <ins>**no average duration**</ins>
4. Verify subcopy says "You can use caching to speed up question loading.", that the link is present (if not white-labeled) and matches [designs](https://www.figma.com/design/CSbCYr3G4CwrUrpaWEJjdB/Loading-states?node-id=4071-394&m=dev), and navigates to [Making dashboards faster](https://www.metabase.com/learn/metabase-basics/administration/administration-and-operation/making-dashboards-faster).
5. Hover over a snail for a card that <ins>**usually loads fast**</ins>
6. Verify same as above except subcopy should say "This usually loads immediately, but is currently taking longer. You can use caching to speed up question loading."
7. Hover over a snail for a card that <ins>**usually loads slow**</ins>
8. Verify same as above except subcopy should say "This usually takes around {x} seconds. You can use caching to speed up question loading."

### Demo

**No average**
<img width="1312" height="818" alt="no-avg" src="https://github.com/user-attachments/assets/e30802f2-fb77-4431-bd67-1c696da2b619" />

**Fast average**
<img width="1312" height="818" alt="fast-avg" src="https://github.com/user-attachments/assets/59810310-ad26-41c2-9cbd-fffe6e5db61c" />

**Slow average**
<img width="1312" height="818" alt="slow-avg" src="https://github.com/user-attachments/assets/d89bee07-0473-4ee8-8704-7d07d9c1118d" />
