### PR TITLE
Add prometheus metrics for semantic search backend

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1770,7 +1770,8 @@
   {:team "Metabot"
    :api  #{metabase-enterprise.semantic-search.core
            metabase-enterprise.semantic-search.init}
-   :uses #{connection-pool
+   :uses #{analytics
+           connection-pool
            models
            premium-features
            search

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -182,7 +182,7 @@
 
 (defmethod get-embedding        "openai" [{:keys [model-name]} text] (openai-get-embedding model-name text))
 (defmethod get-embeddings-batch "openai" [{:keys [model-name]} text] (openai-get-embeddings-batch model-name text))
-(defmethod pull-model           "openai" [_] (log/info "OpenAI provider does not require pulling a model"))
+(defmethod pull-model           "openai" [_] (log/debug "OpenAI provider does not require pulling a model"))
 
 ;;;; Global embedding model
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -2,6 +2,7 @@
   (:require
    [clj-http.client :as http]
    [metabase-enterprise.semantic-search.settings :as semantic-settings]
+   [metabase.analytics.core :as analytics]
    [metabase.util.json :as json]
    [metabase.util.log :as log])
   (:import
@@ -86,6 +87,11 @@
   {"openai" "text-embedding-3-small"
    "ollama" "mxbai-embed-large"})
 
+(def supported-models-for-provider
+  "Get all supported models for a give provider."
+  {"openai" openai-supported-models
+   "ollama" ollama-supported-models})
+
 ;;;; Provider SPI
 
 (defn- dispatch-provider [embedding-model & _] (:provider embedding-model))
@@ -106,6 +112,7 @@
 
 (defn- ollama-get-embedding [model-name text]
   (try
+    ;; TODO count ollama tokens into :metabase-search/semantic-embedding-tokens?
     (log/debug "Generating Ollama embedding for text of length:" (count text))
     (-> (http/post "http://localhost:11434/api/embeddings"
                    {:headers {"Content-Type" "application/json"}
@@ -160,7 +167,10 @@
       (catch Exception e
         (log/error e "Failed to generate OpenAI embeddings for batch of" (count texts) "texts"
                    "with token count:" (count-tokens-batch texts))
-        (throw e)))))
+        (throw e)))
+    (analytics/inc! :metabase-search/semantic-embedding-tokens
+                    {:provider "openai", :model model-name}
+                    (count-tokens-batch texts))))
 
 (defn- openai-get-embedding [model-name text]
   (try
@@ -218,6 +228,16 @@
         (let [embeddings (get-embeddings-batch embedding-model texts)
               text-embedding-map (zipmap texts embeddings)]
           (process-fn text-embedding-map))))))
+
+(comment
+  ;; This gets loaded after metabase.analytics.prometheus/setup-metrics! so the known labels don't get initialized. If
+  ;; we care about this, we need to ensure this namespace gets loaded before setup-metrics! is called, e.g. by requiring
+  ;; this namespace in the semantic search module's init file. See https://github.com/metabase/metabase/pull/52834
+  (defmethod analytics/known-labels :metabase-search/semantic-embedding-tokens
+    [_]
+    (for [provider (keys supported-models-for-provider)
+          model (keys (supported-models-for-provider provider))]
+      {:provider provider :model model})))
 
 (comment
   ;; Configuration:

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -117,11 +117,11 @@
                                      ;; TODO should this return (or at least log) the number of docs actually
                                      ;; updated, not just the number in the batch?
                                      (u/prog1 (->> db-records (map :model) frequencies)
-                                       (log/trace "semantic search processed a batch of" (count db-records)
+                                       (log/debug "semantic search processed a batch of" (count db-records)
                                                   "documents with frequencies" <>)))))
                         (partial merge-with +)
                         (map vector documents embeddings))
-      (log/trace "semantic search processed" (count documents) "total documents with frequencies" <>)
+      (log/info "semantic search processed" (count documents) "total documents with frequencies" <>)
       (analytics-set-index-size! connectable table-name))))
 
 (defn- batch-delete-ids!
@@ -131,12 +131,12 @@
                                    (map (fn [ids]
                                           (jdbc/execute! connectable (ids->sql ids))
                                           (u/prog1 (count ids)
-                                            (log/trace "semantic search deleted a batch of" <>
+                                            (log/debug "semantic search deleted a batch of" <>
                                                        "documents with model type" model)))))
                              +
                              ids)
                   (array-map model))
-      (log/trace "semantic search deleted" (get <> model) "total documents with model type" model)
+      (log/info "semantic search deleted" (get <> model) "total documents with model type" model)
       (analytics-set-index-size! connectable table-name))))
 
 (defn- db-records->update-set

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -213,3 +213,22 @@
                        :content "Tiger Conservation"
                        :embedding (semantic.tu/get-mock-embedding "Tiger Conservation")}]
                      (query-embeddings {:model "card" :model_id "3"}))))))))))
