### PR TITLE
Hide sample database mentions in `<DatabaseForm>` in the embedding setup

### DIFF
--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineField.tsx
@@ -14,6 +14,7 @@ interface DatabaseEngineFieldProps {
   isAdvanced: boolean;
   disabled?: boolean;
   onChange: (engine: string | undefined) => void;
+  showSampleDatabase?: boolean;
 }
 
 export const DatabaseEngineField = ({
@@ -22,6 +23,7 @@ export const DatabaseEngineField = ({
   isAdvanced,
   disabled,
   onChange,
+  showSampleDatabase,
 }: DatabaseEngineFieldProps): JSX.Element => {
   const { values } = useFormikContext<DatabaseData>();
 
@@ -44,6 +46,7 @@ export const DatabaseEngineField = ({
       onSelect={onChange}
       isSetupStep={true}
       engineKey={engineKey}
+      showSampleDatabase={showSampleDatabase}
     />
   );
 };

--- a/frontend/src/metabase/databases/components/DatabaseEngineList/DatabaseEngineList.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineList/DatabaseEngineList.tsx
@@ -28,6 +28,7 @@ import S from "./DatabaseEngineList.module.css";
 type DatabaseEngineListProps =
   | {
       isSetupStep: true;
+      showSampleDatabase?: boolean;
       engineKey?: string;
       onSelect: (engineKey?: string) => void;
     }
@@ -35,12 +36,14 @@ type DatabaseEngineListProps =
       isSetupStep?: never;
       engineKey?: never;
       onSelect: (engineKey: string) => void;
+      showSampleDatabase?: never;
     };
 
 export const DatabaseEngineList = ({
   onSelect,
   isSetupStep,
   engineKey,
+  showSampleDatabase = false,
 }: DatabaseEngineListProps) => {
   const combobox = useCombobox();
   const [search, setSearch] = useState("");
@@ -56,7 +59,7 @@ export const DatabaseEngineList = ({
 
   const databasesList = isExpanded ? searchResults : elevatedEngines;
 
-  const shouldShowSampleDatabaseIndicator = isSetupStep && !engineKey;
+  const sampleDatabaseIndicatorVisible = showSampleDatabase && !engineKey;
 
   const clearSelectedItem = useCallback(() => {
     if (isSetupStep) {
@@ -106,7 +109,7 @@ export const DatabaseEngineList = ({
 
         {databasesList.length > 0 ? (
           <ScrollArea type="hover" scrollHideDelay={300}>
-            {shouldShowSampleDatabaseIndicator && <SampleDatabaseIndicator />}
+            {sampleDatabaseIndicatorVisible && <SampleDatabaseIndicator />}
             <Combobox.Options>
               {databasesList.map(({ value: engineKey, name }) => {
                 return (

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -39,6 +39,10 @@ export interface DatabaseFormConfig {
   };
 }
 
+type ContinueWithoutDataComponent = (props: {
+  onCancel?: () => void;
+}) => JSX.Element;
+
 interface DatabaseFormProps {
   initialValues?: Partial<DatabaseData>;
   autofocusFieldName?: string;
@@ -47,12 +51,12 @@ interface DatabaseFormProps {
   onCancel?: () => void;
   setIsDirty?: (isDirty: boolean) => void;
   config?: DatabaseFormConfig;
+  /**
+   * Whether to show the sample database indicator in the engine list and change the "I'll add my data later" button to "Continue with sample data"
+   */
   showSampleDatabase?: boolean;
-  ContinueWithoutDataSlot?: ({
-    onCancel,
-  }: {
-    onCancel?: () => void;
-  }) => JSX.Element;
+  /** Slot to replace the button to continue without data/with only sample data */
+  ContinueWithoutDataSlot?: ContinueWithoutDataComponent;
 }
 
 export const DatabaseForm = ({
@@ -136,16 +140,8 @@ interface DatabaseFormBodyProps {
   onCancel?: () => void;
   setIsDirty?: (isDirty: boolean) => void;
   config: DatabaseFormConfig;
-  /**
-   * Whether to show the sample database indicator in the engine list and change the "I'll add my data later" button to "Continue with sample data"
-   */
   showSampleDatabase?: boolean;
-  /** Slot to replace the button to continue without data/with sample data */
-  ContinueWithoutDataSlot?: ({
-    onCancel,
-  }: {
-    onCancel?: () => void;
-  }) => JSX.Element;
+  ContinueWithoutDataSlot?: ContinueWithoutDataComponent;
 }
 
 const DatabaseFormBody = ({
@@ -222,11 +218,7 @@ interface DatabaseFormFooterProps {
   isDirty: boolean;
   onCancel?: () => void;
   showSampleDatabase?: boolean;
-  ContinueWithoutDataSlot?: ({
-    onCancel,
-  }: {
-    onCancel?: () => void;
-  }) => JSX.Element;
+  ContinueWithoutDataSlot?: ContinueWithoutDataComponent;
 }
 
 const DatabaseFormFooter = ({

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -47,6 +47,12 @@ interface DatabaseFormProps {
   onCancel?: () => void;
   setIsDirty?: (isDirty: boolean) => void;
   config?: DatabaseFormConfig;
+  showSampleDatabase?: boolean;
+  ContinueWithoutDataSlot?: ({
+    onCancel,
+  }: {
+    onCancel?: () => void;
+  }) => JSX.Element;
 }
 
 export const DatabaseForm = ({
@@ -56,6 +62,8 @@ export const DatabaseForm = ({
   onCancel,
   onEngineChange,
   setIsDirty,
+  showSampleDatabase = false,
+  ContinueWithoutDataSlot,
   config = {},
 }: DatabaseFormProps): JSX.Element => {
   const isAdvanced = config.isAdvanced || false;
@@ -110,6 +118,8 @@ export const DatabaseForm = ({
         onCancel={onCancel}
         setIsDirty={setIsDirty}
         config={config}
+        showSampleDatabase={showSampleDatabase}
+        ContinueWithoutDataSlot={ContinueWithoutDataSlot}
       />
     </FormProvider>
   );
@@ -126,6 +136,16 @@ interface DatabaseFormBodyProps {
   onCancel?: () => void;
   setIsDirty?: (isDirty: boolean) => void;
   config: DatabaseFormConfig;
+  /**
+   * Whether to show the sample database indicator in the engine list and change the "I'll add my data later" button to "Continue with sample data"
+   */
+  showSampleDatabase?: boolean;
+  /** Slot to replace the button to continue without data/with sample data */
+  ContinueWithoutDataSlot?: ({
+    onCancel,
+  }: {
+    onCancel?: () => void;
+  }) => JSX.Element;
 }
 
 const DatabaseFormBody = ({
@@ -139,6 +159,8 @@ const DatabaseFormBody = ({
   onCancel,
   setIsDirty,
   config,
+  showSampleDatabase = false,
+  ContinueWithoutDataSlot,
 }: DatabaseFormBodyProps): JSX.Element => {
   const { values, dirty } = useFormikContext<DatabaseData>();
 
@@ -160,6 +182,7 @@ const DatabaseFormBody = ({
             isAdvanced={isAdvanced}
             onChange={onEngineChange}
             disabled={engineFieldState === "disabled"}
+            showSampleDatabase={showSampleDatabase}
           />
           <DatabaseEngineWarning
             engineKey={engineKey}
@@ -187,6 +210,8 @@ const DatabaseFormBody = ({
         isDirty={dirty}
         isAdvanced={isAdvanced}
         onCancel={onCancel}
+        showSampleDatabase={showSampleDatabase}
+        ContinueWithoutDataSlot={ContinueWithoutDataSlot}
       />
     </Form>
   );
@@ -196,12 +221,20 @@ interface DatabaseFormFooterProps {
   isAdvanced: boolean;
   isDirty: boolean;
   onCancel?: () => void;
+  showSampleDatabase?: boolean;
+  ContinueWithoutDataSlot?: ({
+    onCancel,
+  }: {
+    onCancel?: () => void;
+  }) => JSX.Element;
 }
 
 const DatabaseFormFooter = ({
   isAdvanced,
   isDirty,
   onCancel,
+  showSampleDatabase,
+  ContinueWithoutDataSlot,
 }: DatabaseFormFooterProps) => {
   const { values } = useFormikContext<DatabaseData>();
   const isNew = values.id == null;
@@ -253,11 +286,15 @@ const DatabaseFormFooter = ({
     );
   }
 
+  if (ContinueWithoutDataSlot) {
+    return <ContinueWithoutDataSlot onCancel={onCancel} />;
+  }
+
   // This check happens only during setup where we cannot fetch databases.
   // Unless someone explicitly set the environment variable MB_LOAD_SAMPLE_CONTENT
   // to false, we can assume that the instance loads with the Sample Database.
   // https://www.metabase.com/docs/latest/configuring-metabase/environment-variables#mb_load_sample_content
-  if (hasSampleDatabase !== false) {
+  if (hasSampleDatabase !== false && showSampleDatabase) {
     return (
       <>
         <Button variant="filled" mb="md" mt="lg" onClick={onCancel}>

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -87,6 +87,7 @@ export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
         onSubmit={handleDatabaseSubmit}
         onEngineChange={handleEngineChange}
         onCancel={handleStepCancel}
+        showSampleDatabase={true}
       />
       {isEmailConfigured && (
         <SetupSection

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DataConnectionStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DataConnectionStep.tsx
@@ -1,10 +1,11 @@
+import { useCallback } from "react";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
 import { createDatabase } from "metabase/admin/databases/database";
 import { DatabaseForm } from "metabase/databases/components/DatabaseForm";
 import { useDispatch } from "metabase/lib/redux";
-import { Stack, Text, Title } from "metabase/ui";
+import { Button, Stack, Text, Title } from "metabase/ui";
 import type { DatabaseData } from "metabase-types/api";
 
 import { useEmbeddingSetup } from "../EmbeddingSetupContext";
@@ -19,6 +20,21 @@ export const DataConnectionStep = () => {
     setDatabase(createdDatabase);
     goToNextStep();
   };
+  const onCancel = useCallback(() => {
+    trackEmbeddingSetupClick("add-data-later-or-skip");
+    dispatch(push("/"));
+  }, [dispatch, trackEmbeddingSetupClick]);
+
+  const ContinueWithoutDataButton = useCallback(
+    ({ onCancel }: { onCancel?: () => void }) => {
+      return (
+        <Button variant="subtle" c="text-medium" onClick={onCancel}>
+          {t`I'll add my data later`}
+        </Button>
+      );
+    },
+    [],
+  );
 
   return (
     <Stack gap="xl">
@@ -32,10 +48,9 @@ export const DataConnectionStep = () => {
       <DatabaseForm
         onSubmit={handleSubmit}
         onEngineChange={() => {}}
-        onCancel={() => {
-          trackEmbeddingSetupClick("add-data-later-or-skip");
-          dispatch(push("/"));
-        }}
+        onCancel={onCancel}
+        showSampleDatabase={false}
+        ContinueWithoutDataSlot={ContinueWithoutDataButton}
       />
     </Stack>
   );

--- a/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DataConnectionStep.tsx
+++ b/frontend/src/metabase/setup/components/EmbeddingSetup/steps/DataConnectionStep.tsx
@@ -28,7 +28,7 @@ export const DataConnectionStep = () => {
   const ContinueWithoutDataButton = useCallback(
     ({ onCancel }: { onCancel?: () => void }) => {
       return (
-        <Button variant="subtle" c="text-medium" onClick={onCancel}>
+        <Button variant="subtle" c="text-secondary" onClick={onCancel}>
           {t`I'll add my data later`}
         </Button>
       );


### PR DESCRIPTION
Fix for EMB-613

## Context
https://metaboat.slack.com/archives/C063Q3F1HPF/p1752482094176519

Shorter version:
[Onboarding flow in embedding-specific setup](https://linear.app/metabase/project/onboarding-flow-in-embedding-specific-setup-7e51f285cb53) is using the `<DatabaseForm>` component which is also used in the admin settings and in the normal setup.
That same component was changed in [Replace database selection in setup with a new component](https://github.com/metabase/metabase/pull/60511) in a way that is not compatible with the usage in the embedding setup.
In the embedding setup we currently require them to connect a db, and skipping that steps opts out of the entire flow.
The change was probably planned before we shipped the embedding setup, so it's likely it wasn't planned knowing that the component was used in 3 places instead of two.

This PR does a minimal change to the component to allow all the usages we require.

It's still not clear if the two setups should keep sharing the component, as there are more changes planned for it. This PR's scope is only to make sure we can release 56 with the proper setup and we can discuss the follow up later.


## Changes:
- add `showSampleDatabase` prop that decides if we should show the notice about the sample db being always included
- add a `ContinueWithoutDataSlot` prop/slot to allow customizing the button as we needed

This is a temporary fix, I believe we should refactor the database component to be modular and more flexible

## Demo
Before:
<img width="719" height="510" alt="image" src="https://github.com/user-attachments/assets/3048d0fe-7f1d-48e0-bc53-485bbd06f087" />


After:
<img width="1443" height="824" alt="image" src="https://github.com/user-attachments/assets/201ea14f-0772-4d32-aa36-c1b91f792480" />

Since this is using a custom button passed via slot, I was also able to use the color from the design instead of using the default primary color for the "I'll add my data later"