### PR TITLE
Add test coverage for search indexing during deserialization

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -8,6 +8,8 @@
    [metabase-enterprise.serialization.v2.ingest :as v2.ingest]
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.models.serialization :as serdes]
+   [metabase.search.core :as search]
+   [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.util.compress :as u.compress]
    [metabase.util.random :as u.random]
@@ -160,190 +162,54 @@
         (is (= known-files
                (set (.list (io/file api.serialization/parent-dir)))))))))
 
+(defn- search-result-count [search-string]
+  (:total
+   (search/search
+    (search/search-context
+     {:current-user-id       (mt/user->id :crowberto)
+      :is-superuser?         true
+      :is-impersonated-user? false
+      :is-sandboxed-user?    false
+      :models                nil
+      :current-user-perms    #{"/"}
+      :search-string         search-string}))))
+
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest export-import-test
   (testing "Serialization API e2e"
-    (let [known-files (set (.list (io/file api.serialization/parent-dir)))]
-      (snowplow-test/with-fake-snowplow-collector
-        (mt/with-premium-features #{:serialization}
-          (testing "POST /api/ee/serialization/export"
-            (mt/with-temp [:model/Collection coll  {}
-                           :model/Dashboard  _dash {:collection_id (:id coll)}
-                           :model/Card       card  {:collection_id (:id coll)}]
+    (search.tu/with-temp-index-table
+      (let [known-files (set (.list (io/file api.serialization/parent-dir)))]
+        (snowplow-test/with-fake-snowplow-collector
+          (mt/with-premium-features #{:serialization}
+            (testing "POST /api/ee/serialization/export"
+              (mt/with-temp [:model/Collection coll  {}
+                             :model/Dashboard  _dash {:collection_id (:id coll)}
+                             :model/Card       card  {:collection_id (:id coll), :name "frobinate"}]
 
-              (let [res (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
-                                                  :collection (:id coll) :data_model false :settings false)
-                            io/input-stream)
-                    ;; we're going to re-use it for import, so a copy is necessary
-                    ba  (#'api.serialization/ba-copy res)]
-                (testing "We get only our data and a log file in an archive"
-                  (is (= 4
-                         (with-open [tar (open-tar ba)]
-                           (count
-                            (for [^TarArchiveEntry e (u.compress/entries tar)
-                                  :when              (.isFile e)]
-                              (do
-                                (condp re-find (.getName e)
-                                  #"/export.log$" (testing "Three lines in a log for data files"
-                                                    (is (= (+ #_extract 3 #_store 3)
-                                                           (count (line-seq (io/reader tar))))))
-                                  nil)
-                                (.getName e))))))))
+                (testing "We clear the card from the search index"
+                  (is (= 1 (search-result-count "frobinate")))
+                  (search/delete! :model/Card [(str (:id card))])
+                  (is (= 0 (search-result-count "frobinate"))))
 
-                (testing "Snowplow export event was sent"
-                  (is (=? {"event"           "serialization"
-                           "direction"       "export"
-                           "collection"      (str (:id coll))
-                           "all_collections" false
-                           "data_model"      false
-                           "settings"        false
-                           "field_values"    false
-                           "duration_ms"     (every-pred number? pos?)
-                           "count"           3
-                           "error_count"     0
-                           "source"          "api"
-                           "secrets"         false
-                           "success"         true
-                           "error_message"   nil}
-                          (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))
-
-                (testing "POST /api/ee/serialization/import"
-                  (t2/update! :model/Card {:id (:id card)} {:name (str "qwe_" (:name card))})
-
-                  (let [res (mt/user-http-request :crowberto :post 200 "ee/serialization/import"
-                                                  {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                                  {:file ba})]
-                    (testing "We get our data items back"
-                      (is (= #{"Collection" "Dashboard" "Card" "Database"}
-                             (log-types (line-seq (io/reader (io/input-stream res)))))))
-                    (testing "And they hit the db"
-                      (is (= (:name card)
-                             (t2/select-one-fn :name :model/Card :id (:id card)))))
-                    (testing "Snowplow import event was sent"
-                      (is (=? {"event"         "serialization"
-                               "direction"     "import"
-                               "duration_ms"   pos?
-                               "source"        "api"
-                               "models"        "Card,Collection,Dashboard"
-                               "count"         3
-                               "error_count"   0
-                               "success"       true
-                               "error_message" nil}
-                              (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))
-
-                (mt/with-dynamic-fn-redefs [v2.ingest/ingest-file (let [ingest-file (mt/dynamic-value #'v2.ingest/ingest-file)]
-                                                                    (fn [^File file]
-                                                                      (cond-> (ingest-file file)
-                                                                        (str/includes? (.getName file) (:entity_id card))
-                                                                        (assoc :collection_id "DoesNotExist"))))]
-                  (testing "ERROR /api/ee/serialization/import"
-                    (let [res (binding [api.serialization/*additive-logging* false]
-                                (mt/user-http-request :crowberto :post 500 "ee/serialization/import"
-                                                      {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                                      {:file ba}))
-                          log (slurp (io/input-stream res))]
-                      (testing "3 header lines, then cards+database+collection, then the error"
-                        (is (re-find #"Failed to read file for Collection DoesNotExist" log))
-                        (is (re-find #"Cannot find file" log)) ;; underlying error
-                        (is (= {:deps-chain #{[{:id "**ID**", :model "Card"}]},
-                                :error      :metabase-enterprise.serialization.v2.load/not-found,
-                                :model      "Collection",
-                                :path       [{:id "DoesNotExist", :model "Collection"}],
-                                :table      :collection}
-                               (extract-and-sanitize-exception-map log))))
-                      (testing "Snowplow event about error was sent"
-                        (is (=? {"success"       false
-                                 "event"         "serialization"
-                                 "direction"     "import"
-                                 "source"        "api"
-                                 "duration_ms"   int?
-                                 "count"         0
-                                 "error_count"   0
-                                 "error_message" #"(?s)Failed to read file for Collection DoesNotExist.*"}
-                                (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))
-
-                  (testing "Skipping errors /api/ee/serialization/import"
-                    (let [res (mt/user-http-request :crowberto :post 200 "ee/serialization/import"
-                                                    {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                                    {:file ba}
-                                                    :continue_on_error true)
-                          log (slurp (io/input-stream res))]
-                      (testing "3 header lines, then card+database+coll, error, then dashboard+coll"
-                        (is (= #{"Dashboard" "Card" "Database" "Collection"}
-                               (log-types (str/split-lines log))))
-                        (is (re-find #"Failed to read file for Collection DoesNotExist" log)))
-                      (testing "Snowplow event about error was sent"
-                        (is (=? {"success"     true
-                                 "event"       "serialization"
-                                 "direction"   "import"
-                                 "source"      "api"
-                                 "duration_ms" int?
-                                 "count"       2
-                                 "error_count" 1
-                                 "models"      "Collection,Dashboard"}
-                                (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))))
-
-              (testing "Client error /api/ee/serialization/import"
-                (let [res (mt/user-http-request :crowberto :post 422 "ee/serialization/import"
-                                                {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                                {:file (.getBytes "not an archive" "UTF-8")})
-                      log (slurp (io/input-stream res))]
-                  (is (re-find #"Cannot unpack archive" log))))
-
-              (mt/with-dynamic-fn-redefs [serdes/extract-one (extract-one-error (:entity_id card)
-                                                                                (mt/dynamic-value serdes/extract-one))]
-                (testing "ERROR /api/ee/serialization/export"
-                  (binding [api.serialization/*additive-logging* false]
-                    (let [res (mt/user-http-request :crowberto :post 500 "ee/serialization/export"
+                (let [res (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
                                                     :collection (:id coll) :data_model false :settings false)
-                          log (slurp (io/input-stream res))]
-                      (is (=  {:id        "**ID**",
-                               :entity_id "**ID**",
-                               :model     "Card",
-                               :table     :report_card
-                               :cause     "[test] deliberate error message"}
-                              (extract-and-sanitize-exception-map log)))))
+                              io/input-stream)
+                    ;; we're going to re-use it for import, so a copy is necessary
+                      ba  (#'api.serialization/ba-copy res)]
+                  (testing "We get only our data and a log file in an archive"
+                    (is (= 4
+                           (with-open [tar (open-tar ba)]
+                             (count
+                              (for [^TarArchiveEntry e (u.compress/entries tar)
+                                    :when              (.isFile e)]
+                                (do
+                                  (condp re-find (.getName e)
+                                    #"/export.log$" (testing "Three lines in a log for data files"
+                                                      (is (= (+ #_extract 3 #_store 3)
+                                                             (count (line-seq (io/reader tar))))))
+                                    nil)
+                                  (.getName e))))))))
 
-                  (testing "Snowplow event about error was sent"
-                    (is (=? {"event"           "serialization"
-                             "direction"       "export"
-                             "duration_ms"     pos?
-                             "source"          "api"
-                             "count"           0
-                             "collection"      (str (:id coll))
-                             "all_collections" false
-                             "data_model"      false
-                             "settings"        false
-                             "field_values"    false
-                             "secrets"         false
-                             "success"         false
-                             "error_message"   #"(?s)Error extracting Card \d+ .*"}
-                            (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))
-
-                  (testing "Full stacktrace"
-                    (binding [api.serialization/*additive-logging* false]
-                      (let [res (mt/user-http-request :crowberto :post 500 "ee/serialization/export"
-                                                      :collection (:id coll) :data_model false :settings false
-                                                      :full_stacktrace true)
-                            log (slurp (io/input-stream res))]
-                        (is (< 200
-                               (count (str/split-lines log))))
-                        ;; pop out the error
-                        (snowplow-test/pop-event-data-and-user-id!)))))
-
-                (testing "Skipping errors /api/ee/serialization/export"
-                  (let [res (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
-                                                      :collection (:id coll) :data_model false :settings false
-                                                      :continue_on_error true)
-                                ;; consume response to remove on-disk data
-                                io/input-stream)]
-                    (with-open [tar (open-tar res)]
-                      (doseq [^TarArchiveEntry e (u.compress/entries tar)]
-                        (condp re-find (.getName e)
-                          #"/export.log$" (testing "Three lines in a log for data files"
-                                            (is (= (+ #_extract 3 #_error 1 #_store 2)
-                                                   (count (line-seq (io/reader tar))))))
-                          nil))))
                   (testing "Snowplow export event was sent"
                     (is (=? {"event"           "serialization"
                              "direction"       "export"
@@ -352,27 +218,185 @@
                              "data_model"      false
                              "settings"        false
                              "field_values"    false
-                             "duration_ms"     pos?
-                             "count"           2
-                             "error_count"     1
+                             "duration_ms"     (every-pred number? pos?)
+                             "count"           3
+                             "error_count"     0
                              "source"          "api"
                              "secrets"         false
                              "success"         true
                              "error_message"   nil}
-                            (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))
+                            (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))
 
-              (testing "Only admins can export/import"
-                (is (= "You don't have permissions to do that."
-                       (mt/user-http-request :rasta :post 403 "ee/serialization/export")))
-                (is (= "You don't have permissions to do that."
-                       (mt/user-http-request :rasta :post 403 "ee/serialization/import"
-                                             {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                             {:file (byte-array 0)}))))))))
-      (testing "We've left no new files, every request is cleaned up"
-        ;; if this breaks, check if you consumed every response with io/input-stream. Or `future` is taking too long
-        ;; in `api/on-response!`, so maybe add some Thread/sleep here.
-        (is (= known-files
-               (set (.list (io/file api.serialization/parent-dir)))))))))
+                  (testing "POST /api/ee/serialization/import"
+                    (t2/update! :model/Card {:id (:id card)} {:name (str "qwe_" (:name card))})
+
+                    (let [res (mt/user-http-request :crowberto :post 200 "ee/serialization/import"
+                                                    {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                                    {:file ba})]
+                      (testing "We get our data items back"
+                        (is (= #{"Collection" "Dashboard" "Card" "Database"}
+                               (log-types (line-seq (io/reader (io/input-stream res)))))))
+                      (testing "And they hit the db"
+                        (is (= (:name card)
+                               (t2/select-one-fn :name :model/Card :id (:id card)))))
+                      (testing "Snowplow import event was sent"
+                        (is (=? {"event"         "serialization"
+                                 "direction"     "import"
+                                 "duration_ms"   pos?
+                                 "source"        "api"
+                                 "models"        "Card,Collection,Dashboard"
+                                 "count"         3
+                                 "error_count"   0
+                                 "success"       true
+                                 "error_message" nil}
+                                (-> (snowplow-test/pop-event-data-and-user-id!) last :data)))))
+
+                    (testing "The loaded entities are added to the search index"
+                      (is (= 1 (search-result-count "frobinate")))))
+
+                  (mt/with-dynamic-fn-redefs [v2.ingest/ingest-file (let [ingest-file (mt/dynamic-value #'v2.ingest/ingest-file)]
+                                                                      (fn [^File file]
+                                                                        (cond-> (ingest-file file)
+                                                                          (str/includes? (.getName file) (:entity_id card))
+                                                                          (assoc :collection_id "DoesNotExist"))))]
+                    (testing "ERROR /api/ee/serialization/import"
+                      (let [res (binding [api.serialization/*additive-logging* false]
+                                  (mt/user-http-request :crowberto :post 500 "ee/serialization/import"
+                                                        {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                                        {:file ba}))
+                            log (slurp (io/input-stream res))]
+                        (testing "3 header lines, then cards+database+collection, then the error"
+                          (is (re-find #"Failed to read file for Collection DoesNotExist" log))
+                          (is (re-find #"Cannot find file" log)) ;; underlying error
+                          (is (= {:deps-chain #{[{:id "**ID**", :model "Card"}]},
+                                  :error      :metabase-enterprise.serialization.v2.load/not-found,
+                                  :model      "Collection",
+                                  :path       [{:id "DoesNotExist", :model "Collection"}],
+                                  :table      :collection}
+                                 (extract-and-sanitize-exception-map log))))
+                        (testing "Snowplow event about error was sent"
+                          (is (=? {"success"       false
+                                   "event"         "serialization"
+                                   "direction"     "import"
+                                   "source"        "api"
+                                   "duration_ms"   int?
+                                   "count"         0
+                                   "error_count"   0
+                                   "error_message" #"(?s)Failed to read file for Collection DoesNotExist.*"}
+                                  (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))
+
+                    (testing "Skipping errors /api/ee/serialization/import"
+                      (let [res (mt/user-http-request :crowberto :post 200 "ee/serialization/import"
+                                                      {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                                      {:file ba}
+                                                      :continue_on_error true)
+                            log (slurp (io/input-stream res))]
+                        (testing "3 header lines, then card+database+coll, error, then dashboard+coll"
+                          (is (= #{"Dashboard" "Card" "Database" "Collection"}
+                                 (log-types (str/split-lines log))))
+                          (is (re-find #"Failed to read file for Collection DoesNotExist" log)))
+                        (testing "Snowplow event about error was sent"
+                          (is (=? {"success"     true
+                                   "event"       "serialization"
+                                   "direction"   "import"
+                                   "source"      "api"
+                                   "duration_ms" int?
+                                   "count"       2
+                                   "error_count" 1
+                                   "models"      "Collection,Dashboard"}
+                                  (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))))
+
+                (testing "Client error /api/ee/serialization/import"
+                  (let [res (mt/user-http-request :crowberto :post 422 "ee/serialization/import"
+                                                  {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                                  {:file (.getBytes "not an archive" "UTF-8")})
+                        log (slurp (io/input-stream res))]
+                    (is (re-find #"Cannot unpack archive" log))))
+
+                (mt/with-dynamic-fn-redefs [serdes/extract-one (extract-one-error (:entity_id card)
+                                                                                  (mt/dynamic-value serdes/extract-one))]
+                  (testing "ERROR /api/ee/serialization/export"
+                    (binding [api.serialization/*additive-logging* false]
+                      (let [res (mt/user-http-request :crowberto :post 500 "ee/serialization/export"
+                                                      :collection (:id coll) :data_model false :settings false)
+                            log (slurp (io/input-stream res))]
+                        (is (= {:id        "**ID**",
+                                :entity_id "**ID**",
+                                :model     "Card",
+                                :table     :report_card
+                                :cause     "[test] deliberate error message"}
+                               (extract-and-sanitize-exception-map log)))))
+
+                    (testing "Snowplow event about error was sent"
+                      (is (=? {"event"           "serialization"
+                               "direction"       "export"
+                               "duration_ms"     pos?
+                               "source"          "api"
+                               "count"           0
+                               "collection"      (str (:id coll))
+                               "all_collections" false
+                               "data_model"      false
+                               "settings"        false
+                               "field_values"    false
+                               "secrets"         false
+                               "success"         false
+                               "error_message"   #"(?s)Error extracting Card \d+ .*"}
+                              (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))
+
+                    (testing "Full stacktrace"
+                      (binding [api.serialization/*additive-logging* false]
+                        (let [res (mt/user-http-request :crowberto :post 500 "ee/serialization/export"
+                                                        :collection (:id coll) :data_model false :settings false
+                                                        :full_stacktrace true)
+                              log (slurp (io/input-stream res))]
+                          (is (< 200
+                                 (count (str/split-lines log))))
+                        ;; pop out the error
+                          (snowplow-test/pop-event-data-and-user-id!)))))
+
+                  (testing "Skipping errors /api/ee/serialization/export"
+                    (let [res (-> (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
+                                                        :collection (:id coll) :data_model false :settings false
+                                                        :continue_on_error true)
+                                ;; consume response to remove on-disk data
+                                  io/input-stream)]
+                      (with-open [tar (open-tar res)]
+                        (doseq [^TarArchiveEntry e (u.compress/entries tar)]
+                          (condp re-find (.getName e)
+                            #"/export.log$" (testing "Three lines in a log for data files"
+                                              (is (= (+ #_extract 3 #_error 1 #_store 2)
+                                                     (count (line-seq (io/reader tar))))))
+                            nil))))
+                    (testing "Snowplow export event was sent"
+                      (is (=? {"event"           "serialization"
+                               "direction"       "export"
+                               "collection"      (str (:id coll))
+                               "all_collections" false
+                               "data_model"      false
+                               "settings"        false
+                               "field_values"    false
+                               "duration_ms"     pos?
+                               "count"           2
+                               "error_count"     1
+                               "source"          "api"
+                               "secrets"         false
+                               "success"         true
+                               "error_message"   nil}
+                              (-> (snowplow-test/pop-event-data-and-user-id!) last :data))))))
+
+                (testing "Only admins can export/import"
+                  (is (= "You don't have permissions to do that."
+                         (mt/user-http-request :rasta :post 403 "ee/serialization/export")))
+                  (is (= "You don't have permissions to do that."
+                         (mt/user-http-request :rasta :post 403 "ee/serialization/import"
+                                               {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                               {:file (byte-array 0)}))))))))
+
+        (testing "We've left no new files, every request is cleaned up"
+         ;; if this breaks, check if you consumed every response with io/input-stream. Or `future` is taking too long
+         ;; in `api/on-response!`, so maybe add some Thread/sleep here.
+          (is (= known-files
+                 (set (.list (io/file api.serialization/parent-dir))))))))))
 
 (deftest find-serialization-dir-test
   (testing "We are able to find serialization dir even in presence of various hidden dirs"


### PR DESCRIPTION
Relates to WRK-573, but does not resolve it.

Could not reproduce the issue in test - the real time toucan hooks pick up the insert / update statements as expected.

Can however reproduce the issue when running a dev server 😢 

Make sure to ignore whitespace in the diff.