### PR TITLE
Change `InteractiveQuestion` stories to `SdkQuestion`

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Breakout/Breakout.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Breakout/Breakout.stories.tsx
@@ -7,7 +7,7 @@ import { Breakout } from "./Breakout";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/Breakout/Breakout",
+  title: "EmbeddingSDK/SdkQuestion/Breakout/Breakout",
   component: Breakout,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Breakout/BreakoutDropdown/BreakoutDropdown.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Breakout/BreakoutDropdown/BreakoutDropdown.stories.tsx
@@ -7,7 +7,7 @@ import { BreakoutDropdown } from "./BreakoutDropdown";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/Breakout/BreakoutDropdown",
+  title: "EmbeddingSDK/SdkQuestion/Breakout/BreakoutDropdown",
   component: BreakoutDropdown,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.stories.tsx
@@ -7,7 +7,7 @@ import { BreakoutPicker } from ".";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/Breakout/BreakoutPicker",
+  title: "EmbeddingSDK/SdkQuestion/Breakout/BreakoutPicker",
   component: BreakoutPicker,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/ChartTypeSelectorList/ChartTypeDropdown.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/ChartTypeSelectorList/ChartTypeDropdown.stories.tsx
@@ -7,7 +7,7 @@ import { ChartTypeDropdown } from "./ChartTypeDropdown";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/ChartTypeSelectorsList",
+  title: "EmbeddingSDK/SdkQuestion/ChartTypeSelectorsList",
   component: ChartTypeDropdown,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/DownloadWidget/DownloadWidget.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/DownloadWidget/DownloadWidget.stories.tsx
@@ -7,7 +7,7 @@ import { DownloadWidget, type DownloadWidgetProps } from "./DownloadWidget";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/DownloadWidget",
+  title: "EmbeddingSDK/SdkQuestion/DownloadWidget",
   component: DownloadWidget,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/EditorButton/EditorButton.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/EditorButton/EditorButton.stories.tsx
