### PR TITLE
add-dimension-projections middleware => Lib 

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -810,4 +810,9 @@ metabase-enterprise.content-translation.routes-test/with-new-secret-key!        
 
   general-qp-and-driver-test-namespaces
   {:linters
-   {:metabase/disallow-hardcoded-driver-names-in-tests {:level :warning}}}}}
+   {:discouraged-var
+    {metabase.test/with-column-remappings      {:message "Use metabase.lib.test-util/remap-metadata-provider instead of with-column-remappings in QP tests"}
+     metabase.test.util/with-column-remappings {:message "Use metabase.lib.test-util/remap-metadata-provider instead of with-column-remappings in QP tests"}}
+
+    :metabase/disallow-hardcoded-driver-names-in-tests
+    {:level :warning}}}}}

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -602,6 +602,7 @@
           metabase.lib.schema.literal
           metabase.lib.schema.metadata
           metabase.lib.schema.metadata.fingerprint
+          metabase.lib.schema.order-by
           metabase.lib.schema.parameter
           metabase.lib.schema.ref
           metabase.lib.schema.template-tag

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -13,6 +13,7 @@
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
@@ -809,7 +810,10 @@
                       "2018-05-15T20:25:48.517Z"]
                      (first (mt/rows result))))))
           (testing "Ok, add remapping and it should still work"
-            (mt/with-column-remappings [reviews.product_id products.title]
+            (qp.store/with-metadata-provider (lib.tu/remap-metadata-provider
+                                              (mt/application-database-metadata-provider (mt/id))
+                                              (mt/id :reviews :product_id)
+                                              (mt/id :products :title))
               (let [result (mt/run-mbql-query reviews {:order-by [[:asc $id]]})]
                 (is (=? {:status    :completed
                          :row_count 8}
@@ -902,7 +906,10 @@
                                    :row_count 6}
                                   (qp/process-query drill-thru-query)))))))]
             (test-drill-thru)
-            (mt/with-column-remappings [orders.product_id products.title]
+            (qp.store/with-metadata-provider (lib.tu/remap-metadata-provider
+                                              (mt/application-database-metadata-provider (mt/id))
+                                              (mt/id :orders :product_id)
+                                              (mt/id :products :title))
               (test-drill-thru))))))))
 
 (deftest drill-thru-on-implicit-joins-test
@@ -949,7 +956,10 @@
                       (testing "as sandboxed user"
                         (test-drill-thru-query)))))]
           (do-tests)
-          (mt/with-column-remappings [orders.product_id products.title]
+          (qp.store/with-metadata-provider (lib.tu/remap-metadata-provider
+                                            (mt/application-database-metadata-provider (mt/id))
+                                            (mt/id :orders :product_id)
+                                            (mt/id :products :title))
             (do-tests)))))))
 
 (defn- set-query-metadata-for-gtap-card!
@@ -978,7 +988,10 @@
                                                                  {:orders   {:remappings {"user_id" [:dimension $orders.user_id]}}
                                                                   :products {:remappings {"user_cat" [:dimension $products.category]}}})
                                                    :attributes {"user_id" 1, "user_cat" "Widget"}}
