### PR TITLE
Lower batch size, improve logging, and make it configurable via env var

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -37,3 +37,13 @@
                 (and (setting/get-value-of-type :boolean :semantic-search-enabled)
                      (premium-features/enable-semantic-search?)))
   :type       :boolean)
+
+(defsetting openai-max-tokens-per-batch
+  (deferred-tru "The maximum number of tokens sent in a single OpenAI embedding API call.")
+  :type :integer
+  :default 4000
+  :encryption :no
+  :export? false
+  :visibility :internal
+  :description "Maximum number of texts per batch for embedding.")
+

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -46,4 +46,3 @@
   :export? false
   :visibility :internal
   :description "Maximum number of texts per batch for embedding.")
-


### PR DESCRIPTION
* Adds logging of token count in a failed batched embedding request for debugging
* Changes the batch size to be a `defsetting` so that it can be set via env var
* Sets the default to 4000 tokens for now so that it's hopefully well under the OpenAPI limit