### PR TITLE
Created prototype API for dev work

### DIFF
--- a/dev/src/dev/api/prototype.clj
+++ b/dev/src/dev/api/prototype.clj
@@ -1,0 +1,77 @@
+(ns dev.api.prototype
+  (:require [clojure.java.jdbc :as jdbc]
+            [metabase.api.common :as api]
+            [metabase.api.macros :as api.macros]
+            [metabase.app-db.core :as mdb]
+            [metabase.util.json :as json]
+            [metabase.util.log :as log]
+            [metabase.util.malli.schema :as ms]
+            [toucan2.core :as t2]))
+
+(def ^:private create-table! (mdb/memoize-for-application-db
+                              (fn []
+                                (log/info "Creating prototype_data table if it does not exist")
+                                (t2/with-connection [conn]
+                                  (jdbc/execute! {:connection conn}
+                                                 "create table if not exists dev_prototype_data (
+                                       id serial primary key,
+                                       type varchar(255) not null,
+                                       content text not null
+                                     )"))
+                                :dev_prototype_data)))
+
+(defn- prototype-table
+  "Creates the prototype table if it does not exist"
+  [] (create-table!))
+
+(defn- row->json [row]
+  (assoc (json/decode (:content row)) :id (:id row)))
+
+(api.macros/defendpoint :get "/:type/"
+  "Gets all records of the given type.
+  Any parameters passed will be used for equals filters"
+  [{:keys [type]}
+   query-args]
+  (filter (fn [obj]
+            (every? (fn [[query-k query-v]]
+                      (let [obj-v (get obj (name query-k))]
+                        (= query-v (str obj-v))))
+                    query-args))
+          (map row->json (t2/query {:select   [:id :content]
+                                    :from     [(prototype-table)]
+                                    :where    [:= :type type]
+                                    :order-by [[:id :asc]]}))))
+
+(api.macros/defendpoint :get "/:type/:id"
+  "Returns an existing record"
+  [{:keys [type id]} :- [:map
+                         [:type ms/NonBlankString]
+                         [:id ms/PositiveInt]]]
+  (-> (api/check-404 (t2/query-one {:select [:id :content]
+                                    :from   [(prototype-table)]
+                                    :where  [:= :id id]}))
+      (api/check-404)
+      (row->json)))
+
+(api.macros/defendpoint :post "/:type/"
+  "Create a new record."
+  [{:keys [type]} :- [:map
+                      [:type ms/NonBlankString]]
+   _query-params
+   body]
+  (let [id (t2/insert-returning-pk! (prototype-table)
+                                    {:type    type
+                                     :content (json/encode body)})]
+    (assoc body :id id)))
+
+(api.macros/defendpoint :put "/:type/:id"
+  "Updates an existing record."
+  [{:keys [type id]} :- [:map
+                         [:type ms/NonBlankString]
+                         [:id ms/PositiveInt]]
+   _query-params
+   body]
+  (t2/update! (prototype-table) id
+              {:type    type
+               :content (json/encode body)})
+  (assoc body :id id))

--- a/dev/src/dev/api/prototype.clj
+++ b/dev/src/dev/api/prototype.clj
@@ -85,3 +85,24 @@
               {:type    type
                :content (json/encode body)})
   (assoc body :id id))
+
+(api.macros/defendpoint :delete "/:type/:id"
+  "Deletes an existing record."
+  [{:keys [type id]} :- [:map
+                         [:type ms/NonBlankString]
+                         [:id ms/PositiveInt]]
+   _query-params
+   body]
+  (api/check-404 (t2/delete! (prototype-table) id))
+
+  {:id id})
+
+(api.macros/defendpoint :delete "/:type/all"
+  "Deletes all records of this type. Helpful for resetting to a clean state."
+  [{:keys [type]} :- [:map
+                      [:type ms/NonBlankString]]
+   _query-params
+   body]
+  (t2/delete! (prototype-table) :type type)
+
+  {:message "All records deleted" :type type})

