### PR TITLE
test: ensure popover contains delete permanently in trash

### DIFF
--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -442,7 +442,10 @@ describe("scenarios > collections > trash", () => {
     // });
 
     toggleEllipsisMenuFor("Dashboard A");
-    H.popover().findByText("Delete permanently").click();
+    H.popover()
+      .should("contain", "Delete permanently")
+      .findByText("Delete permanently")
+      .click();
     H.modal().findByText("Delete Dashboard A permanently?").should("exist");
     H.modal().findByText("Delete permanently").click();
     collectionTable().within(() => {
@@ -450,7 +453,10 @@ describe("scenarios > collections > trash", () => {
     });
 
     toggleEllipsisMenuFor("Question A");
-    H.popover().findByText("Delete permanently").click();
+    H.popover()
+      .should("contain", "Delete permanently")
+      .findByText("Delete permanently")
+      .click();
     H.modal().findByText("Delete Question A permanently?").should("exist");
     H.modal().findByText("Delete permanently").click();
     collectionTable().within(() => {
@@ -861,12 +867,11 @@ describe("scenarios > collections > trash", () => {
 });
 
 function toggleEllipsisMenuFor(item) {
-  collectionTable().within(() => {
-    cy.findByText(item)
-      .closest("tr")
-      .find(".Icon-ellipsis")
-      .click({ force: true });
-  });
+  collectionTable()
+    .findByText(item)
+    .closest("tr")
+    .find(".Icon-ellipsis")
+    .click();
 }
 
 function createCollection(collectionInfo, archive) {


### PR DESCRIPTION
A fix for `scenarios > collections > trash should be able to permanently delete <entity> on archived entity page or from trash & trashed collections`

<img width="1410" height="599" alt="image" src="https://github.com/user-attachments/assets/ef0f230c-3dba-419e-b033-b5a147ad35b7" />

✅ [stress test](https://github.com/metabase/metabase/actions/runs/16370971438/job/46258991019)
❌ [master](https://github.com/metabase/metabase/actions/runs/16370962531/job/46258964042)
