### PR TITLE
feat: endpoint for retrieve embedding token from jwt

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -106,7 +106,6 @@
     (when-not jwt
       (throw (ex-info "JWT token is required"
                       {:status "error-jwt-missing" :status-code 400})))
-    
     (let [jwt-data (try
                      (jwt/create-session-from-jwt! jwt request)
                      (catch Throwable e

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -116,7 +116,6 @@
           session (:session jwt-data)
           session-token (:key session)]
       {:status :ok
-       :session_id (str session-token)
        :session_token (str session-token)
        :exp (:exp (:jwt-data jwt-data))
        :iat (:iat (:jwt-data jwt-data))})

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -97,7 +97,7 @@
   [_route-params
    _query-params
    {:keys [jwt]} :- [:map
-                     [:jwt ms/NonBlankString]]
+                     [:jwt {:optional true} [:maybe ms/NonBlankString]]]
    request]
   (try
     (when-not (sso-settings/jwt-enabled)
@@ -114,8 +114,7 @@
                                        e))))
           session (:session jwt-data)
           session-token (:key session)]
-      {:status :ok
-       :session_token (str session-token)
+      {:session_token (str session-token)
        :exp (:exp (:jwt-data jwt-data))
        :iat (:iat (:jwt-data jwt-data))})
     (catch Throwable e

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -111,10 +111,10 @@
       (sync-groups! user jwt-data)
       {:session session, :redirect-url redirect-url, :jwt-data jwt-data})))
 
-(defn create-session-from-jwt!
-  "Public wrapper for creating a session from JWT token data. Used by the to_session endpoint."
+(defn jwt->session
+  "Given a JWT, return a valid session token for the associated user (creating the user if necessary)."
   [jwt request]
-  (session-data jwt request))
+  (-> (session-data jwt request) :session :key))
 
 (defn- throw-react-sdk-embedding-disabled
   []

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -100,8 +100,7 @@
                          (catch Throwable e
                            (throw
                             (ex-info (ex-message e)
-                                     {:status      "error-jwt-bad-unsigning"
-                                      :status-code 401}))))
+                                     {:status-code 401}))))
           login-attrs  (jwt-data->login-attributes jwt-data)
           email        (get jwt-data (jwt-attribute-email))
           first-name   (get jwt-data (jwt-attribute-firstname))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -37,7 +37,6 @@
         (sso-utils/check-user-provisioning :jwt)
         (sso-utils/create-new-sso-user! user))))
 
-
 (def ^:private ^{:arglists '([])} jwt-attribute-email
   (comp keyword sso-settings/jwt-attribute-email))
 

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -37,6 +37,7 @@
         (sso-utils/check-user-provisioning :jwt)
         (sso-utils/create-new-sso-user! user))))
 
+
 (def ^:private ^{:arglists '([])} jwt-attribute-email
   (comp keyword sso-settings/jwt-attribute-email))
 
@@ -110,6 +111,11 @@
           session      (session/create-session! :sso user (request/device-info request))]
       (sync-groups! user jwt-data)
       {:session session, :redirect-url redirect-url, :jwt-data jwt-data})))
+
+(defn create-session-from-jwt!
+  "Public wrapper for creating a session from JWT token data. Used by the to_session endpoint."
+  [jwt request]
+  (session-data jwt request))
 
 (defn- throw-react-sdk-embedding-disabled
   []

--- a/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
@@ -94,30 +94,25 @@
               (is (contains? (:body response) :exp))
               (is (contains? (:body response) :iat))
               (is (string? (get-in response [:body :session_token])))))
-          
           (testing "missing JWT token"
             (let [response (client/client :post "/auth/sso/to_session" {})]
               (is (= 400 (:status response)))
               (is (= "error-jwt-missing" (get-in response [:body :status])))))
-          
           (testing "JWT disabled"
             (mt/with-temporary-setting-values [jwt-enabled false]
               (let [jwt-token (create-valid-jwt-token)
                     response (client/client :post "/auth/sso/to_session" {:jwt jwt-token})]
                 (is (= 400 (:status response)))
                 (is (= "error-jwt-disabled" (get-in response [:body :status]))))))
-          
           (testing "invalid JWT token"
             (let [response (client/client :post "/auth/sso/to_session" {:jwt "invalid-token"})]
               (is (= 401 (:status response)))
               (is (= "error-jwt-invalid" (get-in response [:body :status])))))
-          
           (testing "expired JWT token"
             (let [expired-token (create-valid-jwt-token {:exp (- (int (/ (System/currentTimeMillis) 1000)) 3600)})
                   response (client/client :post "/auth/sso/to_session" {:jwt expired-token})]
               (is (= 401 (:status response)))
               (is (= "error-jwt-invalid" (get-in response [:body :status])))))
