### PR TITLE
Fix zero measure count issue for pivot tables

### DIFF
--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -157,7 +157,7 @@
                         cell-values (mapcat (fn [col-idx]
                                               (let [values (get-row-section col-idx row-idx)]
                                                 (map :value values)))
-                                            (range (/ col-count measure-count)))]
+                                            (range (/ col-count (max measure-count 1))))]
                     ;; Combine left headers with cell values
                     (into left-row cell-values))))]
     (vec result)))

--- a/test/metabase/query_processor/pivot/postprocess_test.clj
+++ b/test/metabase/query_processor/pivot/postprocess_test.clj
@@ -139,4 +139,14 @@
           result (#'pivot.postprocess/build-full-pivot get-row-section left-headers top-headers measure-count)]
       (is (= [["" "Col X"]
               ["Row A"]]
+             result))))
+
+  (testing "handles zero measure-count with no error"
+    (let [get-row-section (constantly [])
+          left-headers []
+          top-headers [["" "Col X"]]
+          measure-count 0
+          result (#'pivot.postprocess/build-full-pivot get-row-section left-headers top-headers measure-count)]
+      (is (= [["" "Col X"]
+              []]
              result)))))


### PR DESCRIPTION
I'm not exactly sure how the count of values could end up at 0, but I was able to manually create a card with this configuration via an API request, which then resulted in `java.lang.ArithmeticException: Divide by zero` when sending emails.

Fixes #60428
