### PR TITLE
fix unknown prop handleAxis on SdkIframeEmbedSetup

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -77,7 +77,7 @@ const SidebarResizer = ({ children }: { children: React.ReactNode }) => {
       maxConstraints={[600, Infinity]}
       onResizeStop={(_, data) => setSidebarWidth(data.size.width)}
       axis="x"
-      handle={<Box className={S.ResizeHandle} />}
+      handle={<div className={S.ResizeHandle} />}
     >
       {children}
     </ResizableBox>


### PR DESCRIPTION
There was a  `React does not recognize the `handleAxis` prop on a DOM element.` error on the console because of the usage of Box, switching it to a div fixed it