### PR TITLE
Add includeDashboardQuestions to the useAvailableData check

### DIFF
--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -79,6 +79,34 @@ describe("scenarios > notebook > data source", () => {
         H.shouldDisplayTabs(["Tables", "Collections"]);
       });
     });
+
+    it("should include dashboard questions when computing which tabs to show (metabase#56887)", () => {
+      const QUESITON_NAME = "Find me";
+
+      H.createDashboard({
+        name: "Test Dashboard",
+      }).then((dashboard) => {
+        H.createQuestionAndAddToDashboard(
+          {
+            name: QUESITON_NAME,
+            dashboard_id: dashboard.body.id,
+            query: {
+              "source-table": ORDERS_ID,
+            },
+          },
+          dashboard.body.id,
+        );
+      });
+
+      H.startNewQuestion();
+
+      H.entityPickerModal().should("exist");
+      H.tabsShouldBe("Tables", ["Tables", "Collections"]);
+
+      H.entityPickerModalTab("Collections").click();
+      H.entityPickerModalItem(1, "Test Dashboard").click();
+      H.entityPickerModalItem(2, QUESITON_NAME).should("exist");
+    });
   });
 
   describe("table as a source", () => {

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -81,14 +81,14 @@ describe("scenarios > notebook > data source", () => {
     });
 
     it("should include dashboard questions when computing which tabs to show (metabase#56887)", () => {
-      const QUESITON_NAME = "Find me";
+      const QUESTION_NAME = "Find me";
 
       H.createDashboard({
         name: "Test Dashboard",
       }).then((dashboard) => {
         H.createQuestionAndAddToDashboard(
           {
-            name: QUESITON_NAME,
+            name: QUESTION_NAME,
             dashboard_id: dashboard.body.id,
             query: {
               "source-table": ORDERS_ID,
@@ -105,7 +105,7 @@ describe("scenarios > notebook > data source", () => {
 
       H.entityPickerModalTab("Collections").click();
       H.entityPickerModalItem(1, "Test Dashboard").click();
-      H.entityPickerModalItem(2, QUESITON_NAME).should("exist");
+      H.entityPickerModalItem(2, QUESTION_NAME).should("exist");
     });
   });
 

--- a/frontend/src/metabase/common/components/Pickers/DataPicker/hooks/useAvailableData.ts
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/hooks/useAvailableData.ts
@@ -12,6 +12,7 @@ export const useAvailableData = ({ databaseId }: Props = {}) => {
       models: ["card"],
       table_db_id: databaseId,
       calculate_available_models: true,
+      include_dashboard_questions: true,
     },
     {
       refetchOnMountOrArgChange: true,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56887

### Description
Adds the `include_dashboard_questions` flag to the search performed in `useAvailableData`. This fixes a bug where the Collections tab wasn't getting rendered in the Entity Picker if all you had access to were dashboard cards.

### How to verify

1. Set up an empty instance (you may need to archive the Examples folder)
2. Create a dashboard and add a dashboard question in our analytics
3. Go to New -> Question
4. You should see the Collection tab appear, and you should be able to navigate to your dashboard question

### Demo
<img width="1293" height="1015" alt="image" src="https://github.com/user-attachments/assets/951cd7bf-469f-400a-ab4e-76174d29caef" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
