### PR TITLE
Refresh Search index after loading serialized entities

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1769,6 +1769,7 @@
            models
            plugins
            premium-features
+           search
            settings
            setup
            util

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -8,6 +8,7 @@
    [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
    [metabase-enterprise.serialization.v2.models :as serdes.models]
    [metabase.models.serialization :as serdes]
+   [metabase.search.core :as search]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]
@@ -155,27 +156,33 @@
   [ingestion & {:keys [backfill? continue-on-error]
                 :or   {backfill?         true
                        continue-on-error false}}]
-  (t2/with-transaction [_tx]
-    ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared dependencies
-    ;; guide the import, and make sure all containers are imported before contents, etc.
-    (when backfill?
-      (serdes.backfill/backfill-ids!))
-    (let [contents (serdes.ingest/ingest-list ingestion)
-          ctx      {:expanding #{}
-                    :seen      #{}
-                    :circular  #{}
-                    :ingestion ingestion
-                    :from-ids  (m/index-by :id contents)
-                    :errors    []}]
-      (log/infof "Starting deserialization, total %s documents" (count contents))
-      (reduce (fn [ctx item]
-                (try
-                  (load-one! ctx item)
-                  (catch Exception e
-                    (when-not continue-on-error
-                      (throw e))
-                    ;; eschew big and scary stacktrace
-                    (log/warnf (u/strip-error e "Skipping deserialization error"))
-                    (update ctx :errors conj e))))
-              ctx
-              contents))))
+  (u/prog1
+    (t2/with-transaction [_tx]
+      ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared dependencies
+      ;; guide the import, and make sure all containers are imported before contents, etc.
+      (when backfill?
+        (serdes.backfill/backfill-ids!))
+      (let [contents (serdes.ingest/ingest-list ingestion)
+            ctx      {:expanding #{}
+                      :seen      #{}
+                      :circular  #{}
+                      :ingestion ingestion
+                      :from-ids  (m/index-by :id contents)
+                      :errors    []}]
+        (log/infof "Starting deserialization, total %s documents" (count contents))
+        (reduce (fn [ctx item]
+                  (try
+                    (load-one! ctx #p item)
+                    (catch Exception e
+                      (when-not continue-on-error
+                        (throw e))
+                      ;; eschew big and scary stacktrace
+                      (log/warnf (u/strip-error e "Skipping deserialization error"))
+                      (update ctx :errors conj e))))
+                ctx
+                contents)))
+    ;; Hack: the transaction above typically takes much longer than our delay on the search indexing queue.
+    ;;       this means that the corresponding entries would have been missing or stale when we indexed them.
+    ;;       ideally, we would delay the indexing somehow, or only reindex what we've loaded.
+    ;;       while we're figuring that out, here's a crude stopgap.
+    (search/reindex!)))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -172,7 +172,7 @@
         (log/infof "Starting deserialization, total %s documents" (count contents))
         (reduce (fn [ctx item]
                   (try
-                    (load-one! ctx #p item)
+                    (load-one! ctx item)
                     (catch Exception e
                       (when-not continue-on-error
                         (throw e))

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -228,15 +228,19 @@
        :model_updated_at (:updated_at entity))
       (merge (specialization/extra-entry-fields entity))))
 
+(defn- table-not-found-exception? [e]
+  ;; Use with care, obviously this can give false positives if used with a query that's *actually* malformed.
+  ;; TODO we should handle the MySQL and MariaDB flavors here too
+  (or (instance? PSQLException (ex-cause e))
+      (instance? JdbcSQLSyntaxErrorException (ex-cause e))))
+
 (defn- safe-batch-upsert! [table-name entries]
   ;; For convenience, no-op if we are not tracking any table.
   (when table-name
     (try
       (specialization/batch-upsert! table-name entries)
       (catch Exception e
-        ;; TODO we should handle the MySQL and MariaDB flavors here too
-        (if (or (instance? PSQLException (ex-cause e))
-                (instance? JdbcSQLSyntaxErrorException (ex-cause e)))
+        (if (table-not-found-exception? e)
           ;; If resetting tracking atoms resolves the issue (which is likely happened because of stale tracking data),
           ;; suppress the issue - but throw it all the way to the caller if the issue persists
           (do (sync-tracking-atoms!)
@@ -287,18 +291,18 @@
                           (when table-name
                             {search-model (try (t2/delete! table-name :model search-model :model_id [:in (set ids)])
                                                ;; Race conditions with table being deleted, especially in tests.
-                                               (catch Exception e
-                                                 ;; In practice, this means that the table no longer exists.
-                                                 (if (or (instance? PSQLException (ex-cause e))
-                                                         (instance? JdbcSQLSyntaxErrorException (ex-cause e)))
-                                                   0
-                                                   (throw e))))})))
+                                               (catch Exception e (if (table-not-found-exception? e) 0 (throw e))))})))
                   (apply merge-with +)
                   (into {}))
       (when (active-table)
-        (analytics/set! :metabase-search/appdb-index-size (:count (t2/query-one {:select [[:%count.* :count]]
-                                                                                 :from   [(active-table)]
-                                                                                 :limit  1})))))))
+        (try
+          (analytics/set! :metabase-search/appdb-index-size (:count (t2/query-one {:select [[:%count.* :count]]
+                                                                                   :from   [(active-table)]
+                                                                                   :limit  1})))
+          (catch Exception e
+            ;; No point tracking the size of the newer index table, since we won't have modified it.
+            (when-not (table-not-found-exception? e)
+              (throw e))))))))
 
 (defn when-index-created
   "Return creation time of the active index, or nil if there is none."


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60437
closes WRK-573

The issue turns out to be the transaction hiding the entities from the indexing thread.

I'm optimistic that we can find a better solution to this, since it's a general problem.