### PR TITLE
Use H helpers insteaed of commands cypress

### DIFF
--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -280,7 +280,7 @@ export function createTestRoles({ type, isWritable }) {
 // will this work for multiple schemas?
 /**
  * @param {Object} obj
- * @param {string} [obj.databaseId] - Defaults to WRITABLE_DB_ID
+ * @param {number} [obj.databaseId] - Defaults to WRITABLE_DB_ID
  * @param {string} obj.name - The table's real name, not its display name
  */
 export function getTableId({ databaseId = WRITABLE_DB_ID, name }) {

--- a/e2e/test/scenarios/admin/performance/preemptiveCaching.cy.spec.ts
+++ b/e2e/test/scenarios/admin/performance/preemptiveCaching.cy.spec.ts
@@ -1,12 +1,6 @@
 const { H } = cy;
 
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
-import {
-  createNativeQuestion,
-  createQuestion,
-  getTableId,
-  visitQuestion,
-} from "e2e/support/helpers";
 
 import {
   advanceServerClockBy,
@@ -46,7 +40,7 @@ describe(
       function runPreemptiveCachingTest(questionId: string) {
         function visitCachedQuestion(questionId: string) {
           cy.log("Visiting the question");
-          visitQuestion(questionId);
+          H.visitQuestion(questionId);
         }
 
         visitCachedQuestion(questionId);
@@ -86,11 +80,11 @@ describe(
       }
 
       it("Returns matching results when an MBQL query is cached preemptively", () => {
-        getTableId({
+        H.getTableId({
           databaseId: WRITABLE_DB_ID,
           name: WRITABLE_TEST_TABLE,
         }).then((tableId) => {
-          createQuestion(
+          H.createQuestion(
             {
               name: "Cached question",
               database: WRITABLE_DB_ID,
@@ -110,7 +104,7 @@ describe(
       });
 
       it("Returns matching results when a native query is cached preemptively", () => {
-        createNativeQuestion(
+        H.createNativeQuestion(
           {
             name: "Cached question",
             database: WRITABLE_DB_ID,

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -1,6 +1,7 @@
 const { H } = cy;
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
+import { FIXTURE_PATH, VALID_CSV_FILES } from "e2e/support/helpers";
 
 const { NOSQL_GROUP, ALL_USERS_GROUP } = USER_GROUPS;
 
@@ -15,7 +16,7 @@ H.describeWithSnowplow(
     });
 
     it("Can upload a CSV file to an empty postgres schema", () => {
-      const testFile = H.VALID_CSV_FILES[0];
+      const testFile = VALID_CSV_FILES[0];
       const EMPTY_SCHEMA_NAME = "empty_uploads";
 
       cy.intercept("PUT", "/api/setting/*").as("saveSettings");
@@ -110,7 +111,7 @@ H.describeWithSnowplow(
           H.expectNoBadSnowplowEvents();
         });
 
-        H.VALID_CSV_FILES.forEach((testFile) => {
+        VALID_CSV_FILES.forEach((testFile) => {
           it(`Can upload ${testFile.fileName} to a collection`, () => {
             uploadFileToCollection(testFile);
 
@@ -165,66 +166,66 @@ H.describeWithSnowplow(
 
         describe("CSV appends", () => {
           it("Can append a CSV file to an existing table", () => {
-            uploadFileToCollection(H.VALID_CSV_FILES[0]);
+            uploadFileToCollection(VALID_CSV_FILES[0]);
             cy.findByTestId("view-footer").findByText(
-              `Showing ${H.VALID_CSV_FILES[0].rowCount} rows`,
+              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
             );
 
             uploadToExisting({
-              testFile: H.VALID_CSV_FILES[0],
+              testFile: VALID_CSV_FILES[0],
               uploadMode: "append",
             });
             cy.findByTestId("view-footer").findByText(
-              `Showing ${H.VALID_CSV_FILES[0].rowCount * 2} rows`,
+              `Showing ${VALID_CSV_FILES[0].rowCount * 2} rows`,
             );
           });
 
           it("Cannot append a CSV file to a table with a different schema", () => {
-            uploadFileToCollection(H.VALID_CSV_FILES[0]);
+            uploadFileToCollection(VALID_CSV_FILES[0]);
             cy.findByTestId("view-footer").findByText(
-              `Showing ${H.VALID_CSV_FILES[0].rowCount} rows`,
+              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
             );
 
             uploadToExisting({
-              testFile: H.VALID_CSV_FILES[1],
+              testFile: VALID_CSV_FILES[1],
               identicalSchema: false,
               uploadMode: "append",
             });
             cy.findByTestId("view-footer").findByText(
-              `Showing ${H.VALID_CSV_FILES[0].rowCount} rows`,
+              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
             );
           });
         });
 
         describe("CSV replacement", () => {
           it("Can replace data in an existing table", () => {
-            uploadFileToCollection(H.VALID_CSV_FILES[0]);
+            uploadFileToCollection(VALID_CSV_FILES[0]);
             cy.findByTestId("view-footer").findByText(
-              `Showing ${H.VALID_CSV_FILES[0].rowCount} rows`,
+              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
             );
 
             uploadToExisting({
-              testFile: H.VALID_CSV_FILES[0],
+              testFile: VALID_CSV_FILES[0],
               uploadMode: "replace",
             });
             cy.findByTestId("view-footer").findByText(
-              `Showing ${H.VALID_CSV_FILES[0].rowCount} rows`,
+              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
             );
           });
 
           it("Cannot data in a table with a different schema", () => {
-            uploadFileToCollection(H.VALID_CSV_FILES[0]);
+            uploadFileToCollection(VALID_CSV_FILES[0]);
             cy.findByTestId("view-footer").findByText(
-              `Showing ${H.VALID_CSV_FILES[0].rowCount} rows`,
+              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
             );
 
             uploadToExisting({
-              testFile: H.VALID_CSV_FILES[1],
+              testFile: VALID_CSV_FILES[1],
               identicalSchema: false,
               uploadMode: "replace",
             });
             cy.findByTestId("view-footer").findByText(
-              `Showing ${H.VALID_CSV_FILES[0].rowCount} rows`,
+              `Showing ${VALID_CSV_FILES[0].rowCount} rows`,
             );
           });
         });
@@ -237,17 +238,17 @@ H.describeWithSnowplow(
       H.enableTracking();
 
       H.enableUploads("postgres");
-      H.headlessUpload(FIRST_COLLECTION_ID, H.VALID_CSV_FILES[0]);
-      H.headlessUpload(FIRST_COLLECTION_ID, H.VALID_CSV_FILES[1]);
+      H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[0]);
+      H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[1]);
 
       H.visitCollection(FIRST_COLLECTION_ID);
 
-      cy.fixture(`${H.FIXTURE_PATH}/${H.VALID_CSV_FILES[2].fileName}`).then(
+      cy.fixture(`${FIXTURE_PATH}/${VALID_CSV_FILES[2].fileName}`).then(
         (file) => {
           cy.get("#upload-input").selectFile(
             {
               contents: Cypress.Buffer.from(file),
-              fileName: H.VALID_CSV_FILES[2].fileName,
+              fileName: VALID_CSV_FILES[2].fileName,
               mimeType: "text/csv",
             },
             { force: true },
@@ -258,12 +259,12 @@ H.describeWithSnowplow(
       cy.findByRole("radio", { name: /Append to a model/ }).click();
 
       cy.findByRole("textbox", { name: "Select a model" })
-        .should("contain.value", H.VALID_CSV_FILES[1].humanName)
+        .should("contain.value", VALID_CSV_FILES[1].humanName)
         .click();
 
-      H.popover().findByText(H.VALID_CSV_FILES[0].humanName).click();
+      H.popover().findByText(VALID_CSV_FILES[0].humanName).click();
       cy.findByRole("textbox", { name: "Select a model" })
-        .should("have.value", H.VALID_CSV_FILES[0].humanName)
+        .should("have.value", VALID_CSV_FILES[0].humanName)
         .click();
     });
   },
@@ -357,12 +358,12 @@ describe("Upload Table Cleanup/Management", { tags: "@external" }, () => {
   });
 
   it("should allow a user to delete an upload table", () => {
-    H.headlessUpload(FIRST_COLLECTION_ID, H.VALID_CSV_FILES[0]);
-    H.headlessUpload(FIRST_COLLECTION_ID, H.VALID_CSV_FILES[0]);
-    H.headlessUpload(FIRST_COLLECTION_ID, H.VALID_CSV_FILES[0]);
+    H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[0]);
+    H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[0]);
+    H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[0]);
 
-    H.headlessUpload(FIRST_COLLECTION_ID, H.VALID_CSV_FILES[1]);
-    H.headlessUpload(FIRST_COLLECTION_ID, H.VALID_CSV_FILES[1]);
+    H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[1]);
+    H.headlessUpload(FIRST_COLLECTION_ID, VALID_CSV_FILES[1]);
 
     cy.visit("/admin/settings/uploads");
     cy.wait("@getUploadTables");
@@ -447,7 +448,7 @@ function uploadToExisting({
 
   H.popover().findByText(uploadOptions[uploadMode]).click();
 
-  cy.fixture(`${H.FIXTURE_PATH}/${testFile.fileName}`).then((file) => {
+  cy.fixture(`${FIXTURE_PATH}/${testFile.fileName}`).then((file) => {
     cy.get("#upload-file-input").selectFile(
       {
         contents: Cypress.Buffer.from(file),

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -1,7 +1,6 @@
 const { H } = cy;
 import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
-import { FIXTURE_PATH } from "e2e/support/helpers";
 
 const { NOSQL_GROUP, ALL_USERS_GROUP } = USER_GROUPS;
 
@@ -243,7 +242,7 @@ H.describeWithSnowplow(
 
       H.visitCollection(FIRST_COLLECTION_ID);
 
-      cy.fixture(`${FIXTURE_PATH}/${H.VALID_CSV_FILES[2].fileName}`).then(
+      cy.fixture(`${H.FIXTURE_PATH}/${H.VALID_CSV_FILES[2].fileName}`).then(
         (file) => {
           cy.get("#upload-input").selectFile(
             {

--- a/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
+++ b/e2e/test/scenarios/custom-column/cc-boolean-functions.cy.spec.ts
@@ -1,5 +1,9 @@
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type {
+  DashboardDetails,
+  StructuredQuestionDetails,
+} from "e2e/support/helpers";
 import type { CardId, DashboardParameterMapping } from "metabase-types/api";
 import { createMockDashboardCard } from "metabase-types/api/mocks";
 
@@ -18,7 +22,7 @@ describe("scenarios > custom column > boolean functions", () => {
 
   describe("expression editor", () => {
     const stringQuestionColumns = ["Category"];
-    const stringQuestionDetails: H.StructuredQuestionDetails = {
+    const stringQuestionDetails: StructuredQuestionDetails = {
       query: {
         "source-table": PRODUCTS_ID,
         fields: [["field", PRODUCTS.CATEGORY, null]],
@@ -28,7 +32,7 @@ describe("scenarios > custom column > boolean functions", () => {
     };
 
     const numberQuestionColumns = ["Total"];
-    const numberQuestionDetails: H.StructuredQuestionDetails = {
+    const numberQuestionDetails: StructuredQuestionDetails = {
       query: {
         "source-table": ORDERS_ID,
         fields: [["field", ORDERS.TOTAL, null]],
@@ -38,7 +42,7 @@ describe("scenarios > custom column > boolean functions", () => {
     };
 
     const dateQuestionColumns = ["Created At"];
-    const dateQuestionDetails: H.StructuredQuestionDetails = {
+    const dateQuestionDetails: StructuredQuestionDetails = {
       query: {
         "source-table": ORDERS_ID,
         fields: [["field", ORDERS.CREATED_AT, null]],
@@ -55,7 +59,7 @@ describe("scenarios > custom column > boolean functions", () => {
       modifiedExpression,
       modifiedExpressionRows,
     }: {
-      questionDetails: H.StructuredQuestionDetails;
+      questionDetails: StructuredQuestionDetails;
       questionColumns: string[];
       newExpression: string;
       newExpressionRows: string[][];
@@ -195,7 +199,7 @@ describe("scenarios > custom column > boolean functions", () => {
 
   describe("query builder", () => {
     describe("same stage", () => {
-      const questionDetails: H.StructuredQuestionDetails = {
+      const questionDetails: StructuredQuestionDetails = {
         query: {
           "source-table": PRODUCTS_ID,
           fields: [
@@ -314,7 +318,7 @@ describe("scenarios > custom column > boolean functions", () => {
     });
 
     describe("previous stage", () => {
-      const questionDetails: H.StructuredQuestionDetails = {
+      const questionDetails: StructuredQuestionDetails = {
         query: {
           "source-table": PRODUCTS_ID,
           expressions: {
@@ -416,7 +420,7 @@ describe("scenarios > custom column > boolean functions", () => {
     });
 
     describe("source card", () => {
-      const questionDetails: H.StructuredQuestionDetails = {
+      const questionDetails: StructuredQuestionDetails = {
         name: "Source",
         query: {
           "source-table": PRODUCTS_ID,
@@ -432,7 +436,7 @@ describe("scenarios > custom column > boolean functions", () => {
 
       function getNestedQuestionDetails(
         cardId: number,
-      ): H.StructuredQuestionDetails {
+      ): StructuredQuestionDetails {
         return {
           name: "Nested",
           query: {
@@ -541,7 +545,7 @@ describe("scenarios > custom column > boolean functions", () => {
   });
 
   describe("dashboards", () => {
-    const questionDetails: H.StructuredQuestionDetails = {
+    const questionDetails: StructuredQuestionDetails = {
       name: "Q1",
       query: {
         "source-table": PEOPLE_ID,
@@ -567,7 +571,7 @@ describe("scenarios > custom column > boolean functions", () => {
       sectionId: "string",
     };
 
-    const dashboardDetails: H.DashboardDetails = {
+    const dashboardDetails: DashboardDetails = {
       name: "D1",
       parameters: [parameterDetails],
     };
@@ -583,7 +587,7 @@ describe("scenarios > custom column > boolean functions", () => {
       };
     }
 
-    function createDashboardWithQuestion(opts?: H.DashboardDetails) {
+    function createDashboardWithQuestion(opts?: DashboardDetails) {
       return H.createDashboard({ ...dashboardDetails, ...opts }).then(
         ({ body: dashboard }) => {
           return H.createQuestion(questionDetails).then(({ body: card }) => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filter-defaults.cy.spec.ts
@@ -1,9 +1,10 @@
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type { StructuredQuestionDetails } from "e2e/support/helpers";
 
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
-const QUESTION: H.StructuredQuestionDetails = {
+const QUESTION: StructuredQuestionDetails = {
   name: "Return input value",
   display: "scalar",
   query: {

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -10,7 +10,6 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { mapPinIcon } from "e2e/support/helpers";
 import { GRID_WIDTH } from "metabase/lib/dashboard_grid";
 import {
   createMockVirtualCard,
@@ -899,7 +898,7 @@ describe("scenarios > dashboard", () => {
         });
 
         H.visitDashboard(dashboardId);
-        mapPinIcon().eq(0).click({ force: true });
+        H.mapPinIcon().eq(0).click({ force: true });
         cy.url().should("include", `/dashboard/${dashboardId}?id=1`);
         cy.contains("Hudson Borer - 1");
       });

--- a/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
+++ b/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
@@ -4,7 +4,6 @@ import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { AUTH_PROVIDER_URL } from "e2e/support/helpers";
 import { visitFullAppEmbeddingUrl } from "e2e/support/helpers/e2e-embedding-helpers";
 import {
   EMBEDDING_SDK_STORY_HOST,
@@ -58,7 +57,7 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
       },
       secret: JWT_SHARED_SECRET,
     }).then((jwtToken) => {
-      cy.intercept("GET", `${AUTH_PROVIDER_URL}?response=json`, {
+      cy.intercept("GET", `${H.AUTH_PROVIDER_URL}?response=json`, {
         jwt: jwtToken,
       });
     });

--- a/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
+++ b/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
@@ -4,6 +4,7 @@ import {
   ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import { AUTH_PROVIDER_URL } from "e2e/support/helpers";
 import { visitFullAppEmbeddingUrl } from "e2e/support/helpers/e2e-embedding-helpers";
 import {
   EMBEDDING_SDK_STORY_HOST,
@@ -57,7 +58,7 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
       },
       secret: JWT_SHARED_SECRET,
     }).then((jwtToken) => {
-      cy.intercept("GET", `${H.AUTH_PROVIDER_URL}?response=json`, {
+      cy.intercept("GET", `${AUTH_PROVIDER_URL}?response=json`, {
         jwt: jwtToken,
       });
     });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -3,7 +3,6 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { entityPickerModal } from "e2e/support/helpers";
 
 import {
   getEmbedSidebar,
@@ -157,7 +156,7 @@ H.describeWithSnowplow(suiteTitle, () => {
       cy.findByTestId("embed-browse-entity-button").click();
     });
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByText("Select a dashboard").should("be.visible");
       cy.findByText("Dashboards").click();
       cy.findByText(SECOND_DASHBOARD_NAME).click();
@@ -195,7 +194,7 @@ H.describeWithSnowplow(suiteTitle, () => {
       cy.findByTestId("embed-browse-entity-button").click();
     });
 
-    entityPickerModal().within(() => {
+    H.entityPickerModal().within(() => {
       cy.findByText("Select a chart").should("be.visible");
       cy.findByText("Questions").click();
       cy.findByText(FIRST_QUESTION_NAME).click();
@@ -246,7 +245,7 @@ H.describeWithSnowplow(suiteTitle, () => {
         cy.findByText(/search for dashboards/).click();
       });
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Select a dashboard").should("be.visible");
       });
     });
@@ -266,7 +265,7 @@ H.describeWithSnowplow(suiteTitle, () => {
         cy.findByText(/search for charts/).click();
       });
 
-      entityPickerModal().within(() => {
+      H.entityPickerModal().within(() => {
         cy.findByText("Select a chart").should("be.visible");
       });
     });

--- a/e2e/test/scenarios/metabot/metabot.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/metabot.cy.spec.ts
@@ -1,24 +1,11 @@
-import {
-  activateToken,
-  assertChatVisibility,
-  chatMessages,
-  closeMetabotViaCloseButton,
-  lastChatMessage,
-  mockMetabotResponse,
-  openMetabotViaCommandPalette,
-  openMetabotViaSearchButton,
-  openMetabotViaShortcutKey,
-  popover,
-  restore,
-  sendMetabotMessage,
-} from "e2e/support/helpers";
+const { H } = cy;
 
 const loremIpsum =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer auctor id erat non sollicitudin. ";
 
 describe("Metabot UI", () => {
   beforeEach(() => {
-    restore();
+    H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/ee/metabot-v3/v2/agent-streaming").as(
       "agentReq",
@@ -33,29 +20,29 @@ describe("Metabot UI", () => {
     });
 
     it("should not be available in OSS", () => {
-      openMetabotViaShortcutKey(false);
-      assertChatVisibility("not.visible");
+      H.openMetabotViaShortcutKey(false);
+      H.assertChatVisibility("not.visible");
       cy.findByLabelText("Navigation bar").within(() => {
         cy.findByText("New").click();
       });
-      popover().findByText("Metabot request").should("not.exist");
-      assertChatVisibility("not.visible");
+      H.popover().findByText("Metabot request").should("not.exist");
+      H.assertChatVisibility("not.visible");
     });
   });
 
   describe("EE", () => {
     beforeEach(() => {
-      activateToken("bleeding-edge");
+      H.activateToken("bleeding-edge");
       cy.visit("/");
       cy.wait("@sessionProperties");
     });
 
     it("should be able to be opened and closed", () => {
-      openMetabotViaSearchButton();
-      closeMetabotViaCloseButton();
+      H.openMetabotViaSearchButton();
+      H.closeMetabotViaCloseButton();
 
-      openMetabotViaCommandPalette();
-      closeMetabotViaCloseButton();
+      H.openMetabotViaCommandPalette();
+      H.closeMetabotViaCloseButton();
 
       // FIXME: shortcut keys aren't working in CI only, but work locally
       // openMetabotViaShortcutKey();
@@ -63,51 +50,51 @@ describe("Metabot UI", () => {
     });
 
     it("should allow a user to send a message to the agent and handle successful or failed responses", () => {
-      openMetabotViaSearchButton();
-      chatMessages().should("not.exist");
+      H.openMetabotViaSearchButton();
+      H.chatMessages().should("not.exist");
 
-      mockMetabotResponse({
+      H.mockMetabotResponse({
         statusCode: 200,
         body: whoIsYourFavoriteResponse,
       });
-      sendMetabotMessage("Who is your favorite?");
+      H.sendMetabotMessage("Who is your favorite?");
 
-      lastChatMessage().should("have.text", "You, but don't tell anyone.");
+      H.lastChatMessage().should("have.text", "You, but don't tell anyone.");
 
-      mockMetabotResponse({ statusCode: 500 });
-      sendMetabotMessage("Who is your favorite?");
-      lastChatMessage().should(
+      H.mockMetabotResponse({ statusCode: 500 });
+      H.sendMetabotMessage("Who is your favorite?");
+      H.lastChatMessage().should(
         "have.text",
         "Metabot is currently offline. Please try again later.",
       );
     });
 
     it("should allow starting a new metabot conversation via the /metabot/new", () => {
-      mockMetabotResponse({
+      H.mockMetabotResponse({
         statusCode: 200,
         body: whoIsYourFavoriteResponse,
       });
       cy.visit("/metabot/new?q=Who%20is%20your%20favorite%3F");
-      assertChatVisibility("visible");
-      lastChatMessage().should("have.text", "You, but don't tell anyone.");
+      H.assertChatVisibility("visible");
+      H.lastChatMessage().should("have.text", "You, but don't tell anyone.");
     });
 
     describe("scroll management", () => {
       it("should not show filler element if there are not messages", () => {
-        openMetabotViaSearchButton();
-        chatMessages().should("not.exist");
+        H.openMetabotViaSearchButton();
+        H.chatMessages().should("not.exist");
         cy.findByTestId("metabot-message-filler").should("not.exist");
       });
 
       it("should correctly size the filler element to take remaining space if messages aren't scrollable", () => {
-        openMetabotViaSearchButton();
+        H.openMetabotViaSearchButton();
 
-        mockMetabotResponse({
+        H.mockMetabotResponse({
           statusCode: 200,
           body: whoIsYourFavoriteResponse,
         });
 
-        sendMetabotMessage("Who is your favorite?");
+        H.sendMetabotMessage("Who is your favorite?");
         cy.findByTestId("metabot-chat-inner-messages")
           .invoke("innerHeight")
           .then((containerHeight) => {
@@ -128,20 +115,20 @@ describe("Metabot UI", () => {
       });
 
       it("should resize filler element and auto-scroll to new prompt on subsequent messages", () => {
-        openMetabotViaSearchButton();
-        mockMetabotResponse({
+        H.openMetabotViaSearchButton();
+        H.mockMetabotResponse({
           statusCode: 200,
           body: whoIsYourFavoriteResponse,
         });
-        sendMetabotMessage("Who is your favorite?");
+        H.sendMetabotMessage("Who is your favorite?");
 
         cy.log("test on message shorter than prompt");
-        mockMetabotResponse({
+        H.mockMetabotResponse({
           statusCode: 200,
           body: `0:"${loremIpsum.repeat(5)}"
 d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
         });
-        sendMetabotMessage("You really mean that?");
+        H.sendMetabotMessage("You really mean that?");
         cy.log("scroll new prompt to top of the scroll area");
         cy.findByTestId("metabot-chat-inner-messages")
           .findByText("You really mean that?")
@@ -155,12 +142,12 @@ d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
           expect($el[0].clientHeight).to.be.greaterThan(0);
         });
 
-        mockMetabotResponse({
+        H.mockMetabotResponse({
           statusCode: 200,
           body: `0:"${loremIpsum.repeat(50)}"
 d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
         });
-        sendMetabotMessage("Keep going...");
+        H.sendMetabotMessage("Keep going...");
 
         cy.log(
           "if the response is longer than the scroll area the filler height should be zero",
@@ -171,16 +158,16 @@ d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
       });
 
       it("should open metabot to the bottom of the conversation when reopened with message history", () => {
-        mockMetabotResponse({
+        H.mockMetabotResponse({
           statusCode: 200,
           body: `0:"${loremIpsum.repeat(5)}"
 d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
         });
-        openMetabotViaSearchButton();
-        sendMetabotMessage("Who is your favorite?");
+        H.openMetabotViaSearchButton();
+        H.sendMetabotMessage("Who is your favorite?");
 
-        closeMetabotViaCloseButton();
-        openMetabotViaSearchButton();
+        H.closeMetabotViaCloseButton();
+        H.openMetabotViaSearchButton();
         cy.findByTestId("metabot-chat-inner-messages").then(($el) => {
           const el = $el[0];
           const isAtBottom = el.scrollTop + el.clientHeight >= el.scrollHeight;

--- a/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/reproductions/metrics-reproductions.cy.spec.ts
@@ -1,5 +1,6 @@
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type { StructuredQuestionDetails } from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
@@ -58,7 +59,7 @@ describe("issue 47058", () => {
 });
 
 describe("issue 44171", () => {
-  const METRIC_A: H.StructuredQuestionDetails = {
+  const METRIC_A: StructuredQuestionDetails = {
     name: "Metric 44171-A",
     type: "metric",
     display: "line",
@@ -75,7 +76,7 @@ describe("issue 44171", () => {
     },
   };
 
-  const METRIC_B: H.StructuredQuestionDetails = {
+  const METRIC_B: StructuredQuestionDetails = {
     name: "Metric 44171-B",
     type: "metric",
     display: "line",

--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -7,7 +7,10 @@ import {
   ORDERS_MODEL_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import type { StructuredQuestionDetails } from "e2e/support/helpers";
+import type {
+  NativeQuestionDetails,
+  StructuredQuestionDetails,
+} from "e2e/support/helpers";
 import type { CardId, FieldReference } from "metabase-types/api";
 
 const {
@@ -682,7 +685,7 @@ describe("issue 25113", () => {
 });
 
 describe("issue 39749", () => {
-  const modelDetails: H.StructuredQuestionDetails = {
+  const modelDetails: StructuredQuestionDetails = {
     type: "model",
     query: {
       "source-table": ORDERS_ID,
@@ -738,7 +741,7 @@ describe("issue 39749", () => {
 });
 
 describe("issue 25885", () => {
-  const mbqlModelDetails: H.StructuredQuestionDetails = {
+  const mbqlModelDetails: StructuredQuestionDetails = {
     type: "model",
     query: {
       "source-table": ORDERS_ID,
@@ -952,7 +955,7 @@ describe("issue 43088", () => {
 describe("issue 39993", () => {
   const columnName = "Exp";
 
-  const modelDetails: H.StructuredQuestionDetails = {
+  const modelDetails: StructuredQuestionDetails = {
     type: "model",
     query: {
       "source-table": ORDERS_ID,
@@ -999,7 +1002,7 @@ describe("issue 34574", () => {
   });
 
   it("should accept markdown for model description and render it properly (metabase#34574)", () => {
-    const modelDetails: H.StructuredQuestionDetails = {
+    const modelDetails: StructuredQuestionDetails = {
       name: "34574",
       type: "model",
       query: {
@@ -1079,7 +1082,7 @@ describe("issue 35840", () => {
   const modelName = "M1";
   const questionName = "Q1";
 
-  const modelDetails: H.StructuredQuestionDetails = {
+  const modelDetails: StructuredQuestionDetails = {
     type: "model",
     name: modelName,
     query: {
@@ -1090,9 +1093,7 @@ describe("issue 35840", () => {
     },
   };
 
-  const getQuestionDetails = (
-    modelId: CardId,
-  ): H.StructuredQuestionDetails => ({
+  const getQuestionDetails = (modelId: CardId): StructuredQuestionDetails => ({
     type: "question",
     name: questionName,
     query: {
@@ -1410,7 +1411,7 @@ describe.skip("issues 28270, 33708", () => {
 });
 
 describe("issue 46221", () => {
-  const modelDetails: H.NativeQuestionDetails = {
+  const modelDetails: NativeQuestionDetails = {
     name: "46221",
     native: { query: "select 42" },
     type: "model",
@@ -1446,7 +1447,7 @@ describe("issue 46221", () => {
 });
 
 describe("issue 20624", () => {
-  const questionDetails: H.StructuredQuestionDetails = {
+  const questionDetails: StructuredQuestionDetails = {
     name: "Question",
     type: "question",
     query: {

--- a/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup-embedding.cy.spec.ts
@@ -1,13 +1,6 @@
-import {
-  assertNoUnstructuredSnowplowEvent,
-  describeWithSnowplowEE,
-  expectUnstructuredSnowplowEvent,
-  main,
-} from "e2e/support/helpers";
-
 const { H } = cy;
 
-describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
+H.describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore("blank");
@@ -24,7 +17,7 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
     );
 
     // `/setup` should not be rendered and its events should not be sent to not add noise to events
-    assertNoUnstructuredSnowplowEvent({
+    H.assertNoUnstructuredSnowplowEvent({
       event: "step_seen", // `step_seen` event is sent on `/setup`, on `/setup/embedding` we send `embedding_setup_step_seen`
     });
   });
@@ -77,7 +70,7 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
     cy.wait("@setting");
     cy.visit("/");
 
-    main()
+    H.main()
       .findByText("Get started with Embedding Metabase in your app")
       .should("be.visible");
   });
@@ -95,7 +88,7 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
     cy.log("0: Welcome step");
     assertEmbeddingOnboardingPageLoaded();
 
-    expectUnstructuredSnowplowEvent({
+    H.expectUnstructuredSnowplowEvent({
       event: "embedding_setup_step_seen",
       event_detail: "welcome",
     });
@@ -119,7 +112,7 @@ describeWithSnowplowEE("scenarios > setup embedding (EMB-477)", () => {
         "be.visible",
       );
 
-      expectUnstructuredSnowplowEvent({
+      H.expectUnstructuredSnowplowEvent({
         event: "embedding_setup_step_seen",
         event_detail: "user-creation",
       });

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -1,9 +1,13 @@
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type {
+  DashboardDetails,
+  StructuredQuestionDetails,
+} from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PEOPLE_ID, PEOPLE } = SAMPLE_DATABASE;
 
-const questionWith2TemporalBreakoutsDetails: H.StructuredQuestionDetails = {
+const questionWith2TemporalBreakoutsDetails: StructuredQuestionDetails = {
   name: "Test question",
   query: {
     "source-table": ORDERS_ID,
@@ -27,7 +31,7 @@ const questionWith2TemporalBreakoutsDetails: H.StructuredQuestionDetails = {
   },
 };
 
-const multiStageQuestionWith2TemporalBreakoutsDetails: H.StructuredQuestionDetails =
+const multiStageQuestionWith2TemporalBreakoutsDetails: StructuredQuestionDetails =
   {
     name: "Test question",
     query: {
@@ -36,7 +40,7 @@ const multiStageQuestionWith2TemporalBreakoutsDetails: H.StructuredQuestionDetai
     },
   };
 
-const questionWith2NumBinsBreakoutsDetails: H.StructuredQuestionDetails = {
+const questionWith2NumBinsBreakoutsDetails: StructuredQuestionDetails = {
   name: "Test question",
   query: {
     "source-table": ORDERS_ID,
@@ -66,7 +70,7 @@ const questionWith2NumBinsBreakoutsDetails: H.StructuredQuestionDetails = {
   },
 };
 
-const multiStageQuestionWith2NumBinsBreakoutsDetails: H.StructuredQuestionDetails =
+const multiStageQuestionWith2NumBinsBreakoutsDetails: StructuredQuestionDetails =
   {
     name: "Test question",
     query: {
@@ -75,7 +79,7 @@ const multiStageQuestionWith2NumBinsBreakoutsDetails: H.StructuredQuestionDetail
     },
   };
 
-const questionWith2BinWidthBreakoutsDetails: H.StructuredQuestionDetails = {
+const questionWith2BinWidthBreakoutsDetails: StructuredQuestionDetails = {
   name: "Test question",
   query: {
     "source-table": PEOPLE_ID,
@@ -105,7 +109,7 @@ const questionWith2BinWidthBreakoutsDetails: H.StructuredQuestionDetails = {
   },
 };
 
-const multiStageQuestionWith2BinWidthBreakoutsDetails: H.StructuredQuestionDetails =
+const multiStageQuestionWith2BinWidthBreakoutsDetails: StructuredQuestionDetails =
   {
     name: "Test question",
     query: {
@@ -114,7 +118,7 @@ const multiStageQuestionWith2BinWidthBreakoutsDetails: H.StructuredQuestionDetai
     },
   };
 
-const questionWith5TemporalBreakoutsDetails: H.StructuredQuestionDetails = {
+const questionWith5TemporalBreakoutsDetails: StructuredQuestionDetails = {
   name: "Test question",
   query: {
     "source-table": ORDERS_ID,
@@ -154,7 +158,7 @@ const questionWith5TemporalBreakoutsDetails: H.StructuredQuestionDetails = {
   },
 };
 
-const questionWith5NumBinsBreakoutsDetails: H.StructuredQuestionDetails = {
+const questionWith5NumBinsBreakoutsDetails: StructuredQuestionDetails = {
   name: "Test question",
   query: {
     "source-table": ORDERS_ID,
@@ -208,7 +212,7 @@ const questionWith5NumBinsBreakoutsDetails: H.StructuredQuestionDetails = {
   },
 };
 
-const dashboardDetails: H.DashboardDetails = {
+const dashboardDetails: DashboardDetails = {
   parameters: [
     {
       id: "1",
@@ -360,7 +364,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column2Name: string;
         }) {
@@ -430,7 +434,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           bucket1Name,
           bucket2Name,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           columnPattern: RegExp;
           bucketLabel: string;
           bucket1Name: string;
@@ -560,7 +564,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column2Name: string;
         }) {
@@ -607,7 +611,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           questionDetails,
           columnNamePattern,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           columnNamePattern: RegExp;
         }) {
           H.createQuestion(questionDetails, { visitQuestion: true });
@@ -773,7 +777,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           expression1,
           expression2,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           expression1: string;
           expression2: string;
         }) {
@@ -897,7 +901,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: string;
           column1MaxValue: string;
@@ -959,7 +963,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: number;
           column1MaxValue: number;
@@ -1050,7 +1054,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column2Name: string;
         }) {
@@ -1117,7 +1121,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column2Name: string;
         }) {
@@ -1222,7 +1226,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: string;
           column1MaxValue: string;
@@ -1282,7 +1286,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: number;
           column1MaxValue: number;
@@ -1382,7 +1386,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           tableColumn1Name,
           tableColumn2Name,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           queryColumn1Name: string;
           queryColumn2Name: string;
           tableColumn1Name: string;
@@ -1476,7 +1480,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: string;
           column1MaxValue: string;
@@ -1542,7 +1546,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column1MinValue: number;
           column1MaxValue: number;
@@ -1635,7 +1639,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column2Name: string;
         }) {
@@ -1705,7 +1709,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           column1Name: string;
           column2Name: string;
         }) {
@@ -1797,7 +1801,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           questionDetails,
           columnName,
         }: {
-          questionDetails: H.StructuredQuestionDetails;
+          questionDetails: StructuredQuestionDetails;
           columnName: string;
         }) {
           H.createQuestion(questionDetails).then(({ body: card }) => {

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -1,6 +1,5 @@
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { moveDnDKitListElement } from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PEOPLE_ID, PEOPLE } = SAMPLE_DATABASE;
 
@@ -625,7 +624,7 @@ describe("scenarios > question > multiple column breakouts", () => {
 
           cy.log("move a column from rows to columns");
           H.openVizSettingsSidebar();
-          moveDnDKitListElement("drag-handle", {
+          H.moveDnDKitListElement("drag-handle", {
             startIndex: 2,
             dropIndex: 3,
           });
@@ -635,7 +634,7 @@ describe("scenarios > question > multiple column breakouts", () => {
             .should("have.length", 2);
 
           cy.log("move a column from columns to rows");
-          moveDnDKitListElement("drag-handle", {
+          H.moveDnDKitListElement("drag-handle", {
             startIndex: 4,
             dropIndex: 1,
           });
@@ -677,7 +676,7 @@ describe("scenarios > question > multiple column breakouts", () => {
 
         cy.log("move an item from columns to measures");
         H.openVizSettingsSidebar();
-        moveDnDKitListElement("drag-handle", {
+        H.moveDnDKitListElement("drag-handle", {
           startIndex: 2,
           dropIndex: 5,
         });
@@ -686,7 +685,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           .should("have.length", 3);
 
         cy.log("move an item from measures to columns");
-        moveDnDKitListElement("drag-handle", {
+        H.moveDnDKitListElement("drag-handle", {
           startIndex: 5,
           dropIndex: 2,
         });

--- a/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
+++ b/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
@@ -1,21 +1,22 @@
 const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import type { NativeQuestionDetails } from "e2e/support/helpers";
 
-const ordersTableQuestionDetails: H.NativeQuestionDetails = {
+const ordersTableQuestionDetails: NativeQuestionDetails = {
   display: "table",
   native: {
     query: "SELECT ID, CREATED_AT, QUANTITY FROM ORDERS ORDER BY ID LIMIT 10",
   },
 };
 
-const peopleTableQuestionDetails: H.NativeQuestionDetails = {
+const peopleTableQuestionDetails: NativeQuestionDetails = {
   display: "table",
   native: {
     query: "SELECT ID, EMAIL, CREATED_AT FROM PEOPLE ORDER BY ID LIMIT 10",
   },
 };
 
-const timeseriesLineQuestionDetails: H.NativeQuestionDetails = {
+const timeseriesLineQuestionDetails: NativeQuestionDetails = {
   display: "line",
   native: {
     query: "SELECT CREATED_AT, QUANTITY FROM ORDERS ORDER BY ID LIMIT 10",
@@ -26,7 +27,7 @@ const timeseriesLineQuestionDetails: H.NativeQuestionDetails = {
   },
 };
 
-const timeseriesWithCategoryLineQuestionDetails: H.NativeQuestionDetails = {
+const timeseriesWithCategoryLineQuestionDetails: NativeQuestionDetails = {
   display: "line",
   native: {
     query:
@@ -38,7 +39,7 @@ const timeseriesWithCategoryLineQuestionDetails: H.NativeQuestionDetails = {
   },
 };
 
-const numericLineQuestionDetails: H.NativeQuestionDetails = {
+const numericLineQuestionDetails: NativeQuestionDetails = {
   display: "line",
   native: {
     query: "SELECT ID, QUANTITY FROM ORDERS ORDER BY ID LIMIT 10",
@@ -49,7 +50,7 @@ const numericLineQuestionDetails: H.NativeQuestionDetails = {
   },
 };
 
-const pinMapQuestionDetails: H.NativeQuestionDetails = {
+const pinMapQuestionDetails: NativeQuestionDetails = {
   display: "map",
   native: {
     query: "SELECT LATITUDE, LONGITUDE FROM PEOPLE ORDER BY ID LIMIT 10",
@@ -61,7 +62,7 @@ const pinMapQuestionDetails: H.NativeQuestionDetails = {
   },
 };
 
-const gridMapQuestionDetails: H.NativeQuestionDetails = {
+const gridMapQuestionDetails: NativeQuestionDetails = {
   display: "map",
   native: {
     query: "SELECT LATITUDE, LONGITUDE FROM PEOPLE ORDER BY ID LIMIT 10",

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -6,6 +6,7 @@ import {
   ORDERS_MODEL_ID,
   SECOND_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import type { StructuredQuestionDetails } from "e2e/support/helpers";
 import { checkNotNull } from "metabase/lib/types";
 
 const { ORDERS_ID, REVIEWS_ID } = SAMPLE_DATABASE;
@@ -208,7 +209,7 @@ describe("scenarios > notebook > data source", () => {
   });
 
   describe("saved entity as a source (aka the virtual table)", () => {
-    const modelDetails: H.StructuredQuestionDetails = {
+    const modelDetails: StructuredQuestionDetails = {
       name: "GUI Model",
       query: { "source-table": REVIEWS_ID, limit: 1 },
       display: "table",

--- a/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
@@ -7,6 +7,7 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_MODEL_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import type { NativeQuestionDetails } from "e2e/support/helpers";
 import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { METAKEY } from "metabase/lib/browser";
 
@@ -214,7 +215,7 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the source model from a nested question where the source is native model", () => {
-      const source: H.NativeQuestionDetails = {
+      const source: NativeQuestionDetails = {
         name: "Native source",
         native: {
           query: "select 1 as foo",
@@ -305,7 +306,7 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the underlying native model", () => {
-      const model: H.NativeQuestionDetails = {
+      const model: NativeQuestionDetails = {
         name: "Native model",
         native: {
           query: "select 1 as foo",

--- a/e2e/test/scenarios/question/offset.cy.spec.ts
+++ b/e2e/test/scenarios/question/offset.cy.spec.ts
@@ -1,5 +1,6 @@
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type { StructuredQuestionDetails } from "e2e/support/helpers";
 import { uuid } from "metabase/lib/uuid";
 import type {
   Aggregation,
@@ -1178,7 +1179,6 @@ describe("scenarios > question > offset", () => {
     const segmentName = "Orders < 100";
     H.createSegment({
       name: segmentName,
-      // @ts-expect-error convert helper to ts
       description: "All orders with a total under $100.",
       table_id: ORDERS_ID,
       definition: {
@@ -1237,7 +1237,7 @@ describe("scenarios > question > offset", () => {
 
   it("should work with metrics (metabase#47854)", () => {
     const metricName = "Count of orders";
-    const ORDERS_SCALAR_METRIC: H.StructuredQuestionDetails = {
+    const ORDERS_SCALAR_METRIC: StructuredQuestionDetails = {
       name: metricName,
       type: "metric",
       description: "A metric",

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -1,7 +1,6 @@
 const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { moveDnDKitElement } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
   SAMPLE_DATABASE;
@@ -555,7 +554,7 @@ describe("scenarios > visualizations > line chart", () => {
       cy.log("Drag and drop the first y-axis field to the last position");
       cy.findAllByTestId("chart-setting-select").then((initial) => {
         cy.findByTestId("chart-settings-widget-graph.metrics").within(() => {
-          moveDnDKitElement(cy.findAllByTestId("drag-handle").first(), {
+          H.moveDnDKitElement(cy.findAllByTestId("drag-handle").first(), {
             vertical: 50,
           });
         });

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -6,7 +6,7 @@ import type { StructuredQuestionDetails } from "e2e/support/helpers";
 const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("issue 43075", () => {
-  const questionDetails: H.StructuredQuestionDetails = {
+  const questionDetails: StructuredQuestionDetails = {
     query: {
       "source-table": PRODUCTS_ID,
       aggregation: [["count"]],
@@ -37,7 +37,7 @@ describe("issue 43075", () => {
 });
 
 describe("issue 41133", () => {
-  const questionDetails: H.StructuredQuestionDetails = {
+  const questionDetails: StructuredQuestionDetails = {
     query: {
       "source-table": PRODUCTS_ID,
     },

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -1,7 +1,6 @@
 const { H } = cy;
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { moveDnDKitListElement } from "e2e/support/helpers";
 import { PIVOT_TABLE_BODY_LABEL } from "metabase/visualizations/visualizations/PivotTable/constants";
 
 const {
@@ -131,7 +130,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
     assertOnPivotSettings();
 
     // Drag the second aggregate (Product category) from table columns to table rows
-    moveDnDKitListElement("drag-handle", {
+    H.moveDnDKitListElement("drag-handle", {
       startIndex: 1,
       dropIndex: 0,
     });


### PR DESCRIPTION
I modified [Ryan's codemode slightly](https://github.com/metabase/metabase/pull/50156#issue-2669072504):

`[jscodeshift](https://www.npmjs.com/package/jscodeshift) codemod used:
jscodeshift --parser=ts -t codemod.js e2e/**/*.cy.spec.(js|ts)`

```js
module.exports = function (fileInfo, api) {
  const j = api.jscodeshift;

  // Helper function to check if an identifier is within a TypeScript type annotation
  function isWithinTypeAnnotation(idPath, typeAnnotation) {
    let current = idPath;
    while (current && current.node !== typeAnnotation) {
      current = current.parent;
      if (!current) return false;
    }
    return current && current.node === typeAnnotation;
  }

  // problematic values to exclude
  const excludedValues = new Set([
    "visitQuestion",
    "filter",
    "duplicateTab",
    "sidebar",
    "saveDashboard",
  ]);

  // Parse the source code
  const root = j(fileInfo.source);

  // Check if there's already a "const { H } = cy;" destructuring assignment
  const hasExistingHDestructuring = root
    .find(j.VariableDeclaration)
    .some((path) => {
      const declaration = path.node.declarations[0];
      return (
        declaration &&
        j.ObjectPattern.check(declaration.id) &&
        declaration.id.properties.some(
          (prop) =>
            j.ObjectProperty.check(prop) &&
            j.Identifier.check(prop.key) &&
            prop.key.name === "H"
        ) &&
        j.Identifier.check(declaration.init) &&
        declaration.init.name === "cy"
      );
    });

  // Find all `import` declarations from "e2e/support/helpers"
  root
    .find(j.ImportDeclaration, { source: { value: "e2e/support/helpers" } })
    .forEach((path) => {
      const importDeclaration = path.node;

      // Skip TypeScript type-only imports
      if (importDeclaration.importKind === "type") {
        return;
      }

      // Collect all imported specifiers
      const specifiersToReplace = importDeclaration.specifiers.filter(
        (spec) => spec.type === "ImportSpecifier",
      );

      if (specifiersToReplace.length > 0) {
        if (hasExistingHDestructuring) {
          // If there's already "const { H } = cy;", just remove the old import
          j(path).remove();
        } else {
          // Replace the import
          const newImport = j.importDeclaration(
            [j.importSpecifier(j.identifier("H"))], // import with alias "H"
            j.literal("e2e/support"),
          );

          // Replace the old import with the new one
          j(path).replaceWith(newImport);
        }

        // Update references to use the namespace
        specifiersToReplace.forEach((specifier) => {
          const importedName = specifier.imported.name;
          const localName = specifier.local.name;

          root
            .find(j.Identifier, { name: localName })
            .filter((idPath) => {
              const parent = idPath.parent.node;

              // Skip identifiers used as keys in object properties
              if (j.Property.check(parent) && parent.key === idPath.node) {
                return false;
              }

              // Skip variable declarations
              if (
                j.VariableDeclarator.check(parent) &&
                parent.id === idPath.node
              ) {
                return false;
              }

              // Skip identifiers used as keys in object literal properties
              if (
                j.Property.check(parent) &&
                parent.key === idPath.node &&
                !parent.computed &&
                parent.shorthand
              ) {
                return false;
              }

              // Skip object key names (e.g., { key: value })
              if (j.Property.check(parent) && parent.key === idPath.node) {
                return false;
              }

              // Skip function parameters (callback arguments) like in map(), filter(), or event handlers
              if (
                j.FunctionExpression.check(parent) ||
                j.ArrowFunctionExpression.check(parent)
              ) {
                // Skip if the identifier is part of the function's parameter list
                if (parent.params && parent.params.includes(idPath.node)) {
                  return false;
                }
              }

              // Skip member expressions like `cy.<name>`
              if (
                j.MemberExpression.check(parent) &&
                parent.property === idPath.node
              ) {
                return false;
              }

              // Skip TypeScript type annotations and references
              if (
                j.TSTypeAnnotation.check(parent) ||
                j.TSTypeReference.check(parent) ||
                j.TSQualifiedName.check(parent) ||
                j.TSTypeLiteral.check(parent) ||
                j.TSInterfaceDeclaration.check(parent) ||
                j.TSTypeAliasDeclaration.check(parent)
              ) {
                return false;
              }

              // Skip when identifier is part of a type annotation (e.g., const foo: Type = ...)
              if (
                j.VariableDeclarator.check(parent) &&
                parent.id &&
                parent.id.typeAnnotation &&
                isWithinTypeAnnotation(idPath, parent.id.typeAnnotation)
              ) {
                return false;
              }

              // Skip type references in various contexts
              let currentParent = idPath.parent;
              while (currentParent) {
                if (
                  j.TSTypeAnnotation.check(currentParent.node) ||
                  j.TSTypeReference.check(currentParent.node) ||
                  j.TSAsExpression.check(currentParent.node)
                ) {
                  return false;
                }
                currentParent = currentParent.parent;
              }

              // only specific values
              // return targetValues.has(importedName);

              return !excludedValues.has(importedName);
            })
            .replaceWith(() => {
              return j.memberExpression(
                j.identifier("H"),
                j.identifier(importedName),
              );
            });

          // Update function calls
          root
            .find(j.CallExpression, { callee: { name: localName } })
            .replaceWith((callPath) =>
              j.callExpression(
                j.memberExpression(
                  j.identifier("H"),
                  j.identifier(importedName),
                ),
                callPath.node.arguments,
              ),
            );
        });
      }
    });

  // Return the transformed source code
  return root.toSource();
};

```