### PR TITLE
[Lib] Misc metadata calculation and conversion bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ CLAUDE.local.md
 .eslintcache
 
 /logs
+/.clojure-mcp

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1564,31 +1564,6 @@
    [:page  PositiveInt]
    [:items PositiveInt]])
 
-(mr/def ::Ident
-  "Unique identifier string for new `:column` refs. The new refs aren't used in legacy MBQL (currently) but the
-  idents for column-introducing new clauses (joins, aggregations, breakouts, expressions) are randomly generated when
-  the clauses are created, so the idents must be preserved in legacy MBQL.
-
-  These are opaque strings under the initial design; I've made them a separate schema for documentation and
-  future-proofing."
-  [:or ::lib.schema.common/non-blank-string :keyword])
-
-(mr/def ::IndexedIdents
-  "Aggregations and breakouts get their `:ident` in legacy MBQL from a separate map, which maps the index of the
-  aggregation or breakout to its ident.
-
-  (That's super unstable, but legacy MBQL is never manipulated anymore. We just need a clean round trip through
-  legacy, so indexes work fine. Idents are stored directly on the clauses in pMBQL.)"
-  ;; TODO: Make the ::Ident values strict once idents are always-populated? That only works for post-normalization
-  ;; queries, but I think we don't apply this schema until normalization.
-  [:map-of ::lib.schema.common/int-greater-than-or-equal-to-zero [:maybe ::Ident]])
-
-(mr/def ::ExpressionIdents
-  "Expressions get their `:ident` in legacy MBQL from a separate map, which maps expression names to idents."
-  ;; TODO: Make the ::Ident values strict once idents are always-populated? That only works for post-normalization
-  ;; queries, but I think we don't apply this schema until normalization.
-  [:map-of ::lib.schema.common/non-blank-string [:maybe ::Ident]])
-
 (mr/def ::MBQLQuery
   [:and
    [:map

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -408,10 +408,10 @@
   "Map of option keys in pMBQL to their legacy names. Keys are renamed before [[disqualify]] drops all namespaced keys."
   {:metabase.lib.field/original-temporal-unit :original-temporal-unit})
 
-(defn- options->legacy-MBQL
+(mu/defn- options->legacy-MBQL :- [:maybe [:map {:min 1}]]
   "Convert an options map in an MBQL clause to the equivalent shape for legacy MBQL. Remove `:lib/*` keys and
   `:effective-type`, which is not used in options maps in legacy MBQL."
-  [m]
+  [m :- [:maybe :map]]
   (->> (cond-> m
          ;; Following construct ensures that transformation mbql -> pmbql -> mbql, does not add base-type where those
          ;; were not present originally. Base types are added in [[metabase.lib.query/add-types-to-fields]].
@@ -430,8 +430,11 @@
   lib.dispatch/dispatch-value
   :hierarchy lib.hierarchy/hierarchy)
 
-(defmethod aggregation->legacy-MBQL :default
-  [[tag options & args]]
+(mu/defmethod aggregation->legacy-MBQL :default
+  [[tag options & args] :- [:cat
+                            :keyword
+                            :map
+                            [:* :any]]]
   (let [inner (into [tag] (map ->legacy-MBQL) args)
         ;; the default value of the :case or :if expression is in the options
         ;; in legacy MBQL
@@ -619,16 +622,12 @@
                (update-list->legacy-boolean-expression :conditions :condition))
            (when (seq (:columns metadata))
              {:source-metadata (stage-metadata->legacy-metadata metadata)})
-           (let [inner-query (chain-stages base {:top-level? false})]
-             (if (or
-                  ;; if [[chain-stages]] returns any additional keys like `:filter` at the top-level then
-                  ;; we need to wrap it all in `:source-query` (QUE-1566)
-                  (seq (set/difference (set (keys inner-query)) #{:source-table :source-query :fields :source-metadata}))
-                  ;; if the last stage has `:fields` and they differ from the `:fields` in join then we need to use
-                  ;; `:source-query` (QUE-1603)
-                  (and (:fields inner-query)
-                       (:fields base)
-                       (not= (:fields inner-query) (:fields base))))
+           (let [inner-query (chain-stages
+                              (dissoc base :fields :conditions)
+                              {:top-level? false})]
+             ;; if [[chain-stages]] returns any additional keys like `:filter` at the top-level then we need to wrap
+             ;; it all in `:source-query` (QUE-1566, QUE-1603)
+             (if (seq (set/difference (set (keys inner-query)) #{:source-table :source-query :source-metadata}))
                {:source-query inner-query}
                inner-query)))))
 

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -5,6 +5,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.card :as lib.card]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.field.util :as lib.field.util]
@@ -164,7 +165,12 @@
    field-ref    :- :mbql.clause/field]
   (when (< *recursive-column-resolution-depth* 2)
     (binding [*recursive-column-resolution-depth* (inc *recursive-column-resolution-depth*)]
-      (when-let [visible-columns (not-empty (lib.metadata.calculation/visible-columns query stage-number))]
+      (when-let [visible-columns (not-empty
+                                  (concat
+                                   (lib.metadata.calculation/visible-columns query stage-number)
+                                   ;; TODO (Cam 7/25/25) -- visible columns does not include aggregations, work around
+                                   ;; it until it gets fixed
+                                   (lib.aggregation/aggregations-metadata query stage-number)))]
         (resolve-column-in-metadata query field-ref visible-columns)))))
 
 (def ^:private opts-propagated-keys

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -17,6 +17,7 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.util :as u]
@@ -160,18 +161,33 @@
 (mu/defn- resolve-column-name :- [:maybe ::lib.metadata.calculation/column-metadata-with-source]
   "String column name: get metadata from the previous stage, if it exists, otherwise if this is the first stage and we
   have a native query or a Saved Question source query or whatever get it from our results metadata."
-  [query        :- ::lib.schema/query
-   stage-number :- :int
-   field-ref    :- :mbql.clause/field]
+  [query                                  :- ::lib.schema/query
+   stage-number                           :- :int
+   [_tag _opts field-name, :as field-ref] :- ::lib.schema.ref/field.literal] ; `:mbql.clause/field` but guaranteed to have a string name
   (when (< *recursive-column-resolution-depth* 2)
     (binding [*recursive-column-resolution-depth* (inc *recursive-column-resolution-depth*)]
-      (when-let [visible-columns (not-empty
-                                  (concat
-                                   (lib.metadata.calculation/visible-columns query stage-number)
-                                   ;; TODO (Cam 7/25/25) -- visible columns does not include aggregations, work around
-                                   ;; it until it gets fixed
-                                   (lib.aggregation/aggregations-metadata query stage-number)))]
-        (resolve-column-in-metadata query field-ref visible-columns)))))
+      (or
+       ;; a column with a name ref and no join alias presumably comes from the previous stage's returned columns, so
+       ;; we should first try to resolve it from there.
+       (when-not (lib.join.util/current-join-alias field-ref)
+         (when-let [previous-stage-number (lib.util/previous-stage-number query stage-number)]
+           (when-let [previous-stage-columns (lib.metadata.calculation/returned-columns query previous-stage-number)]
+             ;; look for a match with the same `desired-column-alias`; if that fails, look for a match with using
+             ;; legacy `deduplicated-name`
+             (when-let [col (some (fn [k]
+                                    (m/find-first #(= (k %) field-name)
+                                                  previous-stage-columns))
+                                  [:lib/desired-column-alias
+                                   :lib/deduplicated-name])]
+               (lib.field.util/update-keys-for-col-from-previous-stage col)))))
+       ;; if the 'simple match' failed then try again by looking at all the visible columns.
+       (when-let [visible-columns (not-empty
+                                   (concat
+                                    (lib.metadata.calculation/visible-columns query stage-number)
+                                    ;; TODO (Cam 7/25/25) -- visible columns does not include aggregations, work around
+                                    ;; it until it gets fixed
+                                    (lib.aggregation/aggregations-metadata query stage-number)))]
+         (resolve-column-in-metadata query field-ref visible-columns))))))
 
 (def ^:private opts-propagated-keys
   "Keys to copy non-nil values directly from `:field` opts into column metadata."

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -179,7 +179,9 @@
                                                   previous-stage-columns))
                                   [:lib/desired-column-alias
                                    :lib/deduplicated-name])]
-               (lib.field.util/update-keys-for-col-from-previous-stage col)))))
+               (-> col
+                   lib.field.util/update-keys-for-col-from-previous-stage
+                   (assoc :lib/source :source/previous-stage))))))
        ;; if the 'simple match' failed then try again by looking at all the visible columns.
        (when-let [visible-columns (not-empty
                                    (concat

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -438,7 +438,7 @@
                                  ;; calculate much metadata -- assume it comes from the previous stage so we at least
                                  ;; have a value for `:lib/source`.
                                  (when (zero? *recursive-column-resolution-depth*)
-                                   (log/warnf "Failed to resolve field ref with name %s in stage %d" (pr-str id-or-name) stage-number))
+                                   (log/infof "Failed to resolve field ref with name %s in stage %d" (pr-str id-or-name) stage-number))
                                  {:lib/source :source/previous-stage}))
          field-id          (if (integer? id-or-name)
                              id-or-name

--- a/src/metabase/lib/field/util.cljc
+++ b/src/metabase/lib/field/util.cljc
@@ -71,14 +71,13 @@
                           :lib/source-column-alias  source-alias
                           :lib/desired-column-alias desired-alias)))))))
 
