### PR TITLE
Add param_fields and repro

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -75,6 +75,7 @@ export interface Card<Q extends DatasetQuery = DatasetQuery>
   creator?: CreatorInfo;
   "last-edit-info"?: LastEditInfo;
   table_id?: TableId;
+  param_fields?: Record<ParameterId, Field[]>;
 }
 
 export interface PublicCard {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -13,6 +13,7 @@ import {
 } from "metabase/query_builder/selectors";
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { setErrorPage } from "metabase/redux/app";
+import { addFields } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getUser } from "metabase/selectors/user";
 import * as Lib from "metabase-lib";
@@ -299,6 +300,10 @@ async function handleQBInit(
       originalCard,
       dispatch,
     });
+  }
+
+  if (card?.param_fields) {
+    await dispatch(addFields(Object.values(card.param_fields).flat()));
   }
 
   await dispatch(loadMetadataForCard(card));

--- a/src/metabase/queries/api/card.clj
+++ b/src/metabase/queries/api/card.clj
@@ -200,7 +200,8 @@
                     :can_delete
                     :can_manage_db
                     [:collection :is_personal]
-                    [:moderation_reviews :moderator_details])
+                    [:moderation_reviews :moderator_details]
+                    :param_fields)
         (update :dashboard #(some-> % (select-keys [:name :id :moderation_status])))
         (cond->
          (card/model? card) (t2/hydrate :persisted

--- a/test/metabase/queries/api/card_test.clj
+++ b/test/metabase/queries/api/card_test.clj
@@ -76,6 +76,7 @@
    :made_public_by_id      nil
    :parameters             []
    :parameter_mappings     []
+   :param_fields           {}
    :moderation_reviews     ()
    :public_uuid            nil
    :query_type             nil
@@ -1357,6 +1358,23 @@
                           mt/boolean-ids-and-timestamps
                           :moderation_reviews
                           (map clean)))))))))))
+
+(deftest fetch-card-param-fields-test
+  (testing "GET /api/card/:id"
+    (testing "Should be able to fetch the Card with :param_fields if you have Collection read perms but no data perms"
+      (mt/with-no-data-perms-for-all-users!
+        (mt/with-temp [:model/Card card {:dataset_query {:database (mt/id)
+                                                         :type     :native
+                                                         :native   {:query         "SELECT id FROM products WHERE {{category}}"
+                                                                    :template-tags {"category" {:dimension    [:field (mt/id :products :category) nil],
+                                                                                                :display-name "Category",
+                                                                                                :id           "_category_",
+                                                                                                :name         "category",
+                                                                                                :required     false,
+                                                                                                :type         :dimension,
+                                                                                                :widget-type  :string/=}}}}}]
+          (is (=? {:param_fields {:_category_ [{:id (mt/id :products :category)}]}}
+                  (mt/user-http-request :rasta :get 200 (str "card/" (u/the-id card))))))))))
 
 (deftest fetch-card-entity-id-test
   (testing "GET /api/card/:id with entity ID"

--- a/test/metabase/queries/api/card_test.clj
+++ b/test/metabase/queries/api/card_test.clj
@@ -76,7 +76,6 @@
    :made_public_by_id      nil
    :parameters             []
    :parameter_mappings     []
-   :param_fields           {}
    :moderation_reviews     ()
    :public_uuid            nil
    :query_type             nil


### PR DESCRIPTION
Repro for https://github.com/metabase/metabase/issues/61418

This PR also fixes the `GET /api/card/:id` endpoint to return `:param_fields` (I was surprised it didn't). But `/api/card/:id/params/:param-key/values` still throw permissions errors, so it requires additional fixes.