### PR TITLE
SEM-497 Filtering preview inputs get auto-focused

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -3058,6 +3058,46 @@ describe("scenarios > admin > datamodel", () => {
         PreviewSection.get().findByText("No data to show").should("be.visible");
       });
     });
+
+    it("should not auto-focus inputs in filtering preview", () => {
+      H.DataModel.visit({
+        databaseId: SAMPLE_DB_ID,
+        schemaId: SAMPLE_DB_SCHEMA_ID,
+        tableId: ORDERS_ID,
+        fieldId: ORDERS.PRODUCT_ID,
+      });
+
+      FieldSection.getPreviewButton().click();
+      PreviewSection.getPreviewTypeInput().findByText("Filtering").click();
+
+      PreviewSection.get()
+        .findByPlaceholderText("Enter an ID")
+        .should("be.visible")
+        .and("not.be.focused");
+
+      FieldSection.getFilteringInput().click();
+      H.popover().findByText("A list of all values").click();
+
+      PreviewSection.get()
+        .findByPlaceholderText("Search the list")
+        .should("be.visible")
+        .and("not.be.focused");
+
+      TableSection.clickField("Tax");
+
+      PreviewSection.get()
+        .findByPlaceholderText("Min")
+        .should("be.visible")
+        .and("not.be.focused");
+
+      FieldSection.getFilteringInput().click();
+      H.popover().findByText("Search box").click();
+
+      PreviewSection.get()
+        .findByPlaceholderText("Enter a number")
+        .should("be.visible")
+        .and("not.be.focused");
+    });
   });
 
   describe("Error handling", { tags: "@external" }, () => {

--- a/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/FilteringPreview.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/PreviewSection/FilteringPreview.tsx
@@ -31,6 +31,7 @@ const FilteringPreviewBase = ({ databaseId, fieldId, table }: Props) => {
 
   return (
     <FilterPickerBody
+      autoFocus={false}
       column={column}
       query={query}
       stageIndex={STAGE_INDEX}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
@@ -31,6 +31,7 @@ function setup({
 
   renderWithProviders(
     <BooleanFilterPicker
+      autoFocus
       query={query}
       stageIndex={0}
       column={column}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -21,6 +21,7 @@ import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 import { CoordinateColumnPicker } from "./CoordinateColumnPicker";
 
 export function CoordinateFilterPicker({
+  autoFocus,
   query,
   stageIndex,
   column,
@@ -108,6 +109,7 @@ export function CoordinateFilterPicker({
           />
         )}
         <CoordinateValueInput
+          autoFocus={autoFocus}
           query={query}
           stageIndex={stageIndex}
           column={column}
@@ -129,6 +131,7 @@ export function CoordinateFilterPicker({
 }
 
 interface CoordinateValueInputProps {
+  autoFocus: boolean;
   query: Lib.Query;
   stageIndex: number;
   column: Lib.ColumnMetadata;
@@ -139,6 +142,7 @@ interface CoordinateValueInputProps {
 }
 
 function CoordinateValueInput({
+  autoFocus,
   query,
   stageIndex,
   column,
@@ -155,7 +159,7 @@ function CoordinateValueInput({
           stageIndex={stageIndex}
           column={column}
           values={values.filter(isNotNull)}
-          autoFocus
+          autoFocus={autoFocus}
           comboboxProps={COMBOBOX_PROPS}
           onChange={onChange}
         />
@@ -169,7 +173,7 @@ function CoordinateValueInput({
         <NumberFilterInput
           value={values[0]}
           placeholder={t`Enter a number`}
-          autoFocus
+          autoFocus={autoFocus}
           w="100%"
           aria-label={t`Filter value`}
           onChange={(newValue) => onChange([newValue])}
@@ -184,7 +188,7 @@ function CoordinateValueInput({
         <NumberFilterInput
           value={values[0]}
           placeholder={t`Min`}
-          autoFocus
+          autoFocus={autoFocus}
           onChange={(newValue) => onChange([newValue, values[1]])}
         />
         <Text mx="sm">{t`and`}</Text>
@@ -204,7 +208,7 @@ function CoordinateValueInput({
           label={t`Upper latitude`}
           value={values[0]}
           placeholder="90"
-          autoFocus
+          autoFocus={autoFocus}
           onChange={(newValue) =>
             onChange([newValue, values[1], values[2], values[3]])
           }

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
@@ -59,6 +59,7 @@ function setup({
 
   renderWithProviders(
     <CoordinateFilterPicker
+      autoFocus
       query={query}
       stageIndex={0}
       column={column}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
@@ -38,6 +38,7 @@ function setup({
 
   renderWithProviders(
     <DateFilterPicker
+      autoFocus
       query={query}
       stageIndex={STAGE_INDEX}
       column={column}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.unit.spec.tsx
@@ -32,6 +32,7 @@ function setup({
 
   renderWithProviders(
     <DefaultFilterPicker
+      autoFocus
       query={query}
       stageIndex={stageIndex}
       column={column}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
@@ -10,6 +10,7 @@ import { TimeFilterPicker } from "../TimeFilterPicker";
 import type { FilterChangeOpts } from "../types";
 
 interface FilterPickerBodyProps {
+  autoFocus?: boolean;
   query: Lib.Query;
   stageIndex: number;
   column: Lib.ColumnMetadata;
@@ -22,6 +23,7 @@ interface FilterPickerBodyProps {
 }
 
 export function FilterPickerBody({
+  autoFocus = true,
   query,
   stageIndex,
   column,
@@ -39,6 +41,7 @@ export function FilterPickerBody({
 
   return (
     <FilterWidget
+      autoFocus={autoFocus}
       query={query}
       stageIndex={stageIndex}
       column={column}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -19,6 +19,7 @@ import { COMBOBOX_PROPS, WIDTH } from "../constants";
 import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 export function NumberFilterPicker({
+  autoFocus,
   query,
   stageIndex,
   column,
@@ -92,6 +93,7 @@ export function NumberFilterPicker({
       </FilterPickerHeader>
       <div>
         <NumberValueInput
+          autoFocus={autoFocus}
           query={query}
           stageIndex={stageIndex}
           column={column}
@@ -113,6 +115,7 @@ export function NumberFilterPicker({
 }
 
 interface NumberValueInputProps {
+  autoFocus: boolean;
   query: Lib.Query;
   stageIndex: number;
   column: Lib.ColumnMetadata;
@@ -123,6 +126,7 @@ interface NumberValueInputProps {
 }
 
 function NumberValueInput({
+  autoFocus,
   query,
   stageIndex,
   column,
@@ -139,7 +143,7 @@ function NumberValueInput({
           stageIndex={stageIndex}
           column={column}
           values={values.filter(isNotNull)}
-          autoFocus
+          autoFocus={autoFocus}
           comboboxProps={COMBOBOX_PROPS}
           onChange={onChange}
         />
@@ -153,7 +157,7 @@ function NumberValueInput({
         <NumberFilterInput
           value={values[0]}
           placeholder={t`Enter a number`}
-          autoFocus
+          autoFocus={autoFocus}
           w="100%"
           aria-label={t`Filter value`}
           onChange={(newValue) => onChange([newValue])}
@@ -168,7 +172,7 @@ function NumberValueInput({
         <NumberFilterInput
           value={values[0]}
           placeholder={t`Min`}
-          autoFocus
+          autoFocus={autoFocus}
           onChange={(newValue) => onChange([newValue, values[1]])}
         />
         <Text mx="sm">{t`and`}</Text>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -60,6 +60,7 @@ function setup({
 
   renderWithProviders(
     <NumberFilterPicker
+      autoFocus
       query={query}
       stageIndex={0}
       column={column}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -17,6 +17,7 @@ import { COMBOBOX_PROPS, WIDTH } from "../constants";
 import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 export function StringFilterPicker({
+  autoFocus,
   query,
   stageIndex,
   column,
@@ -91,6 +92,7 @@ export function StringFilterPicker({
       </FilterPickerHeader>
       <div>
         <StringValueInput
+          autoFocus={autoFocus}
           query={query}
           stageIndex={stageIndex}
           column={column}
@@ -118,6 +120,7 @@ export function StringFilterPicker({
 }
 
 interface StringValueInputProps {
+  autoFocus: boolean;
   query: Lib.Query;
   stageIndex: number;
   column: Lib.ColumnMetadata;
@@ -127,6 +130,7 @@ interface StringValueInputProps {
 }
 
 function StringValueInput({
+  autoFocus,
   query,
   stageIndex,
   column,
@@ -143,7 +147,7 @@ function StringValueInput({
           column={column}
           values={values}
           comboboxProps={COMBOBOX_PROPS}
-          autoFocus
+          autoFocus={autoFocus}
           onChange={onChange}
         />
         <Box pt="md" />

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -59,6 +59,7 @@ function setup({
 
   renderWithProviders(
     <StringFilterPicker
+      autoFocus
       query={query}
       stageIndex={0}
       column={column}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -16,6 +16,7 @@ import { WIDTH } from "../constants";
 import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 export function TimeFilterPicker({
+  autoFocus,
   query,
   stageIndex,
   column,
@@ -89,6 +90,7 @@ export function TimeFilterPicker({
         {valueCount > 0 && (
           <Flex p="md">
             <TimeValueInput
+              autoFocus={autoFocus}
               values={values}
               valueCount={valueCount}
               onChange={setValues}
@@ -108,19 +110,25 @@ export function TimeFilterPicker({
 }
 
 interface TimeValueInputProps {
+  autoFocus: boolean;
   values: TimeValue[];
   valueCount: number;
   onChange: (values: TimeValue[]) => void;
 }
 
-function TimeValueInput({ values, valueCount, onChange }: TimeValueInputProps) {
+function TimeValueInput({
+  autoFocus,
+  values,
+  valueCount,
+  onChange,
+}: TimeValueInputProps) {
   if (valueCount === 1) {
     const [value] = values;
     return (
       <TimeInput
         value={value}
         w="100%"
-        autoFocus
+        autoFocus={autoFocus}
         onChange={(newValue) => onChange([newValue])}
       />
     );
@@ -133,7 +141,7 @@ function TimeValueInput({ values, valueCount, onChange }: TimeValueInputProps) {
         <TimeInput
           value={value1}
           w="100%"
-          autoFocus
+          autoFocus={autoFocus}
           onChange={(newValue1) => onChange([newValue1, value2])}
         />
         <Text>{t`and`}</Text>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -50,6 +50,7 @@ function setup({
 
   render(
     <TimeFilterPicker
+      autoFocus
       query={query}
       stageIndex={0}
       column={column}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
@@ -2,6 +2,7 @@ import type * as Lib from "metabase-lib";
 import type { DefinedClauseName } from "metabase-lib/v1/expressions";
 
 export type FilterPickerWidgetProps = {
+  autoFocus: boolean;
   query: Lib.Query;
   stageIndex: number;
   column: Lib.ColumnMetadata;


### PR DESCRIPTION
Closes [SEM-497](https://linear.app/metabase/issue/SEM-497/filtering-preview-inputs-get-auto-focused)

### Description

Adds `autoFOcus` prop to `FilterPickerWidgetProps` and `FilterPickerBody`.
It defaults to `true`. It's `false` in 1 case: field filtering preview in Admin > Table metadata page.

### How to verify

1. Admin > Table metadata
2. Open a field
3. Open preview
4. Open filtering preview

The input in the filtering preview should not have been autofocused

5. Change filtering for the field

The input in the filtering preview should not have been autofocused

