### PR TITLE
test: fix flakiness in dashcard resizing

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -1162,7 +1162,7 @@ describe("issue 31628", () => {
 
         previousValue()
           .findByText("35%")
-          .then(($element) => H.assertIsEllipsified($element[0]));
+          .should(($element) => H.assertIsEllipsified($element[0]));
       });
     });
 


### PR DESCRIPTION
<img width="1416" height="608" alt="image" src="https://github.com/user-attachments/assets/5b0b909d-c4d4-40f9-a52f-266b127f8b8e" />

https://app.trunk.io/metabase/flaky-tests/test/3361d0a0-cc07-59ed-84f8-54addebce348?repo=metabase%2Fmetabase&intervalDays=7

attempt to fix a flaky test

✅ [stress test](https://github.com/metabase/metabase/actions/runs/16321775957/job/46101187224)
❌ [master](https://github.com/metabase/metabase/actions/runs/16321781526/job/46101206783)

