### PR TITLE
Fix bug in associating batched embeddings with original documents

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -139,8 +139,12 @@
        (fn [text-embedding-map]
          (let [batch-documents
                (keep (fn [doc]
-                       (when-let [embedding (get text-embedding-map (:searchable_text doc))]
-                         (assoc doc :embedding embedding)))
+                       (if-let [embedding (get text-embedding-map (:searchable_text doc))]
+                         (assoc doc :embedding embedding)
+                         (log/warn "No embedding found for document"
+                                   {:model (:model doc)
+                                    :model_id (:model_id doc)
+                                    :searchable_text (:searchable_text doc)})))
                      filtered-documents)]
            (batch-update!
             connectable


### PR DESCRIPTION
Adjusts `process-embeddings-streaming` to pass a map from text->embedding into the processing callback. Uses this to correctly associate documents in a given batch with their embeddings before inserting into the DB.