### PR TITLE
Fix: UXW-28 When deleting a tab with questions saved to the dashboard, no option offered to keep and move those questions

### DIFF
--- a/frontend/src/metabase/common/hooks/use-confirmation.tsx
+++ b/frontend/src/metabase/common/hooks/use-confirmation.tsx
@@ -1,17 +1,18 @@
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { t } from "ttag";
 
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
-import type { ButtonProps } from "metabase/ui";
+import type { ButtonProps, MantineSize } from "metabase/ui";
 
 export type ConfirmationState = {
   title: string;
-  message?: string;
+  message?: string | ReactNode;
   onConfirm: () => void;
   onCancel?: () => void;
   confirmButtonText?: string;
   cancelButtonText?: string;
   confirmButtonProps?: Omit<ButtonProps, "onClick" | "children">;
+  size?: MantineSize;
 };
 
 export const useConfirmation = () => {
@@ -38,6 +39,7 @@ export const useConfirmation = () => {
       message={confirmationState?.message}
       confirmButtonText={confirmationState.confirmButtonText}
       confirmButtonProps={confirmationState.confirmButtonProps}
+      size={confirmationState.size}
     />
   ) : null;
 
@@ -49,6 +51,7 @@ export const useConfirmation = () => {
     confirmButtonText = t`Confirm`,
     cancelButtonText = t`Cancel`,
     confirmButtonProps,
+    size,
   }: ConfirmationState) =>
     setConfirmationState({
       title,
@@ -58,6 +61,7 @@ export const useConfirmation = () => {
       confirmButtonText,
       cancelButtonText,
       confirmButtonProps,
+      size,
     });
 
   return { modalContent, show };

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
@@ -1,15 +1,18 @@
 import { t } from "ttag";
+import { uniq } from "underscore";
 
 import Button from "metabase/common/components/Button";
+import Link from "metabase/common/components/Link";
 import { Sortable } from "metabase/common/components/Sortable";
 import type { TabButtonMenuItem } from "metabase/common/components/TabButton";
 import { TabButton } from "metabase/common/components/TabButton";
 import { TabRow } from "metabase/common/components/TabRow";
 import { useConfirmation } from "metabase/common/hooks/use-confirmation";
+import CS from "metabase/css/core/index.css";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { isVirtualDashCard } from "metabase/dashboard/utils";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
-import { Flex } from "metabase/ui";
+import { Flex, List } from "metabase/ui";
 import type { SelectedTabId } from "metabase-types/store";
 
 import S from "./DashboardTabs.module.css";
@@ -67,25 +70,49 @@ export function DashboardTabs() {
       label: t`Delete`,
       action: (_, value) => {
         const performDelete = () => deleteTab(value);
-        const hasDashboardQuestions = dashboard?.dashcards.some(
+        const tabQuestions = dashboard?.dashcards.filter(
           (dashcard) =>
-            dashcard.dashboard_tab_id === value &&
-            !isVirtualDashCard(dashcard) &&
-            dashcard.card.dashboard_id !== null,
+            dashcard.dashboard_tab_id === value && !isVirtualDashCard(dashcard),
         );
-        if (hasDashboardQuestions) {
-          show({
-            title: t`Delete your tab?`,
-            message: [
-              t`This will also delete the questions that are saved in it.`,
-              t`Are you sure you want to do this?`,
-            ].join(" "),
-            confirmButtonText: t`Delete tab`,
-            onConfirm: performDelete,
-          });
-        } else {
+        const tabDashboardQuestions = tabQuestions?.filter(
+          (dashcard) => dashcard.card.dashboard_id !== null,
+        );
+        const hasDashboardQuestions = !!tabDashboardQuestions?.length;
+        if (!hasDashboardQuestions) {
           performDelete();
+          return;
         }
+        const areAllDashboardQuestions =
+          tabQuestions?.length === tabDashboardQuestions.length;
+        show({
+          size: areAllDashboardQuestions ? "sm" : undefined,
+          title: areAllDashboardQuestions
+            ? t`Delete this tab and its charts?`
+            : t`Delete this tab?`,
+          message: areAllDashboardQuestions ? (
+            t`If you'd like to keep any of them, you can move them to a different tab, dashboard, or collection.`
+          ) : (
+            <>
+              {t`This will also delete any questions saved in it. If you'd like to keep any of these, move them to a different tab, dashboard, or collection.`}
+              <List ml="md" mt="sm">
+                {uniq(tabDashboardQuestions, (dc) => dc.card.id).map(
+                  (dashcard) => (
+                    <List.Item key={dashcard.card.id}>
+                      <Link
+                        to={`/question/${dashcard.card.id}`}
+                        className={CS.link}
+                      >
+                        {dashcard.card.name}
+                      </Link>
+                    </List.Item>
+                  ),
+                )}
+              </List>
+            </>
+          ),
+          confirmButtonText: t`Delete tab`,
+          onConfirm: performDelete,
+        });
       },
     });
   }


### PR DESCRIPTION
Closes #59435
Closes UXW-28

### Description

* Adds confirmation modal when deleting a tab that contains at least one dashboard-only question
* Per [Maz's feedback](https://metaboat.slack.com/archives/C096M2BBGHH/p1753810630487479?thread_ts=1753797499.606869&cid=C096M2BBGHH), slightly different modal if the tab is all dashboard questions vs a mix of saved and dashboard questions

### How to verify

1. Create a dashboard with tabs
2. When deleting a tab that contains only save questions, it shouldn't show a confirmation modal, it should just delete the tab
3. When deleting a tab that contains only dashboard questions, it should show a confirmation modal but NOT list the affected questions
4. When deleting a tab that contains a mix, it should show a confirmation modal and list the affected questions


**Other stuff to test**
* Make sure virtual cards (like links) don't mess up the algo
* Make sure you get the right behavior if the tab you delete isn't the active tab

### Demo

https://github.com/user-attachments/assets/23023f83-59fc-4a2e-9aec-7a340d50c6a1

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
