### PR TITLE
SEM-521 Fix flaky datamodel test

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -48,7 +48,11 @@ describe("scenarios > admin > datamodel", () => {
   });
 
   it("should allow to navigate to a table when on a segments page (SEM-484)", () => {
-    H.DataModel.visit();
+    H.DataModel.visit({
+      databaseId: SAMPLE_DB_ID,
+      schemaId: SAMPLE_DB_SCHEMA_ID,
+      tableId: ORDERS_ID,
+    });
 
     cy.findByRole("link", { name: /Segments/ }).click();
     cy.location("pathname").should("eq", "/admin/datamodel/segments");


### PR DESCRIPTION
Closes [SEM-521](https://linear.app/metabase/issue/SEM-521/flaky-test-e2e-tests-scenarios-admin-datamodel-scenarios-admin)

### Description

Example failure: https://github.com/metabase/metabase/actions/runs/16215326328/job/45783805432

### How to verify

Stress test: https://github.com/metabase/metabase/actions/runs/16343390001