-(defn update-keys-for-col-from-previous-stage
+(mu/defn update-keys-for-col-from-previous-stage :- :map
   "For a column that came from a previous stage, change the keys for things that mean 'this happened in the current
   stage' to the equivalent keys that mean 'this happened at some stage in the past' e.g.
   `:metabase.lib.join/join-alias` and `:lib/expression-name` become `:lib/original-join-alias` and
   `:lib/original-expression-name` respectively."
-  [col]
+  [col :- :map]
   (-> col
-      (assoc :lib/breakout? false)
       (set/rename-keys {:fk-field-id                      :lib/original-fk-field-id
                         :fk-field-name                    :lib/original-fk-field-name
                         :fk-join-alias                    :lib/original-fk-join-alias
@@ -86,7 +85,8 @@
                         :metabase.lib.field/binning       :lib/original-binning
                         :metabase.lib.field/temporal-unit :inherited-temporal-unit
                         :metabase.lib.join/join-alias     :lib/original-join-alias})
-      ;; TODO (Cam 6/26/25) -- should we set `:lib/original-display-name` here too?
-      (assoc :lib/original-name ((some-fn :lib/original-name :name) col)
+      (assoc :lib/breakout? false
+             ;; TODO (Cam 6/26/25) -- should we set `:lib/original-display-name` here too?
+             :lib/original-name ((some-fn :lib/original-name :name) col)
              ;; desired-column-alias is previous stage => source column alias in next stage
              :lib/source-column-alias ((some-fn :lib/desired-column-alias :lib/source-column-alias :name) col))))

--- a/src/metabase/lib/field/util.cljc
+++ b/src/metabase/lib/field/util.cljc
@@ -85,6 +85,7 @@
                         :metabase.lib.field/binning       :lib/original-binning
                         :metabase.lib.field/temporal-unit :inherited-temporal-unit
                         :metabase.lib.join/join-alias     :lib/original-join-alias})
+      ;; TODO (Cam 7/25/25) -- shouldn't this set `:lib/source` as well?
       (assoc :lib/breakout? false
              ;; TODO (Cam 6/26/25) -- should we set `:lib/original-display-name` here too?
              :lib/original-name ((some-fn :lib/original-name :name) col)

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -235,21 +235,18 @@
 
 (mu/defn- column-from-join :- ::lib.metadata.calculation/column-metadata-with-source
   "For a column that comes from a join, add or update metadata as needed, e.g. include join name in the display name."
-  [query           :- ::lib.schema/query
-   stage-number    :- :int
-   column-metadata :- ::lib.schema.metadata/column
-   join-alias      :- ::lib.schema.common/non-blank-string]
-  ;; TODO (Cam 6/19/25) -- we need to get rid of `:source-alias` it's just causing confusion; don't need two keys for
-  ;; join aliases.
-  (let [column-metadata (assoc column-metadata
-                               :source-alias            join-alias
-                               :lib/original-join-alias join-alias)
-        col             (-> (assoc column-metadata
-                                   :display-name (lib.metadata.calculation/display-name query stage-number column-metadata)
-                                   :lib/source   :source/joins)
-                            (with-join-alias join-alias))]
-    (assert (= (lib.join.util/current-join-alias col) join-alias))
-    col))
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   col          :- ::lib.schema.metadata/column
+   join-alias   :- ::lib.schema.join/alias]
+  (assoc col
+         ;; TODO (Cam 6/19/25) -- we need to get rid of `:source-alias` it's just causing confusion; don't need two
+         ;; keys for join aliases.
+         :source-alias            join-alias
+         :lib/original-join-alias join-alias
+         :display-name            (lib.metadata.calculation/display-name query stage-number col)
+         :lib/source              :source/joins
+         ::join-alias             join-alias))
 
 (defmethod lib.metadata.calculation/display-name-method :option/join.strategy
   [_query _stage-number {:keys [strategy]} _style]
@@ -283,6 +280,17 @@
                 (lib.field.util/add-source-and-desired-aliases-xform query))
           cols)))
 
