### PR TITLE
Add custom and default responses to openapi docs

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -107,6 +107,105 @@ redirect_from:
         },
         "required" : [ "zoom", "x", "y", "lat-field", "lon-field" ]
       },
+      "gsheets.response" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "error" : {
+              "type" : "boolean"
+            },
+            "message" : {
+              "type" : "string",
+              "minLength" : 1
+            }
+          },
+          "required" : [ "error", "message" ]
+        }, {
+          "oneOf" : [ {
+            "type" : "object",
+            "properties" : { }
+          }, {
+            "type" : "object",
+            "properties" : {
+              "created_at" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "created_by_id" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "db_id" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "sync_started_at" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "url" : {
+                "type" : "string",
+                "minLength" : 1
+              }
+            },
+            "required" : [ "url", "created_at", "sync_started_at", "created_by_id", "db_id" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "created_at" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "created_by_id" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "db_id" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "last_sync_at" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "next_sync_at" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "url" : {
+                "type" : "string",
+                "minLength" : 1
+              }
+            },
+            "required" : [ "url", "created_at", "last_sync_at", "next_sync_at", "created_by_id", "db_id" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "created_at" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "created_by_id" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "db_id" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "error_message" : {
+                "type" : "string",
+                "minLength" : 1
+              },
+              "url" : {
+                "type" : "string",
+                "minLength" : 1
+              }
+            },
+            "required" : [ "url", "created_at", "error_message", "created_by_id", "db_id" ]
+          } ]
+        } ]
+      },
       "metabase-enterprise.metabot-v3.client.schema.message" : {
         "allOf" : [ {
           "type" : "object",
@@ -192,9 +291,125 @@ redirect_from:
           "properties" : { }
         } ]
       },
+      "metabase-enterprise.metabot-v3.tools.api.answer-sources-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "type" : "object",
+              "properties" : {
+                "metrics" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.full-metric"
+                  }
+                },
+                "models" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.full-table"
+                  }
+                }
+              },
+              "required" : [ "metrics", "models" ]
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
+        } ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.basic-metric" : {
+        "type" : "object",
+        "properties" : {
+          "default_time_dimension_field_id" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "integer"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "metric"
+          }
+        },
+        "required" : [ "id", "type", "name" ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.basic-table" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "fields" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.columns"
+          },
+          "id" : {
+            "type" : "integer"
+          },
+          "metrics" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.basic-metric"
+            }
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "model", "table" ]
+          }
+        },
+        "required" : [ "id", "type", "name", "fields" ]
+      },
       "metabase-enterprise.metabot-v3.tools.api.bucket" : {
         "type" : "string",
         "enum" : [ "millisecond", "second", "minute", "hour", "day", "week", "month", "quarter", "year", "second-of-minute", "minute-of-hour", "hour-of-day", "day-of-week", "day-of-month", "day-of-year", "week-of-year", "month-of-year", "quarter-of-year", "year-of-era" ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.column" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "field_id" : {
+            "type" : "string"
+          },
+          "field_values" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.field-values"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "semantic_type" : {
+            "type" : "string"
+          },
+          "type" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.field-type"
+          }
+        },
+        "required" : [ "field_id", "name" ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.columns" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.column"
+        }
+      },
+      "metabase-enterprise.metabot-v3.tools.api.count" : {
+        "type" : "integer"
       },
       "metabase-enterprise.metabot-v3.tools.api.create-dashboard-subscription-arguments" : {
         "allOf" : [ {
@@ -358,6 +573,28 @@ redirect_from:
           "properties" : { }
         } ]
       },
+      "metabase-enterprise.metabot-v3.tools.api.field-type" : {
+        "type" : "string",
+        "enum" : [ "boolean", "date", "datetime", "time", "number", "string" ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.field-values" : {
+        "anyOf" : [ {
+          "type" : "array",
+          "items" : {
+            "type" : "boolean"
+          }
+        }, {
+          "type" : "array",
+          "items" : {
+            "type" : "number"
+          }
+        }, {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        } ]
+      },
       "metabase-enterprise.metabot-v3.tools.api.field-values-arguments" : {
         "allOf" : [ {
           "type" : "object",
@@ -380,6 +617,38 @@ redirect_from:
         }, {
           "type" : "object",
           "properties" : { }
+        } ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.field-values-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "type" : "object",
+              "properties" : {
+                "field_id" : {
+                  "type" : "string"
+                },
+                "statistics" : {
+                  "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.statistics"
+                },
+                "values" : {
+                  "type" : "array",
+                  "items" : { }
+                }
+              },
+              "required" : [ "field_id" ]
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
         } ]
       },
       "metabase-enterprise.metabot-v3.tools.api.filter" : {
@@ -461,6 +730,86 @@ redirect_from:
           "properties" : { }
         } ]
       },
+      "metabase-enterprise.metabot-v3.tools.api.filtering-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "type" : "object",
+              "properties" : {
+                "query" : {
+                  "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Query"
+                },
+                "query_id" : {
+                  "type" : "string"
+                },
+                "result_columns" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.column"
+                  }
+                },
+                "type" : {
+                  "const" : "query"
+                }
+              },
+              "required" : [ "type", "query_id", "query", "result_columns" ]
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
+        } ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.find-metric-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "type" : "object",
+              "properties" : {
+                "default_time_dimension_field_id" : {
+                  "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.column"
+                },
+                "description" : {
+                  "type" : "string"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "queryable_dimensions" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.column"
+                  }
+                },
+                "type" : {
+                  "const" : "metric"
+                }
+              },
+              "required" : [ "id", "type", "name", "queryable_dimensions" ]
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
+        } ]
+      },
       "metabase-enterprise.metabot-v3.tools.api.find-outliers-arguments" : {
         "allOf" : [ {
           "type" : "object",
@@ -530,6 +879,97 @@ redirect_from:
           "properties" : { }
         } ]
       },
+      "metabase-enterprise.metabot-v3.tools.api.find-outliers-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "type" : "array",
+              "items" : {
+                "type" : "object",
+                "properties" : {
+                  "dimension" : { },
+                  "value" : {
+                    "anyOf" : [ {
+                      "type" : "integer"
+                    }, {
+                      "type" : "number"
+                    } ]
+                  }
+                },
+                "required" : [ "dimension", "value" ]
+              }
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
+        } ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.full-metric" : {
+        "type" : "object",
+        "properties" : {
+          "default_time_dimension_field_id" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "integer"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "queryable_dimensions" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.columns"
+          },
+          "type" : {
+            "const" : "metric"
+          }
+        },
+        "required" : [ "id", "type", "name" ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.full-table" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "fields" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.columns"
+          },
+          "id" : {
+            "type" : "integer"
+          },
+          "metrics" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.basic-metric"
+            }
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "queryable_foreign_key_tables" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.basic-table"
+            }
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "model", "table" ]
+          }
+        },
+        "required" : [ "id", "type", "name", "fields" ]
+      },
       "metabase-enterprise.metabot-v3.tools.api.generate-insights-arguments" : {
         "type" : "object",
         "properties" : {
@@ -572,6 +1012,74 @@ redirect_from:
         },
         "required" : [ "for" ]
       },
+      "metabase-enterprise.metabot-v3.tools.api.get-current-user-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "type" : "object",
+              "properties" : {
+                "email_address" : {
+                  "type" : "string"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "type" : {
+                  "const" : "user"
+                }
+              },
+              "required" : [ "id", "type", "name", "email_address" ]
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
+        } ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.get-dashboard-details-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "type" : "object",
+              "properties" : {
+                "description" : {
+                  "type" : "string"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "type" : {
+                  "const" : "dashboard"
+                }
+              },
+              "required" : [ "id", "type", "name" ]
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
+        } ]
+      },
       "metabase-enterprise.metabot-v3.tools.api.get-metric-details-arguments" : {
         "allOf" : [ {
           "type" : "object",
@@ -598,6 +1106,60 @@ redirect_from:
           "properties" : { }
         } ]
       },
+      "metabase-enterprise.metabot-v3.tools.api.get-metric-details-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.full-metric"
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
+        } ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.get-query-details-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "type" : "object",
+              "properties" : {
+                "query" : {
+                  "type" : "object",
+                  "properties" : { }
+                },
+                "query_id" : {
+                  "type" : "string"
+                },
+                "result_columns" : {
+                  "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.columns"
+                },
+                "type" : {
+                  "const" : "query"
+                }
+              },
+              "required" : [ "type", "query_id", "query", "result_columns" ]
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
+        } ]
+      },
       "metabase-enterprise.metabot-v3.tools.api.get-report-details-arguments" : {
         "allOf" : [ {
           "type" : "object",
@@ -618,6 +1180,43 @@ redirect_from:
         }, {
           "type" : "object",
           "properties" : { }
+        } ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.get-report-details-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "type" : "object",
+              "properties" : {
+                "description" : {
+                  "type" : "string"
+                },
+                "id" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "result_columns" : {
+                  "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.columns"
+                },
+                "type" : {
+                  "const" : "question"
+                }
+              },
+              "required" : [ "id", "type", "name", "result_columns" ]
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
         } ]
       },
       "metabase-enterprise.metabot-v3.tools.api.get-table-details-arguments" : {
@@ -654,6 +1253,25 @@ redirect_from:
         }, {
           "type" : "object",
           "properties" : { }
+        } ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.get-table-details-result" : {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "structured_output" : {
+              "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.full-table"
+            }
+          },
+          "required" : [ "structured_output" ]
+        }, {
+          "type" : "object",
+          "properties" : {
+            "output" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "output" ]
         } ]
       },
       "metabase-enterprise.metabot-v3.tools.api.group-by" : {
@@ -698,6 +1316,9 @@ redirect_from:
           "type" : "object",
           "properties" : { }
         } ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.proportion" : {
+        "type" : "number"
       },
       "metabase-enterprise.metabot-v3.tools.api.query-metric-arguments" : {
         "allOf" : [ {
@@ -781,6 +1402,59 @@ redirect_from:
           "type" : "object",
           "properties" : { }
         } ]
+      },
+      "metabase-enterprise.metabot-v3.tools.api.statistics" : {
+        "type" : "object",
+        "properties" : {
+          "values" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.field-values"
+          },
+          "min" : {
+            "type" : "number"
+          },
+          "percent_url" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.proportion"
+          },
+          "average_length" : {
+            "type" : "number"
+          },
+          "earliest" : {
+            "type" : "string"
+          },
+          "q1" : {
+            "type" : "number"
+          },
+          "max" : {
+            "type" : "number"
+          },
+          "distinct_count" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.count"
+          },
+          "percent_state" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.proportion"
+          },
+          "percent_null" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.proportion"
+          },
+          "avg" : {
+            "type" : "number"
+          },
+          "sd" : {
+            "type" : "number"
+          },
+          "percent_email" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.proportion"
+          },
+          "latest" : {
+            "type" : "string"
+          },
+          "q3" : {
+            "type" : "number"
+          },
+          "percent_json" : {
+            "$ref" : "#/components/schemas/metabase-enterprise.metabot-v3.tools.api.proportion"
+          }
+        }
       },
       "metabase-enterprise.metabot-v3.tools.api.string-filter" : {
         "allOf" : [ {
@@ -920,149 +1594,10 @@ redirect_from:
         },
         "required" : [ "conversation_id" ]
       },
-      "metabase.analyze.fingerprint.schema.Fingerprint" : {
-        "type" : "object",
-        "properties" : {
-          "experimental" : {
-            "type" : "object",
-            "properties" : { }
-          },
-          "global" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.GlobalFingerprint"
-          },
-          "type" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.TypeSpecificFingerprint"
-          }
-        }
-      },
-      "metabase.analyze.fingerprint.schema.GlobalFingerprint" : {
-        "type" : "object",
-        "properties" : {
-          "distinct-count" : {
-            "type" : "integer"
-          },
-          "nil%" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.Percent"
-          }
-        }
-      },
-      "metabase.analyze.fingerprint.schema.NumberFingerprint" : {
-        "type" : "object",
-        "properties" : {
-          "avg" : {
-            "type" : "number"
-          },
-          "max" : {
-            "type" : "number"
-          },
-          "min" : {
-            "type" : "number"
-          },
-          "q1" : {
-            "type" : "number"
-          },
-          "q3" : {
-            "type" : "number"
-          },
-          "sd" : {
-            "type" : "number"
-          }
-        }
-      },
-      "metabase.analyze.fingerprint.schema.Percent" : {
-        "type" : "number"
-      },
-      "metabase.analyze.fingerprint.schema.TemporalFingerprint" : {
-        "type" : "object",
-        "properties" : {
-          "earliest" : {
-            "type" : "string"
-          },
-          "latest" : {
-            "type" : "string"
-          }
-        }
-      },
-      "metabase.analyze.fingerprint.schema.TextFingerprint" : {
-        "type" : "object",
-        "properties" : {
-          "average-length" : {
-            "type" : "number"
-          },
-          "percent-email" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.Percent"
-          },
-          "percent-json" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.Percent"
-          },
-          "percent-state" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.Percent"
-          },
-          "percent-url" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.Percent"
-          }
-        }
-      },
-      "metabase.analyze.fingerprint.schema.TypeSpecificFingerprint" : {
-        "type" : "object",
-        "properties" : {
-          "type/DateTime" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.TemporalFingerprint"
-          },
-          "type/Number" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.NumberFingerprint"
-          },
-          "type/Text" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.TextFingerprint"
-          }
-        }
-      },
-      "metabase.analyze.query-results.MaybeUnnormalizedReference" : { },
-      "metabase.analyze.query-results.ResultColumnMetadata" : {
-        "type" : "object",
-        "properties" : {
-          "field_ref" : {
-            "$ref" : "#/components/schemas/metabase.analyze.query-results.MaybeUnnormalizedReference"
-          },
-          "fingerprint" : {
-            "$ref" : "#/components/schemas/metabase.analyze.fingerprint.schema.Fingerprint"
-          },
-          "base_type" : {
-            "description" : "value must be a valid field data type (keyword or string)."
-          },
-          "id" : {
-            "$ref" : "#/components/schemas/metabase.lib.schema.id.field"
-          },
-          "name" : {
-            "type" : "string"
-          },
-          "semantic_type" : {
-            "description" : "value must be a valid field semantic or relation type (keyword or string)."
-          },
-          "display_name" : {
-            "type" : "string"
-          },
-          "converted_timezone" : {
-            "$ref" : "#/components/schemas/metabase.lib.schema.expression.temporal.timezone-id"
-          },
-          "unit" : {
-            "description" : "value must be a keyword or string.",
-            "anyOf" : [ {
-              "type" : "string"
-            }, {
-              "type" : "string"
-            } ]
-          },
-          "description" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "name", "display_name", "base_type" ]
-      },
       "metabase.analyze.query-results.ResultsMetadata" : {
         "type" : "array",
         "items" : {
-          "$ref" : "#/components/schemas/metabase.analyze.query-results.ResultColumnMetadata"
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.legacy-column-metadata"
         },
         "description" : "value must be an array of valid results column metadata maps.",
         "optional" : true
@@ -1252,9 +1787,1685 @@ redirect_from:
           "required" : [ "type", "subject", "body" ]
         } ]
       },
