### PR TITLE
Add an eslint rule that warns for external references inside the Embedding SDK NPM package code

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/.eslintrc.js
+++ b/enterprise/frontend/src/embedding-sdk/.eslintrc.js
@@ -52,4 +52,28 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: [
+        "sdk-package/**/*.{ts,tsx,js,jsx}",
+        "sdk-shared/**/*.{ts,tsx,js,jsx}",
+      ],
+      excludedFiles: [
+        "**/test/**",
+        "**/*.spec.{ts,tsx,js,jsx}",
+        "**/*.stories.{ts,tsx,js,jsx}",
+      ],
+      rules: {
+        "no-external-references-for-sdk-package-code": [
+          "error",
+          {
+            allowedPaths: [
+              path.join(__dirname, "sdk-package"),
+              path.join(__dirname, "sdk-shared"),
+            ],
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/enterprise/frontend/src/embedding-sdk/sdk-package/components/private/Error/Error.tsx
+++ b/enterprise/frontend/src/embedding-sdk/sdk-package/components/private/Error/Error.tsx
@@ -1,4 +1,5 @@
 import { useMetabaseProviderPropsStore } from "embedding-sdk/sdk-shared/hooks/use-metabase-provider-props-store";
+// eslint-disable-next-line no-external-references-for-sdk-package-code
 import { colors } from "metabase/lib/colors/colors";
 
 type Props = {

--- a/enterprise/frontend/src/embedding-sdk/sdk-package/components/private/Loader/Loader.tsx
+++ b/enterprise/frontend/src/embedding-sdk/sdk-package/components/private/Loader/Loader.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-external-references-for-sdk-package-code
 import { getSdkLoaderCss } from "embedding/sdk-common/lib/get-sdk-loader-css";
 import { useMetabaseProviderPropsStore } from "embedding-sdk/sdk-shared/hooks/use-metabase-provider-props-store";
 import type { CommonStylingProps } from "embedding-sdk/types/props";

--- a/enterprise/frontend/src/embedding-sdk/sdk-package/components/public/MetabaseProvider/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/sdk-package/components/public/MetabaseProvider/MetabaseProvider.tsx
@@ -1,4 +1,5 @@
 import { memo, useId, useMemo } from "react";
+// eslint-disable-next-line no-external-references-for-sdk-package-code
 import useDeepCompareEffect from "react-use/lib/useDeepCompareEffect";
 
 import { ClientSideOnlyWrapper } from "embedding-sdk/sdk-package/components/private/ClientSideOnlyWrapper/ClientSideOnlyWrapper";

--- a/enterprise/frontend/src/embedding-sdk/sdk-package/hooks/private/use-load-sdk-bundle.ts
+++ b/enterprise/frontend/src/embedding-sdk/sdk-package/hooks/private/use-load-sdk-bundle.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 
+// eslint-disable-next-line no-external-references-for-sdk-package-code
 import { SDK_BUNDLE_FULL_PATH } from "build-configs/embedding-sdk/constants/sdk-bundle";
 import { SDK_BUNDLE_SCRIPT_DATA_ATTRIBUTE_PASCAL_CASED } from "embedding-sdk/sdk-package/config";
 import { getSdkBundleScriptElement } from "embedding-sdk/sdk-package/lib/private/get-sdk-bundle-script-element";

--- a/enterprise/frontend/src/embedding-sdk/sdk-package/lib/public/define-metabase-theme.ts
+++ b/enterprise/frontend/src/embedding-sdk/sdk-package/lib/public/define-metabase-theme.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-external-references-for-sdk-package-code
 import { defineMetabaseTheme } from "metabase/embedding-sdk/theme/define-metabase-theme";
 
 export { defineMetabaseTheme };

--- a/frontend/lint/eslint-rules/no-external-references-for-sdk-package-code.js
+++ b/frontend/lint/eslint-rules/no-external-references-for-sdk-package-code.js
@@ -1,0 +1,118 @@
+/* eslint-disable import/no-commonjs */
+/* eslint-env node */
+
+const path = require("path");
+
+const resolve = require("eslint-module-utils/resolve").default;
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow imports/requires in SDK-package code that resolve outside of the allowed directories",
+      category: "Best Practices",
+      recommended: false,
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowedPaths: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 1,
+          },
+        },
+        required: ["allowedPaths"],
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      externalImport:
+        'Import of "{{importPath}}" resolves outside of the allowed directories.',
+    },
+  },
+
+  create(context) {
+    const [{ allowedPaths } = {}] = context.options;
+
+    if (
+      !Array.isArray(allowedPaths) ||
+      allowedPaths.some((allowedPath) => typeof allowedPath !== "string")
+    ) {
+      return {};
+    }
+
+    const cwd = process.cwd();
+    const resolvedAllowedPaths = allowedPaths.map((allowedPath) =>
+      path.resolve(cwd, allowedPath),
+    );
+    const filename = context.getFilename();
+
+    // Only lint files inside one of the allowed directories
+    if (
+      !filename ||
+      filename === "<input>" ||
+      !resolvedAllowedPaths.some((directory) =>
+        filename.startsWith(directory + path.sep),
+      )
+    ) {
+      return {};
+    }
+
+    /**
+     * Resolve an import path and report if it’s outside all allowedDirs
+     */
+    function checkImport(node, importPath) {
+      const resolvedPath = resolve(importPath, context);
+
+      if (!resolvedPath) {
+        return;
+      }
+
+      const absolutePath = path.resolve(resolvedPath);
+
+      if (
+        !resolvedAllowedPaths.some((directory) =>
+          absolutePath.startsWith(directory + path.sep),
+        )
+      ) {
+        context.report({
+          node,
+          messageId: "externalImport",
+          data: { importPath },
+        });
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        if (node.importKind === "type") {
+          return;
+        }
+
+        checkImport(node.source, node.source.value);
+      },
+      ImportExpression(node) {
+        if (
+          node.source.type === "Literal" &&
+          typeof node.source.value === "string"
+        ) {
+          checkImport(node.source, node.source.value);
+        }
+      },
+      CallExpression(node) {
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "require" &&
+          node.arguments.length === 1 &&
+          node.arguments[0].type === "Literal" &&
+          typeof node.arguments[0].value === "string"
+        ) {
+          checkImport(node.arguments[0], node.arguments[0].value);
+        }
+      },
+    };
+  },
+};