-          
           (testing "JWT with different secret"
             (let [wrong-secret-token (jwt/sign {:email "test@example.com"
                                                :first_name "Test"

--- a/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
@@ -73,10 +73,10 @@
   ([claims]
    (let [now (int (/ (System/currentTimeMillis) 1000))
          default-claims {:email "test@example.com"
-                        :first_name "Test"
-                        :last_name "User"
-                        :iat now
-                        :exp (+ now 3600)}]
+                         :first_name "Test"
+                         :last_name "User"
+                         :iat now
+                         :exp (+ now 3600)}]
      (jwt/sign (merge default-claims claims) default-jwt-secret))))
 
 (deftest jwt-to-session-test
@@ -115,11 +115,11 @@
               (is (= "error-jwt-invalid" (get-in response [:body :status])))))
           (testing "JWT with different secret"
             (let [wrong-secret-token (jwt/sign {:email "test@example.com"
-                                               :first_name "Test"
-                                               :last_name "User"
-                                               :iat (int (/ (System/currentTimeMillis) 1000))
-                                               :exp (+ (int (/ (System/currentTimeMillis) 1000)) 3600)}
-                                              "wrong-secret")
+                                                :first_name "Test"
+                                                :last_name "User"
+                                                :iat (int (/ (System/currentTimeMillis) 1000))
+                                                :exp (+ (int (/ (System/currentTimeMillis) 1000)) 3600)}
+                                               "wrong-secret")
                   response (client/client :post "/auth/sso/to_session" {:jwt wrong-secret-token})]
               (is (= 401 (:status response)))
               (is (= "error-jwt-invalid" (get-in response [:body :status]))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -296,16 +296,15 @@
     (with-jwt-default-setup!
       (is
        (= "Token is older than max-age (180)"
-          (:message
-           (client/client :get 401 "/auth/sso" {:request-options {:redirect-strategy :none}}
-                          :return_to default-redirect-uri
-                          :jwt
-                          (jwt/sign
-                           {:email      "test@metabase.com",
-                            :first_name "Test"
-                            :last_name  "User"
-                            :iat        (- (buddy-util/now) (u/minutes->seconds 5))}
-                           default-jwt-secret))))))))
+          (client/client :get 401 "/auth/sso" {:request-options {:redirect-strategy :none}}
+                         :return_to default-redirect-uri
+                         :jwt
+                         (jwt/sign
+                          {:email      "test@metabase.com",
+                           :first_name "Test"
+                           :last_name  "User"
+                           :iat        (- (buddy-util/now) (u/minutes->seconds 5))}
+                          default-jwt-secret)))))))
 
 (defmacro with-users-with-email-deleted {:style/indent 1} [user-email & body]
   `(try


### PR DESCRIPTION
  Context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1753118821607669

  Summary

  Implements a new POST /auth/sso/to_session endpoint that converts JWT tokens to user sessions, enabling programmatic session creation for JWT-authenticated users.

  Changes

  New Endpoint: POST /auth/sso/to_session

  - Location: enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
  - Purpose: Convert JWT tokens to Metabase user sessions
  - Authentication: Requires premium :sso-jwt feature and JWT configuration

  Request/Response Format

  Request:
  {
    "jwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
  }

  Success Response (200):
  {
    "session_token": "uuid-session-token",
    "exp": 1234567890,
    "iat": 1234567890
  }

  Error Responses:
  - 400 - JWT disabled: {"status": "error-jwt-disabled"}
  - 400 - Missing JWT: {"status": "error-jwt-missing"}
  - 401 - Invalid JWT: {"status": "error-jwt-invalid"}

  Implementation Details

  - Validates JWT tokens using existing JWT validation logic
  - Creates or fetches users using existing JWT user provisioning
  - Generates sessions using existing session creation methods
  - Syncs user groups based on JWT claims
  - Handles all error cases with appropriate HTTP status codes

  Supporting Changes

  - JWT Integration: Added public create-session-from-jwt! function in
  enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
  - Tests: Comprehensive test coverage in
  enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj

  Test Coverage

  - ✅ Successful JWT to session conversion
  - ✅ Missing JWT token error handling
  - ✅ JWT disabled scenario
  - ✅ Invalid JWT token handling
  - ✅ Expired JWT token handling
  - ✅ Wrong secret JWT token handling

  Security Considerations

  - Validates JWT tokens using configured shared secret
  - Respects JWT expiration times (3-minute max age)
  - Requires premium SSO features to be enabled
  - Follows existing JWT user provisioning and group sync logic

  Test Plan

  1. Enable JWT SSO configuration with valid secret
  2. Create valid JWT token with user claims
  3. POST to /auth/sso/to_session with JWT token
  4. Verify session token is returned and valid
  5. Test error scenarios (missing/invalid/expired tokens)

  🤖 Generated with https://claude.ai/code