### PR TITLE
SEM-505 The Preview button should be more noticeable and accessible

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -2963,12 +2963,10 @@ describe("scenarios > admin > datamodel", () => {
         PreviewSection.get().should("not.exist");
 
         FieldSection.getPreviewButton().click();
-        FieldSection.getPreviewButton().should("not.exist");
         PreviewSection.get().should("be.visible");
 
         cy.realPress("Escape");
         PreviewSection.get().should("not.exist");
-        FieldSection.getPreviewButton().should("be.visible");
       });
 
       it("should not close the preview when hitting Esc key while modal is open", () => {

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -44,7 +44,7 @@ export const DataModel = ({ children, location, params }: Props) => {
     (database) => database.id === databaseId,
   );
   const isSegments = location.pathname.startsWith("/admin/datamodel/segment");
-  const [isPreviewOpen, { close: closePreview, open: openPreview }] =
+  const [isPreviewOpen, { close: closePreview, toggle: togglePreview }] =
     useDisclosure();
   const [isSyncModalOpen, { close: closeSyncModal, open: openSyncModal }] =
     useDisclosure();
@@ -184,7 +184,7 @@ export const DataModel = ({ children, location, params }: Props) => {
                       parent={parentField}
                       table={table}
                       onFieldValuesClick={openFieldValuesModal}
-                      onPreviewClick={openPreview}
+                      onPreviewClick={togglePreview}
                     />
                   </Box>
                 )}

--- a/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/DataModel.tsx
@@ -176,7 +176,6 @@ export const DataModel = ({ children, location, params }: Props) => {
                     <FieldSection
                       databaseId={databaseId}
                       field={field}
-                      isPreviewOpen={isPreviewOpen}
                       /**
                        * Make sure internal component state is reset when changing fields.
                        * This is to avoid state mix-up with optimistic updates.

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/FieldSection.tsx
@@ -6,7 +6,7 @@ import { getColumnIcon } from "metabase/common/utils/columns";
 import { NameDescriptionInput } from "metabase/metadata/components";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
-import { Box, Group, Stack, Text } from "metabase/ui";
+import { Group, Stack, Text } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { DatabaseId, Field, Table } from "metabase-types/api";
 
@@ -19,13 +19,10 @@ import { FormattingSection } from "./FormattingSection";
 import { MetadataSection } from "./MetadataSection";
 import { useResponsiveButtons } from "./hooks";
 
-const OUTLINE_SAFETY_MARGIN = 2;
-
 interface Props {
   databaseId: DatabaseId;
   field: Field;
   table: Table;
-  isPreviewOpen: boolean;
   parent?: Field;
   onFieldValuesClick: () => void;
   onPreviewClick: () => void;
@@ -34,7 +31,6 @@ interface Props {
 const FieldSectionBase = ({
   databaseId,
   field,
-  isPreviewOpen,
   parent,
   table,
   onFieldValuesClick,
@@ -49,7 +45,7 @@ const FieldSectionBase = ({
     showButtonLabel,
     setFieldValuesButtonWidth,
     setPreviewButtonWidth,
-  } = useResponsiveButtons({ isPreviewOpen });
+  } = useResponsiveButtons();
 
   const handleNameChange = async (name: string) => {
     const { error } = await updateField({ id, display_name: name });
@@ -92,10 +88,11 @@ const FieldSectionBase = ({
 
   return (
     <Stack data-testid="field-section" gap={0} pb="xl">
-      <Box
+      <Stack
         bg="accent-gray-light"
         className={S.header}
-        pb="lg"
+        gap="lg"
+        pb={12}
         pos="sticky"
         pt="xl"
         px="xl"
@@ -112,9 +109,7 @@ const FieldSectionBase = ({
           onDescriptionChange={handleDescriptionChange}
           onNameChange={handleNameChange}
         />
-      </Box>
 
-      <Stack gap={12} mb={12} pt={OUTLINE_SAFETY_MARGIN} px="xl">
         <Group
           align="center"
           gap="md"
@@ -132,16 +127,14 @@ const FieldSectionBase = ({
             ref={buttonsContainerRef}
             wrap="nowrap"
           >
-            {/* keep these conditions in sync with getRequiredWidth in useResponsiveButtons */}
+            {/* keep this in sync with getRequiredWidth in useResponsiveButtons */}
 
-            {!isPreviewOpen && (
-              <ResponsiveButton
-                icon="eye"
-                showLabel={showButtonLabel}
-                onClick={onPreviewClick}
-                onRequestWidth={setPreviewButtonWidth}
-              >{t`Preview`}</ResponsiveButton>
-            )}
+            <ResponsiveButton
+              icon="eye"
+              showLabel={showButtonLabel}
+              onClick={onPreviewClick}
+              onRequestWidth={setPreviewButtonWidth}
+            >{t`Preview`}</ResponsiveButton>
 
             <ResponsiveButton
               icon="gear_settings_filled"

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/hooks.ts
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/hooks.ts
@@ -3,11 +3,7 @@ import { useState } from "react";
 
 const BUTTONS_GAP = 16;
 
-export const useResponsiveButtons = ({
-  isPreviewOpen,
-}: {
-  isPreviewOpen: boolean;
-}) => {
+export const useResponsiveButtons = () => {
   const { ref: buttonsContainerRef, width: buttonsContainerWidth } =
     useElementSize();
   const [previewButtonWidth, setPreviewButtonWidth] = useState(0);
@@ -19,16 +15,10 @@ export const useResponsiveButtons = ({
     : true;
 
   function getRequiredWidth() {
-    /* keep these conditions in sync with JSX in FieldSection */
-
-    let width = fieldValuesButtonWidth;
-
-    if (!isPreviewOpen) {
-      width += previewButtonWidth + BUTTONS_GAP;
-    }
-
-    return width;
+    /* keep this in sync with JSX in FieldSection */
+    return fieldValuesButtonWidth + BUTTONS_GAP + previewButtonWidth;
   }
+
   return {
     buttonsContainerRef,
     showButtonLabel,

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -13,7 +13,7 @@ import {
 } from "metabase/metadata/components";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
-import { Box, Group, Loader, Stack, Text } from "metabase/ui";
+import { Group, Loader, Stack, Text } from "metabase/ui";
 import type { FieldId, Table, TableFieldOrder } from "metabase-types/api";
 
 import type { RouteParams } from "../../types";
@@ -23,8 +23,6 @@ import { ResponsiveButton } from "../ResponsiveButton";
 import { FieldList } from "./FieldList";
 import S from "./TableSection.module.css";
 import { useResponsiveButtons } from "./hooks";
-
-const OUTLINE_SAFETY_MARGIN = 2;
 
 interface Props {
   params: RouteParams;
@@ -138,10 +136,11 @@ const TableSectionBase = ({ params, table, onSyncOptionsClick }: Props) => {
 
   return (
     <Stack data-testid="table-section" gap={0} pb="xl">
-      <Box
+      <Stack
         bg="accent-gray-light"
         className={S.header}
-        pb="lg"
+        gap="lg"
+        pb={12}
         pos="sticky"
         pt="xl"
         px="xl"
@@ -157,70 +156,70 @@ const TableSectionBase = ({ params, table, onSyncOptionsClick }: Props) => {
           onDescriptionChange={handleDescriptionChange}
           onNameChange={handleNameChange}
         />
-      </Box>
 
-      <Stack gap="lg" px="xl" pt={OUTLINE_SAFETY_MARGIN}>
-        <Stack gap={12}>
+        <Group
+          align="center"
+          gap="md"
+          justify="space-between"
+          miw={0}
+          wrap="nowrap"
+        >
+          <Text flex="0 0 auto" fw="bold">{t`Fields`}</Text>
+
           <Group
-            align="center"
+            flex="1"
             gap="md"
-            justify="space-between"
+            justify="flex-end"
             miw={0}
+            ref={buttonsContainerRef}
             wrap="nowrap"
           >
-            <Text flex="0 0 auto" fw="bold">{t`Fields`}</Text>
+            {/* keep these conditions in sync with getRequiredWidth in useResponsiveButtons */}
 
-            <Group
-              flex="1"
-              gap="md"
-              justify="flex-end"
-              miw={0}
-              ref={buttonsContainerRef}
-              wrap="nowrap"
-            >
-              {/* keep these conditions in sync with getRequiredWidth in useResponsiveButtons */}
+            {isUpdatingSorting && (
+              <Loader data-testid="loading-indicator" size="xs" />
+            )}
 
-              {isUpdatingSorting && (
-                <Loader data-testid="loading-indicator" size="xs" />
-              )}
+            {!isSorting && hasFields && (
+              <ResponsiveButton
+                icon="sort_arrows"
+                showLabel={showButtonLabel}
+                onClick={() => setIsSorting(true)}
+                onRequestWidth={setSortingButtonWidth}
+              >{t`Sorting`}</ResponsiveButton>
+            )}
 
-              {!isSorting && hasFields && (
-                <ResponsiveButton
-                  icon="sort_arrows"
-                  showLabel={showButtonLabel}
-                  onClick={() => setIsSorting(true)}
-                  onRequestWidth={setSortingButtonWidth}
-                >{t`Sorting`}</ResponsiveButton>
-              )}
+            {!isSorting && (
+              <ResponsiveButton
+                icon="gear_settings_filled"
+                showLabel={showButtonLabel}
+                onClick={onSyncOptionsClick}
+                onRequestWidth={setSyncButtonWidth}
+              >{t`Sync options`}</ResponsiveButton>
+            )}
 
-              {!isSorting && (
-                <ResponsiveButton
-                  icon="gear_settings_filled"
-                  showLabel={showButtonLabel}
-                  onClick={onSyncOptionsClick}
-                  onRequestWidth={setSyncButtonWidth}
-                >{t`Sync options`}</ResponsiveButton>
-              )}
+            {isSorting && (
+              <FieldOrderPicker
+                value={table.field_order}
+                onChange={handleFieldOrderTypeChange}
+              />
+            )}
 
-              {isSorting && (
-                <FieldOrderPicker
-                  value={table.field_order}
-                  onChange={handleFieldOrderTypeChange}
-                />
-              )}
-
-              {isSorting && (
-                <ResponsiveButton
-                  icon="check"
-                  showLabel={showButtonLabel}
-                  showIconWithLabel={false}
-                  onClick={() => setIsSorting(false)}
-                  onRequestWidth={setDoneButtonWidth}
-                >{t`Done`}</ResponsiveButton>
-              )}
-            </Group>
+            {isSorting && (
+              <ResponsiveButton
+                icon="check"
+                showLabel={showButtonLabel}
+                showIconWithLabel={false}
+                onClick={() => setIsSorting(false)}
+                onRequestWidth={setDoneButtonWidth}
+              >{t`Done`}</ResponsiveButton>
+            )}
           </Group>
+        </Group>
+      </Stack>
 
+      <Stack gap="lg" px="xl">
+        <Stack gap={12}>
           {!hasFields && <EmptyState message={t`This table has no fields`} />}
 
           {isSorting && hasFields && (


### PR DESCRIPTION
Closes [SEM-505](https://linear.app/metabase/issue/SEM-505/the-preview-button-should-be-more-noticeable-and-accessible)

### Description

- Moves "Fields" div to sticky header in Table section
- Moves "Field settings" div to sticky header in Field section
- Shows "Preview" button regardless of whether preview is open
- "Preview" button now toggles the preview visibility

### Demo

https://github.com/user-attachments/assets/edfd16a7-9e5f-4134-bb57-df04dbe677a1

