### PR TITLE
Action v2 API to support Table Editing

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -409,9 +409,10 @@
   clojure.test.check.properties/for-all                                                 clojure.core/let
   clojurewerkz.quartzite.jobs/defjob                                                    clojure.core/defn
   instaparse.core/defparser                                                             clojure.core/def
+  metabase-enterprise.action-v2.test-util/with-test-tables!                             clojure.core/let
   metabase-enterprise.serialization.test-util/with-dbs                                  clojure.core/fn
   metabase-enterprise.serialization.test-util/with-random-dump-dir                      clojure.core/let
-metabase-enterprise.content-translation.routes-test/with-new-secret-key!                clojure.core/fn
+  metabase-enterprise.content-translation.routes-test/with-new-secret-key!              clojure.core/fn
   metabase.actions.test-util/with-actions                                               clojure.core/let
   metabase.api.common/let-404                                                           clojure.core/let
   metabase.app-db.custom-migrations.util/with-temp-scheduler!                           clojure.core/fn

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -48,10 +48,10 @@
  {actions
   {:team "Workflows"
    :api  #{metabase.actions.api
+           metabase.actions.args
            metabase.actions.core
            metabase.actions.init
-           metabase.actions.types
-           metabase.actions.args}
+           metabase.actions.types}
    :uses #{analytics
            api
            collections

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -49,7 +49,9 @@
   {:team "Workflows"
    :api  #{metabase.actions.api
            metabase.actions.core
-           metabase.actions.init}
+           metabase.actions.init
+           metabase.actions.types
+           metabase.actions.args}
    :uses #{analytics
            api
            collections
@@ -1437,6 +1439,18 @@
            util
            warehouse-schema}}
 
+  enterprise/action-v2
+  {:team "Workflows"
+   :api  #{metabase-enterprise.action-v2.api
+           metabase-enterprise.action-v2.core
+           metabase-enterprise.action-v2.init}
+   :uses #{actions
+           api
+           lib
+           query-processor
+           util
+           warehouse-schema}}
+
   enterprise/advanced-config
   {:team "Admin Webapp"
    :api  #{metabase-enterprise.advanced-config.api.logs
@@ -1616,7 +1630,6 @@
            util
            warehouse-schema
            warehouses}}
-
 
   enterprise/email
   {:team "Admin Webapp"
@@ -1843,7 +1856,7 @@
            upload
            util}}}
 
- ;; namespaces matching these patterns (with `re-find`) are excluded from the module linter. Since regex literals
+;; namespaces matching these patterns (with `re-find`) are excluded from the module linter. Since regex literals
  ;; aren't allowed in EDN just used the `(str <regex>)` version i.e. two slashes instead of one.
  ;;
  ;; this is mostly intended for excluding test namespaces or those rare 'glue' namespaces that glue multiple modules

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1856,7 +1856,7 @@
            upload
            util}}}
 
-;; namespaces matching these patterns (with `re-find`) are excluded from the module linter. Since regex literals
+ ;; namespaces matching these patterns (with `re-find`) are excluded from the module linter. Since regex literals
  ;; aren't allowed in EDN just used the `(str <regex>)` version i.e. two slashes instead of one.
  ;;
  ;; this is mostly intended for excluding test namespaces or those rare 'glue' namespaces that glue multiple modules

--- a/enterprise/backend/src/metabase_enterprise/action_v2/actions.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/actions.clj
@@ -66,10 +66,3 @@
 (mu/defmethod actions/default-mapping :data-grid.row/common
   [_ scope]
   (assoc (select-keys scope [:table-id]) :row :metabase-enterprise.action-v2.api/root))
-
-(mu/defmethod actions/default-mapping :data-grid.row/delete
-  [_ scope]
-  (assoc (select-keys scope [:table-id])
-         ;; TODO yeah, a shorter namespace would be nice, that doesn't require importing from EE
-         :row :metabase-enterprise.action-v2.api/input
-         :delete-children [:metabase-enterprise.action-v2.api/param :delete-children]))

--- a/enterprise/backend/src/metabase_enterprise/action_v2/actions.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/actions.clj
@@ -9,7 +9,6 @@
    [methodical.core :as methodical]))
 
 (derive :data-grid.row/create :data-grid.row/common)
-(derive :data-grid.row/create-or-update :data-grid.row/common)
 (derive :data-grid.row/update :data-grid.row/common)
 (derive :data-grid.row/delete :data-grid.row/common)
 

--- a/enterprise/backend/src/metabase_enterprise/action_v2/actions.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/actions.clj
@@ -1,0 +1,76 @@
+(ns metabase-enterprise.action-v2.actions
+  (:require
+   [metabase-enterprise.action-v2.data-editing :as data-editing]
+   [metabase.actions.args :as actions.args]
+   [metabase.actions.core :as actions]
+   [metabase.util :as u]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
+   [methodical.core :as methodical]))
+
+(derive :data-grid.row/create :data-grid.row/common)
+(derive :data-grid.row/create-or-update :data-grid.row/common)
+(derive :data-grid.row/update :data-grid.row/common)
+(derive :data-grid.row/delete :data-grid.row/common)
+
+(defmethod actions/action-arg-map-schema :data-grid.row/common
+  [_action]
+  ::actions.args/table.common)
+
+(defmethod actions/normalize-action-arg-map :data-grid.row/common
+  [_action input]
+  (-> (assoc input :database (:id (actions/cached-database-via-table-id (:table-id input))))
+      (update :row #(update-keys % u/qualified-name))))
+
+(defn- perform-table-row-action!
+  "Perform an action directly, skipping permissions checks etc, and generate outputs based on the table modifications."
+  [action-kw context inputs xform-outputs]
+  (update (actions/perform-nested-action! action-kw context inputs)
+          :outputs
+          xform-outputs))
+
+(defn- post-process [outputs]
+  (for [[table-id diffs] (u/group-by :table-id identity outputs)
+        :let [pretty-rows (data-editing/invalidate-and-present! table-id (map :row diffs))]
+        [op pretty-row] (map vector (map :op diffs) pretty-rows)]
+    {:op op, :table-id table-id, :row pretty-row}))
+
+(defn- coerce-inputs [inputs]
+  (let [input->coerced (u/for-map [[table-id inputs] (group-by :table-id inputs)
+                                   :let [coerced (data-editing/apply-coercions table-id (map :row inputs))]
+                                   input+row (map vector inputs coerced)]
+                         input+row)]
+    (for [input inputs]
+
+      (u/prog1 (assoc input :row (input->coerced input))
+        (log/tracef "coerce row %s => %s" (:row input) (:row <>))))))
+
+(defn- perform-data-grid-action! [action-kw context inputs]
+  (let [next-inputs (coerce-inputs inputs)]
+    (perform-table-row-action! action-kw context next-inputs
+                               (if (= :table.row/delete action-kw)
+                                 identity
+                                 post-process))))
+
+(methodical/defmethod actions/perform-action!* [:sql-jdbc :data-grid.row/create]
+  [_action context inputs]
+  (perform-data-grid-action! :table.row/create context inputs))
+
+(methodical/defmethod actions/perform-action!* [:sql-jdbc :data-grid.row/update]
+  [_action context inputs]
+  (perform-data-grid-action! :table.row/update context inputs))
+
+(methodical/defmethod actions/perform-action!* [:sql-jdbc :data-grid.row/delete]
+  [_action context inputs]
+  (perform-data-grid-action! :table.row/delete context inputs))
+
+(mu/defmethod actions/default-mapping :data-grid.row/common
+  [_ scope]
+  (assoc (select-keys scope [:table-id]) :row :metabase-enterprise.action-v2.api/root))
+
+(mu/defmethod actions/default-mapping :data-grid.row/delete
+  [_ scope]
+  (assoc (select-keys scope [:table-id])
+         ;; TODO yeah, a shorter namespace would be nice, that doesn't require importing from EE
+         :row :metabase-enterprise.action-v2.api/input
+         :delete-children [:metabase-enterprise.action-v2.api/param :delete-children]))

--- a/enterprise/backend/src/metabase_enterprise/action_v2/actions.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/actions.clj
@@ -40,7 +40,6 @@
                                    input+row (map vector inputs coerced)]
                          input+row)]
     (for [input inputs]
-
       (u/prog1 (assoc input :row (input->coerced input))
         (log/tracef "coerce row %s => %s" (:row input) (:row <>))))))
 

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.action-v2.api
   (:require
    [clojure.walk :as walk]
-   [metabase-enterprise.action-v2.describe :as data-editing.describe]
+   [metabase-enterprise.action-v2.execute-form :as data-editing.execute-form]
    [metabase.actions.core :as actions]
    [metabase.actions.types :as types]
    [metabase.api.macros :as api.macros]
@@ -159,7 +159,7 @@
   (let [scope         (actions/hydrate-scope scope)
         unified       (fetch-unified-action scope action)
         partial-input (first (apply-mapping-nested unified nil [input]))]
-    (data-editing.describe/describe-unified-action unified scope partial-input)))
+    (data-editing.execute-form/describe-form unified scope partial-input)))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/action-v2 routes."

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -1,0 +1,256 @@
+(ns metabase-enterprise.action-v2.api
+  (:require
+   [clojure.walk :as walk]
+   [metabase-enterprise.action-v2.data-editing :as data-editing]
+   [metabase-enterprise.action-v2.describe :as data-editing.describe]
+   [metabase.actions.core :as actions]
+   [metabase.actions.types :as types]
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.driver :as driver]
+   [metabase.util :as u]
+   [metabase.util.i18n :as i18n]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn require-authz?
+  "Temporary hack to have auth be off by default, only on if MB_DATA_EDITING_AUTHZ=true.
+  Remove once auth policy is fixed for dashboards."
+  []
+  (= "true" (System/getenv "MB_DATA_EDITING_AUTHZ")))
+
+;; might later be changed, or made driver specific, we might later drop the requirement depending on admin trust
+;; model (e.g are admins trusted with writing arbitrary SQL cases anyway, will non admins ever call this?)
+(def ^:private Identifier
+  "A malli schema for strings that can be used as SQL identifiers"
+  [:re #"^[\w\- ]+$"])
+
+;; upload types are used temporarily, I expect this to change
+(def ^:private column-type->upload-type
+  {"auto_incrementing_int_pk" :metabase.upload/auto-incrementing-int-pk
+   "boolean"                  :metabase.upload/boolean
+   "int"                      :metabase.upload/int
+   "float"                    :metabase.upload/float
+   "varchar255"               :metabase.upload/varchar-255
+   "text"                     :metabase.upload/text
+   "date"                     :metabase.upload/date
+   "datetime"                 :metabase.upload/datetime
+   "offset_datetime"          :metabase.upload/timestamp-with-time-zone})
+
+(def ^:private ColumnType
+  (into [:enum] (keys column-type->upload-type)))
+
+(defn- ensure-database-type [driver column-type]
+  (if-some [upload-type (column-type->upload-type column-type)]
+    (driver/upload-type->database-type driver upload-type)
+    (throw (ex-info (i18n/tru "Not a supported column type: {0}" column-type)
+                    {:status 400, :column-type column-type}))))
+
+(mr/def ::api-model-action-id
+  "Refers to a row in the actions table."
+  ms/PositiveInt)
+
+(mr/def ::api-action-id-primitive-or-data-app
+  "We refer to primitive actions through their names.
+  In future we will also use a special format to refer to actions that are defined within data apps."
+  :string)
+
+(mr/def ::api-action-id
+  "Primitive actions, saved actions, and packed encodings from the picker."
+  [:or
+   ::api-model-action-id
+   ::api-action-id-primitive-or-data-app])
+
+;; TODO Regret this name, let's rename it to something like ::action-expression once it's pure data.
+(mr/def ::action-expression
+  "The internal representation used by our APIs, after we've parsed the relevant ids and fetched their configuration."
+  [:or
+   [:map {:closed true}
+    [:model-action-id ms/PositiveInt]]
+   [:map {:closed true}
+    [:action-kw :keyword]
+    [:mapping :map]]
+   ;; Coming soon:
+   ;; - data app actions (with their mappings)
+   ;; - action expressions (e.g., unsaved data app actions. might not need these with auto save)
+   ;; - dashboard buttons (unless we deprecate them instead)
+   ])
+
+(mr/def ::api-action-expression
+  "A more relaxed version of ::action-expression that can still have opaque identifiers inside inside."
+  ;; TODO let's wait until we've written all our API tests and integrated the FE before typing this.
+  :map)
+
+(mr/def ::api-action-id-or-expression
+  "All the various ways of referring to an action with the v2 APIs."
+  [:or ::api-action-expression ::api-action-id])
+
+(mu/defn- fetch-unified-action :- ::action-expression
+  "Resolve various flavors of action-id into plain data, making it easier to dispatch on. Fetch config etc."
+  [scope :- ::types/scope.hydrated
+   raw   :- ::api-action-id-or-expression]
+  (cond
+    (map? raw)     (throw (ex-info "We do not currently support action expressions." {:status-code 400, :expression raw}))
+    (pos-int? raw) {:model-action-id raw}
+    (string? raw)  (let [kw (keyword raw)]
+                     {:action-kw kw
+                      :mapping   (actions/default-mapping kw scope)})
+    :else
+    (throw (ex-info "Unexpected id value" {:status-code 400, :action raw}))))
+
+(defn- hydrate-mapping [mapping]
+  (walk/postwalk-replace
+   {"::root"   ::root
+    "::key"    ::key
+    "::input"  ::input
+    "::params" ::params
+    "::param"  ::param}
+   mapping))
+
+(defn- augment-params
+  [{:keys [dashcard-id param-map] :as _action} input params]
+  ;; TODO don't fetch the row-data from the db if we only need columns that we already have, i.e. they are in the pk
+  (let [row (delay (let [{:keys [table_id]} (actions/cached-value
+                                             [:dashcard-viz dashcard-id]
+                                             #(t2/select-one-fn :visualization_settings :model/DashboardCard dashcard-id))]
+                     (if-not table_id
+                       ;; this is not an Editable, it must be a question - so we use the client-side row
+                       (update-keys input name)
+                       ;; TODO batch fetching all these rows, across all inputs
+                       (let [fields    (t2/select [:model/Field :id :name :semantic_type] :table_id table_id)
+                             pk-fields (filter #(= :type/PK (:semantic_type %)) fields)
+                             ;; TODO we could restrict which fields we fetch in future
+                             [row]     (data-editing/query-db-rows table_id pk-fields [input])
+                             _         (api/check-404 row)]
+                         ;; TODO it would be more robust to use field-ids instead of names in the configuration
+                         (update-keys row name)))))]
+    (if-not param-map
+      (merge input params)
+      (reduce-kv
+       (fn [acc k v]
+         (let [override (when-not (:visible v) (get params k))]
+           (case (:sourceType v)
+             ;; I don't think the FE can send a value for ask-user, but our tests do it...
+             "ask-user" (assoc acc k (if (contains? params k) override (:value v)))
+             "constant" (assoc acc k (or override (:value v)))
+             ;; Hack for getting partially mapped data for /configure
+             "row-data" (if-not (seq input)
+                          acc
+                          (assoc acc k (or override (get @row (:sourceValueTarget v)))))
+             ;; no mapping? omit the key
+             nil acc)))
+       {}
+       param-map))))
+
+(defn- apply-mapping [{:keys [mapping] :as action} params inputs]
+  (let [mapping (hydrate-mapping mapping)
+        tag?    #(and (vector? %2) (= %1 (first %2)))]
+    (if-not mapping
+      (if (or params (:param-map action))
+        (map #(augment-params action % params) inputs)
+        inputs)
+      (for [input inputs
+            :let [root (augment-params action input params)]]
+        (walk/postwalk
+         (fn [x]
+           (cond
+             ;; TODO handle the fact this stuff can be json-ified better
+             (= ::root x)   root
+             (= ::input x)  input
+             (= ::params x) params
+             ;; specific key
+             (tag? ::key x)   (get root (keyword (second x)))
+             (tag? ::param x) (get params (keyword (second x)))
+             :else
+             x))
+         mapping)))))
+
+(defn- apply-mapping-nested [{:keys [inner-action] :as outer-action} params inputs-before]
+  (let [inputs-after (apply-mapping outer-action params inputs-before)]
+    (if inner-action
+      (recur inner-action nil inputs-after)
+      inputs-after)))
+
+(defn- execute!* [action-id scope params raw-inputs]
+  (let [scope      (actions/hydrate-scope scope)
+        action-def (fetch-unified-action scope action-id)
+        inputs     (apply-mapping-nested action-def params raw-inputs)]
+    (cond
+      (:model-action-id action-def)
+      (throw (ex-info "We do not currently support execution of Model Actions" {:status-code 400}))
+      (:action-kw action-def)
+      (let [action-kw (keyword (:action-kw action-def))]
+        (:outputs (actions/perform-action! action-kw scope inputs)))
+      :else
+      (throw (ex-info "Not able to execute given action yet" {:status-code 400 :scope scope :action action-def})))))
+
+(api.macros/defendpoint :post "/execute"
+  "TODO: docstring"
+  [{}
+   {}
+   {:keys [action_id scope params input]}
+   :- [:map
+       [:action_id ::api-action-id-or-expression]
+       [:scope ::types/scope.raw]
+       [:params {:optional true} :map]
+       [:input :map]]]
+  {:outputs (execute!* action_id scope params [input])})
+
+(api.macros/defendpoint :post "/execute-bulk"
+  "TODO: docstring"
+  [{}
+   {}
+   {:keys [action_id scope inputs params]}
+   :- [:map
+       [:action_id ::api-action-id-or-expression]
+       [:scope ::types/scope.raw]
+       [:inputs [:sequential :map]]
+       [:params {:optional true} [:map-of :keyword :any]]]]
+  {:outputs (execute!* action_id scope params inputs)})
+
+(defn- row-data-mapping
+  ;; TODO get this working with arbitrary nesting of inner actions
+  "HACK: create a placeholder unified action who will map to the values we need from row-data, if we need any"
+  [{:keys [param-map] :as action}]
+  ;; We create a version of the action that will "map" to an input which is just the row data itself.
+  (let [row-data-mapping (u/for-map [[_ {:keys [sourceType sourceValueTarget]}] param-map
+                                     :when (= "row-data" sourceType)]
+                           [sourceValueTarget [::key (keyword sourceValueTarget)]])]
+    (when (seq row-data-mapping)
+      {:inner-action {:action-kw :placeholder}
+       :dashcard-id  (:dashcard-id action)
+       :param-map    (u/for-map [[_ {:keys [sourceType sourceValueTarget] :as param-setting}] param-map
+                                 :when (= "row-data" sourceType)]
+                       [(keyword sourceValueTarget) param-setting])
+       :mapping      row-data-mapping})))
+
+(defn- get-row-data
+  "For a row or header action, fetch underlying database values that'll be used for specific action params in mapping."
+  [action input]
+  ;; it would be nice to avoid using "apply-mapping" twice (once here on this stub action, once later on the real one)
+  (some-> (row-data-mapping action)
+          (apply-mapping-nested nil [input])
+          first
+          not-empty))
+
+(api.macros/defendpoint :post "/execute-form"
+  "Temporary endpoint for describing an actions parameters
+  such that they can be presented correctly in a modal ahead of execution."
+  [{}
+   {}
+   ;; TODO support for bulk actions
+   {:keys [action_id scope input]}]
+  (let [scope         (actions/hydrate-scope scope)
+        unified       (fetch-unified-action scope action_id)
+        row-data      (get-row-data unified input)
+        partial-input (first (apply-mapping-nested unified nil [input]))]
+    (data-editing.describe/describe-unified-action unified scope row-data partial-input)))
+
+(def ^{:arglists '([request respond raise])} routes
+  "`/api/ee/action-v2 routes."
+  (api.macros/ns-handler *ns* +auth))

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -18,25 +18,7 @@
 
 ;; might later be changed, or made driver specific, we might later drop the requirement depending on admin trust
 ;; model (e.g are admins trusted with writing arbitrary SQL cases anyway, will non admins ever call this?)
-(def ^:private Identifier
-  "A malli schema for strings that can be used as SQL identifiers"
-  [:re #"^[\w\- ]+$"])
-
 ;; upload types are used temporarily, I expect this to change
-(def ^:private column-type->upload-type
-  {"auto_incrementing_int_pk" :metabase.upload/auto-incrementing-int-pk
-   "boolean"                  :metabase.upload/boolean
-   "int"                      :metabase.upload/int
-   "float"                    :metabase.upload/float
-   "varchar255"               :metabase.upload/varchar-255
-   "text"                     :metabase.upload/text
-   "date"                     :metabase.upload/date
-   "datetime"                 :metabase.upload/datetime
-   "offset_datetime"          :metabase.upload/timestamp-with-time-zone})
-
-(def ^:private ColumnType
-  (into [:enum] (keys column-type->upload-type)))
-
 (mr/def ::api-action-id
   "Primitive actions, saved actions, and packed encodings from the picker."
   [:or
@@ -225,9 +207,8 @@
    {:keys [action scope input]}]
   (let [scope         (actions/hydrate-scope scope)
         unified       (fetch-unified-action scope action)
-        row-data      (get-row-data unified input)
         partial-input (first (apply-mapping-nested unified nil [input]))]
-    (data-editing.describe/describe-unified-action unified scope row-data partial-input)))
+    (data-editing.describe/describe-unified-action unified scope partial-input)))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/action-v2 routes."

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -140,7 +140,18 @@
       (throw (ex-info "Not able to execute given action yet" {:status-code 400 :scope scope :action action-def})))))
 
 (api.macros/defendpoint :post "/execute"
-  "TODO: docstring"
+  "Execute an action with a single input.
+
+   Takes:
+   - `action`            - an identifier or an expression for what we want to execute.
+   - `scope`             - where the action is being invoked from.
+   - `input`             - a single map. currently these are typically a database table row pk, or query result.
+   - `params` (optional) - a map of values for the parameters taken by the action's mapping.
+
+   The `input` and `params` are used by the relevant mapping to calculate a map argument to the underlying action fn.
+   If there is no mapping, `params` are simply used as overrides for `input`.
+
+   Returns the outputs from the performed action."
   [{}
    {}
    {:keys [action scope params input]}
@@ -148,19 +159,33 @@
        [:action ::api-action-id-or-expression]
        [:scope ::types/scope.raw]
        [:params {:optional true} :map]
-       [:input :map]]]
+       [:input {:optional true} :map]]]
   (api/check-superuser)
   {:outputs (execute!* action scope params [input])})
 
 (api.macros/defendpoint :post "/execute-bulk"
-  "TODO: docstring"
+  "Execute an action with multiple inputs.
+
+   This is typically more efficient than calling execute with each input individually, for example by performing batch
+   SQL operations.
+
+   Takes:
+   - `action`            - an identifier or an expression for what we want to execute.
+   - `scope`             - where the action is being invoked from.
+   - `inputs`            - a list of maps. currently these are typically a database table row pk, or query result.
+   - `params` (optional) - a map of values for the parameters taken by the action's mapping.
+
+   The `inputs` and `params` are used by the relevant mapping to calculate a list of args for the underlying action fn.
+   If there is no mapping, `params` are simply used as overrides for each map within `inputs`.
+
+   Returns the outputs from the performed action."
   [{}
    {}
    {:keys [action scope inputs params]}
    :- [:map
        [:action ::api-action-id-or-expression]
        [:scope ::types/scope.raw]
-       [:inputs [:sequential :map]]
+       [:inputs [:sequential {:min 1} :map]]
        [:params {:optional true} [:map-of :keyword :any]]]]
   (api/check-superuser)
   {:outputs (execute!* action scope params inputs)})

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -18,12 +18,6 @@
 
 (set! *warn-on-reflection* true)
 
-(defn require-authz?
-  "Temporary hack to have auth be off by default, only on if MB_DATA_EDITING_AUTHZ=true.
-  Remove once auth policy is fixed for dashboards."
-  []
-  (= "true" (System/getenv "MB_DATA_EDITING_AUTHZ")))
-
 ;; might later be changed, or made driver specific, we might later drop the requirement depending on admin trust
 ;; model (e.g are admins trusted with writing arbitrary SQL cases anyway, will non admins ever call this?)
 (def ^:private Identifier
@@ -44,12 +38,6 @@
 
 (def ^:private ColumnType
   (into [:enum] (keys column-type->upload-type)))
-
-(defn- ensure-database-type [driver column-type]
-  (if-some [upload-type (column-type->upload-type column-type)]
-    (driver/upload-type->database-type driver upload-type)
-    (throw (ex-info (i18n/tru "Not a supported column type: {0}" column-type)
-                    {:status 400, :column-type column-type}))))
 
 (mr/def ::api-model-action-id
   "Refers to a row in the actions table."

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -172,7 +172,7 @@
       (throw (ex-info "We do not currently support execution of Model Actions" {:status-code 400}))
       (:action-kw action-def)
       (let [action-kw (keyword (:action-kw action-def))]
-        (:outputs (actions/perform-action! action-kw scope inputs)))
+        (:outputs (actions/perform-action! action-kw inputs {:scope scope})))
       :else
       (throw (ex-info "Not able to execute given action yet" {:status-code 400 :scope scope :action action-def})))))
 

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -45,6 +45,19 @@
     [:action-kw :keyword]
     [:mapping [:maybe :map]]]])
 
