### PR TITLE
[pivot] Optimize pivot construction for both backend and frontend

### DIFF
--- a/src/metabase/formatter/impl.clj
+++ b/src/metabase/formatter/impl.clj
@@ -63,16 +63,14 @@
   ([value decimal]
    (if (zero? value)
      0
-     (let [val-string (-> (condp = (type value)
-                            java.math.BigDecimal (.toPlainString ^BigDecimal value)
-                            java.lang.Double     (format "%.20f" value)
-                            java.lang.Float      (format "%.20f" value)
+     (let [val-string (-> (if (instance? java.math.BigDecimal value)
+                            (.toPlainString ^BigDecimal value)
                             (str value))
                           (strip-trailing-zeroes (str decimal)))
            decimal-idx (str/index-of val-string decimal)]
-       (if decimal-idx
-         (- (count val-string) decimal-idx 1)
-         0)))))
+       (min 20 (if decimal-idx
+                 (- (count val-string) decimal-idx 1)
+                 0))))))
 
 (defn- sig-figs-after-decimal
   "Count the number of significant figures after the decimal point in a number.

--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -1,11 +1,10 @@
 (ns metabase.pivot.core
   (:require
-   #?(:cljs [metabase.util.performance :as perf])
-   [flatland.ordered.map :as ordered-map]
    [medley.core :as m]
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.util :as u]
-   [metabase.util.i18n :as i18n])
+   [metabase.util.i18n :as i18n]
+   [metabase.util.performance :as perf])
   (:import
    #?(:clj (java.text Collator))))
 
@@ -110,8 +109,8 @@
               (persistent!
                (reduce
                 (fn [acc row]
-                  (let [grouping-key (ensure-consistent-type (mapv #(nth row %) column-indexes))
-                        values (mapv #(nth row %) val-indexes)]
+                  (let [grouping-key (ensure-consistent-type (perf/mapv #(nth row %) column-indexes))
+                        values (perf/mapv #(nth row %) val-indexes)]
                     (assoc! acc grouping-key values)))
                 (transient {})
                 rows))]
@@ -124,11 +123,12 @@
      "Marks all nodes at the given level as collapsed. 1 = root node; 2 = children
      of the root, etc."
      [tree level]
-     (m/map-vals
-      (if (= level 1)
-        #(assoc % :isCollapsed true)
-        #(update % :children (fn [subtree] (collapse-level subtree (dec level)))))
-      tree)))
+     (if (= level 0)
+       (assoc tree :isCollapsed true)
+       (update tree :children (fn [children]
+                                (reduce #(perf/list-set! %1 %2 (collapse-level (perf/list-nth %1 %2) (dec level)))
+                                        children
+                                        (range (count children))))))))
 
 #?(:cljs
    (defn- add-is-collapsed
@@ -139,37 +139,47 @@
        (reduce
         (fn [tree collapsed-subtotal]
           (cond
-             ;; A plain integer represents an entire level of the tree which is
-             ;; collapsed (1-indexed)
+            ;; A plain integer represents an entire level of the tree which is
+            ;; collapsed (1-indexed)
             (int? collapsed-subtotal)
             (collapse-level tree collapsed-subtotal)
 
-             ;; A seq represents a specific path in the tree which is collapsed
+            ;; A seq represents a specific path in the tree which is collapsed
             (sequential? collapsed-subtotal)
-            (let [key-path (conj (into [] (interpose :children collapsed-subtotal))
-                                 :isCollapsed)]
-              (if-not (nil? (get-in tree key-path))
-                (assoc-in tree key-path true)
-                tree))))
+            (loop [node tree, [c & r] collapsed-subtotal]
+              (let [children (:children node)
+                    idx (perf/map-get (:value->child-pos node) c)
+                    child (perf/list-nth children idx)]
+                (if r
+                  (recur child r)
+                  (do (perf/list-set! children idx (assoc child :isCollapsed true))
+                      tree))))))
         tree
         parsed-collapsed-subtotals))))
 
+#_{:clj-kondo/ignore [:missing-docstring]}
+(defrecord TreeNode [value children value->child-pos isCollapsed])
+
 (defn- add-path-to-tree
-  "Adds a path of values to a row or column tree. Each level of the tree is an
-  ordered map with values as keys, each associated with a sub-map like
-  {:children (ordered-map/ordered-map)}."
-  [path tree]
-  (if (seq path)
+  "Adds a path of values to a row or column tree. The path is represented by the actual row and the list of indexes in
+  that row. Each level of the tree is a TreeNode object that has a value list of children."
+  [tree row indexes-path i]
+  (if (< i (count indexes-path))
     ;; In `add-is-collapsed` we parse JSON from the viz settings to determine
     ;; the path of values to collapse. So we have to roundtrip values from the QP
     ;; to JSON and back to make sure their types match.
-    (let [v (ensure-consistent-type (first path))]
-      (update tree v
-              (fn [node]
-                (let [subtree (or (:children node) (ordered-map/ordered-map))]
-                  (-> node
-                      (assoc :children (add-path-to-tree (rest path) subtree))
-                      (assoc :isCollapsed false))))))
+    (let [index (nth indexes-path i)
+          v (ensure-consistent-type (nth row index))
+          ;; value->child-pos is a mutable map for looking up the child position in the children list by child's value
+          value->child-pos (:value->child-pos tree)
+          children (:children tree)
+          node (or (some->> (perf/map-get value->child-pos v) (perf/list-nth children))
+                   (let [node (->TreeNode v (perf/make-list) (perf/make-map) false)]
+                     (perf/map-put! value->child-pos v (count children))
+                     (perf/list-add! children node)
+                     node))]
+      (add-path-to-tree node row indexes-path (inc i))
+      tree)
     tree))
 
 (defn- select-indexes
@@ -220,7 +230,7 @@
 (defn- compare-fn
   [sort-order]
   (let [locale-compare
-        (fn [a b]
+        (fn [{a :value} {b :value}]
           (cond
             (= a b)
             0
@@ -236,15 +246,21 @@
       nil)))
 
 (defn- sort-tree
-  "Converts each level of a tree to a sorted map as needed, based on the values
-  in `sort-orders`."
+  "Sort each level of a tree as needed, based on the values in `sort-orders`."
   [tree sort-orders]
-  (reduce-kv (fn [dest k v]
-               (assoc dest k (assoc v :children (sort-tree (:children v) (rest sort-orders)))))
-             (if-let [curr-compare-fn (compare-fn (first sort-orders))]
-               (sorted-map-by curr-compare-fn)
-               (ordered-map/ordered-map))
-             tree))
+  (let [children (:children tree)
+        value->child-pos (:value->child-pos tree)
+        rest-orders (rest sort-orders)]
+    (run! (fn [node] (sort-tree node rest-orders)) children)
+    (when-let [curr-compare-fn (compare-fn (first sort-orders))]
+      #?(:clj (.sort ^java.util.ArrayList children curr-compare-fn)
+         :cljs (.sort children curr-compare-fn))
+      ;; Don't forget to recreate value->child-pos because we messed child order.
+      #?(:clj (.clear ^java.util.HashMap value->child-pos)
+         :cljs (.clear value->child-pos))
+      (doseq [i (range (count children))]
+        (perf/map-put! value->child-pos (:value (perf/list-nth children i)) i)))
+    tree))
 
 ;; TODO: can we move this to the COLLAPSED_ROW_SETTING itself?
 #?(:cljs
@@ -262,24 +278,6 @@
                    (nth column-is-collapsible? (dec length) false)))
                all-collapsed-subtotals))))
 
