### PR TITLE
🤖 backported "Ensure postgres downloads don't OOM" (#61170)

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -18,6 +18,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.expression.temporal :as lib.schema.expression.temporal]
+   [metabase.lib.schema.info :as lib.schema.info]
    [metabase.models.setting :refer [defsetting]]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -52,7 +53,8 @@
     ;; a string like 'US/Pacific' or something like that.
     [:session-timezone {:optional true} [:maybe [:ref ::lib.schema.expression.temporal/timezone-id]]]
     ;; whether this Connection should NOT be read-only, e.g. for DDL stuff or inserting data or whatever.
-    [:write? {:optional true} [:maybe :boolean]]]])
+    [:write? {:optional true} [:maybe :boolean]]
+    [:download? {:optional true} [:maybe :boolean]]]])
 
 (defmulti do-with-connection-with-options
   "Fetch a [[java.sql.Connection]] from a `driver`/`db-or-id-or-spec`, and invoke
@@ -376,12 +378,23 @@
     ;; TODO -- for `write?` connections, we should probably disable autoCommit and then manually call `.commit` at after
     ;; `f`... we need to check and make sure that won't mess anything up, since some existing code is already doing it
     ;; manually. (metabase#40014)
-    (when-not write?
-      (try
-        (log/trace (pr-str '(.setAutoCommit conn true)))
-        (.setAutoCommit conn true)
-        (catch Throwable e
-          (log/debug e "Error enabling connection autoCommit"))))
+    (cond (not (or write?
+                   (and (-> options :download?) (= driver :postgres))))
+          (try
+            (log/trace (pr-str '(.setAutoCommit conn true)))
+            (.setAutoCommit conn true)
+            (catch Throwable e
+              (log/debug e "Error enabling connection autoCommit")))
+
+          ;; todo (dan 7/11/25): fixing straightforward postgres oom on downloads in #60733, but seems like write? is
+          ;; not set here. Note this is explicitly silent when `write?`. Lots of tests fail with autocommit false
+          ;; there.
+          (and (-> options :download?) (isa? driver/hierarchy driver :postgres))
+          (try
+            (log/trace (pr-str '(.setAutoCommit conn false)))
+            (.setAutoCommit conn false)
+            (catch Throwable e
+              (log/debug e "Error setting connection autoCommit to false"))))
     (try
       (log/trace (pr-str '(.setHoldability conn ResultSet/CLOSE_CURSORS_AT_COMMIT)))
       (.setHoldability conn ResultSet/CLOSE_CURSORS_AT_COMMIT)
@@ -721,53 +734,58 @@
   [_ sql remark]
   (str "-- " remark "\n" sql))
 
+(mu/defn- download? :- :boolean
+  [context :- [:maybe ::lib.schema.info/context]]
+  (let [download-contexts #{:csv-download :xlsx-download :json-download
+                            :public-csv-download :public-xlsx-download :public-json-download
+                            :embedded-csv-download :embedded-xlsx-download :embedded-json-download}]
+    (boolean (download-contexts context))))
+
 (defn execute-reducible-query
   "Default impl of [[metabase.driver/execute-reducible-query]] for sql-jdbc drivers."
-  {:added "0.35.0", :arglists '([driver query context respond] [driver sql params max-rows context respond])}
-  ([driver {{sql :query, params :params} :native, :as outer-query} context respond]
-   {:pre [(string? sql) (seq sql)]}
-   (let [database (lib.metadata/database (qp.store/metadata-provider))
-         sql      (if (get-in database [:details :include-user-id-and-hash] true)
-                    (->> (qp.util/query->remark driver outer-query)
-                         (inject-remark driver sql))
-                    sql)
-         max-rows (limit/determine-query-max-rows outer-query)]
-     (execute-reducible-query driver sql params max-rows context respond)))
-
-  ([driver sql params max-rows _context respond]
-   (do-with-connection-with-options
-    driver
-    (lib.metadata/database (qp.store/metadata-provider))
-    {:session-timezone (qp.timezone/report-timezone-id-if-supported driver (lib.metadata/database (qp.store/metadata-provider)))}
-    (fn [^Connection conn]
-      (with-open [stmt          (statement-or-prepared-statement driver conn sql params qp.pipeline/*canceled-chan*)
-                  ^ResultSet rs (try
-                                  (execute-statement-or-prepared-statement! driver stmt max-rows params sql)
-                                  (catch Throwable e
-                                    (throw (ex-info (tru "Error executing query: {0}" (ex-message e))
-                                                    {:driver driver
-                                                     :sql    (str/split-lines (driver/prettify-native-form driver sql))
-                                                     :params params
-                                                     :type   qp.error-type/invalid-query}
-                                                    e))))]
-        (let [rsmeta           (.getMetaData rs)
-              results-metadata {:cols (column-metadata driver rsmeta)}]
-          (try (respond results-metadata (reducible-rows driver rs rsmeta qp.pipeline/*canceled-chan*))
-               ;; Following cancels the statment on the dbms side.
-               ;; It avoids blocking `.close` call, in case we reduced the results subset eg. by means of
-               ;; [[metabase.query-processor.middleware.limit/limit-xform]] middleware, while statment is still
-               ;; in progress. This problem was encountered on Redshift. For details see the issue #39018.
-               ;; It also handles situation where query is canceled through [[qp.pipeline/*canceled-chan*]] (#41448).
-               (finally
-                 ;; TODO: Following `when` is in place just to find out if vertica is flaking because of cancelations.
-                 ;;       It should be removed afterwards!
-                 (when-not (= :vertica driver)
-                   (try (.cancel stmt)
-                        (catch SQLFeatureNotSupportedException _
-                          (log/warnf "Statemet's `.cancel` method is not supported by the `%s` driver."
-                                     (name driver)))
-                        (catch Throwable _
-                          (log/warn "Statement cancelation failed."))))))))))))
+  {:added "0.35.0", :arglists '([driver query context respond])}
+  [driver {{sql :query, params :params} :native, :as outer-query} _context respond]
+  {:pre [(string? sql) (seq sql)]}
+  (let [database (lib.metadata/database (qp.store/metadata-provider))
+        sql      (if (get-in database [:details :include-user-id-and-hash] true)
+                   (->> (qp.util/query->remark driver outer-query)
+                        (inject-remark driver sql))
+                   sql)
+        max-rows (limit/determine-query-max-rows outer-query)]
+    (do-with-connection-with-options
+     driver
+     (lib.metadata/database (qp.store/metadata-provider))
+     {:session-timezone (qp.timezone/report-timezone-id-if-supported driver (lib.metadata/database (qp.store/metadata-provider)))
+      :download? (download? (-> outer-query :info :context))}
+     (fn [^Connection conn]
+       (with-open [stmt          (statement-or-prepared-statement driver conn sql params qp.pipeline/*canceled-chan*)
+                   ^ResultSet rs (try
+                                   (execute-statement-or-prepared-statement! driver stmt max-rows params sql)
+                                   (catch Throwable e
+                                     (throw (ex-info (tru "Error executing query: {0}" (ex-message e))
+                                                     {:driver driver
+                                                      :sql    (str/split-lines (driver/prettify-native-form driver sql))
+                                                      :params params
+                                                      :type   qp.error-type/invalid-query}
+                                                     e))))]
+         (let [rsmeta           (.getMetaData rs)
+               results-metadata {:cols (column-metadata driver rsmeta)}]
+           (try (respond results-metadata (reducible-rows driver rs rsmeta qp.pipeline/*canceled-chan*))
+                 ;; Following cancels the statment on the dbms side.
+                 ;; It avoids blocking `.close` call, in case we reduced the results subset eg. by means of
+                 ;; [[metabase.query-processor.middleware.limit/limit-xform]] middleware, while statment is still
+                 ;; in progress. This problem was encountered on Redshift. For details see the issue #39018.
+                 ;; It also handles situation where query is canceled through [[qp.pipeline/*canceled-chan*]] (#41448).
+                (finally
+                   ;; TODO: Following `when` is in place just to find out if vertica is flaking because of cancelations.
+                   ;;       It should be removed afterwards!
+                  (when-not (= :vertica driver)
+                    (try (.cancel stmt)
+                         (catch SQLFeatureNotSupportedException _
+                           (log/warnf "Statemet's `.cancel` method is not supported by the `%s` driver."
+                                      (name driver)))
+                         (catch Throwable _
+                           (log/warn "Statement cancelation failed."))))))))))))
 
 (defn reducible-query
   "Returns a reducible collection of rows as maps from `db` and a given SQL query. This is similar to [[jdbc/reducible-query]] but reuses the


### PR DESCRIPTION
followons from:
backport of https://github.com/metabase/metabase/pull/60807
into 55 in https://github.com/metabase/metabase/pull/61170
into 53: https://github.com/metabase/metabase/pull/61232

and here, into 54

* Ensure postgres downloads don't OOM (#60807)

* Ensure postgres downloads don't OOM

Fixes https://github.com/metabase/metabase/issues/60733

For performance reasons we set autocommit to true. this has an unfortunate consequence that the postgres driver does not honor batch sizes. We go through a lot of trouble to hook the streaming results of a query to the output stream of the download, but the postgres jdbc driver will realize all rows in memory.

A fast way forward is to set autocommit to false only when `write?` (previous condition) or when executing a postgres download, as reported in https://github.com/metabase/metabase/issues/60733.

How to test:
this is difficult. In CI we use

```clojure
  :ci
  {:jvm-opts ["-Xmx12g"
              "-Xms12g"
```

So hitting a query that would deterministically OOM the instance requires a lot more muscle than we realistically want to use.

I'm running the following tests locally:

```
  :small-ram
  {:jvm-opts ["-Xmx400m"
              "-Xms400m"
              "-Dci=TRUE"]}
```

```clojure
(defn- readable [bytes]
  (cond (nil? bytes)  "0 bytes"
        (zero? bytes) "0 bytes"
        :else
        (let [units ["b" "kb" "mb" "gb" "tb"]
              magnitude   1024.0]
          (loop [[unit & remaining] units
                current (double bytes)]
            (if (and (seq remaining) (> current magnitude))
              (recur remaining (/ current magnitude))
              (format "%.1f %s" current unit))))))

(defn- consume
  [^java.io.InputStream is]
  (let [arr (byte-array 8024)]
    (loop [c 0, gas 5000000]
      (let [r (java.io.InputStream/.read is arr 0 (alength arr))]
        (cond (zero? gas)
              (throw (ex-info "Ran out of gas" {}))
              (neg? r) c
              :else (recur (+ c r) (dec gas)))))))

(deftest large-csv-test
  (mt/test-driver :postgres
    (testing "Postgres can download csvs without holding the entire results in memory #(#60733)"
      (let [large-query "SELECT repeat('x', 2048) FROM generate_series(1, 1000000)"
            result (mt/user-real-request :crowberto :post 200 "dataset/csv"
                                         {:request-options {:as :stream}}
                                         {:query       (mt/native-query
                                                        {:query large-query})
                                          :format_rows true})
            size (consume result)]
        (is (> size 2000000000)
            (format "Only consumed %s but expected ~2gb" (readable size)))))))
```

and then

```
❯ time source pg.env && DRIVERS=postgres clojure -X:dev:test:small-ram :only metabase.driver.postgres-test/large-csv-test

Running QP tests against these drivers: #{:postgres}

LONG TEST in metabase.driver.postgres-test/large-csv-test
Test took 23.358 seconds seconds to run

Ran 1 tests in 32.825 seconds
2 assertions, 0 failures, 0 errors.
{:test 1, :pass 2, :fail 0, :error 0, :type :summary, :duration 32825.099875, :single-threaded 1}
Ran 0 tests in parallel, 1 single-threaded.
Finding and running tests took 40.7 s.
All tests passed.
Running after-run hooks...
```

Why not add these tests now?
We probably should write a full memory regression suite. This is a great candidate for a first one. But it seems silly to run a new CI job with just this one job. Push back if you think i'm wrong.

Another area of pushback:
I took the lazy way when determining if a driver should have autocommit set to false or not: i hardcoded it.

```clojure
(and (-> options :download?) (= driver :postgres))
```

The alternative is some method of a new driver multimethod or driver-supports?. The former feels a bit heavy-weight, the latter feels not quite right since this is almost a non-support and all other jdbc drivers do support it, presumably?

I'm quite open to pushback here and invite comments if you see a better way.

* Can't use an if for write?

You'd think you can use an if here but the previous code used a when and is silent on write?. Lots of tests fail relating to datasets in test setup and uploads. Don't want to debug that in this bug fix context so leaving a todo

* remove old arity metadata. thanks eastwood!

* Don't set autoCommit for all postgres and descendant drivers

```clojure
(ns ^:mb/memory metabase.memory.csv-test
  (:require
   [clojure.test :refer :all]
   [metabase.test :as mt]
   [metabase.driver :as driver]))

(set! *warn-on-reflection* true)

(defn- readable [bytes]
  (cond (nil? bytes)  "0 bytes"
        (zero? bytes) "0 bytes"
        :else
        (let [units ["b" "kb" "mb" "gb" "tb"]
              magnitude   1024.0]
          (loop [[unit & remaining] units
                 current (double bytes)]
            (if (and (seq remaining) (> current magnitude))
              (recur remaining (/ current magnitude))
              (format "%.1f %s" current unit))))))

(defn- consume
  [^java.io.InputStream is]
  (let [arr (byte-array 8024)]
    (loop [c 0, gas 5000000]
      (let [r (java.io.InputStream/.read is arr 0 (alength arr))]
        (cond (zero? gas)
              (throw (ex-info "Ran out of gas" {}))
              (neg? r) c
              :else (recur (+ c r) (dec gas)))))))

(def driver->query
  {:sqlite "WITH RECURSIVE generate_series(value) AS (
  SELECT 1
  UNION ALL
  SELECT value + 1 FROM generate_series WHERE value + 1 <= 1000000
)
SELECT replace(hex(zeroblob(1024)), '00', 'xx') FROM generate_series;"
   :postgres "SELECT repeat('x', 2048) FROM generate_series(1, 1000000)"
   :clickhouse "SELECT repeat('x', 2048)
FROM system.numbers
LIMIT 1000000;"
   :redshift "WITH series AS (
  SELECT ROW_NUMBER() OVER () as i
  FROM stl_scan s1, stl_scan s2
  LIMIT 1000000
)
SELECT REPEAT('x', 2048) FROM series;"})

(deftest large-csv-test
  (mt/test-drivers #{:postgres :sqlite :clickhouse :redshift}
    (testing "Postgres can download csvs without holding the entire results in memory #(#60733)"
      (let [large-query (or (driver->query driver/*driver*)
                            (throw (ex-info "Driver doesn't implement big query"
                                            {:driver driver/*driver*
                                             :available (keys driver->query)})))
            result (mt/user-real-request :crowberto :post 200 "dataset/csv"
                                         {:request-options {:as :stream}}
                                         {:query       (mt/native-query
                                                        {:query large-query})
                                          :format_rows true})
            size (consume result)]
        (is (> size 2000000000)
            (format "Only consumed %s but expected ~2gb" (readable size)))))))

(comment
  (mt/set-test-drivers! #{:postgres})
  (mt/set-test-drivers! #{:sqlite})
  (mt/set-test-drivers! #{:clickhouse})
  (mt/set-test-drivers! #{:redshift})
  (mt/test-drivers #{:redshift}
    (mt/db))

  )

```

Verify this with

```
  :small-ram
  {:jvm-opts ["-Xmx400m"
              "-Xms400m"
              "-Dci=TRUE"]}
```

and then

```
;; driver.env:
;; local clickhouse
export MB_CLICKHOUSE_TEST_password="password"
export MB_CLICKHOUSE_TEST_username="default"

;; local postgres
export MB_POSTGRESQL_TEST_USER=dan

export MB_REDSHIFT_TEST_PASSWORD=<value>
export MB_REDSHIFT_TEST_USER=<value>
export MB_REDSHIFT_TEST_DB=<value>
export MB_REDSHIFT_TEST_HOST=<value>
```

and then running:

```
❯ source driver.env && DRIVERS=redshift clojure -X:dev:test:drivers:drivers-dev:ee:ee-dev:small-ram :only metabase.memory.csv-test/large-csv-test
...
Running tests in metabase.memory.csv-test/large-csv-test
Finding tests took 8.3 s.
Running 1 tests
Running before-run hooks...
Running QP tests against these drivers: #{:redshift}
..
LONG TEST in metabase.memory.csv-test/large-csv-test
Test took 188.320 seconds seconds to run

Ran 1 tests in 188.338 seconds
2 assertions, 0 failures, 0 errors.
{:test 1, :pass 2, :fail 0, :error 0, :type :summary, :duration 188337.678584, :single-threaded 1}
Ran 0 tests in parallel, 1 single-threaded.
Finding and running tests took 3.3 mins.
All tests passed.
Running after-run hooks...
```

redshift takes a while.

contrast with

```
❯ source driver.env && DRIVERS=clickhouse,postgres clojure -X:dev:test:drivers:drivers-dev:ee:ee-dev:small-ram :only metabase.memory.csv-test/large-csv-test
...
Running QP tests against these drivers: #{:postgres :clickhouse}
...
LONG TEST in metabase.memory.csv-test/large-csv-test
Test took 46.638 seconds seconds to run

Ran 1 tests in 46.655 seconds
4 assertions, 0 failures, 0 errors.
{:test 1, :pass 4, :fail 0, :error 0, :type :summary, :duration 46655.436333, :single-threaded 1}
Ran 0 tests in parallel, 1 single-threaded.
Finding and running tests took 56.5 s.
All tests passed.
Running after-run hooks...
```

both running locally happen in ~1 minute compared to 3 minutes for redshift

* Remove commented out old arity

this funciton used to have two arities for clarity. But it wasn't another entrypoint, it was just trying to keep things a bit cleaner. But the result is that at the point where we used the string sql query we didn't have the `info` map in lexical scope. Fixing this across arities would have pushed us into 7 positional args, so you might want to switch to a map, but honestly, it's just the same function.

* actually fix cherry pick errors (largely driver-api namespace issue)

* formatting fix

* fmt

---------

> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
