### PR TITLE
MBQL 5 normalization should automatically add options maps

### DIFF
--- a/src/metabase/lib/schema/mbql_clause.cljc
+++ b/src/metabase/lib/schema/mbql_clause.cljc
@@ -80,6 +80,12 @@
      return-type)
    nil))
 
+(defn- normalize-clause [x]
+  (when (sequential? x)
+    (if ((some-fn map? nil?) (second x))
+      x
+      (into [(first x) {}] (rest x)))))
+
 ;;; TODO: Support options more nicely - these don't allow for overriding the options, but we have a few cases where that
 ;;; is necessary. See for example the inclusion of `string-filter-options` in [[metabase.lib.filter]].
 
@@ -94,7 +100,8 @@
          (every? keyword? (map first args))]}
   [:schema
    (into [:catn
-          {:error/message (str "Valid " tag " clause")}
+          {:error/message    (str "Valid " tag " clause")
+           :decode/normalize normalize-clause}
           [:tag [:= {:decode/normalize common/normalize-keyword} tag]]
           [:options [:schema [:ref ::common/options]]]]
          args)])
@@ -105,7 +112,8 @@
   [tag & args]
   {:pre [(simple-keyword? tag)]}
   (into [:tuple
-         {:error/message (str "Valid " tag " clause")}
+         {:error/message    (str "Valid " tag " clause")
+          :decode/normalize normalize-clause}
          [:= {:decode/normalize common/normalize-keyword} tag]
          [:ref ::common/options]]
         args))

--- a/src/metabase/lib/schema/ref.cljc
+++ b/src/metabase/lib/schema/ref.cljc
@@ -9,6 +9,7 @@
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.id :as id]
+   [metabase.lib.schema.join :as lib.schema.join]
    [metabase.lib.schema.mbql-clause :as mbql-clause]
    [metabase.lib.schema.temporal-bucketing :as temporal-bucketing]
    [metabase.types.core]
@@ -25,6 +26,7 @@
                                        opts))}
    ::common/options
    [:map
+    [:join-alias                                 {:optional true} [:ref ::lib.schema.join/alias]]
     [:temporal-unit                              {:optional true} [:ref ::temporal-bucketing/unit]]
     [:binning                                    {:optional true} [:ref ::binning/binning]]
     [:metabase.lib.field/original-effective-type {:optional true} [:ref ::common/base-type]]

--- a/test/metabase/lib/schema/filter_test.cljc
+++ b/test/metabase/lib/schema/filter_test.cljc
@@ -1,13 +1,16 @@
 (ns metabase.lib.schema.filter-test
   (:require
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [are deftest is testing]]
    [clojure.walk :as walk]
    [malli.error :as me]
+   [metabase.lib.core :as lib]
    [metabase.lib.schema]
    [metabase.lib.schema.expression :as expression]
    [metabase.util.malli.registry :as mr]))
 
-(comment metabase.lib.schema/keep-me)
+(comment metabase.lib.schema/keep-me
+         #?(:cljs metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (defn- ensure-uuids [filter-expr]
   (walk/postwalk
@@ -111,3 +114,14 @@
     (let [bson-field [:field {:base-type :type/Array :effective-type :type/Array} 1]]
       (testing "is comparable"
         (is (mr/validate ::expression/boolean (ensure-uuids [:= {} bson-field "abc"])))))))
+
+(deftest ^:parallel normalize-clause-add-options-map-test
+  (is (=? [:=
+           {:lib/uuid string?}
+           [:field {:lib/uuid string?} 2]
+           [:field {:join-alias "Parent", :lib/uuid string?} 1]]
+          (lib/normalize
+           :mbql.clause/=
+           [:=
+            [:field {} 2]
+            [:field {:join-alias "Parent"} 1]]))))


### PR DESCRIPTION
`lib/normalize` (and thus `lib/query`) can now automatically add options maps to clauses if they are missing.

The main purpose of this is to make it easier to write out queries in tests that need to mock out specific MBQL (generally of course it is better to generate the MBQL using lib functions, but for specific bug repros sometimes the fastest path forward is to write the raw MBQL). This will also help move us toward a world where we can normalize directly from MBQL 4 => 5