### PR TITLE
sort parameters in subscription sidebar

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sharing/components/MutableParametersSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sharing/components/MutableParametersSection.tsx
@@ -16,6 +16,8 @@ import {
 } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type { Dashboard, ParameterId, Pulse } from "metabase-types/api";
 
+import { getSortedParameters } from "./utils";
+
 export type MutableParametersSectionProps = {
   className?: string;
   parameters: UiParameter[];
@@ -33,6 +35,10 @@ export const MutableParametersSection = ({
   setPulseParameters,
   hiddenParameters,
 }: MutableParametersSectionProps) => {
+  const sortedParameters = useMemo(() => {
+    return getSortedParameters(dashboard, parameters);
+  }, [parameters, dashboard]);
+
   const pulseParameters = getPulseParameters(pulse);
   const pulseParamValuesById = pulseParameters.reduce((map, parameter) => {
     map[parameter.id] = parameter.value;
@@ -40,12 +46,12 @@ export const MutableParametersSection = ({
   }, {});
 
   const valuePopulatedParameters = getDefaultValuePopulatedParameters(
-    parameters,
+    sortedParameters,
     pulseParamValuesById,
   );
 
   const setParameterValue = (id: ParameterId, value: any) => {
-    const parameter = parameters.find((parameter) => parameter.id === id);
+    const parameter = sortedParameters.find((parameter) => parameter.id === id);
     const operator = parameter && deriveFieldOperatorFromParameter(parameter);
     const filteredParameters = pulseParameters.filter(
       (parameter) => parameter.id !== id,
@@ -63,8 +69,8 @@ export const MutableParametersSection = ({
   };
 
   const connectedParameters = useMemo(() => {
-    return getVisibleParameters(parameters, hiddenParameters);
-  }, [parameters, hiddenParameters]);
+    return getVisibleParameters(sortedParameters, hiddenParameters);
+  }, [sortedParameters, hiddenParameters]);
 
   return _.isEmpty(connectedParameters) ? null : (
     <CollapseSection

--- a/enterprise/frontend/src/metabase-enterprise/sharing/components/MutableParametersSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sharing/components/MutableParametersSection.unit.spec.tsx
@@ -4,7 +4,12 @@ import { renderWithProviders, screen } from "__support__/ui";
 import { createMockUiParameter } from "metabase-lib/v1/parameters/mock";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type { Dashboard, Pulse } from "metabase-types/api";
-import { createMockDashboard, createMockPulse } from "metabase-types/api/mocks";
+import {
+  createMockActionDashboardCard,
+  createMockDashboard,
+  createMockDashboardCard,
+  createMockPulse,
+} from "metabase-types/api/mocks";
 
 import { MutableParametersSection } from "./MutableParametersSection";
 
@@ -83,5 +88,234 @@ describe("MutableParametersSection", () => {
     expect(setPulseParameters).toHaveBeenCalledWith([
       { ...parameter, value: ["abc"], options: undefined },
     ]);
+  });
+
+  describe("parameter ordering", () => {
+    it("should display dashboard-level parameters before inline parameters", () => {
+      const dashboardParam = createMockUiParameter({
+        id: "dashboard-param",
+        name: "Dashboard Level Parameter",
+      });
+      const inlineParam = createMockUiParameter({
+        id: "inline-param",
+        name: "Inline Parameter",
+      });
+
+      const dashboard = createMockDashboard({
+        dashcards: [
+          createMockDashboardCard({
+            id: 1,
+            row: 0,
+            col: 0,
+            inline_parameters: ["inline-param"],
+          }),
+        ],
+      });
+
+      setup({
+        parameters: [inlineParam, dashboardParam], // Pass inline first
+        dashboard,
+        pulse: createMockPulse(),
+      });
+
+      const parameterWidgets = screen.getAllByTestId("parameter-widget");
+      expect(parameterWidgets).toHaveLength(2);
+
+      // Dashboard parameter should come first despite being passed second
+      expect(parameterWidgets[0]).toHaveTextContent(
+        "Dashboard Level Parameter",
+      );
+      expect(parameterWidgets[1]).toHaveTextContent("Inline Parameter");
+    });
+
+    it("should sort inline parameters by dashcard position (row first, then column)", () => {
+      const param1 = createMockUiParameter({
+        id: "param-1",
+        name: "Parameter 1",
+      });
+      const param2 = createMockUiParameter({
+        id: "param-2",
+        name: "Parameter 2",
+      });
+      const param3 = createMockUiParameter({
+        id: "param-3",
+        name: "Parameter 3",
+      });
+      const param4 = createMockUiParameter({
+        id: "param-4",
+        name: "Parameter 4",
+      });
+
+      const dashboard = createMockDashboard({
+        dashcards: [
+          createMockDashboardCard({
+            id: 1,
+            row: 1,
+            col: 0,
+            inline_parameters: ["param-3"],
+          }),
+          createMockDashboardCard({
+            id: 2,
+            row: 0,
+            col: 2,
+            inline_parameters: ["param-2"],
+          }),
+          createMockDashboardCard({
+            id: 3,
+            row: 0,
+            col: 0,
+            inline_parameters: ["param-1"],
+          }),
+          createMockDashboardCard({
+            id: 4,
+            row: 1,
+            col: 1,
+            inline_parameters: ["param-4"],
+          }),
+        ],
+      });
+
+      setup({
+        parameters: [param3, param2, param4, param1], // Pass in random order
+        dashboard,
+        pulse: createMockPulse(),
+      });
+
+      const parameterWidgets = screen.getAllByTestId("parameter-widget");
+      expect(parameterWidgets).toHaveLength(4);
+
+      // Should be ordered by row first, then column
+      expect(parameterWidgets[0]).toHaveTextContent("Parameter 1"); // row 0, col 0
+      expect(parameterWidgets[1]).toHaveTextContent("Parameter 2"); // row 0, col 2
+      expect(parameterWidgets[2]).toHaveTextContent("Parameter 3"); // row 1, col 0
+      expect(parameterWidgets[3]).toHaveTextContent("Parameter 4"); // row 1, col 1
+    });
+
+    it("should handle mixed dashcard types correctly", () => {
+      const dashboardParam = createMockUiParameter({
+        id: "dashboard-param",
+        name: "Dashboard Parameter",
+      });
+      const inlineParam1 = createMockUiParameter({
+        id: "inline-1",
+        name: "Inline Parameter 1",
+      });
+      const inlineParam2 = createMockUiParameter({
+        id: "inline-2",
+        name: "Inline Parameter 2",
+      });
+
+      const dashboard = createMockDashboard({
+        dashcards: [
+          createMockActionDashboardCard({
+            id: 1,
+            row: 0,
+            col: 0,
+            // Action cards don't have inline_parameters
+          }),
+          createMockDashboardCard({
+            id: 2,
+            row: 0,
+            col: 1,
+            inline_parameters: ["inline-1"],
+          }),
+          createMockDashboardCard({
+            id: 3,
+            row: 0,
+            col: 2,
+            inline_parameters: ["inline-2"],
+          }),
+        ],
+      });
+
+      setup({
+        parameters: [inlineParam2, dashboardParam, inlineParam1],
+        dashboard,
+        pulse: createMockPulse(),
+      });
+
+      const parameterWidgets = screen.getAllByTestId("parameter-widget");
+      expect(parameterWidgets).toHaveLength(3);
+
+      // Dashboard parameter first, then inline parameters by position
+      expect(parameterWidgets[0]).toHaveTextContent("Dashboard Parameter");
+      expect(parameterWidgets[1]).toHaveTextContent("Inline Parameter 1"); // col 1
+      expect(parameterWidgets[2]).toHaveTextContent("Inline Parameter 2"); // col 2
+    });
+
+    it("should handle dashcards with multiple inline parameters", () => {
+      const param1 = createMockUiParameter({
+        id: "param-1",
+        name: "Parameter 1",
+      });
+      const param2 = createMockUiParameter({
+        id: "param-2",
+        name: "Parameter 2",
+      });
+      const param3 = createMockUiParameter({
+        id: "param-3",
+        name: "Parameter 3",
+      });
+
+      const dashboard = createMockDashboard({
+        dashcards: [
+          createMockDashboardCard({
+            id: 1,
+            row: 0,
+            col: 1,
+            inline_parameters: ["param-2", "param-3"],
+          }),
+          createMockDashboardCard({
+            id: 2,
+            row: 0,
+            col: 0,
+            inline_parameters: ["param-1"],
+          }),
+        ],
+      });
+
+      setup({
+        parameters: [param2, param3, param1], // Pass param2 first to test ordering
+        dashboard,
+        pulse: createMockPulse(),
+      });
+
+      const parameterWidgets = screen.getAllByTestId("parameter-widget");
+      expect(parameterWidgets).toHaveLength(3);
+
+      // All parameters from col 0 dashcard come before col 1 dashcard
+      expect(parameterWidgets[0]).toHaveTextContent("Parameter 1"); // row 0, col 0
+      // Parameters within the same dashcard maintain their order from inline_parameters array
+      expect(parameterWidgets[1]).toHaveTextContent("Parameter 2"); // row 0, col 1 (first in inline_parameters)
+      expect(parameterWidgets[2]).toHaveTextContent("Parameter 3"); // row 0, col 1 (second in inline_parameters)
+    });
+
+    it("should handle empty inline_parameters arrays", () => {
+      const dashboardParam = createMockUiParameter({
+        id: "dashboard-param",
+        name: "Dashboard Parameter",
+      });
+
+      const dashboard = createMockDashboard({
+        dashcards: [
+          createMockDashboardCard({
+            id: 1,
+            row: 0,
+            col: 0,
+            inline_parameters: [], // Empty array
+          }),
+        ],
+      });
+
+      setup({
+        parameters: [dashboardParam],
+        dashboard,
+        pulse: createMockPulse(),
+      });
+
+      const parameterWidgets = screen.getAllByTestId("parameter-widget");
+      expect(parameterWidgets).toHaveLength(1);
+      expect(parameterWidgets[0]).toHaveTextContent("Dashboard Parameter");
+    });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/sharing/components/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/sharing/components/utils.ts
@@ -1,0 +1,46 @@
+import { hasInlineParameters } from "metabase/dashboard/utils";
+import type { UiParameter } from "metabase-lib/v1/parameters/types";
+import type { Dashboard, DashboardCard } from "metabase-types/api";
+
+export const getSortedParameters = (
+  dashboard: Dashboard,
+  parameters: UiParameter[],
+) => {
+  const inlineParameterIds = new Set<string>();
+  const parameterToDashcard = new Map<string, DashboardCard>();
+
+  dashboard.dashcards.forEach((dashcard) => {
+    if (hasInlineParameters(dashcard)) {
+      dashcard.inline_parameters.forEach((paramId) => {
+        inlineParameterIds.add(paramId);
+        parameterToDashcard.set(paramId, dashcard);
+      });
+    }
+  });
+
+  // Separate dashboard-level and inline parameters
+  const dashboardLevelParams = parameters.filter(
+    (p) => !inlineParameterIds.has(p.id),
+  );
+  const inlineParams = parameters.filter((p) => inlineParameterIds.has(p.id));
+
+  // Sort inline parameters by dashcard position (row first, then col)
+  const sortedInlineParams = inlineParams.sort((a, b) => {
+    const dashcardA = parameterToDashcard.get(a.id);
+    const dashcardB = parameterToDashcard.get(b.id);
+
+    if (!dashcardA || !dashcardB) {
+      return 0;
+    }
+
+    // Sort by row first
+    if (dashcardA.row !== dashcardB.row) {
+      return dashcardA.row - dashcardB.row;
+    }
+    // Then by column
+    return dashcardA.col - dashcardB.col;
+  });
+
+  // Return dashboard-level parameters first, then sorted inline parameters
+  return [...dashboardLevelParams, ...sortedInlineParams];
+};


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60365
Closes [VIZ-1247](https://linear.app/metabase/issue/VIZ-1247/dashboard-subscription-sidebar-should-show-filters-in-the-same-order)

### Description

In Metabase Enterprise it is possible to specify parameter values for dashboard subscriptions. As parameters now can appear in the dashboard body for convenience we want to sort them in the same order in the subscriptions configuration sidebar.

### Demo

<img width="1506" height="1059" alt="Screenshot 2025-07-16 at 11 33 11 PM" src="https://github.com/user-attachments/assets/62f05195-c715-4502-92a8-57279069401c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
