### PR TITLE
skip assigning milestones to embed sdk PRs, closes  EMB-658

### DIFF
--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -124,9 +124,10 @@ async function getOriginalIssues({
     return [];
   }
 
-  // if this isn't a pull request, but is an Embedding SDK issue, skip it
-  if (!issue.pull_request && hasLabel(issue, "Embedding/SDK")) {
-    console.log("  Skip an Embedding SDK issue");
+  // PRs or issues related to the SDK should not show up in core app milestones
+  // We'll probably revert this when/if we land hosted bundle
+  if (hasLabel(issue, "Embedding/SDK")) {
+    console.log("  Skip an Embedding SDK issue or PR");
     return [];
   }
 


### PR DESCRIPTION
Closes EMB-658
Thread: https://metaboat.slack.com/archives/C063Q3F1HPF/p1753214072812369

https://github.com/metabase/metabase/pull/60688 skipped assigning the milestone to the issue, but we also want to support adding them to PRs