### PR TITLE
[Lib] Remove idents part 6

### DIFF
--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -69,8 +69,6 @@ export interface DatasetColumn {
   binning_info?: BinningMetadata | null;
   settings?: Record<string, any>;
   fingerprint?: FieldFingerprint | null;
-  ident?: string;
-  "model/inner_ident"?: string;
 
   // model with customized metadata
   fk_target_field_id?: FieldId | null;

--- a/src/metabase/lib/schema/common.cljc
+++ b/src/metabase/lib/schema/common.cljc
@@ -39,19 +39,11 @@
     (cond-> m
       (string? (:lib/type m)) (update :lib/type keyword))))
 
-(def HORRIBLE-keys
-  "TODO (Cam 6/13/25) -- MEGA HACK -- keys that live in MLv2 that aren't SUPPOSED to be kebab-cased. We can and should
-  remove these keys altogether."
-  #{:model/inner_ident})
-
 (def ^:private ^{:arglists '([k])} memoized-kebab-key
   "Calculating the kebab-case version of a key every time is pretty slow (even with the LRU caching
   [[u/->kebab-case-en]] has), since the keys here are static and finite we can just memoize them forever and
   get a nice performance boost."
-  (u.memo/fast-memo (fn [k]
-                      (if (contains? HORRIBLE-keys k)
-                        k
-                        (u/->kebab-case-en k)))))
+  (u.memo/fast-memo u/->kebab-case-en))
 
 (defn map->kebab-case
   "Convert a map to kebab case, for use with `:decode/normalize`."

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -12,9 +12,7 @@
 
 (defn- kebab-cased-key? [k]
   (and (keyword? k)
-       (or (contains? lib.schema.common/HORRIBLE-keys k)
-           ;; apparently `str/includes?` doesn't work on keywords in ClojureScript ??
-           (not (str/includes? (str k) "_")))))
+       (not (str/includes? (str k) "_"))))
 
 (defn- kebab-cased-map? [m]
   (and (map? m)
@@ -191,8 +189,8 @@
         (as-> m (cond-> m
                   (and (:id m) (not (pos-int? (:id m))))
                   (dissoc :id)))
-        ;; remove deprecated `:ident`
-        (dissoc :ident))))
+        ;; remove deprecated `:ident` and `:model/inner_ident` keys (normalized to `:model/inner-ident`)
+        (dissoc :ident :model/inner-ident))))
 
 (mr/def ::column.validate-expression-source
   "Only allow `:lib/expression-name` when `:lib/source` is `:source/expressions`. If it's anything else, it probably


### PR DESCRIPTION
Remove the exception to allow metadata to have a snake_case` :model/inner_ident` key. This key is no longer populated so no need to the exception any more