### PR TITLE
fix: adjust schemas for inactive tables too

### DIFF
--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -351,6 +351,43 @@
                                 :active true))))
               (is (= 1 (count (mt/rows (mt/run-mbql-query venues {:limit 1}))))))))))))
 
+(deftest multi-level-changes-inactive-table-schemas-too
+  (mt/test-driver
+    :databricks
+    ;; skip if running in multi-level since we are manipulating it in this test
+    (when-not (tx/db-test-env-var :databricks :multi-level-schema false)
+      (let [details (get (mt/db) :details)
+            ;; metabase_ci_multicatalog.test_schema.test (id, name)
+            multicatalog (tx/db-test-env-var :databricks :multicatalog-catalog "metabase_ci_multicatalog")
+            multicatalog-schema (tx/db-test-env-var :databricks :multicatalog-schema "test_schema")
+            multi-pattern (format "%s.%s,%s.%s"
+                                  (:catalog details)
+                                  (:schema-filters-patterns details)
+                                  multicatalog
+                                  multicatalog-schema)]
+        (mt/with-temp [:model/Database {db-id :id :as db} {:engine :databricks :details details}]
+          ;; First sync with multi-level-schema off
+          (mt/with-db
+            db
+            (testing "With multi-level-schema default (off)"
+              (sync/sync-database! (mt/db))
+              ;; originally we have unqualified schemas, only in one catalog
+              (is (= #{"test-data"}
+                     (t2/select-fn-set :schema :model/Table :db_id (mt/id))))))
+          (testing "With multi-level-schema on, schemas are qualified"
+            (t2/update! :model/Database db-id {:details (assoc details
+                                                               :multi-level-schema true
+                                                               :schema-filters-patterns multi-pattern)})
+            ;; Deactivate its tables for testing
+            (t2/update! :model/Table {:db_id db-id} {:active false})
+            (mt/with-db
+              (t2/select-one :model/Database db-id)
+              (sync/sync-database! (mt/db))
+              (is (= #{(format "%s.%s" (:catalog details) "test-data")
+                       (format "%s.%s" multicatalog multicatalog-schema)}
+                     ;; active` *and* inactive tables both have their schemas changed.
+                     (t2/select-fn-set :schema :model/Table :db_id (mt/id)))))))))))
+
 (deftest multi-level-schema-wanted-catalogs-test
   (mt/test-driver
     :databricks

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -241,26 +241,39 @@
         (remove metabase-metadata/is-metabase-metadata-table?)
         (:tables db-metadata)))
 
+(mu/defn- select-tables :- [:set (ms/InstanceOf :model/Table)]
+  "Selects the columns we need for `:model/Table`, with some optional filters"
+  [database :- i/DatabaseInstance
+   & filters]
+  (set (apply
+        t2/select
+        [:model/Table :id :name :schema :description :database_require_filter :estimated_row_count
+         :visibility_type :initial_sync_status]
+        :db_id (u/the-id database)
+        filters)))
+
 (mu/defn- db->our-metadata :- [:set (ms/InstanceOf :model/Table)]
-  "Return information about what Tables we have for this DB in the Metabase application DB."
+  "Return information about what Tables we have for this DB in the Metabase application DB. Only includes active tables."
   [database :- i/DatabaseInstance]
-  (set (t2/select [:model/Table :id :name :schema :description :database_require_filter :estimated_row_count
-                   :visibility_type :initial_sync_status]
-                  :db_id  (u/the-id database)
-                  :active true)))
+  (select-tables database :active true))
+
+(mu/defn- db->our-tables :- [:set (ms/InstanceOf :model/Table)]
+  "Return *all* tables we have for this DB in the Metabase appDB, including inactive ones."
+  [database :- i/DatabaseInstance]
+  (select-tables database))
 
 (mu/defn- adjusted-schemas :- [:maybe [:map-of :string :string]]
   "Returns a map of schemas that should be adjusted to their new names."
   [driver
    database
-   our-metadata :- [:set (ms/InstanceOf :model/Table)]]
+   our-tables :- [:set (ms/InstanceOf :model/Table)]]
   (reduce
    (fn [accum schema]
      (let [new-schema (driver/adjust-schema-qualification driver database schema)]
        (cond-> accum
          (not= schema new-schema) (assoc schema new-schema))))
    nil
-   (into #{} (map :schema our-metadata))))
+   (into #{} (map :schema our-tables))))
 
 (defn- adjust-table-schemas!
   [database schemas-to-update]
@@ -331,14 +344,15 @@
 
   ([database :- i/DatabaseInstance db-metadata]
    ;; determine what's changed between what info we have and what's in the DB
-   (let [driver (driver.u/database->driver database)
+   (let [driver                (driver.u/database->driver database)
          db-table-metadatas    (table-set db-metadata)
          name+schema           #(select-keys % [:name :schema])
          name+schema->db-table (m/index-by name+schema db-table-metadatas)
          our-metadata          (db->our-metadata database)
          multi-level-support?  (driver.u/supports? driver :multi-level-schema database)
          schemas-to-update     (when multi-level-support?
-                                 (adjusted-schemas driver database our-metadata))
+                                 ;; we want to adjust the schemas for all tables (not just active ones from `our-metadata`)
+                                 (adjusted-schemas driver database (db->our-tables database)))
          our-metadata          (cond->> our-metadata
                                  multi-level-support?
                                  (into #{} (map (fn [table]


### PR DESCRIPTION
When toggling the multi-catalog setting for a database, we rename existing schemas to match. For example, if you turn multi-catalog on and have the existing schema `foo`, we'll rename it to `mycatalog.foo`. Similarly, if you have the existing schema `mycatalog.foo` and turn multi-catalog *off*, we'll rename it to `foo`.

We were ignoring inactive schemas here, which meant that if you turned on multi-catalog and some of your tables became inactive (quite possibly because you didn't update the schema filter to match, a major footgun for the user), we would:

- update the tables going one way (`foo` to `mycatalog.foo`) and deactivate for not matching the schema filter, then

- never update the tables again, because now they're inactive

Instead we should update the schemas for inactive tables as well.

Related to [UXW-375: Databricks multiple catalogs - Table "database.catalog.schema.table" is
inactive](https://linear.app/metabase/issue/UXW-375/databricks-multiple-catalogs-table-databasecatalogschematable-is) / https://github.com/metabase/metabase/issues/61492

I don't think this is a complete fix though - we may need to rethink the feature, and possibly just not allow you to change the setting for existing databases.

**Note:** I'm out until August 15th, please feel free to merge this in my absence, make any necessary changes, etc.
