### PR TITLE
run only when the `Type:Documentation` label set

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -15,13 +15,8 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install pngcrush and bc
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y pngcrush bc
-
-    - name: Skip Merge Commits
-      id: merge-check
+    - name: Check for Type:Documentation label on PR
+      id: label-check
       uses: actions/github-script@v7
       with:
         script: |
@@ -49,16 +44,22 @@ jobs:
             core.setOutput('skip', 'false');
           }
 
+    - name: Install pngcrush and bc
+      if: steps.label-check.outputs.skip != 'true'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pngcrush bc
+
     - name: Get changed PNG files
       id: changed-files
-      if: steps.merge-check.outputs.skip != 'true'
+      if: steps.label-check.outputs.skip != 'true'
       uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
       with:
         files: |
           docs/**/*.png
 
     - name: Optimize changed PNG files
-      if: steps.changed-files.outputs.any_changed == 'true' && steps.merge-check.outputs.skip != 'true'
+      if: steps.changed-files.outputs.any_changed == 'true' && steps.label-check.outputs.skip != 'true'
       id: optimize
       run: |
         echo "Optimizing new PNG files with pngcrush..."
@@ -102,7 +103,7 @@ jobs:
         echo "Total bytes saved: ${total_saved} (${total_before} -> ${total_after})"
 
     - name: Check for changes after optimization
-      if: steps.changed-files.outputs.any_changed == 'true' && steps.merge-check.outputs.skip != 'true'
+      if: steps.changed-files.outputs.any_changed == 'true' && steps.label-check.outputs.skip != 'true'
       id: check_changes
       run: |
         git add ${{ steps.changed-files.outputs.all_changed_files }}
@@ -116,7 +117,7 @@ jobs:
         fi
 
     - name: Commit optimized images
-      if: steps.changed-files.outputs.any_changed == 'true' && steps.check_changes.outputs.has_changes == 'true' && steps.merge-check.outputs.skip != 'true'
+      if: steps.changed-files.outputs.any_changed == 'true' && steps.check_changes.outputs.has_changes == 'true' && steps.label-check.outputs.skip != 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       run: |
@@ -153,7 +154,7 @@ jobs:
         echo 'Applied: pngcrush -rem alla -brute -ow'
 
     - name: Output summary
-      if: steps.changed-files.outputs.any_changed == 'true' && steps.merge-check.outputs.skip != 'true'
+      if: steps.changed-files.outputs.any_changed == 'true' && steps.label-check.outputs.skip != 'true'
       run: |
         if [ "${{ steps.check_changes.outputs.has_changes }}" = "false" ]; then
           echo "PNG files were already optimized - no changes needed"

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -8,58 +8,28 @@ on:
 jobs:
   optimize-images:
     runs-on: ubuntu-latest
-
+    if: ${{ contains(github.event.pull_request.labels.*.name,'Type:Documentation') }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Check for Type:Documentation label on PR
-      id: label-check
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const labelToCheck = 'Type:Documentation';
-          const pr = context.payload.pull_request;
-
-          if (!pr) {
-            core.info('Not a pull request event — skipping.');
-            core.setOutput('skip', 'true');
-            return;
-          }
-
-          const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: pr.number,
-          });
-
-          const hasLabel = labels.some(label => label.name === labelToCheck);
-          if (!hasLabel) {
-            core.info(`Label '${labelToCheck}' not found — skipping.`);
-            core.setOutput('skip', 'true');
-          } else {
-            core.info(`Label '${labelToCheck}' found: Running Optimizer.`);
-            core.setOutput('skip', 'false');
-          }
-
     - name: Install pngcrush and bc
-      if: steps.label-check.outputs.skip != 'true'
+      if:
       run: |
         sudo apt-get update
         sudo apt-get install -y pngcrush bc
 
     - name: Get changed PNG files
       id: changed-files
-      if: steps.label-check.outputs.skip != 'true'
       uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
       with:
         files: |
           docs/**/*.png
 
     - name: Optimize changed PNG files
-      if: steps.changed-files.outputs.any_changed == 'true' && steps.label-check.outputs.skip != 'true'
+      if: steps.changed-files.outputs.any_changed == 'true'
       id: optimize
       run: |
         echo "Optimizing new PNG files with pngcrush..."
@@ -103,7 +73,7 @@ jobs:
         echo "Total bytes saved: ${total_saved} (${total_before} -> ${total_after})"
 
     - name: Check for changes after optimization
-      if: steps.changed-files.outputs.any_changed == 'true' && steps.label-check.outputs.skip != 'true'
+      if: steps.changed-files.outputs.any_changed == 'true'
       id: check_changes
       run: |
         git add ${{ steps.changed-files.outputs.all_changed_files }}
@@ -117,7 +87,7 @@ jobs:
         fi
 
     - name: Commit optimized images
-      if: steps.changed-files.outputs.any_changed == 'true' && steps.check_changes.outputs.has_changes == 'true' && steps.label-check.outputs.skip != 'true'
+      if: steps.changed-files.outputs.any_changed == 'true' && steps.check_changes.outputs.has_changes == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       run: |
@@ -154,7 +124,7 @@ jobs:
         echo 'Applied: pngcrush -rem alla -brute -ow'
 
     - name: Output summary
-      if: steps.changed-files.outputs.any_changed == 'true' && steps.label-check.outputs.skip != 'true'
+      if: steps.changed-files.outputs.any_changed == 'true'
       run: |
         if [ "${{ steps.check_changes.outputs.has_changes }}" = "false" ]; then
           echo "PNG files were already optimized - no changes needed"

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -1,9 +1,9 @@
 name: Auto-Optimize Docs PNG Images
 
 on:
-  push:
-    paths:
-      - 'docs/**/*.png'
+  pull_request:
+    types:
+      - labeled
 
 jobs:
   optimize-images:

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -16,7 +16,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install pngcrush and bc
-      if:
       run: |
         sudo apt-get update
         sudo apt-get install -y pngcrush bc

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -22,12 +22,32 @@ jobs:
 
     - name: Skip Merge Commits
       id: merge-check
-      run: |
-        if [ "$(git rev-list --parents -n 1 HEAD | wc -w)" -gt 2 ]; then
-          echo "Merge commit detected. Skipping."
-          echo "skip=true" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const labelToCheck = 'Type:Documentation';
+          const pr = context.payload.pull_request;
+
+          if (!pr) {
+            core.info('Not a pull request event — skipping.');
+            core.setOutput('skip', 'true');
+            return;
+          }
+
+          const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.number,
+          });
+
+          const hasLabel = labels.some(label => label.name === labelToCheck);
+          if (!hasLabel) {
+            core.info(`Label '${labelToCheck}' not found — skipping.`);
+            core.setOutput('skip', 'true');
+          } else {
+            core.info(`Label '${labelToCheck}' found: Running Optimizer.`);
+            core.setOutput('skip', 'false');
+          }
 
     - name: Get changed PNG files
       id: changed-files


### PR DESCRIPTION
This was running too often, and when it was not needed.

Now it runs only when the `Type:Documentation` label is set.
