### PR TITLE
[MBQL Lib] Use stubs for cards and metrics in lib cache keys

### DIFF
--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -1,20 +1,15 @@
 name: "[NOT REQUIRED] SDK Compatibility tests"
 
-# Note: these are currently never called, we're skipping them as they're failing, below is the original triggers
 on:
-  workflow_call:
-
-# Original trigger (commented for reference):
-# on:
-#   push:
-#     branches:
-#       - "master"
-#       - "release-**"
-#   pull_request:
-#     types: [opened, synchronize, reopened]
-#     branches:
-#       - "master"
-#       - "release-**"
+  push:
+    branches:
+      - "master"
+      - "release-**"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - "master"
+      - "release-**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}


### PR DESCRIPTION
Fixes #61253.

### Description

Here's the breakdown of the issue, since it's subtle:
- These objects can contain some vanilla JS objects which in embedding
  contexts can be `Object.preventExtensions()`'d.
  - Eg. the `:visualization-settings` on a card or metric.
- `lib.metadata.cache` uses these objects as part of the cache key.
- Those become the keys of a CLJS map, which uses `cljs.core/hash`
- JS objects and arrays have pointer equality (`identical?` or `===`)
  semantics.
- The default `cljs.core.IHash/-hash` uses `goog.getUid(obj)`.
- That subtly mutates objects, adding a non-`enumerable`
  `closure_uid_123456789` property with an arbitrary sequence number.
- That's adding a property, which is a violation if
  `Object.preventExtensions()` (or `Object.freeze()`) has been used.
    - That silently does nothing by default, but throws in strict mode.

This PR modifies the cache key logic (which already has special handling
for `:lib/metadata`) to replace `:lib/type :metadata/card` and
`:metadata/metric` maps with a stub like `[:metric/card 123]`.

### How to verify

Run the embedding e2e tests like
```bash
yarn build-embedding-sdk
TEST_SUITE=metabase-nodejs-react-sdk-embedding-sample-e2e OPEN_UI=true SAMPLE_APP_ENVIRONMENT=development SAMPLE_APP_BRANCH_NAME=cljs-error-test EMBEDDING_SDK_VERSION=local START_BACKEND=false GENERATE_SNAPSHOTS=false START_CONTAINERS=false ENTERPRISE_TOKEN=$CYPRESS_MB_ALL_FEATURES_TOKEN yarn test-cypress
```

and run the single suite. It failed before this change, and passes now.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
