### PR TITLE
[pivot] Implement optimized clj->js and use it when recalculating pivots on frontend

### DIFF
--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -1,5 +1,6 @@
 (ns metabase.pivot.core
   (:require
+   #?(:cljs [metabase.util.performance :as perf])
    [flatland.ordered.map :as ordered-map]
    [medley.core :as m]
    [metabase.models.visualization-settings :as mb.viz]
@@ -562,7 +563,7 @@
                    (handle-subtotal-cell subtotal-values row-values col-values row-indexes col-indexes value-formatters)
                    (get-normal-cell-values values-by-key index-values value-formatters color-getter))]
       ;; Convert to JavaScript object if in ClojureScript context
-      #?(:cljs (clj->js result)
+      #?(:cljs (perf/clj->js result)
          :clj result))))
 
 (defn- tree-to-array

--- a/src/metabase/pivot/js.cljs
+++ b/src/metabase/pivot/js.cljs
@@ -1,7 +1,8 @@
 (ns metabase.pivot.js
   "Javascript-facing interface for pivot table postprocessing. Wraps functions in metabase.pivot.core."
   (:require
-   [metabase.pivot.core :as pivot]))
+   [metabase.pivot.core :as pivot]
+   [metabase.util.performance :as perf]))
 
 (defn ^:export columns-without-pivot-group
   "Removes the pivot-grouping column from a list of columns, identifying it by name."
@@ -47,4 +48,4 @@
                                                 settings
                                                 col-settings
                                                 make-color-getter)]
-    (clj->js result)))
+    (perf/clj->js result)))


### PR DESCRIPTION
_Disregard first commit, this is intended to be merged after https://github.com/metabase/metabase/pull/61159_.

A big chunk of frontend-side pivot table processing is spent converting CLJS structures to JS structures. Before jumping the shark and rewriting the whole algorithm to maybe use native data structures exclusively to avoid the conversions altogether, this is an attempt to make `clj->js` more efficient. This could probably be useful in other places as well.