--- a/dev/src/dev/api/routes.clj
+++ b/dev/src/dev/api/routes.clj
@@ -1,0 +1,13 @@
+(ns dev.api.routes
+  (:require [dev.api.prototype]
+            [metabase.api.util.handlers :as handlers]))
+
+(comment
+  dev.api.prototype/keep-me)
+
+(def ^:private dev-routes-map
+  {"/prototype" 'dev.api.prototype})
+
+(def ^{:arglists '([request respond raise])} routes
+  ;; This map will be merged at the top level, so /dev/prototype is available.
+  (handlers/route-map-handler {"/dev" (handlers/route-map-handler dev-routes-map)}))

--- a/dev/test/dev/api/prototype_test.clj
+++ b/dev/test/dev/api/prototype_test.clj
@@ -1,7 +1,12 @@
 (ns dev.api.prototype-test
   (:require
    [clojure.test :refer :all]
-   [metabase.test :as mt]))
+   [dev.api.prototype :as proto]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest create-table
+  (t2/query (#'proto/create-table-query)))
 
 (deftest e2e-test
   (let [key (name (gensym "prototype-e2e-test-"))]

--- a/dev/test/dev/api/prototype_test.clj
+++ b/dev/test/dev/api/prototype_test.clj
@@ -133,5 +133,5 @@
             (is (= {:message "All records deleted" :type key}
                    (mt/user-http-request :crowberto :delete 200
                                          (format "dev/prototype/%s/all" key))))
-            (is (= [] (mt/user-http-request :crowberto :get 404
+            (is (= [] (mt/user-http-request :crowberto :get 200
                                             (format "dev/prototype/%s/" key))))))))))

--- a/dev/test/dev/api/prototype_test.clj
+++ b/dev/test/dev/api/prototype_test.clj
@@ -1,0 +1,116 @@
+(ns dev.api.prototype-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]))
+
+(deftest e2e-test
+  (let [key (name (gensym "prototype-e2e-test-"))]
+    (testing "when nothing is in a key, the API returns an empty list"
+      (is (empty? (mt/user-http-request :crowberto :get 200
+                                        (format "dev/prototype/%s/" key)))))
+    (testing "invalid ids return 404"
+      (is (= "Not found." (mt/user-http-request :crowberto :get 404
+                                                (format "dev/prototype/%s/9999" key)))))
+    (testing "can create records in the API"
+      (let [response1 (mt/user-http-request :crowberto :post 200
+                                            (format "dev/prototype/%s/" key)
+                                            {:type    "test1"
+                                             :age     1
+                                             :num-val 4
+                                             :str-val "hi"})
+            response2 (mt/user-http-request :crowberto :post 200
+                                            (format "dev/prototype/%s/" key)
+                                            {:type    "test2"
+                                             :age     2
+                                             :num-val 4
+                                             :str-val "hi"})]
+        (is (partial= {:type "test1" :age 1} response1))
+        (is (pos? (:id response1)))
+        (is (partial= {:type "test2" :age 2} response2))
+        (is (pos? (:id response2)))
+        (is (not= (:id response1) (:id response2)))
+        (testing "can retrieve created records"
+          (is (= {:id      (:id response1)
+                  :type    "test1"
+                  :age     1
+                  :num-val 4
+                  :str-val "hi"}
+                 (mt/user-http-request :crowberto :get 200
+                                       (format "dev/prototype/%s/%s" key (:id response1)))))
+          (is (= {:id      (:id response2)
+                  :type    "test2"
+                  :age     2
+                  :num-val 4
+                  :str-val "hi"}
+                 (mt/user-http-request :crowberto :get 200
+                                       (format "dev/prototype/%s/%s" key (:id response2))))))
+        (testing "Can update (replace) a record"
+          (let [updated-response1 (mt/user-http-request :crowberto :put 200
+                                                        (format "dev/prototype/%s/%s" key (:id response1))
+                                                        {:type    "test1-updated"
+                                                         :count   5
+                                                         :num-val 4
+                                                         :str-val "hi"})]
+            (is (= {:id      (:id response1)
+                    :type    "test1-updated"
+                    :count   5
+                    :num-val 4
+                    :str-val "hi"} updated-response1)))
+          (testing "Updated version is saved"
+            (is (= {:id      (:id response1)
+                    :type    "test1-updated"
+                    :count   5
+                    :num-val 4
+                    :str-val "hi"}
+                   (mt/user-http-request :crowberto :get 200
+                                         (format "dev/prototype/%s/%s" key (:id response1))))))
+          (testing "Other record is unchanged"
+            (is (= {:id      (:id response2)
+                    :type    "test2"
+                    :age     2
+                    :num-val 4
+                    :str-val "hi"}
+                   (mt/user-http-request :crowberto :get 200
+                                         (format "dev/prototype/%s/%s" key (:id response2)))))))
+        (testing "Can search for records"
+          (testing "by number"
+            (is (= [{:id      (:id response1)
+                     :type    "test1-updated"
+                     :count   5
+                     :num-val 4
+                     :str-val "hi"}]
+                   (mt/user-http-request :crowberto :get 200
+                                         (format "dev/prototype/%s/?count=5" key)))))
+          (testing "by string"
+            (is (= [{:id      (:id response1)
+                     :type    "test1-updated"
+                     :count   5
+                     :num-val 4
+                     :str-val "hi"}]
+                   (mt/user-http-request :crowberto :get 200
+                                         (format "dev/prototype/%s/?type=test1-updated" key)))))
+          (testing "by two fields"
+            (is (= [{:id      (:id response1)
+                     :type    "test1-updated"
+                     :count   5
+                     :num-val 4
+                     :str-val "hi"}]
+                   (mt/user-http-request :crowberto :get 200
+                                         (format "dev/prototype/%s/?type=test1-updated&str-val=hi" key)))))
+          (testing "returning multiple records"
+            (is (= [{:id      (:id response1)
+                     :type    "test1-updated"
+                     :count   5
+                     :num-val 4
+                     :str-val "hi"}
+                    {:id      (:id response2)
+                     :type    "test2"
+                     :age     2
+                     :num-val 4
+                     :str-val "hi"}]
+                   (mt/user-http-request :crowberto :get 200
+                                         (format "dev/prototype/%s/?str-val=hi" key)))))
+          (testing "No matches return empty list"
+            (is (empty?
+                 (mt/user-http-request :crowberto :get 200
+                                       (format "dev/prototype/%s/?str-val=none" key))))))))))

--- a/dev/test/dev/api/prototype_test.clj
+++ b/dev/test/dev/api/prototype_test.clj
@@ -118,4 +118,20 @@
           (testing "No matches return empty list"
             (is (empty?
                  (mt/user-http-request :crowberto :get 200
-                                       (format "dev/prototype/%s/?str-val=none" key))))))))))
+                                       (format "dev/prototype/%s/?str-val=none" key)))))
+
+          (testing "Can delete a record"
+            (is (= {:id (:id response1)} (mt/user-http-request :crowberto :delete 200
+                                                               (format "dev/prototype/%s/%s" key (:id response1)))))
+            (is (= "Not found." (mt/user-http-request :crowberto :get 404
+                                                      (format "dev/prototype/%s/%s" key (:id response1)))))
+            (testing "Didn't delete other records"
+              (is (partial= {:id (:id response2)} (mt/user-http-request :crowberto :get 200
+                                                                        (format "dev/prototype/%s/%s" key (:id response2)))))))
+
+          (testing "Can delete all records of a type"
+            (is (= {:message "All records deleted" :type key}
+                   (mt/user-http-request :crowberto :delete 200
+                                         (format "dev/prototype/%s/all" key))))
+            (is (= [] (mt/user-http-request :crowberto :get 404
+                                            (format "dev/prototype/%s/" key))))))))))

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -199,4 +199,7 @@
      (requiring-resolve 'metabase-enterprise.api.routes/routes)
      pass-thru-handler)
    (handlers/route-map-handler route-map)
+   (if (and config/is-dev? (not *compile-files*))
+     (requiring-resolve 'dev.api.routes/routes)
+     pass-thru-handler)
    not-found-handler))


### PR DESCRIPTION
### Description

Defines a new `/api/dev/prototype/*` API that is helpful for prototyping new functionality without building out a whole backend.

Available APIs:
- `GET /api/dev/prototype/{key}/` returns all values for the key. Can pass query string to limit results
- `POST /api/dev/prototype/{key}/` creates a new record
- `PUT /api/dev/prototype/{key}/{id}` updates an existing record
- `DELETE /api/dev/prototype/{key}/{id}` deletes an existing record
- `GET /api/dev/prototype/{key}/{id}` returns an existing record
- (bonus) `DELETE /api/dev/prototype/{key}/all` deletes all records for the given key. For resetting the data to a clean slate

`{key}` can be any string you would like, and values are only returned within the key. 

The value passed to POST/PUT can be any valid JSON and it will be stored

This is only available when running with the `dev` alias 

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