+      "metabase.collections.api.DashboardQuestionCandidate" : {
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "integer",
+            "minimum" : 1
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "sole_dashboard_info" : {
+            "type" : "object",
+            "properties" : {
+              "description" : {
+                "type" : "string"
+              },
+              "id" : {
+                "type" : "integer",
+                "minimum" : 1
+              },
+              "name" : {
+                "type" : "string"
+              }
+            },
+            "required" : [ "id", "name" ]
+          }
+        },
+        "required" : [ "id", "name", "sole_dashboard_info" ]
+      },
+      "metabase.collections.api.DashboardQuestionCandidatesResponse" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/metabase.collections.api.DashboardQuestionCandidate"
+            }
+          },
+          "total" : {
+            "type" : "integer"
+          }
+        },
+        "required" : [ "data", "total" ]
+      },
+      "metabase.collections.api.MoveDashboardQuestionCandidatesResponse" : {
+        "type" : "object",
+        "properties" : {
+          "moved" : {
+            "type" : "array",
+            "items" : {
+              "description" : "value must be an integer greater than zero.",
+              "type" : "integer",
+              "minimum" : 1
+            }
+          }
+        },
+        "required" : [ "moved" ]
+      },
+      "metabase.legacy-mbql.schema.!=" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.*" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.+" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.-" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema./" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.<" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.<=" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.=" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.>" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.>=" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.Addable" : {
+        "anyOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DateTimeExpressionArg"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.interval"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.NumericExpressionArg"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.Aggregation" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.aggregation-options"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.UnnamedAggregation"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.BooleanExpression" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.and"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.or"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.not"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.="
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.!="
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.<"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.>"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.<="
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.>="
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.between"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.starts-with"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.ends-with"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.contains"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.in"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.not-in"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.does-not-contain"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.inside"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.is-empty"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.not-empty"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.is-null"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.not-null"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.relative-time-interval"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.time-interval"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.during"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.Constraints" : {
+        "description" : "Additional constraints added to a query limiting the maximum number of rows that can be returned. Mostly useful\n  because native queries don't support the MBQL `:limit` clause. For MBQL queries, if `:limit` is set, it will\n  override these values.",
+        "type" : "object",
+        "properties" : {
+          "max-results" : {
+            "description" : "Maximum number of results to allow for a query with aggregations. If `max-results-bare-rows` is unset, this\n  applies to all queries",
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.int-greater-than-or-equal-to-zero"
+          },
+          "max-results-bare-rows" : {
+            "description" : "Maximum number of results to allow for a query with no aggregations. If set, this should be LOWER than\n  `:max-results`.",
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.int-greater-than-or-equal-to-zero"
+          }
+        }
+      },
+      "metabase.legacy-mbql.schema.DatabaseID" : {
+        "description" : "Schema for a valid `:database` ID, in the top-level 'outer' query. Either a positive integer (referring to an\n  actual Database), or the saved questions virtual ID, which is a placeholder used for queries using the\n  `:source-table \"card__id\"` shorthand for a source query resolved by middleware (since clients might not know the\n  actual DB for that source query.)",
+        "anyOf" : [ {
+          "$ref" : "#/components/schemas/metabase.lib.schema.id.saved-questions-virtual-database"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.id.database"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.DateOrDatetimeLiteral" : {
+        "description" : "Schema for a valid date or datetime literal.",
+        "anyOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.relative-datetime"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.absolute-datetime"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.literal.datetime"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.literal.date"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.DateTimeExpressionArg" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Aggregation"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.value"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DatetimeExpression"
+        }, {
+          "anyOf" : [ {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DateOrDatetimeLiteral"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+          } ]
+        } ]
+      },
+      "metabase.legacy-mbql.schema.DateTimeUnit" : {
+        "description" : "Valid unit for *datetime* bucketing.",
+        "type" : "string",
+        "enum" : [ "quarter", "day", "hour", "week", "second", "default", "day-of-week", "hour-of-day", "month", "month-of-year", "day-of-month", "year", "day-of-year", "millisecond", "year-of-era", "week-of-year", "quarter-of-year", "minute-of-hour", "minute" ]
+      },
+      "metabase.legacy-mbql.schema.DateUnit" : {
+        "description" : "Valid unit for date bucketing.",
+        "type" : "string",
+        "enum" : [ "quarter", "day", "week", "default", "day-of-week", "month", "month-of-year", "day-of-month", "year", "day-of-year", "year-of-era", "week-of-year", "quarter-of-year" ]
+      },
+      "metabase.legacy-mbql.schema.DatetimeDiffUnit" : {
+        "description" : "Valid units for a datetime-diff clause.",
+        "type" : "string",
+        "enum" : [ "second", "minute", "hour", "day", "week", "month", "quarter", "year" ]
+      },
+      "metabase.legacy-mbql.schema.DatetimeExpression" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.+"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.datetime-add"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.datetime-subtract"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.convert-timezone"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.now"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.date"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.datetime"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.today"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.EqualityComparable" : {
+        "anyOf" : [ {
+          "type" : "boolean"
+        }, {
+          "type" : "number"
+        }, {
+          "type" : "string"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TemporalLiteral"
+        }, {
+          "oneOf" : [ {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.relative-datetime"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+          } ]
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.ExpressionArg"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.value"
+        } ],
+        "optional" : true
+      },
+      "metabase.legacy-mbql.schema.ExpressionArg" : {
+        "oneOf" : [ {
+          "type" : "number"
+        }, {
+          "type" : "boolean"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.BooleanExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.NumericExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DatetimeExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Aggregation"
+        }, {
+          "type" : "string"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.StringExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.value"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.ExtractWeekMode" : {
+        "description" : "Valid modes to extract weeks.",
+        "type" : "string",
+        "enum" : [ "iso", "us", "instance" ]
+      },
+      "metabase.legacy-mbql.schema.FieldOptions" : {
+        "allOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "base-type" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.base-type"
+            },
+            "binning" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.binning.binning",
+              "description" : "Replaces `binning-strategy`.\n\n  Using binning requires the driver to support the `:binning` feature."
+            },
+            "inherited-temporal-unit" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DateTimeUnit"
+            },
+            "join-alias" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.join.alias",
+              "description" : "Replaces `joined-field`.\n\n  `:join-alias` is used to refer to a FieldOrExpression from a different Table/nested query that you are EXPLICITLY\n  JOINING against."
+            },
+            "source-field" : {
+              "description" : "Replaces `fk->`.\n\n  `:source-field` is used to refer to a FieldOrExpression from a different Table you would like IMPLICITLY JOINED to\n     the source table.\n\n  If both `:source-field` and `:join-alias` are supplied, `:join-alias` should be used to perform the join;\n  `:source-field` should be for information purposes only.",
+              "$ref" : "#/components/schemas/metabase.lib.schema.id.field"
+            },
+            "source-field-join-alias" : {
+              "description" : "The join alias of the source field used for an implicit join.",
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+            },
+            "source-field-name" : {
+              "description" : "The name or desired alias of the field used for an implicit join.",
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+            },
+            "temporal-unit" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DateTimeUnit",
+              "description" : "`:temporal-unit` is used to specify DATE BUCKETING for a FieldOrExpression that represents a moment in time of\n  some sort.\n\n  There is no requirement that all `:type/Temporal` derived FieldOrExpressions specify a `:temporal-unit`, but for\n  legacy reasons `:field` clauses that refer to `:type/DateTime` FieldOrExpressions will be automatically \"bucketed\"\n  in the `:breakout` and `:filter` clauses, but nowhere else. Auto-bucketing only applies to `:filter` clauses when\n  values for comparison are `yyyy-MM-dd` date strings. See the `auto-bucket-datetimes` middleware for more details.\n  `:field` clauses elsewhere will not be automatically bucketed, so drivers still need to make sure they do any\n  special datetime handling for plain `:field` clauses when their FieldOrExpression derives from `:type/DateTime`."
+            }
+          }
+        }, {
+          "description" : "If `:base-type` is specified, the `:temporal-unit` must make sense, e.g. no bucketing by `:year`for\n  a `:type/Time` column.",
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.validate-temporal-unit"
+        }, {
+          "description" : "You cannot use `:binning` keys like `:strategy` in the top level.",
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.no-binning-options-at-top-level"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.FieldOrExpressionDef" : {
+        "description" : "Schema for anything that is accepted as a top-level expression definition, either an arithmetic expression such as a\n  `:+` clause or a `:field` or `:value` clause.",
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.NumericExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.StringExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.BooleanExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DatetimeExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.case"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.case:if"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.offset"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.value"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.Fields" : {
+        "allOf" : [ {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+          },
+          "minItems" : 1
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.helpers.distinct"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.Filter" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DatetimeExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.NumericExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.StringExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.BooleanExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.value"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.segment"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.Ident" : {
+        "description" : "Unique identifier string for new `:column` refs. The new refs aren't used in legacy MBQL (currently) but the\n  idents for column-introducing new clauses (joins, aggregations, breakouts, expressions) are randomly generated when\n  the clauses are created, so the idents must be preserved in legacy MBQL.\n\n  These are opaque strings under the initial design; I've made them a separate schema for documentation and\n  future-proofing.",
+        "anyOf" : [ {
+          "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+        }, {
+          "type" : "string"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.IntGreaterThanZeroOrNumericExpression" : {
+        "oneOf" : [ {
+          "description" : "Must be a positive integer.",
+          "type" : "integer",
+          "minimum" : 1
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.NumericExpression"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.Join" : {
+        "description" : "Perform the equivalent of a SQL `JOIN` with another Table or nested `:source-query`. JOINs are either explicitly\n  specified in the incoming query, or implicitly generated when one uses a `:field` clause with `:source-field`.\n\n  In the top-level query, you can reference Fields from the joined table or nested query by including `:source-field`\n  in the `:field` options (known as implicit joins); for explicit joins, you *must* specify `:join-alias` yourself; in\n  the `:field` options, e.g.\n\n    ;; for joins against other Tables/MBQL source queries\n    [:field 1 {:join-alias \"my_join_alias\"}]\n\n    ;; for joins against native queries\n    [:field \"my_field\" {:base-type :field/Integer, :join-alias \"my_join_alias\"}]",
+        "type" : "object",
+        "properties" : {
+          "ident" : {
+            "description" : "An opaque string used as a unique identifier for this join clause, even if it evolves. This string is randomly\n      generated when a join clause is created, so it can never be confused with another join of the same table.",
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Ident"
+          },
+          "strategy" : {
+            "description" : "Defaults to `:left-join`; used for all automatically-generated JOINs\n\n  Driver implementations: this is guaranteed to be present after pre-processing.",
+            "type" : "string",
+            "enum" : [ "full-join", "right-join", "left-join", "inner-join" ]
+          },
+          "source-metadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.legacy-column-metadata"
+            },
+            "description" : "Metadata about the source query being used, if pulled in from a Card via the\n  `:source-table \"card__id\"` syntax. added automatically by the `resolve-card-id-source-tables` middleware."
+          },
+          "condition" : {
+            "description" : "The condition on which to JOIN. Can be anything that is a valid `:filter` clause. For automatically-generated\n  JOINs this is usually something like\n\n    [:= <source-table-fk-field> [:field <dest-table-pk-field> {:join-alias <join-table-alias>}]]",
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Filter"
+          },
+          "source-query" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.SourceQuery"
+          },
+          "fk-field-id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.id.field",
+            "description" : "Mostly used only internally. When a join is implicitly generated via a `:field` clause with\n  `:source-field`, the ID of the foreign key field in the source Table will be recorded here. This information is used\n  to add `fk_field_id` information to the `:cols` in the query results, and also for drill-thru. When generating\n  explicit joins by hand you can usually omit this information, altho it doesn't hurt to include it if you know it.\n\n  Don't set this information yourself. It will have no effect."
+          },
+          "fields" : {
+            "description" : "The Fields from this join to include in parent-level results. This can be either `:none`, `:all`, or a sequence\n  of `:field` clauses.\n\n  * `:none`: no Fields from the joined table or nested query are included (unless indirectly included by breakouts or\n     other clauses). This is the default, and what is used for automatically-generated joins.\n\n  * `:all`: will include all of the Field from the joined table or query\n\n  * a sequence of Field clauses: include only the Fields specified. Valid clauses are the same as the top-level\n    `:fields` clause. This should be non-empty and all elements should be distinct. The normalizer will automatically\n    remove duplicate fields for you, and replace empty clauses with `:none`.\n\n  Driver implementations: you can ignore this clause. Relevant fields will be added to top-level `:fields` clause with\n  appropriate aliases.",
+            "anyOf" : [ {
+              "type" : "string",
+              "enum" : [ "all", "none" ]
+            }, {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Fields"
+            } ]
+          },
+          "source-table" : {
+            "description" : "*What* to JOIN. Self-joins can be done by using the same `:source-table` as in the query where\n  this is specified. YOU MUST SUPPLY EITHER `:source-table` OR `:source-query`, BUT NOT BOTH!",
+            "anyOf" : [ {
+              "$ref" : "#/components/schemas/metabase.lib.schema.id.table"
+            }, {
+              "description" : "`card__<id>` string Table ID",
+              "type" : "string",
+              "pattern" : "^card__[1-9]\\d*$"
+            } ]
+          },
+          "alias" : {
+            "description" : "The name used to alias the joined table or query. This is usually generated automatically and generally looks\n  like `table__via__field`. You can specify this yourself if you need to reference a joined field with a `:join-alias`\n  in the options.\n\n  Driver implementations: This is guaranteed to be present after pre-processing.",
+            "$ref" : "#/components/schemas/metabase.lib.schema.join.alias"
+          }
+        },
+        "required" : [ "condition" ]
+      },
+      "metabase.legacy-mbql.schema.Joins" : {
+        "description" : "Schema for a valid sequence of `Join`s. Must be a non-empty sequence, and `:alias`, if specified, must be unique.",
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Join"
+        },
+        "minItems" : 1
+      },
+      "metabase.legacy-mbql.schema.MBQLQuery" : {
+        "type" : "object",
+        "properties" : {
+          "breakout" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+            },
+            "minItems" : 1
+          },
+          "source-metadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.legacy-column-metadata"
+            },
+            "description" : "Info about the columns of the source query. Added in automatically by middleware. This metadata is\n  primarily used to let power things like binning when used with Field Literals instead of normal Fields."
+          },
+          "source-query" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.SourceQuery"
+          },
+          "limit" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.int-greater-than-or-equal-to-zero"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Filter"
+          },
+          "joins" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Joins"
+          },
+          "aggregation" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Aggregation"
+            },
+            "minItems" : 1
+          },
+          "fields" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Fields"
+          },
+          "source-table" : {
+            "anyOf" : [ {
+              "$ref" : "#/components/schemas/metabase.lib.schema.id.table"
+            }, {
+              "description" : "`card__<id>` string Table ID",
+              "type" : "string",
+              "pattern" : "^card__[1-9]\\d*$"
+            } ]
+          },
+          "order-by" : {
+            "allOf" : [ {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.OrderBy"
+              },
+              "minItems" : 1
+            }, {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.helpers.distinct"
+            } ]
+          },
+          "page" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Page"
+          },
+          "expressions" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.FieldOrExpressionDef"
+            }
+          }
+        }
+      },
+      "metabase.legacy-mbql.schema.MiddlewareOptions" : {
+        "description" : "Additional options that can be used to toggle middleware on or off.",
+        "type" : "object",
+        "properties" : {
+          "add-default-userland-constraints?" : {
+            "type" : "boolean",
+            "description" : "Whether to add some default `max-results` and `max-results-bare-rows` constraints. By default, none are added,\n  although the functions that ultimately power most API endpoints tend to set this to `true`. See\n  `add-constraints` middleware for more details."
+          },
+          "disable-max-results?" : {
+            "description" : "Disable applying a default limit on the query results. Handled in the `add-default-limit` middleware. If true,\n  this will override the `:max-results` and `:max-results-bare-rows` values in `Constraints`.",
+            "type" : "boolean"
+          },
+          "disable-mbql->native?" : {
+            "description" : "Disable the MBQL->native middleware. If you do this, the query will not work at all, so there are no cases where\n  you should set this yourself. This is only used by the `metabase.query-processor.preprocess/preprocess` function to\n  get the fully pre-processed query without attempting to convert it to native.",
+            "type" : "boolean"
+          },
+          "format-rows?" : {
+            "description" : "Should we skip converting datetime types to ISO-8601 strings with appropriate timezone when post-processing\n     results? Used by `metabase.query-processor.middleware.format-rows`default `false`.",
+            "type" : "boolean"
+          },
+          "process-viz-settings?" : {
+            "type" : "boolean",
+            "description" : "Whether to process a question's visualization settings and include them in the result metadata so that they can\n  incorporated into an export. Used by `metabase.query-processor.middleware.visualization-settings`; default\n  `false`."
+          },
+          "skip-results-metadata?" : {
+            "description" : "Should we skip adding `results_metadata` to query results after running the query? Used by\n     `metabase.query-processor.middleware.results-metadata`; default `false`. (Note: we may change the name of this\n     column in the near future, to `result_metadata`, to fix inconsistencies in how we name things.)",
+            "type" : "boolean"
+          },
+          "userland-query?" : {
+            "type" : "boolean",
+            "description" : "Userland queries are ones ran as a result of an API call, Pulse, or the like. Special handling is done in\n  certain userland-only middleware for such queries -- results are returned in a slightly different format, and\n  QueryExecution entries are normally saved, unless you pass `:no-save` as the option."
+          }
+        }
+      },
+      "metabase.legacy-mbql.schema.NativeSourceQuery" : {
+        "type" : "object",
+        "properties" : {
+          "collection" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "native" : { },
+          "template-tags" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TemplateTagMap"
+          }
+        },
+        "required" : [ "native" ]
+      },
+      "metabase.legacy-mbql.schema.NumericExpression" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.+"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.-"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.~1"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.*"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.coalesce"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.length"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.floor"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.ceil"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.round"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.abs"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.power"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.sqrt"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.exp"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.log"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.case"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.case:if"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.datetime-diff"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.integer"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.float"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.temporal-extract"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.get-year"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.get-quarter"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.get-month"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.get-week"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.get-day"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.get-day-of-week"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.get-hour"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.get-minute"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.get-second"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.aggregation"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.NumericExpressionArg" : {
+        "oneOf" : [ {
+          "type" : "number"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.NumericExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Aggregation"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.value"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Reference"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.OrderBy" : {
+        "description" : "Schema for an `order-by` clause subclause.",
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.asc"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.desc"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.OrderComparable" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.value"
+        }, {
+          "anyOf" : [ {
+            "type" : "number"
+          }, {
+            "type" : "string"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TemporalLiteral"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.ExpressionArg"
+          }, {
+            "oneOf" : [ {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.relative-datetime"
+            }, {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+            } ]
+          } ]
+        } ]
+      },
+      "metabase.legacy-mbql.schema.Page" : {
+        "description" : "`page` = page num, starting with 1. `items` = number of items per page.\n  e.g.\n\n    {:page 1, :items 10} = items 1-10\n    {:page 2, :items 10} = items 11-20",
+        "type" : "object",
+        "properties" : {
+          "items" : {
+            "description" : "Must be a positive integer.",
+            "type" : "integer",
+            "minimum" : 1
+          },
+          "page" : {
+            "description" : "Must be a positive integer.",
+            "type" : "integer",
+            "minimum" : 1
+          }
+        },
+        "required" : [ "page", "items" ]
+      },
+      "metabase.legacy-mbql.schema.Parameter" : {
+        "description" : "Schema for the *value* of a parameter (e.g. a Dashboard parameter or a native query template tag) as passed in as\n  part of the `:parameters` list in a query.",
+        "type" : "object",
+        "properties" : {
+          "default" : { },
+          "id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "required" : { },
+          "slug" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "target" : {
+            "oneOf" : [ {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+              }, {
+                "oneOf" : [ {
+                  "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.dimension"
+                }, {
+                  "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.variable"
+                } ]
+              } ]
+            }, {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+              }, {
+                "oneOf" : [ {
+                  "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.dimension"
+                }, {
+                  "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.variable"
+                } ]
+              } ]
+            }, {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+              }, {
+                "oneOf" : [ {
+                  "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.dimension"
+                }, {
+                  "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.variable"
+                } ]
+              } ]
+            } ]
+          },
+          "type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.parameter.type"
+          },
+          "value" : { }
+        },
+        "required" : [ "type" ]
+      },
+      "metabase.legacy-mbql.schema.ParameterList" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Parameter"
+        },
+        "optional" : true
+      },
+      "metabase.legacy-mbql.schema.Query" : {
+        "allOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "update-row" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.actions.row"
+            },
+            "settings" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Settings"
+            },
+            "constraints" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Constraints"
+            },
+            "query" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.MBQLQuery"
+            },
+            "native" : {
+              "type" : "object",
+              "properties" : {
+                "collection" : {
+                  "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+                },
+                "query" : { },
+                "template-tags" : {
+                  "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TemplateTagMap"
+                }
+              },
+              "required" : [ "query" ]
+            },
+            "info" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.info.info",
+              "description" : "Used when recording info about this run in the QueryExecution log; things like context query was\n  ran in and User who ran it."
+            },
+            "middleware" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.MiddlewareOptions"
+            },
+            "database" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DatabaseID"
+            },
+            "type" : {
+              "description" : "Type of query. `:query` = MBQL; `:native` = native.",
+              "type" : "string",
+              "enum" : [ "query", "native" ]
+            },
+            "parameters" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.ParameterList"
+            },
+            "create-row" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.actions.row"
+            }
+          },
+          "required" : [ "type" ]
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.check-keys-for-query-type"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.check-query-does-not-have-source-metadata"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.Reference" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.aggregation"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.expression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.RelativeDatetimeUnit" : {
+        "type" : "string",
+        "enum" : [ "default", "minute", "hour", "day", "week", "month", "quarter", "year" ]
+      },
+      "metabase.legacy-mbql.schema.Settings" : {
+        "description" : "Options that tweak the behavior of the query processor.",
+        "type" : "object",
+        "properties" : {
+          "report-timezone" : {
+            "description" : "The timezone the query should be ran in, overriding the default report timezone for the instance.",
+            "$ref" : "#/components/schemas/metabase.lib.schema.expression.temporal.timezone-id"
+          }
+        }
+      },
+      "metabase.legacy-mbql.schema.SourceQuery" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.NativeSourceQuery"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.MBQLQuery"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.StringExpression" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.substring"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.trim"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.ltrim"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.rtrim"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.replace"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.lower"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.upper"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.concat"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.regex-match-first"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.coalesce"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.case"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.case:if"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.host"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.domain"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.subdomain"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.path"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.month-name"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.quarter-name"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.day-name"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.text"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.split-part"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.StringExpressionArg" : {
+        "oneOf" : [ {
+          "type" : "string"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.StringExpression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.value"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field-or-expression-ref"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.TemplateTag" : {
+        "description" : "Schema for a template tag as specified in a native query. There are four types of template tags, differentiated by\n  `:type`.\n\n  Template tags are used to specify {{placeholders}} in native queries that are replaced with some sort of value when\n  the query itself runs. There are four basic types of template tag for native queries:\n\n  1. Field filters, which are used like\n\n         SELECT * FROM table WHERE {{field_filter}}\n\n     These reference specific Fields and are replaced with entire conditions, e.g. `some_field > 1000`\n\n  2. Raw values, which are used like\n\n         SELECT * FROM table WHERE my_field = {{x}}\n\n     These are replaced with raw values.\n\n   3. Native query snippets, which might be used like\n\n          SELECT * FROM ({{snippet: orders}}) source\n\n      These are replaced with `NativeQuerySnippet`s from the application database.\n\n   4. Source query Card IDs, which are used like\n\n          SELECT * FROM ({{#123}}) source\n\n      These are replaced with the query from the Card with that ID.\n\n  Field filters and raw values usually have their value specified by `:parameters`.",
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TemplateTag:FieldFilter"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TemplateTag:Snippet"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TemplateTag:SourceQuery"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TemplateTag:TemporalUnit"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TemplateTag:RawValue"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.TemplateTag:FieldFilter" : {
+        "description" : "Schema for a field filter template tag.",
+        "type" : "object",
+        "properties" : {
+          "display-name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "required" : {
+            "type" : "boolean"
+          },
+          "type" : {
+            "const" : "dimension"
+          },
+          "alias" : {
+            "type" : "string"
+          },
+          "options" : {
+            "type" : "object",
+            "additionalProperties" : { },
+            "description" : "optional map to be appended to filter clause"
+          },
+          "dimension" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field"
+          },
+          "default" : { },
+          "widget-type" : {
+            "description" : "which type of widget the frontend should show for this Field Filter; this also affects which parameter types\n  are allowed to be specified for it.",
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.WidgetType"
+          }
+        },
+        "required" : [ "type", "name", "display-name", "dimension", "widget-type" ]
+      },
+      "metabase.legacy-mbql.schema.TemplateTag:RawValue" : {
+        "description" : "Schema for a raw value template tag.",
+        "type" : "object",
+        "properties" : {
+          "default" : { },
+          "display-name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "required" : {
+            "type" : "boolean"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "date", "number", "boolean", "text" ]
+          }
+        },
+        "required" : [ "type", "name", "display-name" ]
+      },
+      "metabase.legacy-mbql.schema.TemplateTag:Snippet" : {
+        "description" : "Schema for a native query snippet template tag.",
+        "type" : "object",
+        "properties" : {
+          "database" : {
+            "description" : "Must be a positive integer.",
+            "type" : "integer",
+            "minimum" : 1
+          },
+          "display-name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "snippet-id" : {
+            "description" : "Must be a positive integer.",
+            "type" : "integer",
+            "minimum" : 1
+          },
+          "snippet-name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "type" : {
+            "const" : "snippet"
+          }
+        },
+        "required" : [ "type", "name", "display-name", "snippet-name", "snippet-id" ]
+      },
+      "metabase.legacy-mbql.schema.TemplateTag:SourceQuery" : {
+        "description" : "Schema for a source query template tag.",
+        "type" : "object",
+        "properties" : {
+          "card-id" : {
+            "description" : "Must be a positive integer.",
+            "type" : "integer",
+            "minimum" : 1
+          },
+          "display-name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "type" : {
+            "const" : "card"
+          }
+        },
+        "required" : [ "type", "name", "display-name", "card-id" ]
+      },
+      "metabase.legacy-mbql.schema.TemplateTag:TemporalUnit" : {
+        "description" : "Schema for a temporal unit template tag.",
+        "type" : "object",
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "default" : { },
+          "dimension" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field"
+          },
+          "display-name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "required" : {
+            "type" : "boolean"
+          },
+          "type" : {
+            "const" : "temporal-unit"
+          }
+        },
+        "required" : [ "type", "name", "display-name", "dimension" ]
+      },
+      "metabase.legacy-mbql.schema.TemplateTagMap" : {
+        "description" : "Schema for the `:template-tags` map passed in as part of a native query.\n\n  Map of template tag name -> template tag definition",
+        "type" : "object",
+        "additionalProperties" : {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TemplateTag"
+        }
+      },
+      "metabase.legacy-mbql.schema.TemporalExtractUnit" : {
+        "description" : "Valid units to extract from a temporal.",
+        "type" : "string",
+        "enum" : [ "year-of-era", "quarter-of-year", "month-of-year", "week-of-year-iso", "week-of-year-us", "week-of-year-instance", "day-of-month", "day-of-week", "day-of-week-iso", "hour-of-day", "minute-of-hour", "second-of-minute" ]
+      },
+      "metabase.legacy-mbql.schema.TemporalLiteral" : {
+        "description" : "Schema for valid temporal literals.",
+        "anyOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DateOrDatetimeLiteral"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.TimeLiteral"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.TimeLiteral" : {
+        "description" : "Schema for valid time literals.",
+        "anyOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.time"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.literal.time"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.TimeUnit" : {
+        "description" : "Valid unit for time bucketing.",
+        "type" : "string",
+        "enum" : [ "hour", "second", "default", "hour-of-day", "millisecond", "minute-of-hour", "minute" ]
+      },
+      "metabase.legacy-mbql.schema.UnnamedAggregation" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.NumericExpression"
+        }, {
+          "oneOf" : [ {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.aggregation"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.avg"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.cum-sum"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.distinct"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.distinct-where"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.stddev"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.sum"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.min"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.max"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.metric"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.share"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.count-where"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.sum-where"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.case"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.case:if"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.median"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.percentile"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.ag:var"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.cum-count"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.count"
+          }, {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.offset"
+          } ]
+        } ]
+      },
+      "metabase.legacy-mbql.schema.ValueTypeInfo" : {
+        "description" : "Type info about a value in a `:value` clause. Added automatically by `wrap-value-literals` middleware to values in filter clauses based on the Field in the clause.",
+        "type" : "object",
+        "properties" : {
+          "base_type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.base-type"
+          },
+          "database_type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "semantic_type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.semantic-or-relation-type"
+          },
+          "unit" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.DateTimeUnit"
+          }
+        }
+      },
+      "metabase.legacy-mbql.schema.WidgetType" : {
+        "description" : "Schema for valid values of `:widget-type` for a [[::TemplateTag:FieldFilter]].",
+        "$ref" : "#/components/schemas/metabase.lib.schema.parameter.widget-type"
+      },
+      "metabase.legacy-mbql.schema.abs" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.absolute-datetime" : {
+        "oneOf" : [ { }, {
+          "allOf" : [ ]
+        }, {
+          "allOf" : [ ]
+        } ]
+      },
+      "metabase.legacy-mbql.schema.ag:var" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.aggregation" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.aggregation-options" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.and" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.asc" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.avg" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.between" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.case" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.case:if" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.ceil" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.check-keys-for-query-type" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.check-query-does-not-have-source-metadata" : {
+        "description" : "`:source-metadata` is added to queries when `card__id` source queries are resolved. It contains info about the\n  columns in the source query.\n\n  Where this is added was changed in Metabase 0.33.0 -- previously, when `card__id` source queries were resolved, the\n  middleware would add `:source-metadata` to the top-level; to support joins against source queries, this has been\n  changed so it is always added at the same level the resolved `:source-query` is added.\n\n  This should automatically be fixed by `normalize`; if we encounter it, it means some middleware is not functioning\n  properly."
+      },
+      "metabase.legacy-mbql.schema.coalesce" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.concat" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.contains" : {
+        "anyOf" : [ {
+          "allOf" : [ ]
+        }, {
+          "allOf" : [ ]
+        } ]
+      },
+      "metabase.legacy-mbql.schema.convert-timezone" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.count" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.count-where" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.cum-count" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.cum-sum" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.date" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.datetime" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.datetime-add" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.datetime-diff" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.datetime-subtract" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.day-name" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.desc" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.dimension" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.distinct" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.distinct-where" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.does-not-contain" : {
+        "anyOf" : [ {
+          "allOf" : [ ]
+        }, {
+          "allOf" : [ ]
+        } ]
+      },
+      "metabase.legacy-mbql.schema.domain" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.during" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.ends-with" : {
+        "anyOf" : [ {
+          "allOf" : [ ]
+        }, {
+          "allOf" : [ ]
+        } ]
+      },
+      "metabase.legacy-mbql.schema.exp" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.expression" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.field" : {
+        "allOf" : [ {
+          "allOf" : [ ]
+        }, {
+          "description" : "Fields using names rather than integer IDs are required to specify `:base-type`.",
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.require-base-type-for-field-name"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.field-or-expression-ref" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.expression"
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field"
+        } ]
+      },
+      "metabase.legacy-mbql.schema.float" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.floor" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.get-day" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.get-day-of-week" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.get-hour" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.get-minute" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.get-month" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.get-quarter" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.get-second" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.get-week" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.get-year" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.helpers.distinct" : {
+        "description" : "values must be distinct"
+      },
+      "metabase.legacy-mbql.schema.host" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.in" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.inside" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.integer" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.interval" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.is-empty" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.is-null" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.legacy-column-metadata" : {
+        "description" : "Schema for a single legacy metadata column. This is the pre-Lib equivalent of\n  `:metabase.lib.schema.metadata/column`.",
+        "type" : "object",
+        "properties" : {
+          "field_ref" : {
+            "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Reference"
+          },
+          "fingerprint" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint.fingerprint"
+          },
+          "visibility_type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.visibility-type"
+          },
+          "base_type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.base-type"
+          },
+          "id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.id.field"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "semantic_type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.semantic-or-relation-type"
+          },
+          "display_name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "converted_timezone" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.expression.temporal.timezone-id"
+          },
+          "source" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.legacy-source"
+          },
+          "effective_type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.base-type"
+          },
+          "unit" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.temporal-bucketing.unit"
+          }
+        },
+        "required" : [ "base_type", "display_name", "name" ]
+      },
+      "metabase.legacy-mbql.schema.length" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.log" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.lower" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.ltrim" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.max" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.median" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.metric" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.min" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.month-name" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.no-binning-options-at-top-level" : { },
+      "metabase.legacy-mbql.schema.not" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.not-empty" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.not-in" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.not-null" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.now" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.offset" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.or" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.path" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.percentile" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.power" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.quarter-name" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.regex-match-first" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.relative-datetime" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.relative-time-interval" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.replace" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.require-base-type-for-field-name" : { },
+      "metabase.legacy-mbql.schema.round" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.rtrim" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.segment" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.share" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.split-part" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.sqrt" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.starts-with" : {
+        "anyOf" : [ {
+          "allOf" : [ ]
+        }, {
+          "allOf" : [ ]
+        } ]
+      },
+      "metabase.legacy-mbql.schema.stddev" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.subdomain" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.substring" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.sum" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.sum-where" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.template-tag" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.temporal-extract" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.text" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.time" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.time-interval" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.today" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.trim" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.upper" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.validate-temporal-unit" : { },
+      "metabase.legacy-mbql.schema.value" : {
+        "allOf" : [ ]
+      },
+      "metabase.legacy-mbql.schema.variable" : {
+        "allOf" : [ ]
+      },
+      "metabase.lib.schema.actions.row" : {
+        "type" : "object",
+        "additionalProperties" : { }
+      },
+      "metabase.lib.schema.binning.bin-width" : {
+        "description" : "Bin width (size of each bin).",
+        "$ref" : "#/components/schemas/metabase.lib.schema.common.positive-number"
+      },
+      "metabase.lib.schema.binning.binning" : {
+        "description" : "Schema for `:binning` options passed to a `:field` clause.",
+        "allOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "strategy" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.binning.strategy"
+            }
+          },
+          "required" : [ "strategy" ]
+        }, {
+          "oneOf" : [ {
+            "type" : "object",
+            "properties" : {
+              "strategy" : {
+                "const" : "default"
+              }
+            },
+            "required" : [ "strategy" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "bin-width" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.binning.bin-width"
+              },
+              "strategy" : {
+                "const" : "bin-width"
+              }
+            },
+            "required" : [ "strategy", "bin-width" ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "num-bins" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.binning.num-bins"
+              },
+              "strategy" : {
+                "const" : "num-bins"
+              }
+            },
+            "required" : [ "strategy", "num-bins" ]
+          } ]
+        } ]
+      },
+      "metabase.lib.schema.binning.num-bins" : {
+        "description" : "Number of bins to use.",
+        "type" : "integer",
+        "minimum" : 1
+      },
+      "metabase.lib.schema.binning.strategy" : {
+        "type" : "string",
+        "enum" : [ "bin-width", "default", "num-bins" ]
+      },
+      "metabase.lib.schema.common.base-type" : {
+        "type" : "string"
+      },
+      "metabase.lib.schema.common.int-greater-than-or-equal-to-zero" : {
+        "description" : "Schema representing an integer than must also be greater than or equal to zero.",
+        "type" : "integer",
+        "minimum" : 0
+      },
       "metabase.lib.schema.common.non-blank-string" : {
         "type" : "string",
         "minLength" : 1
+      },
+      "metabase.lib.schema.common.options" : {
+        "default" : { },
+        "type" : "object",
+        "properties" : {
+          "base-type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.base-type"
+          },
+          "database-type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "display-name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "effective-type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.base-type"
+          },
+          "lib/uuid" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.uuid"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "semantic-type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.semantic-or-relation-type"
+          }
+        },
+        "required" : [ "lib/uuid" ]
+      },
+      "metabase.lib.schema.common.positive-number" : { },
+      "metabase.lib.schema.common.semantic-or-relation-type" : {
+        "description" : "valid semantic or relation type",
+        "type" : "string"
+      },
+      "metabase.lib.schema.common.uuid" : {
+        "type" : "string",
+        "minLength" : 36,
+        "maxLength" : 36
       },
       "metabase.lib.schema.expression.temporal.timezone-id" : {
         "allOf" : [ {
@@ -1268,13 +3479,119 @@ redirect_from:
           } ]
         } ]
       },
