### PR TITLE
Fix race condition of ee-extra release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,7 +399,9 @@ jobs:
             });
 
   trigger-ee-extra-pr:
-    needs: verify-s3-download
+    needs:
+      - containerize-ee
+      - verify-s3-download
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
The workflow in the `metabase-ee-extra` repository could run before the
container image tags were created by the workflow in the `metabase`
repository, causing the former to fail.  Fix by making the image push
an explicit dependency of the ee-extra trigger.