### PR TITLE
force ref checkout for pull_request type trigger

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -13,6 +13,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        ref: ${{ github.head_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install pngcrush and bc


### PR DESCRIPTION
For Pull Request on's GitHub Actions checks out in detached HEAD mode by default, meaning it doesn't check out your branch by default. In a pull request trigger, ref is required as GitHub Actions checks out in detached HEAD mode. 

leading to this failed image optimizer run: https://github.com/metabase/metabase/actions/runs/16571612346/job/46865116133?pr=61501