### PR TITLE
Enable fts on native query contents in the semantic search backend

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -54,6 +54,7 @@
      [:legacy_input :jsonb]
      [:embedding [:raw (format "vector(%d)" vector-dimensions)] :not-null]
      [:text_search_vector :tsvector :not-null]
+     [:text_search_with_native_query_vector :tsvector :not-null]
      [:content :text :not-null]
      [:metadata :jsonb]
      [[:constraint unique-constraint-name]
@@ -90,6 +91,16 @@
                           (search/weighted-tsvector "A" (:name doc))
                           (search/weighted-tsvector "B" (:searchable_text doc ""))]
                          (search/weighted-tsvector "A" (:searchable_text doc "")))
+   :text_search_with_native_query_vector
+   (if (:name doc)
+     [:||
+      (search/weighted-tsvector "A" (:name doc))
+      (search/weighted-tsvector "B"
+                                (str/join " " (remove str/blank? [(:searchable_text doc "")
+                                                                  (:native_query doc "")])))]
+     (search/weighted-tsvector "A"
+                               (str/join " " (remove str/blank? [(:searchable_text doc "")
+                                                                 (:native_query doc "")]))))
    :legacy_input        [:cast (json/encode legacy_input) :jsonb]
    :metadata            [:cast (json/encode doc) :jsonb]})
 
@@ -235,6 +246,12 @@
        (-> (sql.helpers/create-index
             [(keyword (fts-index-name index)) :if-not-exists]
             [(keyword table-name) :using-gin [:raw "text_search_vector"]])
+           sql-format-quoted))
+      (jdbc/execute!
+       connectable
+       (-> (sql.helpers/create-index
+            [(keyword (str (fts-index-name index) "_native")) :if-not-exists]
+            [(keyword table-name) :using-gin [:raw "text_search_with_native_query_vector"]])
            sql-format-quoted)))
     (catch Exception e
       (throw (ex-info "Failed to create index table" {} e)))))
@@ -276,22 +293,27 @@
 (defn- keyword-search-query [index search-context]
   (let [filters (search-filters search-context)
         ts-search-expr (search/to-tsquery-expr (:search-string search-context))
-        tsv-lang (search/tsv-language)]
+        tsv-lang (search/tsv-language)
+        vector-column (if (:search-native-query search-context)
+                        :text_search_with_native_query_vector
+                        :text_search_vector)]
     {:select [[:id :id]
               [:model_id :model_id]
               [:model :model]
               [:content :content]
               [:verified :verified]
               [:metadata :metadata]
-              [[:raw "row_number() OVER (ORDER BY ts_rank_cd(text_search_vector, query) DESC)"] :keyword_rank]]
+              [[:raw (format "row_number() OVER (ORDER BY ts_rank_cd(%s, query) DESC)" (name vector-column))]
+               :keyword_rank]]
      :from [(keyword (:table-name index))]
      ;; Using a join allows us to share the query expression between our SELECT and WHERE clauses.
      ;; This follows the same secure pattern as metabase.search.appdb.specialization.postgres/base-query
      :join [[[:raw "to_tsquery('" tsv-lang "', " [:lift ts-search-expr] ")"]
              :query] [:= 1 1]]
-     :where (if (seq filters)
-              (into [:and [:raw "text_search_vector @@ query"]] [filters])
-              [:raw "text_search_vector @@ query"])
+     :where (let [ts-query-filter [:raw (format "%s @@ query" (name vector-column))]]
+              (if (seq filters)
+                (into [:and ts-query-filter] [filters])
+                ts-query-filter))
      :order-by [[:keyword_rank :asc]]
      :limit 100}))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -261,13 +261,13 @@
        connectable
        (-> (sql.helpers/create-index
             [(keyword (fts-index-name index)) :if-not-exists]
-            [(keyword table-name) :using-gin [:raw "text_search_vector"]])
+            [(keyword table-name) :using-gin :text_search_vector])
            sql-format-quoted))
       (jdbc/execute!
        connectable
        (-> (sql.helpers/create-index
             [(keyword (fts-native-index-name index)) :if-not-exists]
-            [(keyword table-name) :using-gin [:raw "text_search_with_native_query_vector"]])
+            [(keyword table-name) :using-gin :text_search_with_native_query_vector])
            sql-format-quoted)))
     (catch Exception e
       (throw (ex-info "Failed to create index table" {} e)))))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -398,10 +398,14 @@
   [row]
   (into {} (map (fn [[k v]] [(keyword (name k)) v]) row)))
 