+(defn- update-keys-for-join-returned-column [col]
+  ;; Things like bucketing that happened in the last stage of the join they should NOT get propagated (QUE-1621) to
+  ;; the parent stage, otherwise we'd be performing the bucketing twice.
+  ;; Use [[lib.field.util/update-keys-for-col-from-previous-stage]] to update all these keys so we make sure stuff
+  ;; like binning and bucketing that should not get propagated are updated appropriately.
+  (merge (lib.field.util/update-keys-for-col-from-previous-stage col)
+         ;; these columns aren't TRULY from a previous stage so we don't want to update `:lib/desired-column-alias` =>
+         ;; `:lib/source-column-alias`; we'll keep the ones we already have. Throw out the
+         ;; changes [[lib.field.util/update-keys-for-col-from-previous-stage]] made to these.
+         (select-keys col [:lib/source-column-alias :lib/desired-column-alias])))
+
 (mu/defn join-fields-to-add-to-parent-stage :- [:maybe [:sequential ::lib.metadata.calculation/column-metadata-with-source]]
   "The resolved `:fields` from a join, which we automatically append to the parent stage's `:fields`."
   [query
@@ -292,7 +300,7 @@
   (when-not (= fields :none)
     (let [cols   (lib.metadata.calculation/returned-columns query stage-number join options)
           cols'  (if (= fields :all)
-                   cols
+                   (map update-keys-for-join-returned-column cols)
                    (for [field-ref fields
                          :let      [match (or (lib.equality/find-matching-column field-ref cols)
                                               (log/warnf "Failed to find matching column in join %s for ref %s, found:\n%s"
@@ -300,20 +308,27 @@
                                                          (pr-str field-ref)
                                                          (u/pprint-to-str cols)))]
                          :when     match]
-                     (assoc match :lib/source-uuid (lib.options/uuid field-ref))))
+                     (-> match
+                         update-keys-for-join-returned-column
+                         (assoc :lib/source-uuid (lib.options/uuid field-ref))
+                         ;; if the ref in join `:fields` is bucketed then we need to propagate this, since the
+                         ;; bucketing will actually take place in the parent stage. Note that this unit can differ
+                         ;; from bucketing done in the last stage of the join --
+                         ;; see [[metabase.lib.join-test/do-not-incorrectly-propagate-temporal-unit-in-returned-columns-test-2]]
+                         (m/assoc-some :metabase.lib.field/temporal-unit (lib.temporal-bucket/raw-temporal-bucket field-ref)))))
           ;; If there was a `:fields` clause but none of them matched the `join-cols` then pretend it was `:fields :all`
           ;; instead. That can happen if a model gets reworked and an old join clause remembers the old fields.
           cols'  (if (empty? cols') cols cols')
           ;; add any remaps for the fields as needed.
-          cols'' (concat
+          cols' (concat
+                 cols'
+                 (lib.metadata.calculation/remapped-columns
+                  (assoc query :stages stages)
+                  0
                   cols'
-                  (lib.metadata.calculation/remapped-columns
-                   (assoc query :stages stages)
-                   0
-                   cols'
-                   options))]
+                  options))]
       (mapv #(column-from-join query stage-number % join-alias)
-            cols''))))
+            cols'))))
 
 (defmethod lib.metadata.calculation/visible-columns-method :mbql/join
   [query stage-number join options]

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.join
   "Functions related to manipulating EXPLICIT joins in MBQL."
   (:require
+   [clojure.set :as set]
    [clojure.string :as str]
    [inflections.core :as inflections]
    [medley.core :as m]
@@ -247,6 +248,7 @@
        :lib/original-join-alias join-alias
        :lib/source              :source/joins
        ::join-alias             join-alias)
+      (set/rename-keys {:lib/expression-name :lib/original-expression-name})
       (as-> $col (assoc $col :display-name (lib.metadata.calculation/display-name query stage-number $col)))))
 
 (defmethod lib.metadata.calculation/display-name-method :option/join.strategy

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -311,7 +311,7 @@
                                               (log/warnf "Failed to find matching column in join %s for ref %s, found:\n%s"
                                                          (pr-str join-alias)
                                                          (pr-str field-ref)
-                                                         (u/pprint-to-str cols)))]
+                                                         (u/pprint-to-str (map :lib/desired-column-alias cols))))]
                          :when     match]
                      (-> match
                          update-keys-for-join-returned-column

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -248,7 +248,11 @@
        :lib/original-join-alias   join-alias
        :lib/source                :source/joins
        ::join-alias               join-alias
-       :lib/original-display-name ((some-fn :lib/original-display-name :display-name) col))
+       ;;
+       ;; TODO (Cam 7/25/25) -- this seems like a correct thing to do but uncommenting
+       ;; it breaks [[metabase.lib.field-test/nested-field-display-name-test-3]]
+       ;;
+       #_:lib/original-display-name #_((some-fn :lib/original-display-name :display-name) col))
       (set/rename-keys {:lib/expression-name :lib/original-expression-name})
       (as-> $col (assoc $col :display-name (lib.metadata.calculation/display-name query stage-number $col)))))
 

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -239,14 +239,15 @@
    stage-number :- :int
    col          :- ::lib.schema.metadata/column
    join-alias   :- ::lib.schema.join/alias]
-  (assoc col
-         ;; TODO (Cam 6/19/25) -- we need to get rid of `:source-alias` it's just causing confusion; don't need two
-         ;; keys for join aliases.
-         :source-alias            join-alias
-         :lib/original-join-alias join-alias
-         :display-name            (lib.metadata.calculation/display-name query stage-number col)
-         :lib/source              :source/joins
-         ::join-alias             join-alias))
+  (-> col
+      (assoc
+       ;; TODO (Cam 6/19/25) -- we need to get rid of `:source-alias` it's just causing confusion; don't need two
+       ;; keys for join aliases.
+       :source-alias            join-alias
+       :lib/original-join-alias join-alias
+       :lib/source              :source/joins
+       ::join-alias             join-alias)
+      (as-> $col (assoc $col :display-name (lib.metadata.calculation/display-name query stage-number $col)))))
 
 (defmethod lib.metadata.calculation/display-name-method :option/join.strategy
   [_query _stage-number {:keys [strategy]} _style]

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -244,10 +244,11 @@
       (assoc
        ;; TODO (Cam 6/19/25) -- we need to get rid of `:source-alias` it's just causing confusion; don't need two
        ;; keys for join aliases.
-       :source-alias            join-alias
-       :lib/original-join-alias join-alias
-       :lib/source              :source/joins
-       ::join-alias             join-alias)
+       :source-alias              join-alias
+       :lib/original-join-alias   join-alias
+       :lib/source                :source/joins
+       ::join-alias               join-alias
+       :lib/original-display-name ((some-fn :lib/original-display-name :display-name) col))
       (set/rename-keys {:lib/expression-name :lib/original-expression-name})
       (as-> $col (assoc $col :display-name (lib.metadata.calculation/display-name query stage-number $col)))))
 

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -289,14 +289,13 @@
   https://metaboat.slack.com/archives/C0645JP1W81/p1749064632710409?thread_ts=1748958872.704799&cid=C0645JP1W81"
   [query :- ::lib.schema/query
    cols  :- [:sequential ::kebab-cased-map]]