-(defn- postprocess-tree
-  "Converts a tree of sorted maps to a tree of vectors. This allows the tree to
-  make a round trip to JavaScript and back to CLJS in `process-pivot-table`
-  without losing ordering information."
-  [tree]
-  (if (empty? tree)
-    []
-    (persistent!
-     (reduce-kv
-      (fn [result value tree-node]
-        (let [children (:children tree-node)
-              processed-children (postprocess-tree children)]
-          (conj! result (assoc tree-node
-                               :value value
-                               :children processed-children))))
-      (transient [])
-      tree))))
-
 (defn build-pivot-trees
   "Constructs the pivot table's tree structures for rows and columns.
 
@@ -287,16 +285,12 @@
   and columns, along with a lookup map for cell values."
   #_{:clj-kondo/ignore [:unused-binding]}
   [rows cols row-indexes col-indexes val-indexes settings col-settings]
-  (let [{:keys [row-tree col-tree]}
-        (reduce
-         (fn [{:keys [row-tree col-tree]} row]
-           (let [row-path (select-indexes row row-indexes)
-                 col-path (select-indexes row col-indexes)]
-             {:row-tree (add-path-to-tree row-path row-tree)
-              :col-tree (add-path-to-tree col-path col-tree)}))
-         {:row-tree (ordered-map/ordered-map)
-          :col-tree (ordered-map/ordered-map)}
-         rows)
+  (let [row-tree (->TreeNode nil (perf/make-list) (perf/make-map) false)
+        col-tree (->TreeNode nil (perf/make-list) (perf/make-map) false)
+        _ (run! (fn [row]
+                  (add-path-to-tree row-tree row row-indexes 0)
+                  (add-path-to-tree col-tree row col-indexes 0))
+                rows)
         ;; Only collapse row tree on the FE (in CLJS); keep it uncollapsed for exports (in CLJ)
         collapsed-row-tree #?(:cljs (add-is-collapsed
                                      row-tree
@@ -307,8 +301,8 @@
         sorted-row-tree (sort-tree collapsed-row-tree row-sort-orders)
         sorted-col-tree (sort-tree col-tree col-sort-orders)
         values-by-key   (build-values-by-key rows cols row-indexes col-indexes val-indexes)]
-    {:row-tree (postprocess-tree sorted-row-tree)
-     :col-tree (postprocess-tree sorted-col-tree)
+    {:row-tree (:children sorted-row-tree)
+     :col-tree (:children sorted-col-tree)
      :values-by-key values-by-key}))
 
 (defn- format-values-in-tree
@@ -583,6 +577,10 @@
       #?(:cljs (perf/clj->js result)
          :clj result))))
 
