### PR TITLE
Closes VIZ-46 number formatting for remapped columns

### DIFF
--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -142,7 +142,7 @@ export function formatValueRaw(
 
   const remapped = getRemappedValue(value as string | number, options);
   if (remapped !== undefined && options.view_as !== "link") {
-    return remapped;
+    value = remapped;
   }
 
   if (value == null) {

--- a/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
@@ -5,89 +5,112 @@ import { createMockColumn } from "metabase-types/api/mocks";
 import type { OptionsType } from "./types";
 import { formatValue } from "./value";
 
-const setup = (value: any, overrides: Partial<OptionsType> = {}) => {
-  mockSettings();
-  const column = createMockColumn({
-    base_type: "type/Float",
-  });
-  const options: OptionsType = {
-    view_as: "auto",
-    column: column,
-    type: "cell",
-    jsx: true,
-    rich: true,
-    clicked: {
-      value: value,
+describe("formatValue", () => {
+  const setup = (value: any, overrides: Partial<OptionsType> = {}) => {
+    mockSettings();
+    const column = createMockColumn({
+      base_type: "type/Float",
+    });
+    const options: OptionsType = {
+      view_as: "auto",
       column: column,
-      origin: {
-        rowIndex: 0,
-        row: [value],
-        cols: [column],
-      },
-      data: [
-        {
-          value: value,
-          col: column,
+      type: "cell",
+      jsx: true,
+      rich: true,
+      clicked: {
+        value: value,
+        column: column,
+        origin: {
+          rowIndex: 0,
+          row: [value],
+          cols: [column],
         },
-      ],
-    },
-    ...overrides,
+        data: [
+          {
+            value: value,
+            col: column,
+          },
+        ],
+      },
+      ...overrides,
+    };
+    render(<>{formatValue(value, options)}</>);
   };
-  render(<>{formatValue(value, options)}</>);
-};
 
-describe("link", () => {
-  it("should not apply prefix or suffix more than once for links with no link_text", () => {
-    setup(23.12, {
-      view_as: "link",
-      prefix: "foo ",
-      suffix: " bar",
-      link_url: "http://google.ca",
+  describe("link", () => {
+    it("should not apply prefix or suffix more than once for links with no link_text", () => {
+      setup(23.12, {
+        view_as: "link",
+        prefix: "foo ",
+        suffix: " bar",
+        link_url: "http://google.ca",
+      });
+      expect(
+        screen.getByText((content) => content.startsWith("foo")),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText((content) => content.endsWith("bar")),
+      ).toBeInTheDocument();
+      expect(screen.getByText("23.12")).toBeInTheDocument();
     });
-    expect(
-      screen.getByText((content) => content.startsWith("foo")),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText((content) => content.endsWith("bar")),
-    ).toBeInTheDocument();
-    expect(screen.getByText("23.12")).toBeInTheDocument();
+
+    it("should not apply prefix or suffix to null values", () => {
+      setup(null, {
+        prefix: "foo ",
+        suffix: " bar",
+      });
+
+      const anyContent = screen.queryByText(/./);
+      expect(anyContent).not.toBeInTheDocument();
+    });
+
+    it("should trim values to specified decimals", () => {
+      setup(23.123459, {
+        decimals: 5,
+        number_style: "decimal",
+        number_separators: ".",
+      });
+      expect(screen.getByText("23.12346")).toBeInTheDocument();
+    });
+
+    it("should preserve number separator formatting when displayed as a link with no URL set", () => {
+      setup(100000.0, {
+        view_as: "link",
+        number_style: "decimal",
+        number_separators: ".,",
+      });
+      expect(screen.getByText("100,000")).toBeInTheDocument();
+    });
+
+    it("should preserve number separator formatting when displayed as a link with a custom URL", () => {
+      setup(100000.0, {
+        view_as: "link",
+        number_style: "decimal",
+        number_separators: ".,",
+        link_url: "http://example.com",
+      });
+      expect(screen.getByText("100,000")).toBeInTheDocument();
+    });
   });
 
-  it("should not apply prefix or suffix to null values", () => {
-    setup(null, {
-      prefix: "foo ",
-      suffix: " bar",
-    });
+  describe("remapped column", () => {
+    it("should apply formatting settings", () => {
+      const column = createMockColumn({
+        base_type: "type/Float",
+        remapped_to_column: createMockColumn({
+          base_type: "type/Text",
+        }),
+        remapping: new Map([
+          [1, "One"],
+          [2, "2"],
+          [3, "Three"],
+        ]),
+      } as any);
+      setup(1, { column, scale: 100 });
+      expect(screen.getByText("One")).toBeInTheDocument();
 
-    const anyContent = screen.queryByText(/./);
-    expect(anyContent).not.toBeInTheDocument();
-  });
-
-  it("should trim values to specified decimals", () => {
-    setup(23.123459, {
-      decimals: 5,
-      number_style: "decimal",
-      number_separators: ".",
+      setup(2, { column, scale: 100 });
+      expect(screen.getByText("200")).toBeInTheDocument();
     });
-    expect(screen.getByText("23.12346")).toBeInTheDocument();
-  });
-
-  it("should preserve number separator formatting when displayed as a link with no URL set", () => {
-    setup(100000.0, {
-      view_as: "link",
-      number_style: "decimal",
-      number_separators: ".,",
-    });
-    expect(screen.getByText("100,000")).toBeInTheDocument();
-  });
-
-  it("should preserve number separator formatting when displayed as a link with a custom URL", () => {
-    setup(100000.0, {
-      view_as: "link",
-      number_style: "decimal",
-      number_separators: ".,",
-      link_url: "http://example.com",
-    });
-    expect(screen.getByText("100,000")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #17427
Closes [VIZ-46: Number format settings incorrectly show for remapped columns](https://linear.app/metabase/issue/VIZ-46/number-format-settings-incorrectly-show-for-remapped-columns)

### Description

An attempt at treating remapped values as typed by their original column, so the formatting settings can be applied to them.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
