### PR TITLE
Bigquery nested fields fix

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -308,7 +308,7 @@
      (keep nested-column-info)
      (completing
       (fn [accum col]
-        (update accum (:nfc-path col) (fnil conj []) col)))
+        (update-in accum [(:table-name col) (:nfc-path col)] (fnil conj []) col)))
      {}
      results)))
 
@@ -369,7 +369,7 @@
      (partition-by :table_name)
      (mapcat (fn [table-rows]
                (let [table-name (:table_name (first table-rows))]
-                 (->> (describe-dataset-rows nested-column-lookup dataset-id table-name table-rows)
+                 (->> (describe-dataset-rows (get nested-column-lookup table-name) dataset-id table-name table-rows)
                       (sort-by (juxt :table-name :database-position :name))))))
      named-rows)))
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61196

Fix for https://github.com/metabase/metabase/pull/59683

Don't union nested fields in a batch


https://github.com/metabase/metabase/pull/59683 introduced an accidental explosion in nested-fields construction whereby we consider the union of nested fields in a shared path across an entire chunk of tables, rather than for a single table. 

Concretely, if table `table1` has a field `a` with a dictionary schema of `{:nested1 {:nested2 ..}}`, and `table2` has a field `a` with a dicionary schema of `{:nested1 {:nested3 ..}}`, we were now incorrectly extending the set of nested fields for fields of both tables to be `{:nested1 {:nested2 .. nested3 ..}}`

In practice this likely happens with dictionaries that have some initial sharing, and later diverge into heterogeneous sets of keys, e.g. timestamps

It is somewhat related to the issue we had observed in [ json-unfolding for postgres ](https://github.com/metabase/metabase/pull/59122), though this was artificially created