+#_{:clj-kondo/ignore [:missing-docstring]}
+(defrecord ResultItem [value rawValue clicked isCollapsed hasSubtotal isGrandTotal isSubtotal isValueColumn depth offset
+                       hasChildren path span maxDepthBelow])
+
 (defn- tree-to-array
   "Flattens a hierarchical tree structure into an array of nodes with positioning information.
    Each node in the result contains:
@@ -600,27 +598,24 @@
     (letfn [(process-tree [nodes depth offset path]
               (if (empty? nodes)
                 {:span 1 :max-depth 0}
-                (loop [remaining nodes
+                (loop [i 0
                        total-span 0
                        max-depth 0
                        current-offset offset]
-                  (if (empty? remaining)
+                  (if (>= i (count nodes))
                     {:span total-span :max-depth (inc max-depth)}
-                    (let [{:keys [children rawValue isGrandTotal isValueColumn] :as node} (first remaining)
+                    (let [{:keys [children rawValue isCollapsed isGrandTotal isSubtotal isValueColumn] :as node} (nth nodes i)
                           path-with-value (if (or isValueColumn isGrandTotal) nil (conj path rawValue))
-                          item            (-> (dissoc node :children)
-                                              (assoc :depth depth)
-                                              (assoc :offset current-offset)
-                                              (assoc :hasChildren (boolean (seq children)))
-                                              (assoc :path path-with-value))
                           item-index      (count @result)
-                          _               (vswap! result conj! item)
+                          _               (vswap! result conj! nil) ;; Placeholder for parent item to be filled in
+                                                                    ;; once children are processed.
                           result-value    (process-tree children (inc depth) current-offset path-with-value)
-                          _               (vswap! result assoc! item-index
-                                                  (-> (nth @result item-index)
-                                                      (assoc :span (:span result-value))
-                                                      (assoc :maxDepthBelow (:max-depth result-value))))]
-                      (recur (rest remaining)
+                          item            (->ResultItem (:value node) rawValue (:clicked node) isCollapsed
+                                                        (:hasSubtotal node) isGrandTotal isSubtotal isValueColumn
+                                                        depth current-offset (boolean (seq children)) path-with-value
+                                                        (:span result-value) (:max-depth result-value))]
+                      (vswap! result assoc! item-index item)
+                      (recur (inc i)
                              (long (+ total-span (:span result-value)))
                              (long (max max-depth (:max-depth result-value)))
                              (+ current-offset (:span result-value))))))))]

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -7,7 +7,7 @@
               [cljs.core :as core]
               [goog.object :as gobject])])
   #?@(:clj [(:import (clojure.lang ITransientCollection LazilyPersistentVector RT)
-                     java.util.Iterator)]
+                     (java.util ArrayList HashMap Iterator))]
       :default ()))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -391,3 +391,47 @@
                                        arr)
                            :else x))]
        (thisfn x))))
