### PR TITLE
Lint against incorrect time elapsed measurements

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -741,6 +741,7 @@ metabase-enterprise.content-translation.routes-test/with-new-secret-key!        
   {:linters
    {:metabase/validate-escaped-single-quotes-in-i18n {:level :warning}
     :metabase/validate-string-or-str-args-to-i18n {:level :warning}
+    :metabase/discourage-millis-duration {:level :warning}
     :discouraged-var
     {clojure.core/with-redefs {:message "Don't use with-redefs outside of tests"}
      clojure.core/eval        {:message "Don't use eval outside of tests"}}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -68,6 +68,7 @@
   :metabase/validate-logging                           {:level :warning}
   :metabase/validate-mb-driver-tests                   {:level :warning}
   :metabase/validate-mb-once                           {:level :warning}
+  :metabase/discourage-millis-duration                 {:level :warning}
 
   :metabase/validate-deftest
   {:level :warning
@@ -501,6 +502,7 @@ metabase-enterprise.content-translation.routes-test/with-new-secret-key!        
    clojure.core/ns                                                                                                           hooks.clojure.core.ns/lint-ns
    clojure.core/require                                                                                                      hooks.clojure.core.require/lint-require
    clojure.core/requiring-resolve                                                                                            hooks.clojure.core.require/lint-requiring-resolve
+   clojure.core/-                                                                                                            hooks.metabase.util.timing/discourage-millis-duration
    clojure.test/deftest                                                                                                      hooks.clojure.test/deftest
    clojure.test/is                                                                                                           hooks.clojure.test/is
    clojure.test/use-fixtures                                                                                                 hooks.clojure.test/use-fixtures

--- a/.clj-kondo/src/hooks/metabase/util/timing.clj
+++ b/.clj-kondo/src/hooks/metabase/util/timing.clj
@@ -1,0 +1,16 @@
+(ns hooks.metabase.util.timing
+  "Custom CLJ Kondo hooks for timing-related linting rules."
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn discourage-millis-duration
+  "Discourage slow and unreliable duration calculations using System/currentTimeMillis "
+  [{:keys [node]}]
+  (let [sexpr (api/sexpr node)]
+    (when (and (list? sexpr) (= (first sexpr) '-) (>= (count sexpr) 2))
+      (let [first-arg (second sexpr)]
+        (when (= first-arg (list 'System/currentTimeMillis))
+          (api/reg-finding!
+           (assoc (meta node)
+                  :message "Avoid System/currentTimeMillis for calculating durations. Use u/start-timer and u/since-ms for more reliability."
+                  :type :metabase/discourage-millis-duration
+                  :level :warning)))))))

--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -108,7 +108,7 @@
             steps   (keys all-steps)}}]
    (let [version (or version
                      (version-properties/current-snapshot-version edition))
-         start-time-ms (System/currentTimeMillis)]
+         start-time-ns (System/nanoTime)]
      (u/step (format "Running build steps for %s version %s: %s"
                      (case edition
                        :oss "Community (OSS) Edition"
@@ -121,7 +121,7 @@
                                                       {:step        step-name
                                                        :valid-steps (keys all-steps)})))]]
          (step-fn {:version version, :edition edition})
-         (u/announce "Did %s in %d ms." step-name (- (System/currentTimeMillis) start-time-ms)))
+         (u/announce "Did %s in %d ms." step-name (/ (- (System/nanoTime) start-time-ns) 1e6)))
        (u/announce "All build steps finished.")))))
 
 (defn build-cli

--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -108,7 +108,7 @@
             steps   (keys all-steps)}}]
    (let [version (or version
                      (version-properties/current-snapshot-version edition))
-         start-time-ns (System/nanoTime)]
+         timer         (u/start-timer)]
      (u/step (format "Running build steps for %s version %s: %s"
                      (case edition
                        :oss "Community (OSS) Edition"
@@ -121,7 +121,7 @@
                                                       {:step        step-name
                                                        :valid-steps (keys all-steps)})))]]
          (step-fn {:version version, :edition edition})
-         (u/announce "Did %s in %d ms." step-name (quot (- (System/nanoTime) start-time-ns) 1000000)))
+         (u/announce "Did %s in %d ms." step-name (u/since-ms timer)))
        (u/announce "All build steps finished.")))))
 
 (defn build-cli

--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -121,7 +121,7 @@
                                                       {:step        step-name
                                                        :valid-steps (keys all-steps)})))]]
          (step-fn {:version version, :edition edition})
