### PR TITLE
feat(sdk): Added 'hide' button to SDK problem banner

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemBanner.module.css
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemBanner.module.css
@@ -2,7 +2,7 @@
   z-index: 1000;
 }
 
-.PopoverDropdown.PopoverDropdown {
+.PopoverDropdown {
   border: none;
 }
 

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemBanner.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemBanner.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 
 import wrenchImage from "assets/img/sdk-banner-wrench.svg";
 import { DEFAULT_FONT } from "embedding-sdk/config";
+import { useSdkDispatch } from "embedding-sdk/store";
+import { setUsageProblem } from "embedding-sdk/store/reducer";
 import type { SdkUsageProblem } from "embedding-sdk/types/usage-problem";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import LogoIcon from "metabase/common/components/LogoIcon";
@@ -25,12 +27,13 @@ export const SdkUsageProblemBanner = ({
   problem,
 }: SdkUsageProblemBannerProps) => {
   const [expanded, setExpanded] = useState(false);
+  const dispatch = useSdkDispatch();
 
   if (!problem) {
     return null;
   }
 
-  const { title } = problem;
+  const { title, severity } = problem;
 
   // When the font family cannot be loaded from the MB instance,
   // due to MB instance outage or missing CORS header,
@@ -89,6 +92,20 @@ export const SdkUsageProblemBanner = ({
             </Text>
 
             <Flex w="100%" justify="end" mt="sm" columnGap="sm">
+              <Button
+                fz="sm"
+                ff={fontFamily}
+                fs="normal"
+                size="md"
+                radius="md"
+                variant="subtle"
+                color="var(--mb-color-text-brand)"
+                onClick={() => {
+                  dispatch(setUsageProblem(null));
+                }}
+              >
+                Hide {severity === "error" ? "error" : "warning"}
+              </Button>
               <ExternalLink role="link" href={problem.documentationUrl}>
                 <Button
                   fz="sm"

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
@@ -7,6 +7,7 @@ import {
 import { mockSettings } from "__support__/settings";
 import { screen, within } from "__support__/ui";
 import * as IsLocalhostModule from "embedding-sdk/lib/is-localhost";
+import { setUsageProblem } from "embedding-sdk/store/reducer";
 import { renderWithSDKProviders } from "embedding-sdk/test/__support__/ui";
 import {
   createMockApiKeyConfig,
@@ -24,6 +25,12 @@ import { createMockState } from "metabase-types/store/mocks";
 const TEST_USER = createMockUser();
 
 jest.mock("metabase/visualizations/register", () => jest.fn(() => {}));
+
+const mockSdkDispatchFn = jest.fn();
+jest.mock("embedding-sdk/store", () => ({
+  ...jest.requireActual("embedding-sdk/store"),
+  useSdkDispatch: () => mockSdkDispatchFn,
+}));
 
 interface Options {
   authConfig: MetabaseAuthConfig;
@@ -211,5 +218,21 @@ describe("SdkUsageProblemDisplay", () => {
       "href",
       "https://www.metabase.com/upgrade",
     );
+  });
+
+  it("hides the problem when 'hide' is clicked", async () => {
+    setup({
+      authConfig: createMockSdkConfig(),
+      isEmbeddingSdkEnabled: true,
+      isDevelopmentMode: true,
+    });
+
+    await userEvent.click(screen.getByTestId(PROBLEM_INDICATOR_TEST_ID));
+
+    const card = screen.getByTestId(PROBLEM_CARD_TEST_ID);
+
+    await userEvent.click(within(card).getByText("Hide warning"));
+
+    expect(mockSdkDispatchFn).toHaveBeenCalledWith(setUsageProblem(null));
   });
 });


### PR DESCRIPTION
Closes [EMB-664: Add "Hide" button to SDK warning/error popover](https://linear.app/metabase/issue/EMB-664/add-hide-button-to-sdk-warningerror-popover)

### Description

Adds a hide button to the SdkUsageProblemDisplay component, like it was intended in the sketches.

### Demo

<img width="642" height="431" alt="image" src="https://github.com/user-attachments/assets/a477b223-8883-456f-86e6-d4c9e9aa3774" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
