### PR TITLE
Only create HNSW embeddings index :if-not-exists

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -193,7 +193,7 @@
         (jdbc/execute!
          tx
          (-> (sql.helpers/create-index
-              (keyword (str "embedding_hnsw_index_" (nano-id/nano-id)))
+              [:embedding_hnsw_idx :if-not-exists]
               [*index-table-name* :using-hnsw [:raw "embedding vector_cosine_ops"]])
              sql-format-quoted))))
     (catch Exception e

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -16,14 +16,13 @@
       (semantic.tu/with-temp-index-table!
         ;; with-temp-index-table! creates the temp table, so drop it in order to test create!.
         (semantic.index/drop-index-table!)
-        (let [embedding-index-pattern "embedding_hnsw_index_%"]
-          (testing "index table is not present before create!"
-            (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))
-            (is (not (semantic.tu/table-has-index? semantic.index/*index-table-name* embedding-index-pattern))))
-          (testing "index table is present after create!"
-            (semantic.index/create-index-table! {:force-reset? false})
-            (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))
-            (is (semantic.tu/table-has-index? semantic.index/*index-table-name* embedding-index-pattern))))))))
+        (testing "index table is not present before create!"
+          (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))
+          (is (not (semantic.tu/table-has-index? semantic.index/*index-table-name* :embedding_hnsw_idx))))
+        (testing "index table is present after create!"
+          (semantic.index/create-index-table! {:force-reset? false})
+          (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))
+          (is (semantic.tu/table-has-index? semantic.index/*index-table-name* :embedding_hnsw_idx)))))))
 
 (deftest drop-index-table!-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -174,12 +174,12 @@
       (catch Exception _ false))))
 
 (defn table-has-index?
-  [table-name index-name-pattern]
+  [table-name index-name]
   (when table-name
     (try
       (let [result (jdbc/execute! @semantic.db/data-source
-                                  ["SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE tablename = ? AND indexname LIKE ?)"
+                                  ["SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE tablename = ? AND indexname = ?)"
                                    (name table-name)
-                                   index-name-pattern])]
+                                   (name index-name)])]
         (-> result first vals first))
       (catch Exception _ false))))


### PR DESCRIPTION
### Description

Since `init!` no longer wipes the index table if it already exists, we also need to only create the embeddings HNSW
index if it does not exist.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
