### PR TITLE
Remove release/update channel selection

### DIFF
--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -7,9 +7,7 @@ on:
       - release-x.*
     tags:
       - v*
-      - nightly-*
       - latest-*
-      - beta-*
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -12,8 +12,6 @@ on:
         description: Tag name to apply to this release
         type: choice
         options:
-          - nightly
-          - beta
           - latest
         required: true
       tag_rollout:
@@ -36,8 +34,6 @@ on:
       tag_name:
         type: string
         # options:
-        #   - nightly
-        #   - beta
         #   - latest
         #   - none (skips everything)
         required: true
@@ -270,7 +266,7 @@ jobs:
         token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         fetch-depth: 0 # we want all branches and tags
         fetch-tags: true
-    - name: Add and push git tag for nightly/beta/latest
+    - name: Add and push git tag for latest
       if: ${{ !inputs.dot-x-tag }}
       run: | # sh
         if [[ "${{ matrix.edition }}" == "ee" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ on:
         options:
           - none
           - latest
-          - beta
-          - nightly
         required: true
         default: 'none'
       auto:
@@ -41,8 +39,6 @@ on:
         # options:
         #   - none
         #   - latest
-        #   - beta
-        #   - nightly
         required: true
         default: 'none'
       auto:

--- a/docs/configuring-metabase/config-template.md
+++ b/docs/configuring-metabase/config-template.md
@@ -259,7 +259,6 @@ config:
     surveys-enabled: true
     synchronous-batch-updates: false
     unaggregated-query-row-limit: null
-    update-channel: latest
     uploads-settings: null
     use-tenants: false
     user-visibility: all

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -1715,15 +1715,6 @@ Maximum number of rows to return specifically on :rows type queries via the API.
 
 Must be less than 1048575, and less than the number configured in MB_AGGREGATED_QUERY_ROW_LIMIT. See also MB_AGGREGATED_QUERY_ROW_LIMIT.
 
-### `MB_UPDATE_CHANNEL`
-
-- Type: string
-- Default: `latest`
-- [Exported as](../installation-and-operation/serialization.md): `update-channel`.
-- [Configuration file name](./config-file.md): `update-channel`
-
-We'll notify you here when there's a new version of this type of release.
-
 ### `MB_UPLOADS_DATABASE_ID [DEPRECATED]`
 
 > DEPRECATED: 0.50.0

--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1431,10 +1431,6 @@ describe("admin > settings > updates", () => {
       .findByText("Check for updates")
       .should("be.visible");
 
-    cy.findByTestId("update-channel-setting")
-      .findByText("Types of releases to check for")
-      .should("be.visible");
-
     cy.findByTestId("settings-updates").within(() => {
       cy.findByText("Metabase 1.86.76 is available. You're running 1.86.70.");
       cy.findByText("Some old feature").should("be.visible");
@@ -1447,36 +1443,7 @@ describe("admin > settings > updates", () => {
       .click();
 
     cy.findByTestId("settings-updates").within(() => {
-      cy.findByText("Types of releases to check for").should("not.exist");
       cy.findByText("Some old feature").should("not.exist");
-    });
-  });
-
-  it("should change release notes based on the selected update channel", () => {
-    cy.findByTestId("settings-updates").within(() => {
-      cy.findByText(/Metabase 1\.86\.76 is available/).should("be.visible");
-      cy.findByText("Some old feature").should("be.visible");
-      cy.findByText("New latest feature").should("be.visible");
-      cy.findByDisplayValue("Stable releases").click();
-    });
-
-    H.popover().findByText("Beta releases").click();
-
-    cy.findByTestId("settings-updates").within(() => {
-      cy.findByText(/Metabase 1\.86\.75\.309 is available/).should(
-        "be.visible",
-      );
-      cy.findByText("New beta feature").should("be.visible");
-      cy.findByDisplayValue("Beta releases").click();
-    });
-
-    H.popover().findByText("Nightly builds").click();
-
-    cy.findByTestId("settings-updates").within(() => {
-      cy.findByText(/Metabase 1\.86\.75\.311 is available/).should(
-        "be.visible",
-      );
-      cy.findByText("New nightly feature").should("be.visible");
     });
   });
 });

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -376,7 +376,6 @@ export const createMockSettings = (
   "notebook-native-preview-sidebar-width": null,
   "query-analysis-enabled": false,
   "check-for-updates": true,
-  "update-channel": "latest",
   "trial-banner-dismissal-timestamp": null,
   "license-token-missing-banner-dismissal-timestamp": [],
   "sdk-iframe-embed-setup-settings": null,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -294,8 +294,6 @@ export type SettingDefinitionMap<
   [K in T]: SettingDefinition<K>;
 };
 
-export type UpdateChannel = "latest" | "beta" | "nightly";
-
 export interface OpenAiModel {
   id: string;
   owned_by: string;
@@ -486,7 +484,6 @@ interface PublicSettings {
   "snowplow-url": string;
   "start-of-week": DayOfWeekId;
   "token-features": TokenFeatures;
-  "update-channel": UpdateChannel;
   version: Version;
   "version-info-last-checked": string | null;
   "airgap-enabled": boolean;

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
@@ -2,7 +2,6 @@ import { t } from "ttag";
 
 import { getCurrentVersion } from "metabase/admin/app/selectors";
 import { useGetVersionInfoQuery } from "metabase/api";
-import { useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { newVersionAvailable } from "metabase/lib/utils";
 import { Indicator } from "metabase/ui";
@@ -12,8 +11,7 @@ import { SettingsNavItem } from "./SettingsNav";
 export function UpdatesNavItem() {
   const { data: versionInfo } = useGetVersionInfoQuery();
   const currentVersion = useSelector(getCurrentVersion);
-  const updateChannel = useSetting("update-channel") ?? "latest";
-  const latestVersion = versionInfo?.[updateChannel]?.version;
+  const latestVersion = versionInfo?.latest?.version;
 
   const isNewVersionAvailable =
     latestVersion && newVersionAvailable({ currentVersion, latestVersion });

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.unit.spec.tsx
@@ -4,7 +4,7 @@ import {
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import type { SettingKey, UpdateChannel } from "metabase-types/api";
+import type { SettingKey } from "metabase-types/api";
 import {
   createMockSettingDefinition,
   createMockSettings,
@@ -13,10 +13,7 @@ import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import { UpdatesNavItem } from "./UpdatesNavItem";
 
-const setup = async (props: {
-  updateChannel: UpdateChannel;
-  versionTag: string;
-}) => {
+const setup = async (props: { versionTag: string }) => {
   const versionNoticeSettings = {
     version: {
       date: "2025-03-19",
@@ -24,7 +21,6 @@ const setup = async (props: {
       tag: props.versionTag,
       hash: "4742ea1",
     },
-    "update-channel": props.updateChannel,
   };
 
   const settings = createMockSettings(versionNoticeSettings);
@@ -32,20 +28,10 @@ const setup = async (props: {
   setupSettingEndpoint({
     settingKey: "version-info",
     settingValue: {
-      beta: {
-        version: "v1.54.0-beta",
-        released: "2025-03-24",
-        highlights: [],
-      },
       latest: {
-        version: "v1.53.8",
+        version: "v1.53.9",
         released: "2025-03-25",
         patch: true,
-        highlights: [],
-      },
-      nightly: {
-        version: "v1.52.3",
-        released: "2024-12-16",
         highlights: [],
       },
     },
@@ -68,7 +54,7 @@ const setup = async (props: {
 
 describe("UpdatesNavItem", () => {
   it("should not show badge if there are no updates available", async () => {
-    await setup({ versionTag: "v1.53.8", updateChannel: "latest" });
+    await setup({ versionTag: "v1.53.8" });
 
     await waitFor(() => {
       const indicatorDot = document.querySelector(
@@ -78,8 +64,8 @@ describe("UpdatesNavItem", () => {
     });
   });
 
-  it("should show badge updates are available", async () => {
-    await setup({ versionTag: "v1.53.8", updateChannel: "beta" });
+  it("should show badge when updates are available", async () => {
+    await setup({ versionTag: "v1.53.8" });
     await waitFor(() => {
       const indicatorDot = document.querySelector(
         '[class*="Indicator-indicator"]',

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/UpdatesSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/UpdatesSettingsPage.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { c, t } from "ttag";
+import { t } from "ttag";
 
 import {
   SettingsPageWrapper,
@@ -29,30 +29,6 @@ export function UpdatesSettingsPage() {
           title={t`Check for updates`}
           inputType="boolean"
         />
-        {checkForUpdates && (
-          <AdminSettingInput
-            name="update-channel"
-            title={t`Types of releases to check for`}
-            options={[
-              {
-                label: c("describes a set of software version releases")
-                  .t`Stable releases`,
-                value: "latest",
-              },
-              {
-                label: c("describes a set of software version releases")
-                  .t`Beta releases`,
-                value: "beta",
-              },
-              {
-                label: c("describes a set of software version releases")
-                  .t`Nightly builds`,
-                value: "nightly",
-              },
-            ]}
-            inputType="select"
-          />
-        )}
         {checkForUpdates && (
           <div
             className={cx(CS.pt3, CS.px2, {

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/UpdatesSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/UpdatesSettingsPage.unit.spec.tsx
@@ -1,16 +1,14 @@
-import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 
 import {
-  findRequests,
   setupPropertiesEndpoints,
   setupSettingEndpoint,
   setupSettingsEndpoints,
   setupUpdateSettingEndpoint,
 } from "__support__/server-mocks";
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import { UndoListing } from "metabase/common/components/UndoListing";
-import type { SettingKey, UpdateChannel } from "metabase-types/api";
+import type { SettingKey } from "metabase-types/api";
 import {
   createMockSettingDefinition,
   createMockSettings,
@@ -19,15 +17,10 @@ import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import { UpdatesSettingsPage } from "./UpdatesSettingsPage";
 
-const setup = async (props: {
-  updateChannel: UpdateChannel;
-  isHosted: boolean;
-  versionTag: string;
-}) => {
+const setup = async (props: { isHosted: boolean; versionTag: string }) => {
   const updatesSettings = {
     "is-hosted?": props.isHosted,
     "check-for-updates": true,
-    "update-channel": "latest",
     version: {
       date: "2025-03-19",
       src_hash: "4df5cf3e5e86b0cc7421d80e2a8835e2ce3afa7d",
@@ -42,18 +35,10 @@ const setup = async (props: {
   setupSettingEndpoint({
     settingKey: "version-info",
     settingValue: {
-      beta: {
-        version: "v1.54.0-beta",
-        released: "2025-03-24",
-      },
       latest: {
         version: "v1.53.8",
         released: "2025-03-25",
         patch: true,
-      },
-      nightly: {
-        version: "v1.52.3",
-        released: "2024-12-16",
       },
     },
   });
@@ -82,13 +67,11 @@ describe("UpdatesSettingsPage", () => {
       setup({
         isHosted: false,
         versionTag: "v1.53.8",
-        updateChannel: "latest",
       }),
     );
 
     [
       "Check for updates",
-      "Types of releases to check for",
       "You're running Metabase 1.53.8 which is the latest and greatest!",
     ].forEach((text) => {
       expect(screen.getByText(text)).toBeInTheDocument();
@@ -100,45 +83,8 @@ describe("UpdatesSettingsPage", () => {
       setup({
         isHosted: false,
         versionTag: "v1.53.8",
-        updateChannel: "latest",
       }),
     );
-
-    expect(
-      await screen.findByDisplayValue("Stable releases"),
-    ).toBeInTheDocument();
     expect(await screen.findByRole("switch")).toBeChecked();
-  });
-
-  it("should update multiple settings", async () => {
-    await setup({
-      isHosted: false,
-      versionTag: "v1.53.8",
-      updateChannel: "latest",
-    });
-
-    await userEvent.click(await screen.findByDisplayValue("Stable releases"));
-    await userEvent.click(screen.getByText("Beta releases"));
-    await userEvent.click(await screen.findByRole("switch"));
-
-    await waitFor(async () => {
-      const puts = await findRequests("PUT");
-      expect(puts).toHaveLength(2);
-    });
-
-    const puts = await findRequests("PUT");
-    const { url: updateChannelPutUrl, body: updateChannelPutBody } = puts[0];
-    const { url: checkForUpdatesPutUrl, body: checkForUpdatesBody } = puts[1];
-
-    expect(updateChannelPutUrl).toContain("/api/setting/update-channel");
-    expect(updateChannelPutBody).toEqual({ value: "beta" });
-
-    expect(checkForUpdatesPutUrl).toContain("/api/setting/check-for-updates");
-    expect(checkForUpdatesBody).toEqual({ value: false });
-
-    await waitFor(() => {
-      const toasts = screen.getAllByLabelText("check_filled icon");
-      expect(toasts).toHaveLength(2);
-    });
   });
 });

--- a/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.tsx
@@ -4,24 +4,18 @@ import { c, t } from "ttag";
 import { getCurrentVersion } from "metabase/admin/app/selectors";
 import { useGetVersionInfoQuery } from "metabase/api";
 import ExternalLink from "metabase/common/components/ExternalLink";
-import { useSetting } from "metabase/common/hooks";
 import ButtonsS from "metabase/css/components/buttons.module.css";
 import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
 import { newVersionAvailable, versionIsLatest } from "metabase/lib/utils";
-import type {
-  UpdateChannel,
-  VersionInfo,
-  VersionInfoRecord,
-} from "metabase-types/api";
+import type { VersionInfo, VersionInfoRecord } from "metabase-types/api";
 
 import S from "./VersionUpdateNotice.module.css";
 
 export function VersionUpdateNotice() {
   const { data: versionInfo } = useGetVersionInfoQuery();
   const currentVersion = useSelector(getCurrentVersion);
-  const updateChannel = useSetting("update-channel") ?? "latest";
-  const latestVersion = versionInfo?.[updateChannel]?.version;
+  const latestVersion = versionInfo?.latest?.version;
   const displayVersion = formatVersion(currentVersion);
 
   if (latestVersion && versionIsLatest({ currentVersion, latestVersion })) {
@@ -33,7 +27,6 @@ export function VersionUpdateNotice() {
       <NewVersionAvailable
         currentVersion={displayVersion}
         latestVersion={latestVersion}
-        updateChannel={updateChannel}
         versionInfo={versionInfo}
       />
     );
@@ -66,15 +59,13 @@ function DefaultUpdateMessage({ currentVersion }: { currentVersion: string }) {
 function NewVersionAvailable({
   currentVersion,
   latestVersion,
-  updateChannel,
   versionInfo,
 }: {
   currentVersion: string;
   latestVersion: string;
-  updateChannel: UpdateChannel;
   versionInfo?: VersionInfo | null;
 }) {
-  const lastestVersionInfo = versionInfo?.[updateChannel];
+  const lastestVersionInfo = versionInfo?.latest;
 
   return (
     <div>

--- a/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/VersionUpdateNotice/VersionUpdateNotice.unit.spec.tsx
@@ -6,7 +6,7 @@ import {
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { UndoListing } from "metabase/common/components/UndoListing";
-import type { SettingKey, UpdateChannel } from "metabase-types/api";
+import type { SettingKey } from "metabase-types/api";
 import {
   createMockSettingDefinition,
   createMockSettings,
@@ -15,11 +15,7 @@ import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import { VersionUpdateNotice } from "./VersionUpdateNotice";
 
-const setup = (props: {
-  updateChannel: UpdateChannel;
-  isHosted: boolean;
-  versionTag: string;
-}) => {
+const setup = (props: { isHosted: boolean; versionTag: string }) => {
   const versionNoticeSettings = {
     version: {
       date: "2025-03-19",
@@ -27,7 +23,6 @@ const setup = (props: {
       tag: props.versionTag,
       hash: "4742ea1",
     },
-    "update-channel": props.updateChannel,
     "is-hosted?": props.isHosted,
   };
 
@@ -37,20 +32,10 @@ const setup = (props: {
   setupSettingEndpoint({
     settingKey: "version-info",
     settingValue: {
-      beta: {
-        version: "v1.54.0-beta",
-        released: "2025-03-24",
-        highlights: [],
-      },
       latest: {
-        version: "v1.53.8",
+        version: "v1.53.9",
         released: "2025-03-25",
         patch: true,
-        highlights: [],
-      },
-      nightly: {
-        version: "v1.52.3",
-        released: "2024-12-16",
         highlights: [],
       },
     },
@@ -77,19 +62,19 @@ const setup = (props: {
 
 describe("VersionUpdateNotice", () => {
   it("should tell the user if they're on the latest version", async () => {
-    setup({ isHosted: false, versionTag: "v1.53.8", updateChannel: "latest" });
+    setup({ isHosted: false, versionTag: "v1.53.9" });
     expect(
       await screen.findByText(
-        "You're running Metabase 1.53.8 which is the latest and greatest!",
+        "You're running Metabase 1.53.9 which is the latest and greatest!",
       ),
     ).toBeInTheDocument();
   });
 
   it("should tell the user if there's a new version", async () => {
-    setup({ isHosted: false, versionTag: "v1.53.8", updateChannel: "beta" });
+    setup({ isHosted: false, versionTag: "v1.53.8" });
     expect(
       await screen.findByText(
-        "Metabase 1.54.0-beta is available. You're running 1.53.8.",
+        "Metabase 1.53.9 is available. You're running 1.53.8.",
       ),
     ).toBeInTheDocument();
   });
@@ -98,7 +83,6 @@ describe("VersionUpdateNotice", () => {
     setup({
       isHosted: false,
       versionTag: "notaversion",
-      updateChannel: "beta",
     });
     expect(
       await screen.findByText("You're running Metabase notaversion"),

--- a/src/metabase/version/settings.clj
+++ b/src/metabase/version/settings.clj
@@ -3,7 +3,7 @@
    [metabase.config.core :as config]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.system.core :as system]
-   [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]))
 
 (defsetting version

--- a/src/metabase/version/settings.clj
+++ b/src/metabase/version/settings.clj
@@ -19,24 +19,6 @@
   :audit   :getter
   :default true)
 
-(defn- set-update-channel! [new-channel]
-  (let [valid-channels #{"latest" "beta" "nightly"}]
-    (when-not (valid-channels new-channel)
-      (throw (IllegalArgumentException.
-              (tru "Invalid update channel ''{0}''. Valid channels are: {1}"
-                   new-channel valid-channels))))
-    (setting/set-value-of-type! :string :update-channel new-channel)))
-
-(defsetting update-channel
-  (deferred-tru "We''ll notify you here when there''s a new version of this type of release.")
-  :visibility :admin
-  :type       :string
-  :encryption :no
-  :export?    true
-  :audit      :getter
-  :setter     set-update-channel!
-  :default    "latest")
-
 (defsetting upgrade-threshold
   (deferred-tru "Threshold (value in 0-100) indicating at which treshold it should offer an upgrade to the latest major version.")
   :visibility :internal

--- a/src/metabase/version/task/upgrade_checks.clj
+++ b/src/metabase/version/task/upgrade_checks.clj
@@ -25,8 +25,7 @@
                                                             {:query-params (m/remove-vals
                                                                             str/blank?
                                                                             {"instance" (version.settings/site-uuid-for-version-info-fetching)
-                                                                             "current-version" (:tag config/mb-version-info)
-                                                                             "channel" (version.settings/update-channel)})})))]
+                                                                             "current-version" (:tag config/mb-version-info)})})))]
     (when (not= status 200)
       (throw (Exception. (format "[%d]: %s" status body))))
     (json/decode+kw body)))

--- a/test/metabase/version/settings_test.clj
+++ b/test/metabase/version/settings_test.clj
@@ -70,4 +70,3 @@
       (testing "rollout is a decimal"
         (let [modified (update version-info :latest assoc :rollout 0.2)]
           (is (= modified (info modified {:current-major 51 :upgrade-threshold-value 25}))))))))
-

--- a/test/metabase/version/settings_test.clj
+++ b/test/metabase/version/settings_test.clj
@@ -71,13 +71,3 @@
         (let [modified (update version-info :latest assoc :rollout 0.2)]
           (is (= modified (info modified {:current-major 51 :upgrade-threshold-value 25}))))))))
 
-(deftest update-channel-test
-  (testing "we can set the update channel"
-    (mt/discard-setting-changes [update-channel]
-      (version.settings/update-channel! "nightly")
-      (is (= "nightly" (version.settings/update-channel)))))
-  (testing "we can't set the update channel to an invalid value"
-    (mt/discard-setting-changes [update-channel]
-      (is (thrown?
-           IllegalArgumentException
-           (version.settings/update-channel! "millennially"))))))

--- a/test/metabase/version/settings_test.clj
+++ b/test/metabase/version/settings_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [metabase.config.core :as config]
-   [metabase.test :as mt]
    [metabase.version.settings :as version.settings]))
 
 (def prevent? #'version.settings/prevent-upgrade?)

--- a/test/metabase/version/task/upgrade_checks_test.clj
+++ b/test/metabase/version/task/upgrade_checks_test.clj
@@ -11,7 +11,7 @@
     (with-redefs [config/is-prod? true]
       (http-fake/with-fake-routes-in-isolation
         {{:address #"https://static.metabase.com/version-info(-ee)?.json.*"
-          :query-params {;; 3 query parameters are sent in prod:
+          :query-params {;; 2 query parameters are sent in prod:
                          ;; - A unique and stable instance UUID, and
                          ;; - The current version
                          :instance (version.settings/site-uuid-for-version-info-fetching)

--- a/test/metabase/version/task/upgrade_checks_test.clj
+++ b/test/metabase/version/task/upgrade_checks_test.clj
@@ -12,20 +12,17 @@
       (http-fake/with-fake-routes-in-isolation
         {{:address #"https://static.metabase.com/version-info(-ee)?.json.*"
           :query-params {;; 3 query parameters are sent in prod:
-                         ;; - A unique and stable instance UUID,
-                         ;; - The current version, and
-                         ;; - the update channel
+                         ;; - A unique and stable instance UUID, and
+                         ;; - The current version
                          :instance (version.settings/site-uuid-for-version-info-fetching)
-                         :current-version (:tag config/mb-version-info)
-                         :channel (version.settings/update-channel)}}
+                         :current-version (:tag config/mb-version-info)}}
          (constantly {:status 200 :body "{}"})}
         (is (= {} (@#'upgrade-checks/get-version-info))))))
 
   (testing "Empty values are omitted from the query params"
     (with-redefs [config/is-prod? true
                   version.settings/site-uuid-for-version-info-fetching (constantly "")
-                  config/mb-version-info (constantly {:tag ""})
-                  version.settings/update-channel (constantly "")]
+                  config/mb-version-info (constantly {:tag ""})]
       (http-fake/with-fake-routes-in-isolation
         {{:address #"https://static.metabase.com/version-info(-ee)?.json.*"
           :query-params {}}

--- a/test_resources/serialization_baseline/settings.yaml
+++ b/test_resources/serialization_baseline/settings.yaml
@@ -59,4 +59,3 @@ start-of-week: null
 subscription-allowed-domains: null
 synchronous-batch-updates: null
 unaggregated-query-row-limit: null
-update-channel: null


### PR DESCRIPTION
Closes DEV-706

### Description

Removes release channel selection from settings. It was a cool idea, but it's not really helping anyone.

We've got much better user experience on the horizon for in-product updates by embedding our new changelog pages from the website.

Before | After
---|---
<img width="860" height="809" alt="Screenshot 2025-07-23 at 8 03 49 AM" src="https://github.com/user-attachments/assets/f6efecd1-0ffd-466c-bd5f-88704e994fa2" /> | <img width="877" height="797" alt="Screenshot 2025-07-23 at 8 03 30 AM" src="https://github.com/user-attachments/assets/f7595f51-3515-4466-8b96-6bf83a4833d7" />


