### PR TITLE
Fix: #56249 Hiding a series raises error: null is not an object (evaluating 'e.removeChild') in Safari

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -102,7 +102,7 @@ function _CartesianChart(props: VisualizationProps) {
         const svg = containerRef.current?.querySelector("svg");
         if (svg) {
           const clipPaths = svg.querySelectorAll('defs > clipPath[id^="zr"]');
-          clipPaths.forEach((cp) => cp.remove());
+          clipPaths.forEach((cp) => cp.setAttribute("id", ""));
         }
       });
     }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56249
Closes UXW-35

### Description

* Looks like this issue was introduced with the fix for #51383.
* The original fix removed clipPath nodes in Safari, which fixed the lines disappearing issue but makes React freak out when you change the chart.
* I tweaked the fix from #51611 to clear the clipPaths' id attributes rather than removing the nodes altogether. React seems content since the nodes still exist, and the lines still render because the clipPaths aren't referenced.
* This seems to also fix the related issues mentioned in this comment https://github.com/metabase/metabase/issues/56249#issuecomment-2992170624

### How to verify

See repro steps in #56249.

Make sure #51383 is still fixed.

### Demo

https://github.com/user-attachments/assets/dea4c3b0-0a76-4faa-8b19-769fbe26d332

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
