### PR TITLE
chore: Refactor sync wait times to use a constant for delay and adjus…

### DIFF
--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -352,7 +352,7 @@ export function waitForSyncToFinish({
   tableAlias,
 }) {
   // 40 x 500ms (20s) should be plenty of time for the sync to finish.
-  if (iteration === 20) {
+  if (iteration === 40) {
     throw new Error("The sync is taking too long. Something is wrong.");
   }
 

--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -14,6 +14,8 @@ import { createQuestion } from "./api";
  **            QA DATABASES             **
  ******************************************/
 
+const SYNC_RETRY_DELAY_MS = 500;
+
 export function addMongoDatabase(displayName = "QA Mongo") {
   const { host, user, password, database: dbName } = QA_DB_CREDENTIALS;
   const port = QA_MONGO_PORT;
@@ -145,7 +147,7 @@ function assertOnDatabaseMetadata(engine) {
 
 function recursiveCheck(id, i = 0) {
   // Let's not wait more than 20s for the sync to finish
-  if (i === 20) {
+  if (i === 40) {
     cy.task(
       "log",
       "The DB sync isn't complete yet, but let's be optimistic about it",
@@ -153,7 +155,7 @@ function recursiveCheck(id, i = 0) {
     return;
   }
 
-  cy.wait(1000);
+  cy.wait(SYNC_RETRY_DELAY_MS);
 
   cy.request("GET", `/api/database/${id}`).then(({ body: database }) => {
     cy.task("log", {
@@ -170,12 +172,12 @@ function recursiveCheck(id, i = 0) {
 
 function recursiveCheckFields(id, i = 0) {
   // Let's not wait more than 10s for the sync to finish
-  if (i === 10) {
+  if (i === 20) {
     cy.task("log", "The field sync isn't complete");
     return;
   }
 
-  cy.wait(1000);
+  cy.wait(SYNC_RETRY_DELAY_MS);
 
   cy.request("GET", `/api/database/${id}/schemas`).then(({ body: schemas }) => {
     const [schema] = schemas;
@@ -350,11 +352,11 @@ export function waitForSyncToFinish({
   tableAlias,
 }) {
   // 40 x 500ms (20s) should be plenty of time for the sync to finish.
-  if (iteration === 40) {
+  if (iteration === 20) {
     throw new Error("The sync is taking too long. Something is wrong.");
   }
 
-  cy.wait(500);
+  cy.wait(SYNC_RETRY_DELAY_MS);
 
   cy.request("GET", `/api/database/${dbId}/metadata`).then(({ body }) => {
     if (!body.tables.length) {


### PR DESCRIPTION
This pull request refactors and improves the synchronization logic in `e2e-qa-databases-helpers.js` by introducing a constant for retry delay, adjusting retry limits, and ensuring consistent usage of the delay constant. These changes aim to make the code more maintainable and improve the clarity of synchronization behavior.

In the context of: https://linear.app/metabase/issue/DEV-707/refactor-cywait-in-e2e-tests this cy.wait make sense, I've just moved them to a constant and unified the 'ticks' 