### PR TITLE
/api/dashboard/save should use the submitter's id as creator_id

### DIFF
--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -1108,7 +1108,7 @@
                                      "/"
                                      (collection/children-location
                                       (t2/select-one :model/Collection :personal_owner_id api/*current-user-id*)))))
-        dashboard (dashboard/save-transient-dashboard! dashboard parent-collection-id)]
+        dashboard (dashboard/save-transient-dashboard! (assoc dashboard :creator_id api/*current-user-id*) parent-collection-id)]
     (events/publish-event! :event/dashboard-create {:object dashboard :user-id api/*current-user-id*})
     dashboard))
 

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5381,3 +5381,13 @@
                                           :size_x  4
                                           :size_y  4}]})
       (is (not (nil? (t2/select-one :model/PulseCard :card_id new-card-id)))))))
+
+(deftest save-dashboard-test
+  (let [response (mt/user-http-request :crowberto :post 200 "dashboard/save" {:auto_apply_filters true,
+                                                                              :name               "Test Dashboard",
+                                                                              :description        "A test dashboard to save"
+                                                                              :creator_id         399381 ;; any passed creator_id is ignored
+                                                                              })]
+    (is (partial= {:name       "Test Dashboard"
+                   :creator_id (mt/user->id :crowberto)} response))))
+

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5390,4 +5390,3 @@
                                                                               })]
     (is (partial= {:name       "Test Dashboard"
                    :creator_id (mt/user->id :crowberto)} response))))
-


### PR DESCRIPTION
### Description

Rather than accepting a passed `creator_id` in `POST /api/dashboard/save`, always use the id of the user calling the API
 
### How to verify

Describe the steps to verify that the changes are working as expected.

1. Make the API call passing a different creator_id
2. See that it uses your id

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
