### PR TITLE
Migrate the new embed flow's snippets to use custom elements

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
@@ -111,9 +111,9 @@ H.describeWithSnowplow(suiteTitle, () => {
       cy.log("both default values should be in the code snippet");
       getEmbedSidebar().within(() => {
         cy.findByText("Get Code").click();
-        codeBlock().should("contain", '"initialParameters"');
-        codeBlock().should("contain", '"id": "123"');
-        codeBlock().should("contain", '"product_id": "456"');
+        codeBlock().should("contain", "initial-parameters=");
+        codeBlock().should("contain", '"id":"123"');
+        codeBlock().should("contain", '"product_id":"456"');
       });
     });
 
@@ -145,7 +145,7 @@ H.describeWithSnowplow(suiteTitle, () => {
       cy.log("code snippet should contain the hidden parameters");
       getEmbedSidebar().within(() => {
         cy.findByText("Get Code").click();
-        codeBlock().should("contain", '"hiddenParameters"');
+        codeBlock().should("contain", "hidden-parameters=");
         codeBlock().should("contain", '"id"');
         codeBlock().should("contain", '"product_id"');
       });
@@ -205,9 +205,9 @@ H.describeWithSnowplow(suiteTitle, () => {
 
       getEmbedSidebar().within(() => {
         cy.findByText("Get Code").click();
-        codeBlock().should("contain", '"initialSqlParameters"');
-        codeBlock().should("not.contain", '"hiddenParameters"'); // not supported for questions yet
-        codeBlock().should("contain", '"id": "123"');
+        codeBlock().should("contain", "initial-sql-parameters=");
+        codeBlock().should("not.contain", "hidden-parameters="); // not supported for questions yet
+        codeBlock().should("contain", '"id":"123"');
       });
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -111,7 +111,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     getEmbedSidebar().within(() => {
       cy.findByLabelText("Existing Metabase Session").should("be.checked");
-      codeBlock().should("contain", "useExistingUserSession: true");
+      codeBlock().should("contain", '"useExistingUserSession": true');
     });
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -98,7 +98,8 @@ H.describeWithSnowplow(suiteTitle, () => {
     getEmbedSidebar().within(() => {
       cy.findByText("Embed Code").should("be.visible");
       codeBlock().should("be.visible");
-      codeBlock().should("contain", "MetabaseEmbed");
+      codeBlock().should("contain", "defineMetabaseConfig");
+      codeBlock().should("contain", "metabase-dashboard");
     });
   });
 
@@ -110,7 +111,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     getEmbedSidebar().within(() => {
       cy.findByLabelText("Existing Metabase Session").should("be.checked");
-      codeBlock().should("contain", '"useExistingUserSession": true');
+      codeBlock().should("contain", "useExistingUserSession: true");
     });
   });
 
@@ -133,18 +134,18 @@ H.describeWithSnowplow(suiteTitle, () => {
     });
   });
 
-  it("should set dashboardId for dashboard experience", () => {
+  it("should set dashboard-id for dashboard experience", () => {
     navigateToGetCodeStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
     });
 
     getEmbedSidebar().within(() => {
-      codeBlock().should("contain", `"dashboardId": ${ORDERS_DASHBOARD_ID}`);
+      codeBlock().should("contain", `dashboard-id="${ORDERS_DASHBOARD_ID}"`);
     });
   });
 
