### PR TITLE
docs(sdk): add limitations around leaflet 1

### DIFF
--- a/docs/embedding/sdk/introduction.md
+++ b/docs/embedding/sdk/introduction.md
@@ -122,7 +122,7 @@ The SDK doesn't support:
 Other limitations:
 
 - Multiple _interactive_ dashboards on the same application page. If you need to embed multiple dashboards on the same application page, you can embed static dashboards.
-- If you have Leaflet 1.x as a dependency in your app, you may run into compatibility issues. You can try using Leafleft 2.x instead 
+- If you have Leaflet 1.x as a dependency in your app, you may run into compatibility issues. You can try using Leaflet 2.x instead 
 
 ## Issues, feature requests and support
 

--- a/docs/embedding/sdk/introduction.md
+++ b/docs/embedding/sdk/introduction.md
@@ -118,7 +118,11 @@ The SDK doesn't support:
 - Subscriptions
 - Alerts
 - Server-side rendering (SSR)
+
+Other limitations:
+
 - Multiple _interactive_ dashboards on the same application page. If you need to embed multiple dashboards on the same application page, you can embed static dashboards.
+- If you have Leaflet 1.x as a dependency in your app, you may run into compatibility issues. You can try using Leafleft 2.x instead 
 
 ## Issues, feature requests and support
 

--- a/docs/embedding/sdk/introduction.md
+++ b/docs/embedding/sdk/introduction.md
@@ -122,7 +122,7 @@ The SDK doesn't support:
 Other limitations:
 
 - Multiple _interactive_ dashboards on the same application page. If you need to embed multiple dashboards on the same application page, you can embed static dashboards.
-- If you have Leaflet 1.x as a dependency in your app, you may run into compatibility issues. You can try using Leaflet 2.x instead 
+- If you have Leaflet 1.x as a dependency in your app, you may run into compatibility issues. You can try using Leaflet 2.x instead.
 
 ## Issues, feature requests and support
 

--- a/enterprise/frontend/src/embedding-sdk/README.md
+++ b/enterprise/frontend/src/embedding-sdk/README.md
@@ -50,6 +50,10 @@ yarn add @metabase/embedding-sdk-react
 
 For more on the SDK, check out the [SDK docs](https://www.metabase.com/docs/latest/embedding/sdk/introduction).
 
+## Limitations
+
+For the current limitations of the SDK, see the [SDK limitations section](https://www.metabase.com/docs/latest/embedding/sdk/introduction#sdk-limitations) of the docs.
+
 ## Development docs
 
-For developing the SDK, see the [dev docs](./dev.md).
+For developing the SDK, see the [dev docs](https://github.com/metabase/metabase/blob/master/enterprise/frontend/src/embedding-sdk/dev.md).


### PR DESCRIPTION
Added limitations around Leaflet 1, as well as add cross-links on limitations and fixed the development section link.