+      "metabase.lib.schema.expression.window..offset.n" : {
+        "type" : "integer"
+      },
+      "metabase.lib.schema.id.action" : {
+        "type" : "integer",
+        "minimum" : 1
+      },
       "metabase.lib.schema.id.card" : {
+        "type" : "integer",
+        "minimum" : 1
+      },
+      "metabase.lib.schema.id.dashboard" : {
+        "type" : "integer",
+        "minimum" : 1
+      },
+      "metabase.lib.schema.id.database" : {
+        "type" : "integer",
+        "minimum" : 1
+      },
+      "metabase.lib.schema.id.dimension" : {
         "type" : "integer",
         "minimum" : 1
       },
       "metabase.lib.schema.id.field" : {
         "type" : "integer",
         "minimum" : 1
+      },
+      "metabase.lib.schema.id.pulse" : {
+        "type" : "integer",
+        "minimum" : 1
+      },
+      "metabase.lib.schema.id.saved-questions-virtual-database" : {
+        "description" : "The ID used to signify that a database is 'virtual' rather than physical.\n\n   A fake integer ID is used so as to minimize the number of changes that need to be made on the frontend -- by using\n   something that would otherwise be a legal ID, *nothing* need change there, and the frontend can query against this\n   'database' none the wiser. (This integer ID is negative which means it will never conflict with a *real* database\n   ID.)\n\n   This ID acts as a sort of flag. The relevant places in the middleware can check whether the DB we're querying is\n   this 'virtual' database and take the appropriate actions.",
+        "const" : -1337
+      },
+      "metabase.lib.schema.id.segment" : {
+        "type" : "integer",
+        "minimum" : 1
+      },
+      "metabase.lib.schema.id.table" : {
+        "type" : "integer",
+        "minimum" : 1
+      },
+      "metabase.lib.schema.id.user" : {
+        "type" : "integer",
+        "minimum" : 1
+      },
+      "metabase.lib.schema.info.context" : {
+        "type" : "string",
+        "enum" : [ "action", "ad-hoc", "cache-refresh", "collection", "map-tiles", "pulse", "dashboard-subscription", "dashboard", "question", "csv-download", "xlsx-download", "json-download", "public-dashboard", "public-question", "public-csv-download", "public-xlsx-download", "public-json-download", "embedded-dashboard", "embedded-question", "embedded-csv-download", "embedded-xlsx-download", "embedded-json-download", "table-grid" ]
+      },
+      "metabase.lib.schema.info.hash" : {
+        "type" : "string",
+        "format" : "byte"
+      },
+      "metabase.lib.schema.info.info" : {
+        "type" : "object",
+        "properties" : {
+          "query-hash" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.info.hash"
+          },
+          "action-id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.id.action"
+          },
+          "pivot/original-query" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          },
+          "executed-by" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.id.user"
+          },
+          "card-entity-id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "card-id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.id.card"
+          },
+          "pivot/result-metadata" : {
+            "oneOf" : [ {
+              "const" : "none"
+            }, {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata.column"
+              }
+            } ]
+          },
+          "context" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.info.context"
+          },
+          "dashboard-id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.id.dashboard"
+          },
+          "metadata/model-metadata" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata.lib-or-legacy-column"
+            }
+          },
+          "pulse-id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.id.pulse"
+          },
+          "card-name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          }
+        }
+      },
+      "metabase.lib.schema.join.alias" : {
+        "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+      },
+      "metabase.lib.schema.literal..string.date" : {
+        "type" : "string",
+        "pattern" : "^\\d{4}-\\d{2}-\\d{2}$"
       },
       "metabase.lib.schema.literal..string.datetime" : {
         "anyOf" : [ {
@@ -1285,17 +3602,623 @@ redirect_from:
           "pattern" : "^\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d{1,6})?)?(?:Z|(?:[+-]\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d{1,6})?)?))$"
         } ]
       },
+      "metabase.lib.schema.literal..string.time" : {
+        "anyOf" : [ {
+          "type" : "string",
+          "pattern" : "^\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d{1,6})?)?$"
+        }, {
+          "type" : "string",
+          "pattern" : "^\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d{1,6})?)?(?:Z|(?:[+-]\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d{1,6})?)?))$"
+        } ]
+      },
       "metabase.lib.schema.literal..string.zone-offset" : {
         "type" : "string",
         "pattern" : "(?:Z|(?:[+-]\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d{1,6})?)?))"
+      },
+      "metabase.lib.schema.literal.date" : {
+        "anyOf" : [ { }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.literal..string.date"
+        } ]
+      },
+      "metabase.lib.schema.literal.datetime" : {
+        "anyOf" : [ {
+          "$ref" : "#/components/schemas/metabase.lib.schema.literal..string.datetime"
+        }, { }, { }, { } ]
+      },
+      "metabase.lib.schema.literal.time" : {
+        "anyOf" : [ {
+          "$ref" : "#/components/schemas/metabase.lib.schema.literal..string.time"
+        }, { }, { } ]
       },
       "metabase.lib.schema.metadata..column.has-field-values" : {
         "type" : "string",
         "enum" : [ "auto-list", "list", "none", "search" ]
       },
