### PR TITLE
rewrite clj-kondo/ignore for consistency

### DIFF
--- a/bin/build/src/i18n/create_artifacts/frontend.clj
+++ b/bin/build/src/i18n/create_artifacts/frontend.clj
@@ -1,6 +1,6 @@
 (ns i18n.create-artifacts.frontend
   (:require
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
+   ^{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/src/metabase/config/core.clj
+++ b/src/metabase/config/core.clj
@@ -1,6 +1,6 @@
 (ns metabase.config.core
   (:require
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
+   ^{:clj-kondo/ignore [:discouraged-namespace]}
    [cheshire.core :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -8,7 +8,7 @@
              [me.flowthing.pp :as pp]
              [metabase.config.core :as config]
              [clojure.pprint :as pprint]
-             #_{:clj-kondo/ignore [:discouraged-namespace]}
+             ^{:clj-kondo/ignore [:discouraged-namespace]}
              [metabase.util.jvm :as u.jvm]
              [metabase.util.string :as u.str]
              [potemkin :as p]

--- a/test/metabase/legacy_mbql/util_test.cljc
+++ b/test/metabase/legacy_mbql/util_test.cljc
@@ -1,6 +1,6 @@
 (ns metabase.legacy-mbql.util-test
   (:require
-   #?@(:clj  (#_{:clj-kondo/ignore [:discouraged-namespace]} [metabase.test :as mt])
+   #?@(:clj  (^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.test :as mt])
        :cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.string :as str]
    [clojure.test :as t]


### PR DESCRIPTION
- transforms these forms into metadata on ns requieres, so lsp sorting
  namespace keeps track of them.

example: calling lsp cleanup namespace will NOT be keep the kondo ignore form
with ns `a` in:
```clj
(:require
 [b]
 #_{:clj-kondo/ignore [:discouraged-namespace]}
 [a])
```

but it will in

```clj
(:require
 [b]
 ^{:clj-kondo/ignore [:discouraged-namespace]}
 [a])
```

Most of the ns require forms already use this pattern, this PR updates the rest of them