+
+;;;; Cross-platform mutable list and map wrapper functions.
+
+(defn make-list
+  "Create an empty mutable list. Returns ArrayList in Clojure, js array in ClojureScript."
+  []
+  #?(:clj (ArrayList.)
+     :cljs #js []))
+
+(defn list-add!
+  "Add a value to the end of a mutable list. Returns the list for chaining."
+  [lst value]
+  #?(:clj (do (.add ^ArrayList lst value) lst)
+     :cljs (do (.push lst value) lst)))
+
+(defn list-set!
+  "Replace the current value in the mutable list by the given index with the new value."
+  [lst index new-value]
+  #?(:clj (do (.set ^ArrayList lst index new-value) lst)
+     :cljs (do (aset lst index new-value) lst)))
+
+(defn list-nth
+  "Get value at index from mutable list."
+  [lst index]
+  #?(:clj (.get ^ArrayList lst index)
+     :cljs (aget lst index)))
+
+(defn make-map
+  "Create an empty mutable map. Returns HashMap in Clojure, plain js object in ClojureScript."
+  []
+  #?(:clj (HashMap.)
+     :cljs (js/Map.)))
+
+(defn map-get
+  "Get value by key from mutable map."
+  [m key]
+  #?(:clj (.get ^HashMap m key)
+     :cljs (.get m key)))
+
+(defn map-put!
+  "Put a key-value pair into a mutable map. Returns the map for chaining."
+  [m key value]
+  #?(:clj (do (.put ^HashMap m key value) m)
+     :cljs (do (.set m key value) m)))

--- a/test/metabase/pivot/core_test.cljc
+++ b/test/metabase/pivot/core_test.cljc
@@ -1,5 +1,7 @@
 (ns metabase.pivot.core-test
   (:require
+   #?@(:cljs
+       [[metabase.test-runner.assert-exprs.approximately-equal]])
    [clojure.test :refer [deftest is testing]]
    [metabase.pivot.core :as pivot]))
 
@@ -101,6 +103,14 @@
            :remapping nil,
            :remapped_from_index nil,
            :base_type "type/BigInteger"}]})
