### PR TITLE
Mage jar-download custom dir fix

### DIFF
--- a/mage/mage/jar_download.clj
+++ b/mage/mage/jar_download.clj
@@ -285,4 +285,4 @@
         (println (str "Socket repl will open on " (c/green socket-port) ". "
                       "See: https://lambdaisland.com/guides/clojure-repls/clojure-repls#org259d775"))
         (println (str "\n\n   Open in browser: " (c/magenta "http://localhost:" port) "\n"))
-        (p/shell {:dir dir :extra-env extra-env} run-jar-cmd)))))
+        (p/shell {:dir u/project-root-directory :extra-env extra-env} run-jar-cmd)))))


### PR DESCRIPTION
The `jar-run-command` already reaches into the jar-download dir, so we should be running the "java" command from the project root.