### PR TITLE
fix timeline events merging logic

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/model.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/model.unit.spec.ts
@@ -1,0 +1,150 @@
+import type { TimeSeriesInterval } from "metabase/visualizations/echarts/cartesian/model/types";
+import type { TimelineEventGroup } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
+import type { RenderingContext } from "metabase/visualizations/types";
+import { createMockTimelineEvent } from "metabase-types/api/mocks";
+
+import { mergeOverlappingTimelineEventGroups } from "./model";
+
+const createMockTimelineEventGroup = (
+  opts?: Partial<TimelineEventGroup>,
+): TimelineEventGroup => ({
+  date: "2024-01-01T00:00:00Z",
+  events: [createMockTimelineEvent()],
+  ...opts,
+});
+
+const createMockRenderingContext = (
+  opts?: Partial<RenderingContext>,
+): RenderingContext => ({
+  getColor: (colorName: string) => colorName,
+  measureText: jest.fn().mockImplementation((text: string) => {
+    const charWidth = 8;
+    return text.length * charWidth;
+  }),
+  measureTextHeight: jest.fn().mockReturnValue(16),
+  fontFamily: "Lato",
+  theme: {
+    cartesian: {
+      label: {
+        fontSize: 12,
+      },
+      goalLine: {
+        label: {
+          fontSize: 12,
+        },
+      },
+      splitLine: {
+        lineStyle: {
+          color: "#E0E0E0",
+        },
+      },
+    },
+    pie: {
+      borderColor: "#FFFFFF",
+    },
+  },
+  ...opts,
+});
+
+const createMockTimeSeriesInterval = (
+  opts?: Partial<TimeSeriesInterval>,
+): TimeSeriesInterval => ({
+  count: 1,
+  unit: "day",
+  ...opts,
+});
+
+// eslint-disable-next-line testing-library/render-result-naming-convention
+const renderingContext = createMockRenderingContext();
+
+describe("mergeOverlappingTimelineEventGroups", () => {
+  it("should not merge events that are far apart", () => {
+    const eventGroups: TimelineEventGroup[] = [
+      createMockTimelineEventGroup({
+        date: "2024-01-01T00:00:00Z",
+        events: [createMockTimelineEvent({ id: 1 })],
+      }),
+      createMockTimelineEventGroup({
+        date: "2024-01-10T00:00:00Z",
+        events: [createMockTimelineEvent({ id: 2 })],
+      }),
+    ];
+
+    const interval = createMockTimeSeriesInterval({ count: 1, unit: "day" });
+    const intervalWidth = 80; // 800px / 10 days
+
+    const result = mergeOverlappingTimelineEventGroups(
+      eventGroups,
+      interval,
+      intervalWidth,
+      renderingContext,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].events).toEqual(eventGroups[0].events);
+    expect(result[1].events).toEqual(eventGroups[1].events);
+  });
+
+  it("should merge events that are close together", () => {
+    const eventGroups: TimelineEventGroup[] = [
+      createMockTimelineEventGroup({
+        date: "2024-01-01T00:00:00Z",
+        events: [createMockTimelineEvent({ id: 1 })],
+      }),
+      createMockTimelineEventGroup({
+        date: "2024-01-01T00:00:09Z",
+        events: [createMockTimelineEvent({ id: 2 })],
+      }),
+    ];
+
+    const interval = createMockTimeSeriesInterval({ count: 1, unit: "minute" });
+    const intervalWidth = 100; // 100px per minute
+
+    const result = mergeOverlappingTimelineEventGroups(
+      eventGroups,
+      interval,
+      intervalWidth,
+      renderingContext,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].events).toEqual([
+      ...eventGroups[0].events,
+      ...eventGroups[1].events,
+    ]);
+  });
+
+  it("should correctly merge events when interval count is greater than 1", () => {
+    const eventGroups: TimelineEventGroup[] = [
+      createMockTimelineEventGroup({
+        date: "2024-01-01T00:00:00Z",
+        events: [createMockTimelineEvent({ id: 1 })],
+      }),
+      createMockTimelineEventGroup({
+        date: "2024-01-01T00:05:00Z",
+        events: [createMockTimelineEvent({ id: 2 })],
+      }),
+      createMockTimelineEventGroup({
+        date: "2024-01-01T00:20:00Z",
+        events: [createMockTimelineEvent({ id: 3 })],
+      }),
+    ];
+
+    const interval = createMockTimeSeriesInterval({ count: 5, unit: "minute" });
+    const intervalWidth = 10; // 10px per 5-minute interval
+
+    const result = mergeOverlappingTimelineEventGroups(
+      eventGroups,
+      interval,
+      intervalWidth,
+      renderingContext,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].events).toEqual([
+      ...eventGroups[0].events,
+      ...eventGroups[1].events,
+    ]);
+    expect(result[1].events).toEqual(eventGroups[2].events);
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #55592
Closes [VIZ-585](https://linear.app/metabase/issue/VIZ-585/events-are-grouped-in-line-chart-even-though-there-is-plenty-of-space)

### Description

Fixes how timeline events get grouped together if they are too close to each other. It did not work correctly on charts where x-axis range is around 1 day with binning by minute. Here is an [example question](http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjUsImFnZ3JlZ2F0aW9uIjpbWyJjb3VudCJdXSwiYnJlYWtvdXQiOltbImZpZWxkIiw0MSx7ImJhc2UtdHlwZSI6InR5cGUvRGF0ZVRpbWUiLCJpbmhlcml0ZWQtdGVtcG9yYWwtdW5pdCI6Im1vbnRoIiwib3JpZ2luYWwtdGVtcG9yYWwtdW5pdCI6Im1vbnRoIiwidGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSJ9XV0sImFnZ3JlZ2F0aW9uLWlkZW50cyI6eyIwIjoiQXpjS2RYcm5xRktWWUhkeGdyLW15In0sImJyZWFrb3V0LWlkZW50cyI6eyIwIjoidFVSS1R2SkpTeG45SEhhRVhkYzB5In0sImZpbHRlciI6WyJiZXR3ZWVuIixbImZpZWxkIiw0MSx7ImJhc2UtdHlwZSI6InR5cGUvRGF0ZVRpbWUiLCJpbmhlcml0ZWQtdGVtcG9yYWwtdW5pdCI6Im1pbnV0ZSIsIm9yaWdpbmFsLXRlbXBvcmFsLXVuaXQiOiJtaW51dGUiLCJ0ZW1wb3JhbC11bml0IjoibWludXRlIn1dLCIyMDI1LTAzLTIwVDE1OjA4IiwiMjAyNS0wMy0yMlQwOTo0MCJdfX0sImRpc3BsYXkiOiJsaW5lIiwiZGlzcGxheUlzTG9ja2VkIjp0cnVlLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6eyJncmFwaC54X2F4aXMuc2NhbGUiOiJ0aW1lc2VyaWVzIiwiZ3JhcGguZGltZW5zaW9ucyI6WyJDUkVBVEVEX0FUIl0sImdyYXBoLm1ldHJpY3MiOlsiY291bnQiXX0sIm9yaWdpbmFsX2NhcmRfaWQiOjg1MSwidHlwZSI6InF1ZXN0aW9uIn0=) based on the sample database on a local instance.

### Demo

Before
<img width="2558" height="722" alt="Screenshot 2025-07-18 at 7 37 50 PM" src="https://github.com/user-attachments/assets/b4629e7a-70d7-47ac-8bbd-95bbdfd9f771" />

After
https://www.loom.com/share/e47cd3f63cb542868810d415f277f101?sid=0ea8562d-00a9-4fbe-94ce-b22071e076ac

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