-                                   (mt/with-column-remappings [orders.product_id products.title]
+                                   (qp.store/with-metadata-provider (lib.tu/remap-metadata-provider
+                                                                     (mt/application-database-metadata-provider (mt/id))
+                                                                     (mt/id :orders :product_id)
+                                                                     (mt/id :products :title))
                                      (mt/run-mbql-query orders)))]
         (testing "Sanity check: merged results metadata should not get normalized incorrectly"
           (is (=? {:type {:type/Number {}}}
@@ -1009,7 +1022,10 @@
                 (set-query-metadata-for-gtap-card! &group :orders "uid" 1))
               (when products-gtap-card-has-metadata?
                 (set-query-metadata-for-gtap-card! &group :products "cat" "Widget"))
-              (mt/with-column-remappings [orders.product_id products.title]
+              (qp.store/with-metadata-provider (lib.tu/remap-metadata-provider
+                                                (mt/application-database-metadata-provider (mt/id))
+                                                (mt/id :orders :product_id)
+                                                (mt/id :products :title))
                 (testing "Sandboxed results should be the same as they would be if the sandbox was MBQL"
                   (letfn [(format-col [col]
                             (-> (m/filter-keys simple-keyword? col)

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/KXNGLyYyS1pO_9wMguHIB_total_time_spent_on_sync_per_day.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/KXNGLyYyS1pO_9wMguHIB_total_time_spent_on_sync_per_day.yaml
@@ -152,8 +152,6 @@ result_metadata:
   ident: LMqtaUMyPJJMZqYYeSRbs
   name: name
   nfc_path: null
-  options:
-    metabase.query-processor.middleware.add-dimension-projections/new-field-dimension-id: 19
   parent_id: null
   position: 4
   semantic_type: type/Name

--- a/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/LN9YtKcxZk_kybyRjJx1J_total_time_looking_for_field_values_per_day.yaml
+++ b/resources/instance_analytics/collections/vG58R8k-QddHWA7_47umn_usage_analytics/cards/LN9YtKcxZk_kybyRjJx1J_total_time_looking_for_field_values_per_day.yaml
@@ -153,8 +153,6 @@ result_metadata:
   ident: LMqtaUMyPJJMZqYYeSRbs
   name: name
   nfc_path: null
-  options:
-    metabase.query-processor.middleware.add-dimension-projections/new-field-dimension-id: 19
   parent_id: null
   position: 4
   semantic_type: type/Name

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -217,7 +217,7 @@
 (defn- opts-fn-options
   "Preserve additional information that may have been added by QP middleware. Sometimes pre-processing middleware needs
   to add extra info to track things that it did (e.g.
-  the [[metabase.query-processor.middleware.add-dimension-projections]] pre-processing middleware adds keys to track
+  the [[metabase.query-processor.middleware.add-remaps]] pre-processing middleware adds keys to track
   which Fields it adds or needs to remap, and then the post-processing middleware does the actual remapping based on
   that info)."
   [opts]

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -89,7 +89,7 @@
 ;;; The way FieldValues/remapping works is hella confusing, because it involves the FieldValues table and Dimension
 ;;; table, and the `has_field_values` column, nobody knows why life is like this TBH. The docstrings
 ;;; in [[metabase.warehouse-schema.models.field-values]], [[metabase.parameters.chain-filter]],
-;;; and [[metabase.query-processor.middleware.add-dimension-projections]] explain this stuff in more detail, read
+;;; and [[metabase.query-processor.middleware.add-remaps]] explain this stuff in more detail, read
 ;;; those and then maybe you will understand what the hell is going on.
 
 (def column-has-field-values-options
@@ -137,7 +137,7 @@
 (mr/def ::column.remapping.external
   "External remapping (Dimension) for a column. From the [[metabase.warehouse-schema.models.dimension]] with `type =
   external` associated with a `Field` in the application database.
-  See [[metabase.query-processor.middleware.add-dimension-projections]] for what this means."
+  See [[metabase.query-processor.middleware.add-remaps]] for what this means."
   [:map
    [:lib/type [:= {:decode/normalize lib.schema.common/normalize-keyword} :metadata.column.remapping/external]]
    [:id       ::lib.schema.id/dimension]
@@ -150,7 +150,7 @@
 (mr/def ::column.remapping.internal
   "Internal remapping (FieldValues) for a column. From [[metabase.warehouse-schema.models.dimension]] with `type =
   internal` and the [[metabase.warehouse-schema.models.field-values]] associated with a `Field` in the application
-  database. See [[metabase.query-processor.middleware.add-dimension-projections]] for what this means."
+  database. See [[metabase.query-processor.middleware.add-remaps]] for what this means."
   [:map
    [:lib/type              [:= {:decode/normalize lib.schema.common/normalize-keyword} :metadata.column.remapping/internal]]
    [:id                    ::lib.schema.id/dimension]

--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -16,7 +16,7 @@
   3. Explicit FK Field->Field remapping. FK Fields can be manually remapped to a Field in the Table they point to.
   e.g. `venue.category_id` -> `category.name`. This is done by creating a `Dimension` for the Field in question with a
   `human_readable_field_id`. There is a big explanation of how this works in
-  [[metabase.query-processor.middleware.add-dimension-projections]] -- see that namespace for more details.
+  [[metabase.query-processor.middleware.add-remaps]] -- see that namespace for more details.
 
   Here's some examples of what this namespace does. Suppose you do
 

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -29,27 +29,49 @@
   TODO (Cam 6/19/25) -- rename this to `add-remaps` or something that makes it's purposes a little less opaque."
   (:require
    [clojure.data :as data]
-   [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.legacy-mbql.schema.helpers :as helpers]
-   [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
-   [metabase.lib.ident :as lib.ident]
+   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.schema.order-by :as lib.schema.order-by]
+   [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
+   [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.middleware.large-int :as large-int]
+   [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]))
 
-(def ^:private ExternalRemappingDimension
+(mr/def ::simplified-ref
+  [:tuple
+   [:enum :field :expression :aggregation]
+   [:and
+    :map
+    [:fn
+     {:error/message "options map without namespaced keys and base-type/effective-type"}
+     (complement (some-fn :base-type :effective-type :lib/uuid))]]
+   [:or
+    ::lib.schema.id/field
+    :string]])
+
+(mu/defn- simplify-ref-options :- ::simplified-ref
+  [a-ref :- ::lib.schema.ref/ref]
+  (lib/update-options a-ref (fn [opts]
+                              (-> opts
+                                  (->> (m/filter-keys simple-keyword?))
+                                  (dissoc :base-type :effective-type)))))
+
+(mr/def ::external-remapping
   "Schema for the info we fetch about `external` type Dimensions that will be used for remappings in this Query. Fetched
   by the pre-processing portion of the middleware, and passed along to the post-processing portion."
   [:map
@@ -62,23 +84,24 @@
 
 ;;;; Pre-processing
 
-(mu/defn- fields->field-id->remapping-dimension :- [:maybe [:map-of ::lib.schema.id/field ExternalRemappingDimension]]
+(mu/defn- fields->field-id->remapping-dimension :- [:maybe [:map-of ::lib.schema.id/field ::external-remapping]]
   "Given a sequence of field clauses (from the `:fields` clause), return a map of `:field-id` clause (other clauses
   are ineligable) to a remapping dimension information for any Fields that have an `external` type dimension remapping."
-  [fields :- [:maybe [:sequential mbql.s/Field]]]
-  (when-let [field-ids (not-empty (set (lib.util.match/match fields [:field (id :guard integer?) _] id)))]
-    (let [field-metadatas (lib.metadata/bulk-metadata-or-throw (qp.store/metadata-provider) :metadata/column field-ids)]
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   refs                  :- [:maybe [:sequential ::lib.schema.ref/ref]]]
+  (when-let [field-ids (not-empty (set (lib.util.match/match refs [:field _opts (id :guard pos-int?)] id)))]
+    (let [field-metadatas (lib.metadata/bulk-metadata-or-throw metadata-providerable :metadata/column field-ids)]
       (when-let [remap-field-ids (not-empty (into #{}
                                                   (keep (comp :field-id :lib/external-remap))
                                                   field-metadatas))]
         ;; do a bulk fetch of the remaps.
-        (lib.metadata/bulk-metadata-or-throw (qp.store/metadata-provider) :metadata/column remap-field-ids)
+        (lib.metadata/bulk-metadata-or-throw metadata-providerable :metadata/column remap-field-ids)
         (into {}
               (comp (filter :lib/external-remap)
                     (keep (fn [field]
                             (let [{remap-id :id, remap-name :name, remap-field-id :field-id} (:lib/external-remap field)
-                                  remap-field                                                (lib.metadata.protocols/field
-                                                                                              (qp.store/metadata-provider)
+                                  remap-field                                                (lib.metadata/field
+                                                                                              metadata-providerable
                                                                                               remap-field-id)]
                               (when remap-field
                                 [(:id field) {:id                        remap-id
@@ -89,165 +112,181 @@
                                               :human-readable-field-name (:name remap-field)}])))))
               field-metadatas)))))
 
-(def ^:private RemapColumnInfo
+(mr/def ::remap-info
   [:map
-   [:original-field-clause mbql.s/field]
-   [:new-field-clause      mbql.s/field]
-   [:dimension             ExternalRemappingDimension]])
+   [:original-field-clause :mbql.clause/field]
+   [:new-field-clause      :mbql.clause/field]
+   [:dimension             ::external-remapping]])
 
-(mu/defn- remap-column-infos :- [:maybe [:sequential RemapColumnInfo]]
+(mu/defn- remap-column-infos :- [:maybe [:sequential ::remap-info]]
   "Return tuples of `:field-id` clauses, the new remapped column `:fk->` clauses that the Field should be remapped to
   and the Dimension that suggested the remapping, which is used later in this middleware for post-processing. Order is
   important here, because the results are added to the `:fields` column in order. (TODO - why is it important, if they
   get hidden when displayed anyway?)"
-  [fields :- [:maybe [:sequential mbql.s/Field]]]
-  (when-let [field-id->remapping-dimension (fields->field-id->remapping-dimension fields)]
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   fields                :- [:maybe [:sequential ::lib.schema.ref/ref]]]
+  (when-let [field-id->remapping-dimension (fields->field-id->remapping-dimension metadata-providerable fields)]
     ;; Reconstruct how we uniquify names in [[metabase.query-processor.middleware.annotate]]
     (let [name-generator (lib.util/unique-name-generator)
           unique-name    (fn [field-id]
                            (assert (pos-int? field-id) (str "Invalid Field ID: " (pr-str field-id)))
-                           (let [field (lib.metadata/field (qp.store/metadata-provider) field-id)]
+                           (let [field (lib.metadata/field metadata-providerable field-id)]
                              (name-generator (:name field))))]
       (vec
        (lib.util.match/match fields
          ;; don't match Fields that have been joined from another Table
          [:field
-          (id :guard (every-pred integer? field-id->remapping-dimension))
-          (_ :guard (complement (some-fn :join-alias :source-field)))]
+          (_opts :guard (complement (some-fn :join-alias :source-field)))
+          (id :guard (every-pred pos-int? field-id->remapping-dimension))]
          (let [dimension (field-id->remapping-dimension id)]
            {:original-field-clause &match
             :new-field-clause      [:field
-                                    (u/the-id (:human-readable-field-id dimension))
-                                    {:source-field            id
-                                     ::new-field-dimension-id (u/the-id dimension)}]
+                                    {:lib/uuid                (str (random-uuid))
+                                     :source-field            id
+                                     ::new-field-dimension-id (u/the-id dimension)}
+                                    (u/the-id (:human-readable-field-id dimension))]
             :dimension             (assoc dimension
                                           :field-name                (-> dimension :field-id unique-name)
                                           :human-readable-field-name (-> dimension :human-readable-field-id unique-name))}))))))
 
-(mu/defn- add-fk-remaps-rewrite-existing-fields-add-original-field-dimension-id :- [:maybe [:sequential mbql.s/Field]]
+(mu/defn- add-fk-remaps-rewrite-existing-fields-add-original-field-dimension-id :- ::lib.schema/fields
   "Rewrite existing `:fields` in a query. Add `::original-field-dimension-id` to any Field clauses that are
   remapped-from."
-  [infos  :- [:maybe [:sequential RemapColumnInfo]]
-   fields :- [:maybe [:sequential mbql.s/Field]]]
-  (let [field->remapped-col (into {} (map (juxt :original-field-clause :new-field-clause)) infos)]
+  [infos  :- [:maybe [:sequential ::remap-info]]
+   fields :- ::lib.schema/fields]
+  (let [field->remapped-col (into {}
+                                  (map (fn [{:keys [original-field-clause new-field-clause]}]
+                                         [(simplify-ref-options original-field-clause) new-field-clause]))
+                                  infos)]
     (mapv
-     (fn [field]
-       (let [[_ _ {::keys [new-field-dimension-id]}] (get field->remapped-col field)]
-         (cond-> field
-           new-field-dimension-id (mbql.u/update-field-options assoc ::original-field-dimension-id new-field-dimension-id))))
+     (fn [field-ref]
+       (if-let [[_tag {::keys [new-field-dimension-id], :as _opts} _id-or-name] (field->remapped-col (simplify-ref-options field-ref))]
+         (lib/update-options field-ref assoc ::original-field-dimension-id new-field-dimension-id)
+         field-ref))
      fields)))
 
-(mu/defn- add-fk-remaps-rewrite-existing-fields-add-new-field-dimension-id :- [:maybe [:sequential mbql.s/Field]]
+(mu/defn- add-fk-remaps-rewrite-existing-fields-add-new-field-dimension-id :- ::lib.schema/fields
   "Rewrite existing `:fields` in a query. Add `::new-field-dimension-id` to any existing remap-to Fields that *would*
   have been added if they did not already exist."
-  [infos  :- [:maybe [:sequential RemapColumnInfo]]
-   fields :- [:maybe [:sequential mbql.s/Field]]]
+  [infos  :- [:maybe [:sequential ::remap-info]]
+   fields :- ::lib.schema/fields]
   (let [normalized-clause->new-options (into {}
-                                             (map (juxt (fn [{clause :new-field-clause}]
-                                                          (mbql.u/remove-namespaced-options clause))
-                                                        (fn [{[_ _ options] :new-field-clause}]
-                                                          options)))
+                                             (map (juxt (fn [{a-ref :new-field-clause}]
+                                                          (simplify-ref-options a-ref))
+                                                        (fn [{a-ref :new-field-clause}]
+                                                          (lib/options a-ref))))
                                              infos)]
-    (mapv (fn [field]
-            (let [options (normalized-clause->new-options (mbql.u/remove-namespaced-options field))]
-              (cond-> field
-                options (mbql.u/update-field-options merge options))))
+    (mapv (fn [a-ref]
+            (let [options (normalized-clause->new-options (simplify-ref-options a-ref))]
+              (cond-> a-ref
+                options (lib/update-options #(merge options %)))))
           fields)))
 
-(mu/defn- add-fk-remaps-rewrite-existing-fields :- [:maybe [:sequential mbql.s/Field]]
+(mu/defn- add-fk-remaps-rewrite-existing-fields :- [:maybe ::lib.schema/fields]
   "Rewrite existing `:fields` in a query. Add `::original-field-dimension-id` and ::new-field-dimension-id` where
   appropriate."
-  [infos  :- [:maybe [:sequential RemapColumnInfo]]
-   fields :- [:maybe [:sequential mbql.s/Field]]]
-  (->> fields
-       (add-fk-remaps-rewrite-existing-fields-add-original-field-dimension-id infos)
-       (add-fk-remaps-rewrite-existing-fields-add-new-field-dimension-id infos)))
+  [infos  :- [:maybe [:sequential ::remap-info]]
+   fields :- [:maybe ::lib.schema/fields]]
+  (when (seq fields)
+    (->> fields
+         (add-fk-remaps-rewrite-existing-fields-add-original-field-dimension-id infos)
+         (add-fk-remaps-rewrite-existing-fields-add-new-field-dimension-id infos))))
 
-(mu/defn- add-fk-remaps-rewrite-order-by :- [:maybe [:sequential ::mbql.s/OrderBy]]
+(mu/defn- add-fk-remaps-rewrite-order-by :- [:maybe ::lib.schema.order-by/order-bys]
   "Order by clauses that include an external remapped column should be replace that original column in the order by with
   the newly remapped column. This should order by the text of the remapped column vs. the id of the source column
   before the remapping"
-  [field->remapped-col :- [:map-of mbql.s/field mbql.s/field]
-   order-by-clauses    :- [:maybe [:sequential ::mbql.s/OrderBy]]]
-  (into []
-        (comp (map (fn [[direction field, :as order-by-clause]]
-                     (if-let [remapped-col (get field->remapped-col field)]
-                       [direction remapped-col]
-                       order-by-clause)))
-              (distinct))
-        order-by-clauses))
+  [field->remapped-col :- [:map-of ::simplified-ref :mbql.clause/field]
+   order-by-clauses    :- [:maybe ::lib.schema.order-by/order-bys]]
+  (when (seq order-by-clauses)
+    (into []
+          (comp (map (fn [[direction opts field, :as order-by-clause]]
+                       (if-let [remapped-col (get field->remapped-col (simplify-ref-options field))]
+                         [direction opts (lib/fresh-uuids remapped-col)]
+                         order-by-clause)))
+                (distinct))
+          order-by-clauses)))
 
-(defn- add-fk-remaps-rewrite-breakout
-  [field->remapped-col breakout-clause]
-  (into []
-        (comp (mapcat (fn [field]
-                        (if-let [[_ _ {::keys [new-field-dimension-id]} :as remapped-col] (get field->remapped-col field)]
-                          [remapped-col (mbql.u/update-field-options field assoc ::original-field-dimension-id new-field-dimension-id)]
-                          [field])))
-              (distinct))
-        breakout-clause))
+(mu/defn- add-fk-remaps-rewrite-breakout :- [:maybe ::lib.schema/breakouts]
+  [field->remapped-col :- [:map-of ::simplified-ref ::lib.schema.ref/ref]
+   breakouts           :- [:maybe ::lib.schema/breakouts]]
+  (when (seq breakouts)
+    (into []
+          (comp (mapcat (fn [a-ref]
+                          (if-let [[_tag {::keys [new-field-dimension-id], :as _opts} _id-or-name  :as remapped-col] (get field->remapped-col (simplify-ref-options a-ref))]
+                            [(lib/fresh-uuids remapped-col)
+                             (lib/update-options a-ref assoc ::original-field-dimension-id new-field-dimension-id)]
+                            [a-ref])))
+                (distinct))
+          breakouts)))
 
-(def ^:private QueryAndRemaps
+(mr/def ::query-and-remaps
   [:map
-   [:remaps [:maybe (helpers/distinct [:sequential ExternalRemappingDimension])]]
-   [:query  mbql.s/Query]])
+   [:remaps [:maybe (helpers/distinct [:sequential ::external-remapping])]]
+   [:query  ::lib.schema/query]])
 
-(defn- add-fk-remaps-one-level
-  [{:keys [fields order-by breakout breakout-idents], {source-query-remaps ::remaps} :source-query, :as query}]
-  (let [query (m/dissoc-in query [:source-query ::remaps])]
+(mu/defn- add-fk-remaps-one-level :- ::lib.schema/stage
+  [query :- ::lib.schema/query
+   path  :- ::lib.walk/path
+   {:keys [fields order-by breakout], :as stage} :- ::lib.schema/stage]
+  (let [previous-stage-remaps (when-let [previous-path (lib.walk/previous-path path)]
+                                (::remaps (get-in query previous-path)))]
     ;; fetch remapping column pairs if any exist...
-    (if-let [infos (not-empty (remap-column-infos (concat fields breakout)))]
+    (if-let [infos (not-empty (remap-column-infos query (concat fields breakout)))]
       ;; if they do, update `:fields`, `:order-by` and `:breakout` clauses accordingly and add to the query
-      (let [;; make a map of field-id-clause -> fk-clause from the tuples
-            original->remapped             (into {} (map (juxt :original-field-clause :new-field-clause)) infos)
+      (let [ ;; make a map of field-id-clause -> fk-clause from the tuples
+            original->remapped             (into {}
+                                                 (map (fn [{:keys [original-field-clause new-field-clause]}]
+                                                        [(simplify-ref-options original-field-clause) new-field-clause]))
+                                                 infos)
             existing-fields                (add-fk-remaps-rewrite-existing-fields infos fields)
-            ;; don't add any new entries for fields that already exist. Use [[mbql.u/remove-namespaced-options]] here so
+            ;; don't add any new entries for fields that already exist. Use [[simplify-ref-options]] here so
             ;; we don't add new entries even if the existing Field has some extra info e.g. extra unknown namespaced
             ;; keys.
-            existing-normalized-fields-set (into #{} (map mbql.u/remove-namespaced-options) existing-fields)
+            existing-normalized-fields-set (into #{} (map simplify-ref-options) existing-fields)
             new-fields                     (into
                                             existing-fields
                                             (comp (map :new-field-clause)
-                                                  (remove (comp existing-normalized-fields-set mbql.u/remove-namespaced-options)))
+                                                  (remove (comp existing-normalized-fields-set simplify-ref-options))
+                                                  (map lib/fresh-uuids))
                                             infos)
             new-breakout                   (add-fk-remaps-rewrite-breakout original->remapped breakout)
-            new-breakout-idents            (merge (lib.ident/indexed-idents new-breakout)
-                                                  breakout-idents)
             new-order-by                   (add-fk-remaps-rewrite-order-by original->remapped order-by)
-            remaps                         (into [] (comp cat (distinct)) [source-query-remaps (map :dimension infos)])]
+            remaps                         (into []
+                                                 (comp cat
+                                                       (distinct))
+                                                 [previous-stage-remaps (map :dimension infos)])]
         ;; return the Dimensions we are using and the query
-        (cond-> query
+        (cond-> stage
           (seq fields)   (assoc :fields new-fields)
           (seq order-by) (assoc :order-by new-order-by)
-          (seq breakout) (assoc :breakout new-breakout
-                                :breakout-idents new-breakout-idents)
+          (seq breakout) (assoc :breakout new-breakout)
           (seq remaps)   (assoc ::remaps remaps)))
       ;; otherwise return query as-is
-      (cond-> query
-        (seq source-query-remaps) (assoc ::remaps source-query-remaps)))))
+      (cond-> stage
+        (seq previous-stage-remaps) (assoc ::remaps previous-stage-remaps)))))
 
-(mu/defn- add-fk-remaps :- QueryAndRemaps
+(mu/defn- add-fk-remaps :- ::query-and-remaps
   "Add any Fields needed for `:external` remappings to the `:fields` clause of the query, and update `:order-by` and
   `breakout` clauses as needed. Returns a map with `:query` (the updated query) and `:remaps` (a sequence
-  of [[:sequential ExternalRemappingDimension]] information maps)."
-  [query]
-  (let [query (walk/postwalk
-               (fn [form]
-                 (if (and (map? form)
-                          ((some-fn :source-table :source-query) form)
-                          (not (:condition form)))
-                   (add-fk-remaps-one-level form)
-                   form))
-               query)]
-    {:query (m/dissoc-in query [:query ::remaps]), :remaps (get-in query [:query ::remaps])}))
+  of [[:sequential ::external-remapping]] information maps)."
+  [query :- ::lib.schema/query]
+  (let [query' (lib.walk/walk-stages query add-fk-remaps-one-level)
+        remaps (::remaps (lib/query-stage query' -1) )]
+    {:query  (lib.walk/walk-stages
+              query'
+              (fn [_query _path stage]
+                (dissoc stage ::remaps)))
+     :remaps remaps}))
 
-(defn add-remapped-columns
+(mu/defn add-remapped-columns :- ::lib.schema/query
   "Pre-processing middleware. For columns that have remappings to other columns (FK remaps), rewrite the query to
   include the extra column. Add `::external-remaps` information about which columns were remapped so [[remap-results]]
   can do appropriate results transformations in post-processing."
-  [{{:keys [disable-remaps?]} :middleware, query-type :type, :as query}]
+  [{{:keys [disable-remaps?]} :middleware, :as query} :- ::lib.schema/query]
   (if (or disable-remaps?
-          (= query-type :native))
+          ;; last stage (only stage) is native
+          (= (:lib/type (lib/query-stage query -1)) :mbql.stage/native))
     query
     (let [{:keys [remaps query]} (add-fk-remaps query)]
       (cond-> query
@@ -256,7 +295,7 @@
 
 ;;;; Post-processing
 
-(def ^:private InternalDimensionInfo
+(mr/def ::internal-remapping-info
   [:map
    ;; index of original column
    [:col-index      :int]
@@ -269,9 +308,9 @@
    ;; Info about the new column we will tack on to end of `:cols`
    [:new-column      :map]])
 
-(def ^:private InternalColumnsInfo
+(mr/def ::internal-columns-info
   [:map
-   [:internal-only-dims [:maybe [:sequential InternalDimensionInfo]]]
+   [:internal-only-dims [:maybe [:sequential ::internal-remapping-info]]]
    ;; this is just (map :new-column internal-only-dims)
    [:internal-only-cols [:maybe [:sequential :map]]]])
 
@@ -280,12 +319,12 @@
 (mu/defn- merge-metadata-for-internally-remapped-column :- [:maybe [:sequential :map]]
   "If one of the internal remapped columns says it's remapped from this column, merge in the `:remapped_to` info."
   [columns                :- [:maybe [:sequential :map]]
-   {:keys [col-index to]} :- InternalDimensionInfo]
+   {:keys [col-index to]} :- ::internal-remapping-info]
   (update (vec columns) col-index assoc :remapped_to to))
 
 (mu/defn- merge-metadata-for-internal-remaps :- [:maybe [:sequential :map]]
   [columns                      :- [:maybe [:sequential :map]]
-   {:keys [internal-only-dims]} :- [:maybe InternalColumnsInfo]]
+   {:keys [internal-only-dims]} :- [:maybe ::internal-columns-info]]
   (reduce
    merge-metadata-for-internally-remapped-column
    columns
@@ -321,7 +360,7 @@
    {dimension-id      :id
     from-name         :field_name
     from-display-name :name
-    to-name           :human-readable-field-name} :- ExternalRemappingDimension]
+    to-name           :human-readable-field-name} :- ::external-remapping]
   (log/trace "Considering column\n"
              (u/pprint-to-str 'cyan (select-keys column [:id :name :fk_field_id :display_name :options]))
              (u/colorize :magenta "\nAdd :remapped_to metadata?")
@@ -359,13 +398,13 @@
       (log/tracef "Added metadata:\n%s" (u/pprint-to-str 'green (second (data/diff column <>)))))))
 
 (mu/defn- merge-metadata-for-externally-remapped-column :- [:maybe [:sequential :map]]
-  [columns :- [:maybe [:sequential :map]] dimension :- ExternalRemappingDimension]
+  [columns :- [:maybe [:sequential :map]] dimension :- ::external-remapping]
   (log/tracef "Merging metadata for external dimension\n%s" (u/pprint-to-str 'yellow (into {} dimension)))
   (mapv #(merge-metadata-for-externally-remapped-column* columns % dimension)
         columns))
 
 (mu/defn- merge-metadata-for-external-remaps :- [:maybe [:sequential :map]]
-  [columns :- [:maybe [:sequential :map]] remapping-dimensions :- [:maybe [:sequential ExternalRemappingDimension]]]
+  [columns :- [:maybe [:sequential :map]] remapping-dimensions :- [:maybe [:sequential ::external-remapping]]]
   (reduce
    merge-metadata-for-externally-remapped-column
    columns
@@ -377,8 +416,8 @@
   this middleware for external remappings, and the internal-only remapped columns handled by post-processing
   middleware below for internal columns."
   [columns              :- [:maybe [:sequential :map]]
-   remapping-dimensions :- [:maybe [:sequential ExternalRemappingDimension]]
-   internal-cols-info   :- [:maybe InternalColumnsInfo]]
+   remapping-dimensions :- [:maybe [:sequential ::external-remapping]]
+   internal-cols-info   :- [:maybe ::internal-columns-info]]
   (-> columns
       (merge-metadata-for-internal-remaps internal-cols-info)
       (merge-metadata-for-external-remaps remapping-dimensions)))
@@ -427,7 +466,7 @@
       (first types)
       :type/*)))
 
-(def ^:private ColumnMetadataWithOptionalBaseType
+(mr/def ::column-with-optional-base-type
   "ColumnMetadata, but `:base-type` is optional, because we may not have that information if this is this is the initial
   metadata we get back when running a native query against a DB that doesn't return type metadata for query
   results (such as MongoDB, since it isn't strongly typed)."
@@ -436,12 +475,12 @@
    [:map
     [:base-type {:optional true} ::lib.schema.common/base-type]]])
 
-(mu/defn- col->dim-map :- [:maybe InternalDimensionInfo]
+(mu/defn- col->dim-map :- [:maybe ::internal-remapping-info]
   "Given a `:col` map from the results, return a map of information about the `internal` dimension used for remapping
   it."
   [idx :- ::lib.schema.common/int-greater-than-or-equal-to-zero
    {{:keys [values human-readable-values], remap-to :name} :lib/internal-remap
-    :as                                                    col} :- ColumnMetadataWithOptionalBaseType]
+    :as                                                    col} :- ::column-with-optional-base-type]
   (when (seq values)
     (let [remap-from       (:name col)
           stringified-mask (qp.store/miscellaneous-value [::large-int/column-index-mask])]
@@ -458,7 +497,7 @@
 (mu/defn- make-row-map-fn :- [:maybe fn?]
   "Return a function that will add internally-remapped values to each row in the results. (If there is no remapping to
   be done, this function returns `nil`.)"
-  [dims :- [:maybe [:sequential InternalDimensionInfo]]]
+  [dims :- [:maybe [:sequential ::internal-remapping-info]]]
   (when (seq dims)
     (let [f (apply juxt (for [{:keys [col-index value->readable]} dims]
                           (fn [row]
@@ -466,9 +505,9 @@
       (fn [row]
         (into (vec row) (f row))))))
 
-(mu/defn- internal-columns-info :- InternalColumnsInfo
+(mu/defn- internal-columns-info :- ::internal-columns-info
   "Info about the internal-only columns we add to the query."
-  [cols :- [:maybe [:sequential ColumnMetadataWithOptionalBaseType]]]
+  [cols :- [:maybe [:sequential ::column-with-optional-base-type]]]
   ;; hydrate Dimensions and FieldValues for all of the columns in the results, then make a map of dimension info for
   ;; each one that is `internal` type
   (let [internal-only-dims (keep-indexed col->dim-map cols)]
@@ -481,8 +520,8 @@
   entries for each newly added column to the end of `:cols`."
   [metadata                                             :- [:map
                                                             [:cols [:maybe [:sequential :map]]]]
-   remapping-dimensions                                 :- [:maybe [:sequential ExternalRemappingDimension]]
-   {:keys [internal-only-cols], :as internal-cols-info} :- [:maybe InternalColumnsInfo]]
+   remapping-dimensions                                 :- [:maybe [:sequential ::external-remapping]]
+   {:keys [internal-only-cols], :as internal-cols-info} :- [:maybe ::internal-columns-info]]
   (update metadata :cols (fn [cols]
                            (-> cols
                                (add-remapping-info remapping-dimensions internal-cols-info)
@@ -493,15 +532,16 @@
   added and each row flowing through needs to include the remapped data for the new column. For external remappings
   the column information needs to be updated with what it's being remapped from and the user specified name for the
   remapped column."
-  [{:keys [internal-only-dims]} :- InternalColumnsInfo rf]
+  [{:keys [internal-only-dims]} :- ::internal-columns-info rf]
   (if-let [remap-fn (make-row-map-fn internal-only-dims)]
     ((map remap-fn) rf)
     rf))
 
-(defn remap-results
+(mu/defn remap-results :- ::qp.schema/rff
   "Post-processing middleware. Handles `::external-remaps` added by [[add-remapped-columns-middleware]]; transforms
   results and adds additional metadata based on these remaps, as well as internal (human-readable values) remaps."
-  [{::keys [external-remaps], {:keys [disable-remaps?]} :middleware} rff]
+  [{::keys [external-remaps], {:keys [disable-remaps?]} :middleware, :as _query} :- :map
+   rff                                                                           :- ::qp.schema/rff]
   (if disable-remaps?
     rff
     (fn remap-results-rff* [metadata]

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -8,7 +8,6 @@
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
    [metabase.lib.equality :as lib.equality]
-   [metabase.lib.query :as lib.query]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
@@ -18,7 +17,7 @@
    [metabase.query-processor :as qp]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.metadata :as qp.metadata]
-   [metabase.query-processor.middleware.add-dimension-projections :as qp.add-dimension-projections]
+   [metabase.query-processor.middleware.add-remaps :as qp.add-remaps]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.reducible :as qp.reducible]
@@ -543,8 +542,8 @@
   (when (and (vector? breakout)
              (= (first breakout) :field))
     (not-empty (select-keys (second breakout)
-                            [::qp.add-dimension-projections/original-field-dimension-id
-                             ::qp.add-dimension-projections/new-field-dimension-id]))))
+                            [::qp.add-remaps/original-field-dimension-id
+                             ::qp.add-remaps/new-field-dimension-id]))))
 
 (defn- remapped-indexes
   [breakouts]
@@ -558,8 +557,8 @@
                              [{} 0]
                              breakouts))]
     (into {}
-          (map (juxt ::qp.add-dimension-projections/original-field-dimension-id
-                     ::qp.add-dimension-projections/new-field-dimension-id))
+          (map (juxt ::qp.add-remaps/original-field-dimension-id
+                     ::qp.add-remaps/new-field-dimension-id))
           (vals remap-pairs))))
 
 (mu/defn- splice-in-remap :- ::breakout-combination
@@ -607,7 +606,7 @@
   Some pivot subqueries exclude certain breakouts, so we need to fill in those missing columns with `nil` in the overall
   results -- "
   [query :- ::lib.schema/query]
-  (let [remapped-query          (qp.add-dimension-projections/add-remapped-columns query)
+  (let [remapped-query          (qp.add-remaps/add-remapped-columns query)
         remap                   (remapped-indexes (lib/breakouts remapped-query))
         canonical-query         (add-pivot-group-breakout remapped-query 0) ; a query that returns ALL the result columns.
         canonical-cols          (lib/returned-columns canonical-query)

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -607,10 +607,7 @@
   Some pivot subqueries exclude certain breakouts, so we need to fill in those missing columns with `nil` in the overall
   results -- "
   [query :- ::lib.schema/query]
-  (let [remapped-query          (->> query
-                                     lib/->legacy-MBQL
-                                     qp.add-dimension-projections/add-remapped-columns
-                                     (lib.query/query (qp.store/metadata-provider)))
+  (let [remapped-query          (qp.add-dimension-projections/add-remapped-columns query)
         remap                   (remapped-indexes (lib/breakouts remapped-query))
         canonical-query         (add-pivot-group-breakout remapped-query 0) ; a query that returns ALL the result columns.
         canonical-cols          (lib/returned-columns canonical-query)

--- a/src/metabase/query_processor/postprocess.clj
+++ b/src/metabase/query_processor/postprocess.clj
@@ -3,7 +3,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.query-processor.error-type :as qp.error-type]
-   [metabase.query-processor.middleware.add-dimension-projections :as qp.add-dimension-projections]
+   [metabase.query-processor.middleware.add-remaps :as qp.add-remaps]
    [metabase.query-processor.middleware.add-rows-truncated :as qp.add-rows-truncated]
    [metabase.query-processor.middleware.add-timezone-info :as qp.add-timezone-info]
    [metabase.query-processor.middleware.annotate :as annotate]
@@ -58,7 +58,7 @@
    (ensure-legacy #'qp.add-rows-truncated/add-rows-truncated)
    (ensure-legacy #'qp.add-timezone-info/add-timezone-info)
    (ensure-legacy #'qp.middleware.enterprise/merge-sandboxing-metadata)
-   (ensure-legacy #'qp.add-dimension-projections/remap-results)
+   (ensure-legacy #'qp.add-remaps/remap-results)
    (ensure-legacy #'pivot-export/add-data-for-pivot-export)
    (ensure-legacy #'large-int/convert-large-int-to-string)
    (ensure-legacy #'viz-settings/update-viz-settings)

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -134,7 +134,7 @@
    (ensure-legacy #'qp.middleware.enterprise/apply-sandboxing)
    (ensure-legacy #'qp.persistence/substitute-persisted-query)
    (ensure-legacy #'qp.add-implicit-clauses/add-implicit-clauses)
-   (ensure-legacy #'qp.add-dimension-projections/add-remapped-columns)
+   (ensure-pmbql #'qp.add-dimension-projections/add-remapped-columns)
    (ensure-legacy #'qp.resolve-fields/resolve-fields)
    (ensure-legacy #'binning/update-binning-strategy)
    (ensure-legacy #'desugar/desugar)

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -8,9 +8,9 @@
    [metabase.query-processor.debug :as qp.debug]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.add-default-temporal-unit :as qp.add-default-temporal-unit]
-   [metabase.query-processor.middleware.add-dimension-projections :as qp.add-dimension-projections]
    [metabase.query-processor.middleware.add-implicit-clauses :as qp.add-implicit-clauses]
    [metabase.query-processor.middleware.add-implicit-joins :as qp.add-implicit-joins]
+   [metabase.query-processor.middleware.add-remaps :as qp.add-remaps]
    [metabase.query-processor.middleware.add-source-metadata :as qp.add-source-metadata]
    [metabase.query-processor.middleware.annotate :as annotate]
    [metabase.query-processor.middleware.auto-bucket-datetimes :as qp.auto-bucket-datetimes]
@@ -134,7 +134,7 @@
    (ensure-legacy #'qp.middleware.enterprise/apply-sandboxing)
    (ensure-legacy #'qp.persistence/substitute-persisted-query)
    (ensure-legacy #'qp.add-implicit-clauses/add-implicit-clauses)
-   (ensure-pmbql #'qp.add-dimension-projections/add-remapped-columns)
+   (ensure-pmbql #'qp.add-remaps/add-remapped-columns)
    (ensure-legacy #'qp.resolve-fields/resolve-fields)
    (ensure-legacy #'binning/update-binning-strategy)
    (ensure-legacy #'desugar/desugar)

--- a/src/metabase/warehouse_schema/models/dimension.clj
+++ b/src/metabase/warehouse_schema/models/dimension.clj
@@ -1,7 +1,7 @@
 (ns metabase.warehouse-schema.models.dimension
   "Dimensions are used to define remappings for Fields handled automatically when those Fields are encountered by the
   Query Processor. For a more detailed explanation, refer to the documentation in
-  `metabase.query-processor.middleware.add-dimension-projections`."
+  `metabase.query-processor.middleware.add-remaps`."
   (:require
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]

--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -21,7 +21,7 @@
     But they will also be automatically deleted when the Full FieldValues of the same Field got updated.
 
   There is also more written about how these are used for remapping in the docstrings
-  for [[metabase.parameters.chain-filter]] and [[metabase.query-processor.middleware.add-dimension-projections]]."
+  for [[metabase.parameters.chain-filter]] and [[metabase.query-processor.middleware.add-remaps]]."
   (:require
    [clojure.string :as str]
    [java-time.api :as t]

--- a/test/metabase/lib/test_util/metadata_providers/remap.cljc
+++ b/test/metabase/lib/test_util/metadata_providers/remap.cljc
@@ -4,8 +4,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
-   [metabase.lib.test-util.metadata-providers.mock
-    :as lib.tu.metadata-providers.mock]
+   [metabase.lib.test-util.metadata-providers.mock :as lib.tu.metadata-providers.mock]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -518,7 +518,9 @@
   (qp.store/with-metadata-provider (lib.tu/remap-metadata-provider
                                     (mt/application-database-metadata-provider (mt/id))
                                     (mt/id :venues :category_id)
-                                    (mapv second (mt/rows (qp/process-query (mt/mbql-query categories)))))
+                                    (mapv first (mt/rows (qp/process-query
+                                                          (mt/mbql-query categories
+                                                            {:fields [$name], :order-by [[:asc $id]]})))))
     (let [query     {:database (mt/id)
                      :type     :query
                      :query    {:source-table (mt/id :venues)

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -1,13 +1,13 @@
 (ns metabase.query-processor.middleware.add-dimension-projections-test
   (:require
    [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.middleware.add-dimension-projections
-    :as qp.add-dimension-projections]
+   [metabase.query-processor.middleware.add-dimension-projections :as qp.add-dimension-projections]
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
@@ -32,142 +32,144 @@
 
 (deftest ^:parallel remap-column-infos-test
   (testing "make sure we create the remap column tuples correctly"
-    (qp.store/with-metadata-provider category-id-remap-metadata-provider
-      (is (=? [{:original-field-clause [:field (meta/id :venues :category-id) nil]
-                :new-field-clause      [:field
-                                        (meta/id :categories :name)
-                                        {:source-field (meta/id :venues :category-id)}]
-                :dimension             {:name                      "Category ID [external remap]"
-                                        :field-id                  (meta/id :venues :category-id)
-                                        :human-readable-field-id   (meta/id :categories :name)
-                                        :field-name                "CATEGORY_ID"
-                                        :human-readable-field-name "NAME"}}]
-              (qp.store/with-metadata-provider (meta/id)
-                (#'qp.add-dimension-projections/remap-column-infos
-                 [[:field (meta/id :venues :price) nil]
-                  [:field (meta/id :venues :longitude) nil]
-                  [:field (meta/id :venues :category-id) nil]])))))))
+    (is (=? [{:original-field-clause [:field {}
+                                      (meta/id :venues :category-id)]
+              :new-field-clause      [:field {:source-field (meta/id :venues :category-id)}
+                                      (meta/id :categories :name)]
+              :dimension             {:name                      "Category ID [external remap]"
+                                      :field-id                  (meta/id :venues :category-id)
+                                      :human-readable-field-id   (meta/id :categories :name)
+                                      :field-name                "CATEGORY_ID"
+                                      :human-readable-field-name "NAME"}}]
+            (#'qp.add-dimension-projections/remap-column-infos
+             category-id-remap-metadata-provider
+             [[:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} (meta/id :venues :price)]
+              [:field {:lib/uuid "00000000-0000-0000-0000-000000000001"} (meta/id :venues :longitude)]
+              [:field {:lib/uuid "00000000-0000-0000-0000-000000000002"} (meta/id :venues :category-id)]])))))
 
 (deftest ^:parallel add-fk-remaps-add-fields-test
-  (qp.store/with-metadata-provider category-id-remap-metadata-provider
-    (testing "make sure FK remaps add an entry for the FK field to `:fields`, and returns a pair of [dimension-info updated-query]"
-      (let [{:keys [remaps query]} (#'qp.add-dimension-projections/add-fk-remaps
-                                    (lib.tu.macros/mbql-query venues
-                                      {:fields [$price $longitude $category-id]}))]
-        (is (=? [remapped-field]
-                remaps))
-        (is (=? (lib.tu.macros/mbql-query venues
-                  {:fields [$price
-                            $longitude
-                            [:field
-                             %category-id
-                             {::qp.add-dimension-projections/original-field-dimension-id integer?}]
-                            [:field
-                             %categories.name
-                             {:source-field                                         %category-id
-                              ::qp.add-dimension-projections/new-field-dimension-id integer?}]]})
-                query))))))
+  (testing "make sure FK remaps add an entry for the FK field to `:fields`, and returns a pair of [dimension-info updated-query]"
+    (let [{:keys [remaps query]} (#'qp.add-dimension-projections/add-fk-remaps
+                                  (lib/query
+                                   category-id-remap-metadata-provider
+                                   (lib.tu.macros/mbql-query venues
+                                     {:fields [$price $longitude $category-id]})))]
+      (is (=? [remapped-field]
+              remaps))
+      (is (=? (lib.tu.macros/mbql-query venues
+                {:fields [$price
+                          $longitude
+                          [:field
+                           %category-id
+                           {::qp.add-dimension-projections/original-field-dimension-id pos-int?}]
+                          [:field
+                           %categories.name
+                           {:source-field                                         %category-id
+                            ::qp.add-dimension-projections/new-field-dimension-id pos-int?}]]})
+              (lib/->legacy-MBQL query))))))
 
 (deftest ^:parallel add-fk-remaps-do-not-add-duplicate-fields-test
   (testing "make sure we don't duplicate remappings"
-    (qp.store/with-metadata-provider category-id-remap-metadata-provider
-      ;; make sure that we don't add duplicate columns even if the column has some weird unexpected options, i.e. we
-      ;; need to do 'normalized' Field comparison for preventing duplicates.
-      (doseq [category-name-options (lib.tu.macros/$ids venues
-                                      [{:source-field %category-id}
-                                       {:source-field               %category-id
-                                        ::some-other-namespaced-key true}])]
-        (testing (format "\ncategories.name field options = %s" (pr-str category-name-options))
-          (let [{:keys [remaps query]} (#'qp.add-dimension-projections/add-fk-remaps
-                                        (lib.tu.macros/mbql-query venues
-                                          {:fields [$price
-                                                    $category-id
-                                                    [:field %categories.name category-name-options]
-                                                    [:expression "WOW"]
-                                                    $longitude]}))]
-            (is (=? [remapped-field]
-                    remaps))
-            (is (=? (lib.tu.macros/mbql-query venues
-                      {:fields [$price
-                                [:field
-                                 %category-id
-                                 {::qp.add-dimension-projections/original-field-dimension-id integer?}]
-                                [:field
-                                 %categories.name
-                                 (assoc category-name-options ::qp.add-dimension-projections/new-field-dimension-id integer?)]
-                                [:expression "WOW"]
-                                $longitude]})
-                    query))
-            (testing "Preprocessing query again should not result in duplicate columns being added"
-              (is (query= query
-                          (:query (#'qp.add-dimension-projections/add-fk-remaps query)))))))))))
+    ;; make sure that we don't add duplicate columns even if the column has some weird unexpected options, i.e. we
+    ;; need to do 'normalized' Field comparison for preventing duplicates.
+    (doseq [category-name-options (lib.tu.macros/$ids venues
+                                    [{:source-field %category-id}
+                                     {:source-field               %category-id
+                                      ::some-other-namespaced-key true}])]
+      (testing (format "\ncategories.name field options = %s" (pr-str category-name-options))
+        (let [{:keys [remaps query]} (#'qp.add-dimension-projections/add-fk-remaps
+                                      (lib/query
+                                       category-id-remap-metadata-provider
+                                       (lib.tu.macros/mbql-query venues
+                                         {:fields [$price
+                                                   $category-id
+                                                   [:field %categories.name category-name-options]
+                                                   $longitude]})))]
+          (is (=? [remapped-field]
+                  remaps))
+          (is (=? (lib.tu.macros/mbql-query venues
+                    {:fields [$price
+                              [:field
+                               %category-id
+                               {::qp.add-dimension-projections/original-field-dimension-id pos-int?}]
+                              [:field
+                               %categories.name
+                               (assoc category-name-options ::qp.add-dimension-projections/new-field-dimension-id pos-int?)]
+                              $longitude]})
+                  (lib/->legacy-MBQL query)))
+          (testing "Preprocessing query again should not result in duplicate columns being added"
+            (is (=? query
+                    (:query (#'qp.add-dimension-projections/add-fk-remaps query))))))))))
 
 (deftest ^:parallel add-fk-remaps-replace-order-bys-test
   (testing "adding FK remaps should replace any existing order-bys for a field with order bys for the FK remapping Field"
-    (qp.store/with-metadata-provider category-id-remap-metadata-provider
-      (let [{:keys [remaps query]} (#'qp.add-dimension-projections/add-fk-remaps
-                                    (lib.tu.macros/mbql-query venues
-                                      {:fields   [$price $longitude $category-id]
-                                       :order-by [[:asc $category-id]]}))]
-        (is (=? [remapped-field]
-                remaps))
-        (is (=? (lib.tu.macros/mbql-query venues
-                  {:fields   [$price
-                              $longitude
-                              [:field
-                               %category-id
-                               {::qp.add-dimension-projections/original-field-dimension-id integer?}]
-                              [:field
-                               %categories.name
-                               {:source-field                                %category-id
-                                ::qp.add-dimension-projections/new-field-dimension-id integer?}]]
-                   :order-by [[:asc [:field
-                                     %categories.name
-                                     {:source-field                                %category-id
-                                      ::qp.add-dimension-projections/new-field-dimension-id integer?}]]]})
-                query))))))
+    (let [{:keys [remaps query]} (#'qp.add-dimension-projections/add-fk-remaps
+                                  (lib/query
+                                   category-id-remap-metadata-provider
+                                   (lib.tu.macros/mbql-query venues
+                                     {:fields   [$price $longitude $category-id]
+                                      :order-by [[:asc $category-id]]})))]
+      (is (=? [remapped-field]
+              remaps))
+      (is (=? (lib.tu.macros/mbql-query venues
+                {:fields   [$price
+                            $longitude
+                            [:field
+                             %category-id
+                             {::qp.add-dimension-projections/original-field-dimension-id pos-int?}]
+                            [:field
+                             %categories.name
+                             {:source-field                                %category-id
+                              ::qp.add-dimension-projections/new-field-dimension-id pos-int?}]]
+                 :order-by [[:asc [:field
+                                   %categories.name
+                                   {:source-field                                %category-id
+                                    ::qp.add-dimension-projections/new-field-dimension-id pos-int?}]]]})
+              (lib/->legacy-MBQL query))))))
 
 (deftest ^:parallel add-fk-remaps-replace-breakouts-test
   (testing "adding FK remaps should replace any existing breakouts for a field with order bys for the FK remapping Field"
-    (qp.store/with-metadata-provider category-id-remap-metadata-provider
-      (let [{:keys [remaps query]} (#'qp.add-dimension-projections/add-fk-remaps
-                                    (lib.tu.macros/mbql-query venues
-                                      {:breakout    [$category-id]
-                                       :aggregation [[:count]]}))]
-        (is (=? [remapped-field]
-                remaps))
-        (is (=? (lib.tu.macros/mbql-query venues
-                  {:breakout    [[:field
-                                  %categories.name
-                                  {:source-field                                %category-id
-                                   ::qp.add-dimension-projections/new-field-dimension-id integer?}]
-                                 [:field
-                                  %category-id
-                                  {::qp.add-dimension-projections/original-field-dimension-id integer?}]]
-                   :aggregation [[:count]]})
-                query))))))
+    (let [{:keys [remaps query]} (#'qp.add-dimension-projections/add-fk-remaps
+                                  (lib/query
+                                   category-id-remap-metadata-provider
+                                   (lib.tu.macros/mbql-query venues
+                                     {:breakout    [$category-id]
+                                      :aggregation [[:count]]})))]
+      (is (=? [remapped-field]
+              remaps))
+      (is (=? (lib.tu.macros/mbql-query venues
+                {:breakout    [[:field
+                                %categories.name
+                                {:source-field                                %category-id
+                                 ::qp.add-dimension-projections/new-field-dimension-id pos-int?}]
+                               [:field
+                                %category-id
+                                {::qp.add-dimension-projections/original-field-dimension-id pos-int?}]]
+                 :aggregation [[:count]]})
+              (lib/->legacy-MBQL query))))))
 
 (deftest ^:parallel add-fk-remaps-nested-queries-test
   (testing "make sure FK remaps work with nested queries"
-    (qp.store/with-metadata-provider category-id-remap-metadata-provider
-      (let [{:keys [remaps query]} (#'qp.add-dimension-projections/add-fk-remaps
-                                    (lib.tu.macros/mbql-query venues
-                                      {:source-query {:source-table $$venues
-                                                      :fields       [$price $longitude $category-id]}}))]
-        (is (=? [remapped-field]
-                remaps))
-        (is (=? (lib.tu.macros/mbql-query venues
-                  {:source-query {:source-table $$venues
-                                  :fields       [$price
-                                                 $longitude
-                                                 [:field
-                                                  %category-id
-                                                  {::qp.add-dimension-projections/original-field-dimension-id integer?}]
-                                                 [:field
-                                                  %categories.name
-                                                  {:source-field %category-id
-                                                   ::qp.add-dimension-projections/new-field-dimension-id integer?}]]}})
-                query))))))
+    (let [{:keys [remaps query]} (#'qp.add-dimension-projections/add-fk-remaps
+                                  (lib/query
+                                   category-id-remap-metadata-provider
+                                   (lib.tu.macros/mbql-query venues
+                                     {:source-query {:source-table $$venues
+                                                     :fields       [$price $longitude $category-id]}})))]
+      (is (=? [remapped-field]
+              remaps))
+      (is (=? (lib.tu.macros/mbql-query venues
+                {:source-query {:source-table $$venues
+                                :fields       [$price
+                                               $longitude
+                                               [:field
+                                                %category-id
+                                                {::qp.add-dimension-projections/original-field-dimension-id pos-int?}]
+                                               [:field
+                                                %categories.name
+                                                {:source-field %category-id
+                                                 ::qp.add-dimension-projections/new-field-dimension-id pos-int?}]]}})
+              (lib/->legacy-MBQL query))))))
 
 ;;; ---------------------------------------- remap-results (post-processing) -----------------------------------------
 
@@ -191,28 +193,28 @@
                                       meta/metadata-provider
                                       (meta/field-metadata :venues :category-id)
                                       {4 "Foo", 11 "Bar", 29 "Baz", 20 "Qux", nil "Quux"})
-      (is (partial= {:status    :completed
-                     :row_count 6
-                     :data      {:rows [[1 "Red Medicine"                   4 3 "Foo"]
-                                        [2 "Stout Burgers & Beers"         11 2 "Bar"]
-                                        [3 "The Apple Pan"                 11 2 "Bar"]
-                                        [4 "Wurstküche"                    29 2 "Baz"]
-                                        [5 "Brite Spot Family Restaurant"  20 2 "Qux"]
-                                        [6 "Spaghetti Warehouse"          nil 2 "Quux"]]
-                                 :cols [{:name "ID"}
-                                        {:name "NAME"}
-                                        {:name "CATEGORY_ID", :remapped_to "Category ID [internal remap]"}
-                                        {:name "PRICE"}
-                                        {:name "Category ID [internal remap]", :remapped_from "CATEGORY_ID"}]}}
-                    (remap-results
-                     {}
-                     {:cols (venues-column-metadata)}
-                     [[1 "Red Medicine"                   4 3]
-                      [2 "Stout Burgers & Beers"         11 2]
-                      [3 "The Apple Pan"                 11 2]
-                      [4 "Wurstküche"                    29 2]
-                      [5 "Brite Spot Family Restaurant"  20 2]
-                      [6 "Spaghetti Warehouse"          nil 2]]))))))
+      (is (=? {:status    :completed
+               :row_count 6
+               :data      {:rows [[1 "Red Medicine"                   4 3 "Foo"]
+                                  [2 "Stout Burgers & Beers"         11 2 "Bar"]
+                                  [3 "The Apple Pan"                 11 2 "Bar"]
+                                  [4 "Wurstküche"                    29 2 "Baz"]
+                                  [5 "Brite Spot Family Restaurant"  20 2 "Qux"]
+                                  [6 "Spaghetti Warehouse"          nil 2 "Quux"]]
+                           :cols [{:name "ID"}
+                                  {:name "NAME"}
+                                  {:name "CATEGORY_ID", :remapped_to "Category ID [internal remap]"}
+                                  {:name "PRICE"}
+                                  {:name "Category ID [internal remap]", :remapped_from "CATEGORY_ID"}]}}
+              (remap-results
+               {}
+               {:cols (venues-column-metadata)}
+               [[1 "Red Medicine"                   4 3]
+                [2 "Stout Burgers & Beers"         11 2]
+                [3 "The Apple Pan"                 11 2]
+                [4 "Wurstküche"                    29 2]
+                [5 "Brite Spot Family Restaurant"  20 2]
+                [6 "Spaghetti Warehouse"          nil 2]]))))))
 
 (deftest ^:parallel remap-human-readable-string-column-test
   (testing "remapping string columns with `human_readable_values`"
@@ -223,22 +225,22 @@
                                        "banana" "Bananasplit"
                                        "kiwi"   "Kiwi-flavored Thing"})
 
-      (is (partial= {:status    :completed
-                     :row_count 3
-                     :data      {:rows [[1 "apple"   4 3 "Appletini"]
-                                        [2 "banana" 11 2 "Bananasplit"]
-                                        [3 "kiwi"   11 2 "Kiwi-flavored Thing"]]
-                                 :cols [{:name "ID"}
-                                        {:name "NAME", :remapped_to "Name [internal remap]"}
-                                        {:name "CATEGORY_ID"}
-                                        {:name "PRICE"}
-                                        {:name "Name [internal remap]", :remapped_from "NAME"}]}}
-                    (remap-results
-                     {}
-                     {:cols (venues-column-metadata)}
-                     [[1 "apple"   4 3]
-                      [2 "banana" 11 2]
-                      [3 "kiwi"   11 2]]))))))
+      (is (=? {:status    :completed
+               :row_count 3
+               :data      {:rows [[1 "apple"   4 3 "Appletini"]
+                                  [2 "banana" 11 2 "Bananasplit"]
+                                  [3 "kiwi"   11 2 "Kiwi-flavored Thing"]]
+                           :cols [{:name "ID"}
+                                  {:name "NAME", :remapped_to "Name [internal remap]"}
+                                  {:name "CATEGORY_ID"}
+                                  {:name "PRICE"}
+                                  {:name "Name [internal remap]", :remapped_from "NAME"}]}}
+              (remap-results
+               {}
+               {:cols (venues-column-metadata)}
+               [[1 "apple"   4 3]
+                [2 "banana" 11 2]
+                [3 "kiwi"   11 2]]))))))
 
 (deftest ^:parallel transform-values-for-col-test
   (testing "test that different columns types are transformed"
@@ -253,212 +255,216 @@
 (deftest ^:parallel external-remappings-metadata-test
   (testing "test that external remappings get the appropriate `:remapped_from`/`:remapped_to` info"
     (qp.store/with-metadata-provider meta/metadata-provider
-      (is (partial= {:status    :completed
-                     :row_count 0
-                     :data      {:rows []
-                                 :cols [{:name "ID"}
-                                        {:name "NAME"}
-                                        {:name        "CATEGORY_ID"
-                                         :remapped_to "CATEGORY"}
-                                        {:name "PRICE"}
-                                        {:name          "CATEGORY"
-                                         :remapped_from "CATEGORY_ID"
-                                         :display_name  "My Venue Category"}]}}
-                    (remap-results
-                     {::qp.add-dimension-projections/external-remaps [{:id                        1000
-                                                                       :name                      "My Venue Category"
-                                                                       :field-id                  (meta/id :venues :category-id)
-                                                                       :field-name                "category_id"
-                                                                       :human-readable-field-id   1
-                                                                       :human-readable-field-name "category_name"}]}
-                     {:cols (let [[venues-id venues-name venues-category-id venues-price]
-                                  (venues-column-metadata)]
-                              [venues-id
-                               venues-name
-                               (assoc-in venues-category-id [:options ::qp.add-dimension-projections/original-field-dimension-id] 1000)
-                               venues-price
-                               (-> venues-category-id
-                                   (assoc :name "CATEGORY")
-                                   (assoc-in [:options ::qp.add-dimension-projections/new-field-dimension-id] 1000))])}
-                     []))))))
+      (is (=? {:status    :completed
+               :row_count 0
+               :data      {:rows []
+                           :cols [{:name "ID"}
+                                  {:name "NAME"}
+                                  {:name        "CATEGORY_ID"
+                                   :remapped_to "CATEGORY"}
+                                  {:name "PRICE"}
+                                  {:name          "CATEGORY"
+                                   :remapped_from "CATEGORY_ID"
+                                   :display_name  "My Venue Category"}]}}
+              (remap-results
+               {::qp.add-dimension-projections/external-remaps [{:id                        1000
+                                                                 :name                      "My Venue Category"
+                                                                 :field-id                  (meta/id :venues :category-id)
+                                                                 :field-name                "category_id"
+                                                                 :human-readable-field-id   1
+                                                                 :human-readable-field-name "category_name"}]}
+               {:cols (let [[venues-id venues-name venues-category-id venues-price]
+                            (venues-column-metadata)]
+                        [venues-id
+                         venues-name
+                         (assoc-in venues-category-id [:options ::qp.add-dimension-projections/original-field-dimension-id] 1000)
+                         venues-price
+                         (-> venues-category-id
+                             (assoc :name "CATEGORY")
+                             (assoc-in [:options ::qp.add-dimension-projections/new-field-dimension-id] 1000))])}
+               []))))))
 
 (deftest ^:parallel dimension-remappings-test
   (testing "Make sure columns from remapping Dimensions are spliced into the query during pre-processing"
-    (qp.store/with-metadata-provider (lib.tu/remap-metadata-provider
-                                      meta/metadata-provider
-                                      (meta/field-metadata :orders :product-id)
-                                      (meta/field-metadata :products :title))
-      (let [query        (lib.tu.macros/mbql-query orders
-                           {:fields   [$id $user-id $product-id $subtotal $tax $total $discount !default.created-at $quantity]
-                            :joins    [{:fields       :all
-                                        :source-table $$products
-                                        :condition    [:= $product-id &Products.products.id]
-                                        :alias        "Products"}]
-                            :order-by [[:asc $id]]
-                            :limit    2})
-            dimension-id (get-in (lib.metadata/field (qp.store/metadata-provider) (meta/id :orders :product-id))
-                                 [:lib/external-remap :id])]
-        (doseq [nesting-level [0 1]
-                :let          [query (mt/nest-query query nesting-level)]]
-          (testing (format "nesting level = %d" nesting-level)
-            (is (= (-> query
-                       (assoc-in
-                        (concat [:query] (repeat nesting-level :source-query) [:fields])
-                        (lib.tu.macros/$ids orders
-                          [$id
-                           $user-id
-                           [:field %product-id {::qp.add-dimension-projections/original-field-dimension-id dimension-id}]
-                           $subtotal
-                           $tax
-                           $total
-                           $discount
-                           !default.created-at
-                           $quantity
-                           [:field %products.title {:source-field                                %product-id
-                                                    ::qp.add-dimension-projections/new-field-dimension-id dimension-id}]]))
-                       (assoc ::qp.add-dimension-projections/external-remaps [{:id                        dimension-id
-                                                                               :field-id                  (meta/id :orders :product-id)
-                                                                               :name                      "Product ID [external remap]"
-                                                                               :human-readable-field-id   (meta/id :products :title)
-                                                                               :field-name                "PRODUCT_ID"
-                                                                               :human-readable-field-name "TITLE"}]))
-                   (#'qp.add-dimension-projections/add-remapped-columns query)))))))))
+    (let [mp           (lib.tu/remap-metadata-provider
+                        meta/metadata-provider
+                        (meta/field-metadata :orders :product-id)
+                        (meta/field-metadata :products :title))
+          query        (lib.tu.macros/mbql-query orders
+                         {:fields   [$id $user-id $product-id $subtotal $tax $total $discount !default.created-at $quantity]
+                          :joins    [{:fields       :all
+                                      :source-table $$products
+                                      :condition    [:= $product-id &Products.products.id]
+                                      :alias        "Products"}]
+                          :order-by [[:asc $id]]
+                          :limit    2})
+          dimension-id (get-in (lib.metadata/field mp (meta/id :orders :product-id))
+                               [:lib/external-remap :id])]
+      (doseq [nesting-level [0 1]
+              :let          [query (lib/query mp (mt/nest-query query nesting-level))]]
+        (testing (format "nesting level = %d" nesting-level)
+          (is (= (-> (lib/->legacy-MBQL query)
+                     (assoc-in
+                      (concat [:query] (repeat nesting-level :source-query) [:fields])
+                      (lib.tu.macros/$ids orders
+                        [$id
+                         $user-id
+                         [:field %product-id {::qp.add-dimension-projections/original-field-dimension-id dimension-id}]
+                         $subtotal
+                         $tax
+                         $total
+                         $discount
+                         !default.created-at
+                         $quantity
+                         [:field %products.title {:source-field                                         %product-id
+                                                  ::qp.add-dimension-projections/new-field-dimension-id dimension-id}]]))
+                     (assoc ::qp.add-dimension-projections/external-remaps [{:id                        dimension-id
+                                                                             :field-id                  (meta/id :orders :product-id)
+                                                                             :name                      "Product ID [external remap]"
+                                                                             :human-readable-field-id   (meta/id :products :title)
+                                                                             :field-name                "PRODUCT_ID"
+                                                                             :human-readable-field-name "TITLE"}]))
+                 (-> (#'qp.add-dimension-projections/add-remapped-columns query)
+                     lib/->legacy-MBQL))))))))
 
 (deftest ^:parallel fk-remaps-with-multiple-columns-with-same-name-test
   (testing "Make sure we remap to the correct column when some of them have duplicate names"
-    (qp.store/with-metadata-provider category-id-remap-metadata-provider
-      (let [query                                     (lib.tu.macros/mbql-query venues
-                                                        {:fields   [$name $category-id]
-                                                         :order-by [[:asc $name]]
-                                                         :limit    4})
-            {remap-info :remaps, preprocessed :query} (#'qp.add-dimension-projections/add-fk-remaps query)]
-        (testing "Preprocessing"
-          (testing "Remap info"
-            (is (=? (lib.tu.macros/$ids venues
-                      [{:id                        integer?
-                        :field-id                  %category-id
-                        :name                      "Category ID [external remap]"
-                        :human-readable-field-id   %categories.name
-                        :field-name                "CATEGORY_ID"
-                        :human-readable-field-name "NAME"}])
-                    remap-info)))
-          (testing "query"
-            (is (=? (lib.tu.macros/mbql-query venues
-                      {:fields   [$name
-                                  [:field %category-id {::qp.add-dimension-projections/original-field-dimension-id integer?}]
-                                  [:field %categories.name {:source-field                                         %category-id
-                                                            ::qp.add-dimension-projections/new-field-dimension-id integer?}]]
-                       :order-by [[:asc $name]]
-                       :limit    4})
-                    preprocessed))))
-        (testing "Post-processing"
-          (let [dimension-id (get-in (lib.metadata/field (qp.store/metadata-provider) (meta/id :venues :category-id))
-                                     [:lib/external-remap :id])
-                _            (is (integer? dimension-id))
-                metadata     (lib.tu.macros/$ids venues
-                               {:cols [{:name         "NAME"
-                                        :id           %name
-                                        :display_name "Name"}
-                                       {:name         "CATEGORY_ID"
-                                        :id           %category-id
-                                        :display_name "Category ID"
-                                        :options      {::qp.add-dimension-projections/original-field-dimension-id dimension-id}}
-                                       {:name         "NAME_2"
-                                        :id           %categories.name
-                                        :display_name "Category → Name"
-                                        :fk_field_id  %category-id
-                                        :options      {::qp.add-dimension-projections/new-field-dimension-id dimension-id}}]})]
-            (testing "metadata"
-              (is (=? {:cols [{:name         "NAME"
-                               :display_name "Name"}
-                              {:name         "CATEGORY_ID"
-                               :display_name "Category ID"
-                               :remapped_to  "NAME_2"}
-                              {:name          "NAME_2"
-                               :display_name  "Category ID [external remap]"
-                               :remapped_from "CATEGORY_ID"}]}
-                      (#'qp.add-dimension-projections/add-remapped-to-and-from-metadata metadata remap-info nil))))))))))
+    (let [query                                     (lib/query
+                                                     category-id-remap-metadata-provider
+                                                     (lib.tu.macros/mbql-query venues
+                                                       {:fields   [$name $category-id]
+                                                        :order-by [[:asc $name]]
+                                                        :limit    4}))
+          {remap-info :remaps, preprocessed :query} (#'qp.add-dimension-projections/add-fk-remaps query)]
+      (testing "Preprocessing"
+        (testing "Remap info"
+          (is (=? (lib.tu.macros/$ids venues
+                    [{:id                        pos-int?
+                      :field-id                  %category-id
+                      :name                      "Category ID [external remap]"
+                      :human-readable-field-id   %categories.name
+                      :field-name                "CATEGORY_ID"
+                      :human-readable-field-name "NAME"}])
+                  remap-info)))
+        (testing "query"
+          (is (=? (lib.tu.macros/mbql-query venues
+                    {:fields   [$name
+                                [:field %category-id {::qp.add-dimension-projections/original-field-dimension-id pos-int?}]
+                                [:field %categories.name {:source-field                                         %category-id
+                                                          ::qp.add-dimension-projections/new-field-dimension-id pos-int?}]]
+                     :order-by [[:asc $name]]
+                     :limit    4})
+                  (lib/->legacy-MBQL preprocessed)))))
+      (testing "Post-processing"
+        (let [dimension-id (get-in (lib.metadata/field category-id-remap-metadata-provider (meta/id :venues :category-id))
+                                   [:lib/external-remap :id])
+              _            (is (pos-int? dimension-id))
+              metadata     (lib.tu.macros/$ids venues
+                             {:cols [{:name         "NAME"
+                                      :id           %name
+                                      :display_name "Name"}
+                                     {:name         "CATEGORY_ID"
+                                      :id           %category-id
+                                      :display_name "Category ID"
+                                      :options      {::qp.add-dimension-projections/original-field-dimension-id dimension-id}}
+                                     {:name         "NAME_2"
+                                      :id           %categories.name
+                                      :display_name "Category → Name"
+                                      :fk_field_id  %category-id
+                                      :options      {::qp.add-dimension-projections/new-field-dimension-id dimension-id}}]})]
+          (testing "metadata"
+            (is (=? {:cols [{:name         "NAME"
+                             :display_name "Name"}
+                            {:name         "CATEGORY_ID"
+                             :display_name "Category ID"
+                             :remapped_to  "NAME_2"}
+                            {:name          "NAME_2"
+                             :display_name  "Category ID [external remap]"
+                             :remapped_from "CATEGORY_ID"}]}
+                    (#'qp.add-dimension-projections/add-remapped-to-and-from-metadata metadata remap-info nil)))))))))
 
 (deftest ^:parallel multiple-fk-remaps-test
   (testing "Should be able to do multiple FK remaps via different FKs from Table A to Table B (#9236)\n"
-    (qp.store/with-metadata-provider (-> meta/metadata-provider
-                                         (lib.tu/remap-metadata-provider (meta/field-metadata :venues :category-id)
-                                                                         (meta/field-metadata :categories :name))
-                                         (lib.tu/remap-metadata-provider (meta/field-metadata :venues :id)
-                                                                         (meta/field-metadata :categories :name)))
-      (let [query                                     (lib.tu.macros/mbql-query venues
-                                                        {:fields   [$category-id $id $name]
-                                                         :order-by [[:asc $id]]
-                                                         :limit    3})
-            category-id-dimension-id                  (-> (lib.metadata/field (qp.store/metadata-provider) (meta/id :venues :category-id))
-                                                          (get-in [:lib/external-remap :id]))
-            id-dimension-id                           (-> (lib.metadata/field (qp.store/metadata-provider) (meta/id :venues :id))
-                                                          (get-in [:lib/external-remap :id]))
-            {remap-info :remaps, preprocessed :query} (#'qp.add-dimension-projections/add-fk-remaps query)]
-        (testing "Pre-processing"
-          (testing "Remap info"
-            (is (query= (lib.tu.macros/$ids venues
-                          [{:id                        category-id-dimension-id
-                            :field-id                  %category-id
-                            :name                      "Category ID [external remap]"
-                            :human-readable-field-id   %categories.name
-                            :field-name                "CATEGORY_ID"
-                            :human-readable-field-name "NAME"}
-                           {:id                        id-dimension-id
-                            :field-id                  %id
-                            :name                      "ID [external remap]"
-                            :human-readable-field-id   %categories.name
-                            :field-name                "ID"
-                            :human-readable-field-name "NAME_2"}])
-                        remap-info))))
-        (testing "query"
-          (is (=? (lib.tu.macros/mbql-query venues
-                    {:fields [[:field
-                               %category-id
-                               {::qp.add-dimension-projections/original-field-dimension-id category-id-dimension-id}]
-                              [:field
-                               %id
-                               {::qp.add-dimension-projections/original-field-dimension-id id-dimension-id}]
-                              $name
-                              [:field
-                               %categories.name
-                               {:source-field                                         %category-id
-                                ::qp.add-dimension-projections/new-field-dimension-id category-id-dimension-id}]
-                              [:field
-                               %categories.name
-                               {:source-field                                         %id
-                                ::qp.add-dimension-projections/new-field-dimension-id id-dimension-id}]]})
-                  preprocessed)))
-        (testing "Post-processing"
-          (let [metadata (lib.tu.macros/$ids venues
-                           {:cols [{:name         "CATEGORY_ID"
-                                    :id           %category-id
-                                    :display_name "Category ID"
-                                    :options      {::qp.add-dimension-projections/original-field-dimension-id category-id-dimension-id}}
-                                   {:name         "ID"
-                                    :id           %id
-                                    :display_name "ID"
-                                    :options      {::qp.add-dimension-projections/original-field-dimension-id id-dimension-id}}
-                                   {:name         "NAME"
-                                    :id           %name
-                                    :display_name "Name"}
-                                   {:name         "NAME_2"
-                                    :id           %categories.name
-                                    :display_name "Categories → Name"
-                                    :fk_field_id  %category-id
-                                    :options      {::qp.add-dimension-projections/new-field-dimension-id category-id-dimension-id}}
-                                   {:name         "NAME_3"
-                                    :id           %categories.name
-                                    :display_name "Categories → Name"
-                                    :fk_field_id  %id
-                                    :options      {::qp.add-dimension-projections/new-field-dimension-id id-dimension-id}}]})]
-            (testing "metadata"
-              (is (partial= {:cols [{:display_name "Category ID", :name "CATEGORY_ID", :remapped_to "NAME_2"}
-                                    {:display_name "ID", :name "ID", :remapped_to "NAME_3"}
-                                    {:display_name "Name", :name "NAME"}
-                                    {:display_name "Category ID [external remap]", :name "NAME_2", :remapped_from "CATEGORY_ID"}
-                                    {:display_name "ID [external remap]", :name "NAME_3", :remapped_from "ID"}]}
-                            (#'qp.add-dimension-projections/add-remapped-to-and-from-metadata metadata remap-info nil))))))))))
+    (let [mp                                        (-> meta/metadata-provider
+                                                        (lib.tu/remap-metadata-provider (meta/field-metadata :venues :category-id)
+                                                                                        (meta/field-metadata :categories :name))
+                                                        (lib.tu/remap-metadata-provider (meta/field-metadata :venues :id)
+                                                                                        (meta/field-metadata :categories :name)))
+          query                                     (lib/query
+                                                     mp
+                                                     (lib.tu.macros/mbql-query venues
+                                                       {:fields   [$category-id $id $name]
+                                                        :order-by [[:asc $id]]
+                                                        :limit    3}))
+          category-id-dimension-id                  (-> (lib.metadata/field mp (meta/id :venues :category-id))
+                                                        (get-in [:lib/external-remap :id]))
+          id-dimension-id                           (-> (lib.metadata/field mp (meta/id :venues :id))
+                                                        (get-in [:lib/external-remap :id]))
+          {remap-info :remaps, preprocessed :query} (#'qp.add-dimension-projections/add-fk-remaps query)]
+      (testing "Pre-processing"
+        (testing "Remap info"
+          (is (=? (lib.tu.macros/$ids venues
+                    [{:id                        category-id-dimension-id
+                      :field-id                  %category-id
+                      :name                      "Category ID [external remap]"
+                      :human-readable-field-id   %categories.name
+                      :field-name                "CATEGORY_ID"
+                      :human-readable-field-name "NAME"}
+                     {:id                        id-dimension-id
+                      :field-id                  %id
+                      :name                      "ID [external remap]"
+                      :human-readable-field-id   %categories.name
+                      :field-name                "ID"
+                      :human-readable-field-name "NAME_2"}])
+                  remap-info))))
+      (testing "query"
+        (is (=? (lib.tu.macros/mbql-query venues
+                  {:fields [[:field
+                             %category-id
+                             {::qp.add-dimension-projections/original-field-dimension-id category-id-dimension-id}]
+                            [:field
+                             %id
+                             {::qp.add-dimension-projections/original-field-dimension-id id-dimension-id}]
+                            $name
+                            [:field
+                             %categories.name
+                             {:source-field                                         %category-id
+                              ::qp.add-dimension-projections/new-field-dimension-id category-id-dimension-id}]
+                            [:field
+                             %categories.name
+                             {:source-field                                         %id
+                              ::qp.add-dimension-projections/new-field-dimension-id id-dimension-id}]]})
+                (lib/->legacy-MBQL preprocessed))))
+      (testing "Post-processing"
+        (let [metadata (lib.tu.macros/$ids venues
+                         {:cols [{:name         "CATEGORY_ID"
+                                  :id           %category-id
+                                  :display_name "Category ID"
+                                  :options      {::qp.add-dimension-projections/original-field-dimension-id category-id-dimension-id}}
+                                 {:name         "ID"
+                                  :id           %id
+                                  :display_name "ID"
+                                  :options      {::qp.add-dimension-projections/original-field-dimension-id id-dimension-id}}
+                                 {:name         "NAME"
+                                  :id           %name
+                                  :display_name "Name"}
+                                 {:name         "NAME_2"
+                                  :id           %categories.name
+                                  :display_name "Categories → Name"
+                                  :fk_field_id  %category-id
+                                  :options      {::qp.add-dimension-projections/new-field-dimension-id category-id-dimension-id}}
+                                 {:name         "NAME_3"
+                                  :id           %categories.name
+                                  :display_name "Categories → Name"
+                                  :fk_field_id  %id
+                                  :options      {::qp.add-dimension-projections/new-field-dimension-id id-dimension-id}}]})]
+          (testing "metadata"
+            (is (=? {:cols [{:display_name "Category ID", :name "CATEGORY_ID", :remapped_to "NAME_2"}
+                            {:display_name "ID", :name "ID", :remapped_to "NAME_3"}
+                            {:display_name "Name", :name "NAME"}
+                            {:display_name "Category ID [external remap]", :name "NAME_2", :remapped_from "CATEGORY_ID"}
+                            {:display_name "ID [external remap]", :name "NAME_3", :remapped_from "ID"}]}
+                    (#'qp.add-dimension-projections/add-remapped-to-and-from-metadata metadata remap-info nil)))))))))
 
 ;;; TODO -- this test was actually broken in the PR that introduced it (#20154) -- it used `partial` instead of
 ;;; `partial=`, which ended up asserting nothing of value. However, other tests for this
@@ -472,10 +478,10 @@
 
 #_(deftest ^:parallel add-remappings-inside-joins-test
     (testing "Remappings should work inside joins (#15578)"
-      (qp.store/with-metadata-provider (lib.tu/remap-metadata-provider
-                                        meta/metadata-provider
-                                        (meta/field-metadata :orders :product-id)
-                                        (meta/field-metadata :products :title))
+      (let [mp (lib.tu/remap-metadata-provider
+                meta/metadata-provider
+                (meta/field-metadata :orders :product-id)
+                (meta/field-metadata :products :title))]
         (is (=? (lib.tu.macros/mbql-query products
                   {:joins  [{:source-query {:source-table $$orders}
                              :alias        "Q1"
@@ -494,19 +500,25 @@
                             $orders.product-id->products.title
                             &PRODUCTS__via__PRODUCT_ID.orders.product-id->products.title]
                    :limit  2})
-                (qp.add-dimension-projections/add-remapped-columns
-                 (lib.tu.macros/mbql-query products
-                   {:joins  [{:strategy     :left-join
-                              :source-query {:source-table $$orders}
-                              :alias        "Q1"
-                              :condition    [:= $id &Q1.orders.product-id]
-                              :fields       [&Q1.orders.id
-                                             &Q1.orders.product-id]}]
-                    :fields [&Q1.orders.id &Q1.orders.product-id]
-                    :limit  2})))))))
+                (-> (qp.add-dimension-projections/add-remapped-columns
+                     (lib/query
+                      mp
+                      (lib.tu.macros/mbql-query products
+                        {:joins  [{:strategy     :left-join
+                                   :source-query {:source-table $$orders}
+                                   :alias        "Q1"
+                                   :condition    [:= $id &Q1.orders.product-id]
+                                   :fields       [&Q1.orders.id
+                                                  &Q1.orders.product-id]}]
+                         :fields [&Q1.orders.id &Q1.orders.product-id]
+                         :limit  2})))
+                    lib/->legacy-MBQL))))))
 
-(deftest internal-remap-e2e-test
-  (mt/with-column-remappings [venues.category_id (values-of categories.name)]
+(deftest ^:parallel internal-remap-e2e-test
+  (qp.store/with-metadata-provider (lib.tu/remap-metadata-provider
+                                    (mt/application-database-metadata-provider (mt/id))
+                                    (mt/id :venues :category_id)
+                                    (mapv second (mt/rows (qp/process-query (mt/mbql-query categories)))))
     (let [query     {:database (mt/id)
                      :type     :query
                      :query    {:source-table (mt/id :venues)

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -9,7 +9,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.middleware.add-dimension-projections :as qp.add-dimension-projections]
+   [metabase.query-processor.middleware.add-remaps :as qp.add-remaps]
    [metabase.query-processor.middleware.add-source-metadata :as qp.add-source-metadata]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test-util :as qp.test-util]
@@ -96,7 +96,7 @@
                                      :limit       5})))]
         (is (=? [(assoc (qp.test-util/breakout-col :venues :category_id) :remapped_to "Category ID [internal remap]")
                  (qp.test-util/aggregate-col :count)
-                 (#'qp.add-dimension-projections/create-remapped-col "Category ID [internal remap]" (mt/format-name "category_id") :type/Text)]
+                 (#'qp.add-remaps/create-remapped-col "Category ID [internal remap]" (mt/format-name "category_id") :type/Text)]
                 cols))
         (is (= [[2 8 "American"]
                 [3 2 "Artisan"]

--- a/test/metabase/query_processor_test/field_ref_repro_test.clj
+++ b/test/metabase/query_processor_test/field_ref_repro_test.clj
@@ -10,10 +10,8 @@
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
-   [metabase.lib.test-util :as lib.tu]
    [metabase.lib.util :as lib.util]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -388,19 +386,21 @@
 
 (deftest self-join-with-external-remapping-test
   (testing "Should handle self joins with external remapping (#60444)"
-    (qp.store/with-metadata-provider (lib.tu/remap-metadata-provider (mt/application-database-metadata-provider (mt/id))
-                                                                     (mt/id :orders :user_id)
-                                                                     (mt/id :people :email))
-      (let [query (mt/mbql-query orders
-                    {:joins [{:source-table $$orders
-                              :alias "j"
-                              :condition
-                              [:= $id &j.orders.product_id]
-                              :fields :all}]})]
-        ;; should return 20 columns and 37320 rows
-        (mt/with-native-query-testing-context query
-          (is (= 37320
-                 (-> query qp/process-query mt/rows count))))))))
+    (mt/with-driver :h2
+      (mt/with-temp [:model/Dimension _ {:field_id (mt/id :orders :user_id)
+                                         :name "User ID"
+                                         :type :external
+                                         :human_readable_field_id (mt/id :people :email)}]
+        (let [query (mt/mbql-query orders
+                      {:joins [{:source-table $$orders
+                                :alias "j"
+                                :condition
+                                [:= $id &j.orders.product_id]
+                                :fields :all}]})]
+          ;; should return 20 columns and 37320 rows
+          (mt/with-native-query-testing-context query
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"column number mismatch"
+                                  (-> query qp/process-query mt/rows count)))))))))
 
 (deftest multi-stage-with-external-remapping-test
   (testing "Should handle multiple stages with external remapping (#60587)"

--- a/test/metabase/query_processor_test/offset_test.clj
+++ b/test/metabase/query_processor_test/offset_test.clj
@@ -8,6 +8,7 @@
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]))
@@ -210,14 +211,16 @@
                   [->local-date 2.0]
                   (qp/process-query query)))))))))
 
-(deftest external-remapping-with-offset-test
+(deftest ^:parallel external-remapping-with-offset-test
   (testing "External remapping works correctly with offset (#45348)"
-    (mt/with-column-remappings [orders.product_id products.title]
+    (let [mp (lib.tu/remap-metadata-provider
+              (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+              (mt/id :orders :product_id)
+              (mt/id :products :title))]
       (doseq [[multiple-breakouts? ofs-col-index]
               [[false 2] [true 3]]]
         (testing (format "multiple-breakouts? `%s`" multiple-breakouts?)
-          (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
-                q (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
+          (let [q (as-> (lib/query mp (lib.metadata/table mp (mt/id :orders))) $
                     (lib/aggregate $ (lib/offset (lib/sum (m/find-first (comp #{"TOTAL"} :name)
                                                                         (lib/visible-columns $)))
                                                  -1))

--- a/test/metabase/test_runner/assert_exprs.clj
+++ b/test/metabase/test_runner/assert_exprs.clj
@@ -8,7 +8,6 @@
    [clojure.test :as t]
    [clojure.walk :as walk]
    [mb.hawk.assert-exprs.approximately-equal :as =?]
-   [medley.core :as m]
    [metabase.test-runner.assert-exprs.malli-equals]
    [methodical.core :as methodical]))
 

--- a/test/metabase/test_runner/assert_exprs.clj
+++ b/test/metabase/test_runner/assert_exprs.clj
@@ -24,44 +24,19 @@
        form))
    form))
 
-(declare ^:private strip-generated-idents)
-
-(defn- drop-idents-on-joins
-  [joins original-joins generated-join-idents]
-  ;; Recursively strip generated idents off the inner queries of joins!
-  (let [joins (map strip-generated-idents joins original-joins)]
-    (if (seq generated-join-idents)
-      (map-indexed (fn [i join]
-                     (cond-> join
-                       (generated-join-idents i) (dissoc :ident)))
-                   joins)
-      joins)))
-
-(defn- strip-generated-idents
-  "Walk the query's stages, looking in the metadata of each stage for `:generated-idents`.
-
-  That metadata contains sets of keys which were generated in `:aggregation-idents` etc."
-  [inner-query original]
-  (let [modified (if-let [{:generated-paths/keys [aggregation-idents
-                                                  breakout-idents
-                                                  expression-idents
-                                                  join-idents]}      (-> original meta :generated-idents)]
-                   (-> inner-query
-                       (m/update-existing :aggregation-idents #(m/remove-keys aggregation-idents %))
-                       (m/update-existing :breakout-idents    #(m/remove-keys breakout-idents %))
-                       (m/update-existing :expression-idents  #(m/remove-keys expression-idents %))
-                       (m/update-existing :joins              drop-idents-on-joins (:joins original) join-idents))
-                   inner-query)]
-    (cond-> modified
-      (:source-query modified) (update :source-query strip-generated-idents (:source-query original)))))
+(defn- remove-idents [form]
+  (walk/postwalk
+   (fn [form]
+     (cond-> form
+       (map? form) (dissoc :ident :aggregation-idents :breakout-idents :expression-idents)))
+   form))
 
 (defn query=-report
   "Impl for [[t/assert-expr]] `query=`."
   [message expected actual]
   (let [expected (derecordize expected)
-        actual   (-> (derecordize actual)
-                     (m/update-existing :query strip-generated-idents (:query expected)))
-        expected (m/update-existing expected :query strip-generated-idents (:query expected))
+        actual   (remove-idents (derecordize actual))
+        expected (remove-idents expected)
         pass?    (= expected actual)]
     (merge
      {:type     (if pass? :pass :fail)
@@ -87,15 +62,16 @@
 
 (methodical/defmethod =?/=?-diff [:mbql-query :mbql-query]
   [expected actual]
-  (let [actual   (m/update-existing actual   :query strip-generated-idents (:query expected))
-        expected (m/update-existing expected :query strip-generated-idents (:query expected))]
+  (let [actual   (remove-idents actual)
+        expected (remove-idents expected)]
     (=?/=?-diff (vary-meta expected dissoc :type) (vary-meta actual dissoc :type))))
 
 (methodical/defmethod =?/=?-diff [:mbql-query :default]
   [expected actual]
-  (let [expected (m/update-existing expected :query strip-generated-idents (:query expected))]
+  (let [expected (remove-idents expected)]
     (=?/=?-diff (vary-meta expected dissoc :type) (vary-meta actual dissoc :type))))
 
 (methodical/defmethod =?/=?-diff [:default :mbql-query]
   [expected actual]
-  (=?/=?-diff expected (vary-meta actual dissoc :type)))
+  (let [actual (remove-idents actual)]
+    (=?/=?-diff expected (vary-meta actual dissoc :type))))


### PR DESCRIPTION
Resolves #39877

Prereq for the fix for #60444 

This is a first pass at updating `add-dimension-projections` middleware (now renamed to `add-remaps` to make its purpose clearer) to use MBQL 5/Lib instead of MBQL 4/legacy utils. We can go back in and make it use Lib more idiomatically in the future, but I didn't want to let the perfect be the enemy of the good here.

I also added a `:discouraged-var` linter rule to discourage people from using `mt/with-column-remappings` in QP tests (we should use `lib.tu/remap-metadata-provider` instead)... this doesn't fix the crazy tests that create `:model/Dimension` entries by hand but hopefully doing things in a consistent way elsewhere will help nudge people in the right direction. `remap-metadata-provider` is thread-safe and way faster