### PR TITLE
Fixup CI for mongo

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -629,24 +629,25 @@
                                 [:asc &c.checkins.id]]
                      :limit    3})]
         (testing "qp.compile"
-          (is (= [{"$lookup"
-                   {:as "join_alias_c"
-                    :from "checkins"
-                    :let {"let__id___1" "$_id",
-                          "let_name___2" "$name"}
-                    :pipeline
-                    [{"$match"
-                      {"$and" [{"$expr" {"$eq" ["$$let__id___1" "$user_id"]}}
-                               {"$expr" {"$eq" ["$$let_name___2" "Felipinho Asklepios"]}}]}}]}}
-                  {"$unwind" {:path "$join_alias_c"
-                              :preserveNullAndEmptyArrays true}}
-                  {"$sort" {"_id" 1
-                            "join_alias_c._id" 1}}
-                  {"$project" {"_id" "$_id"
-                               "c__date" "$join_alias_c.date"
-                               "name" "$name"}}
-                  {"$limit" 3}]
-                 (:query (qp.compile/compile query)))))
+          (is (=? [{"$lookup"
+                    {:as "join_alias_c"
+                     :from "checkins"
+                     :let {"let__id___1" "$_id",
+                           "let_name___2" "$name"}
+                     :pipeline
+                     [{"$project" {}}
+                      {"$match"
+                       {"$and" [{"$expr" {"$eq" ["$$let__id___1" "$user_id"]}}
+                                {"$expr" {"$eq" ["$$let_name___2" "Felipinho Asklepios"]}}]}}]}}
+                   {"$unwind" {:path "$join_alias_c"
+                               :preserveNullAndEmptyArrays true}}
+                   {"$sort" {"_id" 1
+                             "join_alias_c._id" 1}}
+                   {"$project" {"_id" "$_id"
+                                "c__date" "$join_alias_c.date"
+                                "name" "$name"}}
+                   {"$limit" 3}]
+                  (:query (qp.compile/compile query)))))
         (testing "qp.process-query"
           (is (= [[1 "Plato Yeshua" nil]
                   [2 "Felipinho Asklepios" "2013-11-19T00:00:00Z"]

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -431,10 +431,7 @@
   :hierarchy lib.hierarchy/hierarchy)
 
 (mu/defmethod aggregation->legacy-MBQL :default
-  [[tag options & args] :- [:cat
-                            :keyword
-                            :map
-                            [:* :any]]]
+  [[tag options & args] #_#_:- [:cat :keyword :map [:* :any]]]
   (let [inner (into [tag] (map ->legacy-MBQL) args)
         ;; the default value of the :case or :if expression is in the options
         ;; in legacy MBQL


### PR DESCRIPTION
This is not a proper fix. But it highlights where the issue is coming from. 

I'm commenting out a schema here. I suspect that the mongo query processor needs to be updated to send the correct information through rather than the query processor allow for empty or missing options.

Flowing through this for sqlite is:

```
[:count {:lib/uuid "0076be13-858b-4dc3-ae6a-edf02717cc6a"}]
[:count {:lib/uuid "a2f4139e-9aa1-47be-9500-3e8bdaef73b0" :name "count"}]
```

For mongo all that is coming through is:

```
[:count]
```

the queries are:

mongo:
```
{:database 13371339
 :type :native
 :native {:projections [:count]
          :query "[{\"$match\":{\"name\":{{name}}}},{\"$group\":{\"_id\":null,\"count\":{\"$sum\":1}}},{\"$sort\":{\"_id\":1}},{\"$project\":{\"_id\":false,\"count\":true}}]"
          :collection "venues"
          :template-tags {"name" {:name "name"
                                  :display-name "name"
                                  :type "text"
                                  :default "In-N-Out Burger"}}}}
```

and sqlite

```
{:database 13371341
 :type :native
 :native {:query "SELECT COUNT(*) AS \"count\" FROM \"venues\" WHERE \"venues\".\"name\" = {{name}}"
          :template-tags {"name" {:name "name"
                                  :display-name "name"
                                  :type "text"}}}
 :parameters [{:type :text
               :target [:variable
                        [:template-tag "name"]]
               :value "In-N-Out Burger"}]}
```

These can be seen from running:

```
parameters-test=>
(mt/set-test-drivers! #{:mongo :sqlite})
parameters-test=> (clojure.test/run-test template-tag-text-param-test)

Testing metabase.query-processor-test.parameters-test

Ran 1 tests containing 4 assertions.
0 failures, 0 errors.
{:test 1, :pass 4, :fail 0, :error 0, :type :summary}
```

If the schema is restored we observe the following output:

```
parameters-test=> (clojure.test/run-test template-tag-text-param-test)

Testing metabase.query-processor-test.parameters-test

ERROR in (template-tag-text-param-test) (preprocess.clj:196)

:mongo
 Query with all supplied parameters text params
expected: (= 1 (count-with-params :venues :name :text "In-N-Out Burger" options))
  actual: clojure.lang.ExceptionInfo: Error preprocessing query in metabase.query-processor.middleware.parameters/substitute-parameters: Error converting MLv2 query to legacy query: Invalid input: [nil ["end of input, got: nil"]]
...
Ran 1 tests containing 4 assertions.
0 failures, 2 errors.
{:test 1, :pass 2, :fail 0, :error 2, :type :summary}
```

