### PR TITLE
SEM-527 Table picker item text overflows

### DIFF
--- a/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/Results.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/Results.tsx
@@ -14,7 +14,7 @@ import type { FlatItem, TreePath } from "./types";
 import { TYPE_ICONS, hasChildren } from "./utils";
 
 const VIRTUAL_OVERSCAN = 5;
-const ITEM_HEIGHT = 32;
+const ITEM_MIN_HEIGHT = 32;
 const INDENT_OFFSET = 18;
 
 interface Props {
@@ -45,7 +45,7 @@ export function Results({
     count: items.length,
     getScrollElement: () => ref.current,
     overscan: VIRTUAL_OVERSCAN,
-    estimateSize: () => ITEM_HEIGHT,
+    estimateSize: () => ITEM_MIN_HEIGHT,
   });
 
   const virtualItems = virtual.getVirtualItems();
@@ -65,6 +65,18 @@ export function Results({
       virtual.scrollToIndex(index);
     },
     [path.tableId, items, virtual],
+  );
+
+  useEffect(
+    function measureItemsWhenTheyChange() {
+      const { startIndex = 0, endIndex = 0 } = virtual.range ?? {};
+      for (let idx = startIndex; idx <= endIndex; idx++) {
+        virtual.measureElement(
+          ref.current?.querySelector(`[data-index='${idx}']`),
+        );
+      }
+    },
+    [items, virtual],
   );
 
   useEffect(() => {
@@ -211,7 +223,7 @@ export function Results({
               }}
               onFocus={() => onSelectedIndexChange?.(index)}
             >
-              <Flex align="center" mih={ITEM_HEIGHT} py="xs" w="100%">
+              <Flex align="center" mih={ITEM_MIN_HEIGHT} py="xs" w="100%">
                 <Flex align="flex-start" gap="xs" w="100%">
                   <Flex align="center" gap="xs">
                     {hasChildren(type) && (

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/Results.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/Results.tsx
@@ -14,7 +14,7 @@ import type { FlatItem, TreePath } from "./types";
 import { TYPE_ICONS, hasChildren } from "./utils";
 
 const VIRTUAL_OVERSCAN = 5;
-const ITEM_MIN_HEIGHT = 32;
+const ITEM_MIN_HEIGHT = 32; // items can vary in size because of text wrapping
 const INDENT_OFFSET = 18;
 
 interface Props {


### PR DESCRIPTION
Closes [SEM-527](https://linear.app/metabase/issue/SEM-527/table-picker-item-text-overflows)

### Description

Brings back the `useEffect` blindly removed in #61272.


### How to verify

1. Admin > Table metadata
2. Open a table
3. Rename it to have a very long name

Table name should wrap nicely in the table picker (1st column) and its container should be tall enough to accommodate the text.

### Demo

[before](https://github.com/user-attachments/assets/cce0e929-d863-4af9-b03f-a214075f5c29) vs [after](https://github.com/user-attachments/assets/3d8df3cf-0abe-43dc-a69f-876454eb5afe)
