### PR TITLE
docs: Fix "Docker Hub" capitalization

### DIFF
--- a/docs/installation-and-operation/running-metabase-on-azure.md
+++ b/docs/installation-and-operation/running-metabase-on-azure.md
@@ -104,7 +104,7 @@ Now go to the next step where you will select:
 - **Options**: Single container.
 - **Image source**: DockerHub.
 - **Access Type**: Public.
-- **Image and tag**: metabase/metabase:latest (or choose any other docker image tag of your preference, like our Enterprise Edition). To find the latest version, check our [Community Edition Dockerhub repository](https://hub.docker.com/r/metabase/metabase/tags?page=1&ordering=last_updated) and also our [Enterprise Edition Dockerhub Repository](https://hub.docker.com/r/metabase/metabase-enterprise/tags?page=1&ordering=last_updated).
+- **Image and tag**: metabase/metabase:latest (or choose any other docker image tag of your preference, like our Enterprise Edition). To find the latest version, check our [Community Edition Docker Hub repository](https://hub.docker.com/r/metabase/metabase/tags?page=1&ordering=last_updated) and also our [Enterprise Edition Docker Hub Repository](https://hub.docker.com/r/metabase/metabase-enterprise/tags?page=1&ordering=last_updated).
 - **Startup command**: Leave this field empty.
 
 Click **Next** until you get to the last section, then click **Create**, and wait while your application initializes.

--- a/docs/installation-and-operation/running-metabase-on-docker.md
+++ b/docs/installation-and-operation/running-metabase-on-docker.md
@@ -8,7 +8,7 @@ redirect_from:
 
 > To get fast, reliable, and secure deployment with none of the work or hidden costs that come with self-hosting, check out [Metabase Cloud](https://www.metabase.com/cloud/).
 
-Metabase provides an official Docker image via Dockerhub that can be used for deployments on any system that is running Docker.
+Metabase provides an official Docker image via Docker Hub that can be used for deployments on any system that is running Docker.
 
 If you're trying to upgrade your Metabase version on Docker, check out these [upgrading instructions](upgrading-metabase.md).
 


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.


### Description

"Docker Hub" is the correct capitalization, while "Dockerhub" is incorrect.

### How to verify

Build the docs locally.

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
