### PR TITLE
feat: hide enable editing setting for unsupported database drivers

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
@@ -15,7 +15,6 @@ import type { Database, DatabaseData, DatabaseId } from "metabase-types/api";
 
 import {
   DATABASE_TABLE_EDITING_SETTING,
-  ENGINE_SUPPORTED_FOR_TABLE_EDITING,
   isDatabaseTableEditingEnabled,
 } from "../settings";
 
@@ -28,14 +27,8 @@ export function AdminDatabaseTableEditingSection({
     database: { id: DatabaseId } & Partial<DatabaseData>,
   ) => Promise<void>;
 }) {
-  const isEngineSupported = ENGINE_SUPPORTED_FOR_TABLE_EDITING.has(
-    database.engine ?? "",
-  );
-
   const showTableEditingSection =
-    !!database.id &&
-    isEngineSupported &&
-    hasFeature(database, "actions/data-editing");
+    !!database.id && hasFeature(database, "actions/data-editing");
 
   const [error, setError] = useState<string | null>(null);
 
@@ -52,7 +45,7 @@ export function AdminDatabaseTableEditingSection({
     }
   };
 
-  if (!showTableEditingSection || !isEngineSupported) {
+  if (!showTableEditingSection) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
@@ -15,6 +15,7 @@ import type { Database, DatabaseData, DatabaseId } from "metabase-types/api";
 
 import {
   DATABASE_TABLE_EDITING_SETTING,
+  ENGINE_SUPPORTED_FOR_TABLE_EDITING,
   isDatabaseTableEditingEnabled,
 } from "../settings";
 
@@ -27,9 +28,14 @@ export function AdminDatabaseTableEditingSection({
     database: { id: DatabaseId } & Partial<DatabaseData>,
   ) => Promise<void>;
 }) {
-  const isEditingDatabase = !!database.id;
+  const isEngineSupported = ENGINE_SUPPORTED_FOR_TABLE_EDITING.has(
+    database.engine ?? "",
+  );
+
   const showTableEditingSection =
-    isEditingDatabase && hasFeature(database, "actions");
+    !!database.id &&
+    isEngineSupported &&
+    hasFeature(database, "actions/data-editing");
 
   const [error, setError] = useState<string | null>(null);
 
@@ -46,7 +52,7 @@ export function AdminDatabaseTableEditingSection({
     }
   };
 
-  if (!showTableEditingSection) {
+  if (!showTableEditingSection || !isEngineSupported) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/settings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/settings.tsx
@@ -2,6 +2,12 @@ import type { Database } from "metabase-types/api";
 
 export const DATABASE_TABLE_EDITING_SETTING = "database-enable-table-editing";
 
+export const ENGINE_SUPPORTED_FOR_TABLE_EDITING = new Set([
+  "postgres",
+  "mysql",
+  "h2",
+]);
+
 export function isDatabaseTableEditingEnabled(database: Database) {
   return database.settings?.[DATABASE_TABLE_EDITING_SETTING] ?? false;
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/settings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/settings.tsx
@@ -2,12 +2,6 @@ import type { Database } from "metabase-types/api";
 
 export const DATABASE_TABLE_EDITING_SETTING = "database-enable-table-editing";
 
-export const ENGINE_SUPPORTED_FOR_TABLE_EDITING = new Set([
-  "postgres",
-  "mysql",
-  "h2",
-]);
-
 export function isDatabaseTableEditingEnabled(database: Database) {
   return database.settings?.[DATABASE_TABLE_EDITING_SETTING] ?? false;
 }

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -14,6 +14,7 @@ export type DatabaseSettings = {
 
 export type DatabaseFeature =
   | "actions"
+  | "actions/data-editing"
   | "basic-aggregations"
   | "binning"
   | "case-sensitivity-string-filter-options"


### PR DESCRIPTION
Resolves [WRK-617](https://linear.app/metabase/issue/WRK-617/fe-hide-enable-editing-setting-for-unsupported-database-drivers)
