### PR TITLE
fix(sdk): Ensure that custom dashcard menus have precedence over default dashcard menus

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.tsx
@@ -138,7 +138,7 @@ const SdkDashboardInner = ({
   },
   renderDrillThroughQuestion: AdHocQuestionView,
   dashboardActions,
-  dashcardMenu = plugins?.dashboard?.dashboardCardMenu,
+  dashcardMenu,
   getClickActionMode,
   navigateToNewCardFromDashboard = undefined,
   className,
@@ -169,6 +169,9 @@ const SdkDashboardInner = ({
   } = useCommonDashboardParams({
     dashboardId,
   });
+
+  const finalDashcardMenu =
+    plugins?.dashboard?.dashboardCardMenu ?? dashcardMenu;
 
   const [renderModeState, setRenderMode] = useState<
     "dashboard" | "queryBuilder"
@@ -280,7 +283,7 @@ const SdkDashboardInner = ({
       onLoadWithoutCards={handleLoadWithoutCards}
       onError={(error) => dispatch(setErrorPage(error))}
       getClickActionMode={getClickActionMode}
-      dashcardMenu={dashcardMenu}
+      dashcardMenu={finalDashcardMenu}
       dashboardActions={dashboardActions}
       onAddQuestion={(dashboard) => {
         dispatch(setEditingDashboard(dashboard));


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61258
Ensures that when a user specifies a dashcard menu using the plugins system, that dashcard menu implementation overrides any default menu. This happened in EMB-648, where the user's custom dashcard menu settings were overridden by the `InteractiveDashboard` dashcardMenu  