### PR TITLE
Fix conversion of joins with :fields in last stage to legacy

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -605,7 +605,11 @@
 
 (defmethod ->legacy-MBQL :mbql/join [join]
   (let [base     (cond-> (disqualify join)
-                   (and *clean-query* (str/starts-with? (:alias join) legacy-default-join-alias)) (dissoc :alias))
+                   (and *clean-query*
+                        (str/starts-with? (:alias join) legacy-default-join-alias)
+                        ;; added by [[metabase.query-processor.middleware.resolve-joins]]
+                        (not (:qp/keep-default-join-alias join)))
+                   (dissoc :alias))
         metadata (:lib/stage-metadata (last (:stages join)))]
     (merge (-> base
                (dissoc :stages :conditions)
@@ -616,9 +620,15 @@
            (when (seq (:columns metadata))
              {:source-metadata (stage-metadata->legacy-metadata metadata)})
            (let [inner-query (chain-stages base {:top-level? false})]
-             ;; if [[chain-stages]] returns any additional keys like `:filter` at the top-level then we need to wrap
-             ;; it all in `:source-query` (QUE-1566)
-             (if (seq (set/difference (set (keys inner-query)) #{:source-table :source-query :fields :source-metadata}))
+             (if (or
+                  ;; if [[chain-stages]] returns any additional keys like `:filter` at the top-level then
+                  ;; we need to wrap it all in `:source-query` (QUE-1566)
+                  (seq (set/difference (set (keys inner-query)) #{:source-table :source-query :fields :source-metadata}))
+                  ;; if the last stage has `:fields` and they differ from the `:fields` in join then we need to use
+                  ;; `:source-query` (QUE-1603)
+                  (and (:fields inner-query)
+                       (:fields base)
+                       (not= (:fields inner-query) (:fields base))))
                {:source-query inner-query}
                inner-query)))))
 

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -1377,3 +1377,24 @@
                                                     :legacy (#'lib.convert/stage-metadata->legacy-metadata {:columns columns}))))]
               (is (=? (assoc-in {:stages [{} {}]} mbql-5-path (expected-shapes :lib))
                       (lib.convert/->pMBQL query))))))))))
+
+(deftest ^:parallel join-with-fields-in-last-stage-to-legacy-test
+  (testing "converting a join whose last stage has :fields to legacy should not stomp on join :field (QUE-1603)"
+    (let [query {:lib/type :mbql/query
+                 :stages   [{:lib/type     :mbql.stage/mbql
+                             :source-table 1
+                             :joins        [{:lib/type :mbql/join
+                                             :alias    "J"
+                                             :stages   [{:lib/type     :mbql.stage/mbql
+                                                         :source-table 2
+                                                         :fields       [[:field {:lib/uuid "00000000-0000-0000-0000-000000000001"} 1]
+                                                                        [:field {:lib/uuid "00000000-0000-0000-0000-000000000002"} 2]]}]
+                                             :fields   [[:field {:lib/uuid "00000000-0000-0000-0000-000000000003", :join-alias "J"} 1]]}]}]}]
+      (is (= {:type  :query
+              :query {:source-table 1
+                      :joins        [{:alias        "J"
+                                      :source-query {:source-table 2
+                                                     :fields       [[:field 1 nil]
+                                                                    [:field 2 nil]]}
+                                      :fields       [[:field 1 {:join-alias "J"}]]}]}}
+             (lib.convert/->legacy-MBQL query))))))


### PR DESCRIPTION
If a join has `:fields` and its last stage has `:fields` then it is converted to legacy incorrectly (the last stage `:fields` stomp on the join `:fields`). This PR fixes this

Fixes QUE-1603