### PR TITLE
Adjust API docs sort order respecting the kind

### DIFF
--- a/.typedoc/typedoc.common.config.js
+++ b/.typedoc/typedoc.common.config.js
@@ -39,7 +39,7 @@ const config = {
     "SetSignature",
     "Module",
   ],
-  sort: ["alphabetical"],
+  sort: ["kind", "alphabetical"],
   readme: "none",
   excludePrivate: true,
   excludeExternals: true,


### PR DESCRIPTION
Adjust API docs sort order respecting the kind, so exported components/hooks are on the top

<img width="342" height="987" alt="image" src="https://github.com/user-attachments/assets/cb12d98e-fadb-4094-815f-e06b644e4f35" />