+      "metabase.lib.schema.metadata..column.legacy-source" : {
+        "description" : "Possible values for `column.source` -- this is added by [[metabase.lib.metadata.result-metadata]] for historical\n  reasons (it is used in a few places in the FE). DO NOT use this in the backend for any purpose, use `:lib/source`\n  instead.",
+        "type" : "string",
+        "enum" : [ "aggregation", "fields", "breakout", "native" ]
+      },
+      "metabase.lib.schema.metadata..column.remapping.external" : {
+        "description" : "External remapping (Dimension) for a column. From the [[metabase.warehouse-schema.models.dimension]] with `type =\n  external` associated with a `Field` in the application database.\n  See [[metabase.query-processor.middleware.add-dimension-projections]] for what this means.",
+        "type" : "object",
+        "properties" : {
+          "field-id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.id.field"
+          },
+          "id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.id.dimension"
+          },
+          "lib/type" : {
+            "const" : "metadata.column.remapping/external"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          }
+        },
+        "required" : [ "lib/type", "id", "name", "field-id" ]
+      },
+      "metabase.lib.schema.metadata..column.remapping.internal" : {
+        "description" : "Internal remapping (FieldValues) for a column. From [[metabase.warehouse-schema.models.dimension]] with `type =\n  internal` and the [[metabase.warehouse-schema.models.field-values]] associated with a `Field` in the application\n  database. See [[metabase.query-processor.middleware.add-dimension-projections]] for what this means.",
+        "type" : "object",
+        "properties" : {
+          "human-readable-values" : {
+            "type" : "array",
+            "items" : { }
+          },
+          "id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.id.dimension"
+          },
+          "lib/type" : {
+            "const" : "metadata.column.remapping/internal"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "values" : {
+            "type" : "array",
+            "items" : { }
+          }
+        },
+        "required" : [ "lib/type", "id", "name", "values", "human-readable-values" ]
+      },
+      "metabase.lib.schema.metadata..column.source" : {
+        "description" : "`:lib/source` -- where a column came from with respect to the current stage.\n\n  Traditionally, `:lib/source` meant something slightly different -- it denoted what part of the current stage a\n  column came from, and thus included two additional options -- `:source/fields`, for columns used by `:fields`, and\n  `:source/breakouts`, for columns used in `:breakout`. This was not really useful information and made `:lib/source`\n  itself useless for determining if a column was 'inherited' or not (i.e., whether it came from a previous stage,\n  source card, or a join, and should get field name refs instead of field ID refs --\n  see [[metabase.lib.field.util/inherited-column?]]).",
+        "type" : "string",
+        "enum" : [ "source/card", "source/native", "source/previous-stage", "source/table-defaults", "source/aggregations", "source/joins", "source/expressions", "source/implicitly-joinable" ]
+      },
+      "metabase.lib.schema.metadata..column.validate-expression-source" : {
+        "description" : "Only allow `:lib/expression-name` when `:lib/source` is `:source/expressions`. If it's anything else, it probably\n  means it's getting incorrectly propagated from a previous stage (QUE-1342)."
+      },
+      "metabase.lib.schema.metadata..column.validate-native-column" : {
+        "description" : "Certain keys cannot possibly be set when a column comes from directly from native query results, for example\n  `:lib/breakout?` or join aliases"
+      },
+      "metabase.lib.schema.metadata..column.validate-table-defaults-column" : {
+        "description" : "A column with :lib/source :source/table-defaults cannot possibly have a join alias."
+      },
+      "metabase.lib.schema.metadata..column.visibility-type" : {
+        "type" : "string",
+        "enum" : [ "retired", "sensitive", "normal", "hidden", "details-only" ]
+      },
+      "metabase.lib.schema.metadata.column" : {
+        "description" : "Malli schema for a valid map of column metadata, which can mean one of two things:\n\n  1. Metadata about a particular Field in the application database. This will always have an `:id`\n\n  2. Results metadata from a column in `data.cols` and/or `data.results_metadata.columns` in a Query Processor\n     response, or saved in something like `Card.result_metadata`. These *may* have an `:id`, or may not -- columns\n     coming back from native queries or things like `SELECT count(*)` aren't associated with any particular `Field`\n     and thus will not have an `:id`.\n\n  Now maybe these should be two different schemas, but `:id` being there or not is the only real difference; besides\n  that they are largely compatible. So they're the same for now. We can revisit this in the future if we actually want\n  to differentiate between the two versions.",
+        "allOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "visibility-type" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.visibility-type"
+            },
+            "fk-join-alias" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+            },
+            "lib/external-remap" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.remapping.external"
+            },
+            "inherited-temporal-unit" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.temporal-bucketing.unit"
+            },
+            "lib/source-column-alias" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata.source-column-alias"
+            },
+            "database-type" : {
+              "type" : "string"
+            },
+            "lib/type" : {
+              "default" : "metadata/column",
+              "const" : "metadata/column"
+            },
+            "fingerprint" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint.fingerprint"
+            },
+            "display-name" : {
+              "type" : "string"
+            },
+            "id" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.id.field"
+            },
+            "effective-type" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.base-type"
+            },
+            "lib/deduplicated-name" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata.deduplicated-name"
+            },
+            "base-type" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.base-type"
+            },
+            "lib/original-expression-name" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+            },
+            "fk-field-name" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+            },
+            "name" : {
+              "type" : "string"
+            },
+            "lib/card-id" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.id.card"
+            },
+            "lib/expression-name" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+            },
+            "lib/breakout?" : {
+              "type" : "boolean"
+            },
+            "metabase.lib.field/temporal-unit" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.temporal-bucketing.unit"
+            },
+            "metabase.lib.field/binning" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.binning.binning"
+            },
+            "lib/model-display-name" : {
+              "type" : "string"
+            },
+            "has-field-values" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.has-field-values"
+            },
+            "lib/internal-remap" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.remapping.internal"
+            },
+            "selected?" : {
+              "type" : "boolean"
+            },
+            "source-alias" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+            },
+            "source" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.legacy-source"
+            },
+            "metabase.lib.join/join-alias" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.join.alias"
+            },
+            "fk-field-id" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.id.field"
+            },
+            "lib/original-binning" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.binning.binning"
+            },
+            "lib/original-join-alias" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.join.alias"
+            },
+            "lib/original-display-name" : {
+              "type" : "string"
+            },
+            "lib/source" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.source"
+            },
+            "active" : {
+              "type" : "boolean"
+            },
+            "lib/ref-display-name" : {
+              "type" : "string"
+            },
+            "lib/original-name" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata.original-name"
+            },
+            "lib/hack-original-name" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata.original-name"
+            },
+            "semantic-type" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.common.semantic-or-relation-type"
+            },
+            "fk-target-field-id" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.id.field"
+            },
+            "field-ref" : {
+              "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Reference"
+            },
+            "lib/desired-column-alias" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata.desired-column-alias"
+            }
+          },
+          "required" : [ "lib/type", "name", "base-type" ]
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.metadata.kebab-cased-map"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.validate-expression-source"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.validate-native-column"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.validate-table-defaults-column"
+        } ]
+      },
+      "metabase.lib.schema.metadata.deduplicated-name" : {
+        "type" : "string",
+        "description" : "The simply-deduplicated name that was historically used in QP results metadata (originally calculated by\n  the [[metabase.query-processor.middleware.annotate]] middleware, now calculated\n  by [[metabase.lib.middleware.result-metadata]]). This just adds suffixes to column names e.g. `ID` and `ID` become\n  `ID` and `ID_2`, respectively. Kept around because many old field refs use this column name.",
+        "optional" : true
+      },
+      "metabase.lib.schema.metadata.desired-column-alias" : {
+        "type" : "string",
+        "minLength" : 1
+      },
+      "metabase.lib.schema.metadata.fingerprint..fingerprint.global" : {
+        "description" : "Fingerprint values that Fields of all types should have.",
+        "type" : "object",
+        "properties" : {
+          "distinct-count" : {
+            "type" : "integer"
+          },
+          "nil%" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint.percent"
+          }
+        }
+      },
+      "metabase.lib.schema.metadata.fingerprint..fingerprint.number" : {
+        "description" : "Schema for fingerprint information for Fields deriving from `:type/Number`.",
+        "type" : "object",
+        "properties" : {
+          "avg" : {
+            "type" : "number"
+          },
+          "max" : {
+            "type" : "number"
+          },
+          "min" : {
+            "type" : "number"
+          },
+          "q1" : {
+            "type" : "number"
+          },
+          "q3" : {
+            "type" : "number"
+          },
+          "sd" : {
+            "type" : "number"
+          }
+        }
+      },
+      "metabase.lib.schema.metadata.fingerprint..fingerprint.temporal" : {
+        "description" : "Schema for fingerprint information for Fields deriving from `:type/Temporal`.",
+        "type" : "object",
+        "properties" : {
+          "earliest" : {
+            "type" : "string"
+          },
+          "latest" : {
+            "type" : "string"
+          }
+        }
+      },
+      "metabase.lib.schema.metadata.fingerprint..fingerprint.text" : {
+        "description" : "Schema for fingerprint information for Fields deriving from `:type/Text`.",
+        "type" : "object",
+        "properties" : {
+          "average-length" : {
+            "type" : "number"
+          },
+          "percent-email" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint.percent"
+          },
+          "percent-json" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint.percent"
+          },
+          "percent-state" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint.percent"
+          },
+          "percent-url" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint.percent"
+          }
+        }
+      },
+      "metabase.lib.schema.metadata.fingerprint..fingerprint.type-specific" : {
+        "description" : "Schema for type-specific fingerprint information.",
+        "allOf" : [ {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object",
+            "properties" : { }
+          }
+        }, {
+          "type" : "object",
+          "properties" : {
+            "type/DateTime" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint..fingerprint.temporal"
+            },
+            "type/Number" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint..fingerprint.number"
+            },
+            "type/Text" : {
+              "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint..fingerprint.text"
+            }
+          }
+        } ]
+      },
+      "metabase.lib.schema.metadata.fingerprint.fingerprint" : {
+        "description" : "Schema for a Field 'fingerprint' generated as part of the analysis stage. Used to power the 'classification'\n   sub-stage of analysis. Stored as the `fingerprint` column of Field.",
+        "type" : "object",
+        "properties" : {
+          "experimental" : {
+            "type" : "object",
+            "additionalProperties" : { }
+          },
+          "global" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint..fingerprint.global"
+          },
+          "type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint..fingerprint.type-specific"
+          }
+        }
+      },
+      "metabase.lib.schema.metadata.fingerprint.percent" : {
+        "description" : "Schema for something represting a percentage. A floating-point value between (inclusive) 0 and 1.",
+        "type" : "number"
+      },
+      "metabase.lib.schema.metadata.kebab-cased-map" : { },
+      "metabase.lib.schema.metadata.lib-or-legacy-column" : {
+        "description" : "Schema for the maps in card `:result-metadata` and similar. These can be either\n  `:metabase.lib.schema.metadata/result-metadata` (i.e., kebab-cased) maps, or map snake_cased as returned by QP\n  metadata, but they should NOT be a mixture of both -- if we mixed them somehow there is a bug in our code.",
+        "oneOf" : [ {
+          "description" : "Malli schema for a valid map of column metadata, which can mean one of two things:\n\n  1. Metadata about a particular Field in the application database. This will always have an `:id`\n\n  2. Results metadata from a column in `data.cols` and/or `data.results_metadata.columns` in a Query Processor\n     response, or saved in something like `Card.result_metadata`. These *may* have an `:id`, or may not -- columns\n     coming back from native queries or things like `SELECT count(*)` aren't associated with any particular `Field`\n     and thus will not have an `:id`.\n\n  Now maybe these should be two different schemas, but `:id` being there or not is the only real difference; besides\n  that they are largely compatible. So they're the same for now. We can revisit this in the future if we actually want\n  to differentiate between the two versions.",
+          "allOf" : [ {
+            "type" : "object",
+            "properties" : {
+              "visibility-type" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.visibility-type"
+              },
+              "fk-join-alias" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+              },
+              "lib/external-remap" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.remapping.external"
+              },
+              "inherited-temporal-unit" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.temporal-bucketing.unit"
+              },
+              "lib/source-column-alias" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata.source-column-alias"
+              },
+              "database-type" : {
+                "type" : "string"
+              },
+              "lib/type" : {
+                "default" : "metadata/column",
+                "const" : "metadata/column"
+              },
+              "fingerprint" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata.fingerprint.fingerprint"
+              },
+              "display-name" : {
+                "type" : "string"
+              },
+              "id" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.id.field"
+              },
+              "effective-type" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.common.base-type"
+              },
+              "lib/deduplicated-name" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata.deduplicated-name"
+              },
+              "base-type" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.common.base-type"
+              },
+              "lib/original-expression-name" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+              },
+              "fk-field-name" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+              },
+              "name" : {
+                "type" : "string"
+              },
+              "lib/card-id" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.id.card"
+              },
+              "lib/expression-name" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+              },
+              "lib/breakout?" : {
+                "type" : "boolean"
+              },
+              "metabase.lib.field/temporal-unit" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.temporal-bucketing.unit"
+              },
+              "metabase.lib.field/binning" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.binning.binning"
+              },
+              "lib/model-display-name" : {
+                "type" : "string"
+              },
+              "has-field-values" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.has-field-values"
+              },
+              "lib/internal-remap" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.remapping.internal"
+              },
+              "selected?" : {
+                "type" : "boolean"
+              },
+              "source-alias" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+              },
+              "source" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.legacy-source"
+              },
+              "metabase.lib.join/join-alias" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.join.alias"
+              },
+              "fk-field-id" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.id.field"
+              },
+              "lib/original-binning" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.binning.binning"
+              },
+              "lib/original-join-alias" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.join.alias"
+              },
+              "lib/original-display-name" : {
+                "type" : "string"
+              },
+              "lib/source" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.source"
+              },
+              "active" : {
+                "type" : "boolean"
+              },
+              "lib/ref-display-name" : {
+                "type" : "string"
+              },
+              "lib/original-name" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata.original-name"
+              },
+              "lib/hack-original-name" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata.original-name"
+              },
+              "semantic-type" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.common.semantic-or-relation-type"
+              },
+              "fk-target-field-id" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.id.field"
+              },
+              "field-ref" : {
+                "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.Reference"
+              },
+              "lib/desired-column-alias" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.metadata.desired-column-alias"
+              }
+            },
+            "required" : [ "lib/type", "name", "base-type" ]
+          }, {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata.kebab-cased-map"
+          }, {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.validate-expression-source"
+          }, {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.validate-native-column"
+          }, {
+            "$ref" : "#/components/schemas/metabase.lib.schema.metadata..column.validate-table-defaults-column"
+          } ]
+        }, {
+          "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.legacy-column-metadata"
+        } ]
+      },
+      "metabase.lib.schema.metadata.original-name" : {
+        "type" : "string",
+        "description" : "The original name of the column as it appeared in the very first place it came from (i.e., the physical name of the\n  column in the table it appears in). This should be the same as the `:lib/source-column-alias` for the very first\n  usage of the column.\n  Allowed to be blank because some databases like SQL Server allow blank column names.",
+        "optional" : true
+      },
+      "metabase.lib.schema.metadata.source-column-alias" : {
+        "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+      },
+      "metabase.lib.schema.parameter..dimension.target" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.lib.schema.parameter.legacy-field-ref"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.parameter.legacy-expression-ref"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.parameter.template-tag"
+        } ]
+      },
+      "metabase.lib.schema.parameter.DimensionOptions" : {
+        "type" : "object",
+        "properties" : {
+          "stage-number" : {
+            "type" : "integer"
+          }
+        }
+      },
+      "metabase.lib.schema.parameter.dimension" : { },
+      "metabase.lib.schema.parameter.legacy-expression-ref" : {
+        "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.expression"
+      },
+      "metabase.lib.schema.parameter.legacy-field-ref" : {
+        "$ref" : "#/components/schemas/metabase.legacy-mbql.schema.field"
+      },
+      "metabase.lib.schema.parameter.parameter" : {
+        "type" : "object",
+        "properties" : {
+          "default" : { },
+          "id" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "required" : { },
+          "slug" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          },
+          "target" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.parameter.target"
+          },
+          "type" : {
+            "$ref" : "#/components/schemas/metabase.lib.schema.parameter.type"
+          },
+          "value" : { }
+        },
+        "required" : [ "type" ]
+      },
+      "metabase.lib.schema.parameter.target" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/metabase.lib.schema.parameter.legacy-field-ref"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.parameter.dimension"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.parameter.variable"
+        } ]
+      },
+      "metabase.lib.schema.parameter.template-tag" : {
+        "type" : "array",
+        "prefixItems" : [ {
+          "const" : "template-tag"
+        }, {
+          "oneOf" : [ {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+              }
+            },
+            "required" : [ "id" ]
+          }, {
+            "$ref" : "#/components/schemas/metabase.lib.schema.common.non-blank-string"
+          } ]
+        } ]
+      },
+      "metabase.lib.schema.parameter.type" : {
+        "type" : "string",
+        "enum" : [ "category", "date", "string/!=", "number/=", "string/ends-with", "location/state", "boolean/=", "number/between", "date/all-options", "number", "number/>=", "location/country", "temporal-unit", "string/=", "string/does-not-contain", "date/range", "string/starts-with", "string/contains", "date/single", "location/city", "id", "date/relative", "location/zip_code", "date/month-year", "date/quarter-year", "number/!=", "boolean", "text", "number/<=" ]
+      },
+      "metabase.lib.schema.parameter.variable" : {
+        "type" : "array",
+        "prefixItems" : [ {
+          "const" : "variable"
+        }, {
+          "$ref" : "#/components/schemas/metabase.lib.schema.parameter.template-tag"
+        } ]
+      },
+      "metabase.lib.schema.parameter.widget-type" : {
+        "type" : "string",
+        "enum" : [ "none", "category", "date", "string/!=", "number/=", "string/ends-with", "location/state", "boolean/=", "number/between", "date/all-options", "number", "number/>=", "location/country", "temporal-unit", "string/=", "string/does-not-contain", "date/range", "string/starts-with", "string/contains", "date/single", "location/city", "id", "date/relative", "location/zip_code", "date/month-year", "date/quarter-year", "number/!=", "boolean", "text", "number/<=" ]
+      },
+      "metabase.lib.schema.template-tag..raw-value.type" : {
+        "type" : "string",
+        "enum" : [ "date", "number", "boolean", "text" ]
+      },
       "metabase.lib.schema.temporal-bucketing.unit" : {
         "type" : "string",
         "enum" : [ "quarter", "day", "hour", "week", "second", "default", "day-of-week", "hour-of-day", "month", "month-of-year", "day-of-month", "year", "day-of-year", "millisecond", "year-of-era", "second-of-minute", "week-of-year", "quarter-of-year", "minute-of-hour", "minute" ]
+      },
+      "metabase.logger.api.log-level" : {
+        "type" : "string",
+        "enum" : [ "off", "fatal", "error", "warn", "info", "debug", "trace" ]
       },
       "metabase.logger.api.time-unit" : {
         "type" : "string",
@@ -1369,7 +4292,69 @@ redirect_from:
               }
             },
             "required" : [ "payload_type", "payload" ]
-          }, { } ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "creator" : {
+                "type" : "object",
+                "properties" : { }
+              },
+              "handlers" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "active" : {
+                      "type" : "boolean"
+                    },
+                    "channel" : {
+                      "$ref" : "#/components/schemas/metabase.channel.models.channel.Channel"
+                    },
+                    "channel_id" : {
+                      "description" : "value must be an integer greater than zero.",
+                      "type" : "integer",
+                      "minimum" : 1
+                    },
+                    "channel_type" : { },
+                    "notification_id" : {
+                      "description" : "value must be an integer greater than zero.",
+                      "type" : "integer",
+                      "minimum" : 1
+                    },
+                    "recipients" : {
+                      "type" : "array",
+                      "items" : {
+                        "$ref" : "#/components/schemas/metabase.notification.models.NotificationRecipient"
+                      }
+                    },
+                    "template" : {
+                      "$ref" : "#/components/schemas/metabase.channel.models.channel.ChannelTemplate"
+                    },
+                    "template_id" : {
+                      "description" : "value must be an integer greater than zero.",
+                      "type" : "integer",
+                      "minimum" : 1
+                    }
+                  },
+                  "required" : [ "channel_type" ]
+                }
+              },
+              "payload_id" : {
+                "type" : "null"
+              },
+              "payload_type" : {
+                "type" : "string",
+                "enum" : [ "notification/dashboard", "notification/system-event", "notification/testing", "notification/card" ]
+              },
+              "subscriptions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/metabase.notification.models.NotificationSubscription"
+                }
+              }
+            },
+            "required" : [ "payload_type" ]
+          } ]
         }, {
           "oneOf" : [ {
             "type" : "object",
@@ -1439,7 +4424,72 @@ redirect_from:
               }
             },
             "required" : [ "payload_type", "payload" ]
-          }, { } ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "creator" : {
+                "type" : "object",
+                "properties" : { }
+              },
+              "creator_id" : {
+                "type" : "integer"
+              },
+              "handlers" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "active" : {
+                      "type" : "boolean"
+                    },
+                    "channel" : {
+                      "$ref" : "#/components/schemas/metabase.channel.models.channel.Channel"
+                    },
+                    "channel_id" : {
+                      "description" : "value must be an integer greater than zero.",
+                      "type" : "integer",
+                      "minimum" : 1
+                    },
+                    "channel_type" : { },
+                    "notification_id" : {
+                      "description" : "value must be an integer greater than zero.",
+                      "type" : "integer",
+                      "minimum" : 1
+                    },
+                    "recipients" : {
+                      "type" : "array",
+                      "items" : {
+                        "$ref" : "#/components/schemas/metabase.notification.models.NotificationRecipient"
+                      }
+                    },
+                    "template" : {
+                      "$ref" : "#/components/schemas/metabase.channel.models.channel.ChannelTemplate"
+                    },
+                    "template_id" : {
+                      "description" : "value must be an integer greater than zero.",
+                      "type" : "integer",
+                      "minimum" : 1
+                    }
+                  },
+                  "required" : [ "channel_type" ]
+                }
+              },
+              "payload_id" : {
+                "type" : "integer"
+              },
+              "payload_type" : {
+                "type" : "string",
+                "enum" : [ "notification/dashboard", "notification/system-event", "notification/testing", "notification/card" ]
+              },
+              "subscriptions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/metabase.notification.models.NotificationSubscription"
+                }
+              }
+            },
+            "required" : [ "payload_type" ]
+          } ]
         }, {
           "oneOf" : [ {
             "type" : "object",
@@ -1499,7 +4549,61 @@ redirect_from:
               }
             },
             "required" : [ "payload" ]
-          }, { } ]
+          }, {
+            "type" : "object",
+            "properties" : {
+              "creator" : {
+                "type" : "object",
+                "properties" : { }
+              },
+              "handlers" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "active" : {
+                      "type" : "boolean"
+                    },
+                    "channel" : {
+                      "$ref" : "#/components/schemas/metabase.channel.models.channel.Channel"
+                    },
+                    "channel_id" : {
+                      "description" : "value must be an integer greater than zero.",
+                      "type" : "integer",
+                      "minimum" : 1
+                    },
+                    "channel_type" : { },
+                    "notification_id" : {
+                      "description" : "value must be an integer greater than zero.",
+                      "type" : "integer",
+                      "minimum" : 1
+                    },
+                    "recipients" : {
+                      "type" : "array",
+                      "items" : {
+                        "$ref" : "#/components/schemas/metabase.notification.models.NotificationRecipient"
+                      }
+                    },
+                    "template" : {
+                      "$ref" : "#/components/schemas/metabase.channel.models.channel.ChannelTemplate"
+                    },
+                    "template_id" : {
+                      "description" : "value must be an integer greater than zero.",
+                      "type" : "integer",
+                      "minimum" : 1
+                    }
+                  },
+                  "required" : [ "channel_type" ]
+                }
+              },
+              "subscriptions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/metabase.notification.models.NotificationSubscription"
+                }
+              }
+            }
+          } ]
         } ]
       },
       "metabase.notification.models.Notification" : {
@@ -1815,6 +4919,16 @@ redirect_from:
           }
         }
       },
