### PR TITLE
[Metabot] Ensure state is saved on streamed responses

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/test-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/test-utils.ts
@@ -12,10 +12,7 @@ export function createPauses<Count extends number>(count: Count) {
 }
 
 export function createMockReadableStream(
-  textChunks:
-    | string[]
-    | Generator<string, void, unknown>
-    | AsyncGenerator<string, void, unknown>,
+  textChunks: string[] | AsyncGenerator<string, void, unknown>,
   options?: {
     disableAutoInsertNewLines: boolean;
   },

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/test-utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/test-utils.ts
@@ -12,7 +12,10 @@ export function createPauses<Count extends number>(count: Count) {
 }
 
 export function createMockReadableStream(
-  textChunks: string[] | AsyncGenerator<string, void, unknown>,
+  textChunks:
+    | string[]
+    | Generator<string, void, unknown>
+    | AsyncGenerator<string, void, unknown>,
   options?: {
     disableAutoInsertNewLines: boolean;
   },

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -232,7 +232,7 @@ export const sendStreamedAgentRequest = createAsyncThunk<
 
     try {
       const body = { ...req, conversation_id: sessionId };
-      const state = { ...body.state };
+      let state = {};
       let error: unknown = undefined;
 
       const response = await aiStreamingQuery(
@@ -246,9 +246,8 @@ export const sendStreamedAgentRequest = createAsyncThunk<
         {
           onDataPart: (part) => {
             match(part)
-              // ignore state updates, we'll save it to the state when once we've
-              // streamed the full response and know we have a successful request
-              .with({ type: "state" }, () => {})
+              // only update the convo state if the request is successful
+              .with({ type: "state" }, (part) => (state = part.value))
               .with({ type: "navigate_to" }, (part) => {
                 dispatch(push(part.value) as UnknownAction);
               })

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import { logout } from "metabase/auth/actions";
 import { uuid } from "metabase/lib/uuid";
-import type { MetabotHistory, MetabotStateContext } from "metabase-types/api";
+import type { MetabotHistory } from "metabase-types/api";
 
 import { TOOL_CALL_MESSAGES } from "../constants";
 
@@ -105,9 +105,6 @@ export const metabot = createSlice({
       }
 
       state.toolCalls = hasToolCalls ? [] : state.toolCalls;
-    },
-    setStateContext: (state, action: PayloadAction<MetabotStateContext>) => {
-      state.state = action.payload;
     },
     toolCallStart: (
       state,


### PR DESCRIPTION
Closes [BOT-257](https://linear.app/metabase/issue/BOT-257/fix-fe-not-sending-agent-state-in-request-payload)

### Description

Fixes a bug where the metabot conversation `state` context was not getting saved in the client state for streamed requests. I've added tests to ensure that this is works as expected as well.

### How to verify

- Ask metabot to create a query for you
- Ask another question after it has created one
- Verify that the second request body contains a `state` key containing query information from your first request

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
