### PR TITLE
SEM-499 Coercion strategy error briefly shown when disabling casting

### DIFF
--- a/frontend/src/metabase/metadata/components/CoercionStrategyPicker/CoercionStrategyPicker.tsx
+++ b/frontend/src/metabase/metadata/components/CoercionStrategyPicker/CoercionStrategyPicker.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { coercions_for_type } from "cljs/metabase.types.core";
+import { useDebouncedValue } from "metabase/common/hooks/use-debounced-value";
 import { Select, type SelectProps } from "metabase/ui";
 import type { Field } from "metabase-types/api";
 
@@ -22,14 +23,14 @@ export const CoercionStrategyPicker = ({
   ...props
 }: Props) => {
   const [isTouched, setIsTouched] = useState(false);
+  // debounce to prevent error briefly shown when disabling casting
+  const isTouchedDebounced = useDebouncedValue(isTouched, 100);
   const data = useMemo(() => {
     return coercions_for_type(baseType).map((coercion: string) => ({
       label: humanizeCoercionStrategy(coercion),
       value: coercion,
     }));
   }, [baseType]);
-  const error =
-    value == null ? t`To enable casting, please select a data type` : null;
 
   return (
     <Select
@@ -47,7 +48,11 @@ export const CoercionStrategyPicker = ({
         ...comboboxProps,
       }}
       data={data}
-      error={isTouched ? error : null}
+      error={
+        isTouchedDebounced && value == null
+          ? t`To enable casting, please select a data type`
+          : undefined
+      }
       placeholder={t`Select data type`}
       value={value}
       onBlur={() => setIsTouched(true)}


### PR DESCRIPTION
Closes [SEM-499](https://linear.app/metabase/issue/SEM-499/coercion-strategy-error-briefly-shown-when-disabling-casting)

### Description

If user clicks away from the coercion strategy dropdown without making a choice we want to show an error.
However, if user clicks away to disable casting, error should not be shown.
This PR adds a small debounce to prevent that.

I was not able to implement a reliable e2e test for this as the error is only shown for maybe a few milliseconds, so I left a comment near the `useDebouncedValue` usage.

### How to verify

1. Admin > Table metadata > Open a field
2. Enable casting for the field
3. Disable casting

Red error state should never have been shown