### PR TITLE
Parameterization refactor

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -16,12 +16,15 @@
    (some? semantic.db/db-url)
    (semantic.settings/semantic-search-enabled)))
 
+(defn- get-active-index []
+  (semantic.index/default-index (semantic.embedding/get-active-model)))
+
 (defenterprise results
   "Enterprise implementation of semantic search results."
   :feature :semantic-search
   [search-ctx]
   (when-not @semantic.db/data-source (semantic.db/init-db!))
-  (semantic.index/query-index @semantic.db/data-source (semantic.embedding/get-active-model) search-ctx))
+  (semantic.index/query-index @semantic.db/data-source (get-active-index) search-ctx))
 
 (defenterprise update-index!
   "Enterprise implementation of semantic index updating."
@@ -30,25 +33,25 @@
   (when-not @semantic.db/data-source (semantic.db/init-db!))
   (let [documents (vec document-reducible)]
     (when (seq documents)
-      (semantic.index/upsert-index! @semantic.db/data-source (semantic.embedding/get-active-model) documents))))
+      (semantic.index/upsert-index! @semantic.db/data-source (get-active-index) documents))))
 
 (defenterprise delete-from-index!
   "Enterprise implementation of semantic index deletion."
   :feature :semantic-search
   [model ids]
   (when-not @semantic.db/data-source (semantic.db/init-db!))
-  (semantic.index/delete-from-index! @semantic.db/data-source (semantic.embedding/get-active-model) model ids))
+  (semantic.index/delete-from-index! @semantic.db/data-source (get-active-index) model ids))
 
 ;; TODO: add reindexing/table-swapping logic when index is detected as stale
 (defenterprise init!
   "Initialize the semantic search table and populate it with initial data."
   :feature :semantic-search
   [searchable-documents _opts]
-  (let [db (semantic.db/init-db!)
-        embedding-model (semantic.embedding/get-active-model)]
+  (let [db           (semantic.db/init-db!)
+        active-index (get-active-index)]
     (jdbc/with-transaction [tx db]
-      (semantic.index/create-index-table! tx embedding-model {:force-reset? false}))
-    (semantic.index/upsert-index! db embedding-model (into [] searchable-documents))))
+      (semantic.index/create-index-table! tx active-index {:force-reset? false}))
+    (semantic.index/upsert-index! db active-index (into [] searchable-documents))))
 
 (defenterprise reindex!
   "Reindex the semantic search index."
@@ -56,10 +59,10 @@
   [searchable-documents _opts]
   (when-not @semantic.db/data-source (semantic.db/init-db!))
   (let [db @semantic.db/data-source
-        embedding-model (semantic.embedding/get-active-model)]
+        active-index (get-active-index)]
     (jdbc/with-transaction [tx db]
-      (semantic.index/create-index-table! tx embedding-model {:force-reset? false}))
-    (semantic.index/upsert-index! db embedding-model (into [] searchable-documents))))
+      (semantic.index/create-index-table! tx active-index {:force-reset? false}))
+    (semantic.index/upsert-index! db active-index (into [] searchable-documents))))
 
 ;; TODO: implement
 (defenterprise reset-tracking!

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -44,20 +44,22 @@
   "Initialize the semantic search table and populate it with initial data."
   :feature :semantic-search
   [searchable-documents _opts]
-  (let [embedding-model (semantic.embedding/get-active-model)]
-    (jdbc/with-transaction [tx (semantic.db/init-db!)]
+  (let [db (semantic.db/init-db!)
+        embedding-model (semantic.embedding/get-active-model)]
+    (jdbc/with-transaction [tx db]
       (semantic.index/create-index-table! tx embedding-model {:force-reset? false}))
-    (semantic.index/upsert-index! tx embedding-model (into [] searchable-documents))))
+    (semantic.index/upsert-index! db embedding-model (into [] searchable-documents))))
 
 (defenterprise reindex!
   "Reindex the semantic search index."
   :feature :semantic-search
   [searchable-documents _opts]
   (when-not @semantic.db/data-source (semantic.db/init-db!))
-  (let [embedding-model (semantic.embedding/get-active-model)]
-    (jdbc/with-transaction [tx (semantic.db/init-db!)]
+  (let [db @semantic.db/data-source
+        embedding-model (semantic.embedding/get-active-model)]
+    (jdbc/with-transaction [tx db]
       (semantic.index/create-index-table! tx embedding-model {:force-reset? false}))
-    (semantic.index/upsert-index! tx embedding-model (into [] searchable-documents))))
+    (semantic.index/upsert-index! db embedding-model (into [] searchable-documents))))
 
 ;; TODO: implement
 (defenterprise reset-tracking!

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -2,6 +2,7 @@
   "Enterprise implementations of semantic search core functions using defenterprise."
   (:require
    [metabase-enterprise.semantic-search.db :as semantic.db]
+   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase.premium-features.core :refer [defenterprise]]))
@@ -19,7 +20,7 @@
   :feature :semantic-search
   [search-ctx]
   (when-not @semantic.db/data-source (semantic.db/init-db!))
-  (semantic.index/query-index search-ctx))
+  (semantic.index/query-index @semantic.db/data-source (semantic.embedding/get-active-model) search-ctx))
 
 (defenterprise update-index!
   "Enterprise implementation of semantic index updating."
@@ -28,31 +29,32 @@
   (when-not @semantic.db/data-source (semantic.db/init-db!))
   (let [documents (vec document-reducible)]
     (when (seq documents)
-      (semantic.index/upsert-index! documents))))
+      (semantic.index/upsert-index! @semantic.db/data-source (semantic.embedding/get-active-model) documents))))
 
 (defenterprise delete-from-index!
   "Enterprise implementation of semantic index deletion."
   :feature :semantic-search
   [model ids]
   (when-not @semantic.db/data-source (semantic.db/init-db!))
-  (semantic.index/delete-from-index! model ids))
+  (semantic.index/delete-from-index! @semantic.db/data-source (semantic.embedding/get-active-model) model ids))
 
 ;; TODO: add reindexing/table-swapping logic when index is detected as stale
 (defenterprise init!
   "Initialize the semantic search table and populate it with initial data."
   :feature :semantic-search
   [searchable-documents _opts]
-  (semantic.db/init-db!)
-  (semantic.index/create-index-table! {:force-reset? false})
-  (semantic.index/upsert-index! (into [] searchable-documents)))
+  (doto (semantic.db/init-db!)
+    (semantic.index/create-index-table! (semantic.embedding/get-active-model) {:force-reset? false})
+    (semantic.index/populate-index! (semantic.embedding/get-active-model) (into [] searchable-documents))))
 
 (defenterprise reindex!
   "Reindex the semantic search index."
   :feature :semantic-search
   [searchable-documents _opts]
   (when-not @semantic.db/data-source (semantic.db/init-db!))
-  (semantic.index/create-index-table! {:force-reset? false})
-  (semantic.index/upsert-index! (into [] searchable-documents)))
+  (doto @semantic.db/data-source
+    (semantic.index/create-index-table! (semantic.embedding/get-active-model) {:force-reset? false})
+    (semantic.index/populate-index! (semantic.embedding/get-active-model) (into [] searchable-documents))))
 
 ;; TODO: implement
 (defenterprise reset-tracking!

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -215,8 +215,9 @@
                     (process-fn batch-texts embeddings)))
                 batches))
         ;; For other providers, process all at once (existing behavior)
-        (let [embeddings (get-embeddings-batch provider texts)]
+        (let [embeddings (get-embeddings-batch embedding-model texts)]
           (process-fn texts embeddings))))))
+
 (comment
   ;; Configuration:
   ;; MB_EE_EMBEDDING_PROVIDER:  "openai" or "ollama" (default)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -1,11 +1,9 @@
 (ns metabase-enterprise.semantic-search.embedding
   (:require
    [clj-http.client :as http]
-   [clojure.string :as str]
    [metabase-enterprise.semantic-search.settings :as semantic-settings]
    [metabase.util.json :as json]
-   [metabase.util.log :as log]
-   [potemkin.types :as p])
+   [metabase.util.log :as log])
   (:import
    [com.knuddels.jtokkit Encodings]
    [com.knuddels.jtokkit.api Encoding EncodingType]))
@@ -182,12 +180,13 @@
   "The model being used by the current semantic search engine."
   nil)
 
