### PR TITLE
feat(sdk): Add etag-based caching for the Hosted Embedding SDK bundle

### DIFF
--- a/src/metabase/config/core.clj
+++ b/src/metabase/config/core.clj
@@ -130,6 +130,10 @@
   (let [{:keys [tag hash]} mb-version-info]
     (format "%s (%s)" tag hash)))
 
+(def ^String mb-version-hash
+  "A string representing the hash of the current version of Metabase."
+  (:hash mb-version-info))
+
 (def ^String mb-app-id-string
   "A formatted version string including the word 'Metabase' appropriate for passing along
    with database connections so admins can identify them as Metabase ones.

--- a/src/metabase/server/middleware/etag_cache.clj
+++ b/src/metabase/server/middleware/etag_cache.clj
@@ -1,0 +1,41 @@
+(ns metabase.server.middleware.etag-cache
+  "ETag caching-related Ring middleware."
+  (:require
+   [clojure.string :as str]
+   [metabase.config.core :as config]
+   [ring.util.response :as response]))
+
+(set! *warn-on-reflection* true)
+
+(def etag-headers-for-metabase-version-hash
+  "Headers that tell browsers to cache a static resource and revalidate using the etag with the Metabase version hash."
+  {"Cache-Control" "public, max-age=0, must-revalidate"
+   ;; according to the spec, the ETag should be a quoted string
+   "ETag" (str "\"" config/mb-version-hash "\"")})
+
+(defn matches-metabase-version-hash?
+  "Returns true if the If-None-Match header (possibly weak/quoted) equals the current version hash."
+  [if-none-match]
+  (when if-none-match
+    (let [normalized
+          (-> if-none-match
+              ;; strip any leading "W/" (weak ETag) prefix
+              (str/replace-first #"^W/" "")
+              ;; strip any leading or trailing quotes
+              (str/replace #"^\"|\"$" ""))]
+      (= normalized config/mb-version-hash))))
+
+(def not-modified-response
+  "Returns a 304 Not Modified response with ETag and Cache-Control headers for the current Metabase version hash."
+  (-> (response/response "")
+      (response/status 304)
+      (update :headers merge etag-headers-for-metabase-version-hash)))
+
+(defn js-response-with-etag
+  "Given a Ring response map (typically from `resource-response`), set
+   the correct Content-Type and Metabase-version-based cache headers
+   for embedding-sdk.js."
+  [resp]
+  (-> resp
+      (response/content-type "application/javascript; charset=UTF-8")
+      (update :headers merge etag-headers-for-metabase-version-hash)))

--- a/src/metabase/server/middleware/etag_cache.clj
+++ b/src/metabase/server/middleware/etag_cache.clj
@@ -7,35 +7,52 @@
 
 (set! *warn-on-reflection* true)
 
-(def etag-headers-for-metabase-version-hash
+(def etag-header
   "Headers that tell browsers to cache a static resource and revalidate using the etag with the Metabase version hash."
   {"Cache-Control" "public, max-age=0, must-revalidate"
    ;; according to the spec, the ETag should be a quoted string
-   "ETag" (str "\"" config/mb-version-hash "\"")})
+   "ETag" (format "\"%s\"" config/mb-version-hash)})
 
-(defn matches-metabase-version-hash?
+(defn- matches-metabase-version-hash?
   "Returns true if the If-None-Match header (possibly weak/quoted) equals the current version hash."
-  [if-none-match]
-  (when if-none-match
+  [if-none-match-value]
+  (when if-none-match-value
     (let [normalized
-          (-> if-none-match
+          (-> if-none-match-value
               ;; strip any leading "W/" (weak ETag) prefix
               (str/replace-first #"^W/" "")
               ;; strip any leading or trailing quotes
               (str/replace #"^\"|\"$" ""))]
       (= normalized config/mb-version-hash))))
 
-(def not-modified-response
+(def ^:private not-modified-response
   "Returns a 304 Not Modified response with ETag and Cache-Control headers for the current Metabase version hash."
   (-> (response/response "")
       (response/status 304)
-      (update :headers merge etag-headers-for-metabase-version-hash)))
+      (update :headers merge etag-header)))
 
-(defn js-response-with-etag
+(defn- js-response-with-etag
   "Given a Ring response map (typically from `resource-response`), set
    the correct Content-Type and Metabase-version-based cache headers
    for embedding-sdk.js."
-  [resp]
-  (-> resp
+  [response]
+  (-> response
       (response/content-type "application/javascript; charset=UTF-8")
-      (update :headers merge etag-headers-for-metabase-version-hash)))
+      (update :headers merge etag-header)))
+
+(defn js-etag-handler
+  "Returns a Ring handler that serves a JS file with ETag/Cache-Control headers.
+   If the If-None-Match header matches the current version hash and not in dev mode,
+   returns a 304 Not Modified response instead."
+  [resource-path]
+  (fn [request]
+    (let [if-none-match (get-in request [:headers "if-none-match"])]
+      (if (and (not config/is-dev?)
+               (matches-metabase-version-hash? if-none-match))
+
+        ;; send the pre-built 304 response
+        not-modified-response
+
+        ;; else, serve the file
+        (js-response-with-etag
+         (response/resource-response resource-path))))))

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -7,7 +7,6 @@
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as mdb]
    [metabase.appearance.core :as appearance]
-   [metabase.config.core :as config]
    [metabase.core.initialization-status :as init-status]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.server.auth-wrapper :as auth-wrapper]
@@ -63,16 +62,8 @@
 
 #_{:clj-kondo/ignore [:discouraged-var]}
 (defroutes ^:private static-files-handler
-  (GET "/embedding-sdk.js"
-    {{:strs [if-none-match]} :headers}
-    (if (and (not config/is-dev?)
-             (mw.etag-cache/matches-metabase-version-hash? if-none-match))
-      ;; send the pre-built 304 response
-      mw.etag-cache/not-modified-response
-
-      ;; else, serve the file
-      (mw.etag-cache/js-response-with-etag
-       (response/resource-response "frontend_client/app/embedding-sdk.js"))))
+  (GET "/embedding-sdk.js" request
+    ((mw.etag-cache/js-etag-handler "frontend_client/app/embedding-sdk.js") request))
 
   ;; fall back to serving _all_ other files under /app
   (route/resources "/" {:root "frontend_client/app"})

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -7,9 +7,11 @@
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as mdb]
    [metabase.appearance.core :as appearance]
+   [metabase.config.core :as config]
    [metabase.core.initialization-status :as init-status]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.server.auth-wrapper :as auth-wrapper]
+   [metabase.server.middleware.etag-cache :as mw.etag-cache]
    [metabase.server.routes.index :as index]
    [metabase.system.core :as system]
    [metabase.util :as u]
@@ -59,6 +61,23 @@
   ([_request respond _raise]
    (respond (health-handler))))
 
+#_{:clj-kondo/ignore [:discouraged-var]}
+(defroutes ^:private static-files-handler
+  (GET "/embedding-sdk.js"
+    {{:strs [if-none-match]} :headers}
+    (if (and (not config/is-dev?)
+             (mw.etag-cache/matches-metabase-version-hash? if-none-match))
+      ;; send the pre-built 304 response
+      mw.etag-cache/not-modified-response
+
+      ;; else, serve the file
+      (mw.etag-cache/js-response-with-etag
+       (response/resource-response "frontend_client/app/embedding-sdk.js"))))
+
+  ;; fall back to serving _all_ other files under /app
+  (route/resources "/" {:root "frontend_client/app"})
+  (route/not-found {:status 404 :body "Not found."}))
+
 (mu/defn- api-handler :- ::api.macros/handler
   [api-routes :- ::api.macros/handler]
   (fn api-handler* [request respond raise]
@@ -89,10 +108,7 @@
    ;; ^/api/ -> All other API routes
    (context "/api" [] (api-handler api-routes))
    ;; ^/app/ -> static files under frontend_client/app
-   (context "/app" []
-     (route/resources "/" {:root "frontend_client/app"})
-     ;; return 404 for anything else starting with ^/app/ that doesn't exist
-     (route/not-found {:status 404, :body "Not found."}))
+   (context "/app" [] static-files-handler)
    ;; ^/public/ -> Public frontend and download routes
    (context "/public" [] public-routes)
    ;; ^/emebed/ -> Embed frontend and download routes

--- a/test/metabase/server/middleware/etag_cache_test.clj
+++ b/test/metabase/server/middleware/etag_cache_test.clj
@@ -2,34 +2,44 @@
   (:require
    [clojure.test :refer :all]
    [metabase.config.core :as config]
-   [metabase.server.middleware.etag-cache :as mw.etag-cache]))
+   [metabase.server.middleware.etag-cache :as mw.etag-cache]
+   [ring.util.response :as response]))
 
 (set! *warn-on-reflection* true)
 
 (deftest js-etag-handler-test
-  (let [handler (mw.etag-cache/js-etag-handler "frontend_client/app/embedding-sdk.js")
-        etag    (format "\"%s\"" config/mb-version-hash)]
+  (testing "returns 304 when ETag matches and not in dev mode"
+    (with-redefs [config/is-dev? false
+                  response/resource-response
+                  (constantly {:status 200 :headers {} :body "dummy js"})]
+      (let [etag     (format "\"%s\"" config/mb-version-hash)
+            handler  (mw.etag-cache/js-etag-handler "frontend_client/app/embedding-sdk.js")
+            response (handler {:headers {"if-none-match" etag}})]
+        (is (= 304 (:status response)))
+        (is (= "" (:body response)))
+        (is (= mw.etag-cache/etag-header (:headers response))))))
 
-    (testing "returns 304 when ETag matches and not in dev mode"
-      (with-redefs [config/is-dev? false]
-        (let [response (handler {:headers {"if-none-match" etag}})]
-          (is (= 304 (:status response)))
-          (is (= "" (:body response)))
-          (is (= mw.etag-cache/etag-header (:headers response))))))
+  (testing "returns 200 with correct headers when ETag does not match"
+    (with-redefs [config/is-dev? false
+                  response/resource-response
+                  (constantly {:status 200 :headers {} :body "dummy js"})]
+      (let [etag     (format "\"different\"")
+            handler  (mw.etag-cache/js-etag-handler "frontend_client/app/embedding-sdk.js")
+            response (handler {:headers {"if-none-match" etag}})
+            headers  (:headers response)]
+        (is (= 200 (:status response)))
+        (is (= "application/javascript; charset=UTF-8"
+               (get headers "Content-Type")))
+        (is (= mw.etag-cache/etag-header
+               (select-keys headers (keys mw.etag-cache/etag-header))))))))
 
-    (testing "returns 200 with correct headers when ETag does not match"
-      (with-redefs [config/is-dev? false]
-        (let [response (handler {:headers {"if-none-match" "\"different\""}})
-              headers  (:headers response)]
-          (is (= 200 (:status response)))
-          (is (= "application/javascript; charset=UTF-8"
-                 (get headers "Content-Type")))
-          (is (= mw.etag-cache/etag-header
-                 (select-keys headers (keys mw.etag-cache/etag-header)))))))
-
-    (testing "returns 200 when in dev mode, ignoring ETag match"
-      (with-redefs [config/is-dev? true]
-        (let [response (handler {:headers {"if-none-match" etag}})]
-          (is (= 200 (:status response)))
-          (is (= mw.etag-cache/etag-header
-                 (select-keys (:headers response) (keys mw.etag-cache/etag-header)))))))))
+(testing "returns 200 when in dev mode, ignoring ETag match"
+  (with-redefs [config/is-dev? true
+                response/resource-response
+                (constantly {:status 200 :headers {} :body "dummy js"})]
+    (let [etag     (format "\"%s\"" config/mb-version-hash)
+          handler  (mw.etag-cache/js-etag-handler "frontend_client/app/embedding-sdk.js")
+          response (handler {:headers {"if-none-match" etag}})]
+      (is (= 200 (:status response)))
+      (is (= mw.etag-cache/etag-header
+             (select-keys (:headers response) (keys mw.etag-cache/etag-header)))))))

--- a/test/metabase/server/middleware/etag_cache_test.clj
+++ b/test/metabase/server/middleware/etag_cache_test.clj
@@ -1,0 +1,50 @@
+(ns metabase.server.middleware.etag-cache-test
+  (:require
+   [clojure.test                     :refer :all]
+   [metabase.config.core             :as config]
+   [metabase.server.middleware.etag-cache :as mw.etag-cache]))
+
+(set! *warn-on-reflection* true)
+
+(deftest matches-metabase-version-hash?-test
+  (let [hash           config/mb-version-hash
+        quoted      (str "\"" hash "\"")
+        weak-quoted (str "W/" quoted)
+        wrong       "\"not-the-version\""]
+    (testing "returns true for exact quoted ETag"
+      (is (true? (mw.etag-cache/matches-metabase-version-hash? quoted))))
+    (testing "returns true for weak ETag"
+      (is (true? (mw.etag-cache/matches-metabase-version-hash? weak-quoted))))
+    (testing "returns false for non-matching value"
+      (is (false? (mw.etag-cache/matches-metabase-version-hash? wrong))))
+    (testing "returns nil for nil input"
+      (is (nil? (mw.etag-cache/matches-metabase-version-hash? nil))))))
+
+(deftest not-modified-response-test
+  (let [resp mw.etag-cache/not-modified-response
+        hdrs (:headers resp)]
+    (testing "status is 304"
+      (is (= 304 (:status resp))))
+    (testing "body is empty string"
+      (is (= "" (:body resp))))
+    (testing "contains exactly the configured cache headers"
+      (is (= mw.etag-cache/etag-headers-for-metabase-version-hash hdrs)))))
+
+(deftest js-response-with-etag-test
+  (let [dummy-body  "console.log('hello');"
+        base-resp   {:status  200
+                     :headers {}
+                     :body    dummy-body}
+        resp        (mw.etag-cache/js-response-with-etag base-resp)
+        hdrs        (:headers resp)]
+    (testing "status is unchanged"
+      (is (= 200 (:status resp))))
+    (testing "body is preserved"
+      (is (= dummy-body (:body resp))))
+    (testing "Content-Type is set to JavaScript"
+      (is (= "application/javascript; charset=UTF-8"
+             (get hdrs "Content-Type"))))
+    (testing "ETag and Cache-Control headers are merged"
+      (let [expected mw.etag-cache/etag-headers-for-metabase-version-hash]
+        (doseq [[k v] expected]
+          (is (= v (get hdrs k))))))))


### PR DESCRIPTION
The hosted bundle served from an Metabase instance should be cached. The cache should be invalidated when a metabase version is changed.

This PR changes how the `/embedding-sdk.js` static file is served:
- handles `if-none-match` header and returns cached/uncached response
- returns `etag` header with response for `/embedding-sdk.js` request

Etag header is applied only in non-dev mode, so in dev mode we always have the actual code.

Tech proposal:
https://www.notion.so/metabase/Hosted-Embedding-SDK-bundle-22569354c901809897f3c18db6af8922?source=copy_link#22969354c9018000ac82ca213fbe0eac

How to test:
- CI should pass