### PR TITLE
Reversion the migration to fix v_alerts v4 from 56 to 55

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -12111,6 +12111,37 @@ databaseChangeLog:
               WHERE fk_target_field_id IS NOT NULL AND semantic_type = 'type/FK';
       rollback: # not necessary
 
+  - changeSet:
+      id: v55.2025-07-04T15:00:00
+      author: qnkhuat
+      comment: fix v_alerts where cron string contains slash (#60427)
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/alerts/v4/postgres-alerts.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/alerts/v4/mysql-alerts.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/alerts/v4/h2-alerts.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/alerts/v3/postgres-alerts.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/alerts/v3/mysql-alerts.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/alerts/v3/h2-alerts.sql
+            relativeToChangelogFile: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -171,37 +171,6 @@ databaseChangeLog:
                     nullable: false
 
   - changeSet:
-      id: v56.2025-07-04T15:00:00
-      author: qnkhuat
-      comment: fix v_alerts where cron string contains slash (#60427)
-      changes:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/alerts/v4/postgres-alerts.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/alerts/v4/mysql-alerts.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/alerts/v4/h2-alerts.sql
-            relativeToChangelogFile: true
-      rollback:
-        - sqlFile:
-            dbms: postgresql
-            path: instance_analytics_views/alerts/v3/postgres-alerts.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: mysql,mariadb
-            path: instance_analytics_views/alerts/v3/mysql-alerts.sql
-            relativeToChangelogFile: true
-        - sqlFile:
-            dbms: h2
-            path: instance_analytics_views/alerts/v3/h2-alerts.sql
-            relativeToChangelogFile: true
-
-  - changeSet:
       id: v56.2025-07-07T08:02:43
       author: johnswanson
       comment: improve full names in usage analytics - update view `v_users`


### PR DESCRIPTION
This migration was previously created in https://github.com/metabase/metabase/pull/60482 to fix https://github.com/metabase/metabase/issues/60427 but the migration was targeting 56.

This PR replaces the migration to v55 so we can backport it.

Since this migration is idempotent it's ok to run twice on stats, we'll need to clean up databasechange log tho.