### PR TITLE
[github actions] skip pngs optimize for merges

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -20,19 +20,29 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y pngcrush bc
 
+    - name: Skip Merge Commits
+      id: merge-check
+      run: |
+        if [ "$(git rev-list --parents -n 1 HEAD | wc -w)" -gt 2 ]; then
+          echo "Merge commit detected. Skipping."
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
     - name: Get changed PNG files
       id: changed-files
+      if: steps.merge-check.outputs.skip != 'true'
       uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
       with:
         files: |
           docs/**/*.png
 
     - name: Optimize changed PNG files
-      if: steps.changed-files.outputs.any_changed == 'true'
+      if: steps.changed-files.outputs.any_changed == 'true' && steps.merge-check.outputs.skip != 'true'
       id: optimize
       run: |
-        echo "Optimizing PNG files with pngcrush..."
-        echo "Branch:" $(git_current_branch)
+        echo "Optimizing new PNG files with pngcrush..."
+        echo "Branch: $(git_current_branch)"
 
         # Initialize tracking variables
         total_files=0
@@ -72,7 +82,7 @@ jobs:
         echo "Total bytes saved: ${total_saved} (${total_before} -> ${total_after})"
 
     - name: Check for changes after optimization
-      if: steps.changed-files.outputs.any_changed == 'true'
+      if: steps.changed-files.outputs.any_changed == 'true' && steps.merge-check.outputs.skip != 'true'
       id: check_changes
       run: |
         git add ${{ steps.changed-files.outputs.all_changed_files }}
@@ -86,7 +96,7 @@ jobs:
         fi
 
     - name: Commit optimized images
-      if: steps.changed-files.outputs.any_changed == 'true' && steps.check_changes.outputs.has_changes == 'true'
+      if: steps.changed-files.outputs.any_changed == 'true' && steps.check_changes.outputs.has_changes == 'true' && steps.merge-check.outputs.skip != 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       run: |
@@ -123,7 +133,7 @@ jobs:
         echo 'Applied: pngcrush -rem alla -brute -ow'
 
     - name: Output summary
-      if: steps.changed-files.outputs.any_changed == 'true'
+      if: steps.changed-files.outputs.any_changed == 'true' && steps.merge-check.outputs.skip != 'true'
       run: |
         if [ "${{ steps.check_changes.outputs.has_changes }}" = "false" ]; then
           echo "PNG files were already optimized - no changes needed"


### PR DESCRIPTION
While merging a bunch of deps, I noticed this task running for a while on merge commits. But merging shouldn't introduce new pngs, so I've disabled it for merge-commits in this PR