### PR TITLE
test: fix another flakiness in model re-mapping test

### DIFF
--- a/e2e/support/helpers/e2e-models-metadata-helpers.js
+++ b/e2e/support/helpers/e2e-models-metadata-helpers.js
@@ -70,11 +70,14 @@ export function mapColumnTo({ table, column } = {}) {
   cy.findByText("Database column this maps to")
     .parent()
     .findByTestId("select-button")
-    .click({ force: true });
+    .click();
 
   popover().contains(table).click();
-
   popover().contains(column).click();
+
+  cy.findByText("Database column this maps to")
+    .next()
+    .should("contain", `${table} → ${column}`);
 }
 
 export function setModelMetadata(modelId, callback) {

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -539,19 +539,6 @@ describe(
   "filtering based on the remapped column name should result in a correct query (metabase#22715)",
   { tags: "@flaky" },
   () => {
-    function mapColumnTo({ table, column } = {}) {
-      cy.findByText("Database column this maps to")
-        .parent()
-        .contains("None")
-        .click();
-
-      H.popover().findByText(table).click();
-      H.popover().findByText(column).click();
-      cy.findByText("Database column this maps to")
-        .next()
-        .should("contain", `${table} → ${column}`);
-    }
-
     beforeEach(() => {
       cy.intercept("POST", "/api/dataset").as("dataset");
       cy.intercept("PUT", "/api/card/*").as("updateModel");
@@ -573,13 +560,13 @@ describe(
 
         // Let's go straight to the model metadata editor
         cy.visit(`/model/${id}/metadata`);
-        cy.findByText("Database column this maps to");
+        cy.findByText("Database column this maps to").should("be.visible");
 
         // The first column `ID` is automatically selected
-        mapColumnTo({ table: "Orders", column: "ID" });
+        H.mapColumnTo({ table: "Orders", column: "ID" });
         cy.findByText("ALIAS_CREATED_AT").click();
 
-        mapColumnTo({ table: "Orders", column: "Created At" });
+        H.mapColumnTo({ table: "Orders", column: "Created At" });
 
         // Make sure the column name updated before saving
         cy.findByDisplayValue("Created At");


### PR DESCRIPTION
A fix for `should be able to use join native models when SQL column names do not match the names of the mapped fields (metabase#58829)` 

<img width="1903" height="518" alt="image" src="https://github.com/user-attachments/assets/1baa5925-20bf-4c66-8039-6b797f879379" />

https://app.trunk.io/metabase/flaky-tests/test/17cc2721-ff27-582f-82dd-2e18fadac7e1?repo=metabase/metabase&intervalDays=7

✅ [stress test](https://github.com/metabase/metabase/actions/runs/16365476480/job/46241589320)
❌ [master](https://github.com/metabase/metabase/actions/runs/16365470528/job/46241570931)