+(defn- unwrap-pgobject
+  [^PGobject obj]
+  (.getValue ^PGobject obj))
+
 (defn- decode-pgobject
   "Decode a PGObject (returned from a jsonb field) into a Clojure map."
   [^PGobject obj]
-  (json/decode (.getValue ^PGobject obj) true))
+  (json/decode (unwrap-pgobject obj) true))
 
 (defn- decode-metadata
   "Decode `row`s `:metadata`."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
@@ -1,0 +1,25 @@
+(ns metabase-enterprise.semantic-search.index-embedding-test
+  "Tests for things at the intersection of the index and embedding namespaces."
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
+   [metabase-enterprise.semantic-search.index :as semantic.index]
+   [metabase.test :as mt]))
+
+(deftest ^:parallel index-embedding-name-length-test
+  (mt/with-premium-features #{:semantic-search}
+    (testing "index names never exceed 63 bytes for any embedding model"
+      ;; Postgres truncates indentifier names to 63 bytes (+ 1 byte for a terminating NULL). Ensure that none of the
+      ;; index names exceed this limit for any embedding provider + model combination.
+      (doseq [provider (keys semantic.embedding/supported-models-for-provider)
+              [model vector-dimensions] (get semantic.embedding/supported-models-for-provider provider)
+              name-func [:table-name
+                         #'semantic.index/hnsw-index-name
+                         #'semantic.index/fts-index-name
+                         #'semantic.index/fts-native-index-name]]
+        (testing (str "\n" provider " " model " " vector-dimensions "\n" name-func)
+          (let [index (-> {:provider provider
+                           :model-name model
+                           :vector-dimensions vector-dimensions}
+                          semantic.index/default-index)]
+            (is (>= 63 (-> index name-func count)))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
@@ -18,8 +18,8 @@
       (is (= {:table-name "foo_bar_baz"} (sut {:table-name "bar"} {:index-table-qualifier "foo_%s_baz"})))
       (is (= {:table-name "bar"} (sut {:table-name "bar"} {:index-table-qualifier "%s"})))
       (testing "qualifier applies to derived index names"
-        (is (= "foo_bar__hnsw_idx" (-> (sut {:table-name "bar"} {:index-table-qualifier "foo_%s"})
-                                       semantic.index/hnsw-index-name)))))))
+        (is (= "foo_bar_embed_hnsw_idx" (-> (sut {:table-name "bar"} {:index-table-qualifier "foo_%s"})
+                                            semantic.index/hnsw-index-name)))))))
 
 (deftest create-tables-if-not-exists!-test
   (let [pgvector       semantic.tu/db

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -17,12 +17,14 @@
       (testing "index table is not present before create!"
         (is (not (semantic.tu/table-exists-in-db? (:table-name @index-ref))))
         (is (not (semantic.tu/table-has-index? (:table-name @index-ref) (semantic.index/hnsw-index-name @index-ref))))
-        (is (not (semantic.tu/table-has-index? (:table-name @index-ref) (semantic.index/fts-index-name @index-ref)))))
+        (is (not (semantic.tu/table-has-index? (:table-name @index-ref) (semantic.index/fts-index-name @index-ref))))
+        (is (not (semantic.tu/table-has-index? (:table-name @index-ref) (semantic.index/fts-native-index-name @index-ref)))))
       (testing "index table is present after create!"
         (semantic.index/create-index-table-if-not-exists! semantic.tu/db semantic.tu/mock-index {:force-reset? false})
         (is (semantic.tu/table-exists-in-db? (:table-name @index-ref)))
         (is (semantic.tu/table-has-index? (:table-name @index-ref) (semantic.index/hnsw-index-name @index-ref)))
-        (is (semantic.tu/table-has-index? (:table-name @index-ref) (semantic.index/fts-index-name @index-ref)))))))
+        (is (semantic.tu/table-has-index? (:table-name @index-ref) (semantic.index/fts-index-name @index-ref)))
+        (is (semantic.tu/table-has-index? (:table-name @index-ref) (semantic.index/fts-native-index-name @index-ref)))))))
 
 (deftest drop-index-table!-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -115,11 +115,11 @@
         (check-index-has-no-mock-docs))
       (testing "upsert-index! works on a fresh index"
         (is (= {"card" 1, "dashboard" 1}
-               (semantic.tu/upsert-index! semantic.tu/mock-documents)))
+               (semantic.tu/upsert-index! (semantic.tu/mock-documents))))
         (check-index-has-mock-docs))
       (testing "upsert-index! works with duplicate documents"
         (is (= {"card" 1, "dashboard" 1}
-               (semantic.tu/upsert-index! semantic.tu/mock-documents)))
+               (semantic.tu/upsert-index! (semantic.tu/mock-documents))))
         (check-index-has-mock-docs)))))
 
 (deftest delete-from-index!-test
@@ -128,7 +128,7 @@
       (check-index-has-no-mock-docs)
       (testing "upsert-index! before delete!"
         (is (= {"card" 1, "dashboard" 1}
-               (semantic.tu/upsert-index! semantic.tu/mock-documents)))
+               (semantic.tu/upsert-index! (semantic.tu/mock-documents))))
         (check-index-has-mock-docs))
       (testing "delete-from-index! returns nil if you pass it an empty collection"
         (is (nil? (semantic.tu/delete-from-index! "card" [])))
@@ -155,8 +155,8 @@
               extra-docs (map (fn [id doc]
                                 (assoc doc :id id))
                               extra-ids
-                              (flatten (repeat semantic.tu/mock-documents)))
-              mock-docs (into semantic.tu/mock-documents extra-docs)]
+                              (flatten (repeat (semantic.tu/mock-documents))))
+              mock-docs (into (semantic.tu/mock-documents) extra-docs)]
           (testing "ensure upsert! and delete! work when batch size is exceeded"
             (check-index-has-no-mock-docs)
             (testing "upsert-index! with batch processing"
@@ -224,7 +224,7 @@
           (is (= 0.0 (mt/metric-value system :metabase-search/semantic-index-size))))
         (testing "semantic-index-size is updated after upsert-index! on empty db"
           (is (= {"card" 1, "dashboard" 1}
-                 (semantic.tu/upsert-index! semantic.tu/mock-documents)))
+                 (semantic.tu/upsert-index! (semantic.tu/mock-documents))))
           (is (= 2.0 (mt/metric-value system :metabase-search/semantic-index-size))))
         (testing "semantic-index-size is updated after delete-from-index!"
           (is (= {"card" 1}
@@ -232,5 +232,5 @@
           (is (= 1.0 (mt/metric-value system :metabase-search/semantic-index-size))))
         (testing "semantic-index-size is updated after upsert-index! on populated db"
           (is (= {"card" 1, "dashboard" 1}
-                 (semantic.tu/upsert-index! semantic.tu/mock-documents)))
+                 (semantic.tu/upsert-index! (semantic.tu/mock-documents))))
           (is (= 2.0 (mt/metric-value system :metabase-search/semantic-index-size))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -3,7 +3,6 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [honey.sql.helpers :as sql.helpers]
-   [mb.hawk.assert-exprs.approximately-equal :as =?]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.test :as mt]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
@@ -84,7 +84,7 @@
       ;; no specific behaviour, only proxies the active index to the index search
       (testing "is only a proxy for the active index call"
         (let [{:keys [proxy calls]} (spy semantic.index/upsert-index!)
-              documents semantic.tu/mock-documents]
+              documents (semantic.tu/mock-documents)]
           (with-redefs [semantic.index/upsert-index! proxy]
             (testing "check proxies correct args and ret is untouched"
               (let [ret (sut pgvector index-metadata documents)]
@@ -108,7 +108,7 @@
         model1         semantic.tu/mock-embedding-model
         model2         (assoc semantic.tu/mock-embedding-model :model-name "embedagain")
         sut            semantic.pgvector-api/delete-documents!
-        documents      semantic.tu/mock-documents
+        documents      (semantic.tu/mock-documents)
         {card-ids "card", dash-ids "dashboard"} (u/group-by :model :id documents)]
     (test-not-initialized sut pgvector index-metadata model1)
     (with-open [index-ref (open-semantic-search! pgvector index-metadata model1)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -29,6 +29,82 @@
             (let [results (semantic.tu/query-index {:search-string "avian"})]
               (is (= "Bird Watching Tips" (-> results first :name))))))))))
 
