### PR TITLE
Allow "blank" search for field values

### DIFF
--- a/src/metabase/warehouse_schema/api/field.clj
+++ b/src/metabase/warehouse_schema/api/field.clj
@@ -302,7 +302,9 @@
                               [:id        ms/PositiveInt]
                               [:search-id ms/PositiveInt]]
    {:keys [value]} :- [:map
-                       [:value ms/NonBlankString]]]
+                       [:value {:optional true} ms/NonBlankString]]]
+  (when-not value
+    (api/check-400 (request/limit) "Limit required if value is omitted"))
   (let [field        (api/check-404 (t2/select-one :model/Field :id id))
         search-field (api/check-404 (t2/select-one :model/Field :id search-id))]
     (api/check-403 (mi/can-read? field))

--- a/test/metabase/warehouse_schema/api/field_test.clj
+++ b/test/metabase/warehouse_schema/api/field_test.clj
@@ -735,6 +735,22 @@
              (-> (mt/user-http-request :crowberto :get 200 (format "field/%d" (u/the-id field)))
                  :settings))))))
 
+(deftest ^:parallel search-values-test-everything
+  (mt/test-drivers (mt/normal-drivers)
+    (testing "must supply a limit if value is omitted"
+      (is (mt/user-http-request :crowberto :get 400 (format "field/%d/search/%d"
+                                                            (mt/id :venues :id)
+                                                            (mt/id :venues :name)))))
+    (testing "return the first N results if value is omitted"
+      (is (= [[1 "Red Medicine"]
+              [2 "Stout Burgers & Beers"]
+              [3 "The Apple Pan"]]
+             (mt/format-rows-by
+              [int str]
+              (mt/user-http-request :crowberto :get 200 (format "field/%d/search/%d?limit=3"
+                                                                (mt/id :venues :id)
+                                                                (mt/id :venues :name)))))))))
+
 (deftest field-values-remapped-fields-test
   (testing "GET /api/field/:id/values"
     (testing "Should return tuples of [original remapped] for a remapped Field (#13235)"


### PR DESCRIPTION
Relax the signature of the field value search API to allow the omission of a search term.

This simplifies the implementation of combobox components that show an initial preview before the user types anything.

While in theory we could use the /field/:id/values route, this adds complexity to the client due to the different shape of requests and responces, lack of handling of the related search field, and inability (yet) to limit the response size.