-  (when (seq cols)
-    (lib.convert/with-aggregation-list (lib.aggregation/aggregations query)
-      (let [cols (mapv (fn [col]
-                         (let [field-ref (super-broken-legacy-field-ref query col)]
-                           (cond-> col
-                             field-ref (assoc :field-ref field-ref))))
-                       cols)]
-        (deduplicate-field-refs cols)))))
+  (lib.convert/with-aggregation-list (lib.aggregation/aggregations query)
+    (let [cols (mapv (fn [col]
+                       (let [field-ref (super-broken-legacy-field-ref query col)]
+                         (cond-> col
+                           field-ref (assoc :field-ref field-ref))))
+                     cols)]
+      (deduplicate-field-refs cols))))
 
 (mu/defn- deduplicate-names :- [:sequential ::kebab-cased-map]
   "Needed for legacy FE viz settings purposes for the time being. See

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -269,17 +269,34 @@
            lib.convert/->legacy-MBQL
            (fe-friendly-expression-ref col)))))
 
+;; For unambiguous columns we should use broken legacy refs to maintain backward compatibility with legacy viz
+;; settings, which use them as keys. Since ambiguous refs have never worked correctly it is ok to return
+;; 'modern' refs instead.
+(defn- deduplicate-field-refs [cols]
+  (let [duplicate-refs (->> (frequencies (map :field-ref cols))
+                            (m/filter-vals #(> % 1))
+                            keys
+                            set)]
+    (cond->> cols
+      (seq duplicate-refs) (mapv (fn [col]
+                                   (cond-> col
+                                     (duplicate-refs (:field-ref col))
+                                     (update :field-ref (fn [[tag _id-or-name opts]]
+                                                          [tag (:lib/deduplicated-name col) (assoc opts :base-type (:base-type col))]))))))))
+
 (mu/defn- add-legacy-field-refs :- [:sequential ::kebab-cased-map]
   "Add legacy `:field_ref` to QP results metadata which is still used in a single place in the FE -- see
   https://metaboat.slack.com/archives/C0645JP1W81/p1749064632710409?thread_ts=1748958872.704799&cid=C0645JP1W81"
   [query :- ::lib.schema/query
    cols  :- [:sequential ::kebab-cased-map]]
-  (lib.convert/with-aggregation-list (lib.aggregation/aggregations query)
-    (mapv (fn [col]
-            (let [field-ref (super-broken-legacy-field-ref query col)]
-              (cond-> col
-                field-ref (assoc :field-ref field-ref))))
-          cols)))
+  (when (seq cols)
+    (lib.convert/with-aggregation-list (lib.aggregation/aggregations query)
+      (let [cols (mapv (fn [col]
+                         (let [field-ref (super-broken-legacy-field-ref query col)]
+                           (cond-> col
+                             field-ref (assoc :field-ref field-ref))))
+                       cols)]
+        (deduplicate-field-refs cols)))))
 
 (mu/defn- deduplicate-names :- [:sequential ::kebab-cased-map]
   "Needed for legacy FE viz settings purposes for the time being. See
@@ -380,7 +397,13 @@
                                {:error/message "columns should have unique :name(s)"}
                                (fn [cols]
                                  (or (empty? cols)
-                                     (apply distinct? (map :name cols))))]]
+                                     (apply distinct? (map :name cols))))]
+                              ;; QUE-1623
+                              [:fn
+                               {:error/message "columns should have unique :field-ref(s)"}
+                               (fn [cols]
+                                 (or (empty? cols)
+                                     (apply distinct? (map :field-ref cols))))]]
   "Return metadata for columns returned by a pMBQL `query`.
 
   `initial-cols` are (optionally) the initial minimal metadata columns as returned by the driver (usually just column

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -256,7 +256,7 @@
      (some (fn [f]
              (= (f col-2)
                 (f col-1)))
-           [:lib/desired-column-alias :lib/source-column-alias :lib/deduplicated-name]))))
+           [:lib/desired-column-alias :lib/source-column-alias :lib/deduplicated-name :name]))))
 
 (defn- add-cols-from-join
   "The columns from `:fields` may contain columns from `:joins` -- so if the joins specify their own `:fields` we need

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -222,8 +222,8 @@
         (assoc :lib/type :metadata/results))))
 
 (defn- join->pipeline [join]
-  (let [source (select-keys join [:source-table :source-query])
-        stages (inner-query->stages source)
+  (let [stages (inner-query->stages (or (:source-query join)
+                                        (select-keys join [:source-table])))
         stages (if-let [source-metadata (and (>= (count stages) 2)
                                              (:source-metadata join))]
                  (assoc-in stages [(- (count stages) 2) :lib/stage-metadata] (->stage-metadata source-metadata))

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -224,12 +224,11 @@
 (defn- join->pipeline [join]
   (let [stages (inner-query->stages (or (:source-query join)
                                         (select-keys join [:source-table])))
-        stages (if-let [source-metadata (and (>= (count stages) 2)
-                                             (:source-metadata join))]
-                 (assoc-in stages [(- (count stages) 2) :lib/stage-metadata] (->stage-metadata source-metadata))
+        stages (if-let [source-metadata (:source-metadata join)]
+                 (assoc-in stages [(dec (count stages)) :lib/stage-metadata] (->stage-metadata source-metadata))
                  stages)]
     (-> join
-        (dissoc :source-table :source-query)
+        (dissoc :source-table :source-query :source-metadata)
         (update-legacy-boolean-expression->list :condition :conditions)
         (assoc :lib/type :mbql/join
                :stages stages)

--- a/src/metabase/query_processor/middleware/resolve_joined_fields.clj
+++ b/src/metabase/query_processor/middleware/resolve_joined_fields.clj
@@ -5,6 +5,7 @@
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
@@ -24,10 +25,10 @@
     {:error/message "Should not have :condition"}
     (complement :condition)]])
 
-(mu/defn- add-join-alias
-  [{:keys [table-id], field-id :id, :as field}
-   {:keys [joins source-query]}   :- InnerQuery
-   [_ id-or-name opts :as clause] :- mbql.s/field:id]
+(mu/defn- add-join-alias :- mbql.s/field:id
+  [{:keys [table-id], field-id :id, :as field}   :- ::lib.schema.metadata/column
+   {:keys [joins source-query], :as inner-query} :- InnerQuery
+   [_ id-or-name opts :as field-ref]             :- mbql.s/field:id]
   (let [candidate-tables (filter (fn [join]
                                    (when-let [source-table-id (mbql.u/join->source-table-id join)]
                                      (= source-table-id table-id)))
@@ -42,21 +43,23 @@
       ;; can't do anything, so return field as-is
       0
       (if (empty? source-query)
-        clause
-        (recur field source-query clause))
+        field-ref
+        (recur field source-query field-ref))
 
       ;; if there are multiple candidates, try ignoring the implicit ones
       ;; presence of `:fk-field-id` indicates that the join was implicit, as the result of an `fk->` form
       (let [explicit-joins (remove :fk-field-id joins)]
         (if (= (count explicit-joins) 1)
-          (recur field {:joins explicit-joins} clause)
-          (let [{:keys [name]} (lib.metadata/table (qp.store/metadata-provider) table-id)]
+          (recur field {:joins explicit-joins} field-ref)
+          (let [{table-name :name} (lib.metadata/table (qp.store/metadata-provider) table-id)]
             (throw (ex-info (tru "Cannot resolve joined field due to ambiguous joins: table {0} (ID {1}) joined multiple times. You need to specify an explicit `:join-alias` in the field reference."
-                                 name field-id)
-                            {:field      field
-                             :error      qp.error-type/invalid-query
-                             :joins      joins
-                             :candidates candidate-tables}))))))))
+                                 (pr-str table-name) (pr-str table-id))
+                            {:field       field
+                             :field-ref   field-ref
+                             :type        qp.error-type/invalid-query
+                             :joins       joins
+                             :candidates  candidate-tables
+                             :inner-query inner-query}))))))))
 
 (defn- primary-source-table-id
   "Get the ID of the 'primary' table towards which this query is pointing at: either the `:source-table` or indirectly
@@ -95,7 +98,7 @@
 
 (defn- add-join-alias-to-fields-if-needed
   [form]
-  ;; look for any form that has `:joins`, then wrap stuff as needed
+  ;; look for any MBQL inner query, then wrap stuff as needed
   (lib.util.match/replace form
     (m :guard (every-pred map? (mr/validator InnerQuery)))
     (cond-> m

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -623,7 +623,9 @@
          (-> (lib.tu.macros/mbql-query venues
                {:source-table $$venues
                 :joins        [{:alias        "cat"
-                                :source-query {:source-table $$categories}
+                                :source-query {:source-table $$categories
+                                               ;; this will prevent the nesting from getting collapsed
+                                               ::whatever true}
                                 :condition    [:= $category-id &cat.*categories.id]}]
                 :order-by     [[:asc $name]]
                 :limit        3})

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -1437,15 +1437,15 @@
                                      :stages [{:source-table 45050
                                                :fields       [[:field {:base-type :type/BigInteger} 45500]
                                                               [:field {:base-type :type/Text} 45507]]}]}]}]}
