### PR TITLE
run known fixtures ahead of running tests

### DIFF
--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -123,7 +123,7 @@
   (classloader/require 'metabase.test.initialize.row-lock)
   ((resolve 'metabase.test.initialize.row-lock/init!)))
 
-(defn- all-components
+(defn all-components
   "Set of all components/initialization steps that are defined."
   []
   (set (keys (methods do-initialization!))))

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -17,6 +17,7 @@
    [metabase.util :as u]
    [metabase.util.date-2]
    [metabase.util.i18n.impl]
+   [metabase.util.log :as log]
    [pjstadig.humane-test-output :as humane-test-output]))
 
 (set! *warn-on-reflection* true)
@@ -103,7 +104,7 @@
     (u/with-timer-ms [duration-ms]
       (doseq [init-step steps]
         (fixtures/initialize init-step))
-      (println "Initialized" (count steps) "fixtures in" (duration-ms) "ms"))))
+      (log/info (str "Initialized " (count steps) " fixtures in " (duration-ms) "ms")))))
 
 (defn find-and-run-tests-repl
   "Find and run tests from the REPL."

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -12,6 +12,9 @@
    [metabase.core.bootstrap]
    [metabase.test-runner.assert-exprs]
    [metabase.test.data.env :as tx.env]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.test.initialize :as initialize]
+   [metabase.util :as u]
    [metabase.util.date-2]
    [metabase.util.i18n.impl]
    [pjstadig.humane-test-output :as humane-test-output]))
@@ -95,12 +98,21 @@
   ([options]
    (hawk/find-tests-with-options (merge (default-options) options))))
 
+(defn- initialize-all-fixtures []
+  (let [steps (initialize/all-components)]
+    (u/with-timer-ms [duration-ms]
+      (doseq [init-step steps]
+        (fixtures/initialize init-step))
+      (println "Initialized" (count steps) "fixtures in" (duration-ms) "ms"))))
+
 (defn find-and-run-tests-repl
   "Find and run tests from the REPL."
   [options]
+  (initialize-all-fixtures)
   (hawk/find-and-run-tests-repl (merge (default-options) options)))
 
 (defn find-and-run-tests-cli
   "Entrypoint for `clojure -X:test`."
   [options]
+  (initialize-all-fixtures)
   (hawk/find-and-run-tests-cli (merge (default-options) options)))


### PR DESCRIPTION
This runs all known fixtures _before running tests_, which takes 250 ms on a fresh postgres DB.

Alleviates a flakiness issue we saw in CI when a namespace doesn't declare every fixture it needs. [context here](https://metaboat.slack.com/archives/C5XHN8GLW/p1753464660005639)

Test order can shuffle when e.g. new namespaces are added, or when we set a [:randomized-seed](https://github.com/weavejester/eftest/blob/master/eftest/src/eftest/runner.clj#L198C6-L198C20) in test-runner options, and many namespaces do not declare what fixtures they need and rely on other tests to run initialization.
  
