### PR TITLE
allow hide if no results setting in visualizer

### DIFF
--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -8,6 +8,7 @@ import {
   getGenericErrorMessage,
   getPermissionErrorMessage,
 } from "metabase/visualizations/lib/errors";
+import { isVisualizerDashboardCard } from "metabase/visualizer/utils";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import {
   areParameterValuesIdentical,
@@ -336,7 +337,10 @@ const shouldHideCard = (
   dashcardData: Record<CardId, Dataset | null | undefined>,
   wasVisible: boolean,
 ) => {
-  const shouldHideEmpty = dashcard.visualization_settings?.["card.hide_empty"];
+  const dashcardSettings = isVisualizerDashboardCard(dashcard)
+    ? dashcard.visualization_settings?.visualization?.settings
+    : dashcard.visualization_settings;
+  const shouldHideEmpty = dashcardSettings?.["card.hide_empty"];
 
   if (isVirtualDashCard(dashcard) || !shouldHideEmpty) {
     return false;

--- a/frontend/src/metabase/dashboard/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/utils.unit.spec.ts
@@ -281,12 +281,27 @@ describe("Dashboard utils", () => {
       visualization_settings: { "card.hide_empty": true },
     });
 
+    const visualizerCardId = 4;
+    const visualizerCard = createMockDashboardCard({
+      id: visualizerCardId,
+      visualization_settings: {
+        visualization: {
+          display: "table",
+          columnValuesMapping: {},
+          settings: { "card.hide_empty": true },
+        },
+      },
+    });
+
     const loadingData = {
       [normalCardId]: {
         100: null,
       },
       [hidingWhenEmptyCardId]: {
         200: null,
+      },
+      [visualizerCardId]: {
+        300: null,
       },
     };
 
@@ -296,6 +311,9 @@ describe("Dashboard utils", () => {
       },
       [hidingWhenEmptyCardId]: {
         200: createMockDataset(),
+      },
+      [visualizerCardId]: {
+        300: createMockDataset(),
       },
     };
 
@@ -310,9 +328,19 @@ describe("Dashboard utils", () => {
           data: createMockDatasetData({ rows: [[1]] }),
         }),
       },
+      [visualizerCardId]: {
+        300: createMockDataset({
+          data: createMockDatasetData({ rows: [[1]] }),
+        }),
+      },
     };
 
-    const cards = [virtualCard, normalCard, hidingWhenEmptyCard];
+    const cards = [
+      virtualCard,
+      normalCard,
+      hidingWhenEmptyCard,
+      visualizerCard,
+    ];
 
     it("when loading and no cards previously were visible it should show only virtual and normal cards", () => {
       const visibleIds = getVisibleCardIds(cards, loadingData);
@@ -323,10 +351,20 @@ describe("Dashboard utils", () => {
       const visibleIds = getVisibleCardIds(
         cards,
         loadingData,
-        new Set([virtualCardId, normalCardId, hidingWhenEmptyCardId]),
+        new Set([
+          virtualCardId,
+          normalCardId,
+          hidingWhenEmptyCardId,
+          visualizerCardId,
+        ]),
       );
       expect(visibleIds).toStrictEqual(
-        new Set([virtualCardId, normalCardId, hidingWhenEmptyCardId]),
+        new Set([
+          virtualCardId,
+          normalCardId,
+          hidingWhenEmptyCardId,
+          visualizerCardId,
+        ]),
       );
     });
 
@@ -338,7 +376,12 @@ describe("Dashboard utils", () => {
     it("when loaded with data it should show all of cards", () => {
       const visibleIds = getVisibleCardIds(cards, loadedWithData);
       expect(visibleIds).toStrictEqual(
-        new Set([virtualCardId, normalCardId, hidingWhenEmptyCardId]),
+        new Set([
+          virtualCardId,
+          normalCardId,
+          hidingWhenEmptyCardId,
+          visualizerCardId,
+        ]),
       );
     });
   });

--- a/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
+++ b/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
@@ -14,11 +14,7 @@ import {
 import { updateSettings } from "metabase/visualizer/visualizer.slice";
 import type { VisualizationSettings } from "metabase-types/api";
 
-const HIDDEN_SETTING_WIDGETS = [
-  "card.title",
-  "card.description",
-  "card.hide_empty",
-];
+const HIDDEN_SETTING_WIDGETS = ["card.title", "card.description"];
 
 export function VizSettingsSidebar({ className }: { className?: string }) {
   const series = useSelector(getVisualizerRawSeries);


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60757
Closes [UXW-75](https://linear.app/metabase/issue/UXW-75/hide-this-card-if-there-are-no-results-option-not-available-in)

### Description

Enables `card.hide_empty` setting in the visualizer. It allows hiding a dashboard card if the dataset is empty. 

### How to verify

- Add any mbql cartesian chart on a dashboard
- Open the visualizer for the card and enable "hide of no results" setting
- Add an ID parameter and connect it to the card
- Enter any negative ID to ensure the result dataset is empty
- Ensure the card is hidden from dashboard

### Demo

<img width="1342" height="1171" alt="Screenshot 2025-07-25 at 7 39 45 PM" src="https://github.com/user-attachments/assets/17eba3c0-1deb-4ea4-bba9-d1e165fde38c" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