+      "metabase.timeline.api.timeline.Timeline" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "minimum" : 1
+          }
+        },
+        "required" : [ "id" ]
+      },
       "metabase.timeline.api.timeline.include" : {
         "type" : "string",
         "enum" : [ "events" ]
@@ -1874,6 +4988,18 @@ redirect_from:
           }
         },
         "required" : [ "schedule_type" ]
+      },
+      "metabot.reaction.redirect" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "const" : "metabot.reaction/redirect"
+          },
+          "url" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "type", "url" ]
       }
     }
   },
@@ -1892,12 +5018,34 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/action" ]
       },
       "post" : {
         "summary" : "POST /api/action/",
         "description" : "Create a new action.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -2002,6 +5150,17 @@ redirect_from:
         "summary" : "GET /api/action/public",
         "description" : "Fetch a list of Actions with public UUIDs. These actions are publicly-accessible *if* public sharing is enabled.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/action" ]
       }
     },
@@ -2019,6 +5178,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/action" ]
       },
       "delete" : {
@@ -2034,6 +5204,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/action" ]
       }
     },
@@ -2059,6 +5240,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/action" ]
       }
     },
@@ -2076,6 +5268,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -2195,6 +5398,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -2228,6 +5442,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/action" ]
       },
       "delete" : {
@@ -2243,6 +5468,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/action" ]
       }
     },
@@ -2251,6 +5487,17 @@ redirect_from:
         "summary" : "GET /api/activity/most_recently_viewed_dashboard",
         "description" : "Get the most recently viewed dashboard for the current user. Returns a 204 if the user has not viewed any dashboards\n   in the last 24 hours.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/activity" ]
       }
     },
@@ -2259,6 +5506,17 @@ redirect_from:
         "summary" : "GET /api/activity/popular_items",
         "description" : "Get the list of 5 popular things on the instance. Query takes 8 and limits to 5 so that if it finds anything\n  archived, deleted, etc it can usually still get 5. ",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/activity" ]
       }
     },
@@ -2267,6 +5525,17 @@ redirect_from:
         "summary" : "GET /api/activity/recent_views",
         "description" : "Get a list of 100 models (cards, models, tables, dashboards, and collections) that the current user has been viewing most\n  recently. Return a maximum of 20 model of each, if they've looked at at least 20.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/activity" ]
       }
     },
@@ -2294,12 +5563,34 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/activity" ]
       },
       "post" : {
         "summary" : "POST /api/activity/recents",
         "description" : "Adds a model to the list of recently selected items.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -2350,6 +5641,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/alert" ]
       }
     },
@@ -2367,6 +5669,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/alert" ]
       }
     },
@@ -2384,6 +5697,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/alert" ]
       }
     },
@@ -2392,6 +5716,17 @@ redirect_from:
         "summary" : "GET /api/analytics/anonymous-stats",
         "description" : "Anonymous usage stats. Endpoint for testing, and eventually exposing this to instance admins to let them see\n  what is being phoned home.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/analytics" ]
       }
     },
@@ -2400,6 +5735,17 @@ redirect_from:
         "summary" : "POST /api/api-key/",
         "description" : "Create a new API key (and an associated `User`) with the provided name and group ID.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -2427,6 +5773,17 @@ redirect_from:
         "summary" : "GET /api/api-key/",
         "description" : "Get a list of API keys with the default scope. Non-paginated.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/api-key" ]
       }
     },
@@ -2435,6 +5792,17 @@ redirect_from:
         "summary" : "GET /api/api-key/count",
         "description" : "Get the count of API keys in the DB with the default scope.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/api-key" ]
       }
     },
@@ -2452,6 +5820,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -2487,6 +5866,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/api-key" ]
       }
     },
@@ -2504,6 +5894,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/api-key" ]
       }
     },
@@ -2521,6 +5922,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2543,6 +5955,17 @@ redirect_from:
             "type" : "integer"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2571,6 +5994,17 @@ redirect_from:
             } ]
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2615,6 +6049,17 @@ redirect_from:
           },
           "description" : "invalid show value"
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2668,6 +6113,17 @@ redirect_from:
           },
           "description" : "invalid show value"
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2723,6 +6179,17 @@ redirect_from:
           },
           "description" : "invalid show value"
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2787,6 +6254,17 @@ redirect_from:
           },
           "description" : "invalid show value"
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2834,6 +6312,17 @@ redirect_from:
           },
           "description" : "invalid show value"
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2850,6 +6339,17 @@ redirect_from:
             "enum" : [ "adhoc", "transform", "table", "question", "field", "segment", "model" ]
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2899,6 +6399,17 @@ redirect_from:
           },
           "description" : "invalid show value"
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2957,6 +6468,17 @@ redirect_from:
           },
           "description" : "invalid show value"
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/automagic-dashboards" ]
       }
     },
@@ -2965,6 +6487,17 @@ redirect_from:
         "summary" : "GET /api/bookmark/",
         "description" : "Fetch all bookmarks for the user",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/bookmark" ]
       }
     },
@@ -2973,6 +6506,17 @@ redirect_from:
         "summary" : "PUT /api/bookmark/ordering",
         "description" : "Sets the order of bookmarks for user.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3028,6 +6572,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/bookmark" ]
       },
       "delete" : {
@@ -3051,6 +6606,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/bookmark" ]
       }
     },
@@ -3059,6 +6625,17 @@ redirect_from:
         "summary" : "GET /api/bug-reporting/connection-pool-details",
         "description" : "Returns database connection pool info for the current Metabase instance.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/bug-reporting" ]
       }
     },
@@ -3067,6 +6644,17 @@ redirect_from:
         "summary" : "GET /api/bug-reporting/details",
         "description" : "Returns version and system information relevant to filing a bug report against Metabase.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/bug-reporting" ]
       }
     },
@@ -3106,12 +6694,34 @@ redirect_from:
           },
           "description" : "Model id to get configuration for."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/cache" ]
       },
       "put" : {
         "summary" : "PUT /api/cache/",
         "description" : "Store cache configuration.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3142,6 +6752,17 @@ redirect_from:
         "summary" : "DELETE /api/cache/",
         "description" : "Delete cache configurations.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3221,6 +6842,17 @@ redirect_from:
           },
           "description" : "A list of question ids"
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/cache" ]
       }
     },
@@ -3247,12 +6879,34 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       },
       "post" : {
         "summary" : "POST /api/card/",
         "description" : "Create a new `Card`. Card `type` can be `question`, `metric`, or `model`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3342,6 +6996,17 @@ redirect_from:
         "summary" : "POST /api/card/collections",
         "description" : "Bulk update endpoint for Card Collections. Move a set of `Cards` with `card_ids` into a `Collection` with\n  `collection_id`, or remove them from any Collections by passing a `null` `collection_id`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3375,6 +7040,17 @@ redirect_from:
         "summary" : "GET /api/card/embeddable",
         "description" : "Fetch a list of Cards where `enable_embedding` is `true`. The cards can be embedded using the embedding endpoints\n  and a signed JWT.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3392,6 +7068,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3414,6 +7101,17 @@ redirect_from:
         "summary" : "GET /api/card/public",
         "description" : "Fetch a list of Cards with public UUIDs. These cards are publicly-accessible *if* public sharing is enabled.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3447,6 +7145,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3472,6 +7181,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3489,6 +7209,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       },
       "delete" : {
@@ -3504,6 +7235,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3516,11 +7258,28 @@ redirect_from:
           "name" : "card-id",
           "required" : true,
           "schema" : {
-            "type" : "integer",
-            "minimum" : 1
-          },
-          "description" : "value must be an integer greater than zero."
+            "anyOf" : [ {
+              "description" : "value must be an integer greater than zero.",
+              "type" : "integer",
+              "minimum" : 1
+            }, {
+              "description" : "String must be a valid 21-character NanoID string.",
+              "type" : "string",
+              "pattern" : "^[A-Za-z0-9_\\-]{21}$"
+            } ]
+          }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3569,6 +7328,17 @@ redirect_from:
             "$ref" : "#/components/schemas/metabase.query-processor.schema.export-format"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3608,10 +7378,16 @@ redirect_from:
           "name" : "id",
           "required" : true,
           "schema" : {
-            "type" : "integer",
-            "minimum" : 1
-          },
-          "description" : "value must be an integer greater than zero."
+            "anyOf" : [ {
+              "description" : "value must be an integer greater than zero.",
+              "type" : "integer",
+              "minimum" : 1
+            }, {
+              "description" : "String must be a valid 21-character NanoID string.",
+              "type" : "string",
+              "pattern" : "^[A-Za-z0-9_\\-]{21}$"
+            } ]
+          }
         }, {
           "in" : "query",
           "name" : "ignore_view",
@@ -3628,6 +7404,17 @@ redirect_from:
             "enum" : [ "collection" ]
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       },
       "put" : {
@@ -3650,6 +7437,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3751,6 +7549,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3768,6 +7577,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3785,6 +7605,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3816,6 +7647,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3828,11 +7670,28 @@ redirect_from:
           "name" : "id",
           "required" : true,
           "schema" : {
-            "type" : "integer",
-            "minimum" : 1
-          },
-          "description" : "value must be an integer greater than zero."
+            "anyOf" : [ {
+              "description" : "value must be an integer greater than zero.",
+              "type" : "integer",
+              "minimum" : 1
+            }, {
+              "description" : "String must be a valid 21-character NanoID string.",
+              "type" : "string",
+              "pattern" : "^[A-Za-z0-9_\\-]{21}$"
+            } ]
+          }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3870,6 +7729,17 @@ redirect_from:
           "required" : false,
           "schema" : { }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/card" ]
       }
     },
@@ -3878,6 +7748,17 @@ redirect_from:
         "summary" : "POST /api/cards/dashboards",
         "description" : "Get the dashboards that multiple cards appear in. The response is a sequence of maps, each of which has a `card_id`\n  and `dashboards`. `dashboard` may include an `:error` key, either `:unreadable-dashboard` or\n  `:unwritable-dashboard`. In the case of an `unreadable-dashboard` the dashboard details (name, ID) will NOT be\n  present.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3906,6 +7787,17 @@ redirect_from:
         "summary" : "POST /api/cards/move",
         "description" : "Moves a number of Cards to a single collection or dashboard.\n\n  For now, just either succeed or fail as a batch - we can think more about error handling later down the road.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3944,6 +7836,17 @@ redirect_from:
         "summary" : "GET /api/channel/",
         "description" : "Get all channels",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3965,6 +7868,17 @@ redirect_from:
         "summary" : "POST /api/channel/",
         "description" : "Create a channel",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4004,6 +7918,17 @@ redirect_from:
         "summary" : "POST /api/channel/test",
         "description" : "Test a channel connection",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4040,6 +7965,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/channel" ]
       },
       "put" : {
@@ -4055,6 +7991,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4092,12 +8039,34 @@ redirect_from:
         "summary" : "POST /api/cloud-migration/",
         "description" : "Initiate a new cloud migration.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/cloud-migration" ]
       },
       "get" : {
         "summary" : "GET /api/cloud-migration/",
         "description" : "Get the latest cloud migration, if any.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/cloud-migration" ]
       }
     },
@@ -4106,6 +8075,17 @@ redirect_from:
         "summary" : "PUT /api/cloud-migration/cancel",
         "description" : "Cancel any ongoing cloud migrations, if any.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/cloud-migration" ]
       }
     },
@@ -4146,12 +8126,34 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/collection" ]
       },
       "post" : {
         "summary" : "POST /api/collection/",
         "description" : "Create a new Collection.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4201,6 +8203,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/collection" ]
       },
       "put" : {
@@ -4223,6 +8236,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4263,6 +8287,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/collection" ]
       }
     },
@@ -4271,6 +8306,24 @@ redirect_from:
         "summary" : "GET /api/collection/root/dashboard-question-candidates",
         "description" : "Find cards in the root collection that can be moved into dashboards in the root collection. (Same as the above\n  endpoint, but for the root collection)",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:data -> <sequence of map where {:id -> <integer greater than 0>, :name -> <string>, :description -> <nullable string>, :sole_dashboard_info -> <map where {:id -> <integer greater than 0>, :name -> <string>, :description -> <nullable string>}>}>, :total -> <integer>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/metabase.collections.api.DashboardQuestionCandidatesResponse"
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/collection" ]
       }
     },
@@ -4352,6 +8405,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/collection" ]
       }
     },
@@ -4360,6 +8424,24 @@ redirect_from:
         "summary" : "POST /api/collection/root/move-dashboard-question-candidates",
         "description" : "Move candidate cards to the dashboards they appear in (for the root collection)",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:moved -> <sequence of value must be an integer greater than zero.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/metabase.collections.api.MoveDashboardQuestionCandidatesResponse"
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4389,6 +8471,17 @@ redirect_from:
         "summary" : "GET /api/collection/trash",
         "description" : "Fetch the trash collection, as in `/api/collection/:trash-id`",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/collection" ]
       }
     },
@@ -4438,6 +8531,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/collection" ]
       }
     },
@@ -4450,11 +8554,28 @@ redirect_from:
           "name" : "id",
           "required" : true,
           "schema" : {
-            "type" : "integer",
-            "minimum" : 1
-          },
-          "description" : "value must be an integer greater than zero."
+            "anyOf" : [ {
+              "description" : "value must be an integer greater than zero.",
+              "type" : "integer",
+              "minimum" : 1
+            }, {
+              "description" : "String must be a valid 21-character NanoID string.",
+              "type" : "string",
+              "pattern" : "^[A-Za-z0-9_\\-]{21}$"
+            } ]
+          }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/collection" ]
       },
       "put" : {
@@ -4470,6 +8591,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4520,6 +8652,24 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:data -> <sequence of map where {:id -> <integer greater than 0>, :name -> <string>, :description -> <nullable string>, :sole_dashboard_info -> <map where {:id -> <integer greater than 0>, :name -> <string>, :description -> <nullable string>}>}>, :total -> <integer>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/metabase.collections.api.DashboardQuestionCandidatesResponse"
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/collection" ]
       }
     },
@@ -4532,10 +8682,16 @@ redirect_from:
           "name" : "id",
           "required" : true,
           "schema" : {
-            "type" : "integer",
-            "minimum" : 1
-          },
-          "description" : "value must be an integer greater than zero."
+            "anyOf" : [ {
+              "description" : "value must be an integer greater than zero.",
+              "type" : "integer",
+              "minimum" : 1
+            }, {
+              "description" : "String must be a valid 21-character NanoID string.",
+              "type" : "string",
+              "pattern" : "^[A-Za-z0-9_\\-]{21}$"
+            } ]
+          }
         }, {
           "in" : "query",
           "name" : "models",
@@ -4603,6 +8759,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/collection" ]
       }
     },
@@ -4620,6 +8787,24 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:moved -> <sequence of value must be an integer greater than zero.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/metabase.collections.api.MoveDashboardQuestionCandidatesResponse"
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4657,12 +8842,34 @@ redirect_from:
             "enum" : [ "all", "mine", "archived" ]
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       },
       "post" : {
         "summary" : "POST /api/dashboard/",
         "description" : "Create a new Dashboard.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4711,6 +8918,17 @@ redirect_from:
         "summary" : "GET /api/dashboard/embeddable",
         "description" : "Fetch a list of Dashboards where `enable_embedding` is `true`. The dashboards can be embedded using the embedding\n  endpoints and a signed JWT.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -4743,6 +8961,17 @@ redirect_from:
             }
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -4778,6 +9007,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4816,6 +9056,17 @@ redirect_from:
         "summary" : "GET /api/dashboard/public",
         "description" : "Fetch a list of Dashboards with public UUIDs. These dashboards are publicly-accessible *if* public sharing is\n  enabled.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -4824,6 +9075,17 @@ redirect_from:
         "summary" : "POST /api/dashboard/save",
         "description" : "Save a denormalized description of dashboard.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -4841,6 +9103,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -4876,6 +9149,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -4952,6 +9236,17 @@ redirect_from:
             "$ref" : "#/components/schemas/metabase.query-processor.schema.export-format"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -5030,6 +9325,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       },
       "post" : {
@@ -5054,6 +9360,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -5086,6 +9403,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       },
       "delete" : {
@@ -5101,6 +9429,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -5118,6 +9457,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -5163,11 +9513,28 @@ redirect_from:
           "name" : "id",
           "required" : true,
           "schema" : {
-            "type" : "integer",
-            "minimum" : 1
-          },
-          "description" : "value must be an integer greater than zero."
+            "anyOf" : [ {
+              "description" : "value must be an integer greater than zero.",
+              "type" : "integer",
+              "minimum" : 1
+            }, {
+              "description" : "String must be a valid 21-character NanoID string.",
+              "type" : "string",
+              "pattern" : "^[A-Za-z0-9_\\-]{21}$"
+            } ]
+          }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       },
       "delete" : {
@@ -5183,6 +9550,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       },
       "put" : {
@@ -5198,6 +9576,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -5364,6 +9753,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -5471,6 +9871,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -5502,6 +9913,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -5527,6 +9949,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -5544,6 +9977,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -5556,11 +10000,28 @@ redirect_from:
           "name" : "id",
           "required" : true,
           "schema" : {
-            "type" : "integer",
-            "minimum" : 1
-          },
-          "description" : "value must be an integer greater than zero."
+            "anyOf" : [ {
+              "description" : "value must be an integer greater than zero.",
+              "type" : "integer",
+              "minimum" : 1
+            }, {
+              "description" : "String must be a valid 21-character NanoID string.",
+              "type" : "string",
+              "pattern" : "^[A-Za-z0-9_\\-]{21}$"
+            } ]
+          }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -5578,6 +10039,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/dashboard" ]
       }
     },
@@ -5643,12 +10115,34 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       },
       "post" : {
         "summary" : "POST /api/database/",
         "description" : "Add a new `Database`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -5707,6 +10201,17 @@ redirect_from:
         "summary" : "POST /api/database/sample_database",
         "description" : "Add the sample database as a new `Database`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -5715,6 +10220,17 @@ redirect_from:
         "summary" : "POST /api/database/validate",
         "description" : "Validate that we can connect to a database given a set of details.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -5781,6 +10297,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       },
       "put" : {
@@ -5796,6 +10323,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -5864,6 +10402,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -5897,6 +10446,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -5929,6 +10489,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -5946,6 +10517,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -5963,6 +10545,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -5980,6 +10573,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -5997,6 +10601,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6014,6 +10629,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6063,6 +10689,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6080,6 +10717,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6113,6 +10761,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6146,6 +10805,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6179,6 +10849,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6196,6 +10877,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6213,6 +10905,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6230,6 +10933,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6238,6 +10952,17 @@ redirect_from:
         "summary" : "GET /api/database/{virtual-db}/datasets",
         "description" : "Returns a list of all the datasets found for the saved questions virtual database.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6246,6 +10971,17 @@ redirect_from:
         "summary" : "GET /api/database/{virtual-db}/datasets/{schema}",
         "description" : "Returns a list of Tables for the datasets virtual database.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6254,6 +10990,17 @@ redirect_from:
         "summary" : "GET /api/database/{virtual-db}/metadata",
         "description" : "Endpoint that provides metadata for the Saved Questions 'virtual' database. Used for fooling the frontend\n   and allowing it to treat the Saved Questions virtual DB just like any other database.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6262,6 +11009,17 @@ redirect_from:
         "summary" : "GET /api/database/{virtual-db}/schema/{schema}",
         "description" : "Returns a list of Tables for the saved questions virtual database.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6270,6 +11028,17 @@ redirect_from:
         "summary" : "GET /api/database/{virtual-db}/schemas",
         "description" : "Returns a list of all the schemas found for the saved questions virtual database.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/database" ]
       }
     },
@@ -6278,6 +11047,17 @@ redirect_from:
         "summary" : "POST /api/dataset/",
         "description" : "Execute a query and retrieve the results in the usual format. The query will not use the cache.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6300,6 +11080,17 @@ redirect_from:
         "summary" : "POST /api/dataset/native",
         "description" : "Fetch a native version of an MBQL query.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6329,6 +11120,17 @@ redirect_from:
         "summary" : "POST /api/dataset/parameter/remapping",
         "description" : "Return the remapped parameter values for cards or dashboards that are being edited.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6367,6 +11169,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6396,6 +11209,17 @@ redirect_from:
         "summary" : "POST /api/dataset/parameter/values",
         "description" : "Return parameter values for cards or dashboards that are being edited.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6425,6 +11249,17 @@ redirect_from:
         "summary" : "POST /api/dataset/pivot",
         "description" : "Generate a pivoted dataset for an ad-hoc query",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6450,6 +11285,17 @@ redirect_from:
         "summary" : "POST /api/dataset/query_metadata",
         "description" : "Get all of the required query metadata for an ad-hoc query.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6482,6 +11328,17 @@ redirect_from:
             "$ref" : "#/components/schemas/metabase.query-processor.schema.export-format"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6519,6 +11376,17 @@ redirect_from:
         "summary" : "GET /api/ee/advanced-permissions/application/graph",
         "description" : "Fetch a graph of Application Permissions.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/advanced-permissions/application" ]
       },
       "put" : {
@@ -6541,6 +11409,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6577,6 +11456,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/advanced-permissions/impersonation" ]
       }
     },
@@ -6594,6 +11484,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/advanced-permissions/impersonation" ]
       }
     },
@@ -6602,6 +11503,17 @@ redirect_from:
         "summary" : "POST /api/ee/ai-entity-analysis/analyze-chart",
         "description" : "Analyze a chart image using an AI vision model. This function sends the image data to a separate external AI service for analysis.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6649,6 +11561,17 @@ redirect_from:
         "summary" : "POST /api/ee/ai-sql-fixer/fix",
         "description" : "Suggest fixes for a SQL query.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6683,6 +11606,17 @@ redirect_from:
         "summary" : "POST /api/ee/ai-sql-generation/generate",
         "description" : "Generate a SQL query.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6712,6 +11646,17 @@ redirect_from:
         "summary" : "GET /api/ee/audit-app/user/audit-info",
         "description" : "Gets audit info for the current user if he has permissions to access the audit collection.\n  Otherwise return an empty map.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/audit-app/user" ]
       }
     },
@@ -6729,6 +11674,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/audit-app/user" ]
       }
     },
@@ -6737,6 +11693,17 @@ redirect_from:
         "summary" : "POST /api/ee/autodescribe/card/summarize",
         "description" : "Summarize a question.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6817,6 +11784,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/autodescribe" ]
       }
     },
@@ -6825,6 +11803,17 @@ redirect_from:
         "summary" : "GET /api/ee/billing/",
         "description" : "Get billing information. This acts as a proxy between `metabase-billing-info-url` and the client,\n   using the embedding token and signed in user's email to fetch the billing information.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/billing" ]
       }
     },
@@ -6833,6 +11822,17 @@ redirect_from:
         "summary" : "GET /api/ee/content-translation/csv",
         "description" : "Provides content translation dictionary in CSV",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/content-translation" ]
       }
     },
@@ -6848,6 +11848,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/content-translation" ]
       }
     },
@@ -6856,6 +11867,17 @@ redirect_from:
         "summary" : "POST /api/ee/content-translation/upload-dictionary",
         "description" : "Upload a CSV of content translations",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
@@ -6881,6 +11903,60 @@ redirect_from:
         "tags" : [ "/api/ee/content-translation" ]
       }
     },
+    "/api/ee/database-replication/connection/{database-id}" : {
+      "post" : {
+        "summary" : "POST /api/ee/database-replication/connection/{database-id}",
+        "description" : "Create a new PG replication connection for the specified database.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "database-id",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "minimum" : 1
+          },
+          "description" : "value must be an integer greater than zero."
+        } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "tags" : [ "/api/ee/database-replication" ]
+      },
+      "delete" : {
+        "summary" : "DELETE /api/ee/database-replication/connection/{database-id}",
+        "description" : "Delete PG replication connection for the specified database.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "database-id",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "minimum" : 1
+          },
+          "description" : "value must be an integer greater than zero."
+        } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "tags" : [ "/api/ee/database-replication" ]
+      }
+    },
     "/api/ee/database-routing/destination-database" : {
       "post" : {
         "summary" : "POST /api/ee/database-routing/destination-database",
@@ -6893,6 +11969,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6945,6 +12032,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6963,11 +12061,111 @@ redirect_from:
         "tags" : [ "/api/ee/database-routing" ]
       }
     },
+    "/api/ee/email/override" : {
+      "put" : {
+        "summary" : "PUT /api/ee/email/override",
+        "description" : "Update multiple cloud email Settings. You must be a superuser or have `setting` permission to do this.\n  Calling this automatically sets `cloud-smtp-enabled` to true if the settings are valid.",
+        "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "email-smtp-host-override" : {
+                    "anyOf" : [ {
+                      "type" : "string"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  },
+                  "email-smtp-password-override" : {
+                    "anyOf" : [ {
+                      "type" : "string"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  },
+                  "email-smtp-port-override" : {
+                    "anyOf" : [ {
+                      "type" : "integer"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  },
+                  "email-smtp-security-override" : {
+                    "anyOf" : [ {
+                      "type" : "string"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  },
+                  "email-smtp-username-override" : {
+                    "anyOf" : [ {
+                      "type" : "string"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "/api/ee/email" ]
+      },
+      "delete" : {
+        "summary" : "DELETE /api/ee/email/override",
+        "description" : "Clear all cloud email related settings. You must be a superuser or have `setting` permission to do this.",
+        "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "tags" : [ "/api/ee/email" ]
+      }
+    },
     "/api/ee/gsheets/connection" : {
       "post" : {
         "summary" : "POST /api/ee/gsheets/connection",
         "description" : "Hook up a new google drive folder or sheet that will be watched and have its content ETL'd into Metabase.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:error -> <true>, :message -> <value must be a non-blank string.>}, or one of <not-connected = map | syncing = map where {:url -> <value must be a non-blank string.>, :created_at -> <integer greater than 0>, :sync_started_at -> <integer greater than 0>, :created_by_id -> <integer greater than 0>, :db_id -> <integer greater than 0>} | active = map where {:url -> <value must be a non-blank string.>, :created_at -> <integer greater than 0>, :last_sync_at -> <integer greater than 0>, :next_sync_at -> <integer greater than 0>, :created_by_id -> <integer greater than 0>, :db_id -> <integer greater than 0>} | error = map where {:url -> <value must be a non-blank string.>, :created_at -> <integer greater than 0>, :error_message -> <value must be a non-blank string.>, :created_by_id -> <integer greater than 0>, :db_id -> <integer greater than 0>}> dispatched by :status",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/gsheets.response"
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -6990,12 +12188,41 @@ redirect_from:
         "summary" : "GET /api/ee/gsheets/connection",
         "description" : "Check the status of a connection. This endpoint gets polled by FE to determine when to\n  stop showing the setup widget.\n\n  Returns the gsheets shape, with the attached datawarehouse db id at `:db_id`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:error -> <true>, :message -> <value must be a non-blank string.>}, or one of <not-connected = map | syncing = map where {:url -> <value must be a non-blank string.>, :created_at -> <integer greater than 0>, :sync_started_at -> <integer greater than 0>, :created_by_id -> <integer greater than 0>, :db_id -> <integer greater than 0>} | active = map where {:url -> <value must be a non-blank string.>, :created_at -> <integer greater than 0>, :last_sync_at -> <integer greater than 0>, :next_sync_at -> <integer greater than 0>, :created_by_id -> <integer greater than 0>, :db_id -> <integer greater than 0>} | error = map where {:url -> <value must be a non-blank string.>, :created_at -> <integer greater than 0>, :error_message -> <value must be a non-blank string.>, :created_by_id -> <integer greater than 0>, :db_id -> <integer greater than 0>}> dispatched by :status",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/gsheets.response"
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/gsheets" ]
       },
       "delete" : {
         "summary" : "DELETE /api/ee/gsheets/connection",
         "description" : "Disconnect the google service account. There is only one (or zero) at the time of writing.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/gsheets" ]
       }
     },
@@ -7004,6 +12231,17 @@ redirect_from:
         "summary" : "POST /api/ee/gsheets/connection/sync",
         "description" : "Force a sync of the connection now.\n\n  Returns the gsheets shape, with the attached datawarehouse db id at `:db_id`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/gsheets" ]
       }
     },
@@ -7012,6 +12250,30 @@ redirect_from:
         "summary" : "GET /api/ee/gsheets/service-account",
         "description" : "Checks to see if service-account is setup or not, delegates to HM only if we haven't set it from a metabase cluster\n  before.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:email -> <nullable string>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "email" : {
+                      "type" : "string"
+                    }
+                  },
+                  "required" : [ ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/gsheets" ]
       }
     },
@@ -7029,6 +12291,17 @@ redirect_from:
           },
           "description" : "Must be a string like 2020-04 or 2222-11."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/logs" ]
       }
     },
@@ -7037,6 +12310,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/answer-sources",
         "description" : "Return top level meta information about available information sources.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7065,6 +12364,35 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/create-dashboard-subscription",
         "description" : "Create a dashboard subscription.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:output -> <string>, :conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    },
+                    "output" : {
+                      "type" : "string"
+                    }
+                  },
+                  "required" : [ "output", "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7093,6 +12421,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/field-values",
         "description" : "Return statistics and/or values for a given field of a given entity.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7121,6 +12475,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/filter-records",
         "description" : "Construct a query from a metric.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7149,6 +12529,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/find-metric",
         "description" : "Find a metric matching a description.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7183,6 +12589,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/find-outliers",
         "description" : "Find outliers in the values provided by a data source for a given column.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7211,6 +12643,41 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/generate-insights",
         "description" : "Generate insights.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:output -> <string>, :reactions -> <sequence of map where {:type -> <must equal :metabot.reaction/redirect>, :url -> <string>}>, :conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    },
+                    "output" : {
+                      "type" : "string"
+                    },
+                    "reactions" : {
+                      "type" : "array",
+                      "items" : {
+                        "$ref" : "#/components/schemas/metabot.reaction.redirect"
+                      }
+                    }
+                  },
+                  "required" : [ "output", "reactions", "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7239,6 +12706,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/get-current-user",
         "description" : "Get information about user that started the conversation.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7256,6 +12749,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/get-dashboard-details",
         "description" : "Get information about a given dashboard.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7290,6 +12809,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/get-metric-details",
         "description" : "Get information about a given metric.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7318,6 +12863,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/get-query-details",
         "description" : "Get information about a given query.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7353,6 +12924,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/get-report-details",
         "description" : "Get information about a given report.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7381,6 +12978,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/get-table-details",
         "description" : "Get information about a given table or model.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7409,6 +13032,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/query-metric",
         "description" : "Construct a query from a metric.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7437,6 +13086,32 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-tools/query-model",
         "description" : "Construct a query from a model.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:conversation_id -> <value must be a valid UUID.>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "conversation_id" : {
+                      "description" : "value must be a valid UUID.",
+                      "type" : "string",
+                      "pattern" : "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+                    }
+                  },
+                  "required" : [ "conversation_id" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7465,6 +13140,17 @@ redirect_from:
         "summary" : "GET /api/ee/metabot-v3/metabot/",
         "description" : "List configured metabot instances",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/metabot-v3/metabot" ]
       }
     },
@@ -7481,6 +13167,17 @@ redirect_from:
             "minimum" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/metabot-v3/metabot" ]
       }
     },
@@ -7497,6 +13194,17 @@ redirect_from:
             "minimum" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/metabot-v3/metabot" ]
       },
       "put" : {
@@ -7511,6 +13219,17 @@ redirect_from:
             "minimum" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7572,6 +13291,17 @@ redirect_from:
             "minimum" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/metabot-v3/metabot" ]
       }
     },
@@ -7611,6 +13341,17 @@ redirect_from:
             "minimum" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/metabot-v3/metabot" ]
       },
       "delete" : {
@@ -7625,6 +13366,17 @@ redirect_from:
             "minimum" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/metabot-v3/metabot" ]
       }
     },
@@ -7641,6 +13393,17 @@ redirect_from:
             "minimum" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/metabot-v3/metabot" ]
       }
     },
@@ -7665,6 +13428,17 @@ redirect_from:
             "minimum" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/metabot-v3/metabot" ]
       }
     },
@@ -7673,6 +13447,17 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-v3/v2/agent",
         "description" : "Send a chat message to the LLM via the AI Service.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7715,6 +13500,17 @@ redirect_from:
         "summary" : "POST /api/ee/metabot-v3/v2/agent-streaming",
         "description" : "Send a chat message to the LLM via the AI Proxy.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7752,48 +13548,39 @@ redirect_from:
         "tags" : [ "/api/ee/metabot-v3" ]
       }
     },
-    "/api/ee/permission_debug/" : {
-      "get" : {
-        "summary" : "GET /api/ee/permission_debug/",
-        "description" : "This endpoint expects a `user_id`, a `model_id` to debug permissions against, and `action_type`.\n  The type of model we are debugging against is inferred by the `action_type`.\n\n  It will return:\n  - `decision`: The overall permission decision (\"allow\", \"denied\", or \"limited\")\n  - `model-type`: The type of model being checked (e.g., \"question\")\n  - `model-id`: The ID of the model being checked\n  - `segment`: A set of segmentation types applied (e.g., \"sandboxed\", \"impersonated\", \"routed\")\n  - `message`: A sequence of strings explaining the decision\n  - `data`: A map containing details about permissions (table or collection names to group names)\n  - `suggestions`: A map of group IDs to group names that could provide access\n\n  Example requests:\n  - Check if user can read a card: `GET /api/ee/permission_debug?user_id=123&model_id=456&action_type=card/read`\n  - Check if user can query a card: `GET /api/ee/permission_debug?user_id=123&model_id=456&action_type=card/query`\n  - Check if user can download data: `GET /api/ee/permission_debug?user_id=123&model_id=456&action_type=card/download-data`\n\n  Example responses:\n  - Allowed access:\n    ```json\n    {\n      \"decision\": \"allow\",\n      \"model-type\": \"question\",\n      \"model-id\": \"456\",\n      \"segment\": [],\n      \"message\": [\"User has permission to read this card\"],\n      \"data\": {},\n      \"suggestions\": {}\n    }\n    ```\n  - Denied access with blocked table:\n    ```json\n    {\n      \"decision\": \"denied\",\n      \"model-type\": \"question\",\n      \"model-id\": \"456\",\n      \"segment\": [],\n      \"message\": [\"User does not have permission to query this card\"],\n      \"data\": {\"sample-db.PUBLIC.ORDERS\": [\"All Users\"]},\n      \"suggestions\": {}\n    }\n    ```\n  - Limited access:\n    ```json\n    {\n      \"decision\": \"limited\",\n      \"model-type\": \"question\",\n      \"model-id\": \"456\",\n      \"segment\": [],\n      \"message\": [\"User has permission to download some data from this card\"],\n      \"data\": {},\n      \"suggestions\": {}\n    }\n    ```",
-        "parameters" : [ {
-          "in" : "query",
-          "name" : "user_id",
-          "required" : true,
-          "schema" : {
-            "type" : "integer",
-            "minimum" : 1
-          }
-        }, {
-          "in" : "query",
-          "name" : "model_id",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "in" : "query",
-          "name" : "action_type",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "card/read", "card/query", "card/download-data" ]
-          }
-        } ],
-        "tags" : [ "/api/ee/permission_debug" ]
-      }
-    },
     "/api/ee/scim/api_key" : {
       "get" : {
         "summary" : "GET /api/ee/scim/api_key",
         "description" : "Fetch the SCIM API key if one exists. Does *not* return an unmasked key, since we don't have access\n  to that after it is created.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/scim" ]
       },
       "post" : {
         "summary" : "POST /api/ee/scim/api_key",
         "description" : "Create a new SCIM API key, or refresh one that already exists. When called for the first time,\n  this is equivalent to enabling SCIM.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/scim" ]
       }
     },
@@ -7828,12 +13615,34 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/scim/v2" ]
       },
       "post" : {
         "summary" : "POST /api/ee/scim/v2/Groups",
         "description" : "Create a single group, and populates it if necessary.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7894,12 +13703,34 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/scim/v2" ]
       },
       "put" : {
         "summary" : "PUT /api/ee/scim/v2/Groups/{id}",
         "description" : "Update a group.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -7958,6 +13789,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/scim/v2" ]
       }
     },
@@ -7992,12 +13834,34 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/scim/v2" ]
       },
       "post" : {
         "summary" : "POST /api/ee/scim/v2/Users",
         "description" : "Create a single user.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -8101,12 +13965,34 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/scim/v2" ]
       },
       "put" : {
         "summary" : "PUT /api/ee/scim/v2/Users/{id}",
         "description" : "Update a user.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -8208,6 +14094,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -8341,6 +14238,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/serialization" ]
       }
     },
@@ -8365,6 +14273,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
@@ -8449,6 +14368,17 @@ redirect_from:
             "enum" : [ "asc", "desc" ]
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/stale" ]
       }
     },
@@ -8457,6 +14387,17 @@ redirect_from:
         "summary" : "GET /api/ee/upload-management/tables",
         "description" : "Get all `Tables` visible to the current user which were created by uploading a file.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/upload-management" ]
       }
     },
@@ -8482,6 +14423,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/ee/upload-management" ]
       }
     },
@@ -8490,6 +14442,17 @@ redirect_from:
         "summary" : "POST /api/eid-translation/translate",
         "description" : "Translate entity IDs to model IDs.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -8514,12 +14477,59 @@ redirect_from:
         "summary" : "PUT /api/email/",
         "description" : "Update multiple email Settings. You must be a superuser or have `setting` permission to do this.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
                 "type" : "object",
-                "properties" : { }
+                "properties" : {
+                  "email-smtp-host" : {
+                    "anyOf" : [ {
+                      "type" : "string"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  },
+                  "email-smtp-password" : {
+                    "anyOf" : [ {
+                      "type" : "string"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  },
+                  "email-smtp-port" : {
+                    "anyOf" : [ {
+                      "type" : "integer"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  },
+                  "email-smtp-security" : {
+                    "anyOf" : [ {
+                      "type" : "string"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  },
+                  "email-smtp-username" : {
+                    "anyOf" : [ {
+                      "type" : "string"
+                    }, {
+                      "type" : "null"
+                    } ]
+                  }
+                }
               }
             }
           }
@@ -8530,6 +14540,17 @@ redirect_from:
         "summary" : "DELETE /api/email/",
         "description" : "Clear all email related settings. You must be a superuser or have `setting` permission to do this.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/email" ]
       }
     },
@@ -8538,6 +14559,17 @@ redirect_from:
         "summary" : "POST /api/email/test",
         "description" : "Send a test email using the SMTP Settings. You must be a superuser or have `setting` permission to do this.\n  Returns `{:ok true}` if we were able to send the message successfully, otherwise a standard 400 error response.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/email" ]
       }
     },
