### PR TITLE
Create HNSW index on semantic search embeddings column

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -50,6 +50,14 @@
      [[:constraint unique-constraint-name]
       [:unique [:composite :model :model_id]]]]))
 
+(defn sql-format-quoted
+  "Call [[sql/format]] with {:quoted true}.
+
+  Ensures identifiers are quoted since the nano-ids used in temp table names when testing (and various other places)
+  might contain uppercase chars or hyphens which need to be quoted."
+  [honey-sql & {:as opts}]
+  (sql/format honey-sql (merge opts {:quoted true})))
+
 (defn- format-embedding
   "Formats the embedding vector for SQL insertion."
   [embedding]
@@ -118,7 +126,7 @@
        (fn [db-records]
          (-> (sql.helpers/insert-into *index-table-name*)
              (sql.helpers/values db-records)
-             sql/format))
+             sql-format-quoted))
        documents
        embeddings))))
 
@@ -150,13 +158,14 @@
           (sql.helpers/values db-records)
           (sql.helpers/on-conflict :model :model_id)
           (sql.helpers/do-update-set (db-records->update-set db-records))
-          sql/format))
+          sql-format-quoted))
        documents
        embeddings))))
 
 (defn- drop-index-table-sql
   []
-  (sql/format (sql.helpers/drop-table :if-exists *index-table-name*)))
+  (-> (sql.helpers/drop-table :if-exists *index-table-name*)
+      sql-format-quoted))
 
 (defn drop-index-table!
   "Drop the index table if it exists."
@@ -176,13 +185,13 @@
          tx
          (-> (sql.helpers/create-table *index-table-name*)
              (sql.helpers/with-columns (index-table-schema vector-dimensions))
-             sql/format))
+             sql-format-quoted))
         (jdbc/execute!
          tx
          (-> (sql.helpers/create-index
               (keyword (str "embedding_hnsw_index_" (nano-id/nano-id)))
               [*index-table-name* :using-hnsw [:raw "embedding vector_cosine_ops"]])
-             sql/format))))
+             sql-format-quoted))))
     (catch Exception e
       (throw (ex-info "Failed to create index table" {:cause e})))))
 
@@ -273,7 +282,7 @@
             xform       (comp (map unqualify-keys)
                               (map decode-metadata)
                               (map legacy-input-with-score))
-            reducible   (jdbc/plan @db/data-source (sql/format query))]
+            reducible   (jdbc/plan @db/data-source (sql-format-quoted query))]
         (-> (transduce xform conj [] reducible)
             filter-read-permitted)))))
 
@@ -287,7 +296,7 @@
          (sql.helpers/where [:and
                              [:= :model model]
                              [:in :model_id batch-ids]])
-         sql/format))
+         sql-format-quoted))
    model-ids))
 
 (comment

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -113,7 +113,7 @@
                               +
                               ids)
                    (array-map model))
