### PR TITLE
[Metabot] Fix horizontal scrollbar when response contains code

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/AIMarkdown/AIMarkdown.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/AIMarkdown/AIMarkdown.module.css
@@ -2,6 +2,11 @@
   line-height: 1.5;
 }
 
+.aiMarkdown pre {
+  width: 100%;
+  overflow-x: auto;
+}
+
 .aiMarkdown p {
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
### Description

Quick fix, not a perfect fix. When responses contain a code block, the metabot chat would have horizontal scrollbar if the code was too long. This PR localizes the scrollbar for now.

Before:
<img width="960" height="1608" alt="CleanShot 2025-07-17 at 17 43 27@2x" src="https://github.com/user-attachments/assets/63aa4963-0fea-44a5-aaa8-7527278beb82" />

After (note, scrollbar goes away on mac after second or so):
<img width="966" height="1940" alt="CleanShot 2025-07-17 at 17 45 44@2x" src="https://github.com/user-attachments/assets/3bd52e23-5356-49e6-8535-6e640f9bb283" />

### How to verify

- Use the prompt in the screenshot