### PR TITLE
feat: auto assign jwt users to groups by name 

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -15,7 +15,8 @@
    [metabase.sso.core :as sso]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [ring.util.response :as response])
+   [ring.util.response :as response]
+   [toucan2.core :as t2])
   (:import
    (java.net URLEncoder)))
 

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -248,6 +248,15 @@
      :clean-continue-url clean-continue-url
      :origin origin}))
 
+(defn- filter-non-string-attributes
+  [attrs]
+  (->> attrs
+       (filter (fn [[key value]]
+                 (if (string? value)
+                   value
+                   (log/warnf "Dropping SAML attribute '%s' with non-string value: %s" (name key) value))))
+       (into {})))
+
 (defmethod sso.i/sso-post :saml
   ;; Does the verification of the IDP's response and 'logs the user in'. The attributes are available in the response:
   ;; `(get-in saml-info [:assertions :attrs])
@@ -289,7 +298,7 @@
                             :last-name       last-name
                             :email           email
                             :group-names     groups
-                            :user-attributes attrs
+                            :user-attributes (filter-non-string-attributes attrs)
                             :device-info     (request/device-info request)})
             response      (response/redirect (or continue-url (system/site-url)))]
         (if token-value

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -344,7 +344,8 @@
                    :id           true
                    :last_name    "User"
                    :date_joined  true
-                   :common_name  "New User"}
+                   :common_name  "New User"
+                   :tenant_id    false}
                   (-> (mt/boolean-ids-and-timestamps [new-user])
                       first
                       (dissoc :last_login)))))
@@ -387,7 +388,8 @@
                   :id           true
                   :last_name    nil
                   :date_joined  true
-                  :common_name  "newuser@metabase.com"}]
+                  :common_name  "newuser@metabase.com"
+                  :tenant_id    false}]
                 (->>
                  (mt/boolean-ids-and-timestamps (t2/select :model/User :email "newuser@metabase.com"))
                  (map #(dissoc % :last_login)))))))
@@ -411,7 +413,8 @@
                   :id           true
                   :last_name    "User"
                   :date_joined  true
-                  :common_name  "New User"}]
+                  :common_name  "New User"
+                  :tenant_id    false}]
                 (->>
                  (mt/boolean-ids-and-timestamps (t2/select :model/User :email "newuser@metabase.com"))
                  (map #(dissoc % :last_login))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -344,8 +344,7 @@
                    :id           true
                    :last_name    "User"
                    :date_joined  true
-                   :common_name  "New User"
-                   :tenant_id    false}
+                   :common_name  "New User"}
                   (-> (mt/boolean-ids-and-timestamps [new-user])
                       first
                       (dissoc :last_login)))))
@@ -388,8 +387,7 @@
                   :id           true
                   :last_name    nil
                   :date_joined  true
-                  :common_name  "newuser@metabase.com"
-                  :tenant_id    false}]
+                  :common_name  "newuser@metabase.com"}]
                 (->>
                  (mt/boolean-ids-and-timestamps (t2/select :model/User :email "newuser@metabase.com"))
                  (map #(dissoc % :last_login)))))))
@@ -413,8 +411,7 @@
                   :id           true
                   :last_name    "User"
                   :date_joined  true
-                  :common_name  "New User"
-                  :tenant_id    false}]
+                  :common_name  "New User"}]
                 (->>
                  (mt/boolean-ids-and-timestamps (t2/select :model/User :email "newuser@metabase.com"))
                  (map #(dissoc % :last_login))))))))))))
@@ -621,36 +618,6 @@
 
           (testing "no warning for valid string attribute"
             (is (not (some #(re-find #"string_attr" %) (map :message (jwt-log-messages)))))))))))
-
-(deftest jwt-tenant-user-assigned-to-external-users-group-test
-  (testing "JWT user with tenant attribute is assigned to All External Users group when tenants are enabled"
-    (with-jwt-default-setup!
-      (mt/with-additional-premium-features #{:tenants}
-        (mt/with-temporary-setting-values [use-tenants true]
-          (mt/with-temp [:model/Tenant {tenant-id :id} {:slug "external-tenant"
-                                                        :name "External Tenant"}]
-            (with-users-with-email-deleted "tenant-user@metabase.com"
-              (let [response (client/client-real-response :get 302 "/auth/sso"
-                                                          {:request-options {:redirect-strategy :none}}
-                                                          :return_to default-redirect-uri
-                                                          :jwt
-                                                          (jwt/sign
-                                                           {:email      "tenant-user@metabase.com"
-                                                            :first_name "Tenant"
-                                                            :last_name  "User"
-                                                            :tenant     "external-tenant"}
-                                                           default-jwt-secret))]
-                (is (saml-test/successful-login? response))
-
-                (testing "user is assigned to All External Users group"
-                  (let [user-groups (group-memberships
-                                     (u/the-id (t2/select-one-pk :model/User :email "tenant-user@metabase.com")))]
-                    (is (not (contains? user-groups "All Users")))
-                    (is (contains? user-groups "All External Users"))))
-
-                (testing "user has correct tenant_id"
-                  (is (= tenant-id
-                         (t2/select-one-fn :tenant_id :model/User :email "tenant-user@metabase.com"))))))))))))
 
 (deftest jwt-token-test
   (testing "should return IdP URL when embedding SDK header is present but no JWT token is provided"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -112,7 +112,9 @@
 (defn successful-login?
   "Return true if the response indicates a successful user login"
   [resp]
-  (string? (get-in resp [:cookies request/metabase-session-cookie :value])))
+  (or
+   (string? (get-in resp [:cookies request/metabase-session-cookie :value]))
+   (some #(str/starts-with? % request/metabase-session-cookie) (get-in resp [:headers "Set-Cookie"]))))
 
 (defn- do-with-some-validators-disabled!
   "The sample responses all have `InResponseTo=\"_1\"` and invalid assertion signatures (they were edited by hand) so
@@ -545,7 +547,7 @@
          (with-saml-default-setup!
            (try
              (is (not (t2/exists? :model/User :%lower.email "newuser@metabase.com")))
-            ;; login with a user with no givenname or surname attributes
+             ;; login with a user with no givenname or surname attributes
              (let [req-options (saml-post-request-options (new-user-no-names-saml-test-response)
                                                           default-redirect-uri)]
                (is (successful-login? (client/client-real-response :post 302 "/auth/sso" req-options)))
@@ -560,7 +562,7 @@
                         :tenant_id    false}]
                       (->> (mt/boolean-ids-and-timestamps (t2/select :model/User :email "newuser@metabase.com"))
                            (map #(dissoc % :last_login))))))
-            ;; login with the same user, but now givenname and surname attributes exist
+             ;; login with the same user, but now givenname and surname attributes exist
              (let [req-options (saml-post-request-options (new-user-saml-test-response)
                                                           default-redirect-uri)]
                (is (successful-login? (client/client-real-response :post 302 "/auth/sso" req-options)))
@@ -695,7 +697,7 @@
   (testing "Redirect URL (RelayState) should work correctly end-to-end (#13666)"
     (with-other-sso-types-disabled!
       (with-saml-default-setup!
-      ;; The test HTTP client will automatically URL encode these for us.
+        ;; The test HTTP client will automatically URL encode these for us.
         (doseq [redirect-url ["http://localhost:3001/collection/root"
                               default-redirect-uri
                               "http://localhost:3001/"]]
@@ -775,7 +777,7 @@
               (let [req-options (-> (saml-post-request-options
                                      (saml-slo-test-response)
                                      default-redirect-uri)
-                              ;; Client sends their session cookie during the SLO request redirect from the IDP.
+                                    ;; Client sends their session cookie during the SLO request redirect from the IDP.
                                     (assoc-in [:request-options :cookies request/metabase-session-cookie :value] session-key))
                     response    (client/client-real-response :post 302 "/auth/sso/handle_slo" req-options)]
                 (is (str/blank? (get-in response [:cookies request/metabase-session-cookie :value]))
@@ -796,7 +798,7 @@
               (let [req-options (-> (saml-post-request-options
                                      (saml-slo-test-response)
                                      default-redirect-uri)
-                                  ;; Client sends their session cookie during the SLO request redirect from the IDP.
+                                    ;; Client sends their session cookie during the SLO request redirect from the IDP.
                                     (assoc-in [:request-options :cookies request/metabase-session-cookie :value] session-key))
                     response    (client/client-real-response :post 403 "/auth/sso/handle_slo" req-options)]
                 (is (str/blank? (get-in response [:cookies request/metabase-session-cookie :value]))
@@ -893,3 +895,39 @@
                            response))
              (is (str/includes? (:body response) "SAML_AUTH_COMPLETE"))
              (is (str/includes? (:body response) "authData")))))))))
+
+(deftest non-string-saml-attributes-dropped-test
+  (testing "SAML attributes with non-string values are dropped"
+    (with-other-sso-types-disabled!
+      (with-saml-default-setup!
+        (do-with-some-validators-disabled!
+         (fn []
+           ;; Mock the saml-response->attributes function to return mixed attribute types
+           (with-redefs [saml.mt/saml-response->attributes
+                         (fn [_]
+                           {"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" "rasta@metabase.com"
+                            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" "Rasta"
+                            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" "Toucan"
+                            "string_attr" "valid-string"
+                            "number_attr" 42
+                            "boolean_attr" true
+                            "array_attr" ["item1" "item2"]
+                            "object_attr" {:nested "value"}
+                            "null_attr" nil})]
+             (let [req-options (saml-post-request-options (saml-test-response)
+                                                          default-redirect-uri)
+                   response    (client/client-real-response :post 302 "/auth/sso" req-options)]
+               (is (successful-login? response))
+
+               ;; Doesn't test the warning message because there are issues setting up log capture with client-real-response
+               ;; and client-full-response doesn't work with the saml lib
+
+               (testing "only string attributes are saved to login_attributes"
+                 (let [user-attrs (t2/select-one-fn :login_attributes :model/User :email "rasta@metabase.com")]
+                   (is (contains? user-attrs "string_attr"))
+                   (is (= "valid-string" (get user-attrs "string_attr")))
+                   (is (not (contains? user-attrs "number_attr")))
+                   (is (not (contains? user-attrs "boolean_attr")))
+                   (is (not (contains? user-attrs "array_attr")))
+                   (is (not (contains? user-attrs "object_attr")))
+                   (is (not (contains? user-attrs "null_attr")))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -518,8 +518,7 @@
                          :id           true
                          :last_name    "User"
                          :date_joined  true
-                         :common_name  "New User"
-                         :tenant_id    false}
+                         :common_name  "New User"}
                         (-> (mt/boolean-ids-and-timestamps new-user)
                             (dissoc :last_login))))
                  (testing "User Invite Event is logged."
@@ -558,8 +557,7 @@
                         :id           true
                         :last_name    nil
                         :date_joined  true
-                        :common_name  "newuser@metabase.com"
-                        :tenant_id    false}]
+                        :common_name  "newuser@metabase.com"}]
                       (->> (mt/boolean-ids-and-timestamps (t2/select :model/User :email "newuser@metabase.com"))
                            (map #(dissoc % :last_login))))))
              ;; login with the same user, but now givenname and surname attributes exist
@@ -573,8 +571,7 @@
                         :id           true
                         :last_name    "User"
                         :date_joined  true
-                        :common_name  "New User"
-                        :tenant_id    false}]
+                        :common_name  "New User"}]
                       (->> (mt/boolean-ids-and-timestamps (t2/select :model/User :email "newuser@metabase.com"))
                            (map #(dissoc % :last_login))))))
              (finally

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -518,7 +518,8 @@
                          :id           true
                          :last_name    "User"
                          :date_joined  true
-                         :common_name  "New User"}
+                         :common_name  "New User"
+                         :tenant_id    false}
                         (-> (mt/boolean-ids-and-timestamps new-user)
                             (dissoc :last_login))))
                  (testing "User Invite Event is logged."
@@ -557,7 +558,8 @@
                         :id           true
                         :last_name    nil
                         :date_joined  true
-                        :common_name  "newuser@metabase.com"}]
+                        :common_name  "newuser@metabase.com"
+                        :tenant_id    false}]
                       (->> (mt/boolean-ids-and-timestamps (t2/select :model/User :email "newuser@metabase.com"))
                            (map #(dissoc % :last_login))))))
              ;; login with the same user, but now givenname and surname attributes exist
@@ -571,7 +573,8 @@
                         :id           true
                         :last_name    "User"
                         :date_joined  true
-                        :common_name  "New User"}]
+                        :common_name  "New User"
+                        :tenant_id    false}]
                       (->> (mt/boolean-ids-and-timestamps (t2/select :model/User :email "newuser@metabase.com"))
                            (map #(dissoc % :last_login))))))
              (finally

--- a/src/metabase/sso/common.clj
+++ b/src/metabase/sso/common.clj
@@ -8,44 +8,59 @@
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
+(defn- excluded-group-ids
+  []
+  #{(u/the-id (perms/all-users-group))
+    (u/the-id (perms/all-external-users-group))})
+
+(defn- sync-group-memeberships*!
+  [user-or-id to-remove to-add]
+  (when (seq to-remove)
+    (log/debugf "Removing user %s from group(s) %s" (u/the-id user-or-id) to-remove)
+    (try
+      (perms/remove-user-from-groups! user-or-id to-remove)
+      (catch clojure.lang.ExceptionInfo e
+        ;; in case sync attempts to delete the last admin, the pre-delete hooks of
+        ;; [[metabase.permissions.models.permissions-group-membership/PermissionsGroupMembership]] will throw an exception.
+        ;; but we don't want to block user from logging-in, so catch this exception and log a warning
+        (if (= (ex-message e) (str perms/fail-to-remove-last-admin-msg))
+          (log/warn "Attempted to remove the last admin during group sync!"
+                    "Check your SSO group mappings and make sure the Administrators group is mapped correctly.")
+          ;; Raise an error rather than swallowing it since it's worse to leave a user with more permissions than we expect them have
+          (throw e)))))
+  ;; When adding a user to a group we want to allow individual adds to fail with exceptions
+  ;; that we will log
+  (doseq [group-or-id to-add]
+    (log/debugf "Adding user %s to group %s" (u/the-id user-or-id) (u/the-id group-or-id))
+    (try
+      (perms/add-user-to-group! user-or-id group-or-id)
+      (catch Throwable e
+        (log/errorf e "Error adding user %s to group %s" (u/the-id user-or-id) (u/the-id group-or-id))))))
+
 (defn sync-group-memberships!
   "Update the PermissionsGroups a User belongs to, adding or deleting membership entries as needed so that Users is
-  only in `new-groups-or-ids`. Ignores special groups like `all-users`, and only touches groups with mappings set."
-  [user-or-id new-groups-or-ids mapped-groups-or-ids]
-  (let [mapped-group-ids   (set (map u/the-id mapped-groups-or-ids))
-        excluded-group-ids #{(u/the-id (perms/all-users-group))}
-        user-id            (u/the-id user-or-id)
-        current-group-ids  (when (seq mapped-group-ids)
-                             (t2/select-fn-set :group_id :model/PermissionsGroupMembership
-                                               {:where
-                                                [:and
-                                                 [:= :user_id user-id]
-                                                 [:in :group_id mapped-group-ids]
-                                                 [:not-in :group_id excluded-group-ids]]}))
-        new-group-ids      (set/intersection (set (map u/the-id new-groups-or-ids))
-                                             mapped-group-ids)
-        ;; determine what's different between current mapped groups and new mapped groups
-        [to-remove to-add] (data/diff current-group-ids new-group-ids)]
-    ;; remove membership from any groups as needed
-    (when (seq to-remove)
-      (log/debugf "Removing user %s from group(s) %s" user-id to-remove)
-      (try
-        (t2/delete! :model/PermissionsGroupMembership :group_id [:in to-remove], :user_id user-id)
-        (catch clojure.lang.ExceptionInfo e
-         ;; in case sync attempts to delete the last admin, the pre-delete hooks of
-         ;; [[metabase.permissions.models.permissions-group-membership/PermissionsGroupMembership]] will throw an exception.
-         ;; but we don't want to block user from logging-in, so catch this exception and log a warning
-          (if (= (ex-message e) (str perms/fail-to-remove-last-admin-msg))
-            (log/warn "Attempted to remove the last admin during group sync!"
-                      "Check your SSO group mappings and make sure the Administrators group is mapped correctly.")
-            (throw e)))))
-    ;; add new memberships for any groups as needed
-    (doseq [id    to-add
-            :when (not (excluded-group-ids id))]
-      (log/debugf "Adding user %s to group %s" user-id id)
-      ;; if adding membership fails for one reason or another (i.e. if the group doesn't exist) log the error add the
-      ;; user to the other groups rather than failing entirely
-      (try
-        (perms/add-user-to-group! user-id id)
-        (catch Throwable e
-          (log/errorf e "Error adding User %s to Group %s" user-id id))))))
+  only in `new-groups-or-ids`. Ignores special groups like `all-users`, and only optionally only touches groups with mappings set."
+  ([user-or-id new-groups-or-ids]
+   (sync-group-memberships! user-or-id new-groups-or-ids nil)
+   (let [current-group-ids  (t2/select-fn-set :group_id :model/PermissionsGroupMembership
+                                              {:where
+                                               [:and
+                                                [:= :user_id  (u/the-id user-or-id)]
+                                                [:not-in :group_id (excluded-group-ids)]]})
+         [to-remove to-add] (data/diff current-group-ids (set/difference (set (map u/the-id new-groups-or-ids))
+                                                                         (excluded-group-ids)))]
+     (sync-group-memeberships*! user-or-id to-remove to-add)))
+  ([user-or-id new-groups-or-ids mapped-groups-or-ids]
+   (let [mapped-group-ids   (set (map u/the-id mapped-groups-or-ids))
+         current-group-ids  (when (seq mapped-group-ids)
+                              (t2/select-fn-set :group_id :model/PermissionsGroupMembership
+                                                {:where
+                                                 [:and
+                                                  [:= :user_id (u/the-id user-or-id)]
+                                                  [:in :group_id mapped-group-ids]
+                                                  [:not-in :group_id (excluded-group-ids)]]}))
+         new-group-ids      (-> (set (map u/the-id new-groups-or-ids))
+                                (set/intersection mapped-group-ids)
+                                (set/difference (excluded-group-ids)))
+         [to-remove to-add] (data/diff current-group-ids new-group-ids)]
+     (sync-group-memeberships*! user-or-id to-remove to-add))))

--- a/src/metabase/sso/common.clj
+++ b/src/metabase/sso/common.clj
@@ -12,7 +12,7 @@
   []
   #{(u/the-id (perms/all-users-group))})
 
-(defn- sync-group-memeberships*!
+(defn- sync-group-memberships*!
   [user-or-id to-remove to-add]
   (when (seq to-remove)
     (log/debugf "Removing user %s from group(s) %s" (u/the-id user-or-id) to-remove)
@@ -40,7 +40,6 @@
   "Update the PermissionsGroups a User belongs to, adding or deleting membership entries as needed so that Users is
   only in `new-groups-or-ids`. Ignores special groups like `all-users`, and only optionally only touches groups with mappings set."
   ([user-or-id new-groups-or-ids]
-   (sync-group-memberships! user-or-id new-groups-or-ids nil)
    (let [current-group-ids  (t2/select-fn-set :group_id :model/PermissionsGroupMembership
                                               {:where
                                                [:and
@@ -48,7 +47,7 @@
                                                 [:not-in :group_id (excluded-group-ids)]]})
          [to-remove to-add] (data/diff current-group-ids (set/difference (set (map u/the-id new-groups-or-ids))
                                                                          (excluded-group-ids)))]
-     (sync-group-memeberships*! user-or-id to-remove to-add)))
+     (sync-group-memberships*! user-or-id to-remove to-add)))
   ([user-or-id new-groups-or-ids mapped-groups-or-ids]
    (let [mapped-group-ids   (set (map u/the-id mapped-groups-or-ids))
          current-group-ids  (when (seq mapped-group-ids)
@@ -62,4 +61,4 @@
                                 (set/intersection mapped-group-ids)
                                 (set/difference (excluded-group-ids)))
          [to-remove to-add] (data/diff current-group-ids new-group-ids)]
-     (sync-group-memeberships*! user-or-id to-remove to-add))))
+     (sync-group-memberships*! user-or-id to-remove to-add))))

--- a/src/metabase/sso/common.clj
+++ b/src/metabase/sso/common.clj
@@ -10,8 +10,7 @@
 
 (defn- excluded-group-ids
   []
-  #{(u/the-id (perms/all-users-group))
-    (u/the-id (perms/all-external-users-group))})
+  #{(u/the-id (perms/all-users-group))})
 
 (defn- sync-group-memeberships*!
   [user-or-id to-remove to-add]


### PR DESCRIPTION
### Description

Two parts:

1. We expect login_attributes to only be strings. When they are created through SAML or JWT logins we don't actually enforce this, so this filters out non-string attributes printing a warning message if they are passed for these login types.
2. When group sync is turned on and there are no group mappings defined for the jwt integration, we should assign users to groups in the groups claim by matching metabase groups by name. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
