### PR TITLE
Add CLA-signed metabase-automation user and email git config

### DIFF
--- a/.github/actions/upgrade-backend-deps/action.yml
+++ b/.github/actions/upgrade-backend-deps/action.yml
@@ -11,4 +11,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash
-      run: bash ${{ github.action_path }}/upgrade-deps.sh
+      run: |
+        git config --global user.email "github-automation@metabase.com"
+        git config --global user.name "Metabase Automation"
+        bash ${{ github.action_path }}/upgrade-deps.sh


### PR DESCRIPTION
All committers for the branch of a PR must have signed the CLA. For  "Cam's Next-Level CLA Bot" To have an automatic commit not trigger it: this sets the git config email to `github-automation@metabase.com` and the git config user to `Metabase Automation`.