### PR TITLE
Batched requests to OpenAI for fetching vector embeddings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -56,6 +56,7 @@
   com.h2database/h2                         ^:antq/exclude                      ; https://metaboat.slack.com/archives/CKZEMT1MJ/p1727191010259979
                                             {:mvn/version "2.1.214"}            ; embedded SQL database
   com.ibm.icu/icu4j                         {:mvn/version "77.1"}               ; Used to transliterate Unicode characters into Latin characters
+  com.knuddels/jtokkit                      {:mvn/version "1.1.0"}              ; Java tokenizer library for OpenAI models, used for token counting in semantic search
   com.mchange/c3p0                          {:mvn/version "0.10.1"}             ; DB connection pool
   com.snowplowanalytics/snowplow-java-tracker ^:antq/exclude                    ; 2+ depend on apache httpclient 5.x, but saml and clj-http depend on 4.x
   {:mvn/version "1.0.1"}              ; Snowplow analytics

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -73,14 +73,14 @@
                    :else
                    (assoc acc
                           :current-batch (conj current-batch text)
-                          :current-tokens (+ current-tokens tokens)))))]
-    (let [{:keys [batches current-batch]}
-          (reduce step
-                  {:current-batch [] :current-tokens 0 :batches []}
-                  texts)]
-      (if (seq current-batch)
-        (conj batches current-batch)
-        batches))))
+                          :current-tokens (+ current-tokens tokens)))))
+        {:keys [batches current-batch]}
+        (reduce step
+                {:current-batch [] :current-tokens 0 :batches []}
+                texts)]
+    (if (seq current-batch)
+      (conj batches current-batch)
+      batches)))
 
 (defn- default-model-for-provider
   "Get the default model for a given provider."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -4,6 +4,8 @@
    [metabase-enterprise.semantic-search.embedding :as embedding]
    [metabase.test :as mt]))
 
+(set! *warn-on-reflection* true)
+
 (deftest test-get-provider
   (testing "get-provider returns correct provider based on setting"
     (mt/with-temporary-setting-values [ee-embedding-provider "ollama"]
@@ -90,4 +92,42 @@
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"OpenAI API key not configured"
-             (embedding/-get-embedding provider "test text")))))))
+             (embedding/-get-embedding provider "test text")))
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"OpenAI API key not configured"
+             (embedding/-get-embeddings-batch provider ["test text"])))))))
+
+(deftest test-token-counting
+  (testing "count-tokens returns reasonable counts for text"
+    (is (= 2 (#'embedding/count-tokens "Hello world")))
+    (is (= 9 (#'embedding/count-tokens "This is a longer sentence with more tokens.")))
+    (is (zero? (#'embedding/count-tokens "")))
+    (is (nil? (#'embedding/count-tokens nil)))))
+
+(deftest test-batching-logic
+  (testing "create-batches handles empty input"
+    (is (empty? (#'embedding/create-batches [])))
+    (is (empty? (#'embedding/create-batches nil))))
+
+  (testing "create-batches with single short text"
+    (let [texts ["Short text"]
+          batches (#'embedding/create-batches texts)]
+      (is (= 1 (count batches)))
+      (is (= texts (first batches)))))
+
+  (testing "create-batches splits texts appropriately with smaller token limit"
+    ;; Use a smaller token limit to make testing more predictable
+    (binding [embedding/*max-tokens-per-batch* 10]
+      ;; Create texts that would exceed the smaller token limit if combined
+      (let [texts ["This is document 1" "This is document 2" "This is document 3"]
+            batches (#'embedding/create-batches texts)]
+        (is (= [["This is document 1" "This is document 2"] ["This is document 3"]]
+               batches)))))
+
+  (testing "create-batches skips texts that exceed token limit"
+    (binding [embedding/*max-tokens-per-batch* 5]
+      (let [texts ["Short" "This is a much longer text that exceeds the limit" "Also short"]
+            batches (#'embedding/create-batches texts)]
+        ;; Should skip the long text and batch the short ones
+        (is (= [["Short" "Also short"]] batches))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -50,6 +50,11 @@
   [text]
   (get mock-embeddings text [0.01 0.02 0.03 0.04]))
 
+(defn get-mock-embeddings-batch
+  "Lookup embeddings for multiple texts in [[mock-embeddings]]."
+  [texts]
+  (mapv get-mock-embedding texts))
+
 (def mock-documents
   [{:model "card"
     :id "123"
@@ -78,7 +83,7 @@
   #_:clj-kondo/ignore
   `(with-redefs [semantic.embedding/model-dimensions (constantly 4)
                  semantic.embedding/pull-model (constantly nil)
-                 semantic.embedding/get-embedding get-mock-embedding]
+                 semantic.embedding/get-embeddings-batch get-mock-embeddings-batch]
      ~@body))
 
 (defmacro with-temp-index-table! [& body]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -83,7 +83,8 @@
   #_:clj-kondo/ignore
   `(with-redefs [semantic.embedding/model-dimensions (constantly 4)
                  semantic.embedding/pull-model (constantly nil)
-                 semantic.embedding/get-embeddings-batch get-mock-embeddings-batch]
+                 semantic.embedding/get-embeddings-batch get-mock-embeddings-batch
+                 semantic.embedding/get-embedding get-mock-embedding]
      ~@body))
 
 (defmacro with-temp-index-table! [& body]


### PR DESCRIPTION
* Adds a new dependency on https://github.com/knuddelsgmbh/jtokkit for counting tokens in text while batching to ensure we don't go over the OpenAI API limit
* Performs batched requests to generate embeddings when using OpenAI (it's [coming soon for ollama](https://ollama.com/blog/embedding-models) apparently)
* Separates out embedding generation from DB insertion, so that they're separate processes and have independent batching logic 

resolves https://linear.app/metabase/issue/BOT-251/batched-embedding-requests