-       (log/trace "semantic search deleted" <> "total documents with model type" model)))))
+       (log/trace "semantic search deleted" (get <> model) "total documents with model type" model)))))
 
 (defn populate-index!
   "Inserts a set of documents into the index table. Throws when trying to insert

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -176,6 +176,12 @@
          tx
          (-> (sql.helpers/create-table *index-table-name*)
              (sql.helpers/with-columns (index-table-schema vector-dimensions))
+             sql/format))
+        (jdbc/execute!
+         tx
+         (-> (sql.helpers/create-index
+              (keyword (str "embedding_hnsw_index_" (nano-id/nano-id)))
+              [*index-table-name* :using-hnsw [:raw "embedding vector_cosine_ops"]])
              sql/format))))
     (catch Exception e
       (throw (ex-info "Failed to create index table" {:cause e})))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.semantic-search.index-test
   (:require
    [clojure.test :refer :all]
-   [honey.sql :as sql]
    [honey.sql.helpers :as sql.helpers]
    [metabase-enterprise.semantic-search.db :as semantic.db]
    [metabase-enterprise.semantic-search.index :as semantic.index]
@@ -50,7 +49,7 @@
                           (sql.helpers/where :and
                                              [:= :model model]
                                              [:= :model_id model_id])
-                          sql/format))
+                          semantic.index/sql-format-quoted))
        (map #'semantic.index/unqualify-keys)
        (map decode-embedding)))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -11,29 +11,31 @@
 
 (use-fixtures :once #'semantic.tu/once-fixture)
 
-;; TODO figure out why these tests flake
-#_(deftest create-index-table!-test
-    (mt/with-premium-features #{:semantic-search}
-      (semantic.tu/with-mocked-embeddings!
-        (semantic.tu/with-temp-index-table!
-          ;; with-temp-index-table! creates the temp table, so drop it in order to test create!.
-          (semantic.index/drop-index-table!)
+(deftest create-index-table!-test
+  (mt/with-premium-features #{:semantic-search}
+    (semantic.tu/with-mocked-embeddings!
+      (semantic.tu/with-temp-index-table!
+        ;; with-temp-index-table! creates the temp table, so drop it in order to test create!.
+        (semantic.index/drop-index-table!)
+        (let [embedding-index-pattern "embedding_hnsw_index_%"]
           (testing "index table is not present before create!"
-            (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))))
+            (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))
+            (is (not (semantic.tu/table-has-index? semantic.index/*index-table-name* embedding-index-pattern))))
           (testing "index table is present after create!"
             (semantic.index/create-index-table! {:force-reset? false})
-            (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))))))
+            (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))
+            (is (semantic.tu/table-has-index? semantic.index/*index-table-name* embedding-index-pattern))))))))
 
-#_(deftest drop-index-table!-test
-    (mt/with-premium-features #{:semantic-search}
-      (semantic.tu/with-mocked-embeddings!
-        (semantic.tu/with-temp-index-table!
-          ;; with-temp-index-table! creates the temp table
-          (testing "index table is present before drop!"
-            (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))
-          (testing "index table is not present after drop!"
-            (semantic.index/drop-index-table!)
-            (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))))))))
+(deftest drop-index-table!-test
+  (mt/with-premium-features #{:semantic-search}
+    (semantic.tu/with-mocked-embeddings!
+      (semantic.tu/with-temp-index-table!
+        ;; with-temp-index-table! creates the temp table
+        (testing "index table is present before drop!"
+          (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))
+        (testing "index table is not present after drop!"
+          (semantic.index/drop-index-table!)
+          (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))))))))
 
 (defn- decode-embedding
   "Decode `row`s `:embedding`."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -1,9 +1,12 @@
 (ns metabase-enterprise.semantic-search.test-util
   (:require
+   [clojure.string :as str]
    [metabase-enterprise.semantic-search.db :as semantic.db]
    [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
+   [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase.search.core :as search.core]
    [metabase.search.ingestion :as search.ingestion]
+   [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [nano-id.core :as nano-id]
@@ -93,12 +96,12 @@
                search.ingestion/*force-sync* true]
        (try
          (mt/as-admin
-          (semantic.index/create-index-table! {:force-reset? true}))
+           (semantic.index/create-index-table! {:force-reset? true}))
          ~@body
          (finally
            (try
              (mt/as-admin
-              (semantic.index/drop-index-table!))
+               (semantic.index/drop-index-table!))
              (catch Exception e#
                (log/error "Warning: failed to clean up test table" test-table-name# ":" (.getMessage e#)))))))))
 
@@ -106,52 +109,52 @@
   "Add a collection of test documents to that can be indexed to the appdb."
   [& body]
   `(mt/dataset ~(symbol "test-data")
-               (mt/with-temp [:model/Collection       {col1# :id}  {:name "Wildlife Collection" :archived false}
+     (mt/with-temp [:model/Collection       {col1# :id}  {:name "Wildlife Collection" :archived false}
 
-                              :model/Collection       {col2# :id}  {:name "Archived Animals" :archived true}
+                    :model/Collection       {col2# :id}  {:name "Archived Animals" :archived true}
 
-                              :model/Collection       {col3# :id}  {:name "Cryptozoology", :archived false}
+                    :model/Collection       {col3# :id}  {:name "Cryptozoology", :archived false}
 
-                              :model/Card             {card1# :id} {:name "Dog Training Guide" :collection_id col1# :creator_id (mt/user->id :crowberto) :archived false}
+                    :model/Card             {card1# :id} {:name "Dog Training Guide" :collection_id col1# :creator_id (mt/user->id :crowberto) :archived false}
 
-                              :model/Card             {}           {:name "Bird Watching Tips" :collection_id col1# :creator_id (mt/user->id :rasta) :archived false}
+                    :model/Card             {}           {:name "Bird Watching Tips" :collection_id col1# :creator_id (mt/user->id :rasta) :archived false}
 
-                              :model/Card             {}           {:name "Cat Behavior Study" :collection_id col2# :creator_id (mt/user->id :crowberto) :archived true}
+                    :model/Card             {}           {:name "Cat Behavior Study" :collection_id col2# :creator_id (mt/user->id :crowberto) :archived true}
 
-                              :model/Card             {}           {:name "Horse Racing Analysis" :collection_id col1# :creator_id (mt/user->id :rasta) :archived false}
+                    :model/Card             {}           {:name "Horse Racing Analysis" :collection_id col1# :creator_id (mt/user->id :rasta) :archived false}
 
-                              :model/Card             {}           {:name "Fish Tank Setup" :collection_id col2# :creator_id (mt/user->id :crowberto) :archived true}
+                    :model/Card             {}           {:name "Fish Tank Setup" :collection_id col2# :creator_id (mt/user->id :crowberto) :archived true}
 
-                              :model/Card             {}           {:name "Bigfoot Sightings" :collection_id col3# :creator_id (mt/user->id :crowberto), :archived false}
+                    :model/Card             {}           {:name "Bigfoot Sightings" :collection_id col3# :creator_id (mt/user->id :crowberto), :archived false}
 
-                              :model/ModerationReview {}           {:moderated_item_type "card"
+                    :model/ModerationReview {}           {:moderated_item_type "card"
 
-                                                                    :moderated_item_id card1#
+                                                          :moderated_item_id card1#
 
-                                                                    :moderator_id (mt/user->id :crowberto)
+                                                          :moderator_id (mt/user->id :crowberto)
 
-                                                                    :status "verified"
+                                                          :status "verified"
 
-                                                                    :most_recent true}
+                                                          :most_recent true}
 
-                              :model/Dashboard        {}           {:name "Elephant Migration" :collection_id col1# :creator_id (mt/user->id :rasta) :archived false}
+                    :model/Dashboard        {}           {:name "Elephant Migration" :collection_id col1# :creator_id (mt/user->id :rasta) :archived false}
 
-                              :model/Dashboard        {}           {:name "Lion Pride Dynamics" :collection_id col1# :creator_id (mt/user->id :crowberto) :archived false}
+                    :model/Dashboard        {}           {:name "Lion Pride Dynamics" :collection_id col1# :creator_id (mt/user->id :crowberto) :archived false}
 
-                              :model/Dashboard        {}           {:name "Penguin Colony Study" :collection_id col2# :creator_id (mt/user->id :rasta) :archived true}
+                    :model/Dashboard        {}           {:name "Penguin Colony Study" :collection_id col2# :creator_id (mt/user->id :rasta) :archived true}
 
-                              :model/Dashboard        {}           {:name "Whale Communication" :collection_id col1# :creator_id (mt/user->id :crowberto) :archived false}
+                    :model/Dashboard        {}           {:name "Whale Communication" :collection_id col1# :creator_id (mt/user->id :crowberto) :archived false}
 
-                              :model/Dashboard        {}           {:name "Tiger Conservation" :collection_id col2# :creator_id (mt/user->id :rasta) :archived true}
+                    :model/Dashboard        {}           {:name "Tiger Conservation" :collection_id col2# :creator_id (mt/user->id :rasta) :archived true}
 
-                              :model/Dashboard        {}           {:name "Loch Ness Stuff" :collection_id col3# :creator_id (mt/user->id :crowberto), :archived false}
+                    :model/Dashboard        {}           {:name "Loch Ness Stuff" :collection_id col3# :creator_id (mt/user->id :crowberto), :archived false}
 
-                              :model/Database         {db-id# :id} {:name "Animal Database"}
+                    :model/Database         {db-id# :id} {:name "Animal Database"}
 
-                              :model/Table            {}           {:name "Species Table", :db_id db-id#}
+                    :model/Table            {}           {:name "Species Table", :db_id db-id#}
 
-                              :model/Table            {}           {:name "Monsters Table", :db_id db-id#, :active true}]
-                 ~@body)))
+                    :model/Table            {}           {:name "Monsters Table", :db_id db-id#, :active true}]
+       ~@body)))
 
 (defmacro with-index!
   "Ensure a clean, small index for testing populated with a few collections, cards, and dashboards."
@@ -161,6 +164,16 @@
        (search.core/reindex! :search.engine/semantic {:force-reset true})
        ~@body)))
 
+(defn- table->name
+  [table-name-or-kw]
+  (cond-> table-name-or-kw
+    (keyword? table-name-or-kw)
+    ;; TODO The nano ids we use for temp test table names can contain uppercase chars and hyphens, which postgres will
+    ;; convert to lowercase and _ if unquoted. We should just quote the table names and avoid the need for this.
+    (-> name
+        u/lower-case-en
+        (str/replace "-" "_"))))
+
 (defn table-exists-in-db?
   "Check if a table actually exists in the database"
   [table-name]
@@ -168,6 +181,17 @@
     (try
       (let [result (jdbc/execute! @semantic.db/data-source
                                   ["SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = ?)"
-                                   (u/lower-case-en (name table-name))])]
+                                   (table->name table-name)])]
+        (-> result first vals first))
+      (catch Exception _ false))))
+
+(defn table-has-index?
+  [table-name index-name-pattern]
+  (when table-name
+    (try
+      (let [result (jdbc/execute! @semantic.db/data-source
+                                  ["SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE tablename = ? AND indexname LIKE ?)"
+                                   (table->name table-name)
+                                   index-name-pattern])]
         (-> result first vals first))
       (catch Exception _ false))))


### PR DESCRIPTION
Closes BOT-256

### Description

* Create HNSW index on semantic search embeddings column.

pgvector docs recommend to start with the default options. We can tweak the options or even drop the index if perf is acceptable once we get it on stats.

* Ensure identifiers are quoted when formatting honey sql in semantic search index

The nano-ids used in temp table names when testing (and various other places) might contain uppercase chars or hyphens which need to be quoted.

### How to verify

```
EXPLAIN ANALYZE
SELECT 
  "model_id" AS "model_id", 
  "model" AS "model", 
  "content" AS "content", 
  "verified" AS "verified", 
  embedding <=> '[0.24, 0.46, -0.66, 0.88]'::vector AS "distance", 
  "metadata" AS "metadata" 
FROM "test_search_index_9gh2ihR9-jK8Je9aRfLkb" 
ORDER BY "distance" ASC LIMIT 10

Limit  (cost=35.16..45.75 rows=10 width=935) (actual time=0.384..0.410 rows=10 loops=1)
  ->  Index Scan using "embedding_hnsw_index_GpDIcYJA3Ek2AKbg1qAUm" on "test_search_index_9gh2ihR9-jK8Je9aRfLkb"  (cost=35.16..1234.66 rows=1133 width=935) (actual time=0.383..0.406 rows=10 loops=1)
        Order By: (embedding <=> '[0.24,0.46,-0.66,0.88]'::vector)
Planning Time: 0.642 ms
Execution Time: 0.934 ms

SELECT * 
FROM pg_stat_user_indexes 
WHERE 
	relname LIKE 'test_search_index_%' AND
	indexrelname LIKE 'embedding_hnsw_index_%'

| relid  | indexrelid | schemaname | relname                                 | indexrelname                               | idx_scan | last_idx_scan                 | idx_tup_read | idx_tup_fetch |
| ------ | ---------- | ---------- | --------------------------------------- | ------------------------------------------ | -------- | ----------------------------- | ------------ | ------------- |
| 123886 | 123897     | public     | test_search_index_9gh2ihR9-jK8Je9aRfLkb | embedding_hnsw_index_GpDIcYJA3Ek2AKbg1qAUm | 3        | 2025-07-18 23:34:01.428149+00 | 210          | 210           |

```
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
