### PR TITLE
Add nm-semantic-search-in-metabase to uberjar workflow

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -7,9 +7,9 @@ on:
   push:
     branches:
       - master
-      - metabot-v3-main
       - feature-visualizer
       - internal-tools
+      - nm-semantic-search-in-metabase
       - viz-1048-only-visualizer-compatible
     paths-ignore:
       # config files


### PR DESCRIPTION
Closes BOT-241

### Description

Add `nm-semantic-search-in-metabase` to uberjar workflow and remove `metabot-v3-main`

In preparation to deploy the `nm-semantic-search-in-metabase` branch to stats.
