### PR TITLE
Auto-enable simple embedding in embed flow instead of react sdk

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -19,8 +19,7 @@ import { SimpleEmbedTermsCard } from "./SimpleEmbedTermsCard";
 const SdkIframeEmbedSetupContent = () => {
   const { currentStep } = useSdkIframeEmbedSetupContext();
 
-  // TODO: change this to "enable-embedding-simple" when we split the settings
-  const embeddingSdkEnabled = useSetting("enable-embedding-sdk");
+  const isSimpleEmbeddingEnabled = useSetting("enable-embedding-simple");
   const showSimpleEmbedTerms = useSetting("show-simple-embed-terms");
   const [updateSettings] = useUpdateSettingsMutation();
   const [sendToast] = useToast();
@@ -41,16 +40,14 @@ const SdkIframeEmbedSetupContent = () => {
 
   // Automatically enable the embedding SDK if it's not already enabled.
   useEffect(() => {
-    // TODO: change this to "enable-embedding-simple" when we split the settings
-    if (!embeddingSdkEnabled) {
-      updateSettings({ "enable-embedding-sdk": true });
+    if (!isSimpleEmbeddingEnabled) {
+      updateSettings({ "enable-embedding-simple": true });
 
       sendToast({
-        // TODO: change this to simple embedding when we split the settings
-        message: t`Embedded Analytics SDK is enabled. You can configure it in admin settings.`,
+        message: t`Simple embedding is enabled. You can configure it in admin settings.`,
       });
     }
-  }, [embeddingSdkEnabled, sendToast, updateSettings]);
+  }, [isSimpleEmbeddingEnabled, sendToast, updateSettings]);
 
   return (
     <Box className={S.Container}>
@@ -86,7 +83,7 @@ const SdkIframeEmbedSetupContent = () => {
         <Card p="md" h="100%">
           <Stack h="100%">
             {/** Only show the embed preview once the embedding is auto-enabled, or already enabled. */}
-            {embeddingSdkEnabled && <SdkIframeEmbedPreview />}
+            {isSimpleEmbeddingEnabled && <SdkIframeEmbedPreview />}
           </Stack>
         </Card>
       </Box>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.unit.spec.tsx
@@ -18,7 +18,7 @@ import { SdkIframeEmbedSetup } from "./SdkIframeEmbedSetup";
 
 const setup = (options?: {
   showSimpleEmbedTerms?: boolean;
-  embeddingSdkEnabled?: boolean;
+  simpleEmbeddingEnabled?: boolean;
 }) => {
   setupRecentViewsAndSelectionsEndpoints([], ["selections", "views"]);
   setupDashboardEndpoints(createMockDashboard());
@@ -29,7 +29,7 @@ const setup = (options?: {
     storeInitialState: createMockState({
       settings: createMockSettingsState({
         "show-simple-embed-terms": options?.showSimpleEmbedTerms ?? true,
-        "enable-embedding-sdk": options?.embeddingSdkEnabled ?? false,
+        "enable-embedding-simple": options?.simpleEmbeddingEnabled ?? false,
       }),
     }),
   });
@@ -122,7 +122,7 @@ describe("Embed flow > forward and backward navigation", () => {
 
 describe("Embed flow > usage terms card", () => {
   it("shows the simple embed terms card when show-simple-embed-terms is true", () => {
-    setup({ showSimpleEmbedTerms: true, embeddingSdkEnabled: false });
+    setup({ showSimpleEmbedTerms: true, simpleEmbeddingEnabled: false });
 
     expect(screen.getByText("First, some legalese.")).toBeInTheDocument();
     expect(screen.getByText(/When using simple embedding/)).toBeInTheDocument();
@@ -130,7 +130,7 @@ describe("Embed flow > usage terms card", () => {
   });
 
   it("does not show the simple embed terms card when show-simple-embed-terms is false", () => {
-    setup({ showSimpleEmbedTerms: false, embeddingSdkEnabled: false });
+    setup({ showSimpleEmbedTerms: false, simpleEmbeddingEnabled: false });
 
     expect(screen.queryByText("First, some legalese.")).not.toBeInTheDocument();
     expect(
@@ -138,8 +138,8 @@ describe("Embed flow > usage terms card", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows the simple embed terms card even when embedding SDK is already enabled", () => {
-    setup({ showSimpleEmbedTerms: true, embeddingSdkEnabled: true });
+  it("shows the simple embed terms card even when simple embedding is already enabled", () => {
+    setup({ showSimpleEmbedTerms: true, simpleEmbeddingEnabled: true });
 
     // The card should still be shown if show-simple-embed-terms is true
     expect(screen.getByText("First, some legalese.")).toBeInTheDocument();
@@ -147,7 +147,7 @@ describe("Embed flow > usage terms card", () => {
   });
 
   it("handles accepting the terms by making PUT request to update settings", async () => {
-    setup({ showSimpleEmbedTerms: true, embeddingSdkEnabled: true });
+    setup({ showSimpleEmbedTerms: true, simpleEmbeddingEnabled: true });
 
     const gotItButton = screen.getByRole("button", { name: "Got it" });
     await userEvent.click(gotItButton);
@@ -161,13 +161,12 @@ describe("Embed flow > usage terms card", () => {
     expect(matchingRequest).toBeDefined();
   });
 
-  it("automatically enables embedding SDK when entering the flow", async () => {
-    setup({ showSimpleEmbedTerms: true, embeddingSdkEnabled: false });
+  it("automatically enables simple embedding when entering the flow", async () => {
+    setup({ showSimpleEmbedTerms: true, simpleEmbeddingEnabled: false });
 
-    // Verify that enable-embedding-sdk is set to true
-    // TODO: change this to "enable-embedding-simple" once we split the embed settings
+    // Verify that enable-embedding-simple is set to true
     const matchingRequest = await waitForUpdateSetting(
-      "enable-embedding-sdk",
+      "enable-embedding-simple",
       true,
     );
 

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embed_share/jsonschema/1-0-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embed_share/jsonschema/1-0-2
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for tracking embedding enabled and disabled events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "embed_share",
+    "format": "jsonschema",
+    "version": "1-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "embedding_enabled",
+        "embedding_disabled",
+        "sdk_embedding_enabled",
+        "sdk_embedding_disabled",
+        "static_embedding_enabled",
+        "static_embedding_disabled",
+        "interactive_embedding_enabled",
+        "interactive_embedding_disabled"
+      ],
+      "maxLength": 1024
+    },
+    "authorized_origins_set": {
+      "description": "Boolean indicating whether authorized origins are set for embedding",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "number_embedded_questions": {
+      "description": "The number of embedded questions",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "number_embedded_dashboards": {
+      "description": "The number of embedded dashboards",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    }
+  },
+  "required": [
+    "event"
+  ],
+  "additionalProperties": true
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embed_share/jsonschema/1-0-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embed_share/jsonschema/1-0-2
@@ -20,7 +20,9 @@
         "static_embedding_enabled",
         "static_embedding_disabled",
         "interactive_embedding_enabled",
-        "interactive_embedding_disabled"
+        "interactive_embedding_disabled",
+        "simple_embedding_enabled",
+        "simple_embedding_disabled"
       ],
       "maxLength": 1024
     },

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -48,7 +48,7 @@
    :snowplow/task           "1-0-0"
    :snowplow/upsell         "1-0-0"
    :snowplow/action         "1-0-0"
-   :snowplow/embed_share    "1-0-0"
+   :snowplow/embed_share    "1-0-2"
    :snowplow/llm_usage      "1-0-0"
    :snowplow/serialization  "1-0-1"
    :snowplow/simple_event   "1-0-0"


### PR DESCRIPTION
## Summary
- Auto flip enable-embedding-simple instead of enable-embedding-sdk setting in the simple embedding's embed flow

## Changes
- Modified SdkIframeEmbedSetup component to automatically enable simple embedding
- Updated unit tests to reflect the new behavior

## Files Changed
- `enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx`
- `enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.unit.spec.tsx`

🤖 Generated with [Claude Code](https://claude.ai/code)