### PR TITLE
Allow "focusing" a recently moved dashboard filter

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -2694,6 +2694,71 @@ describe("scenarios > dashboard > parameters", () => {
         H.filterWidget({ isEditing: true }).contains("Count").should("exist");
       });
     });
+
+    it("should provide a way to 'focus' the recently moved filter", () => {
+      const TAB_1 = { id: 1, name: "Tab 1" };
+      const TAB_2 = { id: 2, name: "Tab 2" };
+
+      H.createDashboardWithTabs({
+        parameters: [categoryParameter, countParameter],
+        tabs: [TAB_1, TAB_2],
+        dashcards: [
+          createMockDashboardCard({
+            id: -1,
+            card_id: ORDERS_BY_YEAR_QUESTION_ID,
+            dashboard_tab_id: TAB_1.id,
+            size_x: 18,
+            size_y: 6,
+          }),
+          createMockHeadingDashboardCard({
+            id: -2,
+            dashboard_tab_id: TAB_2.id,
+            size_x: 24,
+            size_y: 30,
+            text: "Tall heading card",
+          }),
+          createMockHeadingDashboardCard({
+            id: -3,
+            dashboard_tab_id: TAB_2.id,
+            size_x: 24,
+            size_y: 2,
+            text: "Heading text card",
+          }),
+        ],
+      }).then((dashboard) => {
+        H.visitDashboard(dashboard.id);
+        H.editDashboard();
+      });
+
+      H.editingDashboardParametersContainer().within(() => {
+        H.filterWidget({ isEditing: true }).contains("Count").click();
+      });
+      H.moveDashboardFilter("Heading text card", { showFilter: true });
+
+      // Assert tab changed and the filter is in viewport now
+      cy.location().should((location) => {
+        expect(location.search).to.include("tab=2-tab-2");
+      });
+      H.getDashboardCard(1).within(() => {
+        H.filterWidget({ isEditing: true }).contains("Count").should("exist");
+        H.filterWidget({ isEditing: true })
+          .contains("Count")
+          .isRenderedWithinViewport();
+      });
+
+      // Move filter to another card on the same tab
+      H.moveDashboardFilter("Tall heading card", { showFilter: true });
+      H.getDashboardCard(0).within(() => {
+        H.filterWidget({ isEditing: true }).contains("Count").should("exist");
+        H.filterWidget({ isEditing: true })
+          .contains("Count")
+          .isRenderedWithinViewport();
+      });
+
+      // Move filter to top nav and assert the "Show filter" button isn't displayed
+      H.moveDashboardFilter("Top of page");
+      H.undoToast().button("Show filter").should("not.exist");
+    });
   });
 });
 

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -2736,9 +2736,11 @@ describe("scenarios > dashboard > parameters", () => {
       H.moveDashboardFilter("Heading text card", { showFilter: true });
 
       // Assert tab changed and the filter is in viewport now
-      cy.location().should((location) => {
-        expect(location.search).to.include("tab=2-tab-2");
-      });
+      cy.findByRole("tab", { name: "Tab 2" }).should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
       H.getDashboardCard(1).within(() => {
         H.filterWidget({ isEditing: true }).contains("Count").should("exist");
         H.filterWidget({ isEditing: true })

--- a/frontend/src/metabase-types/store/undo.ts
+++ b/frontend/src/metabase-types/store/undo.ts
@@ -29,6 +29,10 @@ export interface Undo {
   count?: number;
   verb?: string;
   subject?: string;
+  extraAction?: {
+    label: string;
+    action: () => void;
+  };
   ref?: RefObject<HTMLDivElement>;
 }
 

--- a/frontend/src/metabase/common/components/UndoListing.tsx
+++ b/frontend/src/metabase/common/components/UndoListing.tsx
@@ -136,6 +136,20 @@ function UndoToast({
               {undo.actionLabel ?? t`Undo`}
             </UndoButton>
           )}
+          {undo.extraAction && (
+            <UndoButton
+              role="button"
+              onClick={() => {
+                undo.extraAction?.action();
+                if (undo.canDismiss) {
+                  onDismiss();
+                }
+              }}
+              to=""
+            >
+              {undo.extraAction.label}
+            </UndoButton>
+          )}
           {undo.canDismiss && (
             <DismissIcon
               color={

--- a/frontend/src/metabase/dashboard/actions/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions/actions.unit.spec.js
@@ -1,5 +1,10 @@
 import { DashboardApi } from "metabase/services";
-import { createMockRoutingState } from "metabase-types/store/mocks/index";
+import { createMockDashboard } from "metabase-types/api/mocks";
+import {
+  createMockDashboardState,
+  createMockRoutingState,
+  createMockState,
+} from "metabase-types/store/mocks/index";
 
 import { SIDEBAR_NAME } from "../constants";
 
@@ -27,17 +32,18 @@ describe("dashboard actions", () => {
 
   beforeEach(() => {
     dispatch = jest.fn();
-    getState = () => ({
-      dashboard: {
-        dashboardId: 1,
-        dashboards: {
-          1: {
-            id: 1,
-            parameters: [{ id: 123 }, { id: 456 }],
+    getState = () =>
+      createMockState({
+        dashboard: createMockDashboardState({
+          dashboardId: 1,
+          dashboards: {
+            1: createMockDashboard({
+              id: 1,
+              parameters: [{ id: 123 }, { id: 456 }],
+            }),
           },
-        },
-      },
-    });
+        }),
+      });
   });
 
   describe("setSidebar", () => {
@@ -98,7 +104,7 @@ describe("dashboard actions", () => {
 
   describe("setEditingParameter", () => {
     it("should set an edit parameter sidebar when given a parameterId", () => {
-      setEditingParameter(0)(dispatch);
+      setEditingParameter(0)(dispatch, getState);
 
       expect(dispatch).toHaveBeenCalledWith(
         setSidebar({
@@ -109,7 +115,7 @@ describe("dashboard actions", () => {
     });
 
     it("should clear sidebar state when given a nil parameterId", () => {
-      setEditingParameter()(dispatch);
+      setEditingParameter(null)(dispatch, getState);
 
       expect(dispatch).toHaveBeenCalledWith(closeSidebar());
     });

--- a/frontend/src/metabase/dashboard/actions/parameters.tsx
+++ b/frontend/src/metabase/dashboard/actions/parameters.tsx
@@ -264,7 +264,7 @@ export const moveParameter =
 export const setEditingParameter =
   (parameterId: ParameterId | null) =>
   (dispatch: Dispatch, getState: GetState) => {
-    if (!parameterId) {
+    if (parameterId === null) {
       dispatch(closeSidebar());
       return;
     }

--- a/frontend/src/metabase/dashboard/actions/parameters.tsx
+++ b/frontend/src/metabase/dashboard/actions/parameters.tsx
@@ -1,7 +1,9 @@
+import cx from "classnames";
 import { assoc } from "icepick";
 import { t } from "ttag";
 import _ from "underscore";
 
+import CS from "metabase/css/core/index.css";
 import { showAutoWireToast } from "metabase/dashboard/actions/auto-wire-parameters/actions";
 import {
   closeAddCardAutoWireToasts,
@@ -18,6 +20,7 @@ import {
   setParameterType as setParamType,
 } from "metabase/parameters/utils/dashboards";
 import { addUndo, dismissUndo } from "metabase/redux/undo";
+import { Text } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import { getParameterValuesByIdFromQueryParams } from "metabase-lib/v1/parameters/utils/parameter-parsing";
 import {
@@ -214,7 +217,14 @@ export const moveParameter =
 
       dispatch(
         addUndo({
-          message: t`Filter moved`,
+          // Workaround to make the text show up fully without being truncated
+          message: (
+            <Text
+              className={cx(CS.flex, CS.flexFull, CS.flexNoShrink)}
+              c="text-white"
+              w="8rem"
+            >{t`Filter moved`}</Text>
+          ),
           undo: true,
           action: undoMove,
           extraAction: {

--- a/frontend/src/metabase/dashboard/actions/parameters.tsx
+++ b/frontend/src/metabase/dashboard/actions/parameters.tsx
@@ -181,7 +181,11 @@ export const moveParameter =
       );
     }
 
-    if (typeof destination === "object" && destination.type === "dashcard") {
+    const isMovedToTopNav = destination === "top-nav";
+    const isMovedToDashcard =
+      typeof destination === "object" && destination.type === "dashcard";
+
+    if (isMovedToDashcard) {
       const dashcard = dashcardMap[destination.id];
       if (!dashcard) {
         throw new Error(`Dashcard with id ${destination.id} not found`);
@@ -217,7 +221,10 @@ export const moveParameter =
 
       dispatch(
         addUndo({
-          // Workaround to make the text show up fully without being truncated
+          undo: true,
+          action: undoMove,
+
+          // Workaround to make the text show up without being truncated
           message: (
             <Text
               className={cx(CS.flex, CS.flexFull, CS.flexNoShrink)}
@@ -225,14 +232,16 @@ export const moveParameter =
               w="8rem"
             >{t`Filter moved`}</Text>
           ),
-          undo: true,
-          action: undoMove,
-          extraAction: {
-            label: t`Show filter`,
-            action: () => {
-              dispatch(setEditingParameter(parameterId));
-            },
-          },
+
+          // Top nav filters are always visible, so we don't need a "Show" button
+          extraAction: isMovedToTopNav
+            ? null
+            : {
+                label: t`Show filter`,
+                action: () => {
+                  dispatch(setEditingParameter(parameterId));
+                },
+              },
         }),
       );
     }


### PR DESCRIPTION
Adds a "Show filter" button to an undo toast that shows up after a dashboard filter is moved to a dashboard card. Clicking a button should place the filter in the viewport, switch to the dashboard tab if necessary, and open the filter editing sidebar if it's not already open.

### To verify

1. Create a dashboard with tabs, filters and various cards
2. In dashboard edit mode, click a filter, find the "Move filter" button in the sidebar, and move it to a card on a different tab
3. Click "Show filter" and ensure the tab is switched and the page scrolls to place the filter in viewport
4. Try to move a filter to the top nav and ensure that the "Show filter" button isn't displayed (top nav filters are always visible)

### Demo

https://github.com/user-attachments/assets/370509c4-9040-4285-855f-3961825bdbd1

