### PR TITLE
Add aliases to native queries in parameters substitute tests

### DIFF
--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -913,7 +913,7 @@
             (mt/format-rows-by
              [int]
              (process-native
-              :native     {:query         (format "SELECT COUNT(*) FROM %s WHERE {{checkin_date}}" (table-identifier :checkins))
+              :native     {:query         (format "SELECT COUNT(*) AS c FROM %s WHERE {{checkin_date}}" (table-identifier :checkins))
                            :template-tags {"checkin_date" {:name         "checkin_date"
                                                            :display-name "Checkin Date"
                                                            :type         :dimension
@@ -931,7 +931,7 @@
               (mt/format-rows-by
                [int]
                (process-native
-                :native     {:query         (format "SELECT COUNT(*) FROM %s WHERE {{checkin_date}}" (table-identifier :checkins))
+                :native     {:query         (format "SELECT COUNT(*) AS c FROM %s WHERE {{checkin_date}}" (table-identifier :checkins))
                              :template-tags {"checkin_date" {:name         "checkin_date"
                                                              :display-name "Checkin Date"
                                                              :type         :dimension
@@ -949,7 +949,7 @@
               (mt/format-rows-by
                [int]
                (process-native
-                :native     {:query         (format "SELECT COUNT(*) FROM %s WHERE {{checkin_date}}"
+                :native     {:query         (format "SELECT COUNT(*) AS c FROM %s WHERE {{checkin_date}}"
                                                     (table-identifier :checkins))
                              :template-tags {"checkin_date" {:name         "checkin_date"
                                                              :display-name "Checkin Date"
@@ -983,7 +983,7 @@
                   (mt/format-rows-by
                    [int]
                    (process-native
-                    :native     {:query         (format "SELECT COUNT(*) FROM %s WHERE {{last_login_date}}"
+                    :native     {:query         (format "SELECT COUNT(*) as c FROM %s WHERE {{last_login_date}}"
                                                         (table-identifier :users))
                                  :template-tags {"last_login_date" {:name         "last_login_date"
                                                                     :display-name "Last Login Date"
@@ -1002,7 +1002,7 @@
               (mt/format-rows-by
                [int]
                (process-native
-                :native     {:query         (format "SELECT COUNT(*) FROM %s WHERE {{checkin_date}}"
+                :native     {:query         (format "SELECT COUNT(*) AS c FROM %s WHERE {{checkin_date}}"
                                                     (table-identifier :checkins))
                              :template-tags {"checkin_date" {:name         "checkin_date"
                                                              :display-name "Checkin Date"
@@ -1032,7 +1032,7 @@
 
 (defmethod e2e-parse-native-dates-test-sql ::driver/driver
   [_driver]
-  "SELECT cast({{date}} as date)")
+  "SELECT cast({{date}} as date) AS d")
 
 (defmethod e2e-parse-native-dates-test-sql :oracle
   [_driver]

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -983,7 +983,7 @@
                   (mt/format-rows-by
                    [int]
                    (process-native
-                    :native     {:query         (format "SELECT COUNT(*) as c FROM %s WHERE {{last_login_date}}"
+                    :native     {:query         (format "SELECT COUNT(*) AS c FROM %s WHERE {{last_login_date}}"
                                                         (table-identifier :users))
                                  :template-tags {"last_login_date" {:name         "last_login_date"
                                                                     :display-name "Last Login Date"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Adds aliases to stop SQLServer tests errors. Not a root cause fix but just a bandaid for now.

Discussion: https://metaboat.slack.com/archives/C5XHN8GLW/p1753375341902869

Failure: https://metaboat.slack.com/archives/C5XHN8GLW/p1753368431973479

Based on the discussion we might want to have the FE add support for empty display name strings. And have the BE soften the `:display_name` schema to `:string` instead of a non-blank string. Leaving this PR as is for now if we want to stop the failures to unblock other PRs. 

### How to verify

Tests should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
