### PR TITLE
Closes VIZ-703 formatting of time values is incorrect

### DIFF
--- a/frontend/src/metabase/lib/time.ts
+++ b/frontend/src/metabase/lib/time.ts
@@ -139,10 +139,12 @@ export function parseTime(value: moment.Moment | string) {
   if (moment.isMoment(value)) {
     return value;
   } else if (typeof value === "string") {
-    return moment(value, [
-      "HH:mm:ss.sss[Z]",
-      "HH:mm:SS.sss",
-      "HH:mm:SS",
+    // removing the timezone part if it exists, so we can parse the time correctly
+    return moment(value.split(/[+-]/)[0], [
+      "HH:mm:ss.SSSZ",
+      "HH:mm:ss.SSS",
+      "HH:mm:ss",
+      "HH:mm:ss",
       "HH:mm",
     ]);
   }

--- a/frontend/src/metabase/lib/time.unit.spec.ts
+++ b/frontend/src/metabase/lib/time.unit.spec.ts
@@ -1,0 +1,39 @@
+import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
+
+import { parseTime } from "./time";
+
+describe("parseTime", () => {
+  it("should return a moment object for valid time strings", () => {
+    const timeString = "12:34:56";
+    const result = parseTime(timeString);
+    expect(result.isValid()).toBe(true);
+    expect(result.format("HH:mm:ss")).toBe("12:34:56");
+  });
+
+  it("should return a moment object for valid moment objects", () => {
+    const momentObj = moment("2023-10-01T12:34:56");
+    const result = parseTime(momentObj);
+    expect(result.isValid()).toBe(true);
+    expect(result.format()).toBe(momentObj.format());
+  });
+
+  it("should return an invalid moment object for invalid input", () => {
+    const invalidInput = "invalid-time";
+    const result = parseTime(invalidInput);
+    expect(result.isValid()).toBe(false);
+  });
+
+  it("should work with seconds", () => {
+    const timeString = "13:22:11+01:00";
+    const result = parseTime(timeString);
+    expect(result.isValid()).toBe(true);
+    expect(result.format("HH:mm:ss")).toBe("13:22:11");
+  });
+
+  it("should handle time with milliseconds", () => {
+    const timeString = "13:22:11+01:00";
+    const result = parseTime(timeString);
+    expect(result.isValid()).toBe(true);
+    expect(result.format("HH:mm:ss.SSS")).toBe("13:22:11.000");
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57071
Closes [VIZ-703: Formatting of time values is incorrect](https://linear.app/metabase/issue/VIZ-703/formatting-of-time-values-is-incorrect)

### Description

Fixed the parsing formats for times

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