-(defn get-active-model []
+(defn get-active-model
   "Returns *active-model* if defined.
 
   Otherwise get the environments default embedding model according to the ee-embedding-provider / ee-embedding-model settings.
 
   Requires the model dimensions are defined in ollama-supported-models or openai-supported-models (throws if not)."
+  []
   (or *active-model*
       (let [provider (semantic-settings/ee-embedding-provider)
             models (case provider

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -193,10 +193,10 @@
             models (case provider
                      "ollama" ollama-supported-models
                      "openai" openai-supported-models
-                     (throw (ex-info "Not a supported provider" {:provider provider})))
+                     (throw (ex-info (format "Unknown embedding provider: %s" provider) {:provider provider})))
             model-name (or (semantic-settings/ee-embedding-model) (default-model-for-provider provider))
             vector-dimensions (or (get models model-name)
-                                  (throw (ex-info "Not a supported model" {:provider provider, :model-name model-name})))]
+                                  (throw (ex-info (format "Not a supported model: %s" model-name) {:provider provider, :model-name model-name})))]
         {:provider provider
          :model-name model-name
          :vector-dimensions vector-dimensions})))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -185,7 +185,7 @@
 
   Otherwise get the environments default embedding model according to the ee-embedding-provider / ee-embedding-model settings.
 
-  Requires the model dimensions are defined in ollama-supported-models or openai-supported-models (throws if not)."
+  Requires the model dimensions to be defined in ollama-supported-models or openai-supported-models (throws if not)."
   []
   (or *active-model*
       (let [provider (semantic-settings/ee-embedding-provider)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -176,7 +176,7 @@
 
 ;;;; Global embedding model
 
-(def ^:dynamic ^:redef *active-model*
+(def ^:dynamic *active-model*
   "The model being used by the current semantic search engine."
   nil)
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -108,7 +108,7 @@
                              +
                              ids)
                   (array-map model))
-      (log/trace "semantic search deleted" <> "total documents with model type" model))))
+      (log/trace "semantic search deleted" (get <> model) "total documents with model type" model))))
 
 (defn- db-records->update-set
   [db-records]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -19,8 +19,8 @@
 (set! *warn-on-reflection* true)
 
 (comment
-  ((requiring-resolve `metabase-enterprise.semantic-search.db/init-db!))
-  (def db @@(requiring-resolve `metabase-enterprise.semantic-search.db/data-source)))
+  ((requiring-resolve 'metabase-enterprise.semantic-search.db/init-db!))
+  (def db @@(requiring-resolve 'metabase-enterprise.semantic-search.db/data-source)))
 
 (defn sql-format-quoted
   "Call [[sql/format]] with {:quoted true}.
@@ -30,7 +30,10 @@
   [honey-sql & {:as opts}]
   (sql/format honey-sql (merge opts {:quoted true})))
 
-(defn index-table-name [embedding-model]
+(defn index-table-name
+  "Returns the (string) name for a given embedding model. Requires quoting in SQL.
+  e.g. index_table__openai__text-embedding-3-small__1536"
+  [embedding-model]
   (let [{:keys [model-name provider vector-dimensions]} embedding-model]
     (str "index_table__" provider "__" model-name "__" vector-dimensions)))
 
@@ -154,6 +157,7 @@
       sql-format-quoted))
 
 (defn drop-index-table!
+  "Drops the index table for the given embedding model if it exists."
   [connectable embedding-model]
   (jdbc/execute! connectable (drop-index-table-sql embedding-model)))
 
@@ -308,4 +312,4 @@
   #_:clj-kondo/ignore
   (require '[metabase.test :as mt])
   (mt/with-test-user :crowberto
-    (doall (query-index {:search-string "Copper knife"}))))
+    (doall (query-index db embedding-model {:search-string "Copper knife"}))))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -297,13 +297,13 @@
 (comment
   (def embedding-model (embedding/get-active-model))
   (create-index-table! embedding-model {:force-reset? true})
-  (upsert-index! [{:model "card"
-                   :id "1"
-                   :searchable_text "This is a test card"}])
-  (delete-from-index! "card" ["1"])
-  (delete-from-index! "dashboard" ["13"])
+  (upsert-index! db embedding-model [{:model "card"
+                                      :id "1"
+                                      :searchable_text "This is a test card"}])
+  (delete-from-index! db embedding-model "card" ["1"])
+  (delete-from-index! db embedding-model "dashboard" ["13"])
   ;; no user
-  (query-index {:search-string "Copper knife"})
+  (query-index db embedding-model {:search-string "Copper knife"})
 
   #_:clj-kondo/ignore
   (require '[metabase.test :as mt])

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -140,7 +140,7 @@
            (batch-update!
             connectable
             (fn [db-records]
-              (-> (sql.helpers/insert-into *index-table-name*)
+              (-> (sql.helpers/insert-into (keyword (index-table-name embedding-model)))
                   (sql.helpers/values db-records)
                   (sql.helpers/on-conflict :model :model_id)
                   (sql.helpers/do-update-set (db-records->update-set db-records))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -114,22 +114,6 @@
                   (array-map model))
       (log/trace "semantic search deleted" <> "total documents with model type" model))))
 
-(defn populate-index!
-  "Inserts a set of documents into the index table. Throws when trying to insert
-  existing model + model_id pairs. (Use upsert-index! to update existing documents)"
-  [db embedding-model documents]
-  (when (seq documents)
-    (let [texts (mapv :searchable_text documents)
-          embeddings (embedding/get-embeddings-batch embedding-model texts)]
-      (batch-update!
-       db
-       (fn [db-records]
-         (-> (sql.helpers/insert-into (keyword (index-table-name embedding-model)))
-             (sql.helpers/values db-records)
-             (sql/format :quoted true)))
-       documents
-       embeddings))))
-
 (defn- db-records->update-set
   [db-records]
   (let [update-keys (-> db-records first (dissoc :id :model :model_id) keys)
@@ -145,24 +129,24 @@
     (let [filtered-documents (remove #(= (:model %) "indexed-entity") documents)
           searchable-texts   (map :searchable_text filtered-documents)]
       (embedding/process-embeddings-streaming
-        embedding-model
-        searchable-texts
-        (fn [_batch-texts batch-embeddings]
-          (let [batch-documents
-                (mapv (fn [doc embedding]
-                        (assoc doc :embedding embedding))
-                      filtered-documents
-                      batch-embeddings)]
-            (batch-update!
-              connectable
-              (fn [db-records]
-                (-> (sql.helpers/insert-into *index-table-name*)
-                    (sql.helpers/values db-records)
-                    (sql.helpers/on-conflict :model :model_id)
-                    (sql.helpers/do-update-set (db-records->update-set db-records))
-                    sql-format-quoted))
-              batch-documents
-              batch-embeddings)))))))
+       embedding-model
+       searchable-texts
+       (fn [_batch-texts batch-embeddings]
+         (let [batch-documents
+               (mapv (fn [doc embedding]
+                       (assoc doc :embedding embedding))
+                     filtered-documents
+                     batch-embeddings)]
+           (batch-update!
+            connectable
+            (fn [db-records]
+              (-> (sql.helpers/insert-into *index-table-name*)
+                  (sql.helpers/values db-records)
+                  (sql.helpers/on-conflict :model :model_id)
+                  (sql.helpers/do-update-set (db-records->update-set db-records))
+                  sql-format-quoted))
+            batch-documents
+            batch-embeddings)))))))
 
 (defn- drop-index-table-sql
   [embedding-model]
@@ -189,11 +173,11 @@
            (sql.helpers/with-columns (index-table-schema vector-dimensions))
            sql-format-quoted))
       (jdbc/execute!
-        connectable
-        (-> (sql.helpers/create-index
-              [:embedding_hnsw_idx :if-not-exists]
-              [(keyword table-name) :using-hnsw [:raw "embedding vector_cosine_ops"]])
-            sql-format-quoted)))
+       connectable
+       (-> (sql.helpers/create-index
+            [:embedding_hnsw_idx :if-not-exists]
+            [(keyword table-name) :using-hnsw [:raw "embedding vector_cosine_ops"]])
+           sql-format-quoted)))
     (catch Exception e
       (throw (ex-info "Failed to create index table" {:cause e})))))
 
