### PR TITLE
Closes VIZ-1287 - The "settings" button should be pressed when the settings sidebar is open

### DIFF
--- a/frontend/src/metabase/ui/components/buttons/Button/Button.module.css
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.module.css
@@ -48,6 +48,7 @@
     border-color: var(--mb-color-border);
     background-color: var(--mb-color-background);
 
+    &[aria-pressed="true"],
     &:hover {
       color: var(--mb-color-text-hover);
       background-color: var(--mb-color-background-hover);

--- a/frontend/src/metabase/visualizer/components/Footer/Footer.tsx
+++ b/frontend/src/metabase/visualizer/components/Footer/Footer.tsx
@@ -18,7 +18,8 @@ import { useVisualizerUi } from "../VisualizerUiContext";
 import S from "./Footer.module.css";
 
 export function Footer({ className }: { className?: string }) {
-  const { setVizSettingsSidebarOpen } = useVisualizerUi();
+  const { setVizSettingsSidebarOpen, isVizSettingsSidebarOpen } =
+    useVisualizerUi();
   const dispatch = useDispatch();
   const display = useSelector(getVisualizationType);
   const datasets = useSelector(getDatasets);
@@ -41,6 +42,7 @@ export function Footer({ className }: { className?: string }) {
         <Button
           ml="auto"
           data-testid="visualizer-settings-button"
+          aria-pressed={isVizSettingsSidebarOpen}
           onClick={() => {
             trackSimpleEvent({
               event: "visualizer_settings_clicked",


### PR DESCRIPTION
Closes VIZ-1287

### Description

Adds pressed state for visualizer Settings button.

### How to verify

Pressed state defined here: [Figma](https://www.figma.com/design/WJ4PQGf0yjtvDcerHnOWex/Iterate-on-visualizer-UI-UX?node-id=13177-5372&m=dev)

1. Open visualizer modal
2. Click "Settings"
3. Verify button uses pressed state while sidebar is open
4. Close settings sidebar
5. Verify button reverts to non-pressed state

### Demo

https://github.com/user-attachments/assets/0006d265-a63b-45a0-b5a3-eefb62ea97de


### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
- [ ] Retarget to a working branch instead of master?
