### PR TITLE
 feat: separate jwt-set attributes from manual-set 

### DIFF
--- a/e2e/test/scenarios/admin-2/tenants.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/tenants.cy.spec.js
@@ -442,7 +442,7 @@ describe("Tenants - management", () => {
     });
 
     cy.findAllByRole("button", { name: /ellipsis/ })
-      .should("have.length", 2)
+      .should("have.length", 3)
       .last()
       .click();
     H.popover().findByText("Edit user").click();

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/user.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/user.clj
@@ -39,10 +39,16 @@
          (mapcat keys)
          (distinct)
          (take max-login-attributes))
-        (t2/select-fn-reducible :login_attributes [:model/User :login_attributes]
-                                {:where [:and
-                                         [:not= :login_attributes nil]
-                                         [:not= :login_attributes "{}"]]})))
+        (t2/select-fn-reducible (comp (partial apply merge)
+                                      (juxt :jwt_attributes :login_attributes))
+                                [:model/User :login_attributes :jwt_attributes]
+                                {:where [:or
+                                         [:and
+                                          [:not= :jwt_attributes nil]
+                                          [:not= :jwt_attributes "{}"]]
+                                         [:and
+                                          [:not= :login_attributes nil]
+                                          [:not= :login_attributes "{}"]]]})))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/mt/user` routes."

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -55,7 +55,8 @@
               :last_name        last-name
               :email            email
               :sso_source       :jwt
-              :login_attributes user-attributes
+              :login_attributes {}
+              :jwt_attributes   user-attributes
               :tenant_id        (fetch-or-create-tenant! tenant-slug)}]
     (or (sso-utils/fetch-and-update-login-attributes! user (sso-settings/jwt-user-provisioning-enabled?))
         (sso-utils/check-user-provisioning :jwt)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -30,6 +30,7 @@
    ;; TODO - we should avoid hardcoding this to make it easier to add new integrations. Maybe look at something like
    ;; the keys of `(methods sso/sso-get)`
    [:sso_source       [:enum :saml :jwt]]
+   [:jwt_attributes   {:optional true} [:maybe :map]]
    [:login_attributes [:maybe :map]]
    [:tenant_id        [:maybe ms/PositiveInt]]])
 

--- a/enterprise/backend/src/metabase_enterprise/tenants/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/core.clj
@@ -52,6 +52,7 @@
   (let [tenant (when-let [tenant-id (:tenant_id user)]
                  (t2/select-one :model/Tenant :id tenant-id))
         combined-attributes (tenants/combine (:login_attributes user)
+                                             (:jwt_attributes user)
                                              (:attributes tenant)
                                              (when tenant
                                                {"@tenant.slug" (:slug tenant)}))]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
@@ -110,3 +110,29 @@
         (mt/user-http-request :crowberto :put 200 (format "mt/user/%d/attributes" id) {:login_attributes {"foo" "bar"}})
         (is (= {"foo" "bar"}
                (t2/select-one-fn :login_attributes :model/User :id id)))))))
+
+(deftest attributes-endpoint-includes-jwt-attributes-test
+  (testing "GET /api/mt/user/attributes includes keys from jwt_attributes"
+    (mt/with-premium-features #{:sandboxes}
+      (mt/with-temp [:model/User _ {:login_attributes {"department" "engineering"
+                                                       "role" "developer"}}
+                     :model/User _ {:jwt_attributes {"session_id" "abc123"
+                                                     "scope" "read-write"}}
+                     :model/User _ {:login_attributes {"team" "backend"}
+                                    :jwt_attributes {"auth_level" "admin"
+                                                     "region" "us-east"}}]
+        (let [response (mt/user-http-request :crowberto :get 200 "mt/user/attributes")]
+          (testing "includes keys from login_attributes"
+            (is (contains? (set response) "department"))
+            (is (contains? (set response) "role"))
+            (is (contains? (set response) "team")))
+
+          (testing "includes keys from jwt_attributes"
+            (is (contains? (set response) "session_id"))
+            (is (contains? (set response) "scope"))
+            (is (contains? (set response) "auth_level"))
+            (is (contains? (set response) "region")))
+
+          (testing "does not include duplicate keys"
+            (let [response-counts (frequencies response)]
+              (is (every? #(= 1 %) (vals response-counts))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -199,10 +199,10 @@
               (is
                (= default-redirect-uri
                   (get-in response [:headers "Location"]))))
-            (testing "login attributes"
+            (testing "jwt_attributes"
               (is
                (= {"extra" "keypairs", "are" "also present"}
-                  (t2/select-one-fn :login_attributes :model/User :email "rasta@metabase.com"))))))
+                  (t2/select-one-fn :jwt_attributes :model/User :email "rasta@metabase.com"))))))
 
         (testing "with SAML and JWT configured, a GET request without JWT params should redirect to SAML IdP"
           (let [response (client/client-full-response :get 302 "/auth/sso"
@@ -231,7 +231,7 @@
             (testing "login attributes (preferred_method=jwt)"
               (is
                (= {"extra" "keypairs", "are" "also present"}
-                  (t2/select-one-fn :login_attributes :model/User :email "rasta@metabase.com"))))))
+                  (t2/select-one-fn :jwt_attributes :model/User :email "rasta@metabase.com"))))))
 
         (testing "with SAML and JWT configured, a GET request with preferred_method=saml should redirect to SAML IdP"
           (let [response (client/client-full-response :get 302 "/auth/sso"
@@ -267,7 +267,7 @@
         (testing "login attributes"
           (is
            (= {"extra" "keypairs", "are" "also present"}
-              (t2/select-one-fn :login_attributes :model/User :email "rasta@metabase.com"))))))))
+              (t2/select-one-fn :jwt_attributes :model/User :email "rasta@metabase.com"))))))))
 
 (deftest no-open-redirect-test
   (testing "Check that we prevent open redirects to untrusted sites"
@@ -359,7 +359,7 @@
                  (=
                   {"more" "stuff"
                    "for"  "the new user"}
-                  (t2/select-one-fn :login_attributes :model/User :email "newuser@metabase.com")))))))))))
+                  (t2/select-one-fn :jwt_attributes :model/User :email "newuser@metabase.com")))))))))))
 
 (deftest update-account-test
   (testing "A new account with 'Unknown' name will be created for a new JWT user without a first or last name."

--- a/enterprise/backend/test/metabase_enterprise/tenants/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/core_test.clj
@@ -135,15 +135,18 @@
           (let [user {:id 1
                       :email "test@example.com"
                       :tenant_id tenant-id
-                      :login_attributes {"role" "admin" "department" "engineering"}}
+                      :login_attributes {"role" "admin" "department" "engineering"}
+                      :jwt_attributes {"session" "abc123"}}
                 result (tenants/attribute-structure user)]
             (is (= {:id 1
                     :email "test@example.com"
                     :tenant_id tenant-id
                     :login_attributes {"role" "admin"
                                        "department" "engineering"}
+                    :jwt_attributes {"session" "abc123"}
                     :structured_attributes {"role" {:source :user :frozen false :value "admin"}
                                             "department" {:source :user :frozen false :value "engineering"}
+                                            "session" {:source :jwt :frozen false :value "abc123"}
                                             "environment" {:source :tenant :frozen false :value "production"}
                                             "region" {:source :tenant :frozen false :value "us-east-1"}
                                             "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
@@ -161,13 +164,15 @@
           (let [user {:id 1
                       :email "test@example.com"
                       :tenant_id tenant-id
-                      :login_attributes {"role" "user-role" "department" "engineering"}}
+                      :login_attributes {"role" "user-role" "department" "engineering"}
+                      :jwt_attributes nil}
                 result (tenants/attribute-structure user)]
             (is (= {:id 1
                     :email "test@example.com"
                     :tenant_id tenant-id
                     :login_attributes {"role" "user-role"
                                        "department" "engineering"}
+                    :jwt_attributes nil
                     :structured_attributes {"role" {:source :user :frozen false :value "user-role"
                                                     :original {:source :tenant :frozen false :value "tenant-role"}}
                                             "department" {:source :user :frozen false :value "engineering"}
@@ -181,11 +186,13 @@
       (mt/with-temporary-setting-values [use-tenants true]
         (let [user {:id 1
                     :email "test@example.com"
-                    :login_attributes {"role" "admin" "department" "engineering"}}
+                    :login_attributes {"role" "admin" "department" "engineering"}
+                    :jwt_attributes nil}
               result (tenants/attribute-structure user)]
           (is (= {:id 1
                   :email "test@example.com"
                   :login_attributes {"role" "admin" "department" "engineering"}
+                  :jwt_attributes nil
                   :structured_attributes {"role" {:source :user :frozen false :value "admin"}
                                           "department" {:source :user :frozen false :value "engineering"}}}
                  result)))))))
@@ -197,12 +204,14 @@
         (let [user {:id 1
                     :email "test@example.com"
                     :tenant_id nil
-                    :login_attributes {"role" "admin"}}
+                    :login_attributes {"role" "admin"}
+                    :jwt_attributes nil}
               result (tenants/attribute-structure user)]
           (is (= {:id 1
                   :email "test@example.com"
                   :tenant_id nil
                   :login_attributes {"role" "admin"}
+                  :jwt_attributes nil
                   :structured_attributes {"role" {:source :user :frozen false :value "admin"}}}
                  result)))))))
 
@@ -213,12 +222,14 @@
         (let [user {:id 1
                     :email "test@example.com"
                     :tenant_id 99999
-                    :login_attributes {"role" "admin"}}
+                    :login_attributes {"role" "admin"}
+                    :jwt_attributes nil}
               result (tenants/attribute-structure user)]
           (is (= {:id 1
                   :email "test@example.com"
                   :tenant_id 99999
                   :login_attributes {"role" "admin"}
+                  :jwt_attributes nil
                   :structured_attributes {"role" {:source :user :frozen false :value "admin"}}}
                  result)))))))
 
@@ -232,12 +243,14 @@
           (let [user {:id 1
                       :email "test@example.com"
                       :tenant_id tenant-id
-                      :login_attributes {"role" "admin"}}
+                      :login_attributes {"role" "admin"}
+                      :jwt_attributes nil}
                 result (tenants/attribute-structure user)]
             (is (= {:id 1
                     :email "test@example.com"
                     :tenant_id tenant-id
                     :login_attributes {"role" "admin"}
+                    :jwt_attributes nil
                     :structured_attributes {"role" {:source :user :frozen false :value "admin"}
                                             "@tenant.slug" {:source :system :frozen true :value "empty-tenant"}}}
                    result))))))))
@@ -253,12 +266,14 @@
           (let [user {:id 1
                       :email "test@example.com"
                       :tenant_id tenant-id
-                      :login_attributes {"role" "admin"}}
+                      :login_attributes {"role" "admin"}
+                      :jwt_attributes nil}
                 result (tenants/attribute-structure user)]
             (is (= {:id 1
                     :email "test@example.com"
                     :tenant_id tenant-id
                     :login_attributes {"role" "admin"}
+                    :jwt_attributes nil
                     :structured_attributes {"role" {:source :user :frozen false :value "admin"}
                                             "@tenant.slug" {:source :system :frozen true :value "empty-attrs-tenant"}}}
                    result))))))))
@@ -274,11 +289,13 @@
           (let [user {:id 1
                       :email "test@example.com"
                       :tenant_id tenant-id
-                      :login_attributes nil}
+                      :login_attributes nil
+                      :jwt_attributes nil}
                 result (tenants/attribute-structure user)]
             (is (= {:id 1
                     :email "test@example.com"
                     :tenant_id tenant-id :login_attributes nil
+                    :jwt_attributes nil
                     :structured_attributes {"environment" {:source :tenant :frozen false :value "production"}
                                             "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
                    result))))))))
@@ -294,12 +311,14 @@
           (let [user {:id 1
                       :email "test@example.com"
                       :tenant_id tenant-id
-                      :login_attributes {}}
+                      :login_attributes {}
+                      :jwt_attributes nil}
                 result (tenants/attribute-structure user)]
             (is (= {:id 1
                     :email "test@example.com"
                     :tenant_id tenant-id
                     :login_attributes {}
+                    :jwt_attributes nil
                     :structured_attributes {"environment" {:source :tenant :frozen false :value "production"}
                                             "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
                    result))))))))
@@ -318,7 +337,8 @@
                       :last_name "Doe"
                       :is_active true
                       :tenant_id tenant-id
-                      :login_attributes {"role" "user"}}
+                      :login_attributes {"role" "user"}
+                      :jwt_attributes nil}
                 result (tenants/attribute-structure user)]
             (is (= {:id 1
                     :email "test@example.com"
@@ -327,6 +347,7 @@
                     :is_active true
                     :tenant_id tenant-id
                     :login_attributes {"role" "user"}
+                    :jwt_attributes nil
                     :structured_attributes {"role" {:source :user :frozen false :value "user"}
                                             "environment" {:source :tenant :frozen false :value "production"}
                                             "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
@@ -338,11 +359,41 @@
       (let [user {:id 1
                   :email "test@example.com"
                   :tenant_id 1
-                  :login_attributes {"role" "admin"}}
+                  :login_attributes {"role" "admin"}
+                  :jwt_attributes nil}
             result (tenants/attribute-structure user)]
         (is (= {:id 1
                 :email "test@example.com"
                 :tenant_id 1
                 :login_attributes {"role" "admin"}
+                :jwt_attributes nil
                 :structured_attributes {"role" {:source :user :frozen false :value "admin"}}}
                result))))))
+
+(deftest attribute-structure-ee-jwt-overrides-tenant-test
+  (testing "EE version where JWT attributes override tenant attributes"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp
+          [:model/Tenant {tenant-id :id} {:name "Test Tenant"
+                                          :slug "test-tenant"
+                                          :attributes {"environment" "production"
+                                                       "role" "tenant-role"}}]
+          (let [user {:id 1
+                      :email "test@example.com"
+                      :tenant_id tenant-id
+                      :login_attributes {"department" "engineering"}
+                      :jwt_attributes {"role" "jwt-role" "scope" "admin"}}
+                result (tenants/attribute-structure user)]
+            (is (= {:id 1
+                    :email "test@example.com"
+                    :tenant_id tenant-id
+                    :login_attributes {"department" "engineering"}
+                    :jwt_attributes {"role" "jwt-role" "scope" "admin"}
+                    :structured_attributes {"department" {:source :user :frozen false :value "engineering"}
+                                            "role" {:source :jwt :frozen false :value "jwt-role"
+                                                    :original {:source :tenant :frozen false :value "tenant-role"}}
+                                            "scope" {:source :jwt :frozen false :value "admin"}
+                                            "environment" {:source :tenant :frozen false :value "production"}
+                                            "@tenant.slug" {:source :system :frozen true :value "test-tenant"}}}
+                   result))))))))

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget/LoginAttributeMappingEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget/LoginAttributeMappingEditor.tsx
@@ -73,7 +73,9 @@ export const buildStructuredEntries = (
         disabled: frozen,
         revert:
           original ||
-          (source === "tenant" ? { value, source, frozen: false } : undefined),
+          (source === "tenant" || source === "jwt"
+            ? { value, source, frozen: false }
+            : undefined),
       },
     }))
     .sort((a, b) =>
@@ -267,17 +269,32 @@ const ValueInput = ({
   );
 };
 
-const InfoCard = ({ source }: { source?: "tenant" | "system" | "user" }) =>
-  !["tenant", "system"].includes(source ?? "") ? null : (
+const infoText = (source?: "tenant" | "system" | "jwt" | "user"): string => {
+  switch (source) {
+    case "tenant":
+      return t`This attribute is inherited from the tenant, but you can override its value`;
+    case "system":
+      return t`This attribute is system defined`;
+    case "jwt":
+      return t`This attribute was set by the login token, but you can override its value`;
+    default:
+      return "";
+  }
+};
+
+const InfoCard = ({
+  source,
+}: {
+  source?: "tenant" | "system" | "user" | "jwt";
+}) =>
+  !["tenant", "system", "jwt"].includes(source ?? "") ? null : (
     <HoverCard>
       <HoverCard.Target>
         <Icon name="info_filled" c="text-light" />
       </HoverCard.Target>
       <HoverCard.Dropdown maw="20rem">
         <Text p="sm" maw="20rem">
-          {source === "tenant"
-            ? t`This attribute is inherited from the tenant, but you can override its value`
-            : t`This attribute is system defined`}
+          {infoText(source)}
         </Text>
       </HoverCard.Dropdown>
     </HoverCard>

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget/LoginAttributesWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget/LoginAttributesWidget.tsx
@@ -24,8 +24,8 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   userId?: UserId;
 }
 
-// if the value set in the ui is the same as the tenant value, don't save it to the user
-const isTenantValue = (
+// if the value set in the ui is the same as the tenant or jwt value, don't save it to the user
+const isInheritedValue = (
   [key, inputValue]: [UserAttributeKey, UserAttributeValue],
   structuredAttributes: StructuredUserAttributes,
 ) => {
@@ -34,10 +34,12 @@ const isTenantValue = (
     return false;
   }
 
-  const tenantValue =
+  const inheritedValue =
     attribute?.original?.value ??
-    (attribute.source === "tenant" ? attribute.value : undefined);
-  return tenantValue === inputValue;
+    (attribute.source === "tenant" || attribute.source === "jwt"
+      ? attribute.value
+      : undefined);
+  return inheritedValue === inputValue;
 };
 
 export const LoginAttributesWidget = ({
@@ -64,7 +66,7 @@ export const LoginAttributesWidget = ({
     const validEntries = Object.entries(newValue).filter(
       ([key, value]) =>
         !key.startsWith("@") &&
-        !isTenantValue([key, value], structuredAttributes ?? {}),
+        !isInheritedValue([key, value], structuredAttributes ?? {}),
     );
     setValue(Object.fromEntries(validEntries));
   };

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget/LoginAttributesWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/LoginAttributesWidget/LoginAttributesWidget.unit.spec.tsx
@@ -48,6 +48,11 @@ const structuredAttributes: StructuredUserAttributes = {
     frozen: false,
     value: "secret",
   },
+  session: {
+    source: "jwt",
+    frozen: false,
+    value: "abc123",
+  },
   "@tenant.slug": {
     // immutable tenant slug
     source: "system",
@@ -109,6 +114,22 @@ describe("LoginAttributesWidget", () => {
     expect(submittedValues).toEqual({
       login_attributes: {
         personal: "secret",
+      },
+    });
+  });
+
+  it("should not save a user attribute with the same key and value as a JWT attribute", async () => {
+    const { onSubmit } = setup();
+
+    await screen.findByText("Attributes");
+    await changeInput("abc123", "abc123");
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    const submittedValues = onSubmit.mock.calls[0][0];
+    expect(submittedValues).toEqual({
+      login_attributes: {
+        personal: "secret",
+        type: "insect",
       },
     });
   });

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -7,7 +7,7 @@ export type UserAttributeKey = string;
 export type UserAttributeValue = string;
 export type UserAttributeMap = Record<UserAttributeKey, UserAttributeValue>;
 
-export type UserAttributeSource = "system" | "tenant" | "user";
+export type UserAttributeSource = "system" | "tenant" | "jwt" | "user";
 
 type StructuredAttributeBase = {
   frozen: boolean;

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -56,6 +56,7 @@ databaseChangeLog:
                     referencedColumnNames: id
                     foreignKeyName: fk_query_table_analysis_id
                     deleteCascade: true
+
   - changeSet:
       id: v56.2025-06-06T20:11:56
       author: nvoxland
@@ -365,6 +366,21 @@ databaseChangeLog:
                   name: attributes
                   type: ${text.type}
                   remarks: JSON object containing custom tenant attributes
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v56.2025-06-17T20:11:55
+      author: edpaget
+      comment: Add column to user for jwt-set attributes
+      changes:
+        - addColumn:
+            tableName: core_user
+            columns:
+              - column:
+                  name: jwt_attributes
+                  type: ${text.type}
+                  remarks: JSON object containing attributes set through jwt
                   constraints:
                     nullable: true
 

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -41,6 +41,7 @@
 
 (t2/deftransforms :model/User
   {:login_attributes mi/transform-json-no-keywordization
+   :jwt_attributes   mi/transform-json-no-keywordization
    :settings         mi/transform-encrypted-json
    :sso_source       mi/transform-keyword
    :type             mi/transform-keyword})
@@ -192,7 +193,7 @@
 (def admin-or-self-visible-columns
   "Sequence of columns that we can/should return for admins fetching a list of all Users, or for the current user
   fetching themselves. Needed to power the admin page."
-  (into default-user-columns [:sso_source :is_active :updated_at :login_attributes :locale]))
+  (into default-user-columns [:sso_source :is_active :updated_at :login_attributes :jwt_attributes :locale]))
 
 (def non-admin-or-self-visible-columns
   "Sequence of columns that we will allow non-admin Users to see when fetching a list of Users. Why can non-admins see
@@ -298,6 +299,7 @@
    [:email                             ms/Email]
    [:password         {:optional true} [:maybe ms/NonBlankString]]
    [:login_attributes {:optional true} [:maybe LoginAttributes]]
+   [:jwt_attributes   {:optional true} [:maybe LoginAttributes]]
    [:sso_source       {:optional true} [:maybe ms/NonBlankString]]
    [:locale           {:optional true} [:maybe ms/KeywordOrString]]
    [:type             {:optional true} [:maybe ms/KeywordOrString]]
@@ -405,5 +407,5 @@
 
 (defn add-attributes
   "Adds the `:attributes` key to a user."
-  [{:keys [login_attributes] :as user}]
-  (assoc user :attributes (merge {} (tenants/login-attributes user) login_attributes)))
+  [{:keys [login_attributes jwt_attributes] :as user}]
+  (assoc user :attributes (merge {} (tenants/login-attributes user) jwt_attributes login_attributes)))

--- a/test/metabase/tenants/core_test.clj
+++ b/test/metabase/tenants/core_test.clj
@@ -7,13 +7,14 @@
   (testing "combine function with user attributes only"
     (is (= {"key1" {:source :user :frozen false :value "value1"}
             "key2" {:source :user :frozen false :value "value2"}}
-           (tenants/combine {"key1" "value1" "key2" "value2"})))))
+           (tenants/combine {"key1" "value1" "key2" "value2"} nil)))))
 
 (deftest combine-user-and-tenant-attributes-test
   (testing "combine function with user and tenant attributes"
     (is (= {"user-key" {:source :user :frozen false :value "user-value"}
             "tenant-key" {:source :tenant :frozen false :value "tenant-value"}}
            (tenants/combine {"user-key" "user-value"}
+                            nil
                             {"tenant-key" "tenant-value"}
                             nil)))))
 
@@ -24,6 +25,7 @@
                           :value "user-value"
                           :original {:source :tenant :frozen false :value "tenant-value"}}}
            (tenants/combine {"shared-key" "user-value"}
+                            nil
                             {"shared-key" "tenant-value"}
                             nil)))))
 
@@ -31,26 +33,28 @@
   (testing "combine function where system attributes in conflict cause it to throw"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Cannot clobber"
                           (tenants/combine {"@system-key" "user-value"}
+                                           nil
                                            {"@system-key" "tenant-value"}
                                            {"@system-key" "system-value"})))))
 
 (deftest combine-empty-inputs-nil-test
   (testing "combine function with nil input"
-    (is (= {} (tenants/combine nil)))))
+    (is (= {} (tenants/combine nil nil)))))
 
 (deftest combine-empty-inputs-all-nil-test
   (testing "combine function with all nil inputs"
-    (is (= {} (tenants/combine nil nil nil)))))
+    (is (= {} (tenants/combine nil nil nil nil)))))
 
 (deftest combine-empty-inputs-empty-maps-test
   (testing "combine function with empty maps"
-    (is (= {} (tenants/combine {} {} {})))))
+    (is (= {} (tenants/combine {} {} {} {})))))
 
 (deftest combine-nil-user-with-tenant-and-system-test
   (testing "combine function with nil user but tenant and system attributes"
     (is (= {"tenant-key" {:source :tenant :frozen false :value "tenant-value"}
             "@system-key" {:source :system :frozen true :value "system-value"}}
            (tenants/combine nil
+                            nil
                             {"tenant-key" "tenant-value"}
                             {"@system-key" "system-value"})))))
 
@@ -58,47 +62,56 @@
   (testing "OSS version of attribute-structure with user login attributes"
     (let [user {:id 1
                 :email "test@example.com"
-                :login_attributes {"role" "admin" "department" "engineering"}}
+                :login_attributes {"role" "admin" "department" "engineering"}
+                :jwt_attributes {"session" "abc123"}}
           result (tenants/attribute-structure user)]
       (is (= {:id 1
               :email "test@example.com"
               :login_attributes {"role" "admin" "department" "engineering"}
+              :jwt_attributes {"session" "abc123"}
               :structured_attributes {"role" {:source :user :frozen false :value "admin"}
-                                      "department" {:source :user :frozen false :value "engineering"}}}
+                                      "department" {:source :user :frozen false :value "engineering"}
+                                      "session" {:source :jwt :frozen false :value "abc123"}}}
              result)))))
 
 (deftest attribute-structure-oss-with-nil-login-attributes-test
   (testing "OSS version of attribute-structure with nil login attributes"
     (let [user {:id 1
                 :email "test@example.com"
-                :login_attributes nil}
+                :login_attributes nil
+                :jwt_attributes {"token" "xyz789"}}
           result (tenants/attribute-structure user)]
       (is (= {:id 1
               :email "test@example.com"
               :login_attributes nil
-              :structured_attributes {}}
+              :jwt_attributes {"token" "xyz789"}
+              :structured_attributes {"token" {:source :jwt :frozen false :value "xyz789"}}}
              result)))))
 
 (deftest attribute-structure-oss-with-empty-login-attributes-test
   (testing "OSS version of attribute-structure with empty login attributes"
     (let [user {:id 1
                 :email "test@example.com"
-                :login_attributes {}}
+                :login_attributes {}
+                :jwt_attributes nil}
           result (tenants/attribute-structure user)]
       (is (= {:id 1
               :email "test@example.com"
               :login_attributes {}
+              :jwt_attributes nil
               :structured_attributes {}}
              result)))))
 
 (deftest attribute-structure-oss-user-without-login-attributes-key-test
   (testing "OSS version of attribute-structure with user without login_attributes key"
     (let [user {:id 1
-                :email "test@example.com"}
+                :email "test@example.com"
+                :jwt_attributes {"auth" "bearer-token"}}
           result (tenants/attribute-structure user)]
       (is (= {:id 1
               :email "test@example.com"
-              :structured_attributes {}}
+              :jwt_attributes {"auth" "bearer-token"}
+              :structured_attributes {"auth" {:source :jwt :frozen false :value "bearer-token"}}}
              result)))))
 
 (deftest attribute-structure-oss-preserves-other-user-fields-test
@@ -108,7 +121,8 @@
                 :first_name "John"
                 :last_name "Doe"
                 :is_active true
-                :login_attributes {"role" "user"}}
+                :login_attributes {"role" "user"}
+                :jwt_attributes {"scope" "read-write"}}
           result (tenants/attribute-structure user)]
       (is (= {:id 1
               :email "test@example.com"
@@ -116,5 +130,62 @@
               :last_name "Doe"
               :is_active true
               :login_attributes {"role" "user"}
-              :structured_attributes {"role" {:source :user :frozen false :value "user"}}}
+              :jwt_attributes {"scope" "read-write"}
+              :structured_attributes {"role" {:source :user :frozen false :value "user"}
+                                      "scope" {:source :jwt :frozen false :value "read-write"}}}
              result)))))
+
+(deftest combine-jwt-attributes-only-test
+  (testing "combine function with JWT attributes only"
+    (is (= {"jwt-key" {:source :jwt :frozen false :value "jwt-value"}}
+           (tenants/combine nil {"jwt-key" "jwt-value"})))))
+
+(deftest combine-user-overrides-jwt-attributes-test
+  (testing "combine function where user overrides JWT attributes"
+    (is (= {"shared-key" {:source :user
+                          :frozen false
+                          :value "user-value"
+                          :original {:source :jwt :frozen false :value "jwt-value"}}}
+           (tenants/combine {"shared-key" "user-value"}
+                            {"shared-key" "jwt-value"})))))
+
+(deftest combine-jwt-overrides-tenant-attributes-test
+  (testing "combine function where JWT overrides tenant attributes"
+    (is (= {"shared-key" {:source :jwt
+                          :frozen false
+                          :value "jwt-value"
+                          :original {:source :tenant :frozen false :value "tenant-value"}}}
+           (tenants/combine nil
+                            {"shared-key" "jwt-value"}
+                            {"shared-key" "tenant-value"}
+                            nil)))))
+
+(deftest attribute-structure-oss-jwt-overrides-user-test
+  (testing "OSS version where JWT attributes override user attributes"
+    (let [user {:id 1
+                :email "test@example.com"
+                :login_attributes {"role" "user-role"}
+                :jwt_attributes {"role" "jwt-role"}}
+          result (tenants/attribute-structure user)]
+      (is (= {:id 1
+              :email "test@example.com"
+              :login_attributes {"role" "user-role"}
+              :jwt_attributes {"role" "jwt-role"}
+              :structured_attributes {"role" {:source :user :frozen false :value "user-role"
+                                              :original {:source :jwt :frozen false :value "jwt-role"}}}}
+             result)))))
+
+(deftest combine-all-attribute-types-test
+  (testing "combine function with user, JWT, tenant, and system attributes"
+    (is (= {"user-only" {:source :user :frozen false :value "user-val"}
+            "jwt-only" {:source :jwt :frozen false :value "jwt-val"}
+            "tenant-only" {:source :tenant :frozen false :value "tenant-val"}
+            "@system-only" {:source :system :frozen true :value "system-val"}
+            "override-chain" {:source :user
+                              :frozen false
+                              :value "user-wins"
+                              :original {:source :jwt :frozen false :value "jwt-loses"}}}
+           (tenants/combine {"user-only" "user-val" "override-chain" "user-wins"}
+                            {"jwt-only" "jwt-val" "override-chain" "jwt-loses"}
+                            {"tenant-only" "tenant-val"}
+                            {"@system-only" "system-val"})))))

--- a/test/metabase/users/api_test.clj
+++ b/test/metabase/users/api_test.clj
@@ -558,6 +558,7 @@
                                :first_name             user-name
                                :last_name              user-name
                                :common_name            (str user-name " " user-name)
+                               :jwt_attributes         nil
                                :login_attributes       {:test "value"}})
                        (-> resp
                            mt/boolean-ids-and-timestamps
@@ -740,6 +741,7 @@
                          :email        "cam.eron@metabase.com"
                          :first_name   "Cam"
                          :last_name    "Eron"
+                         :jwt_attributes         nil
                          :is_superuser true})
                        (-> (mt/user-http-request :crowberto :put 200 (str "user/" user-id)
                                                  {:last_name "Eron"
@@ -767,6 +769,7 @@
                  :email                  "testuser@metabase.com"
                  :first_name             "Test"
                  :login_attributes       {:test "value"}
+                 :jwt_attributes         nil
                  :common_name            "Test User"
                  :last_name              "User"})
                (-> (mt/user-http-request :crowberto :put 200 (str "user/" user-id)
@@ -842,7 +845,7 @@
         (letfn [(change-user-via-api! [m]
                   (-> (mt/user-http-request :crowberto :put 200 (str "user/" user-id) m)
                       (t2/hydrate :personal_collection_id ::personal-collection-name)
-                      (dissoc :user_group_memberships :personal_collection_id :email :is_superuser)
+                      (dissoc :user_group_memberships :personal_collection_id :email :is_superuser :jwt_attributes)
                       (#(apply (partial dissoc %) (keys @user-defaults)))
                       mt/boolean-ids-and-timestamps))]
           (testing "Name keys ommitted does not update the user"

--- a/test/metabase/users/models/user_test.clj
+++ b/test/metabase/users/models/user_test.clj
@@ -532,9 +532,11 @@
     (testing "should add :attributes key with merged login attributes"
       (with-redefs [tenants/login-attributes (constantly {"tenant_attr" "tenant_value"})]
         (let [user {:login_attributes {"user_attr" "user_value"}
+                    :jwt_attributes {"jwt_attr" "jwt_value"}
                     :email "test@example.com"}
               result (user/add-attributes user)]
           (is (= {"tenant_attr" "tenant_value"
+                  "jwt_attr" "jwt_value"
                   "user_attr" "user_value"}
                  (:attributes result)))
           (is (= user (dissoc result :attributes))))))
@@ -574,6 +576,7 @@
                                                           "tenant_only" "tenant_val"})]
         (let [user {:login_attributes {"shared_key" "user_value"
                                        "user_only" "user_val"}
+                    :jwt_attributes   {"shared_key" "jwt_value"}
                     :email "test@example.com"}
               result (user/add-attributes user)]
           (is (= {"shared_key" "user_value"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/21682

### Description

Saves attributes from a JWT into a separate `jwt_attributes` field that is merged with lower priority than manually set user attributes. It serialize the attributes back using the same mechanism as tenant attributes which allows us to provide a reasonable editing experience. This also updates the front-end attribute editor to handle the jwt attributes in the same way as tenant attributes. 

### Demo

<img width="580" height="354" alt="Screenshot 2025-07-17 at 2 18 50 PM" src="https://github.com/user-attachments/assets/d4524f3c-9376-4116-840e-0978de11616d" />
<img width="594" height="414" alt="Screenshot 2025-07-17 at 2 18 56 PM" src="https://github.com/user-attachments/assets/dc9a943f-39d1-4a44-b72a-c1948b83c39c" />
<img width="652" height="420" alt="Screenshot 2025-07-17 at 2 19 02 PM" src="https://github.com/user-attachments/assets/5ccff7e7-652b-477d-a906-6b0f8a7be9f9" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
