### PR TITLE
Show Application Permission Saving Errors

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/reducer.js
@@ -1,11 +1,14 @@
 import { assocIn } from "icepick";
+import { t } from "ttag";
 
+import { getErrorMessage } from "metabase/api/utils";
 import {
   combineReducers,
   createAction,
   createThunkAction,
   handleActions,
 } from "metabase/lib/redux";
+import { addUndo } from "metabase/redux/undo";
 
 import { ApplicationPermissionsApi } from "./api";
 
@@ -44,13 +47,20 @@ const SAVE_APPLICATION_PERMISSIONS =
   "metabase-enterprise/general-permissions/data/SAVE_APPLICATION_PERMISSIONS";
 export const saveApplicationPermissions = createThunkAction(
   SAVE_APPLICATION_PERMISSIONS,
-  () => async (_dispatch, getState) => {
+  () => async (dispatch, getState) => {
     const { applicationPermissions, applicationPermissionsRevision } =
       getState().plugins.applicationPermissionsPlugin;
 
     const result = await ApplicationPermissionsApi.updateGraph({
       groups: applicationPermissions,
       revision: applicationPermissionsRevision,
+    }).catch((error) => {
+      dispatch(
+        addUndo({
+          icon: "warning",
+          message: getErrorMessage(error, t`Error saving permissions`),
+        }),
+      );
     });
 
     return result;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
@@ -1,4 +1,3 @@
-import cx from "classnames";
 import type { ReactNode } from "react";
 import { useCallback } from "react";
 import type { Route } from "react-router";
@@ -15,10 +14,8 @@ import {
   ToolbarButtonsContainer,
 } from "metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.styled";
 import { getIsHelpReferenceOpen } from "metabase/admin/permissions/selectors/help-reference";
-import Button from "metabase/common/components/Button";
+import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmModal";
-import Modal from "metabase/common/components/Modal";
-import ModalContent from "metabase/common/components/ModalContent";
 import { useToggle } from "metabase/common/hooks/use-toggle";
 import CS from "metabase/css/core/index.css";
 import { useDispatch, useSelector } from "metabase/lib/redux";
@@ -91,7 +88,9 @@ export function PermissionsPageLayout({
 
   const navigateToTab = (tab: PermissionsPageTab) =>
     dispatch(push(`/admin/permissions/${tab}`));
-  const clearSaveError = () => dispatch(clearPermissionsSaveError());
+  const clearSaveError = () => {
+    dispatch(clearPermissionsSaveError());
+  };
 
   const handleToggleHelpReference = useCallback(() => {
     dispatch(toggleHelpReference());
@@ -116,18 +115,16 @@ export function PermissionsPageLayout({
           />
         )}
 
-        <Modal isOpen={saveError != null}>
-          <ModalContent
-            title={t`There was an error saving`}
-            formModal
-            onClose={clearSaveError}
-          >
-            <p className={CS.mb4}>{saveError}</p>
-            <div className={cx(CS.mlAuto)}>
-              <Button onClick={clearSaveError}>{t`OK`}</Button>
-            </div>
-          </ModalContent>
-        </Modal>
+        <ConfirmModal
+          opened={saveError != null}
+          onClose={clearSaveError}
+          onConfirm={clearSaveError}
+          title={t`There was an error saving`}
+          message={saveError}
+          confirmButtonText={t`OK`}
+          confirmButtonProps={{ variant: "outline" }}
+          closeButtonText={null}
+        />
 
         <LeaveRouteConfirmModal isEnabled={!!isDirty} route={route} />
 


### PR DESCRIPTION

### Description

While working on tenant groups permissions, I discovered that we don't show any application permissions saving errors. This adds a simple toast with the error message.

<img width="276" height="91" alt="Screenshot 2025-07-15 at 4 55 44 PM" src="https://github.com/user-attachments/assets/ab4a7e99-2bc6-47f3-93a7-5d409f85a8b4" />

Along the way I also updated the data + collection permission error modal to use our new confirmModal Component.

<img width="693" height="260" alt="Screenshot 2025-07-15 at 4 53 27 PM" src="https://github.com/user-attachments/assets/d6e40952-08b2-45b9-b722-575c1f46a480" />


### How to verify

Use chrome dev tools to block the request urls for permissions saving. then try to save them 😁 