+(mr/def ::execute-form
+  "A description of the form to render for executing an action"
+  [:map
+   [:title :string]
+   ;; TODO fully define the shape of a parameter
+   [:parameters [:sequential [:map {:closed false}
+                              [:id :string]
+                              [:display_name :string]
+                              [:input_type :string]
+                              [:optional :boolean]
+                              [:readonly :boolean]
+                              [:value {:optional true} :any]]]]])
+
 (mu/defn- fetch-unified-action :- ::action-expression
   "Resolve various flavors of action-id into plain data, making it easier to dispatch on. Fetch config etc."
   [scope :- ::types/scope.hydrated
@@ -158,7 +171,7 @@
   [{}
    {}
    ;; TODO support for bulk actions
-   {:keys [action scope input]}]
+   {:keys [action scope input]}] :- ::execute-form
   (api/check-superuser)
   (let [scope         (actions/hydrate-scope scope)
         unified       (fetch-unified-action scope action)

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -99,7 +99,6 @@
         (walk/postwalk
          (fn [x]
            (cond
-             ;; TODO handle the fact this stuff can be json-ified better
              (= ::root x)   root
              (= ::input x)  input
              (= ::params x) params

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.action-v2.execute-form :as data-editing.execute-form]
    [metabase.actions.core :as actions]
    [metabase.actions.types :as types]
+   [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.util.malli :as mu]
@@ -135,6 +136,7 @@
        [:scope ::types/scope.raw]
        [:params {:optional true} :map]
        [:input :map]]]
+  (api/check-superuser)
   {:outputs (execute!* action scope params [input])})
 
 (api.macros/defendpoint :post "/execute-bulk"
@@ -147,6 +149,7 @@
        [:scope ::types/scope.raw]
        [:inputs [:sequential :map]]
        [:params {:optional true} [:map-of :keyword :any]]]]
+  (api/check-superuser)
   {:outputs (execute!* action scope params inputs)})
 
 (api.macros/defendpoint :post "/execute-form"
@@ -156,6 +159,7 @@
    {}
    ;; TODO support for bulk actions
    {:keys [action scope input]}]
+  (api/check-superuser)
   (let [scope         (actions/hydrate-scope scope)
         unified       (fetch-unified-action scope action)
         partial-input (first (apply-mapping-nested unified nil [input]))]

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -62,12 +62,11 @@
     [:model-action-id ms/PositiveInt]]
    [:map {:closed true}
     [:action-kw :keyword]
-    [:mapping :map]]
+    [:mapping :map]]])
    ;; Coming soon:
    ;; - data app actions (with their mappings)
    ;; - action expressions (e.g., unsaved data app actions. might not need these with auto save)
    ;; - dashboard buttons (unless we deprecate them instead)
-   ])
 
 (mr/def ::api-action-expression
   "A more relaxed version of ::action-expression that can still have opaque identifiers inside inside."

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -1,17 +1,14 @@
 (ns metabase-enterprise.action-v2.api
   (:require
    [clojure.walk :as walk]
-   [metabase-enterprise.action-v2.data-editing :as data-editing]
    [metabase-enterprise.action-v2.describe :as data-editing.describe]
    [metabase.actions.core :as actions]
    [metabase.actions.types :as types]
-   [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2]))
+   [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
 

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -8,7 +8,6 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
-   [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]

--- a/enterprise/backend/src/metabase_enterprise/action_v2/coerce.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/coerce.clj
@@ -34,13 +34,13 @@
         (.atZone (ZoneId/of "UTC"))
         str)))
 
-;; the date/time coercions are highly ambigious
-;; in one direction one can make a decision (take the local date, or clock time)
-;; but how do you reverse it?
-;; Often the original SQL string might have been a full date, a zoned or unzoned ISO string,
-;; Needs to be considered properly at some later time.
-;; Idea: make the coercion dependent on previous database string, so if lossy - modify *just* the time, or the date component
-;; * still somewhat ambiguous, e.g did the user *intend* to discard the previous date/time components?
+;; Now that we are adding support for writing back to databases, things get interesting where the conversion is lossy.
+;; If the transformation from database to presentation is lossy, say showing just the date of a zoned ISO string,
+;; how do we update it given a new date?
+;; Perhaps we are happy to reset the time to midnight, use the current time, or carry over the previous time portion?
+;; This last option will complicate our implementation, and can still run into issues with leap seconds, etc.
+;; There are similar complications when only displaying the time portion, dealing with timezones, etc.
+;; This is a thorny area and will need careful consideration at some point.
 
 (defn- json-zdt->date [s]
   (-> s ZonedDateTime/parse .toLocalDate str))

--- a/enterprise/backend/src/metabase_enterprise/action_v2/coerce.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/coerce.clj
@@ -87,7 +87,8 @@
       str))
 
 ;; TODO Missing cases for [[metabase.actions.coerce-test/coercion-fns-static-test]]
