### PR TITLE
Skip CI with `ci skip` label

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   files-changed:
-    if: ${{ github.event.pull_request.labels.*.name != 'ci skip' }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name,'ci skip') }}
     name: Check which files changed
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -36,7 +36,7 @@ jobs:
 
   static-viz-files-changed:
     name: Check whether static-viz files changed
-    if: ${{ github.event.pull_request.labels.*.name != 'ci skip' }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name,'ci skip') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     outputs:


### PR DESCRIPTION
Fixes #61307 

needed contains instead of == 🤦 

Actually works this time

<img width="376" height="545" alt="Screenshot 2025-07-23 at 8 35 32 AM" src="https://github.com/user-attachments/assets/b9f9363b-a439-4271-bea8-5456af8259f3" />

