### PR TITLE
Fix accidental blocking search index init

### DIFF
--- a/src/metabase/search/task/search_index.clj
+++ b/src/metabase/search/task/search_index.clj
@@ -43,7 +43,7 @@
   (search/reindex!))
 
 (defmethod startup/def-startup-logic! ::SearchIndexInit [_]
-  (quick-task/submit-task! (init!)))
+  (quick-task/submit-task! init!))
 
 (defmethod task/init! ::SearchIndexReindex [_]
   (let [job         (jobs/build

--- a/src/metabase/util/quick_task.clj
+++ b/src/metabase/util/quick_task.clj
@@ -24,5 +24,6 @@
   "Submit a task to the single thread executor. This will attempt to serialize repeated requests to sync tables. It
   obviously cannot work across multiple instances."
   ^Future [^Callable f]
+  {:pre [(some? f)]}
   (let [task (bound-fn* f)]
     (.submit ^ExecutorService @executor ^Callable task)))


### PR DESCRIPTION
Corrects the submit-task! call for search initialisation, which was causing indexing to block application startup.

Speculative fix, if it turns out things _should_ actually be eager, we will need to revisit this. 