### PR TITLE
Better batching for semantic search

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -37,7 +37,7 @@
   (when-not @semantic.db/data-source (semantic.db/init-db!))
   (semantic.index/delete-from-index! model ids))
 
-;; TODO: add reindexing logic when index is detected as stale
+;; TODO: add reindexing/table-swapping logic when index is detected as stale
 (defenterprise init!
   "Initialize the semantic search table and populate it with initial data."
   :feature :semantic-search
@@ -50,7 +50,6 @@
   "Reindex the semantic search index."
   :feature :semantic-search
   [searchable-documents _opts]
-  ;; TODO:implement reindexing without dropping the table
   (when-not @semantic.db/data-source (semantic.db/init-db!))
   (semantic.index/create-index-table! {:force-reset? false})
   (semantic.index/upsert-index! (into [] searchable-documents)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -220,6 +220,7 @@
   ([model]
    (-model-dimensions (get-provider) model)))
 
+;; TODO: dedupe embedding fetching for identical values
 (defn process-embeddings-streaming
   "Process texts in provider-appropriate batches, calling process-fn for each batch. process-fn will be called with
   [texts embeddings] for each batch."

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -163,28 +163,22 @@
           endpoint "https://api.openai.com/v1/embeddings"]
       (when-not api-key
         (throw (ex-info "OpenAI API key not configured" {:setting "ee-openai-api-key"})))
-      (let [batches (create-batches (semantic-settings/openai-max-tokens-per-batch) count-tokens texts)
-            batch-results (mapv (fn [batch-texts]
-                                  (try
-                                    (log/info "Generating" (count batch-texts) "OpenAI embeddings in batch")
-                                    (-> (http/post endpoint
-                                                   {:headers {"Content-Type" "application/json"
-                                                              "Authorization" (str "Bearer " api-key)}
-                                                    :body    (json/encode {:model model
-                                                                           :input batch-texts})})
-                                        :body
-                                        (json/decode true)
-                                        :data
-                                        (->> (map :embedding)))
-                                    (catch Exception e
-                                      (log/error e "Failed to generate OpenAI embeddings for batch of" (count batch-texts) "texts"
-                                                 "with token count:" (count-tokens-batch batch-texts))
-                                      (throw e))))
-                                batches)]
-        (log/info "Processed" (count texts) "texts in" (count batches) "batches"
-                  "with token counts:" (mapv count-tokens-batch batches))
-        ;; Flatten the batch results to get a single vector of embeddings
-        (vec (mapcat identity batch-results)))))
+      (try
+        (log/debug "Generating" (count texts) "OpenAI embeddings in batch")
+        (-> (http/post endpoint
+                       {:headers {"Content-Type" "application/json"
+                                  "Authorization" (str "Bearer " api-key)}
+                        :body    (json/encode {:model model
+                                               :input texts})})
+            :body
+            (json/decode true)
+            :data
+            (->> (map :embedding)
+                 vec))
+        (catch Exception e
+          (log/error e "Failed to generate OpenAI embeddings for batch of" (count texts) "texts"
+                     "with token count:" (count-tokens-batch texts))
+          (throw e)))))
 
   (-pull-model [_]
     (log/info "OpenAI provider does not require pulling a model"))
@@ -208,7 +202,7 @@
                        :available-providers (keys providers)})))))
 
 (defn get-embedding
-  "Generate an embedding using the configured provider."
+  "Generate a single embedding using the configured provider. Prefer using `process-embeddings-streaming` for bulk index population."
   [text]
   (-get-embedding (get-provider) text))
 
@@ -226,13 +220,22 @@
   ([model]
    (-model-dimensions (get-provider) model)))
 