@@ -313,9 +297,6 @@
 (comment
   (def embedding-model (embedding/get-active-model))
   (create-index-table! embedding-model {:force-reset? true})
-  (populate-index! [{:model "card"
-                     :id "1"
-                     :searchable_text "This is a test card"}])
   (upsert-index! [{:model "card"
                    :id "1"
                    :searchable_text "This is a test card"}])

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -9,8 +9,8 @@
   (deferred-tru "The embedding provider to use (:openai or :ollama)")
   :encryption :no
   :visibility :settings-manager
-  :default :ollama
-  :type :keyword
+  :default "ollama"
+  :type :string
   :export? false
   :doc "This feature is experimental.")
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -10,18 +10,18 @@
   (testing "get-provider returns correct provider based on setting"
     (mt/with-temporary-setting-values [ee-embedding-provider "ollama"]
       (is (instance? metabase_enterprise.semantic_search.embedding.OllamaProvider
-                     (embedding/get-provider))))
+                     (embedding/get-provider-impl))))
 
     (mt/with-temporary-setting-values [ee-embedding-provider "openai"]
       (is (instance? metabase_enterprise.semantic_search.embedding.OpenAIProvider
-                     (embedding/get-provider)))))
+                     (embedding/get-provider-impl)))))
 
   (testing "get-provider throws on unknown provider"
     (mt/with-temporary-setting-values [ee-embedding-provider "unknown"]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"Unknown embedding provider: :unknown"
-           (embedding/get-provider))))))
+           (embedding/get-provider-impl))))))
 
 (deftest test-model-dimensions-with-settings
   (testing "model-dimensions uses provider defaults when override is nil"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -7,96 +7,84 @@
 (set! *warn-on-reflection* true)
 
 (deftest test-get-provider
-  (testing "get-provider returns correct provider based on setting"
-    (mt/with-temporary-setting-values [ee-embedding-provider "ollama"]
-      (is (instance? metabase_enterprise.semantic_search.embedding.OllamaProvider
-                     (embedding/get-provider-impl))))
+  (binding [embedding/*active-model* nil]
+    (testing "get-active-model returns based on setting"
+      (mt/with-temporary-setting-values [ee-embedding-provider "ollama"]
+        (is (= {:provider "ollama"
+                :model-name "mxbai-embed-large"
+                :vector-dimensions 1024}
+               (embedding/get-active-model))))
 
-    (mt/with-temporary-setting-values [ee-embedding-provider "openai"]
-      (is (instance? metabase_enterprise.semantic_search.embedding.OpenAIProvider
-                     (embedding/get-provider-impl)))))
+      (mt/with-temporary-setting-values [ee-embedding-provider "openai"]
+        (is (= {:provider "openai"
+                :model-name "text-embedding-3-small"
+                :vector-dimensions 1536}
+               (embedding/get-active-model)))))
 
-  (testing "get-provider throws on unknown provider"
-    (mt/with-temporary-setting-values [ee-embedding-provider "unknown"]
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"Unknown embedding provider: :unknown"
-           (embedding/get-provider-impl))))))
+    (testing "get-provider throws on unknown provider"
+      (mt/with-temporary-setting-values [ee-embedding-provider "unknown"]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Unknown embedding provider: unknown"
+             (embedding/get-active-model)))))))
 
 (deftest test-model-dimensions-with-settings
   (testing "model-dimensions uses provider defaults when override is nil"
     (mt/with-temporary-setting-values [ee-embedding-provider "ollama"
                                        ee-embedding-model nil]
-      (is (= 1024 (embedding/model-dimensions))))
+      (is (= 1024 (:vector-dimensions (embedding/get-active-model)))))
 
     (mt/with-temporary-setting-values [ee-embedding-provider "openai"
                                        ee-embedding-model nil]
-      (is (= 1536 (embedding/model-dimensions)))))
+      (is (= 1536 (:vector-dimensions (embedding/get-active-model))))))
 
   (testing "model-dimensions uses override when specified"
     (mt/with-temporary-setting-values [ee-embedding-provider "ollama"
                                        ee-embedding-model "nomic-embed-text"]
-      (is (= 768 (embedding/model-dimensions))))
+      (is (= 768 (:vector-dimensions (embedding/get-active-model)))))
 
     (mt/with-temporary-setting-values [ee-embedding-provider "openai"
                                        ee-embedding-model "text-embedding-3-large"]
-      (is (= 3072 (embedding/model-dimensions)))))
-
-  (testing "model-dimensions with explicit model parameter"
-    (mt/with-temporary-setting-values [ee-embedding-provider "ollama"]
-      (is (= 1024 (embedding/model-dimensions "mxbai-embed-large")))
-      (is (= 768 (embedding/model-dimensions "nomic-embed-text"))))
-
-    (mt/with-temporary-setting-values [ee-embedding-provider "openai"]
-      (is (= 1536 (embedding/model-dimensions "text-embedding-3-small")))
-      (is (= 3072 (embedding/model-dimensions "text-embedding-3-large"))))))
-
-(deftest test-model-dimensions-unsupported-models
-  (testing "model-dimensions returns nil for unsupported models"
-    (mt/with-temporary-setting-values [ee-embedding-provider "ollama"
-                                       ee-embedding-model "unsupported-model"]
-      (is (nil? (embedding/model-dimensions))))
-
-    (mt/with-temporary-setting-values [ee-embedding-provider "openai"
-                                       ee-embedding-model "unsupported-model"]
-      (is (nil? (embedding/model-dimensions))))))
+      (is (= 3072 (:vector-dimensions (embedding/get-active-model)))))))
 
 (deftest test-default-models
   (testing "Provider defaults are used when no override is set"
-    (is (= "text-embedding-3-small" (#'embedding/default-model-for-provider :openai)))
-    (is (= "mxbai-embed-large" (#'embedding/default-model-for-provider :ollama)))
-    (is (nil? (#'embedding/default-model-for-provider :unknown))))
+    (is (= "text-embedding-3-small" (#'embedding/default-model-for-provider "openai")))
+    (is (= "mxbai-embed-large" (#'embedding/default-model-for-provider "ollama")))
+    (is (nil? (#'embedding/default-model-for-provider "unknown"))))
 
   (testing "get-model uses defaults when override is nil or empty"
     (mt/with-temporary-setting-values [ee-embedding-provider "openai"
                                        ee-embedding-model nil]
-      (is (= "text-embedding-3-small" (#'embedding/get-model))))
+      (is (= "text-embedding-3-small" (:model-name (embedding/get-active-model)))))
 
     (mt/with-temporary-setting-values [ee-embedding-provider "openai"
                                        ee-embedding-model ""]
-      (is (= "text-embedding-3-small" (#'embedding/get-model))))
+      (is (= "text-embedding-3-small" (:model-name (embedding/get-active-model)))))
 
     (mt/with-temporary-setting-values [ee-embedding-provider "ollama"
                                        ee-embedding-model nil]
-      (is (= "mxbai-embed-large" (#'embedding/get-model)))))
+      (is (= "mxbai-embed-large" (:model-name (embedding/get-active-model))))))
 
   (testing "get-model uses override when specified"
     (mt/with-temporary-setting-values [ee-embedding-provider "openai"
                                        ee-embedding-model "text-embedding-3-large"]
-      (is (= "text-embedding-3-large" (#'embedding/get-model))))))
+      (is (= "text-embedding-3-large" (:model-name (embedding/get-active-model)))))))
 
 (deftest test-openai-provider-validation
   (testing "OpenAIProvider throws when API key not configured"
-    (let [provider (embedding/->OpenAIProvider)]
+    (let [embedding-model {:provider "openai"
+                           :model-name "text-embedding-3-small"
+                           :vector-dimensions 1536}]
       (mt/with-temporary-setting-values [ee-openai-api-key nil]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"OpenAI API key not configured"
-             (embedding/-get-embedding provider "test text")))
+             (embedding/get-embedding embedding-model "test text")))
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"OpenAI API key not configured"
-             (embedding/-get-embeddings-batch provider ["test text"])))))))
+             (embedding/get-embeddings-batch embedding-model ["test text"])))))))
 
 (deftest test-token-counting
   (testing "count-tokens returns reasonable counts for text"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -16,11 +16,11 @@
       (semantic.index/drop-index-table! semantic.tu/db semantic.tu/mock-index)
       (testing "index table is not present before create!"
         (is (not (semantic.tu/table-exists-in-db? (:table-name @index-ref))))
-        (is (not (semantic.tu/table-has-index? (:table-name @index-ref) :embedding_hnsw_idx))))
+        (is (not (semantic.tu/table-has-index? (:table-name @index-ref) (:index-name @index-ref)))))
       (testing "index table is present after create!"
         (semantic.index/create-index-table! semantic.tu/db semantic.tu/mock-index {:force-reset? false})
         (is (semantic.tu/table-exists-in-db? (:table-name @index-ref)))
-        (is (semantic.tu/table-has-index? (:table-name @index-ref) :embedding_hnsw_idx))))))
+        (is (semantic.tu/table-has-index? (:table-name @index-ref) (:index-name @index-ref)))))))
 
 (deftest drop-index-table!-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -3,10 +3,7 @@
    [clojure.test :refer :all]
    [honey.sql.helpers :as sql.helpers]
    [metabase-enterprise.semantic-search.index :as semantic.index]
-   [metabase-enterprise.semantic-search.test-util :as semantic.tu :refer [query-index
-                                                                          populate-index!
-                                                                          upsert-index!
-                                                                          delete-from-index!]]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.test :as mt]
    [next.jdbc :as jdbc]))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -75,7 +75,7 @@
 (defn- check-index-has-no-mock-docs []
   (let [table-name               (semantic.index/index-table-name semantic.tu/mock-embedding-model)
         table-exists-sql         "select exists(select * from information_schema.tables where table_name = ?) table_exists"
-        [{:keys [table_exists] :as r}] (jdbc/execute! semantic.tu/db [table-exists-sql table-name])]
+        [{:keys [table_exists]}] (jdbc/execute! semantic.tu/db [table-exists-sql table-name])]
     (when table_exists
       (check-index-has-no-mock-card)
       (check-index-has-no-mock-dashboard))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -2,9 +2,11 @@
   (:require
    [clojure.test :refer :all]
    [honey.sql.helpers :as sql.helpers]
-   [metabase-enterprise.semantic-search.db :as semantic.db]
    [metabase-enterprise.semantic-search.index :as semantic.index]
-   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu :refer [query-index
+                                                                          populate-index!
+                                                                          upsert-index!
+                                                                          delete-from-index!]]
    [metabase.test :as mt]
    [next.jdbc :as jdbc]))
 
@@ -12,28 +14,25 @@
 
 (deftest create-index-table!-test
   (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-mocked-embeddings!
-      (semantic.tu/with-temp-index-table!
-        ;; with-temp-index-table! creates the temp table, so drop it in order to test create!.
-        (semantic.index/drop-index-table!)
-        (testing "index table is not present before create!"
-          (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))
-          (is (not (semantic.tu/table-has-index? semantic.index/*index-table-name* :embedding_hnsw_idx))))
-        (testing "index table is present after create!"
-          (semantic.index/create-index-table! {:force-reset? false})
-          (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))
-          (is (semantic.tu/table-has-index? semantic.index/*index-table-name* :embedding_hnsw_idx)))))))
+    (with-open [table-name-ref (semantic.tu/open-temp-index-table!)]
+      ;; open-temp-index-table! creates the temp table, so drop it in order to test create!.
+      (semantic.index/drop-index-table! semantic.tu/db semantic.tu/mock-embedding-model)
+      (testing "index table is not present before create!"
+        (is (not (semantic.tu/table-exists-in-db? @table-name-ref)))
+        (is (not (semantic.tu/table-has-index? @table-name-ref :embedding_hnsw_idx))))
+      (testing "index table is present after create!"
+        (semantic.index/create-index-table! semantic.tu/db semantic.tu/mock-embedding-model {:force-reset? false})
+        (is (semantic.tu/table-exists-in-db? @table-name-ref))
+        (is (semantic.tu/table-has-index? @table-name-ref :embedding_hnsw_idx))))))
 
 (deftest drop-index-table!-test
   (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-mocked-embeddings!
-      (semantic.tu/with-temp-index-table!
-        ;; with-temp-index-table! creates the temp table
-        (testing "index table is present before drop!"
-          (is (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*)))
-        (testing "index table is not present after drop!"
-          (semantic.index/drop-index-table!)
-          (is (not (semantic.tu/table-exists-in-db? semantic.index/*index-table-name*))))))))
+    (with-open [table-name-ref (semantic.tu/open-temp-index-table!)]
+      (testing "index table is present before drop!"
+        (is (semantic.tu/table-exists-in-db? @table-name-ref)))
+      (testing "index table is not present after drop!"
+        (semantic.index/drop-index-table! semantic.tu/db semantic.tu/mock-embedding-model)
+        (is (not (semantic.tu/table-exists-in-db? @table-name-ref)))))))
 
 (defn- decode-embedding
   "Decode `row`s `:embedding`."
@@ -45,40 +44,44 @@
   "Query the full index table and return all documents with decoded embeddings.
   Not used in tests, but useful for debugging."
   []
-  (->> (jdbc/execute! @semantic.db/data-source
+  (->> (jdbc/execute! semantic.tu/db
                       (-> (sql.helpers/select :model :model_id :content :creator_id :embedding)
-                          (sql.helpers/from semantic.index/*index-table-name*)
+                          (sql.helpers/from (keyword (semantic.index/index-table-name semantic.tu/mock-embedding-model)))
                           semantic.index/sql-format-quoted))
        (map #'semantic.index/unqualify-keys)
        (map decode-embedding)))
 
-(defn- query-index
+(defn- query-embeddings
   [{:keys [model model_id]}]
-  (->> (jdbc/execute! @semantic.db/data-source
+  (->> (jdbc/execute! semantic.tu/db
                       (-> (sql.helpers/select :model :model_id :content :creator_id :embedding)
-                          (sql.helpers/from semantic.index/*index-table-name*)
+                          (sql.helpers/from (keyword (semantic.index/index-table-name semantic.tu/mock-embedding-model)))
                           (sql.helpers/where :and
                                              [:= :model model]
                                              [:= :model_id model_id])
                           semantic.index/sql-format-quoted))
        (map #'semantic.index/unqualify-keys)
-       (map decode-embedding)))
+       (mapv decode-embedding)))
 
 (defn- check-index-has-no-mock-card []
   (testing "no mock card present"
     (is (= []
-           (query-index {:model "card"
-                         :model_id "123"})))))
+           (query-embeddings {:model "card"
+                              :model_id "123"})))))
 
 (defn- check-index-has-no-mock-dashboard []
   (testing "no mock dashboard present"
     (is (= []
-           (query-index {:model "dashboard"
-                         :model_id "456"})))))
+           (query-embeddings {:model "dashboard"
+                              :model_id "456"})))))
 
 (defn- check-index-has-no-mock-docs []
-  (check-index-has-no-mock-card)
-  (check-index-has-no-mock-dashboard))
+  (let [table-name               (semantic.index/index-table-name semantic.tu/mock-embedding-model)
+        table-exists-sql         "select exists(select * from information_schema.tables where table_name = ?) table_exists"
+        [{:keys [table_exists] :as r}] (jdbc/execute! semantic.tu/db [table-exists-sql table-name])]
+    (when table_exists
+      (check-index-has-no-mock-card)
+      (check-index-has-no-mock-dashboard))))
 
 (defn- check-index-has-mock-card []
   (is (= [{:model "card"
@@ -86,8 +89,8 @@
            :creator_id 1
            :content "Dog Training Guide"
            :embedding (semantic.tu/get-mock-embedding "Dog Training Guide")}]
-         (query-index {:model "card"
-                       :model_id "123"}))))
+         (query-embeddings {:model "card"
+                            :model_id "123"}))))
 
 (defn- check-index-has-mock-dashboard []
   (is (= [{:model "dashboard"
@@ -95,8 +98,8 @@
            :creator_id 2
            :content "Elephant Migration"
            :embedding (semantic.tu/get-mock-embedding "Elephant Migration")}]
-         (query-index {:model "dashboard"
-                       :model_id "456"}))))
+         (query-embeddings {:model "dashboard"
+                            :model_id "456"}))))
 
 (defn- check-index-has-mock-docs []
   (check-index-has-mock-card)
@@ -104,71 +107,68 @@
 
 (deftest upsert-index!-test
   (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-mocked-embeddings!
-      (semantic.tu/with-temp-index-table!
-        (check-index-has-no-mock-docs)
-        (testing "upsert-index! returns nil if you pass it an empty collection"
-          (is (nil? (semantic.index/upsert-index! [])))
-          (check-index-has-no-mock-docs))
-        (testing "upsert-index! works on a fresh index"
-          (is (= {"card" 1, "dashboard" 1}
-                 (semantic.index/upsert-index! semantic.tu/mock-documents)))
-          (check-index-has-mock-docs))
-        (testing "upsert-index! works with duplicate documents"
-          (is (= {"card" 1, "dashboard" 1}
-                 (semantic.index/upsert-index! semantic.tu/mock-documents)))
-          (check-index-has-mock-docs))))))
+    (with-open [_ (semantic.tu/open-temp-index-table!)]
+      (check-index-has-no-mock-docs)
+      (testing "upsert-index! returns nil if you pass it an empty collection"
+        (is (nil? (semantic.tu/upsert-index! [])))
+        (check-index-has-no-mock-docs))
+      (testing "upsert-index! works on a fresh index"
+        (is (= {"card" 1, "dashboard" 1}
+               (semantic.tu/upsert-index! semantic.tu/mock-documents)))
+        (check-index-has-mock-docs))
+      (testing "upsert-index! works with duplicate documents"
+        (is (= {"card" 1, "dashboard" 1}
+               (semantic.tu/upsert-index! semantic.tu/mock-documents)))
+        (check-index-has-mock-docs)))))
 
 (deftest delete-from-index!-test
   (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-mocked-embeddings!
-      (semantic.tu/with-temp-index-table!
-        (check-index-has-no-mock-docs)
-        (testing "upsert-index! before delete!"
-          (is (= {"card" 1, "dashboard" 1}
-                 (semantic.index/upsert-index! semantic.tu/mock-documents)))
-          (check-index-has-mock-docs))
-        (testing "delete-from-index! returns nil if you pass it an empty collection"
-          (is (nil? (semantic.index/delete-from-index! "card" [])))
-          (check-index-has-mock-docs))
-        (testing "delete-from-index! works for cards"
-          (is (= {"card" 1}
-                 (semantic.index/delete-from-index! "card" ["123"])))
-          (check-index-has-no-mock-card)
-          (check-index-has-mock-dashboard))
-        (testing "delete-from-index! works for dashboards"
-          (is (= {"dashboard" 1}
-                 (semantic.index/delete-from-index! "dashboard" ["456"])))
-          (check-index-has-no-mock-docs))
-        (testing "delete-from-index! doesn't complain if you delete a document that doesn't exist"
-          (is (= {"card" 1}
-                 (semantic.index/delete-from-index! "card" ["123"])))
-          (check-index-has-no-mock-docs))))))
+    (with-open [_ (semantic.tu/open-temp-index-table!)]
+      (check-index-has-no-mock-docs)
+      (testing "upsert-index! before delete!"
+        (is (= {"card" 1, "dashboard" 1}
+               (semantic.tu/upsert-index! semantic.tu/mock-documents)))
+        (check-index-has-mock-docs))
+      (testing "delete-from-index! returns nil if you pass it an empty collection"
+        (is (nil? (semantic.tu/delete-from-index! "card" [])))
+        (check-index-has-mock-docs))
+      (testing "delete-from-index! works for cards"
+        (is (= {"card" 1}
+               (semantic.tu/delete-from-index! "card" ["123"])))
+        (check-index-has-no-mock-card)
+        (check-index-has-mock-dashboard))
+      (testing "delete-from-index! works for dashboards"
+        (is (= {"dashboard" 1}
+               (semantic.tu/delete-from-index! "dashboard" ["456"])))
+        (check-index-has-no-mock-docs))
+      (testing "delete-from-index! doesn't complain if you delete a document that doesn't exist"
+        (is (= {"card" 1}
+               (semantic.tu/delete-from-index! "card" ["123"])))
+        (check-index-has-no-mock-docs)))))
 
 (deftest batch-process-mock-docs!-test
   (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-mocked-embeddings!
-      (semantic.tu/with-temp-index-table!
-        (binding [semantic.index/*batch-size* 1]
-          (let [extra-ids (->> (range 1337 1347) (map str))
-                extra-docs (map (fn [id doc]
-                                  (assoc doc :id id))
-                                extra-ids
-                                (flatten (repeat semantic.tu/mock-documents)))
-                mock-docs (into semantic.tu/mock-documents extra-docs)]
-            (testing "ensure populate! upsert! and delete! work when batch size is exceeded"
-              (check-index-has-no-mock-docs)
-              (testing "upsert-index! with batch processing"
-                (is (= {"card" 6, "dashboard" 6}
-                       (semantic.index/upsert-index! mock-docs)))
-                (check-index-has-mock-docs))
-              (testing "delete-from-index! with batch processing"
-                (testing "delete just the card"
-                  (is (= {"card" 11}
-                         (semantic.index/delete-from-index! "card" (into ["123"] extra-ids))))
-                  (check-index-has-no-mock-card)
-                  (check-index-has-mock-dashboard)))
-              (testing "delete the dashboard"
-                (is (= {"dashboard" 11}
-                       (semantic.index/delete-from-index! "dashboard" (into ["456"] extra-ids))))
-                (check-index-has-no-mock-docs)))))))))
+    (with-open [_ (semantic.tu/open-temp-index-table!)]
+      (binding [semantic.index/*batch-size* 1]
+        (let [extra-ids (->> (range 1337 1347) (map str))
+              extra-docs (map (fn [id doc]
+                                (assoc doc :id id))
+                              extra-ids
+                              (flatten (repeat semantic.tu/mock-documents)))
+              mock-docs (into semantic.tu/mock-documents extra-docs)]
+          (testing "ensure populate! upsert! and delete! work when batch size is exceeded"
+            (check-index-has-no-mock-docs)
+            (testing "upsert-index! with batch processing"
+              (is (= {"card" 6, "dashboard" 6}
+                     (semantic.tu/upsert-index! mock-docs)))
+              (check-index-has-mock-docs))
+            (testing "delete-from-index! with batch processing"
+              (testing "delete just the card"
+                (is (= {"card" 11}
+                       (semantic.tu/delete-from-index! "card" (into ["123"] extra-ids))))
+                (check-index-has-no-mock-card)
+                (check-index-has-mock-dashboard)))
+            (testing "delete the dashboard"
+              (is (= {"dashboard" 11}
+                     (semantic.tu/delete-from-index! "dashboard" (into ["456"] extra-ids))))
+              (check-index-has-no-mock-docs))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.semantic-search.db :as semantic.db]
    [metabase-enterprise.semantic-search.index :as semantic.index]
-   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu :refer [db mock-embedding-model]]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -16,182 +16,177 @@
   (is (some? @semantic.db/data-source))
   (is (= {:test 1} (semantic.db/test-connection!))))
 
+(defn- query-index [search-context]
+  (semantic.index/query-index db mock-embedding-model search-context))
+
 (deftest basic-query-test
   (testing "Simple queries with no filters"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-mocked-embeddings!
-          (semantic.tu/with-index!
-            (testing "Dog-related query finds dog content"
-              (let [results (semantic.index/query-index {:search-string "puppy"})]
-                (is (= "Dog Training Guide" (-> results first :name)))))
+        (semantic.tu/with-index!
+          (testing "Dog-related query finds dog content"
+            (let [results (query-index {:search-string "puppy"})]
+              (is (= "Dog Training Guide" (-> results first :name)))))
 
-            (testing "Bird-related query finds bird content"
-              (let [results (semantic.index/query-index {:search-string "avian"})]
-                (is (= "Bird Watching Tips" (-> results first :name)))))))))))
+          (testing "Bird-related query finds bird content"
+            (let [results (query-index {:search-string "avian"})]
+              (is (= "Bird Watching Tips" (-> results first :name))))))))))
 
 (deftest model-filtering-test
   (testing "Filter results by model type"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-mocked-embeddings!
-          (semantic.tu/with-index!
-            (testing "Filter for cards only"
-              (let [card-results (semantic.index/query-index {:search-string "avian" :models ["card"]})
-                    filtered-results (semantic.tu/filter-for-mock-embeddings card-results)]
-                (is (pos? (count filtered-results)))
-                (is (every? #(= "card" (:model %)) card-results))))
+        (semantic.tu/with-index!
+          (testing "Filter for cards only"
+            (let [card-results (query-index {:search-string "avian" :models ["card"]})
+                  filtered-results (semantic.tu/filter-for-mock-embeddings card-results)]
+              (is (pos? (count filtered-results)))
+              (is (every? #(= "card" (:model %)) card-results))))
 
-            (testing "Filter for dashboards only"
-              (let [dashboard-results (semantic.index/query-index {:search-string "marine mammal" :models ["dashboard"]})
-                    filtered-results (semantic.tu/filter-for-mock-embeddings dashboard-results)]
-                (is (pos? (count filtered-results)))
-                (is (every? #(= "dashboard" (:model %)) dashboard-results))))
+          (testing "Filter for dashboards only"
+            (let [dashboard-results (query-index {:search-string "marine mammal" :models ["dashboard"]})
+                  filtered-results (semantic.tu/filter-for-mock-embeddings dashboard-results)]
+              (is (pos? (count filtered-results)))
+              (is (every? #(= "dashboard" (:model %)) dashboard-results))))
 
-            (testing "Filter for multiple model types"
-              (let [mixed-results (semantic.index/query-index {:search-string "predator" :models ["card" "dashboard"]})
-                    filtered-results (semantic.tu/filter-for-mock-embeddings mixed-results)]
-                (is (pos? (count filtered-results)))
-                (is (every? #(contains? #{"card" "dashboard"} (:model %)) mixed-results))))))))))
+          (testing "Filter for multiple model types"
+            (let [mixed-results (query-index {:search-string "predator" :models ["card" "dashboard"]})
+                  filtered-results (semantic.tu/filter-for-mock-embeddings mixed-results)]
+              (is (pos? (count filtered-results)))
+              (is (every? #(contains? #{"card" "dashboard"} (:model %)) mixed-results)))))))))
 
 (deftest archived-filtering-test
   (testing "Filter results by archived status"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-mocked-embeddings!
-          (semantic.tu/with-index!
-            (testing "Include only non-archived items"
-              (let [active-results (semantic.index/query-index {:search-string "feline" :archived? false})]
-                (is (every? #(not (:archived %))  active-results))))
+        (semantic.tu/with-index!
+          (testing "Include only non-archived items"
+            (let [active-results (query-index {:search-string "feline" :archived? false})]
+              (is (every? #(not (:archived %)) active-results))))
 
-            (testing "Include only archived items"
-              (let [archived-results (semantic.index/query-index {:search-string "feline" :archived? true})
-                    filtered-results (semantic.tu/filter-for-mock-embeddings archived-results)]
-                (is (pos? (count filtered-results)))
-                (is (every? :archived  archived-results))))
+          (testing "Include only archived items"
+            (let [archived-results (query-index {:search-string "feline" :archived? true})
+                  filtered-results (semantic.tu/filter-for-mock-embeddings archived-results)]
+              (is (pos? (count filtered-results)))
+              (is (every? :archived archived-results))))
 
-            (testing "Include all items regardless of archived status"
-              (let [all-results (semantic.index/query-index {:search-string "feline"})
-                    filtered-results (semantic.tu/filter-for-mock-embeddings all-results)]
-                (is (pos? (count filtered-results)))))))))))
+          (testing "Include all items regardless of archived status"
+            (let [all-results (query-index {:search-string "feline"})
+                  filtered-results (semantic.tu/filter-for-mock-embeddings all-results)]
+              (is (pos? (count filtered-results))))))))))
 
 (deftest creator-filtering-test
   (testing "Filter results by creator"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-mocked-embeddings!
-          (semantic.tu/with-index!
-            (testing "Filter by single creator"
-              (let [crowberto-results (semantic.index/query-index {:search-string "aquatic" :created-by [(mt/user->id :crowberto)]})
-                    filtered-results (semantic.tu/filter-for-mock-embeddings crowberto-results)]
-                (is (pos? (count filtered-results)))
-                (is (every? #(= (mt/user->id :crowberto) (:creator_id %)) crowberto-results))))
+        (semantic.tu/with-index!
+          (testing "Filter by single creator"
+            (let [crowberto-results (query-index {:search-string "aquatic" :created-by [(mt/user->id :crowberto)]})
+                  filtered-results (semantic.tu/filter-for-mock-embeddings crowberto-results)]
+              (is (pos? (count filtered-results)))
+              (is (every? #(= (mt/user->id :crowberto) (:creator_id %)) crowberto-results))))
 
-            (testing "Filter by multiple creators"
-              (let [multi-creator-results (semantic.index/query-index {:search-string "endangered species"
-                                                                       :created-by    [(mt/user->id :crowberto) (mt/user->id :rasta)]})]
-                (is (pos? (count multi-creator-results)))
-                (is (every? #(contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %)) multi-creator-results))))))))))
+          (testing "Filter by multiple creators"
+            (let [multi-creator-results (query-index {:search-string "endangered species"
+                                                      :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})]
+              (is (pos? (count multi-creator-results)))
+              (is (every? #(contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %)) multi-creator-results)))))))))
 
 (deftest verified-filtering-test
   (testing "Filter results by verified status"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-mocked-embeddings!
-          (semantic.tu/with-index!
-            (testing "Include only verified items"
-              (let [verified-results (semantic.index/query-index {:search-string "puppy" :verified true})
-                    filtered-results (semantic.tu/filter-for-mock-embeddings verified-results)]
-                (is (pos? (count filtered-results)))
-                (is (every? :verified verified-results))))
+        (semantic.tu/with-index!
+          (testing "Include only verified items"
+            (let [verified-results (query-index {:search-string "puppy" :verified true})
+                  filtered-results (semantic.tu/filter-for-mock-embeddings verified-results)]
+              (is (pos? (count filtered-results)))
+              (is (every? :verified verified-results))))
 
-            (testing "Include all items regardless of verified status when filter not specified"
-              (let [all-results (semantic.index/query-index {:search-string "puppy"})
-                    filtered-results (semantic.tu/filter-for-mock-embeddings all-results)]
-                (is (pos? (count filtered-results)))))))))))
+          (testing "Include all items regardless of verified status when filter not specified"
+            (let [all-results (query-index {:search-string "puppy"})
+                  filtered-results (semantic.tu/filter-for-mock-embeddings all-results)]
+              (is (pos? (count filtered-results))))))))))
 
 (deftest complex-filtering-test
   (testing "Complex filters with multiple criteria"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-mocked-embeddings!
-          (semantic.tu/with-index!
-            (testing "Non-archived cards by specific creator"
-              (let [results (semantic.index/query-index {:search-string "equine"
-                                                         :models ["card"]
-                                                         :archived? false
-                                                         :created-by [(mt/user->id :rasta)]})
-                    filtered-results (semantic.tu/filter-for-mock-embeddings results)]
-                (is (pos? (count filtered-results)))
-                (is (every? #(and (= "card" (:model %))
-                                  (not (:archived %))
-                                  (= (mt/user->id :rasta) (:creator_id %))) results))))
+        (semantic.tu/with-index!
+          (testing "Non-archived cards by specific creator"
+            (let [results (query-index {:search-string "equine"
+                                        :models ["card"]
+                                        :archived? false
+                                        :created-by [(mt/user->id :rasta)]})
+                  filtered-results (semantic.tu/filter-for-mock-embeddings results)]
+              (is (pos? (count filtered-results)))
+              (is (every? #(and (= "card" (:model %))
+                                (not (:archived %))
+                                (= (mt/user->id :rasta) (:creator_id %))) results))))
 
-            (testing "Archived dashboards by multiple creators"
-              (let [results (semantic.index/query-index {:search-string "Antarctic wildlife"
-                                                         :models ["dashboard"]
-                                                         :archived? true
-                                                         :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})
-                    filtered-results (semantic.tu/filter-for-mock-embeddings results)]
-                (is (pos? (count filtered-results)))
-                (is (every? #(and (= "dashboard" (:model %))
-                                  (:archived %)
-                                  (contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %))) results))))
+          (testing "Archived dashboards by multiple creators"
+            (let [results (query-index {:search-string "Antarctic wildlife"
+                                        :models ["dashboard"]
+                                        :archived? true
+                                        :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})
+                  filtered-results (semantic.tu/filter-for-mock-embeddings results)]
+              (is (pos? (count filtered-results)))
+              (is (every? #(and (= "dashboard" (:model %))
+                                (:archived %)
+                                (contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %))) results))))
 
-            (testing "Verified items with additional filters"
-              (let [results (semantic.index/query-index {:search-string "marine mammal"
-                                                         :models ["dashboard"]
-                                                         :verified true
-                                                         :archived? false})]
-                (is (every? #(and (= "dashboard" (:model %))
-                                  (:verified %)
-                                  (not (:archived %))) results))))))))))
+          (testing "Verified items with additional filters"
+            (let [results (query-index {:search-string "marine mammal"
+                                        :models ["dashboard"]
+                                        :verified true
+                                        :archived? false})]
+              (is (every? #(and (= "dashboard" (:model %))
+                                (:verified %)
+                                (not (:archived %))) results)))))))))
 
 (deftest permissions-test
   (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-mocked-embeddings!
-      (semantic.tu/with-index!
-        (let [monsters-table   (t2/select-one-pk :model/Table :name "Monsters Table")
-              q                (fn [model s] (map :name (semantic.index/query-index {:search-string s, :models [model]})))
-              all-users        (perms-group/all-users)
-              unrestrict-table (fn [table-id]
-                                 (data-perms/set-table-permission! all-users table-id :perms/create-queries :query-builder)
-                                 (data-perms/set-table-permission! all-users table-id :perms/view-data      :unrestricted))
-              restrict-table   (fn [table-id]
-                                 (data-perms/set-table-permission! all-users table-id :perms/create-queries :no)
-                                 (data-perms/set-table-permission! all-users table-id :perms/view-data      :blocked))]
-          (perms/revoke-collection-permissions! (perms-group/all-users) (t2/select-one :model/Collection :name "Cryptozoology"))
-          (restrict-table monsters-table)
-          (testing "admin"
-            (mt/with-test-user :crowberto
-              (testing "collection permissions"
-                (is (some #{"Loch Ness Stuff"}   (q "dashboard" "prehistoric monsters")))
-                (is (some #{"Bigfoot Sightings"} (q "card"      "spooky video evidence"))))
-              (testing "data permissions"
-                (is (some #{"Monsters Table"} (q "table" "monster facts"))))))
-          (testing "all-users"
-            (mt/with-test-user :rasta
-              (testing "collection permissions"
-                (is (not-any? #{"Loch Ness Stuff"}   (q "dashboard" "prehistoric monsters")))
-                (is (not-any? #{"Bigfoot Sightings"} (q "card"      "spooky video evidence"))))
-              (testing "data permissions"
-                (is (not-any? #{"Monsters Table"} (q "table" "monster facts"))))
-              (testing "give data permissions"
-                (unrestrict-table monsters-table)
-                (data-perms/disable-perms-cache
-                 (is (some #{"Monsters Table"} (q "table" "monster facts"))))))))))))
+    (semantic.tu/with-index!
+      (let [monsters-table (t2/select-one-pk :model/Table :name "Monsters Table")
+            q (fn [model s] (map :name (query-index {:search-string s, :models [model]})))
+            all-users (perms-group/all-users)
+            unrestrict-table (fn [table-id]
+                               (data-perms/set-table-permission! all-users table-id :perms/create-queries :query-builder)
+                               (data-perms/set-table-permission! all-users table-id :perms/view-data :unrestricted))
+            restrict-table (fn [table-id]
+                             (data-perms/set-table-permission! all-users table-id :perms/create-queries :no)
+                             (data-perms/set-table-permission! all-users table-id :perms/view-data :blocked))]
+        (perms/revoke-collection-permissions! (perms-group/all-users) (t2/select-one :model/Collection :name "Cryptozoology"))
+        (restrict-table monsters-table)
+        (testing "admin"
+          (mt/with-test-user :crowberto
+            (testing "collection permissions"
+              (is (some #{"Loch Ness Stuff"} (q "dashboard" "prehistoric monsters")))
+              (is (some #{"Bigfoot Sightings"} (q "card" "spooky video evidence"))))
+            (testing "data permissions"
+              (is (some #{"Monsters Table"} (q "table" "monster facts"))))))
+        (testing "all-users"
+          (mt/with-test-user :rasta
+            (testing "collection permissions"
+              (is (not-any? #{"Loch Ness Stuff"} (q "dashboard" "prehistoric monsters")))
+              (is (not-any? #{"Bigfoot Sightings"} (q "card" "spooky video evidence"))))
+            (testing "data permissions"
+              (is (not-any? #{"Monsters Table"} (q "table" "monster facts"))))
+            (testing "give data permissions"
+              (unrestrict-table monsters-table)
+              (data-perms/disable-perms-cache
+               (is (some #{"Monsters Table"} (q "table" "monster facts")))))))))))
 
 (deftest basic-batched-query-test
   (testing "Small-batch reindexing"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-mocked-embeddings!
-          (binding [semantic.index/*batch-size* 1]
-            (semantic.tu/with-index!
-              (testing "Horse-related query finds horse content"
-                (let [results (semantic.index/query-index {:search-string "equine"})]
-                  (is (= "Horse Racing Analysis" (-> results first :name)))))
+        (binding [semantic.index/*batch-size* 1]
+          (semantic.tu/with-index!
+            (testing "Horse-related query finds horse content"
+              (let [results (query-index {:search-string "equine"})]
+                (is (= "Horse Racing Analysis" (-> results first :name)))))
 
-              (testing "Tiger-related query finds tiger content"
-                (let [results (semantic.index/query-index {:search-string "endangered species"})]
-                  (is (= "Tiger Conservation" (-> results first :name))))))))))))
+            (testing "Tiger-related query finds tiger content"
+              (let [results (query-index {:search-string "endangered species"})]
+                (is (= "Tiger Conservation" (-> results first :name)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.semantic-search.db :as semantic.db]
    [metabase-enterprise.semantic-search.index :as semantic.index]
-   [metabase-enterprise.semantic-search.test-util :as semantic.tu :refer [db mock-embedding-model]]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -16,20 +16,17 @@
   (is (some? @semantic.db/data-source))
   (is (= {:test 1} (semantic.db/test-connection!))))
 
-(defn- query-index [search-context]
-  (semantic.index/query-index db mock-embedding-model search-context))
-
 (deftest basic-query-test
   (testing "Simple queries with no filters"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
         (semantic.tu/with-index!
           (testing "Dog-related query finds dog content"
-            (let [results (query-index {:search-string "puppy"})]
+            (let [results (semantic.tu/query-index {:search-string "puppy"})]
               (is (= "Dog Training Guide" (-> results first :name)))))
 
           (testing "Bird-related query finds bird content"
-            (let [results (query-index {:search-string "avian"})]
+            (let [results (semantic.tu/query-index {:search-string "avian"})]
               (is (= "Bird Watching Tips" (-> results first :name))))))))))
 
 (deftest model-filtering-test
@@ -38,19 +35,19 @@
       (mt/as-admin
         (semantic.tu/with-index!
           (testing "Filter for cards only"
-            (let [card-results (query-index {:search-string "avian" :models ["card"]})
+            (let [card-results (semantic.tu/query-index {:search-string "avian" :models ["card"]})
                   filtered-results (semantic.tu/filter-for-mock-embeddings card-results)]
               (is (pos? (count filtered-results)))
               (is (every? #(= "card" (:model %)) card-results))))
 
           (testing "Filter for dashboards only"
-            (let [dashboard-results (query-index {:search-string "marine mammal" :models ["dashboard"]})
+            (let [dashboard-results (semantic.tu/query-index {:search-string "marine mammal" :models ["dashboard"]})
                   filtered-results (semantic.tu/filter-for-mock-embeddings dashboard-results)]
               (is (pos? (count filtered-results)))
               (is (every? #(= "dashboard" (:model %)) dashboard-results))))
 
           (testing "Filter for multiple model types"
-            (let [mixed-results (query-index {:search-string "predator" :models ["card" "dashboard"]})
+            (let [mixed-results (semantic.tu/query-index {:search-string "predator" :models ["card" "dashboard"]})
                   filtered-results (semantic.tu/filter-for-mock-embeddings mixed-results)]
               (is (pos? (count filtered-results)))
               (is (every? #(contains? #{"card" "dashboard"} (:model %)) mixed-results)))))))))
@@ -61,17 +58,17 @@
       (mt/as-admin
         (semantic.tu/with-index!
           (testing "Include only non-archived items"
-            (let [active-results (query-index {:search-string "feline" :archived? false})]
+            (let [active-results (semantic.tu/query-index {:search-string "feline" :archived? false})]
               (is (every? #(not (:archived %)) active-results))))
 
           (testing "Include only archived items"
-            (let [archived-results (query-index {:search-string "feline" :archived? true})
+            (let [archived-results (semantic.tu/query-index {:search-string "feline" :archived? true})
                   filtered-results (semantic.tu/filter-for-mock-embeddings archived-results)]
               (is (pos? (count filtered-results)))
               (is (every? :archived archived-results))))
 
           (testing "Include all items regardless of archived status"
-            (let [all-results (query-index {:search-string "feline"})
+            (let [all-results (semantic.tu/query-index {:search-string "feline"})
                   filtered-results (semantic.tu/filter-for-mock-embeddings all-results)]
               (is (pos? (count filtered-results))))))))))
 
@@ -81,14 +78,14 @@
       (mt/as-admin
         (semantic.tu/with-index!
           (testing "Filter by single creator"
-            (let [crowberto-results (query-index {:search-string "aquatic" :created-by [(mt/user->id :crowberto)]})
+            (let [crowberto-results (semantic.tu/query-index {:search-string "aquatic" :created-by [(mt/user->id :crowberto)]})
                   filtered-results (semantic.tu/filter-for-mock-embeddings crowberto-results)]
               (is (pos? (count filtered-results)))
               (is (every? #(= (mt/user->id :crowberto) (:creator_id %)) crowberto-results))))
 
           (testing "Filter by multiple creators"
-            (let [multi-creator-results (query-index {:search-string "endangered species"
-                                                      :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})]
+            (let [multi-creator-results (semantic.tu/query-index {:search-string "endangered species"
+                                                                  :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})]
               (is (pos? (count multi-creator-results)))
               (is (every? #(contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %)) multi-creator-results)))))))))
 
@@ -98,13 +95,13 @@
       (mt/as-admin
         (semantic.tu/with-index!
           (testing "Include only verified items"
-            (let [verified-results (query-index {:search-string "puppy" :verified true})
+            (let [verified-results (semantic.tu/query-index {:search-string "puppy" :verified true})
                   filtered-results (semantic.tu/filter-for-mock-embeddings verified-results)]
               (is (pos? (count filtered-results)))
               (is (every? :verified verified-results))))
 
           (testing "Include all items regardless of verified status when filter not specified"
-            (let [all-results (query-index {:search-string "puppy"})
+            (let [all-results (semantic.tu/query-index {:search-string "puppy"})
                   filtered-results (semantic.tu/filter-for-mock-embeddings all-results)]
               (is (pos? (count filtered-results))))))))))
 
@@ -114,10 +111,10 @@
       (mt/as-admin
         (semantic.tu/with-index!
           (testing "Non-archived cards by specific creator"
-            (let [results (query-index {:search-string "equine"
-                                        :models ["card"]
-                                        :archived? false
-                                        :created-by [(mt/user->id :rasta)]})
+            (let [results (semantic.tu/query-index {:search-string "equine"
+                                                    :models ["card"]
+                                                    :archived? false
+                                                    :created-by [(mt/user->id :rasta)]})
                   filtered-results (semantic.tu/filter-for-mock-embeddings results)]
               (is (pos? (count filtered-results)))
               (is (every? #(and (= "card" (:model %))
@@ -125,10 +122,10 @@
                                 (= (mt/user->id :rasta) (:creator_id %))) results))))
 
           (testing "Archived dashboards by multiple creators"
-            (let [results (query-index {:search-string "Antarctic wildlife"
-                                        :models ["dashboard"]
-                                        :archived? true
-                                        :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})
+            (let [results (semantic.tu/query-index {:search-string "Antarctic wildlife"
+                                                    :models ["dashboard"]
+                                                    :archived? true
+                                                    :created-by [(mt/user->id :crowberto) (mt/user->id :rasta)]})
                   filtered-results (semantic.tu/filter-for-mock-embeddings results)]
               (is (pos? (count filtered-results)))
               (is (every? #(and (= "dashboard" (:model %))
@@ -136,10 +133,10 @@
                                 (contains? #{(mt/user->id :crowberto) (mt/user->id :rasta)} (:creator_id %))) results))))
 
           (testing "Verified items with additional filters"
-            (let [results (query-index {:search-string "marine mammal"
-                                        :models ["dashboard"]
-                                        :verified true
-                                        :archived? false})]
+            (let [results (semantic.tu/query-index {:search-string "marine mammal"
+                                                    :models ["dashboard"]
+                                                    :verified true
+                                                    :archived? false})]
               (is (every? #(and (= "dashboard" (:model %))
                                 (:verified %)
                                 (not (:archived %))) results)))))))))
@@ -148,7 +145,7 @@
   (mt/with-premium-features #{:semantic-search}
     (semantic.tu/with-index!
       (let [monsters-table (t2/select-one-pk :model/Table :name "Monsters Table")
-            q (fn [model s] (map :name (query-index {:search-string s, :models [model]})))
+            q (fn [model s] (map :name (semantic.tu/query-index {:search-string s, :models [model]})))
             all-users (perms-group/all-users)
             unrestrict-table (fn [table-id]
                                (data-perms/set-table-permission! all-users table-id :perms/create-queries :query-builder)
@@ -184,9 +181,9 @@
         (binding [semantic.index/*batch-size* 1]
           (semantic.tu/with-index!
             (testing "Horse-related query finds horse content"
-              (let [results (query-index {:search-string "equine"})]
+              (let [results (semantic.tu/query-index {:search-string "equine"})]
                 (is (= "Horse Racing Analysis" (-> results first :name)))))
 
             (testing "Tiger-related query finds tiger content"
-              (let [results (query-index {:search-string "endangered species"})]
+              (let [results (semantic.tu/query-index {:search-string "endangered species"})]
                 (is (= "Tiger Conservation" (-> results first :name)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -7,8 +7,10 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]
    [metabase.util.log :as log]
-   [nano-id.core :as nano-id]
-   [next.jdbc :as jdbc]))
+   [next.jdbc :as jdbc]
+   [next.jdbc.protocols :as jdbc.protocols])
+  (:import (clojure.lang IDeref)
+           (java.io Closeable)))
 
 (def ^:private init-delay
   (delay
@@ -19,6 +21,15 @@
   (when semantic.db/db-url
     @init-delay
     (f)))
+
+(def db
+  "Proxies the semantic.db/data-source, avoids the deref and prettifies a little"
+  ;; proxy because semantic.db/data-source is not initialised until the fixture runs
+  (reify jdbc.protocols/Sourceable
+    (get-datasource [_] (jdbc.protocols/get-datasource @semantic.db/data-source))))
+
+(comment
+  (jdbc/execute! db ["select 1"]))
 
 (def mock-embeddings
   "Static mapping from strings to (made-up) 4-dimensional embedding vectors for testing. Each pair of strings represents a
@@ -56,6 +67,26 @@
   [texts]
   (mapv get-mock-embedding texts))
 
+;;;; mock provider
+
+(def mock-embedding-model
+  {:provider          "mock"
+   :model-name        "mock-model"
+   :vector-dimensions 4})
+
+(defmethod semantic.embedding/get-embedding        "mock" [_ text] (get-mock-embedding text))
+(defmethod semantic.embedding/get-embeddings-batch "mock" [_ texts] (get-mock-embeddings-batch texts))
+(defmethod semantic.embedding/pull-model           "mock" [_])
+
+(defn query-index [search-context]
+  (semantic.index/query-index db mock-embedding-model search-context))
+
+(defn upsert-index! [documents]
+  (semantic.index/upsert-index! db mock-embedding-model documents))
+
+(defn delete-from-index! [model ids]
+  (semantic.index/delete-from-index! db mock-embedding-model model ids))
+
 (def mock-documents
   [{:model "card"
     :id "123"
@@ -79,36 +110,22 @@
   [results]
   (filter #(contains? mock-embeddings (:name %)) results))
 
-(defn mock-process-embeddings-streaming
-  "Mock implementation of process-embeddings-streaming that uses mock embeddings."
-  [texts process-fn]
-  (when (seq texts)
-    (let [embeddings (get-mock-embeddings-batch texts)]
-      (process-fn texts embeddings))))
+(defn- closeable [o close-fn]
+  (reify
+    IDeref
+    (deref [_] o)
+    Closeable
+    (close [_] (close-fn o))))
 
-(defmacro with-mocked-embeddings! [& body]
-  ;; TODO: it's warning about not using with-redefs outside of tests but we *are* using it in tests
-  #_:clj-kondo/ignore
-  `(with-redefs [semantic.embedding/model-dimensions (constantly 4)
-                 semantic.embedding/pull-model (constantly nil)
-                 semantic.embedding/process-embeddings-streaming mock-process-embeddings-streaming
-                 semantic.embedding/get-embedding get-mock-embedding]
-     ~@body))
-
-(defmacro with-temp-index-table! [& body]
-  `(let [test-table-name# (keyword (str "test_search_index_" (nano-id/nano-id)))]
-     (binding [semantic.index/*index-table-name* test-table-name#
-               search.ingestion/*force-sync* true]
-       (try
-         (mt/as-admin
-           (semantic.index/create-index-table! {:force-reset? true}))
-         ~@body
-         (finally
-           (try
-             (mt/as-admin
-               (semantic.index/drop-index-table!))
-             (catch Exception e#
-               (log/error "Warning: failed to clean up test table" test-table-name# ":" (.getMessage e#)))))))))
+(defn open-temp-index-table! []
+  (closeable
+   (do (semantic.index/create-index-table! db mock-embedding-model {:force-reset? true})
+       (semantic.index/index-table-name mock-embedding-model))
+   (fn cleanup-temp-index-table! [_]
+     (try
+       (semantic.index/drop-index-table! db mock-embedding-model)
+       (catch Exception e
+         (log/error "Warning: failed to clean up test table" (semantic.index/index-table-name mock-embedding-model) e))))))
 
 (defmacro with-indexable-documents!
   "Add a collection of test documents to that can be indexed to the appdb."
@@ -165,8 +182,10 @@
   "Ensure a clean, small index for testing populated with a few collections, cards, and dashboards."
   [& body]
   `(with-indexable-documents!
-     (with-temp-index-table!
-       (search.core/reindex! :search.engine/semantic {:force-reset true})
+     (with-open [_# (open-temp-index-table!)]
+       (binding [semantic.embedding/*active-model* mock-embedding-model
+                 search.ingestion/*force-sync* true]
+         (search.core/reindex! :search.engine/semantic {:force-reset true}))
        ~@body)))
 
 (defn table-exists-in-db?
@@ -174,7 +193,7 @@
   [table-name]
   (when table-name
     (try
-      (let [result (jdbc/execute! @semantic.db/data-source
+      (let [result (jdbc/execute! db
                                   ["SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = ?)"
                                    (name table-name)])]
         (-> result first vals first))
@@ -184,7 +203,7 @@
   [table-name index-name]
   (when table-name
     (try
-      (let [result (jdbc/execute! @semantic.db/data-source
+      (let [result (jdbc/execute! db
                                   ["SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE tablename = ? AND indexname = ?)"
                                    (name table-name)
                                    (name index-name)])]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -12,6 +12,8 @@
   (:import (clojure.lang IDeref)
            (java.io Closeable)))
 
+(set! *warn-on-reflection* true)
+
 (def ^:private init-delay
   (delay
     (when-not @semantic.db/data-source
@@ -125,7 +127,7 @@
      (try
        (semantic.index/drop-index-table! db mock-embedding-model)
        (catch Exception e
-         (log/error "Warning: failed to clean up test table" (semantic.index/index-table-name mock-embedding-model) e))))))
+         (log/error e "Warning: failed to clean up test table" (semantic.index/index-table-name mock-embedding-model)))))))
 
 (defmacro with-indexable-documents!
   "Add a collection of test documents to that can be indexed to the appdb."


### PR DESCRIPTION
Adds new parameters to many functions that previously used environmental/global variables.

- `embedding-model`
   describes the model used for embeddings, and its vector size.
- `index`
   describes a specific semantic search index in the database, so functions that operate on the index can be told _which_ index to operate on.
   
Here is an example of the `index` map:

```clojure
{:embedding-model {:provider "ollama", :model-name "mxbai-embed-large", :vector-dimensions 1024},
 :table-name "index_table__ollama__mxbai-embed-large__1024",
 :index-name "index_table__ollama__mxbai-embed-large__1024__hnsw_idx"}
 ```

The environmental configuration is hoisted up to only apply at the level of integration with metabase search, the lower level functions are appropriately parameterized.

This PR is a part 1 to solving BOT-255 which requires us to be able to switch the model, potentially at runtime. It also provides independence of lower level functions from which index they target so active/pending or testing different kinds of index should be easier. 

The remaining work for BOT-255 will follow this PR, merging this earlier will avoid painful merge conflicts.

Part of this PR refactors the embedding namespace quite aggressively so there maybe controversy there (multimethods are used over the previous provider deftypes).