### PR TITLE
Remove indexed-entities from the semantic search model-set and documents reducible

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -131,9 +131,8 @@
   [connectable index documents]
   (log/info "Populating semantic search index with" (count documents) "documents")
   (when (seq documents)
-    (let [filtered-documents (remove #(= (:model %) "indexed-entity") documents)
-          text->docs         (group-by :searchable_text filtered-documents)
-          searchable-texts   (map :searchable_text filtered-documents)]
+    (let [text->docs         (group-by :searchable_text documents)
+          searchable-texts   (map :searchable_text documents)]
       (embedding/process-embeddings-streaming
        (:embedding-model index)
        searchable-texts

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -270,6 +270,8 @@
   [docs]
   (let [doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
         t2-instances  (for [[t2-model docs] (group-by doc->t2-model docs)
+                            ;; NOTE an "indexed-entity" (:model/ModelIndexValue) does not have an :id column. For now
+                            ;; we are filtering indexed-entities out and they should not appear here.
                             t2-instance     (t2/select t2-model :id [:in (map :id docs)])]
                         t2-instance)
         doc->t2       (comp (u/index-by (juxt :id t2/model) t2-instances)

--- a/src/metabase/search/semantic/core.clj
+++ b/src/metabase/search/semantic/core.clj
@@ -77,6 +77,8 @@
   [_search-ctx]
   (disj search.config/all-models "indexed-entity"))
 
+;; NOTE if you remove this you need to also modify filter-read-permitted to handle indexed-entity docs.
+;; See the corresponding note in metabase-enterprise.semantic-search.index/filter-read-permitted.
 (defn- remove-indexed-entities
   "Remove indexed-entities from `document-reducible`"
   [document-reducible]


### PR DESCRIPTION
### Description

Remove "indexed-entities" from the documents reducible early, prior to turning them into a realized vector in the semantic search backend.

https://metaboat.slack.com/archives/C07SJT1P0ET/p1753122804724569?thread_ts=1753121203.212049&cid=C07SJT1P0ET

### How to verify

Enable [indexed entities](https://www.metabase.com/docs/latest/data-modeling/models#surface-individual-records-in-search-by-matching-against-this-column) on a model column. Verify they are no longer passed to populate-index! or upsert-index!
