### PR TITLE
Update diagnostic info instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,8 @@ body:
     attributes:
       label: Information about your Metabase installation
       description: |
-        Copy and paste the JSON from `Admin -> Troubleshooting`.
+        For versions >= 56, copy and paste the Diagnostic info from `Admin -> Tools -> Help`.
+        For versions < 56, copy and paste the Diagnostic info from `Admin -> Troubleshooting`.
         _This will be automatically formatted into code, so no need for backticks._
       placeholder: |
         {"browser-info": {


### PR DESCRIPTION
closes ADM-1051

## Description

Now that we've moved around our tools and troubleshooting pages in admin settings, we need to update our github issue template to support both the old and new locations.

see: https://metaboat.slack.com/archives/C013N8XL286/p1750791858457979?thread_ts=1750785696.126089&cid=C013N8XL286
