### PR TITLE
[Metabot] Improve loading experience logic

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.module.css
@@ -107,6 +107,7 @@
 .messageActions {
   opacity: 0;
   transition: all 150ms linear;
+  min-height: 1rem;
 }
 
 .messageContainer:hover .messageActions,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -190,8 +190,7 @@ export const MetabotChat = () => {
               {metabot.isDoingScience && (
                 <MetabotThinking
                   toolCalls={metabot.useStreaming ? metabot.toolCalls : []}
-                  hideLoader={
-                    metabot.useStreaming &&
+                  hasStartedResponse={
                     _.last(metabot.messages)?.role === "agent"
                   }
                 />

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -56,17 +56,19 @@ export const UserMessage = ({
       >
         {message.message}
       </Text>
-      {!hideActions && (
-        <Flex className={Styles.messageActions}>
-          <ActionIcon
-            onClick={() => clipboard.copy(message.message)}
-            h="sm"
-            data-testid="metabot-chat-message-copy"
-          >
-            <Icon name="copy" size="1rem" />
-          </ActionIcon>
-        </Flex>
-      )}
+      <Flex className={Styles.messageActions}>
+        {!hideActions && (
+          <>
+            <ActionIcon
+              onClick={() => clipboard.copy(message.message)}
+              h="sm"
+              data-testid="metabot-chat-message-copy"
+            >
+              <Icon name="copy" size="1rem" />
+            </ActionIcon>
+          </>
+        )}
+      </Flex>
     </MessageContainer>
   );
 };
@@ -83,26 +85,28 @@ export const AgentMessage = ({
   return (
     <MessageContainer chatRole={message.role} {...props}>
       <AIMarkdown className={Styles.message}>{message.message}</AIMarkdown>
-      {!hideActions && (
-        <Flex className={Styles.messageActions}>
-          <ActionIcon
-            onClick={() => clipboard.copy(message.message)}
-            h="sm"
-            data-testid="metabot-chat-message-copy"
-          >
-            <Icon name="copy" size="1rem" />
-          </ActionIcon>
-          {onRetry && (
+      <Flex className={Styles.messageActions}>
+        {!hideActions && (
+          <>
             <ActionIcon
-              onClick={() => onRetry(message.id)}
+              onClick={() => clipboard.copy(message.message)}
               h="sm"
-              data-testid="metabot-chat-message-retry"
+              data-testid="metabot-chat-message-copy"
             >
-              <Icon name="revert" size="1rem" />
+              <Icon name="copy" size="1rem" />
             </ActionIcon>
-          )}
-        </Flex>
-      )}
+            {onRetry && (
+              <ActionIcon
+                onClick={() => onRetry(message.id)}
+                h="sm"
+                data-testid="metabot-chat-message-retry"
+              >
+                <Icon name="revert" size="1rem" />
+              </ActionIcon>
+            )}
+          </>
+        )}
+      </Flex>
     </MessageContainer>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotThinking.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotThinking.tsx
@@ -1,4 +1,5 @@
 import cx from "classnames";
+import { useMemo } from "react";
 
 import { Loader, Stack, Text, Transition } from "metabase/ui";
 import type { MetabotToolCall } from "metabase-enterprise/metabot/state";
@@ -48,15 +49,23 @@ const ThoughtProcess = ({ toolCalls }: { toolCalls: MetabotToolCall[] }) => {
 
 export const MetabotThinking = ({
   toolCalls,
-  hideLoader = false,
+  hasStartedResponse,
 }: {
   toolCalls: MetabotToolCall[];
-  hideLoader: boolean;
+  hasStartedResponse: boolean;
 }) => {
+  const toolCallsWithMsgs = useMemo(() => {
+    return toolCalls.filter((tc) => !!tc.message);
+  }, [toolCalls]);
+
+  const showLoader =
+    (!hasStartedResponse && toolCalls.length === 0) ||
+    (toolCalls.length > 0 && toolCallsWithMsgs.length === 0);
+
   return (
     <Stack gap="xs">
-      <ThoughtProcess toolCalls={toolCalls} />
-      {!hideLoader && (
+      <ThoughtProcess toolCalls={toolCallsWithMsgs} />
+      {showLoader && (
         <Loader
           color="brand"
           type="dots"

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot-streaming.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot-streaming.unit.spec.tsx
@@ -383,6 +383,28 @@ describe("metabot-streaming", () => {
         ]);
       });
     });
+
+    it("should start a new message if there's tool calls between streamed text parts", async () => {
+      setup();
+      mockAgentEndpoint(
+        {
+          textChunks: [
+            `0:"Response 1"`,
+            `9:{"toolCallId":"x","toolName":"x","args":""}`,
+            `a:{"toolCallId":"x","result":""}`,
+            `0:"Response 2"`,
+            `d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
+          ],
+        }, // small delay to cause loading state
+      );
+      await enterChatMessage("Request");
+
+      await assertConversation([
+        ["user", "Request"],
+        ["agent", "Response 1"],
+        ["agent", "Response 2"],
+      ]);
+    });
   });
 
   describe("errors", () => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -24,7 +24,7 @@ export type MetabotErrorMessage = {
 export type MetabotToolCall = {
   id: string;
   name: string;
-  message: string;
+  message: string | undefined;
   status: "started" | "ended";
 };
 
@@ -114,15 +114,12 @@ export const metabot = createSlice({
       action: PayloadAction<{ toolCallId: string; toolName: string }>,
     ) => {
       const { toolCallId, toolName } = action.payload;
-      const toolCallMessage = TOOL_CALL_MESSAGES[toolName];
-      if (toolCallMessage) {
-        state.toolCalls.push({
-          id: toolCallId,
-          name: toolName,
-          message: toolCallMessage,
-          status: "started",
-        });
-      }
+      state.toolCalls.push({
+        id: toolCallId,
+        name: toolName,
+        message: TOOL_CALL_MESSAGES[toolName],
+        status: "started",
+      });
     },
     toolCallEnd: (state, action: PayloadAction<{ toolCallId: string }>) => {
       state.toolCalls = state.toolCalls.map((tc) =>


### PR DESCRIPTION
Closes [BOT-252](https://linear.app/metabase/issue/BOT-252/fix-metabot-adding-messages-without-a-space-and-showing-no-loading)

### Description

Before:

https://github.com/user-attachments/assets/9311e89e-e2f7-44b2-ab67-0a967f4f3e5b

After:

https://github.com/user-attachments/assets/6908656d-0b71-495c-bfc1-00a1f65c8716

This also fixes a [bug](https://metaboat.slack.com/archives/C07SJT1P0ET/p1751458798487149) where if a tool is called but there's no message to show a user, further messages streamed in would get merged with the previous message w/o a space.

### How to verify

- Follow the videos above as reference. You want to cause metabot to do something in two steps w/ tool calls in between.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