+
+(defn- lists-to-vecs-recursively [structure]
+  (letfn [(walk [x]
+            (cond (map? x) (update-vals x walk)
+                  #?(:clj (instance? java.util.ArrayList x)
+                     :cljs (array? x)) (mapv walk x)
+                  :else x))]
+    (walk structure)))
 
 (deftest ensure-consistent-type-test
   #?(:clj
@@ -229,17 +239,17 @@
           settings {}
           col-settings [{} {} {} {} {}]
           result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
-      (is (= [{:children [{:children [] :isCollapsed false :value "A"}]
-               :isCollapsed false
-               :value 1}
-              {:children [{:children [] :isCollapsed false :value "B"}]
-               :isCollapsed false
-               :value 2}]
-             (:row-tree result)))
+      (is (=? [{:children [{:children [] :isCollapsed false :value "A"}]
+                :isCollapsed false
+                :value 1}
+               {:children [{:children [] :isCollapsed false :value "B"}]
+                :isCollapsed false
+                :value 2}]
+              (lists-to-vecs-recursively (:row-tree result))))
 
-      (is (= [{:children [] :isCollapsed false :value "Y"}
-              {:children [] :isCollapsed false :value "Z"}]
-             (:col-tree result)))
+      (is (=? [{:children [] :isCollapsed false :value "Y"}
+               {:children [] :isCollapsed false :value "Z"}]
+              (lists-to-vecs-recursively (:col-tree result))))
 
       (is (= [[["Y" 1 "A"] [10]]
               [["Z" 2 "B"] [20]]]
@@ -267,30 +277,32 @@
          ;; Set up collapsed subtotals for level 1 (the root level)
          (let [settings {:pivot_table.collapsed_rows {:value ["1"]}}
                result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
-           (is (= [{:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed true
-                    :value 1}
-                   {:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed true
-                    :value 2}]
-                  (:row-tree result))
+           (is (=?
+                [{:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed true
+                  :value 1}
+                 {:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed true
+                  :value 2}]
+                (lists-to-vecs-recursively (:row-tree result)))
                "Row tree should have correct collapsed state for the root level"))
 
          ;; Set up collapsed subtotals for level 2 (children of the root)
          (let [settings {:pivot_table.collapsed_rows {:value ["1"]}}
                result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
-           (is (= [{:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed true
-                    :value 1}
-                   {:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed true
-                    :value 2}]
-                  (:row-tree result))
-               "Row tree should have correct collapsed state for the chlidren of the root"))))))
+           (is (=?
+                [{:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed true
+                  :value 1}
+                 {:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed true
+                  :value 2}]
+                (lists-to-vecs-recursively (:row-tree result)))
+               "Row tree should have correct collapsed state for the children of the root"))))))
 
 #?(:clj
    (deftest build-pivot-trees-no-collapsing-clj-test
@@ -311,30 +323,32 @@
          ;; Set up collapsed subtotals for level 1 (the root level)
          (let [settings {:pivot_table.collapsed_rows {:value ["1"]}}
                result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
-           (is (= [{:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed false
-                    :value 1}
-                   {:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed false
-                    :value 2}]
-                  (:row-tree result))
+           (is (=?
+                [{:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed false
+                  :value 1}
+                 {:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed false
+                  :value 2}]
+                (lists-to-vecs-recursively (:row-tree result)))
                "Row tree should have correct collapsed state for the root level"))
 
          ;; Set up collapsed subtotals for level 2 (children of the root)
          (let [settings {:pivot_table.collapsed_rows {:value ["1"]}}
                result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
-           (is (= [{:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed false
-                    :value 1}
-                   {:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed false
-                    :value 2}]
-                  (:row-tree result))
-               "Row tree should have correct collapsed state for the chlidren of the root"))))))
+           (is (=?
+                [{:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed false
+                  :value 1}
+                 {:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed false
+                  :value 2}]
+                (lists-to-vecs-recursively (:row-tree result)))
+               "Row tree should have correct collapsed state for the children of the root"))))))
 
 #?(:cljs
    (deftest build-pivot-trees-with-collapsed-paths-test
@@ -356,51 +370,54 @@
          (let [settings {:pivot_table.collapsed_rows {:value ["[1]"]}}
                result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
 
-           (is (= [{:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed true  ;; Only the node with value 1 should be collapsed
-                    :value 1}
-                   {:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed false ;; Node with value 2 should not be collapsed
-                    :value 2}]
-                  (:row-tree result))
+           (is (=?
+                [{:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed true ;; Only the node with value 1 should be collapsed
+                  :value 1}
+                 {:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed false ;; Node with value 2 should not be collapsed
+                  :value 2}]
+                (lists-to-vecs-recursively (:row-tree result)))
                "Row tree should have correct collapsed state for node with value 1 only"))
 
          ;; Test collapsing a specific nested path
          (let [settings {:pivot_table.collapsed_rows {:value ["[1,\"A\"]"]}}
                result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
 
-           (is (= [{:children [{:children [] :isCollapsed true :value "A"}  ;; Only [1,"A"] should be collapsed
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed false
-                    :value 1}
-                   {:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed false
-                    :value 2}]
-                  (:row-tree result))
+           (is (=?
+                [{:children [{:children [] :isCollapsed true :value "A"} ;; Only [1,"A"] should be collapsed
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed false
+                  :value 1}
+                 {:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed false
+                  :value 2}]
+                (lists-to-vecs-recursively (:row-tree result)))
                "Row tree should have correct collapsed state for nested path [1,\"A\"]"))
 
          ;; Test collapsing multiple specific paths
          (let [settings {:pivot_table.collapsed_rows {:value ["[1,\"A\"]", "[2,\"B\"]"]}}
                result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
 
-           (is (= [{:children [{:children [] :isCollapsed true :value "A"}  ;; [1,"A"] should be collapsed
-                               {:children [] :isCollapsed false :value "B"}]
-                    :isCollapsed false
-                    :value 1}
-                   {:children [{:children [] :isCollapsed false :value "A"}
-                               {:children [] :isCollapsed true :value "B"}]  ;; [2,"B"] should be collapsed
-                    :isCollapsed false
-                    :value 2}]
-                  (:row-tree result))
+           (is (=?
+                [{:children [{:children [] :isCollapsed true :value "A"} ;; [1,"A"] should be collapsed
+                             {:children [] :isCollapsed false :value "B"}]
+                  :isCollapsed false
+                  :value 1}
+                 {:children [{:children [] :isCollapsed false :value "A"}
+                             {:children [] :isCollapsed true :value "B"}] ;; [2,"B"] should be collapsed
+                  :isCollapsed false
+                  :value 2}]
+                (lists-to-vecs-recursively (:row-tree result)))
                "Row tree should have correct collapsed state for multiple specific paths"))))))
 
 #?(:cljs
    (deftest build-pivot-trees-collapsed-rows-type-coherence-test
      (testing "build-pivot-trees correctly associates values in the viz settings with values from the QP"
-        ;; Use BigInts and BigDecimals in the raw rows and ensure the collapsed_rows setting still applies
+       ;; Use BigInts and BigDecimals in the raw rows and ensure the collapsed_rows setting still applies
        (let [rows [[1N "A" "Y" 0 10]
                    [1N "B" "Z" 0 20]
                    [2.5M "A" "Y" 0 30]
@@ -416,15 +433,16 @@
              col-settings [{} {} {} {} {}]
              settings {:pivot_table.collapsed_rows {:value ["[1]"]}}
              result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
-         (is (= [{:children [{:children [] :isCollapsed false :value "A"}
-                             {:children [] :isCollapsed false :value "B"}]
-                  :isCollapsed true  ;; Only the node with value 1 should be collapsed
-                  :value 1}
-                 {:children [{:children [] :isCollapsed false :value "A"}
-                             {:children [] :isCollapsed false :value "B"}]
-                  :isCollapsed false ;; Node with value 2 should not be collapsed
-                  :value 2.5}]
-                (:row-tree result)))))))
+         (is (=?
+              [{:children [{:children [] :isCollapsed false :value "A"}
+                           {:children [] :isCollapsed false :value "B"}]
+                :isCollapsed true ;; Only the node with value 1 should be collapsed
+                :value 1}
+               {:children [{:children [] :isCollapsed false :value "A"}
+                           {:children [] :isCollapsed false :value "B"}]
+                :isCollapsed false ;; Node with value 2 should not be collapsed
+                :value 2.5}]
+              (lists-to-vecs-recursively (:row-tree result))))))))
 
 #?(:cljs
    (deftest build-pivot-trees-non-existant-paths
@@ -442,19 +460,62 @@
              col-indexes [2]
              val-indexes [4]
              col-settings [{} {} {} {} {}]
-              ;; Specify paths that do not exist in the data
+             ;; Specify paths that do not exist in the data
              settings {:pivot_table.collapsed_rows {:value ["[3]" "[1,\"C\"]"]}}
              result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes settings col-settings)]
-         (is (= [{:children [{:children [] :isCollapsed false :value "A"}
-                             {:children [] :isCollapsed false :value "B"}]
-                  :isCollapsed false
-                  :value 1}
-                 {:children [{:children [] :isCollapsed false :value "A"}
-                             {:children [] :isCollapsed false :value "B"}]
-                  :isCollapsed false
-                  :value 2}]
-                (:row-tree result))
+         (is (=?
+              [{:children [{:children [] :isCollapsed false :value "A"}
+                           {:children [] :isCollapsed false :value "B"}]
+                :isCollapsed false
+                :value 1}
+               {:children [{:children [] :isCollapsed false :value "A"}
+                           {:children [] :isCollapsed false :value "B"}]
+                :isCollapsed false
+                :value 2}]
+              (lists-to-vecs-recursively (:row-tree result)))
              "Row tree should not have any collapsed nodes for paths that don't exist in the data")))))
