### PR TITLE
[MBQL lib] Fix `:effective-type` for `:temporal-unit :year` etc. when converting

### DIFF
--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -21,7 +21,6 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.schema.ref :as lib.schema.ref]
-   [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
@@ -36,12 +35,12 @@
 (defn- column-metadata-effective-type
   "Effective type of a column when taking the `::temporal-unit` into account. If we have a temporal extraction like
   `:month-of-year`, then this actually returns an integer rather than the 'original` effective type of `:type/Date` or
-  whatever."
-  [{::keys [temporal-unit], :as column-metadata}]
-  (if (and temporal-unit
-           (contains? lib.schema.temporal-bucketing/datetime-extraction-units temporal-unit))
-    :type/Integer
-    ((some-fn :effective-type :base-type) column-metadata)))
+  whatever.
+
+  Defaults to the `:base-type` if there's no `:effective-type`."
+  [column-metadata]
+  (or (lib.options/correct-effective-type column-metadata)
+      (:base-type column-metadata)))
 
 (defmethod lib.metadata.calculation/type-of-method :metadata/column
   [_query _stage-number column-metadata]

--- a/src/metabase/lib/options.cljc
+++ b/src/metabase/lib/options.cljc
@@ -93,7 +93,8 @@
 
   Returns the original `:effective-type` if the special handling doesn't apply, even if it is nil."
   [metadata-or-options]
-  (let [temporal-unit ((some-fn :metabase.lib.field/temporal-unit :temporal-unit) metadata-or-options)]
+  (let [temporal-unit ((some-fn :metabase.lib.field/temporal-unit :temporal-unit :inherited-temporal-unit)
+                       metadata-or-options)]
     (if (and temporal-unit
              (contains? lib.schema.temporal-bucketing/datetime-extraction-units temporal-unit))
       :type/Integer

--- a/src/metabase/lib/schema/temporal_bucketing.cljc
+++ b/src/metabase/lib/schema/temporal_bucketing.cljc
@@ -14,7 +14,7 @@
    :week-of-year
    :month-of-year
    :quarter-of-year
-   :year
+   #_:year
    :year-of-era])
 
 (def date-extraction-units


### PR DESCRIPTION
Fixes #48932.

### Description

The `:effective-type` is correctly set to `:type/Integer` (rather than
`:type/DateTime`) when bucketing by `:year`, `:day-of-week`, etc. but
`:effective-type` is dropped from refs on a round trip through legacy.

This PR corrects the `:effective-type` when converting from legacy by
reusing this `:temporal-unit`-based logic.

### How to verify

Follow the repro steps in #48932; they work correctly now.

### Demo

<img width="1394" height="1318" alt="image" src="https://github.com/user-attachments/assets/07c16767-7130-4dc9-875b-89b15915cf58" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