@@ -10,7 +10,7 @@ import {
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/EditorButton",
+  title: "EmbeddingSDK/SdkQuestion/EditorButton",
   component: EditorButton,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Filter/Filter.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Filter/Filter.stories.tsx
@@ -7,7 +7,7 @@ import { Filter } from "./Filter";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/Filter/Filter",
+  title: "EmbeddingSDK/SdkQuestion/Filter/Filter",
   component: Filter,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Filter/FilterDropdown/FilterDropdown.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Filter/FilterDropdown/FilterDropdown.stories.tsx
@@ -7,7 +7,7 @@ import { FilterDropdown } from "./FilterDropdown";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/Filter/FilterDropdown",
+  title: "EmbeddingSDK/SdkQuestion/Filter/FilterDropdown",
   component: FilterDropdown,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/QuestionSettings/QuestionSettings.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/QuestionSettings/QuestionSettings.stories.tsx
@@ -7,7 +7,7 @@ import { QuestionSettings } from "./QuestionSettings";
 const QUESTION_ID = (window as any).QUESTION_ID || 11;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/QuestionSettings",
+  title: "EmbeddingSDK/SdkQuestion/QuestionSettings",
   component: QuestionSettings,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/QuestionSettings/QuestionSettingsDropdown/QuestionSettingsDropdown.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/QuestionSettings/QuestionSettingsDropdown/QuestionSettingsDropdown.stories.tsx
@@ -7,7 +7,7 @@ import { QuestionSettingsDropdown } from "./QuestionSettingsDropdown";
 const QUESTION_ID = (window as any).QUESTION_ID || 11;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/QuestionSettingsDropdown",
+  title: "EmbeddingSDK/SdkQuestion/QuestionSettingsDropdown",
   component: QuestionSettingsDropdown,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/SdkSaveQuestionForm.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/SdkSaveQuestionForm.stories.tsx
@@ -11,7 +11,7 @@ import { Box, Button, Modal, Stack } from "metabase/ui";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/SaveQuestionForm",
+  title: "EmbeddingSDK/SdkQuestion/SaveQuestionForm",
   component: SdkQuestion,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Summarize/Summarize.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Summarize/Summarize.stories.tsx
@@ -7,7 +7,7 @@ import { Summarize } from "./Summarize";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/Summarize/Summarize",
+  title: "EmbeddingSDK/SdkQuestion/Summarize/Summarize",
   component: Summarize,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Summarize/SummarizeDropdown/SummarizeDropdown.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Summarize/SummarizeDropdown/SummarizeDropdown.stories.tsx
@@ -7,7 +7,7 @@ import { SummarizeDropdown } from "./SummarizeDropdown";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/Summarize/SummarizeDropdown",
+  title: "EmbeddingSDK/SdkQuestion/Summarize/SummarizeDropdown",
   component: SummarizeDropdown,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.stories.tsx
@@ -7,7 +7,7 @@ import { SummarizePicker } from "../SummarizePicker";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/Summarize/SummarizePicker",
+  title: "EmbeddingSDK/SdkQuestion/Summarize/SummarizePicker",
   component: SummarizePicker,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/VisualizationButton/VisualizationButton.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkQuestion/components/VisualizationButton/VisualizationButton.stories.tsx
@@ -11,7 +11,7 @@ import { VisualizationButton } from "./VisualizationButton";
 const QUESTION_ID = (window as any).QUESTION_ID || 12;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/VisualizationButton",
+  title: "EmbeddingSDK/SdkQuestion/VisualizationButton",
   component: VisualizationButton,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/private/util/MultiStepPopover/MultiStepPopover.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/util/MultiStepPopover/MultiStepPopover.stories.tsx
@@ -6,7 +6,7 @@ import { Button, Group, Paper, Stack } from "metabase/ui";
 import { MultiStepPopover } from "./MultiStepPopover";
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/MultiStepPopover",
+  title: "EmbeddingSDK/SdkQuestion/MultiStepPopover",
   component: MultiStepPopover,
   parameters: {
     layout: "fullscreen",

--- a/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion-themed.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion-themed.stories.tsx
@@ -15,7 +15,7 @@ import { SdkQuestion } from "./SdkQuestion";
 const QUESTION_ID = (window as any).QUESTION_ID || questionIds.numberId;
 
 export default {
-  title: "EmbeddingSDK/InteractiveQuestion/Themed",
+  title: "EmbeddingSDK/SdkQuestion/Themed",
   component: SdkQuestion,
   parameters: {
     layout: "fullscreen",


### PR DESCRIPTION
This pull request updates the storybook titles for various components in the `enterprise/frontend/src/embedding-sdk` directory to reflect a new naming convention. The changes replace "InteractiveQuestion" with "SdkQuestion" in the `title` field of each story's metadata.

### Updates to Storybook Titles:
* Changed the `title` for components under the `Breakout` group, including `Breakout`, `BreakoutDropdown`, and `BreakoutPicker`, to use "SdkQuestion" instead of "InteractiveQuestion." [[1]](diffhunk://#diff-e4fa511bdc5b32cad75a22624678ef32486e3b5a479282469ad7b1e73477df5aL10-R10) [[2]](diffhunk://#diff-8cab9f568c4e4e1aff9beb44dcacd8d07e9ea04eeab2bdc5b8d60f035b33855aL10-R10) [[3]](diffhunk://#diff-687428216040b54c74654a778882091fe320596aa4757bcf6822480d40cce952L10-R10)
* Updated the `title` for components under the `Filter` group, such as `Filter` and `FilterDropdown`, to align with the new naming convention. [[1]](diffhunk://#diff-f2f7004450df400a197053fb1fbec352b817611425845ae5627d40a25c1ae683L10-R10) [[2]](diffhunk://#diff-964271b04854185e3016f7922e7abf6dad36a09d651e2aa0d8fab2cafd381970L10-R10)
* Renamed the `title` for components in the `Summarize` group, including `Summarize`, `SummarizeDropdown`, and `SummarizePicker`, to use "SdkQuestion." [[1]](diffhunk://#diff-380c5ff179a215e664bd7c07f2bbfa79d4c0020eb2ffc3f011c5ee10423236a0L10-R10) [[2]](diffhunk://#diff-4c626366197d803754a90f42665715ad44b760753436b7b985f8a5b7b248e26eL10-R10) [[3]](diffhunk://#diff-c0c2199adb3d14ae6b1cb84770a592470690c5d3de0221292530fd10b1d6c8e7L10-R10)
* Applied the same renaming pattern to other components like `ChartTypeSelectorsList`, `DownloadWidget`, `EditorButton`, `QuestionSettings`, `QuestionSettingsDropdown`, `SaveQuestionForm`, `VisualizationButton`, `MultiStepPopover`, and `Themed`. [[1]](diffhunk://#diff-a9efb6f528221d8c9e8ca7b4b5b1e8beb093297a3b16924bc2159011fc7b32e3L10-R10) [[2]](diffhunk://#diff-682fe276fe3585f4d352eeb4757b34b7252c2aeef35c9127faf93703ddb6402cL10-R10) [[3]](diffhunk://#diff-0a121361c2c4655f193e87a687ce7363417ec531900d05bf566721ac17ce3221L13-R13) [[4]](diffhunk://#diff-10dac69c3dcf8e5f39cea6336756af3cab1f1fbab4e991a2f5c1fad7d830c654L10-R10) [[5]](diffhunk://#diff-db34a747194f17f2e36280edda22c186ee71937b73cb672f707e32dcc992b328L10-R10) [[6]](diffhunk://#diff-0f63165814fc30054c490326276402d78cf6bedaadb8b3b78216bfbf9cc639b9L14-R14) [[7]](diffhunk://#diff-45f4b0711d18aae112cc63d713ae87ebc98b29ef8c581edbe09d18f3392f26edL14-R14) [[8]](diffhunk://#diff-6e61762f67fc0ef22c3423917e194033fccf75f0caaa42a375b72389e7f58a6cL9-R9) [[9]](diffhunk://#diff-1428a75c8faa51b7f338d588cc52ee9cebbaafc4255d081a0d97734e00354a58L18-R18)