### PR TITLE
Update the embedding sdk admin settings to add simple embedding toggle

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -104,7 +104,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
       cy.location("pathname").should("eq", embeddingPage);
 
       cy.log("The second section: 'Interactive embedding'");
-      cy.findByRole("article", { name: "Interactive embedding" }).within(() => {
+      cy.findByRole("article", { name: /Interactive embedding/ }).within(() => {
         cy.findByText("Interactive embedding");
 
         cy.findByRole("link", { name: "Learn More" })

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/index.ts
@@ -6,6 +6,7 @@ import { SdkIframeEmbedSetup } from "./components/SdkIframeEmbedSetup";
 // Feature gate the embed setup for gradual rollouts.
 // In the future, we may drop this to enable users to try out new iframe embedding.
 if (hasPremiumFeature("embedding_iframe_sdk")) {
+  PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.isFeatureEnabled = () => true;
   PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.shouldShowEmbedInNewItemMenu = () => true;
   PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.SdkIframeEmbedSetup = SdkIframeEmbedSetup;
 }

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/EmbeddingOption.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/EmbeddingOption.tsx
@@ -5,7 +5,7 @@ import { useUniqueId } from "metabase/common/hooks/use-unique-id";
 import { Flex, Text, Title } from "metabase/ui";
 
 type EmbeddingOptionProps = {
-  title: string;
+  title: ReactNode;
   label?: ReactNode;
   children?: ReactNode;
   description: ReactNode;

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/EmbeddingSdkOptionCard/EmbeddingSdkOptionCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/EmbeddingSdkOptionCard/EmbeddingSdkOptionCard.tsx
@@ -1,9 +1,9 @@
 import { t } from "ttag";
 
+import { UpsellGem } from "metabase/admin/upsells/components/UpsellGem";
 import { useSetting } from "metabase/common/hooks";
-import { Badge } from "metabase/home/components/EmbedHomepage/Badge";
-import { PLUGIN_EMBEDDING } from "metabase/plugins";
-import { Flex, Group } from "metabase/ui";
+import { PLUGIN_EMBEDDING, PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
+import { Group } from "metabase/ui";
 
 import { EmbeddingOption } from "../EmbeddingOption";
 import { LinkButton } from "../LinkButton";
@@ -14,23 +14,18 @@ export function EmbeddingSdkOptionCard() {
   const isEmbeddingSdkEnabled = useSetting("enable-embedding-sdk");
   const isEmbeddingSimpleEnabled = useSetting("enable-embedding-simple");
   const isEE = PLUGIN_EMBEDDING.isEnabled();
+  const isEmbeddingSdkFeatureAvailable = PLUGIN_EMBEDDING_SDK.isEnabled();
   const isAnyEmbeddingEnabled =
     isEmbeddingSdkEnabled || isEmbeddingSimpleEnabled;
 
   return (
     <EmbeddingOption
       icon={<SdkIcon disabled={!isAnyEmbeddingEnabled} />}
-      title={t`Embedded Analytics SDK`}
-      label={
-        <Flex gap="sm">
-          <Badge
-            color="brand"
-            fz="sm"
-            px="sm"
-            py="xs"
-            uppercase
-          >{t`Pro and Enterprise`}</Badge>
-        </Flex>
+      title={
+        <Group gap="sm">
+          {!isEmbeddingSdkFeatureAvailable && <UpsellGem />}
+          {t`Embedded Analytics SDK`}
+        </Group>
       }
       description={t`Interactive embedding with full, granular control. Embed and style individual Metabase components in your app, and tailor the experience to each person. Allows for CSS styling, custom user flows, event subscriptions, and more. Only available with SSO via JWT.`}
     >

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/EmbeddingSdkOptionCard/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/EmbeddingSdkOptionCard/tests/common.unit.spec.tsx
@@ -13,7 +13,6 @@ describe("EmbeddingSdkOptionCard (OSS)", () => {
     await setup();
 
     expect(screen.getByText("Embedded Analytics SDK")).toBeInTheDocument();
-    expect(screen.getByText("Pro and Enterprise")).toBeInTheDocument();
     expect(screen.queryByText("Beta")).not.toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/InteractiveEmbeddingOptionCard/InteractiveEmbeddingOptionCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/InteractiveEmbeddingOptionCard/InteractiveEmbeddingOptionCard.tsx
@@ -1,9 +1,9 @@
 import { jt, t } from "ttag";
 
+import { UpsellGem } from "metabase/admin/upsells/components/UpsellGem";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useSetting } from "metabase/common/hooks";
 import { getPlan } from "metabase/common/utils/plan";
-import { Badge } from "metabase/home/components/EmbedHomepage/Badge";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_EMBEDDING } from "metabase/plugins";
 import { getDocsUrl, getSetting } from "metabase/selectors/settings";
@@ -44,15 +44,11 @@ export const InteractiveEmbeddingOptionCard = () => {
           disabled={!isEE || !isInteractiveEmbeddingEnabled}
         />
       }
-      title={t`Interactive embedding`}
-      label={
-        <Badge
-          fz="sm"
-          px="sm"
-          py="xs"
-          color="brand"
-          uppercase
-        >{t`Pro and Enterprise`}</Badge>
+      title={
+        <Group gap="sm">
+          {!isEE && <UpsellGem />}
+          {t`Interactive embedding`}
+        </Group>
       }
       description={jt`Use interactive embedding when you want to ${(
         <ExternalLink

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.module.css
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.module.css
@@ -1,0 +1,5 @@
+.SectionCard {
+  border-radius: 8px;
+  border: 1px solid var(--mb-color-border);
+  background: var(--mb-color-background);
+}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -119,8 +119,9 @@ export function EmbeddingSdkSettings() {
           <Group align="flex-start" gap="lg">
             <Flex direction="column" gap="md" style={{ flex: 1 }}>
               <EmbeddingToggle
-                label={t`SDK Embedding`}
+                label={t`Embedding SDK for React`}
                 settingKey="enable-embedding-sdk"
+                labelPosition="right"
               />
 
               {isSimpleEmbedFeatureEnabled && (
@@ -131,9 +132,7 @@ export function EmbeddingSdkSettings() {
                     settingKey="enable-embedding-simple"
                   />
 
-                  <Badge size="xs" color="blue" variant="outline">
-                    {t`Beta`}
-                  </Badge>
+                  <Badge size="sm">{t`Beta`}</Badge>
                 </Group>
               )}
             </Flex>
@@ -186,8 +185,8 @@ export function EmbeddingSdkSettings() {
             placeholder="https://*.example.com"
             description={
               isEmbeddingAvailable
-                ? t`Enter the origins for the websites or apps where you want to allow embedding, separated by a space. These origins apply to both SDK and iframe embedding. Localhost is automatically included. Changes will take effect within one minute.`
-                : jt`Try out the SDK on localhost. To enable other sites, ${(<UpsellSdkLink />)} and Enter the origins for the websites or apps where you want to allow SDK embedding.`
+                ? t`Enter the origins for the websites or apps where you want to allow embedding, separated by a space. These origins apply to both SDK and simple embedding. Localhost is automatically included. Changes will take effect within one minute.`
+                : jt`Try out the SDK on localhost. To enable other sites, ${(<UpsellSdkLink />)} and enter the origins for the websites or apps where you want to allow SDK and simple embedding.`
             }
             inputType="text"
             disabled={!canEditSdkOrigins}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -1,5 +1,5 @@
 import { match } from "ts-pattern";
-import { jt, t } from "ttag";
+import { c, jt, t } from "ttag";
 
 import {
   SettingsPageWrapper,
@@ -117,47 +117,63 @@ export function EmbeddingSdkSettings() {
       <SettingsSection>
         <Box>
           <Group align="flex-start" gap="lg">
-            <Flex direction="column" gap="md" style={{ flex: 1 }}>
-              <EmbeddingToggle
-                label={t`Embedding SDK for React`}
-                settingKey="enable-embedding-sdk"
-                labelPosition="right"
-              />
+            <Flex direction="column" gap="md">
+              <Group align="center" justify="space-between" w="100%" gap="xl">
+                <Group gap="sm">
+                  <EmbeddingToggle
+                    label={t`Embedding SDK for React`}
+                    settingKey="enable-embedding-sdk"
+                    labelPosition="right"
+                  />
+                </Group>
+
+                <Text c="text-medium">
+                  {c(
+                    "{0} is the link to quickstart, {1} is the link to documentation",
+                  ).jt`
+                    Check out the ${(
+                      <ExternalLink
+                        href={quickStartUrl}
+                      >{t`quickstart`}</ExternalLink>
+                    )} and
+                    ${(
+                      <ExternalLink
+                        href={documentationUrl}
+                      >{t`documentation`}</ExternalLink>
+                    )}.`}
+                </Text>
+              </Group>
 
               {isSimpleEmbedFeatureEnabled && (
-                <Group align="center" gap="sm">
-                  <EmbeddingToggle
-                    label={t`Simple Embedding`}
-                    labelPosition="right"
-                    settingKey="enable-embedding-simple"
-                  />
+                <Group align="center" justify="space-between" w="100%" gap="xl">
+                  <Group gap="sm">
+                    <EmbeddingToggle
+                      label={t`Simple Embedding`}
+                      labelPosition="right"
+                      settingKey="enable-embedding-simple"
+                    />
 
-                  <Badge size="sm">{t`Beta`}</Badge>
+                    <Badge size="sm">{t`Beta`}</Badge>
+                  </Group>
+
+                  <Text c="text-medium">
+                    {c(
+                      "{0} is the link to quickstart, {1} is the link to documentation",
+                    ).jt`
+                    Check out the ${(
+                      <ExternalLink
+                        href={quickStartUrl}
+                      >{t`quickstart`}</ExternalLink>
+                    )} and
+                    ${(
+                      <ExternalLink
+                        href={documentationUrl}
+                      >{t`documentation`}</ExternalLink>
+                    )}.`}
+                  </Text>
                 </Group>
               )}
             </Flex>
-
-            <Box>
-              <SettingHeader
-                id="get-started"
-                title={
-                  isReactSdkFeatureEnabled
-                    ? t`Get started`
-                    : t`Try Embedded analytics SDK`
-                }
-                description={
-                  isReactSdkFeatureEnabled
-                    ? ""
-                    : t`Use the SDK with API keys for development.`
-                }
-              />
-
-              <Button
-                variant="outline"
-                component={ExternalLink}
-                href={quickStartUrl}
-              >{t`Check out the Quickstart`}</Button>
-            </Box>
           </Group>
         </Box>
 
@@ -210,14 +226,6 @@ export function EmbeddingSdkSettings() {
             >{t`Request version pinning`}</Button>
           </Box>
         )}
-
-        <Text data-testid="sdk-documentation">
-          {jt`Check out the ${(
-            <ExternalLink key="sdk-doc" href={documentationUrl}>
-              {t`documentation`}
-            </ExternalLink>
-          )} for more.`}
-        </Text>
       </SettingsSection>
     </SettingsPageWrapper>
   );

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -133,11 +133,13 @@ export function EmbeddingSdkSettings() {
                   ).jt`
                     Check out the ${(
                       <ExternalLink
+                        key="quickstart-sdk"
                         href={quickStartUrl}
                       >{t`quickstart`}</ExternalLink>
                     )} and
                     ${(
                       <ExternalLink
+                        key="documentation-sdk"
                         href={documentationUrl}
                       >{t`documentation`}</ExternalLink>
                     )}.`}
@@ -156,17 +158,20 @@ export function EmbeddingSdkSettings() {
                     <Badge size="sm">{t`Beta`}</Badge>
                   </Group>
 
+                  {/** TODO: update the quickstart and documentation link to link to simple embedding docs */}
                   <Text c="text-medium">
                     {c(
                       "{0} is the link to quickstart, {1} is the link to documentation",
                     ).jt`
                     Check out the ${(
                       <ExternalLink
+                        key="quickstart-simple"
                         href={quickStartUrl}
                       >{t`quickstart`}</ExternalLink>
                     )} and
                     ${(
                       <ExternalLink
+                        key="documentation-simple"
                         href={documentationUrl}
                       >{t`documentation`}</ExternalLink>
                     )}.`}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -117,11 +117,11 @@ export function EmbeddingSdkSettings() {
     .otherwise(() => null);
 
   return (
-    <SettingsPageWrapper title={t`Embedded Analytics SDK`}>
+    <SettingsPageWrapper title={t`Embedding SDK`}>
       <UpsellDevInstances location="embedding-page" />
 
-      <Box p="lg" className={S.SectionCard}>
-        <Group mb="md">
+      <Flex direction="column" p="lg" className={S.SectionCard} gap="sm">
+        <Group>
           <Text size="lg" fw={600} c="text-dark">
             {t`Embedded analytics SDK for React`}
           </Text>
@@ -136,7 +136,7 @@ export function EmbeddingSdkSettings() {
 
           <Group gap="md">
             <Button
-              size="compact-sm"
+              size="compact-xs"
               variant="outline"
               component={ExternalLink}
               href={quickStartUrl}
@@ -147,7 +147,7 @@ export function EmbeddingSdkSettings() {
             </Button>
 
             <Button
-              size="compact-sm"
+              size="compact-xs"
               variant="outline"
               component={ExternalLink}
               href={documentationUrl}
@@ -158,11 +158,11 @@ export function EmbeddingSdkSettings() {
             </Button>
           </Group>
         </Group>
-      </Box>
+      </Flex>
 
       {isSimpleEmbedFeatureEnabled && (
         <Box p="lg" className={S.SectionCard}>
-          <Flex direction="column" gap="md">
+          <Flex direction="column" gap="sm">
             <Group gap="sm">
               <Text size="lg" fw={600} c="text-dark">
                 {t`Simple SDK Embedding`}
@@ -180,7 +180,7 @@ export function EmbeddingSdkSettings() {
 
               <Group gap="md">
                 <Button
-                  size="compact-sm"
+                  size="compact-xs"
                   variant="outline"
                   component={ExternalLink}
                   href={quickStartUrl}
@@ -191,7 +191,7 @@ export function EmbeddingSdkSettings() {
                 </Button>
 
                 <Button
-                  size="compact-sm"
+                  size="compact-xs"
                   variant="outline"
                   component={ExternalLink}
                   href={documentationUrl}
@@ -225,7 +225,7 @@ export function EmbeddingSdkSettings() {
 
                   <HoverCard.Dropdown>
                     <Box p="md" w={270}>
-                      <Text size="md" lh="lg" c="text-medium">
+                      <Text lh="lg" c="text-medium">
                         {t`Separate values with a space. Localhost is automatically included. Changes will take effect within one minute.`}
                       </Text>
                     </Box>

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { match } from "ts-pattern";
 import { jt, t } from "ttag";
 
@@ -6,6 +7,7 @@ import { UpsellDevInstances } from "metabase/admin/upsells";
 import { UpsellSdkLink } from "metabase/admin/upsells/UpsellSdkLink";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl, useSetting, useUrlWithUtm } from "metabase/common/hooks";
+import CS from "metabase/css/core/index.css";
 import { isEEBuild } from "metabase/lib/utils";
 import {
   PLUGIN_EMBEDDING_IFRAME_SDK_SETUP,
@@ -17,7 +19,6 @@ import {
   Badge,
   Box,
   Button,
-  Divider,
   Flex,
   Group,
   HoverCard,
@@ -84,7 +85,11 @@ export function EmbeddingSdkSettings() {
   );
 
   const ImplementJwtLink = (
-    <ExternalLink key="implement-jwt" href={implementJwtUrl}>
+    <ExternalLink
+      key="implement-jwt"
+      href={implementJwtUrl}
+      className={cx(CS.link, CS.textBold)}
+    >
       {t`implement JWT SSO`}
     </ExternalLink>
   );
@@ -115,62 +120,44 @@ export function EmbeddingSdkSettings() {
     <SettingsPageWrapper title={t`Embedded Analytics SDK`}>
       <UpsellDevInstances location="embedding-page" />
 
-      <Box className={S.SectionCard}>
-        <Box p="lg">
-          <Group mb="md">
-            <Text size="lg" fw={600} c="text-dark">
-              {t`Embedded analytics SDK for React`}
-            </Text>
-          </Group>
-
-          <Group gap="sm" align="center" justify="space-between" w="100%">
-            <EmbeddingToggle
-              label={t`Enabled`}
-              settingKey="enable-embedding-sdk"
-              labelPosition="right"
-            />
-
-            <Group gap="md">
-              <Button
-                size="compact-sm"
-                variant="outline"
-                component={ExternalLink}
-                href={quickStartUrl}
-                rightSection={<Icon size={12} name="external" />}
-                fz="sm"
-              >
-                {t`Quick start`}
-              </Button>
-
-              <Button
-                size="compact-sm"
-                variant="outline"
-                component={ExternalLink}
-                href={documentationUrl}
-                rightSection={<Icon size={12} name="external" />}
-                fz="sm"
-              >
-                {t`Documentation`}
-              </Button>
-            </Group>
-          </Group>
-        </Box>
-
-        <Divider />
-
-        <Alert
-          data-testid="sdk-settings-alert-info"
-          icon={
-            <Icon color="var(--mb-color-text-secondary)" name="info_filled" />
-          }
-          px="xl"
-          bg="none"
-          bd="none"
-        >
-          <Text size="sm" c="text-medium">
-            {apiKeyBannerText}
+      <Box p="lg" className={S.SectionCard}>
+        <Group mb="md">
+          <Text size="lg" fw={600} c="text-dark">
+            {t`Embedded analytics SDK for React`}
           </Text>
-        </Alert>
+        </Group>
+
+        <Group gap="sm" align="center" justify="space-between" w="100%">
+          <EmbeddingToggle
+            label={t`Enabled`}
+            settingKey="enable-embedding-sdk"
+            labelPosition="right"
+          />
+
+          <Group gap="md">
+            <Button
+              size="compact-sm"
+              variant="outline"
+              component={ExternalLink}
+              href={quickStartUrl}
+              rightSection={<Icon size={12} name="external" />}
+              fz="sm"
+            >
+              {t`Quick start`}
+            </Button>
+
+            <Button
+              size="compact-sm"
+              variant="outline"
+              component={ExternalLink}
+              href={documentationUrl}
+              rightSection={<Icon size={12} name="external" />}
+              fz="sm"
+            >
+              {t`Documentation`}
+            </Button>
+          </Group>
+        </Group>
       </Box>
 
       {isSimpleEmbedFeatureEnabled && (
@@ -271,6 +258,20 @@ export function EmbeddingSdkSettings() {
           >{t`Request version pinning`}</Button>
         </Box>
       )}
+
+      <Alert
+        data-testid="sdk-settings-alert-info"
+        icon={
+          <Icon color="var(--mb-color-text-secondary)" name="info_filled" />
+        }
+        px="lg"
+        bg="none"
+        bd="1px solid var(--mb-color-border)"
+      >
+        <Text size="sm" c="text-medium" lh="lg">
+          {apiKeyBannerText}
+        </Text>
+      </Alert>
     </SettingsPageWrapper>
   );
 }

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -1,10 +1,7 @@
 import { match } from "ts-pattern";
-import { c, jt, t } from "ttag";
+import { jt, t } from "ttag";
 
-import {
-  SettingsPageWrapper,
-  SettingsSection,
-} from "metabase/admin/components/SettingsSection";
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { UpsellDevInstances } from "metabase/admin/upsells";
 import { UpsellSdkLink } from "metabase/admin/upsells/UpsellSdkLink";
 import ExternalLink from "metabase/common/components/ExternalLink";
@@ -20,9 +17,11 @@ import {
   Badge,
   Box,
   Button,
+  Divider,
   Flex,
   Group,
   Icon,
+  Popover,
   Text,
 } from "metabase/ui";
 
@@ -114,124 +113,176 @@ export function EmbeddingSdkSettings() {
     <SettingsPageWrapper title={t`Embedded Analytics SDK`}>
       <UpsellDevInstances location="embedding-page" />
 
-      <SettingsSection>
-        <Box>
-          <Group align="flex-start" gap="lg">
-            <Flex direction="column" gap="md">
-              <Group align="center" justify="space-between" w="100%" gap="xl">
-                <Group gap="sm">
-                  <EmbeddingToggle
-                    label={t`Embedding SDK for React`}
-                    settingKey="enable-embedding-sdk"
-                    labelPosition="right"
-                  />
-                </Group>
+      <Box
+        bd="1px solid var(--mb-color-border)"
+        bg="var(--mb-color-background)"
+        style={{ borderRadius: 8 }}
+      >
+        <Box p="lg">
+          <Group mb="md">
+            <Text size="lg" fw={600} c="text-dark">
+              {t`Embedded analytics SDK for React`}
+            </Text>
+          </Group>
 
-                <Text c="text-medium">
-                  {c(
-                    "{0} is the link to quickstart, {1} is the link to documentation",
-                  ).jt`
-                    Check out the ${(
-                      <ExternalLink
-                        key="quickstart-sdk"
-                        href={quickStartUrl}
-                      >{t`quickstart`}</ExternalLink>
-                    )} and
-                    ${(
-                      <ExternalLink
-                        key="documentation-sdk"
-                        href={documentationUrl}
-                      >{t`documentation`}</ExternalLink>
-                    )}.`}
-                </Text>
-              </Group>
+          <Group gap="sm" align="center" justify="space-between" w="100%">
+            <EmbeddingToggle
+              label={t`Enabled`}
+              settingKey="enable-embedding-sdk"
+              labelPosition="right"
+            />
 
-              {isSimpleEmbedFeatureEnabled && (
-                <Group align="center" justify="space-between" w="100%" gap="xl">
-                  <Group gap="sm">
-                    <EmbeddingToggle
-                      label={t`Simple Embedding`}
-                      labelPosition="right"
-                      settingKey="enable-embedding-simple"
-                    />
+            <Group gap="md">
+              <Button
+                size="compact-sm"
+                variant="outline"
+                component={ExternalLink}
+                href={quickStartUrl}
+                rightSection={<Icon size={12} name="external" />}
+                fz="sm"
+              >
+                {t`Quick start`}
+              </Button>
 
-                    <Badge size="sm">{t`Beta`}</Badge>
-                  </Group>
-
-                  {/** TODO: update the quickstart and documentation link to link to simple embedding docs */}
-                  <Text c="text-medium">
-                    {c(
-                      "{0} is the link to quickstart, {1} is the link to documentation",
-                    ).jt`
-                    Check out the ${(
-                      <ExternalLink
-                        key="quickstart-simple"
-                        href={quickStartUrl}
-                      >{t`quickstart`}</ExternalLink>
-                    )} and
-                    ${(
-                      <ExternalLink
-                        key="documentation-simple"
-                        href={documentationUrl}
-                      >{t`documentation`}</ExternalLink>
-                    )}.`}
-                  </Text>
-                </Group>
-              )}
-            </Flex>
+              <Button
+                size="compact-sm"
+                variant="outline"
+                component={ExternalLink}
+                href={documentationUrl}
+                rightSection={<Icon size={12} name="external" />}
+                fz="sm"
+              >
+                {t`Documentation`}
+              </Button>
+            </Group>
           </Group>
         </Box>
+
+        <Divider />
 
         <Alert
           data-testid="sdk-settings-alert-info"
           icon={
             <Icon color="var(--mb-color-text-secondary)" name="info_filled" />
           }
-          bg="var(--mb-color-background-info)"
-          style={{
-            borderColor: "var(--mb-color-border)",
-          }}
+          px="xl"
+          bg="none"
+          bd="none"
           variant="outline"
-          px="lg"
-          py="md"
-          maw={620}
         >
-          <Text size="sm">{apiKeyBannerText}</Text>
+          <Text size="sm" c="text-medium">
+            {apiKeyBannerText}
+          </Text>
         </Alert>
+      </Box>
 
-        <Box>
-          <AdminSettingInput
-            name="embedding-app-origins-sdk"
-            title={t`Authorized Origins`}
-            placeholder="https://*.example.com"
-            description={
-              isEmbeddingAvailable
-                ? t`Enter the origins for the websites or apps where you want to allow embedding, separated by a space. These origins apply to both SDK and simple embedding. Localhost is automatically included. Changes will take effect within one minute.`
-                : jt`Try out the SDK on localhost. To enable other sites, ${(<UpsellSdkLink />)} and enter the origins for the websites or apps where you want to allow SDK and simple embedding.`
-            }
-            inputType="text"
-            disabled={!canEditSdkOrigins}
-          />
+      {isSimpleEmbedFeatureEnabled && (
+        <Box
+          bg="var(--mb-color-background)"
+          p="lg"
+          bd="1px solid var(--mb-color-border)"
+          style={{ borderRadius: 8 }}
+        >
+          <Flex direction="column" gap="md">
+            <Group gap="sm">
+              <Text size="lg" fw={600} c="text-dark">
+                {t`Simple SDK Embedding`}
+              </Text>
+
+              <Badge size="sm">{t`Beta`}</Badge>
+            </Group>
+
+            <Group gap="sm" align="center" justify="space-between" w="100%">
+              <EmbeddingToggle
+                label={t`Enabled`}
+                labelPosition="right"
+                settingKey="enable-embedding-simple"
+              />
+
+              <Group gap="md">
+                <Button
+                  size="compact-sm"
+                  variant="outline"
+                  component={ExternalLink}
+                  href={quickStartUrl}
+                  rightSection={<Icon size={12} name="external" />}
+                  fz="sm"
+                >
+                  {t`Quick start`}
+                </Button>
+
+                <Button
+                  size="compact-sm"
+                  variant="outline"
+                  component={ExternalLink}
+                  href={documentationUrl}
+                  rightSection={<Icon size={12} name="external" />}
+                  fz="sm"
+                >
+                  {t`Documentation`}
+                </Button>
+              </Group>
+            </Group>
+          </Flex>
         </Box>
+      )}
 
-        {isEmbeddingAvailable && isHosted && (
-          <Box>
-            <SettingHeader
-              id="version-pinning"
-              title={t`Version pinning`}
-              description={t`Metabase Cloud instances are automatically upgraded to new releases. SDK packages are strictly compatible with specific version of Metabase. You can request to pin your Metabase to a major version and upgrade your Metabase and SDK dependency in a coordinated fashion.`}
-            />
-            <Button
-              size="compact-md"
-              variant="outline"
-              leftSection={<Icon size={12} name="mail" aria-hidden />}
-              component={ExternalLink}
-              fz="0.75rem"
-              href="mailto:help@metabase.com"
-            >{t`Request version pinning`}</Button>
-          </Box>
-        )}
-      </SettingsSection>
+      <Box
+        bg="var(--mb-color-background)"
+        p="lg"
+        bd="1px solid var(--mb-color-border)"
+        style={{ borderRadius: 8 }}
+      >
+        <Group gap="xs" mb="md">
+          <Text size="lg" fw={600} c="text-dark">
+            {t`Cross-Origin Resource Sharing (CORS)`}
+          </Text>
+          <Popover width={300} position="top" withArrow shadow="md">
+            <Popover.Target>
+              <Icon
+                size={16}
+                name="info"
+                c="text-medium"
+                style={{ cursor: "pointer" }}
+              />
+            </Popover.Target>
+            <Popover.Dropdown>
+              <Text size="sm">
+                {isEmbeddingAvailable
+                  ? t`Enter the origins for the websites or apps where you want to allow embedding, separated by a space. These origins apply to both SDK and simple embedding. Localhost is automatically included. Changes will take effect within one minute.`
+                  : jt`Try out the SDK on localhost. To enable other sites, ${(<UpsellSdkLink />)} and enter the origins for the websites or apps where you want to allow SDK and simple embedding.`}
+              </Text>
+            </Popover.Dropdown>
+          </Popover>
+        </Group>
+        <Text c="text-medium" mb="md">
+          {t`Enter the origins for the websites or apps where you want to allow SDK embedding.`}
+        </Text>
+        <AdminSettingInput
+          name="embedding-app-origins-sdk"
+          placeholder="https://*.example.com"
+          inputType="text"
+          disabled={!canEditSdkOrigins}
+        />
+      </Box>
+
+      {isEmbeddingAvailable && isHosted && (
+        <Box>
+          <SettingHeader
+            id="version-pinning"
+            title={t`Version pinning`}
+            description={t`Metabase Cloud instances are automatically upgraded to new releases. SDK packages are strictly compatible with specific version of Metabase. You can request to pin your Metabase to a major version and upgrade your Metabase and SDK dependency in a coordinated fashion.`}
+          />
+          <Button
+            size="compact-md"
+            variant="outline"
+            leftSection={<Icon size={12} name="mail" aria-hidden />}
+            component={ExternalLink}
+            fz="0.75rem"
+            href="mailto:help@metabase.com"
+          >{t`Request version pinning`}</Button>
+        </Box>
+      )}
     </SettingsPageWrapper>
   );
 }

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -20,14 +20,16 @@ import {
   Divider,
   Flex,
   Group,
+  HoverCard,
   Icon,
-  Popover,
   Text,
 } from "metabase/ui";
 
 import { SettingHeader } from "../../SettingHeader";
 import { AdminSettingInput } from "../../widgets/AdminSettingInput";
 import { EmbeddingToggle } from "../EmbeddingToggle";
+
+import S from "./EmbeddingSdkSettings.module.css";
 
 const utmTags = {
   utm_source: "product",
@@ -113,11 +115,7 @@ export function EmbeddingSdkSettings() {
     <SettingsPageWrapper title={t`Embedded Analytics SDK`}>
       <UpsellDevInstances location="embedding-page" />
 
-      <Box
-        bd="1px solid var(--mb-color-border)"
-        bg="var(--mb-color-background)"
-        style={{ borderRadius: 8 }}
-      >
+      <Box className={S.SectionCard}>
         <Box p="lg">
           <Group mb="md">
             <Text size="lg" fw={600} c="text-dark">
@@ -168,7 +166,6 @@ export function EmbeddingSdkSettings() {
           px="xl"
           bg="none"
           bd="none"
-          variant="outline"
         >
           <Text size="sm" c="text-medium">
             {apiKeyBannerText}
@@ -177,12 +174,7 @@ export function EmbeddingSdkSettings() {
       </Box>
 
       {isSimpleEmbedFeatureEnabled && (
-        <Box
-          bg="var(--mb-color-background)"
-          p="lg"
-          bd="1px solid var(--mb-color-border)"
-          style={{ borderRadius: 8 }}
-        >
+        <Box p="lg" className={S.SectionCard}>
           <Flex direction="column" gap="md">
             <Group gap="sm">
               <Text size="lg" fw={600} c="text-dark">
@@ -227,38 +219,34 @@ export function EmbeddingSdkSettings() {
         </Box>
       )}
 
-      <Box
-        bg="var(--mb-color-background)"
-        p="lg"
-        bd="1px solid var(--mb-color-border)"
-        style={{ borderRadius: 8 }}
-      >
-        <Group gap="xs" mb="md">
-          <Text size="lg" fw={600} c="text-dark">
-            {t`Cross-Origin Resource Sharing (CORS)`}
-          </Text>
-          <Popover width={300} position="top" withArrow shadow="md">
-            <Popover.Target>
-              <Icon
-                size={16}
-                name="info"
-                c="text-medium"
-                style={{ cursor: "pointer" }}
-              />
-            </Popover.Target>
-            <Popover.Dropdown>
-              <Text size="sm">
+      <Box py="lg" px="xl" className={S.SectionCard}>
+        <AdminSettingInput
+          title={t`Cross-Origin Resource Sharing (CORS)`}
+          description={
+            <Group align="center" mt="xs" gap="sm">
+              <Text c="text-medium" fz="md">
                 {isEmbeddingAvailable
-                  ? t`Enter the origins for the websites or apps where you want to allow embedding, separated by a space. These origins apply to both SDK and simple embedding. Localhost is automatically included. Changes will take effect within one minute.`
+                  ? t`Enter the origins for the websites or apps where you want to allow SDK embedding.`
                   : jt`Try out the SDK on localhost. To enable other sites, ${(<UpsellSdkLink />)} and enter the origins for the websites or apps where you want to allow SDK and simple embedding.`}
               </Text>
-            </Popover.Dropdown>
-          </Popover>
-        </Group>
-        <Text c="text-medium" mb="md">
-          {t`Enter the origins for the websites or apps where you want to allow SDK embedding.`}
-        </Text>
-        <AdminSettingInput
+
+              {isEmbeddingAvailable && (
+                <HoverCard position="bottom">
+                  <HoverCard.Target>
+                    <Icon name="info_filled" c="text-medium" cursor="pointer" />
+                  </HoverCard.Target>
+
+                  <HoverCard.Dropdown>
+                    <Box p="md" w={270}>
+                      <Text size="md" lh="lg" c="text-medium">
+                        {t`Separate values with a space. Localhost is automatically included. Changes will take effect within one minute.`}
+                      </Text>
+                    </Box>
+                  </HoverCard.Dropdown>
+                </HoverCard>
+              )}
+            </Group>
+          }
           name="embedding-app-origins-sdk"
           placeholder="https://*.example.com"
           inputType="text"

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
@@ -84,5 +84,5 @@ export async function setup({
     );
   });
 
-  await screen.findByText("Embedded Analytics SDK");
+  await screen.findByText("Embedded analytics SDK for React");
 }

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/setup.tsx
@@ -21,7 +21,9 @@ import { EmbeddingSdkSettings } from "../EmbeddingSdkSettings";
 
 export interface SetupOpts {
   showSdkEmbedTerms?: Settings["show-sdk-embed-terms"];
+  showSimpleEmbedTerms?: Settings["show-simple-embed-terms"];
   isEmbeddingSdkEnabled?: Settings["enable-embedding-sdk"];
+  isEmbeddingSimpleEnabled?: Settings["enable-embedding-simple"];
   isHosted?: Settings["is-hosted?"];
   hasEnterprisePlugins?: boolean;
   tokenFeatures?: Partial<TokenFeatures>;
@@ -29,14 +31,18 @@ export interface SetupOpts {
 
 export async function setup({
   showSdkEmbedTerms = true,
+  showSimpleEmbedTerms = true,
   isEmbeddingSdkEnabled = false,
+  isEmbeddingSimpleEnabled = false,
   isHosted = false,
   hasEnterprisePlugins = false,
   tokenFeatures = {},
 }: SetupOpts = {}) {
   const settings = createMockSettings({
     "show-sdk-embed-terms": showSdkEmbedTerms,
+    "show-simple-embed-terms": showSimpleEmbedTerms,
     "enable-embedding-sdk": isEmbeddingSdkEnabled,
+    "enable-embedding-simple": isEmbeddingSimpleEnabled,
     "is-hosted?": isHosted,
     "token-features": createMockTokenFeatures(tokenFeatures),
   });
@@ -78,5 +84,5 @@ export async function setup({
     );
   });
 
-  await screen.findByText("Embedding SDK");
+  await screen.findByText("Embedded Analytics SDK");
 }

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/simple-embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/simple-embedding.unit.spec.tsx
@@ -27,9 +27,11 @@ describe("EmbeddingSdkSettings (EE with Simple Embedding feature)", () => {
     const toggles = screen.getAllByRole("switch");
     expect(toggles).toHaveLength(2);
 
-    expect(screen.getByText("Embedding SDK for React")).toBeInTheDocument();
+    expect(
+      screen.getByText("Embedded analytics SDK for React"),
+    ).toBeInTheDocument();
 
-    expect(screen.getByText("Simple Embedding")).toBeInTheDocument();
+    expect(screen.getByText("Simple SDK Embedding")).toBeInTheDocument();
     expect(screen.queryAllByText("Beta")).toHaveLength(1);
   });
 
@@ -44,7 +46,8 @@ describe("EmbeddingSdkSettings (EE with Simple Embedding feature)", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
     // Check the Simple Embedding toggle
-    await userEvent.click(screen.getByLabelText("Simple Embedding"));
+    const toggles = screen.getAllByRole("switch");
+    await userEvent.click(toggles[1]); // Second toggle is for Simple SDK Embedding
 
     // Should show the legalese modal
     expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -61,7 +64,8 @@ describe("EmbeddingSdkSettings (EE with Simple Embedding feature)", () => {
       showSimpleEmbedTerms: true,
     });
 
-    await userEvent.click(screen.getByLabelText("Simple Embedding"));
+    const toggles = screen.getAllByRole("switch");
+    await userEvent.click(toggles[1]); // Second toggle is for Simple SDK Embedding
     await userEvent.click(screen.getByText("Agree and continue"));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
@@ -84,7 +88,9 @@ describe("EmbeddingSdkSettings (EE with Simple Embedding feature)", () => {
         showSimpleEmbedTerms: false,
       });
 
-      expect(screen.getByText("Authorized Origins")).toBeInTheDocument();
+      expect(
+        screen.getByText("Cross-Origin Resource Sharing (CORS)"),
+      ).toBeInTheDocument();
 
       const originInput = screen.getByPlaceholderText("https://*.example.com");
       expect(originInput).toBeDisabled();

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/simple-embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/simple-embedding.unit.spec.tsx
@@ -1,0 +1,109 @@
+import userEvent from "@testing-library/user-event";
+
+import { findRequests } from "__support__/server-mocks";
+import { screen } from "__support__/ui";
+
+import { type SetupOpts, setup as baseSetup } from "./setup";
+
+const setup = (opts: SetupOpts = {}) =>
+  baseSetup({
+    hasEnterprisePlugins: true,
+    tokenFeatures: {
+      embedding_sdk: true,
+      embedding_iframe_sdk: true,
+    },
+    ...opts,
+  });
+
+describe("EmbeddingSdkSettings (EE with Simple Embedding feature)", () => {
+  it("should show both SDK and Simple Embedding toggles", async () => {
+    await setup({
+      isEmbeddingSdkEnabled: false,
+      isEmbeddingSimpleEnabled: false,
+      showSdkEmbedTerms: false,
+      showSimpleEmbedTerms: false,
+    });
+
+    // Check that both toggles are present
+    const switches = screen.getAllByRole("switch");
+    expect(switches).toHaveLength(2);
+
+    // Check for the labels
+    expect(screen.getByText("SDK Embedding")).toBeInTheDocument();
+    expect(screen.getByText("Simple Embedding")).toBeInTheDocument();
+
+    // Check for the Beta badge
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+  });
+
+  it("should show 'Authorized Origins' instead of 'Cross-Origin Resource Sharing (CORS)'", async () => {
+    await setup({
+      isEmbeddingSdkEnabled: true,
+      showSdkEmbedTerms: false,
+    });
+
+    expect(screen.getByText("Authorized Origins")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Cross-Origin Resource Sharing (CORS)"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should enable CORS field when either SDK or Simple Embedding is enabled", async () => {
+    await setup({
+      isEmbeddingSdkEnabled: false,
+      isEmbeddingSimpleEnabled: true,
+      showSdkEmbedTerms: false,
+      showSimpleEmbedTerms: false,
+    });
+
+    const input = screen.getByDisplayValue("");
+    expect(input).toBeEnabled();
+  });
+
+  it("should show legalese modal when Simple Embedding toggle is enabled", async () => {
+    await setup({
+      isEmbeddingSdkEnabled: false,
+      isEmbeddingSimpleEnabled: false,
+      showSdkEmbedTerms: false,
+      showSimpleEmbedTerms: true,
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // Click on the Simple Embedding toggle (second switch)
+    const switches = screen.getAllByRole("switch");
+    await userEvent.click(switches[1]);
+
+    // Should show the legalese modal
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("First, some legalese")).toBeInTheDocument();
+    expect(screen.getByText("Decline and go back")).toBeInTheDocument();
+    expect(screen.getByText("Agree and continue")).toBeInTheDocument();
+  });
+
+  it("should update simple embedding settings when user accepts terms", async () => {
+    await setup({
+      isEmbeddingSdkEnabled: false,
+      isEmbeddingSimpleEnabled: false,
+      showSdkEmbedTerms: false,
+      showSimpleEmbedTerms: true,
+    });
+
+    // Click on the Simple Embedding toggle (second switch)
+    const switches = screen.getAllByRole("switch");
+    await userEvent.click(switches[1]);
+
+    // Accept the terms
+    await userEvent.click(screen.getByText("Agree and continue"));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    const puts = await findRequests("PUT");
+    expect(puts).toHaveLength(1);
+    const [{ body }] = puts;
+    expect(body).toEqual({
+      "enable-embedding-simple": true,
+      "show-simple-embed-terms": false,
+    });
+  });
+});

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle/EmbeddingToggle.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingToggle/EmbeddingToggle.tsx
@@ -18,6 +18,7 @@ export type EmbeddingToggleProps = {
 
 export function EmbeddingToggle({
   settingKey,
+  labelPosition = "left",
   ...switchProps
 }: EmbeddingToggleProps) {
   const { value, settingDetails, updateSetting } = useAdminSetting(settingKey);
@@ -62,7 +63,7 @@ export function EmbeddingToggle({
       <Switch
         label={isEnabled ? t`Enabled` : t`Disabled`}
         size="sm"
-        labelPosition="left"
+        labelPosition={labelPosition}
         checked={isEnabled}
         wrapperProps={{
           "data-testid": "switch-with-env-var",

--- a/frontend/src/metabase/admin/settings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/tests/setup.tsx
@@ -70,7 +70,7 @@ export const ossRoutes: RouteMap = {
   },
   embeddingSdk: {
     path: "/embedding-in-other-applications/sdk",
-    testPattern: /Enable Embedded analytics SDK/i,
+    testPattern: /Embedding SDK for React/i,
   },
   license: { path: "/license", testPattern: /Looking for more/i },
   appearance: {

--- a/frontend/src/metabase/admin/settings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/tests/setup.tsx
@@ -70,7 +70,7 @@ export const ossRoutes: RouteMap = {
   },
   embeddingSdk: {
     path: "/embedding-in-other-applications/sdk",
-    testPattern: /Embedding SDK for React/i,
+    testPattern: /Embedded analytics SDK for React/i,
   },
   license: { path: "/license", testPattern: /Looking for more/i },
   appearance: {

--- a/frontend/src/metabase/admin/upsells/UpsellSdkLink.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellSdkLink.tsx
@@ -28,6 +28,8 @@ export function UpsellSdkLink() {
         c="brand"
         className={linkStyles.link}
         key="upgrade-button"
+        fw="bold"
+        fz="inherit"
       >
         {t`upgrade to Metabase Pro`}
       </UnstyledButton>

--- a/frontend/src/metabase/admin/upsells/UpsellSdkLink.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellSdkLink.tsx
@@ -25,7 +25,6 @@ export function UpsellSdkLink() {
     return (
       <UnstyledButton
         onClick={triggerUpsellFlow}
-        fz="sm"
         c="brand"
         className={linkStyles.link}
         key="upgrade-button"
@@ -34,6 +33,7 @@ export function UpsellSdkLink() {
       </UnstyledButton>
     );
   }
+
   return (
     <ExternalLink key="upgrade-url" href={upgradeUrl}>
       {t`upgrade to Metabase Pro`}

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -562,6 +562,7 @@ export const PLUGIN_EMBEDDING_IFRAME_SDK = {
 };
 
 export const PLUGIN_EMBEDDING_IFRAME_SDK_SETUP = {
+  isFeatureEnabled: () => false,
   shouldShowEmbedInNewItemMenu: () => false,
   SdkIframeEmbedSetup: (): ReactNode => null,
 };


### PR DESCRIPTION
Implements the embedding settings detail page with two toggles for SDK and simple embedding.

### How to verify

1. Navigate to Admin Settings → Embedding → SDK
2. Verify both "Embedding SDK for React" and "Simple Embedding" toggles are displayed
3. Confirm "Simple Embedding" shows Beta badge
4. Test that "Authorized Origins" field enables/disables based on toggle states
5. Verify legalese modal appears when enabling Simple Embedding
6. Run unit tests to confirm all pass: `yarn jest frontend/src/metabase/admin/settings/tests/`

### Demo

<img width="2508" height="1759" alt="image" src="https://github.com/user-attachments/assets/b9cb3328-2641-450a-8a20-74c972a5678c" />

<img width="2060" height="1482" alt="image" src="https://github.com/user-attachments/assets/5fc84e1c-46ca-4c22-986b-3dab6f9ff14a" />

<img width="2050" height="1644" alt="image" src="https://github.com/user-attachments/assets/103d487c-4166-48e6-a11e-b723cbd43d8b" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR