### PR TITLE
Add onClick to UpsellPill

### DIFF
--- a/frontend/src/metabase/admin/upsells/components/UpsellPill.stories.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellPill.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from "@storybook/addon-actions";
 import type { ComponentProps } from "react";
 
 import { ReduxProvider } from "__support__/storybook";
@@ -54,6 +55,14 @@ export default {
 
 export const Default = {
   render: DefaultTemplate,
+};
+
+export const WithOnClick = {
+  render: DefaultTemplate,
+  args: {
+    ...args,
+    onClick: action("clicked"),
+  },
 };
 
 export const Multiline = {

--- a/frontend/src/metabase/admin/upsells/components/UpsellPill.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellPill.tsx
@@ -1,22 +1,26 @@
 import { useMount } from "react-use";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
+import { UnstyledButton } from "metabase/ui";
 
 import { UpsellGem } from "./UpsellGem";
 import { UpsellWrapper } from "./UpsellWrapper";
 import S from "./Upsells.module.css";
 import { trackUpsellClicked, trackUpsellViewed } from "./analytics";
 import { useUpsellLink } from "./use-upsell-link";
+
 export function _UpsellPill({
   children,
   link,
   campaign,
   source: location,
+  onClick,
 }: {
   children: React.ReactNode;
   link: string;
   campaign: string;
   source: string;
+  onClick?: () => void;
 }) {
   const url = useUpsellLink({
     url: link,
@@ -27,6 +31,21 @@ export function _UpsellPill({
   useMount(() => {
     trackUpsellViewed({ location, campaign });
   });
+
+  if (onClick) {
+    return (
+      <UnstyledButton
+        onClick={() => {
+          trackUpsellClicked({ location, campaign });
+          onClick();
+        }}
+        className={S.UpsellPillComponent}
+      >
+        <UpsellGem />
+        {children}
+      </UnstyledButton>
+    );
+  }
 
   return (
     <ExternalLink


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-97/migrate-upsellpill-to-the-new-upsell-flow

### Description

- Added `onClick` behavior
- I'm not migrating any specific upsells, because this one UpsellPill is only [used once](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/admin/upsells/UpsellEmailWhitelabel.tsx#L14) and hidden from self-hosted