-          (lib.convert/->pMBQL '{:database 45001
-                                 :type     :query
-                                 :query    {:source-table 45060
-                                            :joins        [{:strategy     :left-join
-                                                            :alias        "PRODUCTS__via__PRODUCT_ID"
-                                                            :fk-field-id  45607
-                                                            :condition    [:=
-                                                                           [:field 45607 nil]
-                                                                           [:field 45500 {:join-alias "PRODUCTS__via__PRODUCT_ID"}]]
-                                                            :source-query {:source-table 45050
-                                                                           :fields       [[:field 45500 {:base-type :type/BigInteger}]
-                                                                                          [:field 45507 {:base-type :type/Text}]]}}]}}))))
+          (lib.convert/->pMBQL {:database 45001
+                                :type     :query
+                                :query    {:source-table 45060
+                                           :joins        [{:strategy     :left-join
+                                                           :alias        "PRODUCTS__via__PRODUCT_ID"
+                                                           :fk-field-id  45607
+                                                           :condition    [:=
+                                                                          [:field 45607 nil]
+                                                                          [:field 45500 {:join-alias "PRODUCTS__via__PRODUCT_ID"}]]
+                                                           :source-query {:source-table 45050
+                                                                          :fields       [[:field 45500 {:base-type :type/BigInteger}]
+                                                                                         [:field 45507 {:base-type :type/Text}]]}}]}}))))

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -1276,37 +1276,36 @@
               (lib/->legacy-MBQL query))))))
 
 (deftest ^:parallel convert-join-with-fields-test
-  (testing ":fields is allowed in a join top-level, we don't need to wrap it in :source-query"
-    (let [query {:lib/type :mbql/query
-                 :stages   [{:lib/type     :mbql.stage/mbql
-                             :joins        [{:alias      "c"
-                                             :conditions [[:=
-                                                           {:lib/uuid "4822482b-727b-471b-8d18-973d87861522"}
-                                                           [:field
-                                                            {:lib/uuid  "c68f5bbf-a45a-4a28-b235-a60dcb2d73be"
-                                                             :base-type :type/Integer}
-                                                            33402]
-                                                           [:field
-                                                            {:join-alias "c"
-                                                             :lib/uuid   "d0f55447-6941-4c7a-a192-a37d87ea0111"
-                                                             :base-type  :type/BigInteger}
-                                                            33100]]]
-                                             :lib/type   :mbql/join
-                                             :stages     [{:lib/type     :mbql.stage/mbql
-                                                           :source-table 33010
-                                                           :fields       [[:field {:lib/uuid "7d4cb0c9-f7ec-4712-8fe7-4d06e9a3944a"} 33101]]}]}]
-                             :source-table 33040}]
-                 :database 33001}]
-      (is (=? {:database 33001
-               :type     :query
-               :query    {:joins        [{:alias        "c"
-                                          :condition    [:=
-                                                         [:field 33402 {:base-type :type/Integer}]
-                                                         [:field 33100 {:join-alias "c", :base-type :type/BigInteger}]]
-                                          :source-table 33010
-                                          :fields       [[:field 33101 nil]]}]
-                          :source-table 33040}}
-              (lib/->legacy-MBQL query))))))
+  (let [query {:lib/type :mbql/query
+               :stages   [{:lib/type     :mbql.stage/mbql
+                           :joins        [{:alias      "c"
+                                           :conditions [[:=
+                                                         {:lib/uuid "4822482b-727b-471b-8d18-973d87861522"}
+                                                         [:field
+                                                          {:lib/uuid  "c68f5bbf-a45a-4a28-b235-a60dcb2d73be"
+                                                           :base-type :type/Integer}
+                                                          33402]
+                                                         [:field
+                                                          {:join-alias "c"
+                                                           :lib/uuid   "d0f55447-6941-4c7a-a192-a37d87ea0111"
+                                                           :base-type  :type/BigInteger}
+                                                          33100]]]
+                                           :lib/type   :mbql/join
+                                           :stages     [{:lib/type     :mbql.stage/mbql
+                                                         :source-table 33010
+                                                         :fields       [[:field {:lib/uuid "7d4cb0c9-f7ec-4712-8fe7-4d06e9a3944a"} 33101]]}]}]
+                           :source-table 33040}]
+               :database 33001}]
+    (is (=? {:database 33001
+             :type     :query
+             :query    {:joins        [{:alias        "c"
+                                        :condition    [:=
+                                                       [:field 33402 {:base-type :type/Integer}]
+                                                       [:field 33100 {:join-alias "c", :base-type :type/BigInteger}]]
+                                        :source-query {:source-table 33010
+                                                       :fields       [[:field 33101 nil]]}}]
+                        :source-table 33040}}
+            (lib/->legacy-MBQL query)))))
 
 (deftest ^:parallel join-native-source-query->legacy-test
   (testing "join :source-query should rename :query to :native for native stages"

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -72,9 +72,13 @@
     (testing  "simple queries"
       (doseq [query [base (lib/append-stage base)]
               :let  [cols (lib/visible-columns query)]]
-        (is (= ["Grandparent: Parent: Child" "Grandparent" "Grandparent: Parent"]
+        (is (= ["Grandparent: Parent: Child"
+                "Grandparent"
+                "Grandparent: Parent"]
                (map #(lib/display-name query %) cols)))
-        (is (= ["Grandparent: Parent: Child" "Grandparent" "Grandparent: Parent"]
+        (is (= ["Grandparent: Parent: Child"
+                "Grandparent"
+                "Grandparent: Parent"]
                (map #(lib/display-name query -1 % :long) cols)))
         (is (=? [{:display-name      "Grandparent: Parent: Child"
                   :long-display-name "Grandparent: Parent: Child"}
@@ -82,7 +86,10 @@
                   :long-display-name "Grandparent"}
                  {:display-name      "Grandparent: Parent"
                   :long-display-name "Grandparent: Parent"}]
-                (map #(lib/display-info query -1 %) cols)))))
+                (map #(lib/display-info query -1 %) cols)))))))
+
+(deftest ^:parallel nested-field-display-name-test-2
+  (let [base (lib/query grandparent-parent-child-metadata-provider (meta/table-metadata :venues))]
     (testing "breakout"
       (is (=? [{:display-name      "Grandparent: Parent: Child"
                 :long-display-name "Grandparent: Parent: Child"}]
@@ -92,7 +99,10 @@
                    (lib/breakout base)
                    lib/append-stage
                    lib/visible-columns
-                   (map #(lib/display-info base -1 %))))))
+                   (map #(lib/display-info base -1 %))))))))
+
+(deftest ^:parallel nested-field-display-name-test-3
+  (let [base (lib/query grandparent-parent-child-metadata-provider (meta/table-metadata :venues))]
     (testing "join"
       (let [join-column (second (lib/visible-columns base))
             base        (-> base

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -1822,3 +1822,62 @@
                  cols
                  {:display-name "18512#2"}
                  {:display-name "Products → Created At: Month"}))))))))
+
+(deftest ^:parallel do-not-incorrectly-propagate-temporal-unit-in-returned-columns-test
+  (testing "temporal unit should not be incorrectly propagated by join-fields-to-add-to-parent-stage in the refs in :fields are not bucketed (QUE-1621)"
+    (doseq [fields [[[:field (meta/id :people :birth-date) {:join-alias "Q2"}]
+                     [:field "count" {:base-type :type/Integer, :join-alias "Q2"}]]
+                    :all]]
+      (testing (str "\nfields =\n" (u/pprint-to-str fields))
+        (let [query (lib/query
+                     meta/metadata-provider
+                     (lib.tu.macros/mbql-query people
+                       {:source-query {:source-table $$people
+                                       :breakout     [!month.created-at]
+                                       :aggregation  [[:count]]}
+                        :joins        [{:source-query {:source-table $$people
+                                                       :breakout     [!month.birth-date]
+                                                       :aggregation  [[:count]]}
+                                        :alias        "Q2"
+                                        :condition    [:= !month.created-at !month.&Q2.birth-date]
+                                        :fields       fields}]}))]
+          ;; these SHOULD NOT include `:metabase.lib.field/temporal-unit`, so don't change this to `=?`.
+          (is (= [{:lib/source-column-alias  "BIRTH_DATE"
+                   ::lib.join/join-alias     "Q2"
+                   :lib/desired-column-alias "Q2__BIRTH_DATE"
+                   :lib/original-name        "BIRTH_DATE"
+                   :inherited-temporal-unit  :month}
+                  {:lib/source-column-alias  "count"
+                   ::lib.join/join-alias     "Q2"
+                   :lib/desired-column-alias "Q2__count"
+                   :lib/original-name        "count"}]
+                 (map #(select-keys % [:lib/source-column-alias
+                                       ::lib.join/join-alias
+                                       :lib/desired-column-alias
+                                       :lib/original-name
+                                       :metabase.lib.field/temporal-unit
+                                       :inherited-temporal-unit])
+                      (lib.join/join-fields-to-add-to-parent-stage query -1 (first (lib/joins query -1)) {})))))))))
+
+(deftest ^:parallel do-not-incorrectly-propagate-temporal-unit-in-returned-columns-test-2
+  (testing "DO propagate temporal unit if it is included in join :fields"
+    (let [query (lib/query
+                 meta/metadata-provider
+
+                 (lib.tu.macros/mbql-query people
+                   {:source-query {:source-table $$people
+                                   :breakout     [!month.created-at]
+                                   :aggregation  [[:count]]}
+                    :joins        [{:source-query {:source-table $$people
+                                                   :breakout     [!year.birth-date]
+                                                   :aggregation  [[:count]]}
+                                    :alias        "Q2"
+                                    :condition    [:= !month.created-at !month.&Q2.birth-date]
+                                    :fields       [[:field (meta/id :people :birth-date) {:join-alias "Q2", :temporal-unit :month}]
+                                                   [:field "count" {:base-type :type/Integer, :join-alias "Q2"}]]}]}))]
+      (is (= [{:lib/desired-column-alias         "Q2__BIRTH_DATE"
+               :metabase.lib.field/temporal-unit :month
+               :inherited-temporal-unit          :year}
+              {:lib/desired-column-alias "Q2__count"}]
+             (map #(select-keys % [:lib/desired-column-alias :metabase.lib.field/temporal-unit :inherited-temporal-unit])
+                  (lib.join/join-fields-to-add-to-parent-stage query -1 (first (lib/joins query -1)) {})))))))

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -831,7 +831,7 @@
                 "Another call should result in ZERO additional cache misses -- we should be returning the cached value")))))))
 
 (deftest ^:parallel returned-columns-no-duplicates-test
-  (testing "QUE-1607"
+  (testing "Don't return columns from a join twice (QUE-1607)"
     (let [mp    meta/metadata-provider
           query (lib/query
                  mp
@@ -843,8 +843,7 @@
                                 :condition    [:= $id &Orders.orders.product-id]
                                 :fields       [[:field "sum" {:join-alias "Orders", :base-type :type/Integer}]]}]
                     :fields   [$title $category]
-                    :order-by [[:asc $id]]
-                    :limit    3}))
+                    :order-by [[:asc $id]]}))
           cols  (lib/returned-columns query -1)]
       (is (= ["TITLE"
               "CATEGORY"
@@ -854,13 +853,66 @@
                [:field {} (meta/id :products :category)]
                [:field {:join-alias "Orders"} "sum"]]
               (mapv lib/ref cols)))
-      (let [query' (assoc-in query [:stages 0 :fields] (mapv lib/ref cols))
-            cols'  (lib/returned-columns query' -1)]
-        (is (= ["TITLE"
-                "CATEGORY"
-                "Orders__sum"]
-               (mapv :lib/desired-column-alias cols')))
-        (is (=? [[:field {} (meta/id :products :title)]
-                 [:field {} (meta/id :products :category)]
-                 [:field {:join-alias "Orders"} "sum"]]
-                (mapv lib/ref cols')))))))
+      (testing "update stage :fields to include the columns from the join already"
+        (let [query' (assoc-in query [:stages 0 :fields] (mapv lib/ref cols))
+              cols'  (lib/returned-columns query' -1)]
+          (is (= ["TITLE"
+                  "CATEGORY"
+                  "Orders__sum"]
+                 (mapv :lib/desired-column-alias cols')))
+          (is (=? [[:field {} (meta/id :products :title)]
+                   [:field {} (meta/id :products :category)]
+                   [:field {:join-alias "Orders"} "sum"]]
+                  (mapv lib/ref cols'))))))))
+
+(deftest ^:parallel do-not-incorrectly-propagate-temporal-unit-in-returned-columns-test
+  (testing "temporal unit should not be incorrectly propagated in returned-columns past the stage where the bucketing was done"
+    (let [query (lib/query
+                 meta/metadata-provider
+
+                 (lib.tu.macros/mbql-query people
+                   {:source-query {:source-table $$people
+                                   :breakout     [!month.created-at]
+                                   :aggregation  [[:count]]}
+                    :joins        [{:source-query {:source-table $$people
+                                                   :breakout     [!month.birth-date]
+                                                   :aggregation  [[:count]]}
+                                    :alias        "Q2"
+                                    :condition    [:= !month.created-at !month.&Q2.birth-date]
+                                    :fields       [[:field (meta/id :people :birth-date) {:join-alias "Q2"}]
+                                                   [:field "count" {:base-type :type/Integer, :join-alias "Q2"}]]}]}))]
+      (is (= [{:lib/desired-column-alias "CREATED_AT"
+               :inherited-temporal-unit  :month}
+              {:lib/desired-column-alias "count"}
+              {:lib/desired-column-alias "Q2__BIRTH_DATE"
+               :inherited-temporal-unit  :month}
+              {:lib/desired-column-alias "Q2__count"}]
+             (map #(select-keys % [:lib/desired-column-alias :metabase.lib.field/temporal-unit :inherited-temporal-unit])
+                  (lib/returned-columns query)))))))
+
+(deftest ^:parallel returned-columns-no-duplicates-test-2
+  (testing "Don't return columns from a join twice (QUE-1607)"
+    (let [query (lib/query
+                 meta/metadata-provider
+                 (lib.tu.macros/mbql-query people
+                   {:source-query {:source-table $$people
+                                   :breakout     [!month.created-at]
+                                   :aggregation  [[:count]]}
+                    :joins        [{:source-query {:source-table $$people
+                                                   :breakout     [!month.birth-date]
+                                                   :aggregation  [[:count]]}
+                                    :alias        "Q2"
+                                    :condition    [:= !month.created-at !month.&Q2.birth-date]
+                                    :fields       [[:field (meta/id :people :birth-date) {:join-alias "Q2"}]
+                                                   [:field "count" {:base-type :type/Integer, :join-alias "Q2"}]]}]
+                    :fields       [[:field (meta/id :people :created-at) {:inherited-temporal-unit :month}]
+                                   [:field "count" {:base-type :type/Integer}]
+                                   [:field (meta/id :people :birth-date) {:join-alias "Q2"}]
+                                   [:field "count" {:base-type :type/Integer, :join-alias "Q2"}]]
+                    :order-by     [[:asc !month.created-at]]}))
+          cols (lib/returned-columns query)]
+      (is (= ["CREATED_AT"
+              "count"
+              "Q2__BIRTH_DATE"
+              "Q2__count"]
+             (mapv :lib/desired-column-alias cols))))))

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -8,6 +8,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.stage :as lib.stage]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
@@ -834,7 +835,7 @@
 
 (deftest ^:parallel test-QUE-1607
   (testing "QUE-1607"
-    (is (#'metabase.lib.stage/add-cols-from-join-duplicate?
+    (is (#'lib.stage/add-cols-from-join-duplicate?
          {:base-type                    :type/Integer
           :display-name                 "Sum of Quantity"
           :effective-type               :type/Integer

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -831,3 +831,31 @@
                 :lib/desired-column-alias "count"
                 :display-name             "Count"}]
               (lib/returned-columns query))))))
+
+(deftest ^:parallel test-QUE-1607
+  (testing "QUE-1607"
+    (is (#'metabase.lib.stage/add-cols-from-join-duplicate?
+         {:base-type                    :type/Integer
+          :display-name                 "Sum of Quantity"
+          :effective-type               :type/Integer
+          :lib/deduplicated-name        "sum"
+          :lib/desired-column-alias     "Orders__sum"
+          :lib/original-join-alias      "Orders"
+          :lib/original-name            "sum"
+          :lib/source                   :source/joins
+          :lib/source-column-alias      "sum"
+          :lib/source-uuid              "4d059464-4190-40ae-bc4e-717ff016e157"
+          :lib/type                     :metadata/column
+          :metabase.lib.join/join-alias "Orders"
+          :name                         "sum"
+          :semantic-type                :type/Quantity
+          :source-alias                 "Orders"}
+         {:base-type                    :type/Integer
+          :display-name                 "Sum"
+          :effective-type               :type/Integer
+          :lib/original-join-alias      "Orders"
+          :lib/source                   :source/joins
+          :lib/source-uuid              "91b22976-279d-4052-b269-e4cd83a6683b"
+          :lib/type                     :metadata/column
+          :metabase.lib.join/join-alias "Orders"
+          :name                         "sum"}))))

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -462,3 +462,22 @@
            (lib.util/find-stage-index-and-clause-by-uuid query "a1898aa6-4928-4e97-837d-e440ce21085e")))
     (is (nil? (lib.util/find-stage-index-and-clause-by-uuid query "00000000-0000-0000-0000-000000000002")))
     (is (nil? (lib.util/find-stage-index-and-clause-by-uuid query 0 "a1898aa6-4928-4e97-837d-e440ce21085e")))))
+
+(deftest ^:parallel do-not-add-extra-stages-to-join-test
+  (is (=? {:stages [{:source-table 45060
+                     :joins        [{:alias  "PRODUCTS__via__PRODUCT_ID"
+                                     :stages [{:source-table 45050
+                                               :fields       [[:field 45500 {:base-type :type/BigInteger}]
+                                                              [:field 45507 {:base-type :type/Text}]]}]}]}]}
+          (lib.util/pipeline '{:database 45001
+                               :type     :query
+                               :query    {:source-table 45060
+                                          :joins        [{:strategy     :left-join
+                                                          :alias        "PRODUCTS__via__PRODUCT_ID"
+                                                          :fk-field-id  45607
+                                                          :condition    [:=
+                                                                         [:field 45607 nil]
+                                                                         [:field 45500 {:join-alias "PRODUCTS__via__PRODUCT_ID"}]]
+                                                          :source-query {:source-table 45050
+                                                                         :fields       [[:field 45500 {:base-type :type/BigInteger}]
+                                                                                        [:field 45507 {:base-type :type/Text}]]}}]}}))))

--- a/test/metabase/lib_be/metadata/jvm_test.clj
+++ b/test/metabase/lib_be/metadata/jvm_test.clj
@@ -44,50 +44,50 @@
             (lib.metadata.calculation/returned-columns query)))))
 
 (deftest ^:parallel join-with-aggregation-reference-in-fields-metadata-test
-  (mt/dataset test-data
-    (let [query      (mt/mbql-query products
-                       {:joins  [{:source-query {:source-table $$orders
-                                                 :breakout     [$orders.product_id]
-                                                 :aggregation  [[:sum $orders.quantity]]}
-                                  :alias        "Orders"
-                                  :condition    [:= $id &Orders.orders.product_id]
-                                  :fields       [&Orders.orders.product_id
-                                                 &Orders.*sum/Integer]}]
-                        :fields [$id]})
-          mlv2-query (lib/query (lib.metadata.jvm/application-database-metadata-provider (mt/id))
-                                (lib.convert/->pMBQL query))]
-      (is (=? [{:base-type                :type/BigInteger
-                :semantic-type            :type/PK
-                :table-id                 (mt/id :products)
-                :name                     "ID"
-                :lib/source               :source/table-defaults
-                :lib/source-column-alias  "ID"
-                :effective-type           :type/BigInteger
-                :id                       (mt/id :products :id)
-                :lib/desired-column-alias "ID"
-                :display-name             "ID"}
-               {:metabase.lib.join/join-alias "Orders"
-                :base-type                    :type/Integer
-                :semantic-type                :type/FK
-                :table-id                     (mt/id :orders)
-                :name                         "PRODUCT_ID"
-                :lib/source                   :source/joins
-                :lib/source-column-alias      "PRODUCT_ID"
-                :effective-type               :type/Integer
-                :id                           (mt/id :orders :product_id)
-                :lib/desired-column-alias     "Orders__PRODUCT_ID"
-                :display-name                 "Product ID"
-                :source-alias                 "Orders"}
-               {:metabase.lib.join/join-alias "Orders"
-                :lib/type                     :metadata/column
-                :base-type                    :type/Integer
-                :name                         "sum"
-                :lib/source                   :source/joins
-                :lib/source-column-alias      "sum"
-                :effective-type               :type/Integer
-                :lib/desired-column-alias     "Orders__sum"
-                :display-name                 "Orders → Sum of Quantity" #_"Sum of Quantity"
-                :source-alias                 "Orders"}]
+  (let [query      (mt/mbql-query products
+                     {:joins  [{:source-query {:source-table $$orders
+                                               :breakout     [$orders.product_id]
+                                               :aggregation  [[:sum $orders.quantity]]}
+                                :alias        "Orders"
+                                :condition    [:= $id &Orders.orders.product_id]
+                                :fields       [&Orders.orders.product_id
+                                               &Orders.*sum/Integer]}]
+                      :fields [$id]})
+        mlv2-query (lib/query (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+                              (lib.convert/->pMBQL query))]
+    (is (=? [{:base-type                :type/BigInteger
+              :semantic-type            :type/PK
+              :table-id                 (mt/id :products)
+              :name                     "ID"
+              :lib/source               :source/table-defaults
+              :lib/source-column-alias  "ID"
+              :effective-type           :type/BigInteger
+              :id                       (mt/id :products :id)
+              :lib/desired-column-alias "ID"
+              :display-name             "ID"}
+             {:metabase.lib.join/join-alias "Orders"
+              :base-type                    :type/Integer
+              :semantic-type                :type/FK
+              :table-id                     (mt/id :orders)
+              :name                         "PRODUCT_ID"
+              :lib/source                   :source/joins
+              :lib/source-column-alias      "PRODUCT_ID"
+              :effective-type               :type/Integer
+              :id                           (mt/id :orders :product_id)
+              :lib/desired-column-alias     "Orders__PRODUCT_ID"
+              :display-name                 "Orders → Product ID"
+              :source-alias                 "Orders"}
+             {:metabase.lib.join/join-alias "Orders"
+              :lib/type                     :metadata/column
+              :base-type                    :type/Integer
+              :name                         "sum"
+              :lib/source                   :source/joins
+              :lib/source-column-alias      "sum"
+              :effective-type               :type/Integer
+              :lib/desired-column-alias     "Orders__sum"
+              :display-name                 "Orders → Sum of Quantity"
+              :source-alias                 "Orders"}]
+            (binding [lib.metadata.calculation/*display-name-style* :long]
               (lib.metadata.calculation/returned-columns mlv2-query))))))
 
 (deftest ^:synchronized with-temp-source-question-metadata-test

--- a/test/metabase/query_processor/middleware/resolve_joined_fields_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_joined_fields_test.clj
@@ -2,8 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.middleware.resolve-joined-fields
-    :as resolve-joined-fields]
+   [metabase.query-processor.middleware.resolve-joined-fields :as resolve-joined-fields]
    [metabase.test :as mt]
    [metabase.util :as u]))
 

--- a/test/metabase/query_processor_test/model_test.clj
+++ b/test/metabase/query_processor_test/model_test.clj
@@ -76,8 +76,8 @@
               "Average of Rating"
               ;; the 'correct' display name here seems to change any time we touch anything. Some previous values:
               #_"Products+Reviews Summary - Reviews → Created At: Month → Reviews → Created At: Month"
-              #_"Products+Reviews Summary - Reviews → Created At: Month → Created At: Month"
-              "Products+Reviews Summary - Reviews → Created At: Month → Created At"
+              #_"Products+Reviews Summary - Reviews → Created At: Month → Created At"
+              "Products+Reviews Summary - Reviews → Created At: Month → Created At: Month"
               "Products+Reviews Summary - Reviews → Created At: Month → Sum of Price"]
              (->> (qp/process-query question)
                   mt/cols


### PR DESCRIPTION
When converting a legacy join that has `:source-query` to MBQL 5 we were incorrectly adding an additional blank stage; fix this

Fixes QUE-1607
Fixes QUE-1608
Fixes QUE-1621
Fixes QUE-1623
Fixes QUE-1625

This should improve performance in field resolution as well -- it might fix #61281 or might not