--- a/frontend/src/metabase/lib/colors/colors.ts
+++ b/frontend/src/metabase/lib/colors/colors.ts
@@ -4,6 +4,7 @@
 // frontend/src/metabase/css/core/colors.module.css
 // frontend/src/metabase/styled-components/containers/GlobalStyles/GlobalStyles.tsx
 // frontend/src/metabase/styled-components/theme/css-variables.ts
+// NOTE: this file is used in the embedding SDK, so it should not contain anything else except the `colors` constant.
 export const colors = {
   brand: "#509EE3",
   summarize: "#88BF4D",

--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
     "esbuild": "^0.25.0",
     "eslint": "7.32.0",
     "eslint-import-resolver-webpack": "^0.13.10",
+    "eslint-module-utils": "^2.12.1",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-depend": "^0.9.0",
     "eslint-plugin-i18next": "^6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10096,6 +10096,13 @@ eslint-import-resolver-webpack@^0.13.10:
     resolve "^2.0.0-next.5"
     semver "^5.7.2"
 
+eslint-module-utils@^2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz#f76d3220bfb83c057651359295ab5854eaad75ff"
+  integrity sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==
+  dependencies:
+    debug "^3.2.7"
+
 eslint-module-utils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz#e439fee65fc33f6bba630ff621efc38ec0375c49"


### PR DESCRIPTION
The PR adds a eslint rule that warns for external references inside the Embedding SDK NPM package code. The NPM package code should be a small as possible, so	we should not reference anything external that may pull unexpected things into the SDK NPM package bundle

How to verify:
- CI should pass.

