### PR TITLE
Improve function that returns available parameter mapping options

### DIFF
--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
@@ -19,7 +19,10 @@ import {
   getSelectedTabId,
   getTabs,
 } from "metabase/dashboard/selectors";
-import { isQuestionDashCard } from "metabase/dashboard/utils";
+import {
+  findDashCardForInlineParameter,
+  isQuestionDashCard,
+} from "metabase/dashboard/utils";
 import {
   getMappingOptionByTarget,
   getParameterMappingOptions,
@@ -61,11 +64,14 @@ export function showAutoWireToast(
       excludeDashcardIds: [dashcard.id],
     });
 
+    const dashcards = Object.values(dashboardState.dashcards);
+
     const dashcardAttributes = getAutoWiredMappingsForDashcards(
       parameter,
       dashcardsToAutoApply,
       target,
       questions,
+      dashcards,
     );
 
     const shouldShowToast = dashcardAttributes.length > 0;
@@ -86,6 +92,7 @@ export function showAutoWireToast(
       dashcard,
       target,
       questions,
+      dashcards,
     );
 
     const tabs = getTabs(getState());
@@ -154,11 +161,17 @@ export function showAutoWireToastNewCard({
     const processedParameterIds = new Set();
 
     for (const parameter of parameters) {
+      const parameterDashcard = findDashCardForInlineParameter(
+        parameter.id,
+        Object.values(dashcards),
+      );
+
       const dashcardMappingOptions = getParameterMappingOptions(
         targetQuestion,
         parameter,
         targetDashcard.card,
         targetDashcard,
+        parameterDashcard,
       );
 
       for (const dashcard of dashcards) {

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
@@ -3,6 +3,7 @@ import _ from "underscore";
 import { isActionDashCard } from "metabase/actions/utils";
 import { getExistingDashCards } from "metabase/dashboard/actions/utils";
 import {
+  findDashCardForInlineParameter,
   isQuestionDashCard,
   isVirtualDashCard,
 } from "metabase/dashboard/utils";
@@ -64,18 +65,24 @@ export function getMatchingParameterOption(
   targetDashcard: QuestionDashboardCard,
   targetDimension: ParameterTarget,
   questions: Record<CardId, Question>,
+  dashcards: DashboardCard[],
 ): ParameterMappingOption | null | undefined {
   if (!targetDashcard) {
     return null;
   }
 
   const targetQuestion = questions[targetDashcard.card.id];
+  const parameterDashcard = findDashCardForInlineParameter(
+    parameter.id,
+    dashcards,
+  );
 
   const mappingOptions = getParameterMappingOptions(
     targetQuestion,
     parameter,
     targetDashcard.card,
     targetDashcard,
+    parameterDashcard,
   );
 
   const matchedOption = getMappingOptionByTarget(
@@ -92,6 +99,7 @@ export function getAutoWiredMappingsForDashcards(
   targetDashcards: QuestionDashboardCard[],
   target: ParameterTarget,
   questions: Record<CardId, Question>,
+  dashcards: DashboardCard[],
 ): SetMultipleDashCardAttributesOpts {
   if (targetDashcards.length === 0) {
     return [];
@@ -105,6 +113,7 @@ export function getAutoWiredMappingsForDashcards(
       targetDashcard,
       target,
       questions,
+      dashcards,
     );
 
     if (selectedMappingOption && targetDashcard.card_id) {

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -511,9 +511,19 @@ export const getQuestionByCard = createCachedSelector(
 });
 
 export const getDashcardParameterMappingOptions = createCachedSelector(
-  [getQuestionByCard, getEditingParameter, getCard, getDashCard],
-  (question, parameter, card, dashcard) => {
-    return _getParameterMappingOptions(question, parameter, card, dashcard);
+  [getQuestionByCard, getEditingParameter, getCard, getDashCard, getDashcards],
+  (question, parameter, card, dashcard, dashcards) => {
+    const parameterDashcard =
+      parameter != null
+        ? findDashCardForInlineParameter(parameter.id, Object.values(dashcards))
+        : null;
+    return _getParameterMappingOptions(
+      question,
+      parameter,
+      card,
+      dashcard,
+      parameterDashcard,
+    );
   },
 )((state, props) => {
   return props.card.id ?? props.dashcard.id;

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -132,7 +132,15 @@ export function getParameterMappingOptions(
   parameter: Parameter | null | undefined = null,
   card: Card | VirtualCard,
   dashcard: BaseDashboardCard | null | undefined = null,
+  parameterDashcard: BaseDashboardCard | null | undefined = null,
 ): ParameterMappingOption[] {
+  const isInlineParameterOnCardFromOtherTab =
+    parameterDashcard != null &&
+    parameterDashcard.dashboard_tab_id !== dashcard?.dashboard_tab_id;
+  if (isInlineParameterOnCardFromOtherTab) {
+    return [];
+  }
+
   if (dashcard && isVirtualDashCard(dashcard)) {
     if (["heading", "text"].includes(card.display)) {
       const tagNames = tag_names(dashcard.visualization_settings.text || "");

--- a/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
@@ -482,6 +482,46 @@ describe("parameters/utils/mapping-options", () => {
       expect(options).toEqual([]);
     });
   });
+
+  describe("parameterDashcard filtering", () => {
+    it("should return empty array when parameterDashcard is from a different tab", () => {
+      const card = structured({ "source-table": ORDERS_ID });
+      const question = new Question(card, metadata);
+      const dashcard = createMockDashboardCard({ dashboard_tab_id: 1 });
+      const parameterDashcard = createMockDashboardCard({
+        dashboard_tab_id: 2,
+      });
+
+      const options = getParameterMappingOptions(
+        question,
+        { type: "date/single" },
+        card,
+        dashcard,
+        parameterDashcard,
+      );
+
+      expect(options).toEqual([]);
+    });
+
+    it("should return normal options when parameterDashcard is on same tab", () => {
+      const card = structured({ "source-table": ORDERS_ID });
+      const question = new Question(card, metadata);
+      const dashcard = createMockDashboardCard({ dashboard_tab_id: 1 });
+      const parameterDashcard = createMockDashboardCard({
+        dashboard_tab_id: 1,
+      });
+
+      const options = getParameterMappingOptions(
+        question,
+        { type: "date/single" },
+        card,
+        dashcard,
+        parameterDashcard,
+      );
+
+      expect(options.length).toBeGreaterThan(0);
+    });
+  });
 });
 
 describe("getMappingOptionByTarget", () => {


### PR DESCRIPTION
Closes [VIZ-1160](https://linear.app/metabase/issue/VIZ-1160/getparametermappingoptions-should-act-as-if-inline-parameters-are)

### Description

`getParameterMappingOptions` returns available parameter mapping options. With inline parameters inside dashcards we allow mapping cards that are on the same tab so for dashcards on the other tab we should not return any options.

### How to verify

CI should be green

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
