### PR TITLE
feat: make tenanting attribute editable on FE

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.tsx
@@ -42,6 +42,7 @@ export const SettingsJWTForm = () => {
   const { data: settingValues, isLoading: isLoadingValues } =
     useGetSettingsQuery();
   const { value: jwtEnabled, updateSettings } = useAdminSetting("jwt-enabled");
+  const { value: tenantEnabled } = useAdminSetting("use-tenants");
 
   const handleSubmit = async (values: Partial<JWTFormValues>) => {
     const result = await updateSettings({
@@ -136,6 +137,15 @@ export const SettingsJWTForm = () => {
                       settingDetails?.["jwt-attribute-lastname"],
                     )}
                   />
+                  {tenantEnabled && (
+                    <FormTextInput
+                      name="jwt-attribute-tenant"
+                      label={t`Tenant assignment attribute`}
+                      {...getExtraFormFieldProps(
+                        settingDetails?.["jwt-attribute-tenant"],
+                      )}
+                    />
+                  )}
                 </Stack>
               </FormSection>
               <FormSection
@@ -178,6 +188,7 @@ const getFormValues = (
     "jwt-attribute-email",
     "jwt-attribute-firstname",
     "jwt-attribute-lastname",
+    "jwt-attribute-tenant",
   ]);
 
   if (jwtSettings["jwt-user-provisioning-enabled?"] == null) {

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
@@ -21,7 +21,10 @@ const GROUPS = [
 ];
 
 const setup = async (
-  settingValues?: Partial<JWTFormValues> & { "jwt-enabled"?: boolean },
+  settingValues?: Partial<JWTFormValues> & {
+    "jwt-enabled"?: boolean;
+    "use-tenants"?: boolean;
+  },
 ) => {
   const settings = createMockSettings(settingValues);
   setupSettingsEndpoints([]);
@@ -84,6 +87,45 @@ describe("SettingsJWTForm", () => {
     // it's strange that there's no special JWT endpoint when other SSO methods have endpoints with fancy validation 🤷‍♀️
     expect(url).toMatch(/\/api\/setting$/);
     expect(body).toEqual(ATTRS);
+  });
+
+  it("should not show tenant attribute unless tenanting is on", async () => {
+    await setup();
+
+    expect(
+      screen.queryByText(/Tenant assignment attribute/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show tenant attribute when tenanting is on", async () => {
+    await setup({ "use-tenants": true });
+
+    await userEvent.type(
+      await screen.findByRole("textbox", { name: /JWT Identity Provider URI/ }),
+      ATTRS["jwt-identity-provider-uri"],
+    );
+    await userEvent.type(
+      await screen.findByRole("textbox", {
+        name: /String used by the JWT signing key/,
+      }),
+      ATTRS["jwt-shared-secret"],
+    );
+
+    await userEvent.type(
+      await screen.findByRole("textbox", {
+        name: /Tenant assignment attribute/,
+      }),
+      "Cat",
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: /Save/ }));
+
+    const puts = await findRequests("PUT");
+    expect(puts).toHaveLength(1);
+    const [{ url, body }] = puts;
+
+    expect(url).toMatch(/\/api\/setting$/);
+    expect(body).toHaveProperty("jwt-attribute-tenant", "Cat");
   });
 
   it("User provisioning should not appear if JWT has not been enabled", async () => {

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -263,6 +263,7 @@ export const createMockSettings = (
   "jwt-attribute-email": null,
   "jwt-attribute-firstname": null,
   "jwt-attribute-lastname": null,
+  "jwt-attribute-tenant": null,
   "jwt-group-sync": false,
   "ldap-configured?": false,
   "ldap-enabled": false,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -562,6 +562,7 @@ export interface EnterpriseSettings extends Settings {
   "jwt-attribute-email": string | null;
   "jwt-attribute-firstname": string | null;
   "jwt-attribute-lastname": string | null;
+  "jwt-attribute-tenant": string | null;
   "jwt-group-sync": boolean | null;
   "saml-enabled": boolean;
   "saml-configured": boolean;


### PR DESCRIPTION
### Description

Makes the tenanting attribute setting user editable from the JWT authentications settings page. This is hidden until tenanting is turned on for an instance using the `use-tenants` setting. 

### Demo

<img width="789" height="441" alt="Screenshot 2025-07-18 at 2 49 04 PM" src="https://github.com/user-attachments/assets/67d7f85b-6357-46c1-8f6e-818fcc89f8f0" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
