### PR TITLE
fix: make test not parallel to avoid flake

### DIFF
--- a/test/metabase/warehouses/api_test.clj
+++ b/test/metabase/warehouses/api_test.clj
@@ -1604,7 +1604,7 @@
 ;;; |                      GET /api/database/:id/schemas & GET /api/database/:id/schema/:schema                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest ^:parallel get-schemas-test
+(deftest get-schemas-test
   (testing "GET /api/database/:id/schemas"
     (testing "Multiple schemas are ordered by name"
       (mt/with-temp


### PR DESCRIPTION
### Description

Resolve a flake caused by running this test in parallel on mariadb. The root issue is that trying to wrap the cluster-locked operations in a savepoint-based approximation of a nested transaction fails with the specific way the mariadb jdbc driver handles the setTimeout option on the prepare statement. It works differently in mysql and postgresql has nested transactions so it does not fail there. 
