### PR TITLE
Prefix the embedding index with the *index-table-name*

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -157,6 +157,10 @@
   ([]   (jdbc/execute! @db/data-source (drop-index-table-sql)))
   ([tx] (jdbc/execute! tx (drop-index-table-sql))))
 
+(defn- embedding-index-name
+  []
+  (str (name *index-table-name*) "_embedding_hnsw_idx"))
+
 (defn create-index-table!
   "Ensure that the index table exists and is ready to be populated. If
   force-reset? is true, drops and recreates the table if it exists."
@@ -174,7 +178,7 @@
         (jdbc/execute!
          tx
          (-> (sql.helpers/create-index
-              [:embedding_hnsw_idx :if-not-exists]
+              [(embedding-index-name) :if-not-exists]
               [*index-table-name* :using-hnsw [:raw "embedding vector_cosine_ops"]])
              sql-format-quoted))))
     (catch Exception e

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -16,13 +16,14 @@
       (semantic.tu/with-temp-index-table!
         ;; with-temp-index-table! creates the temp table, so drop it in order to test create!.
         (semantic.index/drop-index-table!)
-        (testing "index table is not present before create!"
-          (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))
-          (is (not (semantic.tu/table-has-index? semantic.index/*index-table-name* :embedding_hnsw_idx))))
-        (testing "index table is present after create!"
-          (semantic.index/create-index-table! {:force-reset? false})
-          (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))
-          (is (semantic.tu/table-has-index? semantic.index/*index-table-name* :embedding_hnsw_idx)))))))
+        (let [embedding-index-name (#'semantic.index/embedding-index-name)]
+          (testing "index table is not present before create!"
+            (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))
+            (is (not (semantic.tu/table-has-index? semantic.index/*index-table-name* embedding-index-name))))
+          (testing "index table is present after create!"
+            (semantic.index/create-index-table! {:force-reset? false})
+            (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))
+            (is (semantic.tu/table-has-index? semantic.index/*index-table-name* embedding-index-name))))))))
 
 (deftest drop-index-table!-test
   (mt/with-premium-features #{:semantic-search}


### PR DESCRIPTION
### Description

Fix-up for #61305

Prefix the embedding index with the `*index-table-name*`  to ensure the index name for temporary test tables is distinct from the index name for the main table. Otherwise, the `:if-not-exists` condition prevents adding the index to temp tests tables if you already have a `search_index` table in your db.

### How to verify

Run the `create-index-table!-test` from your REPL when connected to a DB that already has the search_index populated.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