-         (u/announce "Did %s in %d ms." step-name (/ (- (System/nanoTime) start-time-ns) 1e6)))
+         (u/announce "Did %s in %d ms." step-name (quot (- (System/nanoTime) start-time-ns) 1000000)))
        (u/announce "All build steps finished.")))))
 
 (defn build-cli

--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -23,9 +23,9 @@
   (u/filename u/project-root-directory "target" "uberjar" "metabase.jar"))
 
 (defn- do-with-duration-ms [thunk f]
-  (let [start-time-ns (System/nanoTime)
-        result        (thunk)
-        elapsed-ms    (quot (- (System/nanoTime) start-time-ns) 1000000)]
+  (let [timer      (u/start-timer)
+        result     (thunk)
+        elapsed-ms (u/since-ms timer)]
     (f elapsed-ms)
     result))
 

--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -25,7 +25,7 @@
 (defn- do-with-duration-ms [thunk f]
   (let [start-time-ns (System/nanoTime)
         result        (thunk)
-        elapsed-ms    (/ (- (System/nanoTime) start-time-ns) 1e6)]
+        elapsed-ms    (quot (- (System/nanoTime) start-time-ns) 1000000)]
     (f elapsed-ms)
     result))
 

--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -23,10 +23,10 @@
   (u/filename u/project-root-directory "target" "uberjar" "metabase.jar"))
 
 (defn- do-with-duration-ms [thunk f]
-  (let [start-time-ms (System/currentTimeMillis)
+  (let [start-time-ns (System/nanoTime)
         result        (thunk)
-        duration      (- (System/currentTimeMillis) start-time-ms)]
-    (f duration)
+        elapsed-ms    (/ (- (System/nanoTime) start-time-ns) 1e6)]
+    (f elapsed-ms)
     result))
 
 (defmacro ^:private with-duration-ms [[duration-ms-binding] & body]

--- a/bin/build/src/build_drivers/build_driver.clj
+++ b/bin/build/src/build_drivers/build_driver.clj
@@ -35,5 +35,5 @@
          (copy-source-files/copy-source-files! driver edition)
          (compile-source-files/compile-clojure-source-files! driver edition)
          (create-uberjar/create-uberjar! driver edition)
-         (u/announce "Built %s driver in %d ms." driver (/ (- (System/nanoTime) start-time-ns) 1e6))
+         (u/announce "Built %s driver in %d ms." driver (quot (- (System/nanoTime) start-time-ns) 1000000))
          (verify/verify-driver driver))))))

