### PR TITLE
Fix upsell flow with undefined store-url setting

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -115,6 +115,7 @@ describe("snapshots", () => {
       "license-token-missing-banner-dismissal-timestamp",
       new Date().toISOString(),
     );
+    updateSetting("store-url", "https://test-store.metabase.com");
   }
 
   function addUsersAndGroups() {

--- a/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
+++ b/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
@@ -78,13 +78,13 @@ export function useUpsellFlow({
   }, [updateToken, storeOrigin]);
 
   useEffect(() => {
+    sendToast({
+      icon: "warning",
+      message: error,
+      timeout: NOTIFICATION_TIMEOUT,
+    });
     if (error && storeWindowRef.current) {
       sendMessageTokenActivation(false, storeWindowRef.current, storeOrigin);
-      sendToast({
-        icon: "warning",
-        message: error,
-        timeout: NOTIFICATION_TIMEOUT,
-      });
     }
   }, [tokenStatus, error, sendToast, storeOrigin]);
 

--- a/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
+++ b/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
@@ -24,7 +24,7 @@ export function useUpsellFlow({
   const storeWindowRef = useRef<WindowProxy | null>(null);
   const [sendToast] = useToast();
   const storeUrl = useStoreUrl("checkout/upgrade/self-hosted");
-  const storeOrigin = new URL(storeUrl).origin;
+  const storeOrigin = storeUrl ? new URL(storeUrl).origin : undefined;
   const { updateToken, tokenStatus, error } = useLicense(() => {
     sendToast({
       message: t`License activated successfully`,
@@ -98,9 +98,12 @@ function createListener({
   storeOrigin,
 }: {
   updateToken: (token: string) => Promise<void>;
-  storeOrigin: string;
+  storeOrigin: string | undefined;
 }) {
   return (event: MessageEvent<LicenseTokenMessage>) => {
+    if (!storeOrigin) {
+      return;
+    }
     const token = handleMessageFromStore(event, storeOrigin);
     if (token) {
       updateToken(token);
@@ -144,8 +147,11 @@ function handleMessageFromStore(
 function sendMessageTokenActivation(
   success: boolean,
   storeWindow: WindowProxy,
-  storeOrigin: string,
+  storeOrigin: string | undefined,
 ) {
+  if (!storeOrigin) {
+    return;
+  }
   storeWindow.postMessage(
     {
       source: "metabase-instance",
@@ -165,12 +171,15 @@ function getStoreUrlWithParams({
   email,
   siteName,
 }: {
-  storeUrl: string;
+  storeUrl: string | undefined;
   firstName: string;
   lastName: string;
   email: string;
   siteName: string;
 }) {
+  if (!storeUrl) {
+    return undefined;
+  }
   const returnUrl = window.location.href;
   const returnUrlEncoded = encodeURIComponent(returnUrl);
   const siteNameEncoded = encodeURIComponent(siteName);

--- a/frontend/src/metabase/admin/performance/components/test-utils.tsx
+++ b/frontend/src/metabase/admin/performance/components/test-utils.tsx
@@ -1,5 +1,8 @@
 import { setupEnterprisePlugins } from "__support__/enterprise";
-import { setupDatabasesEndpoints } from "__support__/server-mocks";
+import {
+  setupDatabasesEndpoints,
+  setupTokenStatusEndpoint,
+} from "__support__/server-mocks";
 import { setupPerformanceEndpoints } from "__support__/server-mocks/performance";
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
@@ -25,7 +28,7 @@ export interface SetupOpts {
 }
 
 export const setupStrategyEditorForDatabases = ({
-  hasEnterprisePlugins,
+  hasEnterprisePlugins = false,
   tokenFeatures = {},
 }: SetupOpts = {}) => {
   const storeInitialState = createMockState({
@@ -40,6 +43,7 @@ export const setupStrategyEditorForDatabases = ({
   if (hasEnterprisePlugins) {
     setupEnterprisePlugins();
   }
+  setupTokenStatusEndpoint(hasEnterprisePlugins);
 
   const cacheConfigs = [
     createMockCacheConfigWithMultiplierStrategy({ model_id: 1 }),

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/test/AuthenticationSettingsPage.setup.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/test/AuthenticationSettingsPage.setup.tsx
@@ -2,6 +2,7 @@ import {
   setupApiKeyEndpoints,
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
+  setupTokenStatusEndpoint,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders } from "__support__/ui";
@@ -80,6 +81,7 @@ export const setup = async (
   setupUpdateSettingEndpoint();
   setupSettingsEndpoints([]);
   setupApiKeyEndpoints(testApiKeys);
+  setupTokenStatusEndpoint(isEnterprise);
 
   renderWithProviders(
     <div>

--- a/frontend/src/metabase/admin/upsells/components/use-upsell-link.ts
+++ b/frontend/src/metabase/admin/upsells/components/use-upsell-link.ts
@@ -2,7 +2,7 @@ import { useUrlWithUtm } from "metabase/common/hooks";
 
 interface UpsellLinkProps {
   /* The URL we're sending them to */
-  url: string;
+  url: string | undefined;
   /* The name of the feature we're trying to sell */
   campaign: string;
   /* The location, specific component/view of the upsell notification */

--- a/frontend/src/metabase/common/hooks/use-url-with-utm/use-url-with-utm.ts
+++ b/frontend/src/metabase/common/hooks/use-url-with-utm/use-url-with-utm.ts
@@ -1,6 +1,17 @@
 import { useSelector } from "metabase/lib/redux";
 import { type UtmProps, getUrlWithUtm } from "metabase/selectors/settings";
 
-export function useUrlWithUtm(url: string, utm: UtmProps) {
-  return useSelector((state) => getUrlWithUtm(state, { url, ...utm }));
+export function useUrlWithUtm(url: string, utm: UtmProps): string;
+export function useUrlWithUtm(url: undefined, utm: UtmProps): undefined;
+export function useUrlWithUtm(
+  url: string | undefined,
+  utm: UtmProps,
+): string | undefined;
+export function useUrlWithUtm(url: string | undefined, utm: UtmProps) {
+  return useSelector((state) => {
+    if (!url) {
+      return undefined;
+    }
+    return getUrlWithUtm(state, { url, ...utm });
+  });
 }

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/setup.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/setup.tsx
@@ -2,7 +2,10 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";
-import { setupParameterValuesEndpoints } from "__support__/server-mocks";
+import {
+  setupParameterValuesEndpoints,
+  setupTokenStatusEndpoint,
+} from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
 import type {
@@ -78,6 +81,7 @@ export async function setup({
     values: [],
     has_more_values: false,
   });
+  setupTokenStatusEndpoint(hasEnterprisePlugins);
 
   const settings = mockSettings({
     "enable-embedding": true,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/setup.tsx
@@ -5,6 +5,7 @@ import {
   setupAuditInfoEndpoint,
   setupCardEndpoints,
   setupRevisionsEndpoints,
+  setupTokenStatusEndpoint,
   setupUsersEndpoints,
 } from "__support__/server-mocks";
 import { setupPerformanceEndpoints } from "__support__/server-mocks/performance";
@@ -38,7 +39,7 @@ export const setup = async ({
   card = createMockCard(),
   settings = createMockSettings(),
   user,
-  hasEnterprisePlugins,
+  hasEnterprisePlugins = false,
 }: SetupOpts = {}) => {
   const currentUser = createMockUser(user);
   setupCardEndpoints(card);
@@ -63,6 +64,8 @@ export const setup = async ({
   if (hasEnterprisePlugins) {
     setupEnterprisePlugins();
   }
+
+  setupTokenStatusEndpoint(hasEnterprisePlugins);
 
   const TestQuestionInfoSidebar = () => (
     <QuestionInfoSidebar question={question} onSave={onSave} />

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -53,8 +53,12 @@ export const getStoreUrl = (path: StorePaths = "") => {
 };
 
 export function getStoreUrlFromState(state: State, path: StorePaths = "") {
-  const storeUrl = new URL(path, getSetting(state, "store-url"));
-  return storeUrl.toString();
+  const storeUrl = getSetting(state, "store-url");
+  if (!storeUrl) {
+    return undefined;
+  }
+  const url = new URL(path, storeUrl);
+  return url.toString();
 }
 
 export const migrateToCloudGuideUrl = () =>


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-103/fix-useupsellflow-failing-for-non-admins

### Description

The `store-url` variable can be at times undefined: for non-admin users and briefly for admin when the store setting was not yet fetched from API. To guard against it `useUpsellFlow` hook is now taking into account this value being undefined.

Alternative option to solve the issue would be to add wrappers to all upsells, that render the upsell only for admins. But this solution implies adding yet another wrapper - something we didn't want to do. On top of that, even for admins, `store-url` setting can be briefly undefined and cause a fatal error on `new URL(path, url)` - I've experienced that once. 
With reactive patterns, like hooks, we should IMHO embrace handling `undefined` value.

Also, some missing mocks caused by upsells' migration, were added.