-(def ^:private unimplemented-coercion-functions
+(def unimplemented-coercion-functions
+  "A list of coercion options we still need to implement, used to suppress our coverage tests."
   #{:Coercion/Bytes->Temporal
     :Coercion/DateTime->Date
     :Coercion/Float->Integer

--- a/enterprise/backend/src/metabase_enterprise/action_v2/coerce.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/coerce.clj
@@ -1,0 +1,120 @@
+(ns metabase-enterprise.action-v2.coerce
+  (:require
+   [metabase.util.date-2 :as u.date])
+  (:import
+   (clojure.lang BigInt)
+   (java.time LocalDateTime ZonedDateTime ZoneId)
+   (java.time.format DateTimeFormatter)))
+
+(set! *warn-on-reflection* true)
+
+(defn- json-zdt->unix-millis ^long [s]
+  (let [zdt->milli (fn [^ZonedDateTime zdt]
+                     (-> zdt .toInstant .toEpochMilli))]
+    (-> s u.date/parse zdt->milli)))
+
+(defn- json-zdt->unix-seconds [s]
+  (-> s json-zdt->unix-millis (quot 1000)))
+
+(defn- json-zdt->unix-micros [s]
+  (-> s json-zdt->unix-millis ^BigInt (* 1000N) .toBigInteger))
+
+(defn- json-zdt->unix-nanos [s]
+  (-> s json-zdt->unix-millis ^BigInt (* 1000000N) .toBigInteger))
+
+(let [^DateTimeFormatter formatter (DateTimeFormatter/ofPattern "yyyyMMddHHmmss")
+      format                       (fn [t]
+                                     (.format ^DateTimeFormatter formatter t))]
+  (defn- json-zdt->yyyymmddhhmmss [s]
+    (-> s u.date/parse format))
+
+  (defn- yyyymmddhhmmss->json-zdt
+    [yyyymmddhhmmss]
+    (-> (LocalDateTime/parse yyyymmddhhmmss formatter)
+        (.atZone (ZoneId/of "UTC"))
+        str)))
+
+;; the date/time coercions are highly ambigious
+;; in one direction one can make a decision (take the local date, or clock time)
+;; but how do you reverse it?
+;; Often the original SQL string might have been a full date, a zoned or unzoned ISO string,
+;; Needs to be considered properly at some later time.
+;; Idea: make the coercion dependent on previous database string, so if lossy - modify *just* the time, or the date component
+;; * still somewhat ambiguous, e.g did the user *intend* to discard the previous date/time components?
+
+(defn- json-zdt->date [s]
+  (-> s ZonedDateTime/parse .toLocalDate str))
+
+(defn- json-zdt->time [s]
+  (-> s ZonedDateTime/parse .toLocalTime str))
+
+(defn- millis->json-zdt
+  [millis]
+  (-> millis
+      java.time.Instant/ofEpochMilli
+      (java.time.ZonedDateTime/ofInstant (java.time.ZoneId/systemDefault))
+      str))
+
+(defn- unix-seconds->json-zdt
+  [unix-seconds]
+  (millis->json-zdt (* unix-seconds 1000)))
+
+(defn- unix-millis->json-zdt
+  [unix-millis]
+  (millis->json-zdt unix-millis))
+
+(defn- unix-micros->json-zdt
+  [unix-micros]
+  (millis->json-zdt (quot unix-micros 1000)))
+
+(defn- unix-nanos->json-zdt
+  [unix-nanos]
+  (millis->json-zdt (quot unix-nanos 1000000)))
+
+(defn- date->json-zdt
+  [date]
+  (-> date
+      java.time.LocalDate/parse
+      (.atStartOfDay (java.time.ZoneId/systemDefault))
+      str))
+
+(defn- time->json-zdt
+  [time]
+  (-> time
+      java.time.LocalTime/parse
+      (.atDate (java.time.LocalDate/now))
+      (.atZone (java.time.ZoneId/systemDefault))
+      str))
+
+(def coercion-fns
+  "Maps a coercion strategy to a map containing both input and output conversion functions.
+
+  :in  - Function to convert from input JSON to database format
+  :out - Function to convert from database format to JSON output
+
+  Assumes the input/output values are valid for the coercion strategy and can fit within bounds."
+  ;; TODO: missing (second (clojure.data/diff (into #{} (keys coercion-fns)) (descendants :Coercion/*)))
+  ;;{:Coercion/Bytes->Temporal
+  ;; :Coercion/UNIXTime->Temporal
+  ;; :Coercion/String->Float
+  ;; :Coercion/Number->Temporal
+  ;; :Coercion/String->Number
+  ;; :Coercion/YYYYMMDDHHMMSSBytes->Temporal
+  ;; :Coercion/String->Temporal
+  ;; :Coercion/ISO8601->Temporal}
+  {:Coercion/UNIXSeconds->DateTime          {:in  #'json-zdt->unix-seconds
+                                             :out #'unix-seconds->json-zdt}
+   :Coercion/UNIXMilliSeconds->DateTime     {:in  #'json-zdt->unix-millis
+                                             :out #'unix-millis->json-zdt}
+   :Coercion/UNIXMicroSeconds->DateTime     {:in  #'json-zdt->unix-micros
+                                             :out #'unix-micros->json-zdt}
+   :Coercion/UNIXNanoSeconds->DateTime      {:in  #'json-zdt->unix-nanos
+                                             :out #'unix-nanos->json-zdt}
+   :Coercion/YYYYMMDDHHMMSSString->Temporal {:in  #'json-zdt->yyyymmddhhmmss
+                                             :out #'yyyymmddhhmmss->json-zdt}
+   :Coercion/ISO8601->DateTime              {:in  identity
+                                             :out identity}
+   :Coercion/ISO8601->Date                  {:in  #'json-zdt->date
+                                             :out #'date->json-zdt}
+   :Coercion/ISO8601->Time                  {:in  #'json-zdt->time
+                                             :out #'time->json-zdt}})

--- a/enterprise/backend/src/metabase_enterprise/action_v2/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/core.clj
@@ -1,0 +1,6 @@
+(ns metabase-enterprise.action-v2.core
+  (:require
+   [potemkin :as p]))
+
+(comment
+  p/keep-me)

--- a/enterprise/backend/src/metabase_enterprise/action_v2/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/data_editing.clj
@@ -1,0 +1,143 @@
+(ns metabase-enterprise.action-v2.data-editing
+  (:require
+   [clojure.set :as set]
+   [medley.core :as m]
+   [metabase-enterprise.action-v2.coerce :as data-editing.coerce]
+   [metabase.api.common :as api]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.query-processor :as qp]
+   [metabase.query-processor.store :as qp.store]
+   [metabase.util :as u]
+   [metabase.warehouse-schema.models.field-values :as field-values]
+   [toucan2.core :as t2]))
+
+(defn select-table-pk-fields
+  "Given a table-id, return the :model/Field instances corresponding to its PK columns. Do not assume any ordering."
+  [table-id]
+  (u/prog1 (api/check-404 (t2/select :model/Field :table_id table-id :semantic_type :type/PK :active true))
+    (api/check-500 (pos? (count <>)))))
+
+(defn get-row-pks
+  "Given a row, strip it down to just its primary keys."
+  [pk-fields row]
+  (->> (map :name pk-fields)
+       (select-keys (update-keys row u/qualified-name))
+       ;; Hack for now, pending discussion of the ideal fix
+       ;; https://linear.app/metabase/issue/WRK-281/undo-deletes-a-record-instead-of-reverting-the-edits
+       ;; See https://metaboat.slack.com/archives/C0641E4PB9B/p1744978660610899
+       (m/map-vals #(if (uuid? %) (str %) %))))
+
+(defn- valid-pks [pks]
+  (every? some? (vals pks)))
+
+(defn- apply*
+  "Work around the fact that the lib logical operators don't have a 0 or 1 arity."
+  [f clauses]
+  (if (<= (count clauses) 1)
+    (first clauses)
+    (apply f clauses)))
+
+(defn- qp-result->row-map
+  [{:keys [rows cols]}]
+  ;; rows from the request are keywordized
+  (let [col-names (map (comp keyword :name) cols)]
+    (map #(zipmap col-names %) rows)))
+
+(defn query-db-rows
+  "Return the current representation of the given rows that we would return to the frontend, indexed by their pks."
+  [table-id pk-fields rows]
+  (assert (seq pk-fields) "Table must have at least one primary key column")
+  ;; TODO pass in the db-id from above rather
+  (when (seq rows)
+    (let [{:keys [db_id]} (api/check-404 (t2/select-one :model/Table table-id))
+          row-pks (seq (map (partial get-row-pks pk-fields) rows))]
+      (assert (every? valid-pks row-pks) "All rows must have valid primary keys")
+      (qp.store/with-metadata-provider db_id
+        (let [mp    (qp.store/metadata-provider)
+              query (lib/query mp (lib.metadata/table mp table-id))
+              query (lib/filter
+                     query
+                     ;; We can optimize the most common case considerably.
+                     (if (= 1 (count pk-fields))
+                       (apply lib/in
+                              (lib.metadata/field mp (:id (first pk-fields)))
+                              (map (comp val first) row-pks))
+                       ;; Optimizing this could be done in many cases, but it would be complex.
+                       (apply* lib/or
+                               (for [row-pk row-pks]
+                                 (apply* lib/and
+                                         (for [field pk-fields]
+                                           (lib/= (lib.metadata/field mp (:id field))
+                                                  (get row-pk (:name field)))))))))]
+          (->> query
+               qp/userland-query-with-default-constraints
+               qp/process-query
+               :data
+               qp-result->row-map))))))
+
+(defn apply-coercions
+  "For fields that have a coercion_strategy, apply the coercion function (defined in data-editing.coerce) to the corresponding value in each row.
+  Intentionally does not coerce primary key values (behaviour for pks with coercion strategies is undefined)."
+  [table-id input-rows]
+  (let [input-keys  (into #{} (mapcat keys) input-rows)
+        field-names (map name input-keys)
+        fields      (t2/select :model/Field :table_id table-id :name [:in field-names])
+        coerce-fn   (->> (for [{field-name :name, :keys [coercion_strategy, semantic_type]} fields
+                               :when (not (isa? semantic_type :type/PK))]
+                           [(keyword field-name)
+                            (or (when (nil? coercion_strategy) identity)
+                                (:in (data-editing.coerce/coercion-fns coercion_strategy))
+                                (throw (ex-info "Coercion strategy has no defined coercion function"
+                                                {:status 400
+                                                 :field field-name
+                                                 :coercion_strategy coercion_strategy})))])
+                         (into {}))
+        coerce      (fn [k v] (some-> v ((coerce-fn (keyword k) identity))))]
+    (for [row input-rows]
+      (m/map-kv-vals coerce row))))
+
+(defn- invalidate-field-values! [table-id rows]
+  ;; Be conservative with respect to case sensitivity, invalidate every field when there is ambiguity.
+  (let [ln->values  (u/group-by first second (for [row rows [k v] row] [(u/lower-case-en (name k)) v]))
+        lower-names (keys ln->values)
+        ln->ids     (when (seq lower-names)
+                      (u/group-by
+                       :lower_name :id
+                       (t2/query {:select [:id [[:lower :name] :lower_name]]
+                                  :from   [(t2/table-name :model/Field)]
+                                  :where  [:and
+                                           [:= :table_id table-id]
+                                           [:in [:lower :name] lower-names]
+                                           [:in :has_field_values ["list" "auto-list"]]
+                                           [:= :semantic_type "type/Category"]]})))
+        stale-fields (->> (for [[lower-name field-ids] ln->ids
+                                :let [new-values (into #{} (filter some?) (ln->values lower-name))
+                                      old-values (into #{} cat (t2/select-fn-vec :values :model/FieldValues
+                                                                                 :field_id [:in field-ids]))]]
+                            (when (seq (set/difference new-values old-values))
+                              field-ids))
+                          (apply concat))]
+    ;; Note that for now we only rescan field values when values are *added* and not when they are *removed*.
+    (when (seq stale-fields)
+      ;; Using a future is not ideal, it would be better to use a queue and a single worker, to avoid tying up threads.
+      (future
+        (->> (t2/select :model/Field :id [:in stale-fields])
+             (run! field-values/create-or-update-full-field-values!))))))
+
+;; TODO this is fairly dirty, would be cleaner to map from db values to de-coerced values via middleware
+;;      invalidation could perhaps be done in response to effect, or in middleware (to dedupe for chained actions)
+(defn invalidate-and-present!
+  "We invalidate the field-values, in case any new category values were added.
+  The FE also expects data to be formatted according to PQ logic, e.g. considering semantic types.
+  Actions, however, return raw values, since lossy coercions would limit composition.
+  So, we apply the coercions here."
+  [table-id rows]
+  ;; We could optimize this significantly:
+  ;; 1. Skip if no category fields were changes on update.
+  ;; 2. Check whether all corresponding categorical field values are already in the database.
+  (invalidate-field-values! table-id rows)
+  ;; right now the FE works off qp outputs, which coerce output row data
+  ;; still feels messy, revisit this
+  (let [pk-fields (select-table-pk-fields table-id)]
+    (query-db-rows table-id pk-fields rows)))

--- a/enterprise/backend/src/metabase_enterprise/action_v2/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/data_editing.clj
@@ -15,6 +15,8 @@
   (:import
    (java.util.concurrent ArrayBlockingQueue)))
 
+(set! *warn-on-reflection* true)
+
 (def ^:private ^ArrayBlockingQueue global-field-value-invalidate-queue
   "Queue used to recalculate the field values for updated columns in the background."
   (ArrayBlockingQueue. 1000))
@@ -142,7 +144,7 @@
                           (apply concat))]
     ;; Note that for now we only rescan field values when values are *added* and not when they are *removed*.
     (when (seq stale-fields)
-      (let [queue ^ArrayBlockingQueue (or *field-value-invalidate-queue* global-field-value-invalidate-queue)]
+      (let [^ArrayBlockingQueue queue (or *field-value-invalidate-queue* global-field-value-invalidate-queue)]
         (.offer queue stale-fields)))))
 
 ;; TODO this is fairly dirty, would be cleaner to map from db values to de-coerced values via middleware

--- a/enterprise/backend/src/metabase_enterprise/action_v2/describe.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/describe.clj
@@ -94,7 +94,11 @@
                           :field_id                (:id field)
                           :human_readable_field_id (-> field :dimensions first :human_readable_field_id)
                           :optional                (not required)
-                          :nullable                (:database_is_nullable field)
+
+                          :nullable                (:database_is_nullable field
+                                                                          ;; can the remove the default "false"
+                                                                          ;; value once #60263 is merged
+                                                                          false)
                           :database_default        (:database_default field)
                           :readonly                (or (= "readonly" (:visibility param-setting))
                                                        (not (dashcard-column-editable? (:name field))))

--- a/enterprise/backend/src/metabase_enterprise/action_v2/describe.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/describe.clj
@@ -1,0 +1,127 @@
+(ns metabase-enterprise.action-v2.describe
+  (:require
+   [metabase.api.common :as api]
+   [metabase.util :as u]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
+   [toucan2.core :as t2]))
+
+(mr/def ::describe-param
+  [:map #_{:closed true}
+   [:id                                :string]
+   [:display_name                      :string]
+   [:field_id         {:optional true} pos-int?]
+   [:input_type                        [:enum "dropdown" "textarea" "date" "datetime" "text"]]
+   [:semantic_type    {:optional true} :keyword]
+   [:optional                          :boolean]
+   [:nullable                          :boolean]
+   [:readonly                          :boolean]
+   [:database_default {:optional true} :any]
+   ;; value can be nil, so this is optional to avoid confusion
+   [:value            {:optional true} :any]
+   [:value_options    {:optional true} [:sequential :any]]
+   ;; is it more useful if we have field_id instead of this?
+   [:human_readable_field_id {:optional true} pos-int?]])
+
+(mr/def ::action-description
+  [:map {:closed true}
+   [:title :string]
+   [:parameters [:sequential ::describe-param]]])
+
+(defn- field-input-type
+  [field field-values]
+  (case (:type field-values)
+    (:list :auto-list :search) "dropdown"
+    (condp #(isa? %2 %1) (:semantic_type field)
+      :type/Description "textarea"
+      :type/Category    "dropdown"
+      :type/FK          "dropdown"
+      (condp #(isa? %2 %1) (:base_type field)
+        :type/Date     "date"
+        :type/DateTime "datetime"
+        "text"))))
+
+(defn- describe-table-action
+  [{:keys [action-kw
+           table-id
+           param-map
+           dashcard-viz
+           row-data]}]
+  (when-not table-id
+    (throw (ex-info "Must provide table-id" {:status-code 400})))
+  (let [table                       (api/read-check (t2/select-one :model/Table :id table-id :active true))
+        fields                      (-> (t2/select :model/Field :table_id table-id :active true {:order-by [[:position]]})
+                                        (t2/hydrate :dimensions
+                                                    :has_field_values
+                                                    :values))
+        ;; it's a huge assumption that there's always dashcard-viz
+        ;; TODO: this should live in our configuration
+        dashcard-column-editable?   (or (some-> dashcard-viz :table.editableColumns set)
+                                        ;; columns are assumed editable if no dashcard-viz specialisation
+                                        (constantly true))
+        dashcard-sort               (zipmap (map :name (:table.columns dashcard-viz)) (range))
+        field-name->dashcard-column (u/index-by :name (:table.columns dashcard-viz))
+        field-sort                  (zipmap (map :name fields) (range))
+        sort-key                    (fn [{:keys [name]}]
+                                      (or (dashcard-sort name) ; prefer user defined sort in the dashcard
+                                          (+ (inc (count dashcard-sort))
+                                             (field-sort name))))]
+    {:title      (format "%s: %s" (:display_name table) (u/capitalize-en (name action-kw)))
+     :parameters (->> (for [field (sort-by sort-key fields)
+                            :let [{field-values :values} field
+                                  pk                     (= :type/PK (:semantic_type field))
+                                  param-setting          (get param-map (keyword (:name field)))
+                                  dashcard-column        (field-name->dashcard-column (:name field))]
+                            :when (case action-kw
+                                    ;; create does not take pk cols if auto increment, todo generated cols?
+                                    (:table.row/create :data-grid.row/create) (not (:database_is_auto_increment field))
+                                    ;; delete only requires pk cols
+                                    (:table.row/delete :data-grid.row/delete) pk
+                                    ;; update takes both the pk and field (if not a row action)
+                                    (:table.row/update
+                                     :table.row/create-or-update
+                                     :data-grid.row/update
+                                     :data-grid.row/create-or-update) true)
+                            ;; row-actions can explicitly hide parameters
+                            :when (not= "hidden" (:visibility param-setting))
+                            ;; dashcard column context can hide parameters (if defined)
+                            :when (:enabled dashcard-column true)
+                            :let [required (or pk (:database_required field))]]
+                        (u/remove-nils
+                         {:id                      (:name field) ;; TODO we shouldn't use field name as id I think, what if we have 1 field that maps to 2 params?
+                          :display_name            (:display_name field)
+                          :semantic_type           (:semantic_type field)
+                          :input_type              (field-input-type field field-values)
+                          :field_id                (:id field)
+                          :human_readable_field_id (-> field :dimensions first :human_readable_field_id)
+                          :optional                (not required)
+                          :nullable                (:database_is_nullable field)
+                          :database_default        (:database_default field)
+                          :readonly                (or (= "readonly" (:visibility param-setting))
+                                                       (not (dashcard-column-editable? (:name field))))
+                          ;; TODO oh dear, we need to worry about case sensitivity issue now (e.g. in tests)
+                          ;; it would be much better if our mappings were based on field ids.
+                          ;; probably not an issue in practice, because FE is writing the config AND calling execute-form
+                          ;; with likely the same names for fields (fingers crossed)
+                          :value                   (get row-data (:sourceValueTarget param-setting))}))
+                      vec)}))
+
+(mu/defn describe-unified-action :- ::action-description
+  "Describe parameters of an unified action."
+  [action-def scope row-data partial-input]
+  (cond
+    (:action-id action-def)
+    (throw (ex-info "We do not currently support execution of Model Actions" {:status-code 400}))
+
+    ;; TODO remove assumption that all primitives are table actions
+    (:action-kw action-def)
+    (describe-table-action
+     {:action-kw    (:action-kw action-def)
+      :table-id     (:table-id partial-input)
+      :param-map    (:param-map action-def)
+      ;; TODO see how to remove
+      ;; tried commenting it out and no tests failed, so will leave this here as reference for now
+      ;; (also don't see any code that could ever populate this tho)
+      :dashcard-viz nil})
+    :else
+    (throw (ex-info "Not able to execute given action yet" {:status-code 500 :scope scope :action-def action-def}))))

--- a/enterprise/backend/src/metabase_enterprise/action_v2/describe.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/describe.clj
@@ -111,7 +111,7 @@
 
 (mu/defn describe-unified-action :- ::action-description
   "Describe parameters of an unified action."
-  [action-def scope row-data partial-input]
+  [action-def scope partial-input]
   (cond
     (:action-id action-def)
     (throw (ex-info "We do not currently support execution of Model Actions" {:status-code 400}))

--- a/enterprise/backend/src/metabase_enterprise/action_v2/describe.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/describe.clj
@@ -79,16 +79,15 @@
                                     (:table.row/delete :data-grid.row/delete) pk
                                     ;; update takes both the pk and field (if not a row action)
                                     (:table.row/update
-                                     :table.row/create-or-update
-                                     :data-grid.row/update
-                                     :data-grid.row/create-or-update) true)
+                                     :data-grid.row/update) true)
                             ;; row-actions can explicitly hide parameters
                             :when (not= "hidden" (:visibility param-setting))
                             ;; dashcard column context can hide parameters (if defined)
                             :when (:enabled dashcard-column true)
                             :let [required (or pk (:database_required field))]]
                         (u/remove-nils
-                         {:id                      (:name field) ;; TODO we shouldn't use field name as id I think, what if we have 1 field that maps to 2 params?
+                         ;; TODO yet another comment about how field id would be a better key, due to case issues
+                         {:id                      (:name field)
                           :display_name            (:display_name field)
                           :semantic_type           (:semantic_type field)
                           :input_type              (field-input-type field field-values)

--- a/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.action-v2.describe
+(ns metabase-enterprise.action-v2.execute-form
   (:require
    [metabase.api.common :as api]
    [metabase.util :as u]
@@ -106,7 +106,7 @@
                           :value                   (get row-data (:sourceValueTarget param-setting))}))
                       vec)}))
 
-(mu/defn describe-unified-action :- ::action-description
+(mu/defn describe-form :- ::action-description
   "Describe parameters of an unified action."
   [action-def scope partial-input]
   (cond

--- a/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
@@ -14,7 +14,11 @@
    [:input_type                        [:enum "dropdown" "textarea" "date" "datetime" "text"]]
    [:semantic_type    {:optional true} :keyword]
    [:optional                          :boolean]
-   [:nullable                          :boolean]
+   ;; TODO in practice this should never be null (and we strip nils current)
+   ;;      for table editing actions, this relies on a driver feature that must be implemented for the driver to support
+   ;;      data editing, but it could still be NULL in the database when the field metadata was loaded from a serialized
+   ;;      definition from an older version.
+   [:nullable         {:optional true} :boolean]
    [:readonly                          :boolean]
    [:database_default {:optional true} :any]
    ;; value can be nil, so this is optional to avoid confusion
@@ -91,11 +95,7 @@
                           :field_id                (:id field)
                           :human_readable_field_id (-> field :dimensions first :human_readable_field_id)
                           :optional                (not required)
-
-                          :nullable                (:database_is_nullable field
-                                                                          ;; can the remove the default "false"
-                                                                          ;; value once #60263 is merged
-                                                                          false)
+                          :nullable                (:database_is_nullable field)
                           :database_default        (:database_default field)
                           :readonly                (or (= "readonly" (:visibility param-setting))
                                                        (not (column-editable? (:name field))))

--- a/enterprise/backend/src/metabase_enterprise/action_v2/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/init.clj
@@ -1,0 +1,3 @@
+(ns metabase-enterprise.action-v2.init
+  (:require
+   [metabase-enterprise.action-v2.actions]))

--- a/enterprise/backend/src/metabase_enterprise/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes.clj
@@ -73,7 +73,8 @@
 (def ^:private ee-routes-map
   "/api/ee routes. The following routes are NICE and do follow the `/ee/<feature>/` naming convention. Please add new
   routes here and follow the convention."
-  {"/advanced-permissions"         (premium-handler metabase-enterprise.advanced-permissions.api.routes/routes :advanced-permissions)
+  {"/action-v2"                    (premium-handler metabase-enterprise.action-v2.api/routes :actions)
+   "/advanced-permissions"         (premium-handler metabase-enterprise.advanced-permissions.api.routes/routes :advanced-permissions)
    "/ai-entity-analysis"           (premium-handler metabase-enterprise.ai-entity-analysis.api/routes :ai-entity-analysis)
    "/ai-sql-fixer"                 (premium-handler metabase-enterprise.ai-sql-fixer.api/routes :ai-sql-fixer)
    "/ai-sql-generation"            (premium-handler metabase-enterprise.ai-sql-generation.api/routes :ai-sql-generation)

--- a/enterprise/backend/src/metabase_enterprise/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes.clj
@@ -37,8 +37,7 @@
          metabase-enterprise.llm.api/keep-me)
 
 (def ^:private required-feature->message
-  {:actions                    (deferred-tru "Action")
-   :advanced-permissions       (deferred-tru "Advanced Permissions")
+  {:advanced-permissions       (deferred-tru "Advanced Permissions")
    :attached-dwh               (deferred-tru "Attached DWH")
    :audit-app                  (deferred-tru "Audit app")
    :ai-sql-fixer               (deferred-tru "AI SQL Fixer")
@@ -52,6 +51,7 @@
    :metabot-v3                 (deferred-tru "MetaBot")
    :scim                       (deferred-tru "SCIM configuration")
    :serialization              (deferred-tru "Serialization")
+   :table-data-editing         (deferred-tru "Table Data Editing")
    :upload-management          (deferred-tru "Upload Management")
    :database-routing           (deferred-tru "Database Routing")
    :cloud-custom-smtp          (deferred-tru "Custom SMTP")})
@@ -75,7 +75,8 @@
 (def ^:private ee-routes-map
   "/api/ee routes. The following routes are NICE and do follow the `/ee/<feature>/` naming convention. Please add new
   routes here and follow the convention."
-  {"/action-v2"                    (premium-handler metabase-enterprise.action-v2.api/routes :actions)
+  ;; Postponing a granular flag for :actions until it's used more widely.
+  {"/action-v2"                    (premium-handler metabase-enterprise.action-v2.api/routes :table-data-editing)
    "/advanced-permissions"         (premium-handler metabase-enterprise.advanced-permissions.api.routes/routes :advanced-permissions)
    "/ai-entity-analysis"           (premium-handler metabase-enterprise.ai-entity-analysis.api/routes :ai-entity-analysis)
    "/ai-sql-fixer"                 (premium-handler metabase-enterprise.ai-sql-fixer.api/routes :ai-sql-fixer)

--- a/enterprise/backend/src/metabase_enterprise/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes.clj
@@ -5,6 +5,7 @@
   These routes should generally live under prefixes like `/api/ee/<feature>/` -- see the
   `enterprise/backend/README.md` for more details."
   (:require
+   [metabase-enterprise.action-v2.api]
    [metabase-enterprise.advanced-config.api.logs]
    [metabase-enterprise.advanced-permissions.api.routes]
    [metabase-enterprise.ai-entity-analysis.api]
@@ -36,7 +37,8 @@
          metabase-enterprise.llm.api/keep-me)
 
 (def ^:private required-feature->message
-  {:advanced-permissions       (deferred-tru "Advanced Permissions")
+  {:actions                    (deferred-tru "Action")
+   :advanced-permissions       (deferred-tru "Advanced Permissions")
    :attached-dwh               (deferred-tru "Attached DWH")
    :audit-app                  (deferred-tru "Audit app")
    :ai-sql-fixer               (deferred-tru "AI SQL Fixer")

--- a/enterprise/backend/src/metabase_enterprise/core/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/core/init.clj
@@ -6,6 +6,7 @@
 
   See https://metaboat.slack.com/archives/CKZEMT1MJ/p1736556522733279 for rationale behind this pattern."
   (:require
+   [metabase-enterprise.action-v2.init]
    [metabase-enterprise.advanced-config.init]
    [metabase-enterprise.audit-app.init]
    [metabase-enterprise.cache.init]

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -143,7 +143,8 @@
 
 (deftest table-operations-via-action-execute-with-uuid-pk-test
   (mt/with-premium-features #{actions-feature-flag}
-    (mt/test-drivers data-editing-drivers
+    ;; MySQL does not support a UUID type (or at least if it does, our create-table syntax is wrong)
+    (mt/test-drivers (disj data-editing-drivers :mysql)
       (data-editing.tu/with-test-tables! [table-id [{:id [:uuid]
                                                      :name [:text]
                                                      :song [:text]}

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -595,20 +595,25 @@
             (is (= [] (field-values)))
 
             (create! [{:n "a"}])
+            (is (pos? (.size test-queue)))
             (process-queue!)
             (is (= ["a"] (field-values)))
 
             (create! [{:n "b"} {:n "c"}])
+            (is (pos? (.size test-queue)))
             (process-queue!)
             (is (= ["a" "b" "c"] (field-values)))
 
             (update! [{:id 2, :n "d"}])
+            (is (pos? (.size test-queue)))
             (process-queue!)
             (is (= ["a" "c" "d"] (field-values)))
 
             (create! [{:n "a"}])
+            (is (zero? (.size test-queue)))
             (process-queue!)
             (update! [{:id 1, :n "e"}])
+            (is (pos? (.size test-queue)))
             (process-queue!)
             (is (= ["a" "c" "d" "e"] (field-values)))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -51,7 +51,7 @@
 
 (defn- delete-rows!
   ([table-id rows]
-   (update-rows! table-id 200 rows))
+   (delete-rows! table-id 200 rows))
   ([table-id response-code rows]
    (mt/user-http-request :crowberto :post response-code execute-bulk-url
                          {:action :data-grid.row/delete

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -516,9 +516,6 @@
           (update! [{:id 1, :n "e"}])
           (is (= ["a" "c" "d" "e"] (expect-field-values ["a" "c" "d" "e"]))))))))
 
-;; actions (need this to associate with the route namespace)
-;; data-editing (keep this to control whether the data-grid.row actions are callable?)
-
 (deftest execute-form-built-in-table-action-test
   (mt/with-premium-features #{actions-feature-flag}
     (mt/test-drivers data-editing-drivers

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -463,10 +463,6 @@
                                   (is (= input (:o qp-row))))
                                 (is (= expected (:o (first (get-db-state)))))))))))]
 
-        ;; TODO have this fail if there are gaps in our testing
-        ;;      ... and then fill in the gaps :-D
-        ;;     (we can ignore driver specific types outside of Postgres and MySQL)
-
         ;;    type     coercion                                     input                          database
         (->> [:text    nil                                          "a"                            "a"
               :text    :Coercion/YYYYMMDDHHMMSSString->Temporal     "2025-03-25T14:34:00Z"         "20250325143400"

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -53,38 +53,38 @@
     (mt/assert-has-premium-feature-error "Editing Table Data" (mt/user-http-request :crowberto :post 402 execute-bulk-url))
     (mt/assert-has-premium-feature-error "Editing Table Data" (mt/user-http-request :crowberto :post 402 execute-form-url))))
 
+;; To Chris: I'm trying to get this tests passed
 (deftest table-operations-via-action-execute-test
   (mt/with-premium-features #{:actions}
     (mt/test-drivers #{:h2 :postgres}
       (data-editing.tu/with-test-tables! [table-id data-editing.tu/default-test-table]
-        (let [url "action/v2/execute-bulk"]
-          (testing "Initially the table is empty"
-            (is (= [] (table-rows table-id))))
+        (testing "Initially the table is empty"
+          (is (= [] (table-rows table-id))))
 
-          (testing "POST should insert new rows"
-            (is (= #{{:op "created", :table-id table-id, :row {:id 1, :name "Pidgey", :song "Car alarms"}}
-                     {:op "created", :table-id table-id, :row {:id 2, :name "Spearow", :song "Hold music"}}
-                     {:op "created", :table-id table-id, :row {:id 3, :name "Farfetch'd", :song "The land of lisp"}}}
-                   (set
-                    (:outputs
-                     (mt/user-http-request :crowberto :post 200 url
-                                           {:action_id "data-grid.row/create"
-                                            :scope     {:table-id table-id}
-                                            :inputs    [{:name "Pidgey"     :song "Car alarms"}
-                                                        {:name "Spearow"    :song "Hold music"}
-                                                        {:name "Farfetch'd" :song "The land of lisp"}]})))))
+        (testing "POST should insert new rows"
+          (is (= #{{:op "created", :table-id table-id, :row {:id 1, :name "Pidgey", :song "Car alarms"}}
+                   {:op "created", :table-id table-id, :row {:id 2, :name "Spearow", :song "Hold music"}}
+                   {:op "created", :table-id table-id, :row {:id 3, :name "Farfetch'd", :song "The land of lisp"}}}
+                 (set
+                  (:outputs
+                   (mt/user-http-request :crowberto :post 200 execute-bulk-url
+                                         {:action_id "data-grid.row/create"
+                                          :scope     {:table-id table-id}
+                                          :inputs    [{:name "Pidgey"     :song "Car alarms"}
+                                                      {:name "Spearow"    :song "Hold music"}
+                                                      {:name "Farfetch'd" :song "The land of lisp"}]})))))
 
-            (is (= [[1 "Pidgey" "Car alarms"]
-                    [2 "Spearow" "Hold music"]
-                    [3 "Farfetch'd" "The land of lisp"]]
-                   (table-rows table-id))))
+          (is (= [[1 "Pidgey" "Car alarms"]
+                  [2 "Spearow" "Hold music"]
+                  [3 "Farfetch'd" "The land of lisp"]]
+                 (table-rows table-id))))
 
-          (testing "PUT should update the relevant rows and columns"
+        #_(testing "PUT should update the relevant rows and columns"
             (is (= #{{:op "updated", :table-id table-id :row {:id 1, :name "Pidgey",     :song "Join us now and share the software"}}
                      {:op "updated", :table-id table-id :row {:id 2, :name "Speacolumn", :song "Hold music"}}}
                    (set
                     (:outputs
-                     (mt/user-http-request :crowberto :post 200 url
+                     (mt/user-http-request :crowberto :post 200 execute-bulk-url
                                            {:action_id "data-grid.row/update"
                                             :scope     {:table-id table-id}
                                             :inputs    [{:id 1 :song "Join us now and share the software"}
@@ -95,12 +95,12 @@
                      [3 "Farfetch'd" "The land of lisp"]}
                    (set (table-rows table-id)))))
 
-          (testing "PUT can also do bulk updates"
+        #_(testing "PUT can also do bulk updates"
             (is (= #{{:op "updated", :table-id table-id, :row {:id 1, :name "Pidgey",     :song "The Star-Spangled Banner"}}
                      {:op "updated", :table-id table-id, :row {:id 2, :name "Speacolumn", :song "The Star-Spangled Banner"}}}
                    (set
                     (:outputs
-                     (mt/user-http-request :crowberto :post 200 url
+                     (mt/user-http-request :crowberto :post 200 execute-bulk-url
                                            {:action_id "data-grid.row/update"
                                             :scope     {:table-id table-id}
                                             :inputs    [{:id 1}
@@ -112,18 +112,18 @@
                      [3 "Farfetch'd" "The land of lisp"]}
                    (set (table-rows table-id)))))
 
-          (testing "DELETE should remove the corresponding rows"
+        #_(testing "DELETE should remove the corresponding rows"
             (is (= #{{:op "deleted", :table-id table-id, :row {:id 1}}
                      {:op "deleted", :table-id table-id, :row {:id 2}}}
                    (set
                     (:outputs
-                     (mt/user-http-request :crowberto :post 200 url
+                     (mt/user-http-request :crowberto :post 200 execute-bulk-url
                                            {:action_id "data-grid.row/delete"
                                             :scope     {:table-id table-id}
                                             :inputs    [{:id 1}
                                                         {:id 2}]})))))
             (is (= [[3 "Farfetch'd" "The land of lisp"]]
-                   (table-rows table-id)))))))))
+                   (table-rows table-id))))))))
 
 (deftest table-operations-via-action-execute-with-compound-pk-test
   (mt/with-premium-features #{:actions}

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -396,10 +396,9 @@
               ;; :d == data-editing   only allowed to edit if editing enabled
               ;; :s == super-user     only allowed to edit if a superuser
               tests
-              ;; TODO: figure out the expected permisison model for non-super users
-              [;#{:a}       ["You don't have permissions to do that." 403]
-               ;#{:d}       ["You don't have permissions to do that." 403]
-               ;#{:a :d}    ["You don't have permissions to do that." 403]
+              [#{:a}       ["You don't have permissions to do that." 403]
+               #{:d}       ["You don't have permissions to do that." 403]
+               #{:a :d}    ["You don't have permissions to do that." 403]
                #{:s}       ["Data editing is not enabled."           400]
                #{:s :a}    ["Data editing is not enabled."           400]
                #{:s :d}    :ok

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -501,7 +501,8 @@
    (check-coercion-fn-coverage #{} test-cases))
   ([exclusions test-cases]
    (let [covered-fns  (into #{} (keep second) test-cases)
-         expected-fns (descendants :Coercion/*)
+         ;; Strip out Coercions defined in tests, e.g. clojure.types.core-test/Coerce-BigInteger-To-Instant
+         expected-fns (into #{} (filter (comp #{"Coercion"} namespace)) (descendants :Coercion/*))
          [unknown missing] (data/diff covered-fns expected-fns)]
      (testing "There are no unnecessary transformations (or stale keywords)"
        (is (empty? unknown)))

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -591,7 +591,6 @@
                                    (#'data-editing/batch-invalidate-field-values! [field-ids])
                                    (recur)))]
           (binding [data-editing/*field-value-invalidate-queue* test-queue]
-            ;; TODO this can flake sometimes, not sure why (left over state from other tests?)
             (is (= [] (field-values)))
 
             (create! [{:n "a"}])

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -115,7 +115,7 @@
         (testing "DELETE should remove the corresponding rows"
           (is (= #{{:op "deleted", :table-id table-id, :row {:id 1}}
                    {:op "deleted", :table-id table-id, :row {:id 2}}}
-                 (seth
+                 (set
                   (:outputs
                    (delete-rows! table-id [{:id 1} {:id 2}])))))
           (is (= [[3 "Farfetch'd" "The land of lisp"]]

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -1,0 +1,756 @@
+(ns ^:mb/driver-tests metabase-enterprise.action-v2.api-test
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
+   [clojure.test :refer :all]
+   [metabase-enterprise.action-v2.test-util :as data-editing.tu]
+   [metabase.actions.models :as actions]
+   [metabase.actions.test-util :as actions.tu]
+   [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc :as sql-jdbc]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.query-processor :as qp]
+   [metabase.sync.core :as sync]
+   [metabase.test :as mt]
+   [metabase.test.data.sql :as sql.tx]
+   [metabase.util :as u]
+   [metabase.warehouse-schema.models.field-values :as field-values]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- table-rows [table-id]
+  (mt/rows
+   (qp/process-query
+    {:database (mt/id)
+     :type     :query
+     :query    {:source-table table-id}})))
+
+(def ^:private execute-url "/ee/action-v2/execute")
+(def ^:private execute-bulk-url "/ee/action-v2/execute-bulk")
+(def ^:private execute-form-url "/ee/action-v2/execute-bulk")
+
+(defn- create-rows! [table-id rows]
+  (mt/user-http-request :crowberto :post 200 execute-bulk-url
+                        {:action :data-grid.row/create
+                         :scope  {:table-id table-id}
+                         :inputs rows}))
+
+(defn- update-rows! [table-id rows]
+  (mt/user-http-request :crowberto :post 200 execute-bulk-url
+                        {:action :data-grid.row/update
+                         :scope  {:table-id table-id}
+                         :inputs rows}))
+
+(deftest feature-flag-required-test
+  (mt/with-premium-features #{}
+    (mt/assert-has-premium-feature-error "Editing Table Data" (mt/user-http-request :crowberto :post 402 execute-url))
+    (mt/assert-has-premium-feature-error "Editing Table Data" (mt/user-http-request :crowberto :post 402 execute-bulk-url))
+    (mt/assert-has-premium-feature-error "Editing Table Data" (mt/user-http-request :crowberto :post 402 execute-form-url))))
+
+(deftest table-operations-via-action-execute-test
+  (mt/with-premium-features #{:actions}
+    (mt/test-drivers #{:h2 :postgres}
+      (data-editing.tu/with-test-tables! [table-id data-editing.tu/default-test-table]
+        (let [url "action/v2/execute-bulk"]
+          (testing "Initially the table is empty"
+            (is (= [] (table-rows table-id))))
+
+          (testing "POST should insert new rows"
+            (is (= #{{:op "created", :table-id table-id, :row {:id 1, :name "Pidgey", :song "Car alarms"}}
+                     {:op "created", :table-id table-id, :row {:id 2, :name "Spearow", :song "Hold music"}}
+                     {:op "created", :table-id table-id, :row {:id 3, :name "Farfetch'd", :song "The land of lisp"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/create"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:name "Pidgey"     :song "Car alarms"}
+                                                        {:name "Spearow"    :song "Hold music"}
+                                                        {:name "Farfetch'd" :song "The land of lisp"}]})))))
+
+            (is (= [[1 "Pidgey" "Car alarms"]
+                    [2 "Spearow" "Hold music"]
+                    [3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id))))
+
+          (testing "PUT should update the relevant rows and columns"
+            (is (= #{{:op "updated", :table-id table-id :row {:id 1, :name "Pidgey",     :song "Join us now and share the software"}}
+                     {:op "updated", :table-id table-id :row {:id 2, :name "Speacolumn", :song "Hold music"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/update"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id 1 :song "Join us now and share the software"}
+                                                        {:id 2 :name "Speacolumn"}]})))))
+
+            (is (= #{[1 "Pidgey" "Join us now and share the software"]
+                     [2 "Speacolumn" "Hold music"]
+                     [3 "Farfetch'd" "The land of lisp"]}
+                   (set (table-rows table-id)))))
+
+          (testing "PUT can also do bulk updates"
+            (is (= #{{:op "updated", :table-id table-id, :row {:id 1, :name "Pidgey",     :song "The Star-Spangled Banner"}}
+                     {:op "updated", :table-id table-id, :row {:id 2, :name "Speacolumn", :song "The Star-Spangled Banner"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/update"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id 1}
+                                                        {:id 2}]
+                                            :params    {:song "The Star-Spangled Banner"}})))))
+
+            (is (= #{[1 "Pidgey" "The Star-Spangled Banner"]
+                     [2 "Speacolumn" "The Star-Spangled Banner"]
+                     [3 "Farfetch'd" "The land of lisp"]}
+                   (set (table-rows table-id)))))
+
+          (testing "DELETE should remove the corresponding rows"
+            (is (= #{{:op "deleted", :table-id table-id, :row {:id 1}}
+                     {:op "deleted", :table-id table-id, :row {:id 2}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/delete"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id 1}
+                                                        {:id 2}]})))))
+            (is (= [[3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id)))))))))
+
+(deftest table-operations-via-action-execute-with-compound-pk-test
+  (mt/with-premium-features #{:actions}
+    (mt/test-drivers #{:h2 :postgres}
+      (data-editing.tu/with-test-tables! [table-id [{:id_1   'auto-inc-type
+                                                     :id_2   'auto-inc-type
+                                                     :name  [:text]
+                                                     :song  [:text]}
+                                                    {:primary-key [:id_1 :id_2]}]]
+        (let [url "action/v2/execute-bulk"]
+          (testing "Initially the table is empty"
+            (is (= [] (table-rows table-id))))
+
+          (testing "POST should insert new rows"
+            (is (= #{{:op "created", :table-id table-id, :row {:id_1 1, :id_2 1, :name "Pidgey",     :song "Car alarms"}}
+                     {:op "created", :table-id table-id, :row {:id_1 2, :id_2 2, :name "Spearow",    :song "Hold music"}}
+                     {:op "created", :table-id table-id, :row {:id_1 3, :id_2 3, :name "Farfetch'd", :song "The land of lisp"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/create"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:name "Pidgey"     :song "Car alarms"}
+                                                        {:name "Spearow"    :song "Hold music"}
+                                                        {:name "Farfetch'd" :song "The land of lisp"}]})))))
+
+            (is (= [[1 1 "Pidgey" "Car alarms"]
+                    [2 2 "Spearow" "Hold music"]
+                    [3 3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id))))
+
+          (testing "PUT should update the relevant rows and columns"
+            (is (= #{{:op "updated", :table-id table-id :row {:id_1 1, :id_2 1, :name "Pidgey",     :song "Join us now and share the software"}}
+                     {:op "updated", :table-id table-id :row {:id_1 2, :id_2 2, :name "Speacolumn", :song "Hold music"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/update"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id_1 1, :id_2 1, :song "Join us now and share the software"}
+                                                        {:id_1 2, :id_2 2, :name "Speacolumn"}]})))))
+
+            (is (= #{[1 1 "Pidgey" "Join us now and share the software"]
+                     [2 2 "Speacolumn" "Hold music"]
+                     [3 3 "Farfetch'd" "The land of lisp"]}
+                   (set (table-rows table-id)))))
+
+          (testing "PUT can also do bulk updates"
+            (is (= #{{:op "updated", :table-id table-id, :row {:id_1 1, :id_2 1, :name "Pidgey",     :song "The Star-Spangled Banner"}}
+                     {:op "updated", :table-id table-id, :row {:id_1 2, :id_2 2, :name "Speacolumn", :song "The Star-Spangled Banner"}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/update"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id_1 1, :id_2 1}
+                                                        {:id_1 2, :id_2 2}]
+                                            :params    {:song "The Star-Spangled Banner"}})))))
+
+            (is (= #{[1 1 "Pidgey" "The Star-Spangled Banner"]
+                     [2 2 "Speacolumn" "The Star-Spangled Banner"]
+                     [3 3 "Farfetch'd" "The land of lisp"]}
+                   (set (table-rows table-id)))))
+
+          (testing "DELETE should remove the corresponding rows"
+            (is (= #{{:op "deleted", :table-id table-id, :row {:id_1 1, :id_2 1}}
+                     {:op "deleted", :table-id table-id, :row {:id_1 2, :id_2 2}}}
+                   (set
+                    (:outputs
+                     (mt/user-http-request :crowberto :post 200 url
+                                           {:action_id "data-grid.row/delete"
+                                            :scope     {:table-id table-id}
+                                            :inputs    [{:id_1 1, :id_2 1}
+                                                        {:id_1 2, :id_2 2}]})))))
+            (is (= [[3 3 "Farfetch'd" "The land of lisp"]]
+                   (table-rows table-id)))))))))
+
+;; TODO update now that we don't detect or delete children automatically, or require confirmation for casacades, or have undo
+(deftest simple-delete-with-children-test
+  (binding [actions.tu/*actions-test-data-tables* #{"people" "products" "orders"}]
+    (mt/with-premium-features #{:actions}
+      (data-editing.tu/with-temp-test-db!
+        (let [body {:action_id "data-grid.row/delete"
+                    :scope     {:table-id (mt/id :products)}
+                    :inputs    [{(mt/format-name :id) 1}
+                                {(mt/format-name :id) 2}]}
+              children-count (fn []
+                               (let [result (mt/rows (qp/process-query {:database (mt/id)
+                                                                        :type     :query
+                                                                        :query    {:source-table (mt/id :orders)
+                                                                                   :aggregation  [[:count]]
+                                                                                   :breakout     [(mt/$ids $orders.product_id)]
+                                                                                   :filter        [:in (mt/$ids $orders.product_id) 1 2]}}))]
+                                 (zipmap (map first result) (map second result))))]
+
+          (testing "sanity check that we have children rows"
+            (is (= {1 93
+                    2 98}
+                   (children-count))))
+          (testing "delete without delete-children param will return errors with children count"
+            (is (=? {:errors {:type "metabase.actions.error/children-exist", :children-count {(mt/id :orders) 191}}}
+                    (mt/user-http-request :crowberto :post 400 execute-bulk-url
+                                          body))))
+
+          (testing "success with delete-children options"
+            (is (=? {:outputs [{:table-id (mt/id :products) :op "deleted" :row {(keyword (mt/format-name :id)) 1}}
+                               {:table-id (mt/id :products) :op "deleted" :row {(keyword (mt/format-name :id)) 2}}]}
+                    (mt/user-http-request :crowberto :post 200 execute-bulk-url
+                                          (assoc body :params {:delete-children true}))))
+            (is (empty? (children-count)))
+            (testing "the change is not undoable"
+              (is (= "Your previous change cannot be undone"
+                     (mt/user-http-request :crowberto :post 405 execute-bulk-url
+                                           {:action_id "data-editing/undo"
+                                            :scope     {:table-id (mt/id :products)}
+                                            :inputs    []}))))))))))
+
+(mt/defdataset self-referential-categories
+  [["category"
+    [{:field-name "name" :base-type :type/Text :not-null? true}
+     {:field-name "parent_id" :base-type :type/Integer :fk :category}]
+    [["Electronics" nil]
+     ["Phones" 1]
+     ["Laptops" 1]
+     ["Smartphones" 2]
+     ["Gaming Laptops" 3]]]])
+
+;; Update this too with actual behavior
+(deftest simple-delete-with-self-referential-children-test
+  (mt/with-premium-features #{:actions}
+    (data-editing.tu/with-actions-temp-db self-referential-categories
+      (let [body {:action_id "data-grid.row/delete"
+                  :scope     {:table-id (mt/id :category)}
+                  :inputs    [{(mt/format-name :id) 1}]}
+            children-count (fn [parent-id]
+                             (let [result (mt/rows (qp/process-query {:database (mt/id)
+                                                                      :type     :query
+                                                                      :query    {:source-table (mt/id :category)
+                                                                                 :aggregation  [[:count]]
+                                                                                 :filter       [:= (mt/$ids $category.parent_id) parent-id]}}))]
+                               (-> result first first)))]
+
+        (testing "sanity check that we have self-referential children"
+          (is (= 2 (children-count 1)))
+          (is (= 1 (children-count 2)))
+          (is (= 1 (children-count 3))))
+
+        (testing "delete parent with self-referential children should return error without delete-children param"
+          (is (=? {:errors {:type "metabase.actions.error/children-exist", :children-count {(mt/id :category) 4}}}
+                  (mt/user-http-request :crowberto :post 400 execute-bulk-url body))))
+
+        (testing "success with delete-children option should cascade delete all descendants"
+          (is (=? {:outputs [{:table-id (mt/id :category)
+                              :op       "deleted"
+                              :row      {(keyword (mt/format-name :id)) 1}}]}
+                  (mt/user-http-request :crowberto :post 200 execute-bulk-url
+                                        (assoc body :params {:delete-children true}))))
+          (is (= 0 (count (table-rows (mt/id :category)))))
+
+          (testing "the change is not undoable for self-referential cascades"
+            (is (= "Your previous change cannot be undone"
+                   (mt/user-http-request :crowberto :post 405 execute-bulk-url
+                                         {:action_id "data-editing/undo"
+                                          :scope     {:table-id (mt/id :category)}
+                                          :inputs    []})))))))))
+
+(mt/defdataset mutual-recursion-users-teams
+  [["user"
+    [{:field-name "id" :base-type :type/Integer :pk? true}
+     {:field-name "name" :base-type :type/Text :not-null? true}
+     {:field-name "team_id" :base-type :type/Integer #_:fk #_:team}]
+    [[1 "Alice" 1]
+     [2 "Bob" 2]]]
+   ["team"
+    [{:field-name "id" :base-type :type/Integer :pk? true}
+     {:field-name "name" :base-type :type/Text :not-null? true}
+     {:field-name "manager_id" :base-type :type/Integer :fk :user}]
+    [[1 "Alpha" nil]
+     [2 "Beta" 1]]]])
+
+(deftest mutual-recursion-delete-test
+  (mt/test-drivers #{:h2 :postgres}
+    (mt/with-premium-features #{:actions}
+      (data-editing.tu/with-actions-temp-db mutual-recursion-users-teams
+        (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+                       (sql.tx/add-fk-sql driver/*driver*
+                                          mutual-recursion-users-teams
+                                          {:table-name "user"}
+                                          {:fk :team :field-name "team_id"})
+                       {:transaction? false})
+        (sync/sync-database! (mt/db))
+        (let [users-table-id (mt/id :user)
+              teams-table-id (mt/id :team)
+              delete-user-body {:action_id "data-grid.row/delete"
+                                :scope     {:table-id users-table-id}
+                                :inputs    [{(mt/format-name :id) 1}]}]
+
+          (testing "delete user involved in mutual recursion should return error without delete-children param"
+            (is (=? {:errors {:type "metabase.actions.error/children-exist"
+                              :children-count {(mt/id :team) 1
+                                               (mt/id :user) 1}}}
+                    (mt/user-http-request :crowberto :post 400 execute-bulk-url delete-user-body))))
+          (testing "delete with delete-children should handle mutual recursion gracefully"
+            ; When deleting Alice with delete-children, it should:
+            ; 1. Delete Alice (user 1)
+            ; 2. This should cascade to Team Beta (which Alice manages)
+            ; 3. Deleting Team Beta should cascade to Bob (who belong to Team Beta)
+            (is (=? {:outputs [{:table-id users-table-id
+                                :op       "deleted"
+                                :row      {(keyword (mt/format-name :id)) 1}}]}
+                    (mt/user-http-request :crowberto :post 200 execute-bulk-url
+                                          (assoc delete-user-body :params {:delete-children true}))))
+
+            (let [remaining-users (table-rows users-table-id)
+                  remaining-teams (table-rows teams-table-id)]
+              (testing "mutual recursion cascade should delete interconnected records"
+                (is (empty? remaining-users))
+                (is (= 1 (count remaining-teams)))))))))))
+
+(deftest editing-allowed-test
+  (mt/with-premium-features #{:actions}
+    (mt/test-drivers #{:h2 :postgres}
+      (testing "40x returned if user/database not configured for editing"
+        (let [test-endpoints (fn [flags]
+                               (data-editing.tu/with-test-tables! [table-id data-editing.tu/default-test-table]
+                                 (let [actions-enabled (:a flags)
+                                       editing-enabled (:d flags)
+                                       superuser       (:s flags)
+                                       url             execute-bulk-url
+                                       settings        {:database-enable-table-editing (boolean editing-enabled)
+                                                        :database-enable-actions       (boolean actions-enabled)}
+                                       user            (if superuser :crowberto :rasta)
+                                       req             mt/user-http-request-full-response]
+                                   (mt/with-temp-vals-in-db :model/Database (mt/id) {:settings settings}
+                                     {:settings settings
+                                      :user     user
+                                      :responses {:create (req user :post url {:action :data-grid.row/create, :inputs [{:name "Pidgey" :song "Car alarms"}]})
+                                                  :update (req user :post url {:action :data-grid.row/update, :inputs [{:id 1 :song "Join us now and share the software"}]})
+                                                  :delete (req user :post url {:action :data-grid.row/delete, :inputs [{:id 1}]})}}))))
+
+              error-or-ok
+              (fn [{:keys [status body]}]
+                (if (<= 200 status 299)
+                  :ok
+                  [(:message body body) status]))
+
+              ;; Shorthand config notation
+              ;; :a == action-editing should not affect result
+              ;; :d == data-editing   only allowed to edit if editing enabled
+              ;; :s == super-user     only allowed to edit if a superuser
+              tests
+              [#{:a}       ["You don't have permissions to do that." 403]
+               #{:d}       ["You don't have permissions to do that." 403]
+               #{:a :d}    ["You don't have permissions to do that." 403]
+               #{:s}       ["Data editing is not enabled."           400]
+               #{:s :a}    ["Data editing is not enabled."           400]
+               #{:s :d}    :ok
+               #{:s :a :d} :ok]]
+          (doseq [[flags expected] (partition 2 tests)
+                  :let [{:keys [settings user responses]} (test-endpoints flags)]
+                  [verb  response] responses]
+            (testing (format "%s user: %s, settings: %s" verb user settings)
+              (is (= expected (error-or-ok response))))))))))
+
+;; TODO this needs to be updated to use the execute api
+(deftest coercion-test
+  (mt/with-premium-features #{:actions}
+    (mt/test-drivers #{:h2 :postgres}
+      (let [create! #(mt/user-http-request :crowberto :post execute-bulk-url {:action :data-grid.row/create, :scope {:table-id %1}, :inputs %2})
+            update! #(mt/user-http-request :crowberto :post execute-bulk-url {:action :data-grid.row/update, :scope {:table-id %1}, :inputs %2})
+            always-lossy #{:Coercion/UNIXNanoSeconds->DateTime
+                           :Coercion/UNIXMicroSeconds->DateTime
+                           :Coercion/ISO8601->Date
+                           :Coercion/ISO8601->Time}
+            driver-lossy (case driver/*driver*
+                           :postgres #{:Coercion/UNIXMilliSeconds->DateTime}
+                           #{})
+            lossy? (set/union always-lossy driver-lossy)
+            do-test (fn [t coercion-strategy input expected]
+                      (testing (str t " " coercion-strategy " " input)
+                        (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+                                                                       :o  [t :null]}
+                                                                      {:primary-key [:id]}]]
+                          (let [table-name-kw (t2/select-one-fn (comp keyword :name) [:model/Table :name] table-id)
+                                field-id      (t2/select-one-fn :id [:model/Field :id] :table_id table-id :name "o")
+                                driver        driver/*driver*
+                                get-qp-state  (fn [] (map #(zipmap [:id :o] %) (table-rows table-id)))
+                                get-db-state  (fn [] (sql-jdbc/query driver (mt/id) {:select [:*] :from [table-name-kw]}))]
+                            (t2/update! :model/Field field-id {:coercion_strategy coercion-strategy})
+                            (testing "create"
+                              (let [row {:o input}
+                                    {returned-state :created-rows} (create! table-id [row])
+                                    qp-state (get-qp-state)
+                                    _ (is (= 1 (count returned-state)))]
+                                (when-not (lossy? coercion-strategy)
+                                  (is (= qp-state returned-state) "we should return the same coerced output that table/$table-id/data would return")
+                                  (is (= input (:o (first qp-state))) "the qp value should be the same as the input"))
+                                (is (= expected (:o (first (get-db-state)))))))
+                            (testing "update"
+                              (let [[{id :id}] (:created-rows (create! table-id [{:o nil}]))
+                                    _ (is (some? id))
+                                    {returned-state :updated} (update! table-id [{:id id, :o input}])
+                                    [qp-row] (filter (comp #{id} :id) (get-qp-state))]
+                                (is (= 1 (count returned-state)))
+                                (is (some? qp-row))
+                                (when-not (lossy? coercion-strategy)
+                                  (is (= [qp-row] returned-state))
+                                  (is (= input (:o qp-row))))
+                                (is (= expected (:o (first (get-db-state)))))))))))]
+
+        ;;    type     coercion                                     input                          database
+        (->> [:text    nil                                          "a"                            "a"
+              :text    :Coercion/YYYYMMDDHHMMSSString->Temporal     "2025-03-25T14:34:00Z"         "20250325143400"
+              :text    :Coercion/ISO8601->DateTime                  "2025-03-25T14:34:42.314Z"     "2025-03-25T14:34:42.314Z"
+              :text    :Coercion/ISO8601->Date                      "2025-03-25T00:00:00Z"         "2025-03-25"
+              :text    :Coercion/ISO8601->Time                      "1999-04-05T14:34:42Z"         "14:34:42"
+
+              ;; note fractional seconds in input, remains undefined for Seconds
+              :int     :Coercion/UNIXSeconds->DateTime              "2025-03-25T14:34:42Z"         (quot (inst-ms #inst "2025-03-25T14:34:42Z") 1000)
+              :bigint  :Coercion/UNIXMilliSeconds->DateTime         "2025-03-25T14:34:42.314Z"     (inst-ms #inst "2025-03-25T14:34:42.314Z")
+
+              ;; note fractional secs beyond millis are discarded   (lossy)
+              :bigint  :Coercion/UNIXMicroSeconds->DateTime         "2025-03-25T14:34:42.314121Z"  (* (inst-ms #inst "2025-03-25T14:34:42.314Z") 1000)
+              :bigint  :Coercion/UNIXNanoSeconds->DateTime          "2025-03-25T14:34:42.3141212Z" (* (inst-ms #inst "2025-03-25T14:34:42.314Z") 1000000)
+
+              ;; nil safe
+              :text    :Coercion/YYYYMMDDHHMMSSString->Temporal     nil                            nil
+
+              ;; seconds component does not work properly here, lost by qp output, bug in existing code?
+              #_#_#_#_:text :Coercion/YYYYMMDDHHMMSSString->Temporal     "2025-03-25T14:34:42Z"     "20250325143442"]
+             (partition 4)
+             (run! #(apply do-test %)))))))
+
+;; TODO update this to use the execute api
+(deftest field-values-invalidated-test
+  (mt/with-premium-features #{:actions}
+    (mt/test-drivers #{:h2 :postgres}
+      (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type, :n [:text]} {:primary-key [:id]}]]
+        (let [field-id     (t2/select-one-fn :id :model/Field :table_id table-id :name "n")
+              _            (t2/update! :model/Field {:id field-id} {:semantic_type "type/Category"})
+              field-values #(vec (:values (field-values/get-latest-full-field-values field-id)))
+              create!      #(create-rows table-id %)
+              update!      #(mt/user-http-request :crowberto :put 200 execute-bulk-url {:rows %})
+              expect-field-values
+              (fn [expect]                     ; redundantly pass expect get ok-ish assert errors (preserve last val)
+                (let [last-res (volatile! nil)]
+                  (or (u/poll {:thunk       (fn [] (vreset! last-res (field-values)))
+                               :done?       #(= expect %)
+                               :timeout-ms  1000
+                               :interval-ms 1})
+                      @last-res)))]
+          (is (= [] (field-values)))
+
+          (create! [{:n "a"}])
+          (is (= ["a"] (expect-field-values ["a"])))
+
+          (create! [{:n "b"} {:n "c"}])
+          (is (= ["a" "b" "c"] (expect-field-values ["a" "b" "c"])))
+
+          (update! [{:id 2, :n "d"}])
+          (is (= ["a" "c" "d"] (expect-field-values ["a" "c" "d"])))
+
+          (create! [{:n "a"}])
+          (update! [{:id 1, :n "e"}])
+          (is (= ["a" "c" "d" "e"] (expect-field-values ["a" "c" "d" "e"]))))))))
+
+;; actions (need this to associate with the route namespace)
+;; data-editing (keep this to control whether the data-grid.row actions are callable?)
+
+(deftest unified-execute-test
+  (let [url "action/v2/execute"
+        req #(mt/user-http-request-full-response (:user % :crowberto) :post url
+                                                 (merge {:scope {:unknown :model-action} :input {}}
+                                                        (dissoc % :user-id)))]
+    (mt/with-premium-features #{:actions}
+      (mt/test-drivers #{:h2 :postgres}
+        (mt/with-non-admin-groups-no-root-collection-perms
+          (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+                                                         :name [:text]
+                                                         :status [:text]}
+                                                        {:primary-key [:id]}]]
+            (mt/with-temp [:model/Card          model    {:type           :model
+                                                          :table_id       table-id
+                                                          :database_id    (mt/id)
+                                                          :dataset_query  {:database (mt/id)
+                                                                           :type :query
+                                                                           :query {:source-table table-id}}}
+                           :model/Action        action   {:type           :implicit
+                                                          :name           "update"
+                                                          :model_id       (:id model)
+                                                          :parameters     [{:id "a"
+                                                                            :name "Id"
+                                                                            :slug "id"}
+                                                                           {:id "b"
+                                                                            :name "Name"
+                                                                            :slug "name"}
+                                                                           {:id "c"
+                                                                            :name "Status"
+                                                                            :slug "status"}]}
+                           :model/ImplicitAction _       {:action_id      (:id action)
+                                                          :kind           "row/update"}
+                           :model/Dashboard     dash     {}
+                           :model/DashboardCard dashcard {:dashboard_id   (:id dash)
+                                                          :card_id        (:id model)
+                                                          :visualization_settings
+                                                          {:table_id table-id
+                                                           :editableTable.enabledActions
+                                                           (let [param-maps
+                                                                 ;; TODO change these to use field ids, to test the translation
+                                                                 [{:parameterId "id",     :sourceType "row-data", :sourceValueTarget "id"}
+                                                                  {:parameterId "name",   :sourceType "row-data", :sourceValueTarget "name"}
+                                                                  {:parameterId "status", :sourceType "row-data", :sourceValueTarget "status"}]]
+                                                             [{:id                "dashcard:unknown:abcdef"
+                                                               :actionId          (:id action)
+                                                               :actionType        "data-grid/custom-action"
+                                                               :parameterMappings param-maps
+                                                               :enabled           true}
+                                                              {:id                "dashcard:unknown:fedcba"
+                                                               :actionId          "table.row/update"
+                                                               :actionType        "data-grid/custom-action"
+                                                               :mapping           {:table-id table-id
+                                                                                   :row      "::root"}
+                                                               :parameterMappings param-maps
+                                                               :enabled           true}
+                                                              {:id                "dashcard:unknown:xyzabc"
+                                                               :actionId          (#'actions/encoded-action-id :table.row/update table-id)
+                                                               :actionType        "data-grid/custom-action"
+                                                               :parameterMappings param-maps
+                                                               :enabled           true}])}}]
+              (testing "no access to the model"
+                (is (= 403 (:status (req {:user      :rasta
+                                          :action_id (:id action)
+                                          :scope     {:dashcard-id (:id dashcard)}
+                                          :input     {:id 1}
+                                          :params    {:status "approved"}})))))
+              ;; should not need this permission for model actions
+              (data-editing.tu/with-data-editing-enabled! false
+                (testing "non-row action modifying a row"
+                  (testing "underlying row does not exist, action not executed"
+                    (is (= 400 (:status (req {:action_id (:id action)
+                                              :scope     {:dashcard-id (:id dashcard)}
+                                              :input     {:id 1}
+                                              :params    {:status "approved"}})))))
+                  (testing "underlying row exists, action executed"
+                    (data-editing.tu/with-data-editing-enabled! true
+                      (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url table-id)
+                                            {:rows [{:name "Widgets", :status "waiting"}]}))
+                    (is (= {:status 200
+                            :body   {:outputs [{:rows-updated 1}]}}
+                           (-> (req {:action_id (:id action)
+                                     :scope     {:dashcard-id (:id dashcard)}
+                                     :input     {:id 1}
+                                     :params    {:status "approved"}})
+                               (select-keys [:status :body]))))))
+                (testing "dashcard row action modifying a row - implicit action"
+                  (let [action-id "dashcard:unknown:abcdef"]
+                    (testing "underlying row does not exist, action not executed"
+                      (is (= 404 (:status (req {:action_id action-id
+                                                :scope     {:dashcard-id (:id dashcard)}
+                                                :input     {:id 2}
+                                                :params    {:status "approved"}})))))
+                    (testing "underlying row exists, action executed"
+                      (data-editing.tu/with-data-editing-enabled! true
+                        (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url table-id)
+                                              {:rows [{:name "Sprockets", :status "waiting"}]}))
+                      (is (= {:status 200
+                              :body   {:outputs [{:rows-updated 1}]}}
+                             (-> (req {:action_id action-id
+                                       :scope     {:dashcard-id (:id dashcard)}
+                                       :input     {:id 2}
+                                       :params    {:status "approved"}})
+                                 (select-keys [:status :body]))))))))
+              ;; but it is necessary for the primitives
+              (data-editing.tu/with-data-editing-enabled! true
+                (testing "dashcard row action modifying a row - primitive action"
+                  (let [action-id "dashcard:unknown:fedcba"]
+                    (testing "underlying row does not exist, action not executed"
+                      (is (= 404 (:status (req {:action_id action-id
+                                                :scope     {:dashcard-id (:id dashcard)}
+                                                :input     {:id 3}
+                                                :params    {:status "approved"}})))))
+                    (testing "underlying row exists, action executed"
+                      (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url table-id)
+                                            {:rows [{:name "Braai tongs", :status "waiting"}]})
+                      (is (= {:status 200
+                              :body   {:outputs [{:table-id table-id
+                                                  :op       "updated"
+                                                  :row      {:id 3, :name "Braai tongs", :status "approved"}}]}}
+                             (-> (req {:action_id action-id
+                                       :scope     {:dashcard-id (:id dashcard)}
+                                       :input     {:id 3}
+                                       :params    {:status "approved"}})
+                                 (select-keys [:status :body])))))))))))))))
+
+;; TODO we may want to test that data-grid/built-in actions can't get called in they're disabled?
+;;    i.e. the data-editing premium feature is enabled
+
+(deftest unified-execute-server-side-mapping-test
+  (mt/with-premium-features #{:actions}
+    (mt/test-drivers #{:h2 :postgres}
+      (data-editing.tu/with-test-tables! [table-1-id [{:id  'auto-inc-type
+                                                       :col [:text]}
+                                                      {:primary-key [:id]}]
+                                          table-2-id [{:id 'auto-inc-type
+                                                       :a  [:text]
+                                                       :b  [:text]
+                                                       :c  [:text]
+                                                       :d  [:text]}
+                                                      {:primary-key [:id]}]]
+
+        (mt/with-temp [:model/Card          model    {:type           :model
+                                                      :table_id       table-1-id
+                                                      :database_id    (mt/id)
+                                                      :dataset_query  {:database (mt/id)
+                                                                       :type     :query
+                                                                       :query    {:source-table table-1-id}}}
+                       :model/Dashboard     dash     {}
+                       :model/DashboardCard dashcard {:dashboard_id   (:id dash)
+                                                      :card_id        (:id model)
+                                                      :visualization_settings
+                                                      {:table_id table-1-id
+                                                       :editableTable.enabledActions
+                                                       [{:id         "dashcard:unknown:my-row-action"
+                                                         :actionId   "table.row/create"
+                                                         :actionType "data-grid/custom-action"
+                                                         :mapping    {:table-id table-2-id
+                                                                      :row      {:a ["::key" "aa"]
+                                                                                 :b ["::key" "bb"]
+                                                                                 :c ["::key" "cc"]
+                                                                                 :d ["::key" "dd"]}}
+                                                         :parameterMappings
+                                                         [{:parameterId "aa" :sourceType "row-data" :sourceValueTarget "col"}
+                                                          {:parameterId "bb" :sourceType "ask-user"}
+                                                          {:parameterId "cc" :sourceType "ask-user" :value "default"}
+                                                          {:parameterId "dd" :sourceType "constant" :value "hard-coded"}]
+                                                         :enabled    true}]}}]
+          (testing "dashcard row action modifying a row - primitive action"
+            (let [action-id "dashcard:unknown:my-row-action"]
+              (testing "underlying row does not exist, action not executed"
+                (mt/user-http-request :crowberto :post 404 execute-url {:action_id action-id
+                                                                        :scope  {:dashcard-id (:id dashcard)}
+                                                                        :input  {:id 1}
+                                                                        :params {:status "approved"}}))
+              (testing "underlying row exists, action executed\n"
+                (mt/user-http-request :crowberto :post 200 (data-editing.tu/table-url table-1-id)
+                                      {:rows [{:col "database-value"}]})
+                (let [base-req {:action_id action-id
+                                :scope     {:dashcard-id (:id dashcard)}
+                                :input     {:id 1, :col "stale-value"}
+                                :params    {:bb nil}}]
+                  ;; TODO don't have a way to make params required for non-legacy actions yet, d'oh
+                  ;;      oh well, let nil spill through
+                  (testing "missing required param"
+                    (is (=? {:outputs [{:table-id table-2-id
+                                        :op       "created"
+                                        :row      {:id 1
+                                                   :a  "database-value"
+                                                   :b  nil
+                                                   :c  "default"
+                                                   :d  "hard-coded"}}]}
+                            (mt/user-http-request :crowberto :post 200 execute-url base-req))))
+                  (testing "missing optional param"
+                    (is (=? {:outputs [{:table-id table-2-id
+                                        :op       "created"
+                                        :row      {:id 2
+                                                   :a  "database-value"
+                                                   :b  "necessary"
+                                                   :c  "default"
+                                                   :d  "hard-coded"}}]}
+                            (mt/user-http-request :crowberto :post 200 execute-url (assoc-in base-req [:params :bb] "necessary")))))
+                  (testing "null optional param"
+                    (is (= {:outputs [{:table-id table-2-id
+                                       :op       "created"
+                                       :row      {:id 3
+                                                  :a  "database-value"
+                                                  :b  "necessary"
+                                                  :c  nil
+                                                  :d  "hard-coded"}}]}
+                           (mt/user-http-request :crowberto :post 200 execute-url (-> base-req
+                                                                                      (assoc-in [:params :bb] "necessary")
+                                                                                      (assoc-in [:params :cc] nil))))))
+                  (testing "provided optional param"
+                    (is (= {:outputs [{:table-id table-2-id
+                                       :op       "created"
+                                       :row      {:id 4
+                                                  :a  "database-value"
+                                                  :b  "necessary"
+                                                  :c  "optional"
+                                                  :d  "hard-coded"}}]}
+                           (mt/user-http-request :crowberto :post 200 execute-url (-> base-req
+                                                                                      (assoc-in [:params :bb] "necessary")
+                                                                                      (assoc-in [:params :cc] "optional")))))))))))))))
+
+(deftest execute-form-built-in-table-action-test
+  (mt/with-premium-features #{:actions}
+    (mt/test-drivers #{:h2 :postgres}
+      (data-editing.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+                                                     :text      [:text]
+                                                     :int       [:int]
+                                                     :timestamp [:timestamp]
+                                                     :date [:date]
+                                                     :inactive [:text]}
+                                                    {:primary-key [:id]}]]
+        ;; This inactive field should not show up
+        (t2/update! :model/Field {:table_id table-id, :name "inactive"} {:active false})
+        (testing "table actions"
+          (let [create-id           "data-grid.row/create"
+                update-id           "data-grid.row/update"
+                delete-id           "data-grid.row/delete"
+                scope               {:table-id table-id}]
+
+            (testing "create"
+              (is (=? {:parameters [{:id "text"      :display_name "Text"      :input_type "text"}
+                                    {:id "int"       :display_name "Int"       :input_type "text"}
+                                    {:id "timestamp" :display_name "Timestamp" :input_type "datetime"}
+                                    {:id "date"      :display_name "Date"      :input_type "date"}]}
+                      (mt/user-http-request :crowberto :post 200 "action/v2/execute-form"
+                                            {:scope     scope
+                                             :action_id create-id}))))
+
+            (testing "update"
+              (is (=? {:parameters [{:id "id"        :display_name "ID"        :input_type "text"}
+                                    {:id "text"      :display_name "Text"      :input_type "text"}
+                                    {:id "int"       :display_name "Int"       :input_type "text"}
+                                    {:id "timestamp" :display_name "Timestamp" :input_type "datetime"}
+                                    {:id "date"      :display_name "Date"      :input_type "date"}]}
+                      (mt/user-http-request :crowberto :post 200 "action/v2/execute-form"
+                                            {:scope     scope
+                                             :action_id update-id}))))
+
+            (testing "delete"
+              (is (=? {:parameters [{:id "id" :display_name "ID" :input_type "text"}]}
+                      (mt/user-http-request :crowberto :post 200 "action/v2/execute-form"
+                                            {:scope     scope
+                                             :action_id delete-id}))))))))))

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -42,6 +42,8 @@
 (defn create-rows!
   ([table-id rows]
    (create-rows! table-id :crowberto 200 rows))
+  ([table-id response-code rows]
+   (create-rows! table-id :crowberto response-code rows))
   ([table-id user response-code rows]
    (mt/user-http-request user :post response-code execute-bulk-url
                          {:action :data-grid.row/create
@@ -51,6 +53,8 @@
 (defn- update-rows!
   ([table-id rows]
    (update-rows! table-id :crowberto 200 rows))
+  ([table-id response-code rows]
+   (update-rows! table-id :crowberto response-code rows))
   ([table-id user response-code rows & [params]]
    (mt/user-http-request user :post response-code execute-bulk-url
                          (cond->
@@ -62,6 +66,8 @@
 (defn- delete-rows!
   ([table-id rows]
    (delete-rows! table-id :crowberto 200 rows))
+  ([table-id response-code rows]
+   (delete-rows! table-id :crowberto response-code rows))
   ([table-id user response-code rows]
    (mt/user-http-request user :post response-code execute-bulk-url
                          {:action :data-grid.row/delete
@@ -116,7 +122,7 @@
                    {:op "updated", :table-id table-id, :row {:id 2, :name "Speacolumn", :song "The Star-Spangled Banner"}}}
                  (set
                   (:outputs
-                   (update-rows! table-id 200 [{:id 1} {:id 2}] {:song "The Star-Spangled Banner"})))))
+                   (update-rows! table-id :crowberto 200 [{:id 1} {:id 2}] {:song "The Star-Spangled Banner"})))))
 
           (is (= #{[1 "Pidgey" "The Star-Spangled Banner"]
                    [2 "Speacolumn" "The Star-Spangled Banner"]
@@ -385,9 +391,11 @@
                                       :responses {:create (create-rows! table-id user status-code [{:name "Pidgey" :song "Car alarms"}])
                                                   :update (update-rows! table-id user status-code [{:id 1 :song "Join us now and share the software"}])
                                                   :delete (delete-rows! table-id user status-code [{:id 1}])}}))))
-
-              error-or-ok    (fn [res] (if (string? res) res (:message res :ok)))
-
+              error-or-ok (fn [res]
+                            (cond
+                              (string? res)  res
+                              (:message res) (:message res)
+                              :else          :ok))
               ;; Shorthand config notation
               ;; :a == action-editing should not affect result
               ;; :d == data-editing   only allowed to edit if editing enabled

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase-enterprise.action-v2.api-test
   (:require
+   [clojure.data :as data]
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.test :refer :all]
@@ -15,7 +16,6 @@
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.test.data.sql :as sql.tx]
-   [metabase.util :as u]
    [metabase.warehouse-schema.models.field-values :as field-values]
    [toucan2.core :as t2])
   (:import
@@ -502,7 +502,7 @@
   ([exclusions test-cases]
    (let [covered-fns  (into #{} (keep second) test-cases)
          expected-fns (descendants :Coercion/*)
-         [unknown missing] (clojure.data/diff covered-fns expected-fns)]
+         [unknown missing] (data/diff covered-fns expected-fns)]
      (testing "There are no unnecessary transformations (or stale keywords)"
        (is (empty? unknown)))
      (testing "All expected coercion options are tested"

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -364,11 +364,9 @@
                                  (let [actions-enabled (:a flags)
                                        editing-enabled (:d flags)
                                        superuser       (:s flags)
-                                       url             execute-bulk-url
                                        settings        {:database-enable-table-editing (boolean editing-enabled)
                                                         :database-enable-actions       (boolean actions-enabled)}
-                                       user            (if superuser :crowberto :rasta)
-                                       req             mt/user-http-request-full-response]
+                                       user            (if superuser :crowberto :rasta)]
                                    (mt/with-temp-vals-in-db :model/Database (mt/id) {:settings settings}
                                      {:settings settings
                                       :user     user

--- a/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.action-v2.coerce-test
   (:require
+   [clojure.data :as data]
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -74,7 +75,7 @@
 
   ;; TODO: fix this test by implementing all strategies
   (let [implemented (set (keys coerce/coercion-fns))
-        [unknown missing] (clojure.data/diff implemented (descendants :Coercion/*))]
+        [unknown missing] (data/diff implemented (descendants :Coercion/*))]
     (testing "There are no unnecessary transformations (or stale keywords)"
       (is (nil? unknown)))
     (testing "There are no gaps in our transformations"

--- a/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
@@ -75,7 +75,8 @@
 
   ;; TODO: fix this test by implementing all strategies
   (let [implemented (set (keys coerce/coercion-fns))
-        [unknown missing] (data/diff implemented (descendants :Coercion/*))]
+        expected-fns (into #{} (filter (comp #{"Coercion"} namespace)) (descendants :Coercion/*))
+        [unknown missing] (data/diff implemented expected-fns)]
     (testing "There are no unnecessary transformations (or stale keywords)"
       (is (nil? unknown)))
     (testing "There are no gaps in our transformations"

--- a/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
@@ -1,0 +1,76 @@
+(ns metabase-enterprise.action-v2.coerce-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.action-v2.coerce :as coerce]
+   [metabase.test :as mt]))
+
+(deftest coercion-conversions-test
+  (mt/with-clock #t "2000-01-01T00:00:00Z"
+    (let [test-cases
+          [{:strategy :Coercion/UNIXSeconds->DateTime
+            :input    "2024-03-20T15:30:45Z[UTC]"
+            :output   1710948645}
+
+           {:strategy :Coercion/UNIXMilliSeconds->DateTime
+            :input    "2024-03-20T15:30:45Z[UTC]"
+            :output   1710948645000}
+
+           {:strategy :Coercion/UNIXMicroSeconds->DateTime
+            :input    "2024-03-20T15:30:45Z[UTC]"
+            :output   1710948645000000}
+
+           {:strategy :Coercion/UNIXNanoSeconds->DateTime
+            :input    "2024-03-20T15:30:45Z[UTC]"
+            :output   1710948645000000000}
+
+           {:strategy :Coercion/YYYYMMDDHHMMSSString->Temporal
+            :input    "2024-03-20T15:30Z[UTC]"  ;; Note: seconds set to 00 since the format doesn't preserve seconds
+            :output   "20240320153000"}
+
+           {:strategy :Coercion/ISO8601->DateTime
+            :input    "2024-03-20T15:30:45Z[UTC]"
+            :output   "2024-03-20T15:30:45Z[UTC]"}
+
+           {:strategy :Coercion/ISO8601->Date
+            :input    "2024-03-20T00:00Z[UTC]"
+            :output   "2024-03-20"}
+
+           {:strategy :Coercion/ISO8601->Time
+            :input    "2025-05-01T15:30:45Z[UTC]"
+            :reversed #(str/ends-with? % "T15:30:45Z[UTC]")
+            :output   "15:30:45"}]]
+
+      (doseq [{:keys [strategy input reversed output]} test-cases]
+        (testing (format "Testing %s conversions" strategy)
+          (let [reversed?        (or reversed #{input})
+                {:keys [in out]} (get coerce/coercion-fns strategy)]
+            ;; Test input conversion (JSON -> Database format)
+            (testing "Input conversion"
+              (is (= output (in input))
+                  (format "Input conversion failed for %s: expected %s, got %s"
+                          strategy output (in input))))
+
+            ;; Test output conversion (Database format -> JSON)
+            (testing "Output conversion"
+              (is (reversed? (out output))
+                  (format "Output conversion failed for %s: expected %s, got %s"
+                          strategy
+                          (if-not reversed
+                            input
+                            (str "something like " input))
+                          (out output))))
+
+            ;; Test roundtrip conversion
+            (testing "Roundtrip conversion"
+              (is (reversed? (-> input in out))
+                  (format "Roundtrip conversion failed for %s: %s -> %s -> %s"
+                          strategy input (in input) (out (in input)))))))))))
+
+(deftest coercion-fns-static-test
+  (testing "all coercion pair have to have an in and out function"
+    (testing (every? #(and (fn? (:in %)) (fn? (:out %))) coerce/coercion-fns)))
+
+  ;; TODO: fix this test by implementing all strategies
+  #_(testing "all coercion strategies are covered"
+      (is (empty? (second (diff (into #{} (keys coerce/coercion-fns)) (descendants :Coercion/*)))))))

--- a/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/coerce_test.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.action-v2.coerce-test
   (:require
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.action-v2.coerce :as coerce]
@@ -72,5 +73,10 @@
     (testing (every? #(and (fn? (:in %)) (fn? (:out %))) coerce/coercion-fns)))
 
   ;; TODO: fix this test by implementing all strategies
-  #_(testing "all coercion strategies are covered"
-      (is (empty? (second (diff (into #{} (keys coerce/coercion-fns)) (descendants :Coercion/*)))))))
+  (let [implemented (set (keys coerce/coercion-fns))
+        [unknown missing] (clojure.data/diff implemented (descendants :Coercion/*))]
+    (testing "There are no unnecessary transformations (or stale keywords)"
+      (is (nil? unknown)))
+    (testing "There are no gaps in our transformations"
+      ;; TODO implement these remaining cases
+      (is (empty? (set/difference missing @#'coerce/unimplemented-coercion-functions))))))

--- a/enterprise/backend/test/metabase_enterprise/action_v2/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/test_util.clj
@@ -1,0 +1,112 @@
+(ns metabase-enterprise.action-v2.test-util
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [clojure.walk :as walk]
+   [metabase.actions.test-util :as actions.tu]
+   [metabase.driver :as driver]
+   [metabase.sync.core :as sync]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn sync-new-table!
+  "Syncs a new table by name, returns the table id."
+  [db table-name]
+  (let [table (sync/create-table! db {:name table-name
+                                      ;; todo figure out how to determine default schema from driver
+                                      :schema (case (:engine db) :postgres "public" nil)
+                                      :display_name table-name
+                                      :field_order  :database})]
+    (sync/sync-fields-for-table! db table)
+    (:id table)))
+
+(defn- create-test-table! [db table-name column-map create-table-opts]
+  (let [_  (driver/create-table! (:engine db)
+                                 (:id db)
+                                 table-name
+                                 column-map
+                                 create-table-opts)]
+    (sync-new-table! db table-name)))
+
+(defn toggle-data-editing-enabled! [db-id on-or-off]
+  (let [current-settings (t2/select-one-fn :settings :model/Database db-id)]
+    (t2/update! :model/Database db-id {:settings (assoc current-settings :database-enable-table-editing (boolean on-or-off))})))
+
+(defmacro with-data-editing-enabled! [on-or-off & body]
+  `(mt/with-temp-vals-in-db :model/Database (mt/id) {:settings {:database-enable-table-editing ~on-or-off}}
+     ~@body))
+
+(def default-test-table
+  "The default test table config."
+  [{:id    'auto-inc-type
+    :name  [:text]
+    :song  [:text]}
+   {:primary-key [:id]}])
+
+(defn do-with-test-tables!
+  "Impl of [[with-test-tables!]]."
+  [[column-map create-table-opts] thunk]
+  (let [db            (t2/select-one :model/Database (mt/id))
+        driver        (:engine db)
+        auto-inc-type (driver/upload-type->database-type driver :metabase.upload/auto-incrementing-int-pk)
+        column-map    (walk/postwalk-replace {'auto-inc-type auto-inc-type} column-map)
+        table-name    (str "temp_table_" (str/replace (random-uuid) "-" "_"))
+        cleanup       (fn []
+                        (driver/drop-table! driver (mt/id) table-name)
+                        (t2/delete! :model/Table :name table-name))]
+    (try
+      (thunk (create-test-table! db table-name column-map create-table-opts))
+      (catch Exception e
+        (try (cleanup) (catch Exception cleanup-ex (.addSuppressed e cleanup-ex)))
+        (throw e)))))
+
+(defmacro with-test-tables!
+  "Execute `body` with temporary table(s) created in the test database that has actions and table editing enabled.
+  You may specify multiple table specifications to create multiple tables.
+  Each table specification should be a vector containing `[column-map create-table-opts]`.
+  The symbol `auto-inc-type` can be used in column maps to denote the driver-specific auto-incrementing type for
+  primary keys.
+
+  Each table is created with a unique name and is automatically cleaned up after the body concludes. The body is
+  executed within an empty database context (mt/with-empty-db).
+
+  DOES NOT CREATE TABLES UNTIL THE BODY IS EXECUTED!
+
+    ;; create a single table with default schema
+    (with-test-tables! [table-id [{:id 'auto-inc-type, :name [:text], :song [:text]}
+                                  {:primary-key [:id]}]]
+      ...)
+
+    ;; create multiple tables
+    (with-test-tables! [users-table [{:id 'auto-inc-type, :name [:text]} {:primary-key [:id]}]
+                        posts-table [{:id 'auto-inc-type, :user_id [:int], :content [:text]} {:primary-key [:id]}]]
+      ...)"
+  [[table-binding table-spec & more] & body]
+  `(mt/with-empty-db
+     (t2/update! :model/Database (mt/id) {:settings {:database-enable-table-editing true
+                                                     :database-enable-actions       true}})
+     (do-with-test-tables!
+      ~table-spec
+      (fn [~table-binding]
+        ~@(if (seq more)
+            [`(with-test-tables! ~(vec more) ~@body)]
+            body)))))
+
+(defmacro with-temp-test-db!
+  "Sets up a temporary database in the appdb to do destrcutive tests.
+
+  Use (mt/id), (mt/db) etc to get the database id and database object."
+  [& body]
+  `(actions.tu/with-actions-test-data
+     (toggle-data-editing-enabled! (mt/id) true)
+     ~@body))
+
+(defmacro with-actions-temp-db
+  "Like [[actions.tu/with-actions-temp-db]] but with table editing enabled"
+  [dataset-definition & body]
+  `(actions.tu/with-actions-temp-db ~dataset-definition
+     (t2/update! :model/Database (mt/id) {:settings {:database-enable-table-editing true
+                                                     :database-enable-actions       true}})
+     ~@body))

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -19,6 +19,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
+   [methodical.core :as m]
    [methodical.core :as methodical]
    [nano-id.core :as nano-id]
    [toucan2.core :as t2])
@@ -67,7 +68,7 @@
   (into #{}
         (comp (filter sequential?)
               (map second))
-        (keys (methods perform-action!*))))
+        (keys (m/primary-methods perform-action!*))))
 
 (methodical/defmethod perform-action!* :default
   [action context _inputs]

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -298,7 +298,7 @@
           (do
             ;; TODO more granular controls
             (when-not (api/check-superuser)
-              (throw (ex-info (i18n/tru "You don't have permissions to do that.") {:status-code 403})))
+              (throw (ex-info (i18n/tru "You don''t have permissions to do that.") {:status-code 403})))
             (check-data-editing-enabled-for-database! db))))
 
       (log/with-context {:db-id (:id db)}

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -295,7 +295,11 @@
           :model-action
           (check-actions-enabled-for-database! db)
           :data-editing
-          (check-data-editing-enabled-for-database! db)))
+          (do
+            ;; TODO more granular controls
+            (when-not (api/check-superuser)
+              (throw (ex-info (i18n/tru "You don't have permissions to do that.") {:status-code 403})))
+            (check-data-editing-enabled-for-database! db))))
 
       (log/with-context {:db-id (:id db)}
         (binding [*misc-value-cache* (atom {:databases (zipmap (map :id dbs) dbs)})]

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -36,7 +36,7 @@
 (defmethod default-mapping :table.row/common
   [_ scope]
   (when (= :table (:type scope))
-    (assoc (select-keys scope [:table-id]) :row :metabase-enterprise.data-editing.api/root)))
+    (assoc (select-keys scope [:table-id]) :row :metabase-enterprise.action-v2.api/root)))
 
 (methodical/defmulti perform-action!*
   "Multimethod for doing an Action. The specific `action` is a keyword like `:model.row/create` or `:table.row/create`; the shape
@@ -331,7 +331,7 @@
 (mu/defn perform-action!
   "This is the Old School version of [[perform-action!], before we returned effects and added generic bulk application."
   [action arg-map & {:keys [scope] :as opts}]
-  (try (let [scope             (or scope {:unknown :legacy-action})
+  (try (let [scope             (or scope {:unknown :model-action})
              {:keys [outputs]} (perform-action-v2! action scope [arg-map] (dissoc opts :scope))]
          (assert (= 1 (count outputs)) "The legacy action APIs do not support actions with multiple outputs")
          (first outputs))

--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -19,7 +19,6 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [methodical.core :as m]
    [methodical.core :as methodical]
    [nano-id.core :as nano-id]
    [toucan2.core :as t2])
@@ -68,7 +67,7 @@
   (into #{}
         (comp (filter sequential?)
               (map second))
-        (keys (m/primary-methods perform-action!*))))
+        (keys (methodical/primary-methods perform-action!*))))
 
 (methodical/defmethod perform-action!* :default
   [action context _inputs]

--- a/src/metabase/actions/core.clj
+++ b/src/metabase/actions/core.clj
@@ -29,6 +29,7 @@
   cached-table
   default-mapping
   perform-action!
+  perform-action-v2!
   ;; allow actions to be defined in the data-editing module
   perform-action!*
   perform-nested-action!]

--- a/src/metabase/actions/types.clj
+++ b/src/metabase/actions/types.clj
@@ -3,7 +3,7 @@
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]))
 
-;; Maybe we want to add an origin? e.g., CRUD API versus action execute API versus v2 API. YAGNI for now.
+;; This covers some cases that we aren't yet landing support for, but the code is fairly benign and unlikely to change.
 
 (mr/def ::missing-id
   [:int {:min -1, :max -1}])
@@ -14,7 +14,7 @@
   [[:map [:dashboard-id ms/PositiveInt]]
    [:map [:dashcard-id ms/PositiveInt]]
    [:map [:card-id ms/PositiveInt]]
-   ;; We represent model-actions, which get called against a model, distinctly. Treated the same as card-id, mostly.
+   ;; We represent model-actions distinctly. Treated the same as card-id, mostly.
    [:map [:model-id ms/PositiveInt]]
    [:map [:table-id ms/PositiveInt]]
    [:map [:webhook-id ms/PositiveInt]]

--- a/src/metabase/actions/types.clj
+++ b/src/metabase/actions/types.clj
@@ -14,11 +14,11 @@
   [[:map [:dashboard-id ms/PositiveInt]]
    [:map [:dashcard-id ms/PositiveInt]]
    [:map [:card-id ms/PositiveInt]]
-   ;; We represent legacy-actions, which get called against a model, distinctly. Treated the same as card-id, mostly.
+   ;; We represent model-actions, which get called against a model, distinctly. Treated the same as card-id, mostly.
    [:map [:model-id ms/PositiveInt]]
    [:map [:table-id ms/PositiveInt]]
    [:map [:webhook-id ms/PositiveInt]]
-   [:map [:unknown [:enum :legacy-action]]]])
+   [:map [:unknown [:enum :model-action]]]])
 
 ;; Relaxed, as we support it being
 (mr/def ::scope.raw

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -170,11 +170,11 @@
            pool-size
            max-batch-messages
            max-next-ms]
-    :or   {success-handler (constantly nil)
-           err-handler (constantly nil)
-           pool-size       1
+    :or   {success-handler    (constantly nil)
+           err-handler        (constantly nil)
+           pool-size          1
            max-batch-messages 50
-           max-next-ms     100}} :- ::listener-options]
+           max-next-ms        100}} :- ::listener-options]
   (if (listener-exists? listener-name)
     (log/errorf "Listener %s already exists" listener-name)
 

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -21,7 +21,7 @@
 
 (use-fixtures :each (fn [thunk] (mt/with-test-user :rasta (thunk))))
 
-(def ^:private test-scope {:unknown :legacy-action})
+(def ^:private test-scope {:unknown :model-action})
 
 (defmacro with-actions-test-data-and-actions-permissively-enabled!
   "Combines [[mt/with-actions-test-data-and-actions-enabled]] with full permissions."

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -244,6 +244,7 @@
   user->id
   user-descriptor
   user-http-request
+  user-http-request-full-response
   user-real-request
   with-group
   with-group-for-user

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -223,6 +223,11 @@
   (partial user-request client/client))
 
 (def ^{:arglists '([test-user-name-or-user-or-id method expected-status-code? endpoint
+                    request-options? http-body-map? & {:as query-params}])} user-http-request-full-response
+  "Like user-http-request but uses the full-response client so will return the http response instead of the body"
+  (partial user-request client/client-full-response))
+
+(def ^{:arglists '([test-user-name-or-user-or-id method expected-status-code? endpoint
                     request-options? http-body-map? & {:as query-params}])} user-real-request
   "Like [[user-http-request]] but instead of calling the app handler, this makes an actual http request."
   (partial user-request client/real-client))


### PR DESCRIPTION
Closes WRK-599

We need the ability to execute "implicit" actions directly for this project.

This introduces a new set of `/ee/action-v2` routes to support this.