--- a/bin/build/src/build_drivers/build_driver.clj
+++ b/bin/build/src/build_drivers/build_driver.clj
@@ -24,8 +24,8 @@
    (build-driver! driver edition nil))
 
   ([driver edition {:keys [project-dir target-dir], :as options}]
-   (let [edition       (or edition :oss)
-         start-time-ns (System/nanoTime)]
+   (let [edition (or edition :oss)
+         timer   (u/start-timer)]
      (binding [c/*driver-project-dir* (or project-dir
                                           c/*driver-project-dir*)
                c/*target-directory*   (or target-dir
@@ -35,5 +35,5 @@
          (copy-source-files/copy-source-files! driver edition)
          (compile-source-files/compile-clojure-source-files! driver edition)
          (create-uberjar/create-uberjar! driver edition)
-         (u/announce "Built %s driver in %d ms." driver (quot (- (System/nanoTime) start-time-ns) 1000000))
+         (u/announce "Built %s driver in %d ms." driver (u/since-ms timer))
          (verify/verify-driver driver))))))

--- a/bin/build/src/build_drivers/build_driver.clj
+++ b/bin/build/src/build_drivers/build_driver.clj
@@ -25,7 +25,7 @@
 
   ([driver edition {:keys [project-dir target-dir], :as options}]
    (let [edition       (or edition :oss)
-         start-time-ms (System/currentTimeMillis)]
+         start-time-ns (System/nanoTime)]
      (binding [c/*driver-project-dir* (or project-dir
                                           c/*driver-project-dir*)
                c/*target-directory*   (or target-dir
@@ -35,5 +35,5 @@
          (copy-source-files/copy-source-files! driver edition)
          (compile-source-files/compile-clojure-source-files! driver edition)
          (create-uberjar/create-uberjar! driver edition)
-         (u/announce "Built %s driver in %d ms." driver (- (System/currentTimeMillis) start-time-ms))
+         (u/announce "Built %s driver in %d ms." driver (/ (- (System/nanoTime) start-time-ns) 1e6))
          (verify/verify-driver driver))))))

--- a/bin/build/src/build_drivers/compile_source_files.clj
+++ b/bin/build/src/build_drivers/compile_source_files.clj
@@ -44,7 +44,7 @@
   "Compile the Clojure source files for a driver."
   [driver edition]
   (u/step "Compile clojure source files"
-    (let [start-time-ms (System/currentTimeMillis)
+    (let [start-time-ns (System/nanoTime)
           source-paths  (driver-source-paths driver edition)
           target-dir    (c/compiled-source-target-dir driver)
           namespaces    (source-path-namespaces source-paths)]
@@ -57,4 +57,4 @@
           (compile a-namespace)))
       (u/announce "Compiled %d namespace(s) in %d ms."
                   (count namespaces)
-                  (- (System/currentTimeMillis) start-time-ms)))))
+                  (/ (- (System/nanoTime) start-time-ns) 1e6)))))

--- a/bin/build/src/build_drivers/compile_source_files.clj
+++ b/bin/build/src/build_drivers/compile_source_files.clj
@@ -57,4 +57,4 @@
           (compile a-namespace)))
       (u/announce "Compiled %d namespace(s) in %d ms."
                   (count namespaces)
-                  (/ (- (System/nanoTime) start-time-ns) 1e6)))))
+                  (quot (- (System/nanoTime) start-time-ns) 1000000)))))

--- a/bin/build/src/build_drivers/compile_source_files.clj
+++ b/bin/build/src/build_drivers/compile_source_files.clj
@@ -44,10 +44,10 @@
   "Compile the Clojure source files for a driver."
   [driver edition]
   (u/step "Compile clojure source files"
-    (let [start-time-ns (System/nanoTime)
-          source-paths  (driver-source-paths driver edition)
-          target-dir    (c/compiled-source-target-dir driver)
-          namespaces    (source-path-namespaces source-paths)]
+    (let [timer        (u/start-timer)
+          source-paths (driver-source-paths driver edition)
+          target-dir   (c/compiled-source-target-dir driver)
+          namespaces   (source-path-namespaces source-paths)]
       (u/announce "Compiling Clojure source files in %s to %s" (pr-str source-paths) target-dir)
       (u/create-directory-unless-exists! target-dir)
       (u/announce "Compiling namespaces %s" (pr-str namespaces))
@@ -57,4 +57,4 @@
           (compile a-namespace)))
       (u/announce "Compiled %d namespace(s) in %d ms."
                   (count namespaces)
-                  (quot (- (System/nanoTime) start-time-ns) 1000000)))))
+                  (u/since-ms timer)))))

--- a/bin/build/src/build_drivers/copy_source_files.clj
+++ b/bin/build/src/build_drivers/copy_source_files.clj
@@ -33,4 +33,4 @@
       (copy-files dirs (c/compiled-source-target-dir driver))
       (u/announce "Copied files in %d directories in %d ms."
                   (count dirs)
-                  (/ (- (System/nanoTime) start-time-ns) 1e6)))))
+                  (quot (- (System/nanoTime) start-time-ns) 1000000)))))

--- a/bin/build/src/build_drivers/copy_source_files.clj
+++ b/bin/build/src/build_drivers/copy_source_files.clj
@@ -25,12 +25,12 @@
   "Copy source files into the build driver JAR."
   [driver edition]
   (u/step (format "Copy %s source files" driver)
-    (let [start-time-ns (System/nanoTime)
-          dirs          (:paths (c/driver-edn driver edition))]
+    (let [timer (u/start-timer)
+          dirs  (:paths (c/driver-edn driver edition))]
       (assert (every? u/absolute? dirs)
               (format "All dirs should be absolute, got: %s" (pr-str dirs)))
       (u/announce "Copying files in %s" (pr-str dirs))
       (copy-files dirs (c/compiled-source-target-dir driver))
       (u/announce "Copied files in %d directories in %d ms."
                   (count dirs)
-                  (quot (- (System/nanoTime) start-time-ns) 1000000)))))
+                  (u/since-ms timer)))))

--- a/bin/build/src/build_drivers/copy_source_files.clj
+++ b/bin/build/src/build_drivers/copy_source_files.clj
@@ -25,7 +25,7 @@
   "Copy source files into the build driver JAR."
   [driver edition]
   (u/step (format "Copy %s source files" driver)
-    (let [start-time-ms (System/currentTimeMillis)
+    (let [start-time-ns (System/nanoTime)
           dirs          (:paths (c/driver-edn driver edition))]
       (assert (every? u/absolute? dirs)
               (format "All dirs should be absolute, got: %s" (pr-str dirs)))
@@ -33,4 +33,4 @@
       (copy-files dirs (c/compiled-source-target-dir driver))
       (u/announce "Copied files in %d directories in %d ms."
                   (count dirs)
-                  (- (System/currentTimeMillis) start-time-ms)))))
+                  (/ (- (System/nanoTime) start-time-ns) 1e6)))))

--- a/bin/build/src/build_drivers/create_uberjar.clj
+++ b/bin/build/src/build_drivers/create_uberjar.clj
@@ -79,7 +79,7 @@
   "Build a driver jar for `driver`, either an `:oss` or `:ee` `edition`."
   [driver edition]
   (u/step (format "Write %s %s uberjar -> %s" driver edition (c/driver-jar-destination-path driver))
-    (let [start-time-ms (System/currentTimeMillis)]
+    (let [start-time-ns (System/nanoTime)]
       (b/uber
        {:class-dir         (c/compiled-source-target-dir driver)
         :uber-file         (c/driver-jar-destination-path driver)
@@ -89,4 +89,4 @@
         ;; we need to skip this file since on MacOS it conflicts with other licenses, see:
         ;; https://ask.clojure.org/index.php/13231/switch-tools-build-pull-from-jars-rather-than-exploding-onto
         :exclude           ["META-INF/LICENSE"]})
-      (u/announce "Created uberjar in %d ms." (- (System/currentTimeMillis) start-time-ms)))))
+      (u/announce "Created uberjar in %d ms." (/ (- (System/nanoTime) start-time-ns) 1e6)))))

--- a/bin/build/src/build_drivers/create_uberjar.clj
+++ b/bin/build/src/build_drivers/create_uberjar.clj
@@ -79,7 +79,7 @@
   "Build a driver jar for `driver`, either an `:oss` or `:ee` `edition`."
   [driver edition]
   (u/step (format "Write %s %s uberjar -> %s" driver edition (c/driver-jar-destination-path driver))
-    (let [start-time-ns (System/nanoTime)]
+    (let [timer (u/start-timer)]
       (b/uber
        {:class-dir         (c/compiled-source-target-dir driver)
         :uber-file         (c/driver-jar-destination-path driver)
@@ -89,4 +89,4 @@
         ;; we need to skip this file since on MacOS it conflicts with other licenses, see:
         ;; https://ask.clojure.org/index.php/13231/switch-tools-build-pull-from-jars-rather-than-exploding-onto
         :exclude           ["META-INF/LICENSE"]})
-      (u/announce "Created uberjar in %d ms." (quot (- (System/nanoTime) start-time-ns) 1000000)))))
+      (u/announce "Created uberjar in %d ms." (u/since-ms timer)))))

--- a/bin/build/src/build_drivers/create_uberjar.clj
+++ b/bin/build/src/build_drivers/create_uberjar.clj
@@ -89,4 +89,4 @@
         ;; we need to skip this file since on MacOS it conflicts with other licenses, see:
         ;; https://ask.clojure.org/index.php/13231/switch-tools-build-pull-from-jars-rather-than-exploding-onto
         :exclude           ["META-INF/LICENSE"]})
-      (u/announce "Created uberjar in %d ms." (/ (- (System/nanoTime) start-time-ns) 1e6)))))
+      (u/announce "Created uberjar in %d ms." (quot (- (System/nanoTime) start-time-ns) 1000000)))))

--- a/bin/build/src/metabuild_common/core.clj
+++ b/bin/build/src/metabuild_common/core.clj
@@ -55,6 +55,8 @@
 
  [misc
   parse-as-keyword
+  since-ms
+  start-timer
   varargs]
 
  [out

--- a/bin/build/src/metabuild_common/misc.clj
+++ b/bin/build/src/metabuild_common/misc.clj
@@ -13,6 +13,16 @@
   (vary-meta `(into-array ~klass ~objects)
              assoc :tag (format "[L%s;" (.getCanonicalName ^Class (ns-resolve *ns* klass)))))
 
+(defn start-timer
+  "Return a relative timestamp for tracking durations. Treat this as opaque, it does not correspond to wallclock time."
+  []
+  (System/nanoTime))
+
+(defn since-ms
+  "Return how many milliseconds have elapsed since the given timer was started."
+  [timer]
+  (quot (- (System/nanoTime) timer) 1000000))
+
 (defn parse-as-keyword
   "Like [[clojure.core/keyword]], but with a couple of tweaks to make it better for parsing command-line args:
 

--- a/src/metabase/app_db/liquibase.clj
+++ b/src/metabase/app_db/liquibase.clj
@@ -372,12 +372,12 @@
               unrun-migrations-count (count to-run-migrations)]
           (if (pos? unrun-migrations-count)
             (let [^Contexts contexts nil
-                  start-time         (System/currentTimeMillis)]
+                  timer              (u/start-timer)]
               (log/infof "Running %s migrations ..." unrun-migrations-count)
               (doseq [^ChangeSet change to-run-migrations]
                 (log/tracef "To run migration %s" (.getId change)))
               (.update liquibase contexts)
-              (log/infof "Migration complete in %s" (u/format-milliseconds (- (System/currentTimeMillis) start-time))))
+              (log/infof "Migration complete in %s" (u/format-milliseconds (u/since-ms timer))))
             (log/info "Migration lock cleared, but nothing to do here! Migrations were finished by another instance.")))))
     (log/info "No unrun migrations found.")))
 

--- a/src/metabase/channel/task/refresh_slack_channel_user_cache.clj
+++ b/src/metabase/channel/task/refresh_slack_channel_user_cache.clj
@@ -7,6 +7,7 @@
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.slack :as slack]
    [metabase.task.core :as task]
+   [metabase.util :as u]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
@@ -14,11 +15,11 @@
 (defn ^:private job []
   (if (slack/slack-configured?)
     (let [_        (log/info "Starting Slack user/channel startup cache refresh...")
-          start-ms (System/currentTimeMillis)
+          timer    (u/start-timer)
           _        (slack/refresh-channels-and-usernames!)]
       (log/infof "Slack user/channel startup cache refreshed with %s entries, took %sms."
                  (count (:channels (channel.settings/slack-cached-channels-and-usernames)))
-                 (- (System/currentTimeMillis) start-ms)))
+                 (u/since-ms timer)))
     (log/info "Slack is not configured, not refreshing slack user/channel cache.")))
 
 (def ^:private job-key "metabase.task.refresh-channel-cache.job")

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -183,7 +183,7 @@
   (queue/start-listeners!)
   (init-status/set-complete!)
   (let [start-time (.getStartTime (ManagementFactory/getRuntimeMXBean))
-        duration   (- (System/currentTimeMillis) start-time)]
+        duration   (u/since-ms-wall-clock start-time)]
     (log/infof "Metabase Initialization COMPLETE in %s" (u/format-milliseconds duration))))
 
 (defn init!

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -12,6 +12,7 @@
    [metabase.queries.models.query :as query]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.util :as qp.util]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
@@ -22,7 +23,8 @@
 (defn- add-running-time [{start-time-ms :start_time_millis, :as query-execution}]
   (-> query-execution
       (assoc :running_time (when start-time-ms
-                             (- (System/currentTimeMillis) start-time-ms)))
+                             ;; Consider having `:start_time_nanos` instead, to avoid the pitfalls of system clocks.
+                             (u/since-ms-wall-clock start-time-ms)))
       (dissoc :start_time_millis)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/server/statistics_handler.clj
+++ b/src/metabase/server/statistics_handler.clj
@@ -74,7 +74,7 @@
       (prometheus/inc! :jetty/expires-total))
     (onComplete [^AsyncEvent event]
       (let [request (.. ^AsyncContextEvent event getHttpChannelState getBaseRequest)
-            time-ms (- (System/currentTimeMillis) (.getTimeStamp request))]
+            time-ms (u/since-ms-wall-clock (.getTimeStamp request))]
         (dec! request-counter)
         (request-time (/ time-ms 1000))
         (update-response request)

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -224,7 +224,7 @@
         (when (u/ignore-exceptions
                 (u.password/bcrypt-verify token reset_token))
           ;; check that the reset was triggered within the last 48 HOURS, after that the token is considered expired
-          (let [token-age (- (System/currentTimeMillis) reset_triggered)]
+          (let [token-age (u/since-ms-wall-clock reset_triggered)]
             (when (< token-age (reset-token-ttl-ms))
               user)))))))
 

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1086,6 +1086,14 @@
      [timer]
      (/ (- (System/nanoTime) timer) 1e6)))
 
+#?(:clj
+   (defn since-ms-wall-clock
+     "Return how many milliseconds have elapsed since the given system millisecond time.
+     For cases where you can't use u/start-timer, e.g., external time sources or process boundaries."
+     [start-ms]
+     #_{:clj-kondo/ignore [:metabase/discourage-millis-duration]}
+     (- (System/currentTimeMillis) start-ms)))
+
 (defn group-by
   "(group-by first                  [[1 3]   [1 4]   [2 5]])   => {1 [[1 3] [1 4]], 2 [[2 5]]}
    (group-by first second           [[1 3]   [1 4]   [2 5]])   => {1 [3 4],         2 [5]}

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1068,6 +1068,12 @@
            result (.encodeInto (js/TextEncoder.) s buf)] ;; JS obj {read: chars_converted, write: bytes_written}
        (subs s 0 (.-read result)))))
 
+;; The next two helpers exist to squelch the anti-pattern of using `System/currentTimeMillis` for computing durations.
+;; Unlike its better known sibling, `System/nanoTime` avoids a costly system call fetching the wall clock time, and
+;; instead uses a relative counter which is unaffected by system clock corrections, and guaranteed increasing.
+;;
+;; Our linter won't force you to use these helpers, but they're convenient if you're thinking in milliseconds.
+
 #?(:clj
    (defn start-timer
      "Start and return a timer. Treat the \"timer\" as an opaque object, the implementation may change."

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1084,7 +1084,7 @@
    (defn since-ms
      "Return how many milliseconds have elapsed since the given timer was started."
      [timer]
-     (/ (- (System/nanoTime) timer) 1e6)))
+     (quot (- (System/nanoTime) timer) 1000000)))
 
 #?(:clj
    (defn since-ms-wall-clock

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1084,7 +1084,7 @@
    (defn since-ms
      "Return how many milliseconds have elapsed since the given timer was started."
      [timer]
-     (quot (- (System/nanoTime) timer) 1000000)))
+     (/ (- (System/nanoTime) timer) 1e6)))
 
 #?(:clj
    (defn since-ms-wall-clock

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1069,7 +1069,7 @@
        (subs s 0 (.-read result)))))
 
 ;; The next two helpers exist to squelch the anti-pattern of using `System/currentTimeMillis` for computing durations.
-;; Unlike its better known sibling, `System/nanoTime` avoids a costly system call to fetch the wall clock time, 
+;; Unlike its better known sibling, `System/nanoTime` avoids a costly system call to fetch the wall clock time,
 ;; instead using a relative counter which is unaffected by system clock corrections, and guaranteed to be increasing.
 ;;
 ;; Our linter won't force you to use these helpers, but they're convenient if you're thinking in milliseconds.

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1069,8 +1069,8 @@
        (subs s 0 (.-read result)))))
 
 ;; The next two helpers exist to squelch the anti-pattern of using `System/currentTimeMillis` for computing durations.
-;; Unlike its better known sibling, `System/nanoTime` avoids a costly system call fetching the wall clock time, and
-;; instead uses a relative counter which is unaffected by system clock corrections, and guaranteed increasing.
+;; Unlike its better known sibling, `System/nanoTime` avoids a costly system call to fetch the wall clock time, 
+;; instead using a relative counter which is unaffected by system clock corrections, and guaranteed to be increasing.
 ;;
 ;; Our linter won't force you to use these helpers, but they're convenient if you're thinking in milliseconds.
 

--- a/test/metabase/server/streaming_response_test.clj
+++ b/test/metabase/server/streaming_response_test.clj
@@ -113,13 +113,13 @@
           (dotimes [_ num-requests]
             (future (http/post url request)))
           (Thread/sleep 100)
-          (let [start-time-ms (System/currentTimeMillis)]
+          (let [timer (u/start-timer)]
             (is (= {:status "ok"} (client/client :get 200 "health")))
             (testing "Health endpoint should complete before the first round of queries completes"
               (is (> @remaining (inc (- num-requests thread-pool-size)))))
             (testing "Health endpoint should complete in under 500ms regardless of how many queries are running"
               (testing "(Usually this is under 100ms but might be a little over if CircleCI is being slow)"
-                (let [elapsed-ms (- (System/currentTimeMillis) start-time-ms)]
+                (let [elapsed-ms (u/since-ms timer)]
                   (is (< elapsed-ms 500)))))))))))
 
 (deftest cancelation-test


### PR DESCRIPTION
This common pattern is a pet peeve of mine, due to past trauma where negative and outlier values set off pager alarms. There are multiple upsides to just doing it the right way, and the only downside is the inconvenient precision.

I introduced some utils ages ago to make it easier to get this stuff right, but we're still accruing instances of the wrong way. 