-(defn get-embeddings-batch
-  "Generate embeddings for multiple texts using the configured provider.
-   Each provider handles its own batching logic internally if needed."
-  [texts]
+(defn process-embeddings-streaming
+  "Process texts in provider-appropriate batches, calling process-fn for each batch. process-fn will be called with
+  [texts embeddings] for each batch."
+  [texts process-fn]
   (when (seq texts)
     (let [provider (get-provider)]
-      (-get-embeddings-batch provider texts))))
+      (if (instance? OpenAIProvider provider)
+        ;; For OpenAI, use token-aware batching and stream processing
+        (let [batches (create-batches (semantic-settings/openai-max-tokens-per-batch) count-tokens texts)]
+          (run! (fn [batch-texts]
+                  (let [embeddings (-get-embeddings-batch provider batch-texts)]
+                    (process-fn batch-texts embeddings)))
+                batches))
+        ;; For other providers, process all at once (existing behavior)
+        (let [embeddings (-get-embeddings-batch provider texts)]
+          (process-fn texts embeddings))))))
 
 (comment
   ;; Configuration:

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -41,6 +41,7 @@
   [row]
   (update row :embedding #'semantic.index/decode-pgobject))
 
+#_:clj-kondo/ignore
 (defn- full-index
   "Query the full index table and return all documents with decoded embeddings.
   Not used in tests, but useful for debugging."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -41,6 +41,17 @@
   [row]
   (update row :embedding #'semantic.index/decode-pgobject))
 
+(defn- full-index
+  "Query the full index table and return all documents with decoded embeddings.
+  Not used in tests, but useful for debugging."
+  []
+  (->> (jdbc/execute! @semantic.db/data-source
+                      (-> (sql.helpers/select :model :model_id :content :creator_id :embedding)
+                          (sql.helpers/from semantic.index/*index-table-name*)
+                          semantic.index/sql-format-quoted))
+       (map #'semantic.index/unqualify-keys)
+       (map decode-embedding)))
+
 (defn- query-index
   [{:keys [model model_id]}]
   (->> (jdbc/execute! @semantic.db/data-source
@@ -91,24 +102,6 @@
   (check-index-has-mock-card)
   (check-index-has-mock-dashboard))
 
-(deftest populate-index!-test
-  (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-mocked-embeddings!
-      (semantic.tu/with-temp-index-table!
-        (check-index-has-no-mock-docs)
-        (testing "populate-index! returns nil if you pass it an empty collection"
-          (is (nil? (semantic.index/populate-index! [])))
-          (check-index-has-no-mock-docs))
-        (testing "populate-index! works on a fresh index"
-          (is (= {"card" 1, "dashboard" 1}
-                 (semantic.index/populate-index! semantic.tu/mock-documents)))
-          (check-index-has-mock-docs))
-        (testing "populate-index! throws if you try to insert duplicate documents"
-          (is (thrown-with-msg?
-               org.postgresql.util.PSQLException
-               #"ERROR: duplicate key value violates unique constraint.*"
-               (semantic.index/populate-index! semantic.tu/mock-documents))))))))
-
 (deftest upsert-index!-test
   (mt/with-premium-features #{:semantic-search}
     (semantic.tu/with-mocked-embeddings!
@@ -131,9 +124,9 @@
     (semantic.tu/with-mocked-embeddings!
       (semantic.tu/with-temp-index-table!
         (check-index-has-no-mock-docs)
-        (testing "populate-index! before delete!"
+        (testing "upsert-index! before delete!"
           (is (= {"card" 1, "dashboard" 1}
-                 (semantic.index/populate-index! semantic.tu/mock-documents)))
+                 (semantic.index/upsert-index! semantic.tu/mock-documents)))
           (check-index-has-mock-docs))
         (testing "delete-from-index! returns nil if you pass it an empty collection"
           (is (nil? (semantic.index/delete-from-index! "card" [])))
@@ -165,10 +158,6 @@
                 mock-docs (into semantic.tu/mock-documents extra-docs)]
             (testing "ensure populate! upsert! and delete! work when batch size is exceeded"
               (check-index-has-no-mock-docs)
-              (testing "populate-index! with batch processing"
-                (is (= {"card" 6, "dashboard" 6}
-                       (semantic.index/populate-index! mock-docs)))
-                (check-index-has-mock-docs))
               (testing "upsert-index! with batch processing"
                 (is (= {"card" 6, "dashboard" 6}
                        (semantic.index/upsert-index! mock-docs)))
@@ -178,8 +167,8 @@
                   (is (= {"card" 11}
                          (semantic.index/delete-from-index! "card" (into ["123"] extra-ids))))
                   (check-index-has-no-mock-card)
-                  (check-index-has-mock-dashboard))
-                (testing "delete the dashboard"
-                  (is (= {"dashboard" 11}
-                         (semantic.index/delete-from-index! "dashboard" (into ["456"] extra-ids))))
-                  (check-index-has-no-mock-docs))))))))))
+                  (check-index-has-mock-dashboard)))
+              (testing "delete the dashboard"
+                (is (= {"dashboard" 11}
+                       (semantic.index/delete-from-index! "dashboard" (into ["456"] extra-ids))))
+                (check-index-has-no-mock-docs)))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -79,12 +79,19 @@
   [results]
   (filter #(contains? mock-embeddings (:name %)) results))
 
+(defn mock-process-embeddings-streaming
+  "Mock implementation of process-embeddings-streaming that uses mock embeddings."
+  [texts process-fn]
+  (when (seq texts)
+    (let [embeddings (get-mock-embeddings-batch texts)]
+      (process-fn texts embeddings))))
+
 (defmacro with-mocked-embeddings! [& body]
   ;; TODO: it's warning about not using with-redefs outside of tests but we *are* using it in tests
   #_:clj-kondo/ignore
   `(with-redefs [semantic.embedding/model-dimensions (constantly 4)
                  semantic.embedding/pull-model (constantly nil)
-                 semantic.embedding/get-embeddings-batch get-mock-embeddings-batch
+                 semantic.embedding/process-embeddings-streaming mock-process-embeddings-streaming
                  semantic.embedding/get-embedding get-mock-embedding]
      ~@body))
 


### PR DESCRIPTION
Instead of doing batched requests to fetch embeddings for _all_ documents, and then subsequently populating the index, we can populate the index after each batch is fetched. I've added `process-embeddings-streaming` which takes a `process-fn` to process the results of each embedding batch. This is passed in by callers, and is intended to separate the concerns of fetching embeddings with the concerns of handling documents & writing them to the search index.

I don't think this is a perfect structure but it's quick way to get this sort of integration working without ripping out the entire structure.