### PR TITLE
fix: don't recurse in check-block-permissions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/block_permissions.clj
@@ -1,12 +1,10 @@
 (ns metabase-enterprise.advanced-permissions.models.permissions.block-permissions
   (:require
    [metabase.api.common :as api]
-   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.query-permissions.core :as query-perms]
    [metabase.query-processor.error-type :as qp.error-type]
-   [metabase.query-processor.store :as qp.store]
    [metabase.util.i18n :refer [tru]]))
 
 (defn- throw-block-permissions-exception
@@ -23,19 +21,14 @@
   [[metabase.collections.models.collection]] for more details."
   :feature :advanced-permissions
   [{database-id :database :as query}]
-  (let [{:keys [table-ids card-ids]} (query-perms/query->source-ids query)
-        table-permissions            (map (partial perms/table-permission-for-user api/*current-user-id*
-                                                   :perms/view-data database-id)
-                                          table-ids)]
+  (let [{:keys [table-ids]} (query-perms/query->source-ids query)
+        table-permissions   (map (partial perms/table-permission-for-user api/*current-user-id*
+                                          :perms/view-data database-id)
+                                 table-ids)]
     ;; Make sure we don't have block permissions for the entire DB or individual tables referenced by the query.
     (or
      (not= :blocked (perms/full-db-permission-for-user api/*current-user-id* :perms/view-data database-id))
      (= #{:unrestricted} (set table-permissions))
      (throw-block-permissions-exception))
-
-    ;; Recursively check block permissions for any Cards referenced by the query
-    (doseq [card-id card-ids]
-      (let [{query :dataset-query} (lib.metadata.protocols/card (qp.store/metadata-provider) card-id)]
-        (check-block-permissions query)))
 
     true))

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -137,9 +137,7 @@
           ;; Check that we permissions for any source cards first, then check that we have requisite data permissions
           ;; Recursively check permissions for any source Cards
           (doseq [card-id source-card-ids]
-            (let [{query :dataset-query} (lib.metadata.protocols/card (qp.store/metadata-provider) card-id)]
-              (binding [*card-id* card-id]
-                (check-query-permissions* query))))
+            (query-perms/check-card-read-perms database-id card-id))
 
           ;; Check that we have the data permissions to run this card
           (query-perms/check-data-perms outer-query required-perms :throw-exceptions? true)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61051
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Fixes the block table permissions check to not recursively check included cards for blocks. This is unnecessary since we already assemble the full list of tables to be checked for blocks in `source->query-ids`, so at best this just causes us to recheck the same tables on each run. At worst, the bug hit here, we load a source card with an unexpanded query that causes to incorrectly fail the table check. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
