### PR TITLE
Replace getStoreUrl usage with useStoreUrl

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -487,7 +487,7 @@ describe("Cloud settings section", () => {
     cy.findByTestId("admin-layout-sidebar").findByText(/Cloud/i).click();
     cy.findByTestId("admin-layout-content")
       .findByText("Go to the Metabase Store")
-      .should("have.attr", "href", "https://store.metabase.com/");
+      .should("have.attr", "href", "https://test-store.metabase.com/");
   });
 
   it("should prompt us to migrate to cloud if we are not hosted", () => {

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveAddDataPanel.tsx
@@ -3,9 +3,9 @@ import type { PropsWithChildren } from "react";
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
-import { BUY_STORAGE_URL, UpsellStorage } from "metabase/admin/upsells";
+import { UpsellStorage } from "metabase/admin/upsells";
 import { skipToken } from "metabase/api";
-import { useHasTokenFeature } from "metabase/common/hooks";
+import { useHasTokenFeature, useStoreUrl } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { getSubpathSafeUrl } from "metabase/lib/urls";
 import {
@@ -137,6 +137,7 @@ export const GdriveAddDataPanel = ({
 
   const isAdmin = useSelector(getUserIsAdmin);
   const hasStorage = useHasTokenFeature("attached_dwh");
+  const storeUrl = useStoreUrl("account/storage");
 
   const showGdrive = useShowGdrive();
   const { data: folder, error } = useGetGsheetsFolderQuery(
@@ -217,7 +218,7 @@ export const GdriveAddDataPanel = ({
           error={t`Metabase Storage is full. Add more storage to continue syncing.`}
         >
           <Group gap="sm" mt="sm" align="center">
-            <CTALink href={BUY_STORAGE_URL} text={t`Add storage`} />
+            <CTALink href={storeUrl} text={t`Add storage`} />
             <CTALink href={folderUrl} text={t`Go to Google Drive`} />
           </Group>
         </ErrorAlert>

--- a/enterprise/frontend/src/metabase-enterprise/google_drive/PausedModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/PausedModal.tsx
@@ -1,9 +1,8 @@
 import { t } from "ttag";
 
-import { BUY_STORAGE_URL } from "metabase/admin/upsells";
 import { skipToken, useGetDatabaseQuery } from "metabase/api";
 import ExternalLink from "metabase/common/components/ExternalLink";
-import { useSetting } from "metabase/common/hooks";
+import { useSetting, useStoreUrl } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { _FileUploadErrorModal } from "metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal";
@@ -12,6 +11,7 @@ import { Box, Button, Modal, Stack, Text } from "metabase/ui";
 import databaseError from "./database-error.svg?component";
 
 function PausedModal({ onClose }: { onClose: () => void }) {
+  const storeUrl = useStoreUrl("account/storage");
   const isAdmin = useSelector(getUserIsAdmin);
 
   return (
@@ -34,7 +34,7 @@ function PausedModal({ onClose }: { onClose: () => void }) {
               <Button
                 variant="filled"
                 component={ExternalLink}
-                href={BUY_STORAGE_URL}
+                href={storeUrl}
                 target="_blank"
               >
                 {t`Add more storage`}

--- a/enterprise/frontend/src/metabase-enterprise/license/components/BillingInfo/BillingInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/BillingInfo/BillingInfo.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
 import Alert from "metabase/common/components/Alert";
 import { ButtonLink } from "metabase/common/components/ExternalLink";
-import { getStoreUrl } from "metabase/selectors/settings";
+import { useStoreUrl } from "metabase/common/hooks";
 import { Anchor, Box, Icon, Text } from "metabase/ui";
 import type { BillingInfo as IBillingInfo } from "metabase-types/api";
 
@@ -65,7 +65,7 @@ const BillingInfoError = () => {
 };
 
 const BillingGoToStore = () => {
-  const url = getStoreUrl();
+  const url = useStoreUrl();
 
   return (
     <>

--- a/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
+++ b/frontend/src/metabase/admin/settings/components/GeneralSettings/DevInstanceBanner.tsx
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
-import { useSetting } from "metabase/common/hooks";
-import { getStoreUrl } from "metabase/selectors/settings";
+import { useSetting, useStoreUrl } from "metabase/common/hooks";
 import { Alert, Anchor, Icon, Text } from "metabase/ui";
 
 export function DevInstanceBanner() {
@@ -37,10 +36,11 @@ function BannerBody({
   linkText: string;
   copyText: string;
 }) {
+  const storeUrl = useStoreUrl();
   return (
     <Text lh="1.25rem">
       {copyText}{" "}
-      <Anchor fw="bold" href={getStoreUrl()} target="_blank">
+      <Anchor fw="bold" href={storeUrl} target="_blank">
         {linkText}
       </Anchor>
     </Text>

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CloudSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CloudSettingsPage.tsx
@@ -5,8 +5,7 @@ import {
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
 import { ButtonLink } from "metabase/common/components/ExternalLink";
-import { useHasTokenFeature } from "metabase/common/hooks";
-import { getStoreUrl } from "metabase/selectors/settings";
+import { useHasTokenFeature, useStoreUrl } from "metabase/common/hooks";
 import { Box, Icon } from "metabase/ui";
 
 import { CloudPanel } from "../CloudPanel";
@@ -23,7 +22,7 @@ export function CloudSettingsPage() {
 }
 
 export const SettingsCloudStoreLink = () => {
-  const url = getStoreUrl();
+  const url = useStoreUrl();
 
   return (
     <SettingsSection>

--- a/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
-import { useSetting } from "metabase/common/hooks";
-import { getStoreUrl } from "metabase/selectors/settings";
+import { useSetting, useStoreUrl } from "metabase/common/hooks";
 import { Text } from "metabase/ui";
 
 import { UpsellBanner } from "./components";
@@ -10,9 +9,10 @@ type LOCATION = "embedding-page" | "settings-general";
 
 export function UpsellDevInstances({ location }: { location: LOCATION }) {
   const isDevMode = useSetting("development-mode?");
+  const storeUrl = useStoreUrl("account/new-dev-instance");
   const campaign = "dev_instances";
 
-  if (isDevMode) {
+  if (isDevMode || storeUrl === undefined) {
     return null;
   }
 
@@ -21,7 +21,7 @@ export function UpsellDevInstances({ location }: { location: LOCATION }) {
       title={t`Get a development instance`}
       campaign={campaign}
       buttonText={t`Set up`}
-      buttonLink={getStoreUrl("account/new-dev-instance")}
+      buttonLink={storeUrl}
       location={location}
       dismissible
     >

--- a/frontend/src/metabase/admin/upsells/UpsellStorage.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellStorage.tsx
@@ -1,23 +1,25 @@
 import { t } from "ttag";
 
-import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
-import { getStoreUrl } from "metabase/selectors/settings";
+import {
+  useHasTokenFeature,
+  useSetting,
+  useStoreUrl,
+} from "metabase/common/hooks";
 import { List } from "metabase/ui";
 
 import { UpsellBanner } from "./components";
 
-/**
- * @link https://linear.app/metabase/issue/CLO-4190/create-url-for-buy-storage-page-without-purchase-id
- */
-export const BUY_STORAGE_URL = getStoreUrl("account/storage");
-
 export const UpsellStorage = ({ location }: { location: string }) => {
   const campaign = "storage";
+  /**
+   * @link https://linear.app/metabase/issue/CLO-4190/create-url-for-buy-storage-page-without-purchase-id
+   */
+  const storeUrl = useStoreUrl("account/storage");
 
   const isHosted = useSetting("is-hosted?");
   const hasStorage = useHasTokenFeature("attached_dwh");
 
-  if (!isHosted || hasStorage) {
+  if (!isHosted || hasStorage || storeUrl === undefined) {
     return null;
   }
 
@@ -25,7 +27,7 @@ export const UpsellStorage = ({ location }: { location: string }) => {
     <UpsellBanner
       campaign={campaign}
       buttonText={t`Add`}
-      buttonLink={BUY_STORAGE_URL}
+      buttonLink={storeUrl}
       location={location}
       title={t`Add Metabase Storage`}
       large

--- a/frontend/src/metabase/common/hooks/use-store-url/use-store-url.ts
+++ b/frontend/src/metabase/common/hooks/use-store-url/use-store-url.ts
@@ -1,9 +1,6 @@
 import { useSelector } from "metabase/lib/redux";
-import {
-  type StorePaths,
-  getStoreUrlFromState,
-} from "metabase/selectors/settings";
+import { type StorePaths, getStoreUrl } from "metabase/selectors/settings";
 
 export function useStoreUrl(storePath: StorePaths = "") {
-  return useSelector((state) => getStoreUrlFromState(state, storePath));
+  return useSelector((state) => getStoreUrl(state, storePath));
 }

--- a/frontend/src/metabase/nav/components/PaymentBanner/PaymentBanner.tsx
+++ b/frontend/src/metabase/nav/components/PaymentBanner/PaymentBanner.tsx
@@ -3,8 +3,8 @@ import { jt, t } from "ttag";
 
 import { Banner } from "metabase/common/components/Banner";
 import ExternalLink from "metabase/common/components/ExternalLink";
+import { useStoreUrl } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
-import { getStoreUrl } from "metabase/selectors/settings";
 import { Text } from "metabase/ui";
 import type { TokenStatus } from "metabase-types/api";
 
@@ -13,6 +13,8 @@ interface PaymentBannerProps {
 }
 
 export const PaymentBanner = ({ tokenStatus }: PaymentBannerProps) => {
+  const storeUrl = useStoreUrl();
+
   return match(tokenStatus.status)
     .with("past-due", () => (
       <Banner
@@ -23,7 +25,7 @@ export const PaymentBanner = ({ tokenStatus }: PaymentBannerProps) => {
               <ExternalLink
                 key="payment-past-due"
                 className={CS.link}
-                href={getStoreUrl()}
+                href={storeUrl}
               >
                 {t`review your payment settings`}
               </ExternalLink>
@@ -40,7 +42,7 @@ export const PaymentBanner = ({ tokenStatus }: PaymentBannerProps) => {
             <ExternalLink
               key="payment-unpaid"
               className={CS.link}
-              href={getStoreUrl()}
+              href={storeUrl}
             >
               {t`Review your payment settings`}
             </ExternalLink>

--- a/frontend/src/metabase/nav/components/TrialBanner/TrialBanner.tsx
+++ b/frontend/src/metabase/nav/components/TrialBanner/TrialBanner.tsx
@@ -2,8 +2,8 @@ import { msgid, ngettext, t } from "ttag";
 
 import { Banner } from "metabase/common/components/Banner";
 import ExternalLink from "metabase/common/components/ExternalLink";
+import { useStoreUrl } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
-import { getStoreUrl } from "metabase/selectors/settings";
 import { Flex, Text } from "metabase/ui";
 
 export const TrialBanner = ({
@@ -14,7 +14,7 @@ export const TrialBanner = ({
   onClose: () => void;
 }) => {
   const lastDay = daysRemaining === 0;
-  const href = getStoreUrl("account/manage/plans");
+  const href = useStoreUrl("account/manage/plans");
 
   return (
     <Banner

--- a/frontend/src/metabase/nav/components/TrialBanner/TrialBanner.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/TrialBanner/TrialBanner.unit.spec.tsx
@@ -1,13 +1,36 @@
 import { fireEvent } from "@testing-library/react";
 
-import { render, screen } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
+import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import { TrialBanner } from "./TrialBanner";
+
+function setup({
+  daysRemaining,
+  onClose,
+}: {
+  daysRemaining: number;
+  onClose: () => void;
+}) {
+  return renderWithProviders(
+    <TrialBanner daysRemaining={daysRemaining} onClose={onClose} />,
+    {
+      storeInitialState: {
+        settings: createMockSettingsState(
+          createMockSettings({
+            "store-url": "https://store.metabase.com",
+          }),
+        ),
+      },
+    },
+  );
+}
 
 describe("TrialBanner", () => {
   it("should trigger `onClose` on the _close_ icon click", () => {
     const clickHandler = jest.fn();
-    render(<TrialBanner daysRemaining={6} onClose={clickHandler} />);
+    setup({ daysRemaining: 6, onClose: clickHandler });
 
     expect(screen.getByText("6 days left in your trial.")).toBeInTheDocument();
     expect(
@@ -24,13 +47,13 @@ describe("TrialBanner", () => {
   });
 
   it("should render correctly with the 1 day remaining", () => {
-    render(<TrialBanner daysRemaining={1} onClose={() => {}} />);
+    setup({ daysRemaining: 1, onClose: () => {} });
 
     expect(screen.getByText("1 day left in your trial.")).toBeInTheDocument();
   });
 
   it("should render correctly on the last day of the trial", () => {
-    render(<TrialBanner daysRemaining={0} onClose={() => {}} />);
+    setup({ daysRemaining: 0, onClose: () => {} });
 
     expect(
       screen.getByText("Today is the last day of your trial."),

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
@@ -1,7 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
 import { screen, within } from "__support__/ui";
-import { BUY_STORAGE_URL } from "metabase/admin/upsells";
 
 import { setupHostedInstance, setupProUpload } from "./setup";
 
@@ -150,7 +149,10 @@ describe("Add data modal (Pro: hosted instance with the attached DWH)", () => {
 
     const upsellLink = within(alert).getByRole("link", { name: "Add storage" });
     expect(upsellLink).toBeInTheDocument();
-    expect(upsellLink).toHaveAttribute("href", BUY_STORAGE_URL);
+    expect(upsellLink).toHaveAttribute(
+      "href",
+      "https://store.metabase.com/account/storage",
+    );
 
     const driveLink = within(alert).getByRole("link", {
       name: "Go to Google Drive",

--- a/frontend/src/metabase/selectors/selectors.unit.spec.ts
+++ b/frontend/src/metabase/selectors/selectors.unit.spec.ts
@@ -166,7 +166,9 @@ describe("getStoreUrlFromState", () => {
       }),
     });
 
-    expect(getStoreUrl(stateUndefined)).toBeUndefined();
-    expect(getStoreUrl(stateCorruptedString)).toBeUndefined();
+    expect(getStoreUrl(stateUndefined)).toBe("https://store.metabase.com/");
+    expect(getStoreUrl(stateCorruptedString)).toBe(
+      "https://store.metabase.com/",
+    );
   });
 });

--- a/frontend/src/metabase/selectors/selectors.unit.spec.ts
+++ b/frontend/src/metabase/selectors/selectors.unit.spec.ts
@@ -10,7 +10,7 @@ import {
 import {
   getDocsUrl,
   getIsPaidPlan,
-  getStoreUrlFromState,
+  getStoreUrl,
   getUpgradeUrl,
 } from "./settings";
 
@@ -146,12 +146,27 @@ describe("getStoreUrlFromState", () => {
       }),
     });
 
-    expect(getStoreUrlFromState(state)).toBe(
-      "https://test-store.metabase.com/",
-    );
+    expect(getStoreUrl(state)).toBe("https://test-store.metabase.com/");
 
-    expect(getStoreUrlFromState(state, "account/manage/plans")).toBe(
+    expect(getStoreUrl(state, "account/manage/plans")).toBe(
       "https://test-store.metabase.com/account/manage/plans",
     );
+  });
+
+  it("should return for falsey values", () => {
+    const stateUndefined = createMockState({
+      settings: createMockSettingsState({
+        "store-url": undefined,
+      }),
+    });
+
+    const stateCorruptedString = createMockState({
+      settings: createMockSettingsState({
+        "store-url": "false",
+      }),
+    });
+
+    expect(getStoreUrl(stateUndefined)).toBeUndefined();
+    expect(getStoreUrl(stateCorruptedString)).toBeUndefined();
   });
 });

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -47,13 +47,9 @@ export type StorePaths =
   /** EE, self-hosted upsell that communicates back with the instance */
   | "checkout/upgrade/self-hosted";
 
-export function getStoreUrlFromState(state: State, path: StorePaths = "") {
-  const storeUrl = getSetting(state, "store-url");
-  if (!storeUrl) {
-    return undefined;
-  }
-
+export function getStoreUrl(state: State, path: StorePaths = "") {
   try {
+    const storeUrl = getSetting(state, "store-url");
     const url = new URL(path, storeUrl);
     return url.toString();
   } catch {

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -47,13 +47,15 @@ export type StorePaths =
   /** EE, self-hosted upsell that communicates back with the instance */
   | "checkout/upgrade/self-hosted";
 
+const DEFAULT_STORE_URL = "https://store.metabase.com/";
+
 export function getStoreUrl(state: State, path: StorePaths = "") {
   try {
     const storeUrl = getSetting(state, "store-url");
     const url = new URL(path, storeUrl);
     return url.toString();
   } catch {
-    return undefined;
+    return DEFAULT_STORE_URL;
   }
 }
 

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -47,18 +47,18 @@ export type StorePaths =
   /** EE, self-hosted upsell that communicates back with the instance */
   | "checkout/upgrade/self-hosted";
 
-// @deprecated Please use getStoreUrlFromState or useStoreUrl that read the store-url from the state
-export const getStoreUrl = (path: StorePaths = "") => {
-  return `https://store.metabase.com/${path}`;
-};
-
 export function getStoreUrlFromState(state: State, path: StorePaths = "") {
   const storeUrl = getSetting(state, "store-url");
   if (!storeUrl) {
     return undefined;
   }
-  const url = new URL(path, storeUrl);
-  return url.toString();
+
+  try {
+    const url = new URL(path, storeUrl);
+    return url.toString();
+  } catch {
+    return undefined;
+  }
 }
 
 export const migrateToCloudGuideUrl = () =>

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
@@ -2,13 +2,13 @@ import { c, t } from "ttag";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
 import FormSubmitButton from "metabase/common/components/FormSubmitButton";
+import { useStoreUrl } from "metabase/common/hooks";
 import {
   Form,
   FormErrorMessage,
   FormProvider,
   FormTextInput,
 } from "metabase/forms";
-import { getStoreUrl } from "metabase/selectors/settings";
 import {
   Box,
   Button,
@@ -36,9 +36,10 @@ export const LicenseTokenForm = ({
   onSkip,
   initialValue = "",
 }: LicenseTokenFormProps) => {
+  const storeUrl = useStoreUrl("checkout");
   const storeLink = (
     <ExternalLink
-      href={getStoreUrl("checkout")}
+      href={storeUrl}
       key="store-link"
     >{t`Try Metabase for free`}</ExternalLink>
   );


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-94/migrate-rest-of-usage-of-legacy-getstoreurl-function

### Description

I've replaced all usages of `getStoreUrl` with the newer API `getStoreUrlFromState`/`useStoreUrl`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
