### PR TITLE
Ensure that semantic search entrypoints are safe to call without init!

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.log :as log]
    [next.jdbc :as jdbc]))
 
 (defn- get-pgvector-datasource! []
@@ -17,6 +18,9 @@
 
 (defn- get-index-metadata []
   semantic.index-metadata/default-index-metadata)
+
+(defn- index-active? [pgvector index-metadata]
+  (boolean (semantic.index-metadata/get-active-index-state pgvector index-metadata)))
 
 (defenterprise supported?
   "Enterprise implementation of semantic search engine support check."
@@ -40,23 +44,27 @@
   :feature :semantic-search
   [document-reducible]
   (let [pgvector (get-pgvector-datasource!)
-        index-metadata (get-index-metadata)
-        embedding-model (get-configured-embedding-model)]
-    (jdbc/with-transaction [tx pgvector]
-      (semantic.pgvector-api/init-semantic-search! tx index-metadata embedding-model))
-    (semantic.pgvector-api/index-documents! pgvector index-metadata (vec document-reducible))))
+        index-metadata (get-index-metadata)]
+    (if-not (index-active? pgvector index-metadata)
+      (log/warn "update-index! called prior to init!")
+      (semantic.pgvector-api/index-documents!
+       pgvector
+       index-metadata
+       (vec document-reducible)))))
 
 (defenterprise delete-from-index!
   "Enterprise implementation of semantic index deletion."
   :feature :semantic-search
   [model ids]
-  ;; If data-source has not been initialized, then presumably the index doesn't exist yet.
-  (when @semantic.db/data-source
-    (semantic.pgvector-api/delete-documents!
-     (get-pgvector-datasource!)
-     (get-index-metadata)
-     model
-     (vec ids))))
+  (let [pgvector (get-pgvector-datasource!)
+        index-metadata (get-index-metadata)]
+    (if-not (index-active? pgvector index-metadata)
+      (log/warn "delete-from-index! called prior to init!")
+      (semantic.pgvector-api/delete-documents!
+       pgvector
+       index-metadata
+       model
+       (vec ids)))))
 
 ;; TODO: add reindexing/table-swapping logic when index is detected as stale
 (defenterprise init!

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/without_init_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/without_init_test.clj
@@ -1,0 +1,42 @@
+(ns metabase-enterprise.semantic-search.without-init-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.core :as semantic]
+   [metabase-enterprise.semantic-search.db :as semantic.db]
+   [metabase-enterprise.semantic-search.index :as semantic.index]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.test :as mt]))
+
+;; When booting a new install from a fresh app db, we can wind up getting calls into the search backend from things
+;; like loading the sample or audit db content before search has been initialized, and therefore before receiving an
+;; init! call. These tests ensure that we can handle such calls and don't throw if it does happen.
+
+(defn- without-init! [test-func]
+  (mt/with-premium-features #{:semantic-search}
+    (try
+      (with-redefs [semantic.db/data-source (atom nil)
+                    semantic/get-index-metadata (constantly semantic.tu/mock-index-metadata)
+                    semantic/get-configured-embedding-model (constantly semantic.tu/mock-embedding-model)]
+        (test-func))
+      (finally
+        (semantic.index/drop-index-table! semantic.tu/db semantic.tu/mock-index)))))
+
+(deftest reindex!-without-init!-test
+  (without-init!
+   #(testing "reindex! works without init!"
+      (is (= {"card" 1, "dashboard" 1}
+             (semantic/reindex! (semantic.tu/mock-documents) {})))
+      (semantic.tu/check-index-has-mock-docs))))
+
+(deftest update-index!-without-init!-test
+  (without-init!
+   #(testing "update-index! works without init!"
+      (is (= {"card" 1, "dashboard" 1}
+             (semantic/update-index! (semantic.tu/mock-documents))))
+      (semantic.tu/check-index-has-mock-docs))))
+
+(deftest delete-from-index!-without-init!-test
+  (without-init!
+   #(testing "delete-from-index! is a no-op without init!"
+      (is (nil? (semantic/delete-from-index! "card" ["123"])))
+      (is (not (semantic.tu/table-exists-in-db? (:table-name semantic.tu/mock-index)))))))


### PR DESCRIPTION
Closes BOT-265

### Description

When booting a new install from a fresh app db, we can wind up getting calls into the search backend from things like loading the sample or audit db content before search has been initialized, and therefore before receiving an `init!` call. The same is true for the appdb backend, but the appdb backend is resilient to such calls and either ensures the index is created when needed (e.g. in `reindex!`) or treats the call as a no-op if no index has been created (e.g. `delete!`).

Ideally calls into search would not happen until after init, and we should probably fix this bug, but it seems sensible to ensure we don't throw in the semantic search backend if it does happen.

* Ensure that semantic search entrypoints are safe to call without `init!`
* Move more helpers into `semantic.test-util namespace`
* Add tests for calling semantic search entrypoints prior to calling `init!`

### How to verify

Wipe your appdb and restart metabase. Prior to these changes, you will see a handful of errors like so followed by a stacktrace. These come from search attempting to update the index when loading the sample db and/or audit db content. After these changes, no errors should appear.

```
2025-07-25 00:40:07,037 ERROR semantic.core :: Error updating semantic search index 
org.postgresql.util.PSQLException: ERROR: relation "index_table__ollama__mxbai-embed-large__1024" does not exist
```
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