@@ -8553,6 +14585,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8582,6 +14625,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8590,6 +14644,17 @@ redirect_from:
         "summary" : "GET /api/embed/card/{token}/params/{param-key}/search/{prefix}",
         "description" : "Embedded version of chain filter search endpoint.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8612,6 +14677,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8627,6 +14703,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8665,6 +14752,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8680,6 +14778,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8713,6 +14822,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8762,6 +14882,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8770,6 +14901,17 @@ redirect_from:
         "summary" : "GET /api/embed/dashboard/{token}/params/{param-key}/remapping",
         "description" : "Embedded version of the remapped dashboard param value endpoint.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8778,6 +14920,17 @@ redirect_from:
         "summary" : "GET /api/embed/dashboard/{token}/params/{param-key}/search/{prefix}",
         "description" : "Embedded version of chain filter search endpoint.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8800,6 +14953,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8815,6 +14979,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8848,6 +15023,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8909,6 +15095,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -8988,6 +15185,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/embed" ]
       }
     },
@@ -9013,6 +15221,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/field" ]
       },
       "put" : {
@@ -9028,6 +15247,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9105,6 +15335,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9145,6 +15386,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/field" ]
       }
     },
@@ -9162,6 +15414,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/field" ]
       }
     },
@@ -9179,6 +15442,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/field" ]
       }
     },
@@ -9213,6 +15487,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/field" ]
       }
     },
@@ -9230,6 +15515,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/field" ]
       }
     },
@@ -9264,6 +15560,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/field" ]
       }
     },
@@ -9281,6 +15588,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/field" ]
       }
     },
@@ -9298,6 +15616,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/field" ]
       },
       "post" : {
@@ -9313,6 +15642,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9356,6 +15696,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/geojson" ]
       }
     },
@@ -9372,6 +15723,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/geojson" ]
       }
     },
@@ -9380,6 +15742,17 @@ redirect_from:
         "summary" : "PUT /api/google/settings",
         "description" : "Update Google Sign-In related settings. You must be a superuser to do this.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9408,6 +15781,17 @@ redirect_from:
         "summary" : "PUT /api/ldap/settings",
         "description" : "Update LDAP related settings. You must be a superuser to do this.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9440,6 +15824,17 @@ redirect_from:
         "summary" : "POST /api/logger/adjustment",
         "description" : "Temporarily adjust the log levels.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9465,6 +15860,17 @@ redirect_from:
         "summary" : "DELETE /api/logger/adjustment",
         "description" : "Undo any log level adjustments.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/logger" ]
       }
     },
@@ -9473,6 +15879,17 @@ redirect_from:
         "summary" : "GET /api/logger/logs",
         "description" : "Logs.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/logger" ]
       }
     },
@@ -9481,6 +15898,51 @@ redirect_from:
         "summary" : "GET /api/logger/presets",
         "description" : "Get all known presets.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "sequence of map where {:id -> <keyword>, :display_name -> <string>, :loggers -> <sequence of map where {:name -> <string>, :level -> <enum of :off, :fatal, :error, :warn, :info, :debug, :trace>}>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "display_name" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "loggers" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "level" : {
+                              "$ref" : "#/components/schemas/metabase.logger.api.log-level"
+                            },
+                            "name" : {
+                              "type" : "string"
+                            }
+                          },
+                          "required" : [ "name", "level" ]
+                        }
+                      }
+                    },
+                    "required" : [ "id", "display_name", "loggers" ]
+                  }
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/logger" ]
       }
     },
@@ -9489,6 +15951,17 @@ redirect_from:
         "summary" : "GET /api/login-history/current",
         "description" : "Fetch recent logins for the current user.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/login-history" ]
       }
     },
@@ -9497,6 +15970,17 @@ redirect_from:
         "summary" : "POST /api/model-index/",
         "description" : "Create ModelIndex.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9531,6 +16015,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/model-index" ]
       }
     },
@@ -9548,6 +16043,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/model-index" ]
       },
       "delete" : {
@@ -9563,6 +16069,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/model-index" ]
       }
     },
@@ -9571,6 +16088,17 @@ redirect_from:
         "summary" : "POST /api/moderation-review/",
         "description" : "Create a new `ModerationReview`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9624,12 +16152,34 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/mt/gtap" ]
       },
       "post" : {
         "summary" : "POST /api/mt/gtap/",
         "description" : "Create a new GTAP.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9666,6 +16216,17 @@ redirect_from:
         "summary" : "POST /api/mt/gtap/validate",
         "description" : "Validate a sandbox which may not have yet been saved. This runs the same validation that is performed when the\n  sandbox is saved, but doesn't actually save the sandbox.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9705,6 +16266,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/mt/gtap" ]
       },
       "put" : {
@@ -9720,6 +16292,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9752,6 +16335,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/mt/gtap" ]
       }
     },
@@ -9760,6 +16354,17 @@ redirect_from:
         "summary" : "GET /api/mt/user/attributes",
         "description" : "Fetch a list of possible keys for User `login_attributes`. This just looks at keys that have already been set for\n  existing Users and returns those. ",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/mt/user" ]
       }
     },
@@ -9777,6 +16382,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9809,12 +16425,34 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/native-query-snippet" ]
       },
       "post" : {
         "summary" : "POST /api/native-query-snippet/",
         "description" : "Create a new `NativeQuerySnippet`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9858,6 +16496,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/native-query-snippet" ]
       },
       "put" : {
@@ -9873,6 +16522,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9960,12 +16620,34 @@ redirect_from:
             "enum" : [ "notification/dashboard", "notification/system-event", "notification/testing", "notification/card" ]
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/notification" ]
       },
       "post" : {
         "summary" : "POST /api/notification/",
         "description" : "Create a new notification, return the created notification.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -9983,6 +16665,17 @@ redirect_from:
         "summary" : "POST /api/notification/send",
         "description" : "Send an unsaved notification.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10000,6 +16693,17 @@ redirect_from:
         "summary" : "POST /api/notification/unsubscribe/",
         "description" : "Allow non-users to unsubscribe from notifications, with the hash given through email.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10031,6 +16735,17 @@ redirect_from:
         "summary" : "POST /api/notification/unsubscribe/undo",
         "description" : "Allow non-users to undo an unsubscribe from notifications, with the hash given through email.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10071,6 +16786,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/notification" ]
       },
       "put" : {
@@ -10086,6 +16812,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10112,6 +16849,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10148,6 +16896,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/notification" ]
       }
     },
@@ -10156,6 +16915,17 @@ redirect_from:
         "summary" : "POST /api/notify/db/attached_datawarehouse",
         "description" : "Sync the attached datawarehouse. Can provide in the body:\n  - table_name and schema_name: both strings. Will look for an existing table and sync it, otherwise will try to find a\n  new table with that name and sync it. If it cannot find a table it will throw an error. If table_name is empty or\n  blank, will sync the entire database.\n  - synchronous?: is a boolean value to indicate if this should block on the result.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10196,6 +16966,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10237,6 +17018,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10265,6 +17057,17 @@ redirect_from:
         "summary" : "GET /api/permissions/graph",
         "description" : "Fetch a graph of all Permissions.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/permissions" ]
       },
       "put" : {
@@ -10287,6 +17090,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10314,6 +17128,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/permissions" ]
       }
     },
@@ -10331,6 +17156,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/permissions" ]
       }
     },
@@ -10339,12 +17175,34 @@ redirect_from:
         "summary" : "GET /api/permissions/group",
         "description" : "Fetch all `PermissionsGroups`, including a count of the number of `:members` in that group.\n  This API requires superuser or group manager of more than one group.\n  Group manager is only available if `advanced-permissions` is enabled and returns only groups that user\n  is manager of.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/permissions" ]
       },
       "post" : {
         "summary" : "POST /api/permissions/group",
         "description" : "Create a new `PermissionsGroup`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10378,6 +17236,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10409,6 +17278,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/permissions" ]
       }
     },
@@ -10426,6 +17306,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/permissions" ]
       }
     },
@@ -10434,12 +17325,34 @@ redirect_from:
         "summary" : "GET /api/permissions/membership",
         "description" : "Fetch a map describing the group memberships of various users.\n   This map's format is:\n\n    {<user-id> [{:membership_id    <id>\n                 :group_id         <id>\n                 :is_group_manager boolean}]}",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/permissions" ]
       },
       "post" : {
         "summary" : "POST /api/permissions/membership",
         "description" : "Add a `User` to a `PermissionsGroup`. Returns updated list of members belonging to the group.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10483,6 +17396,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/permissions" ]
       }
     },
@@ -10500,6 +17424,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10530,6 +17465,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/permissions" ]
       }
     },
@@ -10538,6 +17484,17 @@ redirect_from:
         "summary" : "GET /api/persist/",
         "description" : "List the entries of [[PersistedInfo]] in order to show a status page.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/persist" ]
       }
     },
@@ -10555,6 +17512,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/persist" ]
       }
     },
@@ -10572,6 +17540,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/persist" ]
       }
     },
@@ -10589,6 +17568,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/persist" ]
       }
     },
@@ -10606,6 +17596,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/persist" ]
       }
     },
@@ -10623,6 +17624,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/persist" ]
       }
     },
@@ -10640,6 +17652,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/persist" ]
       }
     },
@@ -10648,6 +17671,17 @@ redirect_from:
         "summary" : "POST /api/persist/disable",
         "description" : "Disable global setting to allow databases to persist models. This will remove all tasks to refresh tables, remove\n  that option from databases which might have it enabled, and delete all cached tables.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/persist" ]
       }
     },
@@ -10656,6 +17690,17 @@ redirect_from:
         "summary" : "POST /api/persist/enable",
         "description" : "Enable global setting to allow databases to persist models.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/persist" ]
       }
     },
@@ -10664,6 +17709,17 @@ redirect_from:
         "summary" : "POST /api/persist/set-refresh-schedule",
         "description" : "Set the cron schedule to refresh persisted models.\n   Shape should be JSON like {cron: \"0 30 1/8 * * ? *\"}.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10698,6 +17754,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/persist" ]
       }
     },
@@ -10706,6 +17773,17 @@ redirect_from:
         "summary" : "GET /api/premium-features/token/status",
         "description" : "Fetch info about the current Premium-Features premium features token including whether it is `valid`, a `trial` token, its\n  `features`, when it is `valid-thru`, and the `status` of the account.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/premium-features" ]
       }
     },
@@ -10722,6 +17800,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/preview_embed" ]
       }
     },
@@ -10751,6 +17840,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/preview_embed" ]
       }
     },
@@ -10767,6 +17867,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/preview_embed" ]
       }
     },
@@ -10783,6 +17894,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/preview_embed" ]
       }
     },
@@ -10817,6 +17939,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/preview_embed" ]
       }
     },
@@ -10825,6 +17958,17 @@ redirect_from:
         "summary" : "GET /api/preview_embed/dashboard/{token}/params/{param-key}/remapping",
         "description" : "Embedded version of the remapped dashboard param value endpoint.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/preview_embed" ]
       }
     },
@@ -10833,6 +17977,17 @@ redirect_from:
         "summary" : "GET /api/preview_embed/dashboard/{token}/params/{param-key}/values",
         "description" : "Embedded version of chain filter values endpoint.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/preview_embed" ]
       }
     },
@@ -10849,6 +18004,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/preview_embed" ]
       }
     },
@@ -10883,6 +18049,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/preview_embed" ]
       }
     },
@@ -10891,6 +18068,17 @@ redirect_from:
         "summary" : "POST /api/product-feedback/",
         "description" : "Endpoint to provide feedback from the product",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10932,6 +18120,17 @@ redirect_from:
           },
           "description" : "value must be a valid UUID."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -10949,6 +18148,17 @@ redirect_from:
           },
           "description" : "value must be a valid UUID."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -10981,6 +18191,17 @@ redirect_from:
           },
           "description" : "value must be a valid UUID."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11011,6 +18232,17 @@ redirect_from:
           "required" : true,
           "schema" : { }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11044,6 +18276,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11069,6 +18312,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11094,6 +18348,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11142,6 +18407,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11159,6 +18435,17 @@ redirect_from:
           },
           "description" : "value must be a valid UUID."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11202,6 +18489,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11244,6 +18542,17 @@ redirect_from:
             "$ref" : "#/components/schemas/metabase.query-processor.schema.export-format"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -11305,6 +18614,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       },
       "post" : {
@@ -11329,6 +18649,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -11374,6 +18705,17 @@ redirect_from:
           "required" : true,
           "schema" : { }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11407,6 +18749,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11432,6 +18785,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11475,6 +18839,17 @@ redirect_from:
             "minimum" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11500,6 +18875,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11543,6 +18929,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11606,6 +19003,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11687,6 +19095,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/public" ]
       }
     },
@@ -11720,12 +19139,34 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/pulse" ]
       },
       "post" : {
         "summary" : "POST /api/pulse/",
         "description" : "Create a new `Pulse`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -11778,6 +19219,17 @@ redirect_from:
         "summary" : "GET /api/pulse/form_input",
         "description" : "Provides relevant configuration information and user choices for creating/updating Pulses.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/pulse" ]
       }
     },
@@ -11795,6 +19247,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/pulse" ]
       }
     },
@@ -11812,6 +19275,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/pulse" ]
       }
     },
@@ -11829,6 +19303,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/pulse" ]
       }
     },
@@ -11846,6 +19331,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/pulse" ]
       }
     },
@@ -11854,6 +19350,17 @@ redirect_from:
         "summary" : "POST /api/pulse/test",
         "description" : "Test send an unsaved pulse.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -11899,6 +19406,17 @@ redirect_from:
         "summary" : "POST /api/pulse/unsubscribe/",
         "description" : "Allow non-users to unsubscribe from pulses/subscriptions, with the hash given through email.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -11930,6 +19448,17 @@ redirect_from:
         "summary" : "POST /api/pulse/unsubscribe/undo",
         "description" : "Allow non-users to undo an unsubscribe from pulses/subscriptions, with the hash given through email.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -11970,6 +19499,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/pulse" ]
       },
       "put" : {
@@ -11985,6 +19525,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12041,6 +19592,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/pulse" ]
       }
     },
@@ -12066,6 +19628,17 @@ redirect_from:
             "enum" : [ "card", "dashboard", "segment" ]
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/revision" ]
       }
     },
@@ -12074,6 +19647,17 @@ redirect_from:
         "summary" : "POST /api/revision/revert",
         "description" : "Revert an object to a prior revision.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12125,13 +19709,24 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/revision" ]
       }
     },
     "/api/search/" : {
       "get" : {
         "summary" : "GET /api/search/",
-        "description" : "Search for items in Metabase.\n  For the list of supported models, check [[metabase.search.config/all-models]].\n\n  Filters:\n  - `archived`: set to true to search archived items only, default is false\n  - `table_db_id`: search for tables, cards, and models of a certain DB\n  - `models`: only search for items of specific models. If not provided, search for all models\n  - `filters_items_in_personal_collection`: only search for items in personal collections\n  - `created_at`: search for items created at a specific timestamp\n  - `created_by`: search for items created by a specific user\n  - `last_edited_at`: search for items last edited at a specific timestamp\n  - `last_edited_by`: search for items last edited by a specific user\n  - `search_native_query`: set to true to search the content of native queries\n  - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)\n  - `ids`: search for items with those ids, works iff single value passed to `models`\n\n  Note that not all item types support all filters, and the results will include only models that support the provided filters. For example:\n  - The `created-by` filter supports dashboards, models, actions, and cards.\n  - The `verified` filter supports models and cards.\n\n  A search query that has both filters applied will only return models and cards.",
+        "description" : "Search for items in Metabase.\n  For the list of supported models, check [[metabase.search.config/all-models]].\n\n  Filters:\n  - `archived`: set to true to search archived items only, default is false\n  - `table_db_id`: search for tables, cards, and models of a certain DB\n  - `models`: only search for items of specific models. If not provided, search for all models\n  - `filters_items_in_personal_collection`: only search for items in personal collections\n  - `created_at`: search for items created at a specific timestamp\n  - `created_by`: search for items created by a specific user\n  - `last_edited_at`: search for items last edited at a specific timestamp\n  - `last_edited_by`: search for items last edited by a specific user\n  - `search_native_query`: set to true to search the content of native queries\n  - `verified`: set to true to search for verified items only (requires Content Management or Official Collections premium feature)\n  - `ids`: search for items with those ids, works iff single value passed to `models`\n  - `display_type`: search for cards/models with specific display types\n  - `has_temporal_dimensions`: set to true to search for cards with temporal dimensions only\n\n  Note that not all item types support all filters, and the results will include only models that support the provided filters. For example:\n  - The `created-by` filter supports dashboards, models, actions, and cards.\n  - The `verified` filter supports models and cards.\n\n  A search query that has both filters applied will only return models and cards.",
         "parameters" : [ {
           "in" : "query",
           "name" : "q",
@@ -12202,6 +19797,24 @@ redirect_from:
               "type" : "integer",
               "minimum" : 1
             }
+          }
+        }, {
+          "in" : "query",
+          "name" : "display_type",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "minLength" : 1
+            }
+          }
+        }, {
+          "in" : "query",
+          "name" : "has_temporal_dimensions",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean"
           }
         }, {
           "in" : "query",
@@ -12288,6 +19901,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/search" ]
       }
     },
@@ -12296,6 +19920,17 @@ redirect_from:
         "summary" : "POST /api/search/force-reindex",
         "description" : "This will trigger an immediate reindexing, if we are using search index.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/search" ]
       }
     },
@@ -12304,6 +19939,17 @@ redirect_from:
         "summary" : "POST /api/search/re-init",
         "description" : "This will blow away any search indexes, re-create, and re-populate them.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/search" ]
       }
     },
@@ -12325,6 +19971,17 @@ redirect_from:
           "required" : false,
           "schema" : { }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/search" ]
       },
       "put" : {
@@ -12344,6 +20001,17 @@ redirect_from:
           "required" : false,
           "schema" : { }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/search" ]
       }
     },
@@ -12352,6 +20020,17 @@ redirect_from:
         "summary" : "POST /api/segment/",
         "description" : "Create a new `Segment`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12387,6 +20066,17 @@ redirect_from:
         "summary" : "GET /api/segment/",
         "description" : "Fetch *all* `Segments`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/segment" ]
       }
     },
@@ -12404,6 +20094,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/segment" ]
       },
       "put" : {
@@ -12419,6 +20120,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12481,6 +20193,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/segment" ]
       }
     },
@@ -12498,6 +20221,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/segment" ]
       }
     },
@@ -12506,6 +20240,17 @@ redirect_from:
         "summary" : "POST /api/session/",
         "description" : "Login.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12532,6 +20277,17 @@ redirect_from:
         "summary" : "DELETE /api/session/",
         "description" : "Logout.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/session" ]
       }
     },
@@ -12540,6 +20296,17 @@ redirect_from:
         "summary" : "POST /api/session/forgot_password",
         "description" : "Send a reset email when user has forgotten their password.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12564,6 +20331,17 @@ redirect_from:
         "summary" : "POST /api/session/google_auth",
         "description" : "Login with Google Auth.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12588,6 +20366,17 @@ redirect_from:
         "summary" : "POST /api/session/password-check",
         "description" : "Endpoint that checks if the supplied password meets the currently configured password complexity rules.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12620,6 +20409,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/session" ]
       }
     },
@@ -12628,6 +20428,17 @@ redirect_from:
         "summary" : "GET /api/session/properties",
         "description" : "Get all properties and their values. These are the specific `Settings` that are readable by the current user, or are\n  public if no user is logged in.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/session" ]
       }
     },
@@ -12636,6 +20447,17 @@ redirect_from:
         "summary" : "POST /api/session/reset_password",
         "description" : "Reset password with a reset token.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12664,12 +20486,34 @@ redirect_from:
         "summary" : "GET /api/setting/",
         "description" : "Get all `Settings` and their values. You must be a superuser or have `setting` permission to do this.\n  For non-superusers, a list of visible settings and values can be retrieved using the /api/session/properties endpoint.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/setting" ]
       },
       "put" : {
         "summary" : "PUT /api/setting/",
         "description" : "Update multiple `Settings` values. If called by a non-superuser, only user-local settings can be updated.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12695,6 +20539,17 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/setting" ]
       },
       "put" : {
@@ -12708,6 +20563,30 @@ redirect_from:
             "type" : "string"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "value" : { }
+                },
+                "required" : [ "value" ]
+              }
+            }
+          }
+        },
         "tags" : [ "/api/setting" ]
       }
     },
