### PR TITLE
Fix transparent background for SQL editor autocomplete suggestions

### DIFF
--- a/frontend/src/metabase/common/components/CodeMirror/CodeMirror.module.css
+++ b/frontend/src/metabase/common/components/CodeMirror/CodeMirror.module.css
@@ -61,7 +61,7 @@
       border-left-width: 1.6px;
     }
 
-    .cm-tooltip {
+    .cm-tooltip:not(.cm-tooltip-autocomplete) {
       border: none !important;
       background: none !important;
     }


### PR DESCRIPTION
## Summary
- Fixed transparent background issue for SQL editor autocomplete suggestions
- Changed `.cm-tooltip` CSS selector to `.cm-tooltip:not(.cm-tooltip-autocomplete)` to exclude autocomplete tooltips
- This allows autocomplete suggestions to use their proper background styling while preserving other tooltip behavior

## Test plan
- [ ] Open the SQL editor and start typing a query
- [ ] Trigger autocomplete suggestions (e.g., type "SELECT * FROM" and start typing a table name)
- [ ] Verify that autocomplete suggestions now have a solid background and are readable against the underlying code
- [ ] Verify that other CodeMirror tooltips still work as expected

Fixes #61087

🤖 Generated with [Claude Code](https://claude.ai/code)