+
+(deftest build-pivot-trees-sort-trees-test
+  (let [rows [[1 "A" "Y" 0 10]
+              [1 "B" "Z" 0 20]
+              [2 "A" "Y" 0 30]
+              [2 "B" "Z" 0 40]]
+        cols [{:name "col0" :source "breakout"}
+              {:name "col1" :source "breakout"}
+              {:name "col2" :source "breakout"}
+              {:name "pivot-grouping" :source "breakout"}
+              {:name "count" :source "aggregation"}]
+        row-indexes [0 1]
+        col-indexes [2]
+        val-indexes [4]]
+    (testing "ascending sort order for first column"
+      (let [result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes {}
+                                            [{:pivot_table.column_sort_order "ascending"} {} {} {} {}])]
+        (is (=? [{:value 1
+                  :children [{:value "A"} {:value "B"}]}
+                 {:value 2
+                  :children [{:value "A"} {:value "B"}]}]
+                (lists-to-vecs-recursively (:row-tree result))))))
+
+    (testing "descending sort order for first column"
+      (let [result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes {}
+                                            [{:pivot_table.column_sort_order "descending"} {} {} {} {}])]
+        (is (=? [{:value 2
+                  :children [{:value "A"} {:value "B"}]}
+                 {:value 1
+                  :children [{:value "A"} {:value "B"}]}]
+                (lists-to-vecs-recursively (:row-tree result))))))
+
+    (testing "descending sort order for first two columns"
+      (let [result (pivot/build-pivot-trees rows cols row-indexes col-indexes val-indexes {}
+                                            [{:pivot_table.column_sort_order "descending"}
+                                             {:pivot_table.column_sort_order "descending"}
+                                             {} {} {}])]
+        (is (=? [{:value 2
+                  :children [{:value "B"} {:value "A"}]}
+                 {:value 1
+                  :children [{:value "B"} {:value "A"}]}]
+                (lists-to-vecs-recursively (:row-tree result))))))))
 
 (deftest create-row-section-getter-test
   (testing "Returns a function that correctly retrieves cell values"
@@ -501,31 +562,31 @@
                  :children [{:value "X" :rawValue "X" :children []}
                             {:value "Y" :rawValue "Y" :children []}]}]
           result (#'pivot/tree-to-array tree)]
-      (is (= [{:value "A"
-               :rawValue "A"
-               :depth 0
-               :offset 0
-               :hasChildren true
-               :path ["A"]
-               :span 2
-               :maxDepthBelow 1}
-              {:value "X"
-               :rawValue "X"
-               :depth 1
-               :offset 0
-               :hasChildren false
-               :path ["A" "X"]
-               :span 1
-               :maxDepthBelow 0}
-              {:value "Y"
-               :rawValue "Y"
-               :depth 1
-               :offset 1
-               :hasChildren false
-               :path ["A" "Y"]
-               :span 1
-               :maxDepthBelow 0}]
-             result)))))
+      (is (=? [{:value "A"
+                :rawValue "A"
+                :depth 0
+                :offset 0
+                :hasChildren true
+                :path ["A"]
+                :span 2
+                :maxDepthBelow 1}
+               {:value "X"
+                :rawValue "X"
+                :depth 1
+                :offset 0
+                :hasChildren false
+                :path ["A" "X"]
+                :span 1
+                :maxDepthBelow 0}
+               {:value "Y"
+                :rawValue "Y"
+                :depth 1
+                :offset 1
+                :hasChildren false
+                :path ["A" "Y"]
+                :span 1
+                :maxDepthBelow 0}]
+              result)))))
 
 #?(:clj
    (deftest ^:parallel ensure-is-int-test


### PR DESCRIPTION
The idea here is to rewrite processing-heavy parts of the algorithm to use mutable data structures instead of PersistentVectors/PersistentHashMaps. This reduces memory pressure (useful both on the backend and in the browser) and is overall faster. Backend benchmarks so far (when exporting the pivot as csv) show ~2x time improvement.

Another improvement is the introduction of records to replace plain maps. During pivot processing, a lot of those maps are created, so it is cheaper to make a positional objects instead. In the end, it all gets trasnformed with clj->js (on frontend), and on backend the records seem to work too if returned in place of maps.

There are more improvements that can be made, but this is sufficient to be reviewed on its own.