+(defn- index-of-name
+  "Return the index of the item with :name `name` in `coll`"
+  [coll name]
+  (first (keep-indexed (fn [idx item]
+                         (when (= name (:name item))
+                           idx))
+                       coll)))
+
+(deftest native-query-test
+  (testing "Tests for :search-native-query"
+    (mt/with-premium-features #{:semantic-search}
+      (mt/as-admin
+        (semantic.tu/with-index!
+          (let [not-top-10? #(or (nil? %) (< 10 %))]
+            (doseq [{:keys [name desc search-string search-native-query? expected-index?]}
+                    [{:name "Dog Training Guide"
+                      :desc "contains"
+                      :search-string "AVG(tricks)"
+                      :search-native-query? false
+                      :expected-index? not-top-10?}
+                     {:name "Dog Training Guide"
+                      :desc "contains"
+                      :search-string "AVG(tricks)"
+                      :search-native-query? true
+                      :expected-index? zero?}
+                     {:name "Dog Training Guide"
+                      :desc "contains"
+                      :search-string "GROUP BY breed"
+                      :search-native-query? false
+                      :expected-index? not-top-10?}
+                     {:name "Dog Training Guide"
+                      :desc "contains"
+                      :search-string "GROUP BY breed"
+                      :search-native-query? true
+                      :expected-index? zero?}
+                     {:name "Dog Training Guide"
+                      :desc "does not contain"
+                      :search-string "SUM(tricks)"
+                      :search-native-query? false
+                      :expected-index? not-top-10?}
+                     {:name "Dog Training Guide"
+                      :desc "does not contain"
+                      :search-string "SUM(tricks)"
+                      :search-native-query? true
+                      :expected-index? not-top-10?}
+                     {:name "Bird Watching Tips"
+                      :desc "does not contain (no native query)"
+                      :search-string "AVG(tricks)"
+                      :search-native-query? true
+                      :expected-index? not-top-10?}
+                     {:name "Dog Training Guide"
+                      :desc "semantic search"
+                      :search-string "puppy"
+                      :search-native-query? true
+                      :expected-index? zero?}
+                     {:name "Bird Watching Tips"
+                      :desc "semantic search"
+                      :search-string "avian"
+                      :search-native-query? true
+                      :expected-index? zero?}
+                     {:name "Dog Training Guide"
+                      :desc "non-native keyword query"
+                      :search-string "Training"
+                      :search-native-query? true
+                      :expected-index? zero?}
+                     {:name "Bird Watching Tips"
+                      :desc "non-native keyword query"
+                      :search-string "Watching"
+                      :search-native-query? true
+                      :expected-index? zero?}]]
+              (testing (format "\n%s %s %s %s" name desc search-string search-native-query?)
+                (is (-> (semantic.tu/query-index {:search-string search-string
+                                                  :search-native-query search-native-query?})
+                        (index-of-name name)
+                        expected-index?))))))))))
+
 (deftest model-filtering-test
   (testing "Filter results by model type"
     (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -179,13 +179,9 @@
                     :model/Card             {}           {:name "Bigfoot Sightings" :collection_id col3# :creator_id (mt/user->id :crowberto), :archived false}
 
                     :model/ModerationReview {}           {:moderated_item_type "card"
-
                                                           :moderated_item_id card1#
-
                                                           :moderator_id (mt/user->id :crowberto)
-
                                                           :status "verified"
-
                                                           :most_recent true}
 
                     :model/Dashboard        {}           {:name "Elephant Migration" :collection_id col1# :creator_id (mt/user->id :rasta) :archived false}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -116,6 +116,9 @@
 (defn delete-from-index! [model ids]
   (semantic.index/delete-from-index! db mock-index model ids))
 
+(defn dog-training-native-query []
+  (mt/native-query {:query "SELECT AVG(tricks) FROM dogs WHERE age > 7 GROUP BY breed"}))
+
 (def mock-documents
   [{:model "card"
     :id "123"
@@ -166,7 +169,8 @@
 
                     :model/Collection       {col3# :id}  {:name "Cryptozoology", :archived false}
 
-                    :model/Card             {card1# :id} {:name "Dog Training Guide" :collection_id col1# :creator_id (mt/user->id :crowberto) :archived false}
+                    :model/Card             {card1# :id} {:name "Dog Training Guide" :collection_id col1# :creator_id (mt/user->id :crowberto) :archived false
+                                                          :query_type "native" :dataset_query (dog-training-native-query)}
 
                     :model/Card             {}           {:name "Bird Watching Tips" :collection_id col1# :creator_id (mt/user->id :rasta) :archived false}
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -10,6 +10,7 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [next.jdbc :as jdbc]
    [next.jdbc.protocols :as jdbc.protocols]
@@ -119,23 +120,33 @@
 (defn dog-training-native-query []
   (mt/native-query {:query "SELECT AVG(tricks) FROM dogs WHERE age > 7 GROUP BY breed"}))
 
-(def mock-documents
-  [{:model "card"
-    :id "123"
-    :searchable_text "Dog Training Guide"
-    :created_at #t "2025-01-01T12:00:00Z"
-    :creator_id 1
-    :archived false
-    :legacy_input {:model "card" :id "123"}
-    :metadata {:title "Dog Training Guide" :description "How to teach an old dog new tricks"}}
-   {:model "dashboard"
-    :id "456"
-    :searchable_text "Elephant Migration"
-    :created_at #t "2025-02-01T12:00:00Z"
-    :creator_id 2
-    :archived true
-    :legacy_input {:model "dashboard" :id "456"}
-    :metadata {:title "Elephant Migration" :description "How do elephants deal with schema upgrades?"}}])
+(defn dog-training-native-query-json []
+  (-> (dog-training-native-query)
+      json/encode))
+
+(defn mock-documents []
+  (let [native-query-json (dog-training-native-query-json)]
+    [{:model "card"
+      :id "123"
+      :searchable_text "Dog Training Guide"
+      :created_at #t "2025-01-01T12:00:00Z"
+      :creator_id 1
+      :archived false
+      :legacy_input {:id "123"
+                     :model "card"
+                     :dataset_query native-query-json}
+      :native_query native-query-json
+      :metadata {:title "Dog Training Guide"
+                 :description "How to teach an old dog new tricks"
+                 :native-query native-query-json}}
+     {:model "dashboard"
+      :id "456"
+      :searchable_text "Elephant Migration"
+      :created_at #t "2025-02-01T12:00:00Z"
+      :creator_id 2
+      :archived true
+      :legacy_input {:model "dashboard" :id "456"}
+      :metadata {:title "Elephant Migration" :description "How do elephants deal with schema upgrades?"}}]))
 
 (defn filter-for-mock-embeddings
   "Filter results to only include items whose names are keys in mock-embeddings map."

--- a/frontend/src/metabase/search/components/SearchSidebar/SearchSidebar.tsx
+++ b/frontend/src/metabase/search/components/SearchSidebar/SearchSidebar.tsx
@@ -49,21 +49,11 @@ export const SearchSidebar = ({ value, onChange }: SearchSidebarProps) => {
 
   const onOutputChange = (key: FilterTypeKeys, val?: SearchQueryParamValue) => {
     if (!val) {
-      const omitKeys = _.compact([
-        key,
-        // when enabling semantic search, prevent native queries from being searched
-        key === SearchFilterKeys.DisableSemanticSearch &&
-          SearchFilterKeys.NativeQuery,
-      ]);
-      onChange(_.omit(value, omitKeys));
+      onChange(_.omit(value, key));
     } else {
       onChange({
         ...value,
         [key]: val,
-        // when enabling native queries search, prevent semantic search from being used
-        ...(key === SearchFilterKeys.NativeQuery && val
-          ? { [SearchFilterKeys.DisableSemanticSearch]: "true" }
-          : {}),
       });
     }
   };


### PR DESCRIPTION
Closes BOT-237

### Description

* Enable fts on native query contents in the semantic search backend

Update the semantic search backend to handle fts of native query contents in exactly the same way as the appdb
backend, namely: all keyword search content gets indexed into two separate columns, one with and one without native
query contents. At runtime, we decide which column to query against based on the user's search setting.

For now, this only modifies the keyword search side of the hybrid search result. The semantic search on the vector
embeddings still does not include native query contents, but any keyword matches can still get blended into the result
set by the RRF ranking.

* Ensure index names do not exceed postgres max of 63 characters
* Allow to toggle NativeQuery independent of DisableSemanticSearch in SearchSidebar.tsx
* Add tests

### How to verify

Search for keywords that appear in a card's native query after enabling the "Search the contents of native queries" toggle in the search sidebar settings (see screenshots below).

### Demo

Searching for `SUM(TOTAL)` which occurs in the native query for the "My Orders Query" card. Without native queries enabled, it appears much further down the list, at position 18.

<img width="1156" height="585" alt="Screenshot 2025-07-28 at 3 46 16 PM" src="https://github.com/user-attachments/assets/9ec2375a-7832-411e-ba7a-9a5c5f4b3b70" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
