### PR TITLE
Prg-104-run-the-new-upsell-flow-only-for-self-hosted-mb-instances

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -45,10 +45,7 @@ describe("formatting > whitelabel", { tags: "@EE" }, () => {
         "https://www.metabase.com/docs/latest/configuring-metabase/appearance",
       )
       .and("include", "utm_");
-    cy.findByRole("link", { name: "Try for free" })
-      .should("have.attr", "href")
-      .and("include", "https://www.metabase.com/upgrade")
-      .and("include", "utm_");
+    cy.findByRole("button", { name: "Try for free" });
 
     cy.log("Upsell icon should now be visible in the sidebar link");
     cy.findAllByTestId("settings-sidebar-link")

--- a/e2e/test/scenarios/admin/troubleshooting.cy.spec.js
+++ b/e2e/test/scenarios/admin/troubleshooting.cy.spec.js
@@ -549,9 +549,6 @@ describe("admin > tools", () => {
     cy.findByRole("heading", {
       name: "Troubleshoot faster",
     }).should("be.visible");
-    cy.findByRole("link", { name: "Try for free" })
-      .should("have.attr", "href")
-      .and("include", "https://www.metabase.com/upgrade")
-      .and("include", "utm_");
+    cy.findByRole("button", { name: "Try for free" });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
+++ b/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
@@ -3,7 +3,12 @@ import { t } from "ttag";
 
 import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { useUpsellLink } from "metabase/admin/upsells/components/use-upsell-link";
-import { useSetting, useStoreUrl, useToast } from "metabase/common/hooks";
+import {
+  useHasTokenFeature,
+  useSetting,
+  useStoreUrl,
+  useToast,
+} from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { useLicense } from "metabase-enterprise/settings/hooks/use-license";
 
@@ -21,6 +26,7 @@ export function useUpsellFlow({
   campaign: string;
   location: string;
 }) {
+  const isHosted = useHasTokenFeature("hosting");
   const storeWindowRef = useRef<WindowProxy | null>(null);
   const [sendToast] = useToast();
   const storeUrl = useStoreUrl("checkout/upgrade/self-hosted");
@@ -87,6 +93,13 @@ export function useUpsellFlow({
       sendMessageTokenActivation(false, storeWindowRef.current, storeOrigin);
     }
   }, [tokenStatus, error, sendToast, storeOrigin]);
+
+  // upsell flow is available only for self-hosted instances
+  if (isHosted) {
+    return {
+      triggerUpsellFlow: undefined,
+    };
+  }
 
   return {
     triggerUpsellFlow: openStoresTab,

--- a/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
+++ b/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
@@ -3,13 +3,9 @@ import { t } from "ttag";
 
 import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { useUpsellLink } from "metabase/admin/upsells/components/use-upsell-link";
-import {
-  useHasTokenFeature,
-  useSetting,
-  useStoreUrl,
-  useToast,
-} from "metabase/common/hooks";
+import { useSetting, useStoreUrl, useToast } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
+import { getIsHosted } from "metabase/setup/selectors";
 import { useLicense } from "metabase-enterprise/settings/hooks/use-license";
 
 const NOTIFICATION_TIMEOUT = 30_000;
@@ -26,7 +22,7 @@ export function useUpsellFlow({
   campaign: string;
   location: string;
 }) {
-  const isHosted = useHasTokenFeature("hosting");
+  const isHosted = useSelector(getIsHosted);
   const storeWindowRef = useRef<WindowProxy | null>(null);
   const [sendToast] = useToast();
   const storeUrl = useStoreUrl("checkout/upgrade/self-hosted");

--- a/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.unit.spec.tsx
@@ -25,7 +25,11 @@ const TestComponent = ({
 
   return (
     <div>
-      <button onClick={triggerUpsellFlow}>Trigger Upsell Flow</button>
+      {triggerUpsellFlow !== undefined ? (
+        <button onClick={triggerUpsellFlow}>Trigger Upsell Flow</button>
+      ) : (
+        <div>Upsell flow is not available</div>
+      )}
     </div>
   );
 };
@@ -40,11 +44,13 @@ const setupContainer = ({
     is_superuser: true,
   },
   tokenActivation = true,
+  isHosted = false,
 }: Partial<{
   campaign: string;
   location: string;
   currentUser: Partial<User>;
   tokenActivation: boolean;
+  isHosted: boolean;
 }> = {}) => {
   const mockWindowOpen = jest.fn();
   Object.defineProperty(window, "open", {
@@ -61,6 +67,7 @@ const setupContainer = ({
     settings: mockSettings({
       "site-name": "Basemeta",
       "store-url": "https://test-store.metabase.com",
+      "is-hosted?": isHosted,
     }),
     currentUser: createMockUser(currentUser),
   });
@@ -207,6 +214,13 @@ describe("useUpsellFlow", () => {
           ),
         ).toBeInTheDocument();
       });
+    });
+
+    it("should not show upsell flow if the instance is hosted", () => {
+      setupContainer({ isHosted: true });
+      expect(
+        screen.getByText("Upsell flow is not available"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/admin/upsells/UpsellStorage.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellStorage.tsx
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
 import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
-import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 import { getStoreUrl } from "metabase/selectors/settings";
 import { List } from "metabase/ui";
 
@@ -14,10 +13,6 @@ export const BUY_STORAGE_URL = getStoreUrl("account/storage");
 
 export const UpsellStorage = ({ location }: { location: string }) => {
   const campaign = "storage";
-  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
-    campaign,
-    location,
-  });
 
   const isHosted = useSetting("is-hosted?");
   const hasStorage = useHasTokenFeature("attached_dwh");
@@ -28,13 +23,12 @@ export const UpsellStorage = ({ location }: { location: string }) => {
 
   return (
     <UpsellBanner
-      campaign="storage"
+      campaign={campaign}
       buttonText={t`Add`}
       buttonLink={BUY_STORAGE_URL}
       location={location}
       title={t`Add Metabase Storage`}
       large
-      onClick={triggerUpsellFlow}
     >
       <List
         mt="xs"

--- a/frontend/src/metabase/admin/upsells/components/UpsellBigCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBigCard.tsx
@@ -71,19 +71,8 @@ export const _UpsellBigCard: React.FC<UpsellBigCardProps> = ({
           <Text lh="xl" mb="lg">
             {children}
           </Text>
-          {match(buttonLink)
-            .with(P.string, () => (
-              <ExternalLink
-                className={S.UpsellCTALink}
-                href={url}
-                onClickCapture={() =>
-                  trackUpsellClicked({ location, campaign })
-                }
-              >
-                {buttonText}
-              </ExternalLink>
-            ))
-            .otherwise(() => (
+          {match(onClick)
+            .with(P.nonNullable, () => (
               <Box
                 component="button"
                 className={S.UpsellCTALink}
@@ -94,6 +83,17 @@ export const _UpsellBigCard: React.FC<UpsellBigCardProps> = ({
               >
                 {buttonText}
               </Box>
+            ))
+            .otherwise(() => (
+              <ExternalLink
+                className={S.UpsellCTALink}
+                href={url}
+                onClickCapture={() =>
+                  trackUpsellClicked({ location, campaign })
+                }
+              >
+                {buttonText}
+              </ExternalLink>
             ))}
         </Stack>
       </Flex>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
@@ -22,7 +22,7 @@ describe("Add data modal (Starter: hosted instance without the attached DWH)", (
       ).toBeInTheDocument();
       expect(screen.getByText("Upload CSV files")).toBeInTheDocument();
       expect(screen.getByText("Sync with Google Sheets")).toBeInTheDocument();
-      const upsellLink = screen.getByRole("button", { name: "Add" });
+      const upsellLink = screen.getByRole("link", { name: "Add" });
       expect(upsellLink).toBeInTheDocument();
     });
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-104/run-the-new-upsell-flow-only-for-self-hosted-mb-instances

### Description

For hosted instances useUpsellFlow will return now `undefined` as `triggerUpsellFlow`. In that way the flow is ignored in that type of environment. 