+
+(deftest prometheus-metrics-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-open [_ (semantic.tu/open-temp-index!)]
+      (mt/with-prometheus-system! [_ system]
+        (testing "semantic-index-size starts at zero"
+          (is (= 0.0 (mt/metric-value system :metabase-search/semantic-index-size))))
+        (testing "semantic-index-size is updated after upsert-index! on empty db"
+          (is (= {"card" 1, "dashboard" 1}
+                 (semantic.tu/upsert-index! semantic.tu/mock-documents)))
+          (is (= 2.0 (mt/metric-value system :metabase-search/semantic-index-size))))
+        (testing "semantic-index-size is updated after delete-from-index!"
+          (is (= {"card" 1}
+                 (semantic.tu/delete-from-index! "card" ["123"])))
+          (is (= 1.0 (mt/metric-value system :metabase-search/semantic-index-size))))
+        (testing "semantic-index-size is updated after upsert-index! on populated db"
+          (is (= {"card" 1, "dashboard" 1}
+                 (semantic.tu/upsert-index! semantic.tu/mock-documents)))
+          (is (= 2.0 (mt/metric-value system :metabase-search/semantic-index-size))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -155,7 +155,7 @@
                               extra-ids
                               (flatten (repeat semantic.tu/mock-documents)))
               mock-docs (into semantic.tu/mock-documents extra-docs)]
-          (testing "ensure populate! upsert! and delete! work when batch size is exceeded"
+          (testing "ensure upsert! and delete! work when batch size is exceeded"
             (check-index-has-no-mock-docs)
             (testing "upsert-index! with batch processing"
               (is (= {"card" 6, "dashboard" 6}

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -276,7 +276,9 @@
       ;; 1ms -> 10minutes
                           :buckets [1 500 1000 5000 10000 30000 60000 120000 300000 600000]})
    (prometheus/gauge :metabase-search/appdb-index-size
-                     {:description "Number of rows in the active index table."})
+                     {:description "Number of rows in the active appdb index table."})
+   (prometheus/gauge :metabase-search/semantic-index-size
+                     {:description "Number of rows in the active semantic index table."})
    (prometheus/gauge :metabase-search/queue-size
                      {:description "Number of updates on the search indexing queue."})
    (prometheus/counter :metabase-search/response-ok

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -291,6 +291,10 @@
    (prometheus/gauge :metabase-search/engine-active
                      {:description "Whether a given engine is active. This does NOT mean that it is the default."
                       :labels [:engine]})
+   (prometheus/counter :metabase-search/semantic-embedding-tokens
+                       {:description (str "Number of tokens consumed by the given embedding model and provider. "
+                                          "Not all providers track token use.")
+                        :labels [:model :provider]})
    ;; notification metrics
    (prometheus/counter :metabase-notification/send-ok
                        {:description "Number of successful notification sends."

--- a/src/metabase/search/semantic/core.clj
+++ b/src/metabase/search/semantic/core.clj
@@ -88,18 +88,20 @@
 (defmethod search.engine/update! :search.engine/semantic
   [_ document-reducible]
   (try
+    (log/info "Updating semantic search engine")
     (update-index! (-> document-reducible
                        remove-indexed-entities))
     (catch Exception e
-      (log/error e "Error updating semantic search index")
+      (log/error e "Error updating semantic search engine")
       {})))
 
 (defmethod search.engine/delete! :search.engine/semantic
   [_ model ids]
   (try
+    (log/info "Deleting from semantic search engine")
     (delete-from-index! model ids)
     (catch Exception e
-      (log/error e "Error deleting from semantic search index")
+      (log/error e "Error deleting from semantic search engine")
       {})))
 
 (defmethod search.engine/init! :search.engine/semantic
@@ -110,7 +112,7 @@
                remove-indexed-entities)
            opts)
     (catch Exception e
-      (log/error e "Failed to initialize semantic search engine")
+      (log/error e "Error initializing semantic search engine")
       (throw e))))
 
 (defmethod search.engine/reindex! :search.engine/semantic
@@ -120,9 +122,8 @@
     (reindex! (-> (search.ingestion/searchable-documents)
                   remove-indexed-entities)
               opts)
-    (log/info "Semantic search engine reindexed successfully")
     (catch Exception e
-      (log/error e "Failed to reindex semantic search engine")
+      (log/error e "Error reindexing semantic search engine")
       (throw e))))
 
 (comment
@@ -137,4 +138,4 @@
   (try
     (reset-tracking!)
     (catch Exception e
-      (log/debug e "Error resetting semantic search tracking"))))
+      (log/debug e "Error resetting tracking for semantic search engine"))))


### PR DESCRIPTION
Closes [BOT-229](https://linear.app/metabase/issue/BOT-229/monitoring)

### Description

* Add `:metabase-search/semantic-index-size` prometheus metric
  And update it on `upsert-index!` / `delete-from-index!`. This metric mirrors the corresponding `:metabase-search/appdb-index-size`, which is the only metric exposed by appdb backend.
* Add `:metabase-search/semantic-embedding-tokens` prometheus metric
  This metric tracks token usage by the embedding model. Currently only implemented for OpenAI models.
* minor clean up of log levels / messages.
  Make sure batched index updates are logged at debug rather than trace, but that the final log with total counts is logged at info, etc.

### How to verify

Define `MB_PROMETHEUS_SERVER_PORT=9191` then check to make sure metrics are created / incremented.

```
$ http localhost:9191/metrics | fgrep semantic | fgrep -v c3p0
metabase_search_engine_active{engine="semantic",} 1.0
# HELP metabase_search_semantic_index_size Number of rows in the active semantic index table.
# TYPE metabase_search_semantic_index_size gauge
metabase_search_semantic_index_size 4721.0
# HELP metabase_search_semantic_embedding_tokens_total Number of tokens consumed by the given embedding model and provider.
# TYPE metabase_search_semantic_embedding_tokens_total counter
metabase_search_semantic_embedding_tokens_total{model="text-embedding-3-small",provider="openai",} 103.0
metabase_search_engine_default{engine="semantic",} 1.0
# HELP metabase_search_semantic_embedding_tokens_created Number of tokens consumed by the given embedding model and provider.
# TYPE metabase_search_semantic_embedding_tokens_created gauge
metabase_search_semantic_embedding_tokens_created{model="text-embedding-3-small",provider="openai",} 1.753146889613E9
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
