### PR TITLE
Don't try to update setting as non-admin

### DIFF
--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -237,6 +237,7 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
     allLoaded,
     showTimelinesForCollection,
     card,
+    isAdmin,
     isLoadingComplete,
     closeQB,
     route,
@@ -252,6 +253,7 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
     (series: Series) => {
       const isNonTable = series[0].card.display !== "table";
       if (
+        isAdmin &&
         !didFirstNonTableChartGenerated &&
         !didTrackFirstNonTableChartGeneratedRef.current &&
         isNonTable
@@ -260,7 +262,12 @@ function QueryBuilderInner(props: QueryBuilderInnerProps) {
         didTrackFirstNonTableChartGeneratedRef.current = true;
       }
     },
-    [card, didFirstNonTableChartGenerated, setDidFirstNonTableChartRender],
+    [
+      isAdmin,
+      card,
+      didFirstNonTableChartGenerated,
+      setDidFirstNonTableChartRender,
+    ],
   );
 
   const forceUpdate = useForceUpdate();


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59050
We're using a setting as a half-baked way to track whether we've ever created a non-table chart. We do this regardless of whether you're an admin or not, but the endpoint responds with a 403 if you're not an admin.

Honestly motivation here was fixing [UXW-152: 403 thrown for non-admins when viewing question re:
non-table-chart-generated](https://linear.app/metabase/issue/UXW-152/403-thrown-for-non-admins-when-viewing-question-re-non-table-chart) but it feels a little silly. But... it's not *completely* unreasonable.
