### PR TITLE
Allow supression of case and coalesce arg typechecks

### DIFF
--- a/src/metabase/lib/schema/expression/conditional.cljc
+++ b/src/metabase/lib/schema/expression/conditional.cljc
@@ -94,15 +94,16 @@
        {:error/message "All clauses should have the same type"}
        (fn
          [[_tag _opts pred-expr-pairs default]]
-         (let [exprs (concat
-                      (map second pred-expr-pairs)
-                      (when (some? default)
-                        [default]))
-               types (map expression/type-of exprs)
-               return-type (case-coalesce-return-type types)]
-           (or
-            (not= return-type :type/*)
-            (some #{:expression/type.unknown} types))))]]])
+         (or expression/*suppress-expression-type-check?*
+          (let [exprs (concat
+                        (map second pred-expr-pairs)
+                        (when (some? default)
+                          [default]))
+                types (map expression/type-of exprs)
+                return-type (case-coalesce-return-type types)]
+            (or
+              (not= return-type :type/*)
+              (some #{:expression/type.unknown} types)))))]]])
 
   (defmethod expression/type-of-method tag
     [[_tag _opts pred-expr-pairs default]]
@@ -126,11 +127,12 @@
      {:error/message "All clauses should have the same type"}
      (fn
        [[_coalesce _opts & exprs]]
-       (let [types (map expression/type-of exprs)
-             return-type (case-coalesce-return-type types)]
-         (or
-          (not= return-type :type/*)
-          (some #{:expression/type.unknown} types))))]]])
+       (or expression/*suppress-expression-type-check?*
+        (let [types (map expression/type-of exprs)
+              return-type (case-coalesce-return-type types)]
+          (or
+            (not= return-type :type/*)
+            (some #{:expression/type.unknown} types)))))]]])
 
 (defmethod expression/type-of-method :coalesce
   [[_coalesce _opts & exprs]]

--- a/src/metabase/lib/schema/expression/conditional.cljc
+++ b/src/metabase/lib/schema/expression/conditional.cljc
@@ -95,15 +95,15 @@
        (fn
          [[_tag _opts pred-expr-pairs default]]
          (or expression/*suppress-expression-type-check?*
-          (let [exprs (concat
-                        (map second pred-expr-pairs)
-                        (when (some? default)
-                          [default]))
-                types (map expression/type-of exprs)
-                return-type (case-coalesce-return-type types)]
-            (or
-              (not= return-type :type/*)
-              (some #{:expression/type.unknown} types)))))]]])
+             (let [exprs (concat
+                          (map second pred-expr-pairs)
+                          (when (some? default)
+                            [default]))
+                   types (map expression/type-of exprs)
+                   return-type (case-coalesce-return-type types)]
+               (or
+                (not= return-type :type/*)
+                (some #{:expression/type.unknown} types)))))]]])
 
   (defmethod expression/type-of-method tag
     [[_tag _opts pred-expr-pairs default]]
@@ -128,11 +128,11 @@
      (fn
        [[_coalesce _opts & exprs]]
        (or expression/*suppress-expression-type-check?*
-        (let [types (map expression/type-of exprs)
-              return-type (case-coalesce-return-type types)]
-          (or
-            (not= return-type :type/*)
-            (some #{:expression/type.unknown} types)))))]]])
+           (let [types (map expression/type-of exprs)
+                 return-type (case-coalesce-return-type types)]
+             (or
+              (not= return-type :type/*)
+              (some #{:expression/type.unknown} types)))))]]])
 
 (defmethod expression/type-of-method :coalesce
   [[_coalesce _opts & exprs]]

--- a/test/metabase/lib/schema/expression/conditional_test.cljc
+++ b/test/metabase/lib/schema/expression/conditional_test.cljc
@@ -51,62 +51,64 @@
       [[] 1])))
 
 (deftest ^:parallel case-schema-type-compatibility-valid-test
-  (are [a b] (true?
-              (mr/validate :mbql.clause/case
-                           [:case
-                            {:lib/uuid (str (random-uuid))}
-                            [[true a]
-                             [true b]]]))
-    10 20
-    10 20.5
-    "A" "B"
-    "A" ""
-    true false
-    true true
-    false false
-    (value-expr :type/Date "2023-03-08")
-    (value-expr :type/Date "2023-03-09")
-    (value-expr :type/Date "2023-03-08")
-    (value-expr :type/DateTime "2023-03-09T04:33:45")
-    (value-expr :type/Date "2023-03-08")
-    (value-expr :type/DateTimeWithTZ "2023-03-09T04:33:45Z")
-    (value-expr :type/DateTime "2023-03-09T04:33:45")
-    (value-expr :type/Date "2023-03-09")
-    (value-expr :type/DateTime "2023-03-08T04:33:45")
-    (value-expr :type/DateTime "2023-03-09T04:33:45")
-    (value-expr :type/DateTime "2023-03-09T04:33:45")
-    (value-expr :type/DateTimeWithTZ "2023-03-09T04:33:45Z")
+  (binding [expression/*suppress-expression-type-check?* false]
+    (are [a b] (true?
+                (mr/validate :mbql.clause/case
+                            [:case
+                              {:lib/uuid (str (random-uuid))}
+                              [[true a]
+                              [true b]]]))
+      10 20
+      10 20.5
+      "A" "B"
+      "A" ""
+      true false
+      true true
+      false false
+      (value-expr :type/Date "2023-03-08")
+      (value-expr :type/Date "2023-03-09")
+      (value-expr :type/Date "2023-03-08")
+      (value-expr :type/DateTime "2023-03-09T04:33:45")
+      (value-expr :type/Date "2023-03-08")
+      (value-expr :type/DateTimeWithTZ "2023-03-09T04:33:45Z")
+      (value-expr :type/DateTime "2023-03-09T04:33:45")
+      (value-expr :type/Date "2023-03-09")
+      (value-expr :type/DateTime "2023-03-08T04:33:45")
+      (value-expr :type/DateTime "2023-03-09T04:33:45")
+      (value-expr :type/DateTime "2023-03-09T04:33:45")
+      (value-expr :type/DateTimeWithTZ "2023-03-09T04:33:45Z")
 
-    ; TODO: this case should fail due to Time and Date not being compatible,
-    ; but until we have a better way to handle this, we just allow it and document
-    ; here as a test.
-    (value-expr :type/Date "2023-03-08")
-    (value-expr :type/Time "15:00:55")))
+      ; TODO: this case should fail due to Time and Date not being compatible,
+      ; but until we have a better way to handle this, we just allow it and document
+      ; here as a test.
+      (value-expr :type/Date "2023-03-08")
+      (value-expr :type/Time "15:00:55"))))
 
 (deftest ^:parallel case-schema-type-compatibility-invalid-test
-  (are [a b] (false?
-              (mr/validate :mbql.clause/case
-                           [:case
-                            {:lib/uuid (str (random-uuid))}
-                            [[true a]
-                             [true b]]]))
-    10 "A"
-    10.5 "B"
-    true "A"
-    true 10
-    true 10.5
-    10 (value-expr :type/Date "2023-03-08")
-    10 (value-expr :type/DateTime "2023-03-08T04:33:45")
-    10 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
-    10.5 (value-expr :type/Date "2023-03-08")
-    10.5 (value-expr :type/DateTime "2023-03-08T04:33:45")
-    10.5 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
-    "A" (value-expr :type/Date "2023-03-08")
-    "A" (value-expr :type/DateTime "2023-03-08T04:33:45")
-    "A" (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
-    true (value-expr :type/Date "2023-03-08")
-    true (value-expr :type/DateTime "2023-03-08T04:33:45")
-    true (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")))
+  (binding [expression/*suppress-expression-type-check?* false]
+    (are [a b] (false?
+                (mr/validate :mbql.clause/case
+                            [:case
+                              {:lib/uuid (str (random-uuid))}
+                              [[true a]
+                              [true b]]]))
+      10 "A"
+      10.5 "B"
+      true "A"
+      true 10
+      true 10.5
+      10 (value-expr :type/Date "2023-03-08")
+      10 (value-expr :type/DateTime "2023-03-08T04:33:45")
+      10 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      10.5 (value-expr :type/Date "2023-03-08")
+      10.5 (value-expr :type/DateTime "2023-03-08T04:33:45")
+      10.5 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      "A" (value-expr :type/Date "2023-03-08")
+      "A" (value-expr :type/DateTime "2023-03-08T04:33:45")
+      "A" (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      true (value-expr :type/Date "2023-03-08")
+      true (value-expr :type/DateTime "2023-03-08T04:33:45")
+      true (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z"))))
 
 (deftest ^:parallel case-schema-type-compatibility-ignore-invalid-test
   (binding [expression/*suppress-expression-type-check?* true]
@@ -187,71 +189,74 @@
        (value-expr :type/Time "15:03:55")])))
 
 (deftest ^:parallel coalesce-schema-invalid-test
-  (testing "schema validation for invalid :coalesce expressions"
-    (are [args] (false?
-                 (mr/validate :mbql.clause/coalesce
-                              (into [:coalesce {:lib/uuid (str (random-uuid))}] args)))
-      [1]
-      [1 "A"]
-      ["A"]
-      ["A" (value-expr :type/Date "2023-03-08")]
-      ["A" (value-expr :type/DateTime "2023-03-08T15:03:55")]
-      ["A" (value-expr :type/DateTimeWithTZ "2023-03-08T15:03:55Z")])))
+  (binding [expression/*suppress-expression-type-check?* false]
+    (testing "schema validation for invalid :coalesce expressions"
+      (are [args] (false?
+                  (mr/validate :mbql.clause/coalesce
+                                (into [:coalesce {:lib/uuid (str (random-uuid))}] args)))
+        [1]
+        [1 "A"]
+        ["A"]
+        ["A" (value-expr :type/Date "2023-03-08")]
+        ["A" (value-expr :type/DateTime "2023-03-08T15:03:55")]
+        ["A" (value-expr :type/DateTimeWithTZ "2023-03-08T15:03:55Z")]))))
 
 (deftest ^:parallel coalesce-schema-type-compatibility-valid-test
-  (are [a b] (true?
-              (mr/validate :mbql.clause/coalesce
-                           [:coalesce
-                            {:lib/uuid (str (random-uuid))}
-                            a b]))
-    10 20
-    10 20.5
-    "A" "B"
-    "A" ""
-    true false
-    true true
-    false false
-    (value-expr :type/Date "2023-03-08")
-    (value-expr :type/Date "2023-03-09")
-    (value-expr :type/Date "2023-03-08")
-    (value-expr :type/DateTime "2023-03-09T04:33:45")
-    (value-expr :type/Date "2023-03-08")
-    (value-expr :type/DateTimeWithTZ "2023-03-09T04:33:45Z")
-    (value-expr :type/DateTime "2023-03-09T04:33:45")
-    (value-expr :type/Date "2023-03-09")
-    (value-expr :type/DateTime "2023-03-08T04:33:45")
-    (value-expr :type/DateTime "2023-03-09T04:33:45")
-    (value-expr :type/DateTime "2023-03-09T04:33:45")
-    (value-expr :type/DateTimeWithTZ "2023-03-09T04:33:45Z")
-    ; TODO: this case should fail due to Time and Date not being compatible,
-    ; but until we have a better way to handle this, we just allow it and document
-    ; here as a test.
-    (value-expr :type/Date "2023-03-08")
-    (value-expr :type/Time "15:00:55")))
+  (binding [expression/*suppress-expression-type-check?* false]
+    (are [a b] (true?
+                (mr/validate :mbql.clause/coalesce
+                            [:coalesce
+                              {:lib/uuid (str (random-uuid))}
+                              a b]))
+      10 20
+      10 20.5
+      "A" "B"
+      "A" ""
+      true false
+      true true
+      false false
+      (value-expr :type/Date "2023-03-08")
+      (value-expr :type/Date "2023-03-09")
+      (value-expr :type/Date "2023-03-08")
+      (value-expr :type/DateTime "2023-03-09T04:33:45")
+      (value-expr :type/Date "2023-03-08")
+      (value-expr :type/DateTimeWithTZ "2023-03-09T04:33:45Z")
+      (value-expr :type/DateTime "2023-03-09T04:33:45")
+      (value-expr :type/Date "2023-03-09")
+      (value-expr :type/DateTime "2023-03-08T04:33:45")
+      (value-expr :type/DateTime "2023-03-09T04:33:45")
+      (value-expr :type/DateTime "2023-03-09T04:33:45")
+      (value-expr :type/DateTimeWithTZ "2023-03-09T04:33:45Z")
+      ; TODO: this case should fail due to Time and Date not being compatible,
+      ; but until we have a better way to handle this, we just allow it and document
+      ; here as a test.
+      (value-expr :type/Date "2023-03-08")
+      (value-expr :type/Time "15:00:55"))))
 
 (deftest ^:parallel coalesce-schema-type-compatibility-invalid-test
-  (are [a b] (false?
-              (mr/validate :mbql.clause/coalesce
-                           [:coalesce
-                            {:lib/uuid (str (random-uuid))}
-                            a b]))
-    10 "A"
-    10.5 "B"
-    true "A"
-    true 10
-    true 10.5
-    10 (value-expr :type/Date "2023-03-08")
-    10 (value-expr :type/DateTime "2023-03-08T04:33:45")
-    10 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
-    10.5 (value-expr :type/Date "2023-03-08")
-    10.5 (value-expr :type/DateTime "2023-03-08T04:33:45")
-    10.5 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
-    "A" (value-expr :type/Date "2023-03-08")
-    "A" (value-expr :type/DateTime "2023-03-08T04:33:45")
-    "A" (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
-    true (value-expr :type/Date "2023-03-08")
-    true (value-expr :type/DateTime "2023-03-08T04:33:45")
-    true (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")))
+  (binding [expression/*suppress-expression-type-check?* false]
+    (are [a b] (false?
+                (mr/validate :mbql.clause/coalesce
+                            [:coalesce
+                              {:lib/uuid (str (random-uuid))}
+                              a b]))
+      10 "A"
+      10.5 "B"
+      true "A"
+      true 10
+      true 10.5
+      10 (value-expr :type/Date "2023-03-08")
+      10 (value-expr :type/DateTime "2023-03-08T04:33:45")
+      10 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      10.5 (value-expr :type/Date "2023-03-08")
+      10.5 (value-expr :type/DateTime "2023-03-08T04:33:45")
+      10.5 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      "A" (value-expr :type/Date "2023-03-08")
+      "A" (value-expr :type/DateTime "2023-03-08T04:33:45")
+      "A" (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      true (value-expr :type/Date "2023-03-08")
+      true (value-expr :type/DateTime "2023-03-08T04:33:45")
+      true (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z"))))
 
 (deftest ^:parallel coalesce-schema-type-compatibility-ingore-invalid-test
   (binding [expression/*suppress-expression-type-check?* true]

--- a/test/metabase/lib/schema/expression/conditional_test.cljc
+++ b/test/metabase/lib/schema/expression/conditional_test.cljc
@@ -54,10 +54,10 @@
   (binding [expression/*suppress-expression-type-check?* false]
     (are [a b] (true?
                 (mr/validate :mbql.clause/case
-                            [:case
+                             [:case
                               {:lib/uuid (str (random-uuid))}
                               [[true a]
-                              [true b]]]))
+                               [true b]]]))
       10 20
       10 20.5
       "A" "B"
@@ -88,10 +88,10 @@
   (binding [expression/*suppress-expression-type-check?* false]
     (are [a b] (false?
                 (mr/validate :mbql.clause/case
-                            [:case
+                             [:case
                               {:lib/uuid (str (random-uuid))}
                               [[true a]
-                              [true b]]]))
+                               [true b]]]))
       10 "A"
       10.5 "B"
       true "A"
@@ -114,10 +114,10 @@
   (binding [expression/*suppress-expression-type-check?* true]
     (are [a b] (true?
                 (mr/validate :mbql.clause/case
-                            [:case
+                             [:case
                               {:lib/uuid (str (random-uuid))}
                               [[true a]
-                              [true b]]]))
+                               [true b]]]))
       10 "A"
       10.5 "B"
       true "A"
@@ -192,7 +192,7 @@
   (binding [expression/*suppress-expression-type-check?* false]
     (testing "schema validation for invalid :coalesce expressions"
       (are [args] (false?
-                  (mr/validate :mbql.clause/coalesce
+                   (mr/validate :mbql.clause/coalesce
                                 (into [:coalesce {:lib/uuid (str (random-uuid))}] args)))
         [1]
         [1 "A"]
@@ -205,7 +205,7 @@
   (binding [expression/*suppress-expression-type-check?* false]
     (are [a b] (true?
                 (mr/validate :mbql.clause/coalesce
-                            [:coalesce
+                             [:coalesce
                               {:lib/uuid (str (random-uuid))}
                               a b]))
       10 20
@@ -237,7 +237,7 @@
   (binding [expression/*suppress-expression-type-check?* false]
     (are [a b] (false?
                 (mr/validate :mbql.clause/coalesce
-                            [:coalesce
+                             [:coalesce
                               {:lib/uuid (str (random-uuid))}
                               a b]))
       10 "A"
@@ -262,7 +262,7 @@
   (binding [expression/*suppress-expression-type-check?* true]
     (are [a b] (true?
                 (mr/validate :mbql.clause/coalesce
-                            [:coalesce
+                             [:coalesce
                               {:lib/uuid (str (random-uuid))}
                               a b]))
       10 "A"

--- a/test/metabase/lib/schema/expression/conditional_test.cljc
+++ b/test/metabase/lib/schema/expression/conditional_test.cljc
@@ -108,6 +108,32 @@
     true (value-expr :type/DateTime "2023-03-08T04:33:45")
     true (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")))
 
+(deftest ^:parallel case-schema-type-compatibility-ignore-invalid-test
+  (binding [expression/*suppress-expression-type-check?* true]
+    (are [a b] (true?
+                (mr/validate :mbql.clause/case
+                            [:case
+                              {:lib/uuid (str (random-uuid))}
+                              [[true a]
+                              [true b]]]))
+      10 "A"
+      10.5 "B"
+      true "A"
+      true 10
+      true 10.5
+      10 (value-expr :type/Date "2023-03-08")
+      10 (value-expr :type/DateTime "2023-03-08T04:33:45")
+      10 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      10.5 (value-expr :type/Date "2023-03-08")
+      10.5 (value-expr :type/DateTime "2023-03-08T04:33:45")
+      10.5 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      "A" (value-expr :type/Date "2023-03-08")
+      "A" (value-expr :type/DateTime "2023-03-08T04:33:45")
+      "A" (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      true (value-expr :type/Date "2023-03-08")
+      true (value-expr :type/DateTime "2023-03-08T04:33:45")
+      true (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z"))))
+
 (deftest ^:parallel case-type-of-test
   (testing "type-of logic for :case expressions"
     ;; In QP and MLv2: `expression/type-of-method :case`
@@ -226,6 +252,31 @@
     true (value-expr :type/Date "2023-03-08")
     true (value-expr :type/DateTime "2023-03-08T04:33:45")
     true (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")))
+
+(deftest ^:parallel coalesce-schema-type-compatibility-ingore-invalid-test
+  (binding [expression/*suppress-expression-type-check?* true]
+    (are [a b] (true?
+                (mr/validate :mbql.clause/coalesce
+                            [:coalesce
+                              {:lib/uuid (str (random-uuid))}
+                              a b]))
+      10 "A"
+      10.5 "B"
+      true "A"
+      true 10
+      true 10.5
+      10 (value-expr :type/Date "2023-03-08")
+      10 (value-expr :type/DateTime "2023-03-08T04:33:45")
+      10 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      10.5 (value-expr :type/Date "2023-03-08")
+      10.5 (value-expr :type/DateTime "2023-03-08T04:33:45")
+      10.5 (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      "A" (value-expr :type/Date "2023-03-08")
+      "A" (value-expr :type/DateTime "2023-03-08T04:33:45")
+      "A" (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z")
+      true (value-expr :type/Date "2023-03-08")
+      true (value-expr :type/DateTime "2023-03-08T04:33:45")
+      true (value-expr :type/DateTimeWithTZ "2023-03-08T04:33:45Z"))))
 
 (deftest ^:parallel coalesce-test
   (is (mr/validate


### PR DESCRIPTION
This PR makes it so that the extra clause type checks for `:case` and `:coalesce` (which were introduced in https://github.com/metabase/metabase/pull/59038) are allowed to be suppressed using `*suppress-expression-type-check?*`.


This check is causing issues on startup so we want to be able to ignore it.