### PR TITLE
Remove transaction from batched semantic search index updates

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -19,21 +19,21 @@
           ;; with-temp-index-table! creates the temp table, so drop it in order to test create!.
           (semantic.index/drop-index-table!)
           (testing "index table is not present before create!"
-            (is (not (semantic.tu/table-exists-in-db?! semantic.index/*index-table-name*))))
+            (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))))
           (testing "index table is present after create!"
             (semantic.index/create-index-table! {:force-reset? false})
-            (is (semantic.tu/table-exists-in-db?! semantic.index/*index-table-name*)))))))
+            (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))))))
 
 #_(deftest drop-index-table!-test
     (mt/with-premium-features #{:semantic-search}
       (semantic.tu/with-mocked-embeddings!
         (semantic.tu/with-temp-index-table!
-        ;; with-temp-index-table! creates the temp table
+          ;; with-temp-index-table! creates the temp table
           (testing "index table is present before drop!"
-            (is (semantic.tu/table-exists-in-db?! semantic.index/*index-table-name*)))
+            (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))
           (testing "index table is not present after drop!"
             (semantic.index/drop-index-table!)
-            (is (not (semantic.tu/table-exists-in-db?! semantic.index/*index-table-name*))))))))
+            (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))))))))
 
 (defn- decode-embedding
   "Decode `row`s `:embedding`."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -161,7 +161,7 @@
        (search.core/reindex! :search.engine/semantic {:force-reset true})
        ~@body)))
 
-(defn table-exists-in-db?!
+(defn table-exists-in-db?
   "Check if a table actually exists in the database"
   [table-name]
   (when table-name


### PR DESCRIPTION
### Description

Small follow-ups from #61117

https://github.com/metabase/metabase/pull/61117#discussion_r2216328661

* Drop uneccessary ! from table-exists-in-db?!
* Don't wrap batched index updates in a transaction
