### PR TITLE
refactor(sdk): Adjust SDK CLI to work with Hosted Bundle

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/cli/snippets/analytics-dashboard-snippet.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/snippets/analytics-dashboard-snippet.ts
@@ -1,16 +1,13 @@
+import { SDK_PACKAGE_NAME } from "../constants/config";
 import type { DashboardInfo } from "../types/dashboard";
-import { getSdkPackageName } from "../utils/snippets-helpers";
 
 interface Options {
   dashboards: DashboardInfo[];
   userSwitcherEnabled: boolean;
-  isNextJs: boolean;
 }
 
 export const getAnalyticsDashboardSnippet = (options: Options) => {
-  const { dashboards, userSwitcherEnabled, isNextJs } = options;
-
-  const sdkPackageName = getSdkPackageName({ isNextJs });
+  const { dashboards, userSwitcherEnabled } = options;
 
   let imports = `import { ThemeSwitcher } from './theme-switcher'`;
 
@@ -20,7 +17,7 @@ export const getAnalyticsDashboardSnippet = (options: Options) => {
 
   return `
 import { useState, useContext, useReducer } from 'react'
-import { InteractiveDashboard, InteractiveQuestion } from '${sdkPackageName}'
+import { InteractiveDashboard, InteractiveQuestion } from '${SDK_PACKAGE_NAME}'
 import { AnalyticsContext } from "./analytics-provider"
 
 ${imports}

--- a/enterprise/frontend/src/embedding-sdk/cli/snippets/embedding-provider-snippet.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/snippets/embedding-provider-snippet.ts
@@ -1,16 +1,13 @@
-import { getSdkPackageName } from "../utils/snippets-helpers";
+import { SDK_PACKAGE_NAME } from "../constants/config";
 
 interface Options {
   instanceUrl: string;
   apiKey: string;
   userSwitcherEnabled: boolean;
-  isNextJs: boolean;
 }
 
 export const getEmbeddingProviderSnippet = (options: Options) => {
-  const { instanceUrl, apiKey, userSwitcherEnabled, isNextJs } = options;
-
-  const sdkPackageName = getSdkPackageName({ isNextJs });
+  const { instanceUrl, apiKey, userSwitcherEnabled } = options;
 
   let imports = "";
   let apiKeyOrAuthUriConfig = "";
@@ -25,7 +22,7 @@ export const getEmbeddingProviderSnippet = (options: Options) => {
 
   return `
 import {useContext, useMemo} from 'react'
-import {MetabaseProvider} from '${sdkPackageName}'
+import {MetabaseProvider} from '${SDK_PACKAGE_NAME}'
 
 ${imports}
 

--- a/enterprise/frontend/src/embedding-sdk/cli/utils/snippets-helpers.ts
+++ b/enterprise/frontend/src/embedding-sdk/cli/utils/snippets-helpers.ts
@@ -1,13 +1,4 @@
-import {
-  GENERATED_COMPONENTS_DEFAULT_PATH,
-  SDK_PACKAGE_NAME,
-} from "../constants/config";
-
-/**
- * Applies the compatibility layer for Next.js.
- */
-export const getSdkPackageName = ({ isNextJs }: { isNextJs: boolean }) =>
-  isNextJs ? `${SDK_PACKAGE_NAME}/nextjs` : SDK_PACKAGE_NAME;
+import { GENERATED_COMPONENTS_DEFAULT_PATH } from "../constants/config";
 
 /**
  * Where should we save the generated components by default?


### PR DESCRIPTION
The Hosted Bundle deprecates Next.js compat, so we can adjust CLI snippets to use main SDK entry point directly for Nextjs