### PR TITLE
Bigq memory pressure

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -377,7 +377,7 @@
 (def ^:private num-table-partitions
   "Number of tables to batch for describe-fields. Too low and we'll do too many queries, which is slow.
    Too high and we'll hold too many fields of a dataset in memory, which risks causing OOMs."
-  1024)
+  128)
 
 (defn- list-table-names [driver database project-id dataset-id]
   (try


### PR DESCRIPTION
Reduce memory pressure from bigq sync
- reduce the batch size of tables to 128
- introduces a hard limit of 5 nested fields for unfolding in dictionary
- reintroduces scoping of nested fields by table-name