-  it("should set questionId for chart experience", () => {
+  it("should set question-id for chart experience", () => {
     navigateToGetCodeStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
@@ -153,16 +154,16 @@ H.describeWithSnowplow(suiteTitle, () => {
     getEmbedSidebar().within(() => {
       codeBlock().should(
         "contain",
-        `"questionId": ${ORDERS_COUNT_QUESTION_ID}`,
+        `question-id="${ORDERS_COUNT_QUESTION_ID}"`,
       );
     });
   });
 
-  it("should set template=exploration for exploration experience", () => {
+  it("should use metabase-question for exploration experience", () => {
     navigateToGetCodeStep({ experience: "exploration" });
 
     getEmbedSidebar().within(() => {
-      codeBlock().should("contain", '"template": "exploration"');
+      codeBlock().should("contain", "metabase-question");
     });
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -63,7 +63,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", "drills=false");
+    codeBlock().should("contain", 'drills="false"');
   });
 
   it("toggles downloads for dashboard", () => {
@@ -93,7 +93,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", "with-downloads=true");
+    codeBlock().should("contain", 'with-downloads="true"');
   });
 
   it("toggles dashboard title for dashboards", () => {
@@ -123,7 +123,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", "with-title=false");
+    codeBlock().should("contain", 'with-title="false"');
   });
 
   it("toggles drill-through for charts", () => {
@@ -161,7 +161,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", "drills=false");
+    codeBlock().should("contain", 'drills="false"');
   });
 
   it("toggles downloads for charts", () => {
@@ -195,7 +195,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", "with-downloads=true");
+    codeBlock().should("contain", 'with-downloads="true"');
   });
 
   it("toggles chart title for charts", () => {
@@ -223,7 +223,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", "with-title=false");
+    codeBlock().should("contain", 'with-title="false"');
   });
 
   it("toggles save button for exploration", () => {
@@ -256,7 +256,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", "is-save-enabled=false");
+    codeBlock().should("contain", 'is-save-enabled="false"');
   });
 
   it("can change brand color", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -294,6 +294,9 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", 'theme: {"brand":"#FF0000"}');
+
+    codeBlock().should("contain", '"theme": {');
+    codeBlock().should("contain", '"colors": {');
+    codeBlock().should("contain", '"brand": "#FF0000"');
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -63,7 +63,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", '"isDrillThroughEnabled": false');
+    codeBlock().should("contain", "drills=false");
   });
 
   it("toggles downloads for dashboard", () => {
@@ -93,7 +93,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", '"withDownloads": true');
+    codeBlock().should("contain", "with-downloads=true");
   });
 
   it("toggles dashboard title for dashboards", () => {
@@ -123,7 +123,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", '"withTitle": false');
+    codeBlock().should("contain", "with-title=false");
   });
 
   it("toggles drill-through for charts", () => {
@@ -161,7 +161,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", '"isDrillThroughEnabled": false');
+    codeBlock().should("contain", "drills=false");
   });
 
   it("toggles downloads for charts", () => {
@@ -195,7 +195,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", '"withDownloads": true');
+    codeBlock().should("contain", "with-downloads=true");
   });
 
   it("toggles chart title for charts", () => {
@@ -223,7 +223,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", '"withTitle": false');
+    codeBlock().should("contain", "with-title=false");
   });
 
   it("toggles save button for exploration", () => {
@@ -256,7 +256,7 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", '"isSaveEnabled": false');
+    codeBlock().should("contain", "is-save-enabled=false");
   });
 
   it("can change brand color", () => {
@@ -294,6 +294,6 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", '"brand": "#FF0000"');
+    codeBlock().should("contain", 'theme: {"brand":"#FF0000"}');
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
@@ -1,67 +1,16 @@
 import { useMemo } from "react";
-import _ from "underscore";
 
 import { useSetting } from "metabase/common/hooks";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
-import type { SdkIframeEmbedSetupSettings } from "../types";
-import { filterEmptySettings } from "../utils/filter-empty-settings";
-
-// Example target ID for the embed snippet.
-const SNIPPET_EMBED_TARGET = "metabase-embed";
+import { getEmbedSnippet } from "../utils/embed-snippet";
 
 export function useSdkIframeEmbedSnippet() {
   const instanceUrl = useSetting("site-url");
-  const { settings } = useSdkIframeEmbedSetupContext();
+  const { settings, experience } = useSdkIframeEmbedSetupContext();
 
   return useMemo(
-    () => getSnippet({ settings, instanceUrl }),
-    [instanceUrl, settings],
+    () => getEmbedSnippet({ settings, instanceUrl, experience }),
+    [instanceUrl, settings, experience],
   );
-}
-
-function getSnippet({
-  settings,
-  instanceUrl,
-}: {
-  settings: SdkIframeEmbedSetupSettings;
-  instanceUrl: string;
-}): string {
-  const cleanedSettings = {
-    // Only include useExistingUserSession if it is true.
-    ..._.omit(settings, ["useExistingUserSession"]),
-    ...(settings.useExistingUserSession
-      ? { useExistingUserSession: true }
-      : {}),
-
-    // Append these settings that can't be controlled by users.
-    instanceUrl,
-    target: `#${SNIPPET_EMBED_TARGET}`,
-  };
-
-  // filter out empty arrays, strings, objects, null and undefined.
-  // this keeps the embed settings readable.
-  const filteredSettings = filterEmptySettings(cleanedSettings);
-
-  // format the json settings with proper indentation
-  const formattedSettings = JSON.stringify(filteredSettings, null, 2)
-    .replace(/^{/, "")
-    .replace(/}$/, "")
-    .split("\n")
-    .map((line) => `  ${line}`)
-    .join("\n")
-    .trim();
-
-  // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
-  return `<script src="${instanceUrl}/app/embed.js"></script>
-
-<div id="${SNIPPET_EMBED_TARGET}" style="height: 100vh"></div>
-
-<script>
-  const { MetabaseEmbed } = window["metabase.embed"];
-
-  const embed = new MetabaseEmbed({
-    ${formattedSettings}
-  });
-</script>`;
 }

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
@@ -11,6 +11,8 @@ import type {
   SdkIframeEmbedSetupSettings,
 } from "../types";
 
+import { filterEmptySettings } from "./filter-empty-settings";
+
 type SettingKey = Exclude<keyof SdkIframeEmbedBaseSettings, "_isLocalhost">;
 
 export function getEmbedSnippet({
@@ -33,13 +35,38 @@ export function getEmbedSnippet({
     ALLOWED_EMBED_SETTING_KEYS_MAP[experience],
   );
 
+  const config = _.pick(settings, ALLOWED_EMBED_SETTING_KEYS_MAP.base);
+
+  const cleanedConfig = {
+    ..._.omit(config, ["useExistingUserSession"]),
+
+    // Only include useExistingUserSession if it is true.
+    ...(config.useExistingUserSession ? { useExistingUserSession: true } : {}),
+
+    // Append these settings that can't be controlled by users.
+    instanceUrl,
+  };
+
+  // filter out empty arrays, strings, objects, null and undefined.
+  // this keeps the embed settings readable.
+  const filteredConfig = filterEmptySettings(cleanedConfig);
+
+  // format the json settings with proper indentation
+  const formattedConfig = JSON.stringify(filteredConfig, null, 2)
+    .replace(/^{/, "")
+    .replace(/}$/, "")
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n")
+    .trim();
+
   // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
   return `<script src="${instanceUrl}/app/embed.js"></script>
 
 <script>
   const { defineMetabaseConfig } = window["metabase.embed"];
   defineMetabaseConfig({
-    instanceUrl: "${instanceUrl}",${settings.useExistingUserSession ? "\n    useExistingUserSession: true," : ""}${settings.theme ? `\n    theme: ${JSON.stringify(settings.theme)},` : ""}${settings.locale ? `\n    locale: "${settings.locale}",` : ""}
+    ${formattedConfig}
   });
 </script>
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
@@ -51,22 +51,11 @@ const toDashCase = (str: string): string =>
   str.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
 
 // Convert values to string attributes
-const formatAttributeValue = (value: any): string => {
-  if (typeof value === "string") {
-    return `"${value}"`;
-  }
-
-  if (typeof value === "boolean") {
-    return value ? "true" : "false";
-  }
-
-  if (typeof value === "number") {
-    return `"${value}"`;
-  }
-
+const formatAttributeValue = (value: unknown): string => {
   if (Array.isArray(value) || typeof value === "object") {
     return `'${JSON.stringify(value)}'`;
   }
+
   return `"${value}"`;
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
@@ -1,0 +1,103 @@
+import { match } from "ts-pattern";
+
+import {
+  ALLOWED_EMBED_SETTING_KEYS_MAP,
+  type AllowedEmbedSettingKey,
+} from "metabase-enterprise/embedding_iframe_sdk/constants";
+import type { SdkIframeEmbedBaseSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
+
+import type {
+  SdkIframeEmbedSetupExperience,
+  SdkIframeEmbedSetupSettings,
+} from "../types";
+
+type SettingKey = Exclude<keyof SdkIframeEmbedBaseSettings, "_isLocalhost">;
+
+export function getEmbedSnippet({
+  settings,
+  instanceUrl,
+  experience,
+}: {
+  settings: SdkIframeEmbedSetupSettings;
+  instanceUrl: string;
+  experience: SdkIframeEmbedSetupExperience;
+}): string {
+  const elementName = match(experience)
+    .with("dashboard", () => "metabase-dashboard")
+    .with("chart", () => "metabase-question")
+    .with("exploration", () => "metabase-question")
+    .exhaustive();
+
+  const attributes = transformEmbedSettingsToAttributes(
+    settings,
+    ALLOWED_EMBED_SETTING_KEYS_MAP[experience],
+  );
+
+  // eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins.
+  return `<script src="${instanceUrl}/app/embed.js"></script>
+
+<script>
+  const { defineMetabaseConfig } = window["metabase.embed"];
+  defineMetabaseConfig({
+    instanceUrl: "${instanceUrl}",${settings.useExistingUserSession ? "\n    useExistingUserSession: true," : ""}${settings.theme ? `\n    theme: ${JSON.stringify(settings.theme)},` : ""}${settings.locale ? `\n    locale: "${settings.locale}",` : ""}
+  });
+</script>
+
+<${elementName} ${attributes}></${elementName}>`;
+}
+
+// Convert camelCase keys to lower-dash-case for web components
+const toDashCase = (str: string): string =>
+  str.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+
+// Convert values to string attributes
+const formatAttributeValue = (value: any): string => {
+  if (typeof value === "string") {
+    return `"${value}"`;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+
+  if (typeof value === "number") {
+    return `"${value}"`;
+  }
+
+  if (Array.isArray(value) || typeof value === "object") {
+    return `'${JSON.stringify(value)}'`;
+  }
+  return `"${value}"`;
+};
+
+export function transformEmbedSettingsToAttributes(
+  settings: Partial<SdkIframeEmbedSetupSettings>,
+  keysToProcess: AllowedEmbedSettingKey[],
+): string {
+  const attributes: string[] = [];
+
+  for (const key of keysToProcess) {
+    const value = (settings as any)[key];
+
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    // Skip base configuration keys that go into defineMetabaseConfig
+    if (ALLOWED_EMBED_SETTING_KEYS_MAP.base.includes(key as SettingKey)) {
+      continue;
+    }
+
+    // TODO: rename the setting field to `drills` to match the attribute name
+    // transform isDrillThroughEnabled to drills
+    if (key === "isDrillThroughEnabled") {
+      attributes.push(`drills=${formatAttributeValue(value)}`);
+      continue;
+    }
+
+    const attributeName = toDashCase(key);
+    attributes.push(`${attributeName}=${formatAttributeValue(value)}`);
+  }
+
+  return attributes.join(" ");
+}

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
@@ -1,11 +1,17 @@
 import userEvent from "@testing-library/user-event";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";
-import { setupDatabasesEndpoints } from "__support__/server-mocks";
+import {
+  setupDatabasesEndpoints,
+  setupPropertiesEndpoints,
+} from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import type { Database, TokenFeatures } from "metabase-types/api";
-import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import {
+  createMockSettings,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 import { createMockState } from "metabase-types/store/mocks";
 
@@ -29,6 +35,7 @@ async function setup({
 
   setupDatabasesEndpoints(databases);
   setupEnterprisePlugins();
+  setupPropertiesEndpoints(createMockSettings());
 
   renderWithProviders(<NewItemMenu trigger={<button>New</button>} />, {
     storeInitialState: createMockState({ settings }),


### PR DESCRIPTION
Closes EMB-654

We decided to use the new Web Components API for creating embeds, instead of with the MetabaseEmbed class. This PR updates the embedding setup flow to generate code snippets using custom elements syntax.

### Changes Made

- **Web Components Syntax**: Updated embed snippet generation to use custom elements (`<metabase-dashboard>`, `<metabase-question>`) instead of the previous MetabaseEmbed class approach
- **Attribute Formatting**: Implemented proper HTML attribute formatting with dash-case naming (e.g., `with-title`, `dashboard-id`) and quoted values
- **Element Mapping**: 
  - Dashboard embeds → `<metabase-dashboard>`
  - Chart embeds → `<metabase-question>`
  - Exploration embeds → `<metabase-question>`
- **Configuration Structure**: Maintained the `defineMetabaseConfig()` setup while transitioning the embedding elements to custom components
- **Test Updates**: Fixed test assertions to match the new attribute syntax (e.g., `drills="false"` instead of `drills=false`)

### How to verify

1. **Admin Setup Flow**: Go to Admin → Embedding → Add a new embed
2. **Dashboard Embedding**: 
   - Select a dashboard and go through the embed setup
   - In the "Get Code" step, verify the snippet uses `<metabase-dashboard>` element
   - Check that attributes use proper syntax like `dashboard-id="123"` and `with-title="false"`
3. **Question/Chart Embedding**:
   - Select a question and go through the embed setup  
   - Verify the snippet uses `<metabase-question>` element
   - Check attribute formatting matches web components standards
4. **Options Testing**: Toggle various embed options (downloads, title, drills) and verify the generated attributes are properly quoted
5. **Authentication**: Test both "Existing Metabase Session" (includes `"useExistingUserSession": true`) and SSO authentication methods

### Demo

The generated snippets now follow this pattern:
```html
<script src="http://localhost:3000/app/embed.js"></script>

<script>
  const { defineMetabaseConfig } = window["metabase.embed"];
  defineMetabaseConfig({
    "instanceUrl": "http://localhost:3000",
    "useExistingUserSession": true
  });
</script>

<metabase-dashboard dashboard-id="1" with-title="false" drills="true"></metabase-dashboard>
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] Code follows web components attribute naming conventions (dash-case)
- [x] All embed experiences (dashboard, chart, exploration) use appropriate custom elements
- [x] Attribute values are properly quoted for HTML compliance