@@ -12716,6 +20595,17 @@ redirect_from:
         "summary" : "POST /api/setup/",
         "description" : "Special endpoint for creating the first user during setup. This endpoint both creates the user AND logs them in and\n  returns a session ID. This endpoint can also be used to add a database, create and invite a second admin, and/or\n  set specific settings from the setup flow.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12795,6 +20685,17 @@ redirect_from:
         "summary" : "GET /api/setup/user_defaults",
         "description" : "Returns object containing default user details for initial setup, if configured,\n   and if the provided token value matches the token in the configuration value.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/setup" ]
       }
     },
@@ -12803,6 +20704,17 @@ redirect_from:
         "summary" : "POST /api/slack/bug-report",
         "description" : "Send diagnostic information to the configured Slack channels.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12826,6 +20738,17 @@ redirect_from:
         "summary" : "GET /api/slack/manifest",
         "description" : "Returns the YAML manifest file that should be used to bootstrap new Slack apps",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/slack" ]
       }
     },
@@ -12834,6 +20757,17 @@ redirect_from:
         "summary" : "PUT /api/slack/settings",
         "description" : "Update Slack related settings. You must be a superuser to do this. Also updates the slack-cache.\n  There are 3 cases where we alter the slack channel/user cache:\n  1. falsy token           -> clear\n  2. invalid token         -> clear\n  3. truthy, valid token   -> refresh ",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12860,12 +20794,34 @@ redirect_from:
         "summary" : "GET /api/table/",
         "description" : "Get all `Tables`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       },
       "put" : {
         "summary" : "PUT /api/table/",
         "description" : "Update all `Table` in `ids`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -12926,6 +20882,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       }
     },
@@ -12943,6 +20910,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       }
     },
@@ -12967,6 +20945,17 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       },
       "put" : {
@@ -12982,6 +20971,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -13037,6 +21037,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
@@ -13076,6 +21087,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       }
     },
@@ -13093,6 +21115,30 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:success -> <must equal true>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "success" : {
+                      "const" : true
+                    }
+                  },
+                  "required" : [ "success" ]
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -13124,6 +21170,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       }
     },
@@ -13165,6 +21222,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       }
     },
@@ -13182,6 +21250,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       }
     },
@@ -13199,6 +21278,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
@@ -13238,6 +21328,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       }
     },
@@ -13255,6 +21356,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       }
     },
@@ -13272,6 +21384,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/table" ]
       }
     },
@@ -13280,6 +21403,17 @@ redirect_from:
         "summary" : "GET /api/task/",
         "description" : "Fetch a list of recent tasks stored as Task History",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/task" ]
       }
     },
@@ -13288,6 +21422,17 @@ redirect_from:
         "summary" : "GET /api/task/info",
         "description" : "Return raw data about all scheduled tasks (i.e., Quartz Jobs and Triggers).",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/task" ]
       }
     },
@@ -13296,6 +21441,17 @@ redirect_from:
         "summary" : "GET /api/task/unique-tasks",
         "description" : "Returns possibly empty vector of unique task names in alphabetical order. It is expected that number of unique\n  tasks is small, hence no need for pagination. If that changes this endpoint and function that powers it should\n  reflect that.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/task" ]
       }
     },
@@ -13313,7 +21469,250 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/task" ]
+      }
+    },
+    "/api/testing/echo" : {
+      "post" : {
+        "summary" : "POST /api/testing/echo",
+        "description" : "Simple echo hander. Fails when you POST with `?fail=true`.",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "fail",
+          "required" : true,
+          "schema" : {
+            "default" : false,
+            "type" : "boolean"
+          }
+        } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "tags" : [ "/api/testing" ]
+      },
+      "get" : {
+        "summary" : "GET /api/testing/echo",
+        "description" : "Simple echo hander. Fails when you GET with `?fail=true`.",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "fail",
+          "required" : true,
+          "schema" : {
+            "default" : false,
+            "type" : "boolean"
+          }
+        }, {
+          "in" : "query",
+          "name" : "body",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "description" : "value must be a valid JSON string."
+        } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "tags" : [ "/api/testing" ]
+      }
+    },
+    "/api/testing/mark-stale" : {
+      "post" : {
+        "summary" : "POST /api/testing/mark-stale",
+        "description" : "Mark the card or dashboard as stale",
+        "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "date-str" : {
+                    "type" : "string"
+                  },
+                  "id" : {
+                    "description" : "value must be an integer greater than zero.",
+                    "type" : "integer",
+                    "minimum" : 1
+                  },
+                  "model" : {
+                    "type" : "string"
+                  }
+                },
+                "required" : [ "id", "model" ]
+              }
+            }
+          }
+        },
+        "tags" : [ "/api/testing" ]
+      }
+    },
+    "/api/testing/refresh-caches" : {
+      "post" : {
+        "summary" : "POST /api/testing/refresh-caches",
+        "description" : "Manually triggers the cache refresh task, if Enterprise code is available.",
+        "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "tags" : [ "/api/testing" ]
+      }
+    },
+    "/api/testing/restore/{name}" : {
+      "post" : {
+        "summary" : "POST /api/testing/restore/{name}",
+        "description" : "Restore a database snapshot for testing purposes.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "name",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "minLength" : 1
+          }
+        } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "tags" : [ "/api/testing" ]
+      }
+    },
+    "/api/testing/set-time" : {
+      "post" : {
+        "summary" : "POST /api/testing/set-time",
+        "description" : "Make java-time see world at exact time.",
+        "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "add-ms" : {
+                    "description" : "value must be an integer.",
+                    "type" : "integer"
+                  },
+                  "time" : {
+                    "description" : "value must be a valid date string",
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags" : [ "/api/testing" ]
+      }
+    },
+    "/api/testing/snapshot/{name}" : {
+      "post" : {
+        "summary" : "POST /api/testing/snapshot/{name}",
+        "description" : "Snapshot the database for testing purposes.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "name",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "minLength" : 1
+          }
+        } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "tags" : [ "/api/testing" ]
+      }
+    },
+    "/api/testing/stats" : {
+      "post" : {
+        "summary" : "POST /api/testing/stats",
+        "description" : "Triggers a send of instance usage stats",
+        "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
+        "tags" : [ "/api/testing" ]
       }
     },
     "/api/tiles/{card-id}/{zoom}/{x}/{y}/{lat-field}/{lon-field}" : {
@@ -13376,6 +21775,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/tiles" ]
       }
     },
@@ -13457,6 +21867,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/tiles" ]
       }
     },
@@ -13473,6 +21894,17 @@ redirect_from:
           },
           "description" : "value must be a valid JSON string."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/tiles" ]
       }
     },
@@ -13481,6 +21913,17 @@ redirect_from:
         "summary" : "POST /api/timeline-event/",
         "description" : "Create a new [[TimelineEvent]].",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -13548,6 +21991,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/timeline-event" ]
       },
       "put" : {
@@ -13563,6 +22017,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -13618,6 +22083,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/timeline-event" ]
       }
     },
@@ -13626,6 +22102,24 @@ redirect_from:
         "summary" : "POST /api/timeline/",
         "description" : "Create a new [[Timeline]].",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:id -> <integer greater than 0>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/metabase.timeline.api.timeline.Timeline"
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -13681,6 +22175,27 @@ redirect_from:
             "type" : "boolean"
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "sequence of map where {:id -> <integer greater than 0>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/metabase.timeline.api.timeline.Timeline"
+                  }
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/timeline" ]
       }
     },
@@ -13704,6 +22219,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/timeline" ]
       }
     },
@@ -13736,6 +22262,17 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/timeline" ]
       }
     },
@@ -13784,6 +22321,24 @@ redirect_from:
           },
           "description" : "value must be a valid date string"
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "map where {:id -> <integer greater than 0>}",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/metabase.timeline.api.timeline.Timeline"
+                }
+              }
+            }
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/timeline" ]
       },
       "put" : {
@@ -13799,6 +22354,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -13847,6 +22413,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/timeline" ]
       }
     },
@@ -13855,6 +22432,17 @@ redirect_from:
         "summary" : "POST /api/upload/csv",
         "description" : "Create a table and model populated with the values from the attached CSV. Returns the model ID if successful.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
@@ -13897,6 +22485,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/user-key-value" ]
       }
     },
@@ -13921,6 +22520,17 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -13958,12 +22568,34 @@ redirect_from:
             "minLength" : 1
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/user-key-value" ]
       },
       "delete" : {
         "summary" : "DELETE /api/user-key-value/namespace/{namespace}/key/{key}",
         "description" : "Deletes a KV-pair for the user",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/user-key-value" ]
       }
     },
@@ -14003,12 +22635,34 @@ redirect_from:
             "default" : false
           }
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/user" ]
       },
       "post" : {
         "summary" : "POST /api/user/",
         "description" : "Create a new `User`, return a 400 if the email address is already taken",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -14052,6 +22706,17 @@ redirect_from:
         "summary" : "GET /api/user/current",
         "description" : "Fetch the current `User`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/user" ]
       }
     },
@@ -14060,6 +22725,17 @@ redirect_from:
         "summary" : "GET /api/user/recipients",
         "description" : "Fetch a list of `Users`. Returns only active users. Meant for non-admins unlike GET /api/user.\n\n   - If user-visibility is :all or the user is an admin, include all users.\n   - If user-visibility is :group, include only users in the same group (excluding the all users group).\n   - If user-visibility is :none or the user is sandboxed, include only themselves.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/user" ]
       }
     },
@@ -14077,6 +22753,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/user" ]
       },
       "put" : {
@@ -14092,6 +22779,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -14152,6 +22850,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/user" ]
       }
     },
@@ -14169,6 +22878,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/user" ]
       }
     },
@@ -14186,6 +22906,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -14219,6 +22950,17 @@ redirect_from:
           },
           "description" : "value must be an integer greater than zero."
         } ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/user" ]
       }
     },
@@ -14227,6 +22969,17 @@ redirect_from:
         "summary" : "GET /api/util/random_token",
         "description" : "Return a cryptographically secure random 32-byte token, encoded as a hexadecimal string.\n   Intended for use when creating a value for `embedding-secret-key`.",
         "parameters" : [ ],
+        "responses" : {
+          "2XX" : {
+            "description" : "Successful response"
+          },
+          "4XX" : {
+            "description" : "Client error response"
+          },
+          "5XX" : {
+            "description" : "Server error response"
+          }
+        },
         "tags" : [ "/api/util" ]
       }
     }

--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -148,8 +148,6 @@
 
 (comment
 
-  (schema->response-obj schema)
-
   (mjs-collect-definitions :metabase.timeline.api.timeline/Timeline)
   (schema->response-obj :metabase.timeline.api.timeline/Timeline))
 

--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -130,6 +130,28 @@
                   schema))
               (mc/children schema))))))
 
+(def ^:private default-response-schema
+  "Default response schema for OpenAPI endpoints. This is used when the endpoint does not specify a response schema."
+  {"2XX" {:description "Successful response"}
+   "4XX" {:description "Client error response"}
+   "5XX" {:description "Server error response"}})
+
+(mu/defn- schema->response-obj :- [:maybe :metabase.api.open-api/path-item.responses]
+  "Convert a Malli schema to an OpenAPI response schema.
+
+  This is used to convert the `:response-schema` in [[metabase.api.macros/defendpoint]] to an OpenAPI response schema."
+  [schema]
+  (let [jss-schema (mjs-collect-definitions schema)]
+    {"2XX" (-> {:description (or (:description jss-schema) (umd/describe schema))}
+               (assoc :content {"application/json" {:schema (fix-json-schema jss-schema)}}))}))
+
+(comment
+
+  (schema->response-obj schema)
+
+  (mjs-collect-definitions :metabase.timeline.api.timeline/Timeline)
+  (schema->response-obj :metabase.timeline.api.timeline/Timeline))
+
 (mu/defn- path-item :- :metabase.api.open-api/path-item
   "Generate OpenAPI desc for `defendpoint` 2.0 ([[metabase.api.macros/defendpoint]]) handler.
 
@@ -137,28 +159,31 @@
   [full-path :- string?
    form      :- :metabase.api.macros/parsed-args]
   (try
-    (let [method                    (:method form)
-          route-params              (when-let [schema (get-in form [:params :route :schema])]
-                                      (schema->params* schema (constantly :path) nil))
-          query-params              (when-let [schema (get-in form [:params :query :schema])]
-                                      (schema->params* schema (constantly :query) nil))
-          params                    (concat
-                                     (for [param route-params]
-                                       (assoc param :in :path))
-                                     query-params)
-          ctype                     (if (get-in form [:metadata :multipart])
-                                      "multipart/form-data"
-                                      "application/json")
-          body-schema               (some-> (if (= ctype "multipart/form-data")
-                                              (multipart-schema form)
-                                              (get-in form [:params :body :schema]))
-                                            mjs-collect-definitions
-                                            fix-json-schema)]
+    (let [method          (:method form)
+          route-params    (when-let [schema (get-in form [:params :route :schema])]
+                            (schema->params* schema (constantly :path) nil))
+          query-params    (when-let [schema (get-in form [:params :query :schema])]
+                            (schema->params* schema (constantly :query) nil))
+          params          (concat
+                           (for [param route-params]
+                             (assoc param :in :path))
+                           query-params)
+          ctype           (if (get-in form [:metadata :multipart])
+                            "multipart/form-data"
+                            "application/json")
+          body-schema     (some-> (if (= ctype "multipart/form-data")
+                                    (multipart-schema form)
+                                    (get-in form [:params :body :schema]))
+                                  mjs-collect-definitions
+                                  fix-json-schema)
+          response-schema (:response-schema form)]
       ;; summary is the string in the sidebar of Scalar
       (cond-> {:summary     (str (u/upper-case-en (name method)) " " full-path)
                :description (some-> (:docstr form) str)
-               :parameters params}
-        body-schema (assoc :requestBody {:content {ctype {:schema body-schema}}})))
+               :parameters params
+               :responses  default-response-schema}
+        body-schema     (assoc :requestBody {:content {ctype {:schema body-schema}}})
+        response-schema (update :responses merge (schema->response-obj response-schema))))
     (catch Throwable e
       (throw (ex-info (str (format "Error creating OpenAPI spec for endpoint %s %s: %s"
                                    (:method form)
@@ -201,7 +226,7 @@
 
   (metabase.api.macros.defendpoint.open-api/path-item
    "/api/card/:id/series"
-   (:form (metabase.api.macros/find-route 'metabase.queries.api.card :get "/:id/series"))
+   (:form (metabase.api.macros/find-route 'metabase.queries.api.card :get "/:id/series")))
 
-   (-> (mjs/transform :metabase.util.cron/CronScheduleString {::mjs/definitions-path "#/components/schemas/"})
-       fix-json-schema)))
+  (-> (mjs/transform :metabase.util.cron/CronScheduleString {::mjs/definitions-path "#/components/schemas/"})
+      fix-json-schema))

--- a/src/metabase/api/macros/defendpoint/open_api.clj
+++ b/src/metabase/api/macros/defendpoint/open_api.clj
@@ -11,6 +11,7 @@
    [metabase.api.open-api]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.describe :as umd]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]))
 

--- a/src/metabase/api/open_api.clj
+++ b/src/metabase/api/open_api.clj
@@ -98,7 +98,7 @@
    [:map
 
     [:type [:= :string]]
-    [:format    {:optional true} [:= :binary]]
+    [:format    {:optional true} [:enum :binary "binary" :byte "byte"]]
     [:minLength {:optional true} integer?]
     [:maxLength {:optional true} integer?]
     [:pattern   {:optional true} (ms/InstanceOfClass java.util.regex.Pattern)]]])
@@ -139,7 +139,6 @@
   [:merge
    ::parameter.schema.typed.common
    [:map
-
     [:type                 [:= :object]]
     [:properties           {:optional true} [:map-of :string [:ref ::parameter.schema]]]
     [:additionalProperties {:optional true} [:multi
@@ -275,13 +274,26 @@
               [:map
                [:schema ::parameter.schema]]]]])
 
+(mr/def ::path-item.responses
+  [:map-of
+   ;; can be exact status codes: "200" status code ranges: "5XX" and or "default"
+   :string
+   [:map
+    [:description :string]
+    [:content     {:optional true} [:map-of
+                                    [:enum "application/json" "multipart/form-data"]
+                                    [:map [:schema ::parameter.schema]]]]
+    ;; TODO -- headers, links, etc.
+    ]])
+
 (mr/def ::path-item
   [:map
    [:summary     :string]
    [:description :string]
    [:parameters  [:sequential ::parameter]]
    [:requestBody {:optional true} ::path-item.request-body]
-   [:tags        {:optional true} [:sequential :string]]])
+   [:tags        {:optional true} [:sequential :string]]
+   [:responses   ::path-item.responses]])
 
 (mr/def ::components
   [:map

--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -35,6 +35,6 @@
          openapi-object                 (openapi-object)]
      (with-open [w (java.io.FileWriter. output-file)]
        (.write w before)
-       (json/encode-to openapi-object  w {:pretty true})
+       (json/encode-to openapi-object w {:pretty true})
        (.write w after)))
    (println "Done.")))


### PR DESCRIPTION
Resolves #61303

- if there is a return schema on defendpoint, use that to determine the return schema
- otherwise return the new default one

-----

I am unsure if we should actually use `umd/describe` to generate the text for a response's description if it's not there already, here's what it looks like:


"sequence of map where {:id -> <integer greater than 0>}"

The grammar is bad, but it does give a little more info than `[ { "id" : 1 } ]` 🤷‍♂️ 

---

## Route with a return schema:

<img width="1171" height="708" alt="Screenshot 2025-07-22 at 12 20 10 PM" src="https://github.com/user-attachments/assets/4bcd3b35-d2cf-4aa9-8cd5-40d8d1af3677" />


## Route missing a return schema (gets default return info):

<img width="1164" height="454" alt="Screenshot 2025-07-22 at 12 25 33 PM" src="https://github.com/user-attachments/assets/f787a0fc-051f-4f9f-96ce-8e16832cb165" />

----

# Implementation Notes

API docs generation uses data generated by defendpoint.

The defendpoint macro modifies it's namespace's metadata with info about: routes / route-params / query-params and body-params.

It also returns a thunk that shows that information, so you can see it from the repl by wrapping it like so:

```clojure
(:form ((defendpoint ...)))
```

### Relevant Namespaces:

#### metabase.api.macros.defendpoint.open-api

This is where the actual generation happens

Bottom of this ns has some comments you can use to test stuff out (repl driven mode)

e.g.

`(open-api-spec (metabase.api.macros/ns-routes 'metabase.geojson.api) "/api/geojson")`

Returns data for that namespace, prefixed by the api/geojson path.


Visit: http://localhost:3000/api/docs/ to see the entire thing running.

#### metabase.api.macros/defendpoint

Implementation notes:

We never had a [response](https://swagger.io/docs/specification/v3_0/describing-responses/) object, so I am adding it now.

#### https://github.com/metabase/metabase/blob/master/src/metabase/cmd/endpoint_dox.clj#L29

this generates the openapi json file

### What status codes can be reutnred from any response?

Just cover the basics now, fix the issue, and revisit if we want excellent schemas. (May require changes to defendpoint to get 100% perfect output)

#### default

Add a default to avoid getting the errror state on the issue

#### 200
 
Many of our routes do not have a return schema, so will need a default to avoid the error. 
(Eventually we should probably make all endpoints declare their return types!)

- adding it to `::path-item`
- computing it from the `:form` value returned by defendpoint's thunk
  - formatting it when there _is_ a return schema
    - including for files
  - adding default when there _is not_

#### Verification

Start the backend, visit: http://localhost:3000/api/docs/ to see the entire thing running.

Also the `docs/api.html` file is (re)generated by running [generate-dox!](https://github.com/metabase/metabase/blob/endpoint-dox-response-schemas/src/metabase/cmd/endpoint_dox.clj#L26). Can inspect that file and see the responses, tho it's hard to see that it's right without looking at the actual site ofc.

