### PR TITLE
run third tier on devex team label

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -25,7 +25,7 @@ jobs:
         id: check_team_and_branch
         run: |
           IS_MASTER_OR_RELEASE="${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') }}"
-          HAS_TEAM_LABEL="${{ contains(github.event.pull_request.labels.*.name, '.Team/Drivers') || contains(github.event.pull_request.labels.*.name, '.Team/Querying') || contains(github.event.pull_request.labels.*.name, '.Team/SemanticLayer') }}"
+          HAS_TEAM_LABEL="${{ contains(github.event.pull_request.labels.*.name, '.Team/Drivers') || contains(github.event.pull_request.labels.*.name, '.Team/Querying') || contains(github.event.pull_request.labels.*.name, '.Team/SemanticLayer') || contains(github.event.pull_request.labels.*.name, '.Team/DevEx) }}"
 
 
           echo "Is master or release: ${IS_MASTER_OR_RELEASE}"

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -25,7 +25,7 @@ jobs:
         id: check_team_and_branch
         run: |
           IS_MASTER_OR_RELEASE="${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') }}"
-          HAS_TEAM_LABEL="${{ contains(github.event.pull_request.labels.*.name, '.Team/Drivers') || contains(github.event.pull_request.labels.*.name, '.Team/Querying') || contains(github.event.pull_request.labels.*.name, '.Team/SemanticLayer') || contains(github.event.pull_request.labels.*.name, '.Team/DevEx) }}"
+          HAS_TEAM_LABEL="${{ contains(github.event.pull_request.labels.*.name, '.Team/Drivers') || contains(github.event.pull_request.labels.*.name, '.Team/Querying') || contains(github.event.pull_request.labels.*.name, '.Team/SemanticLayer') || contains(github.event.pull_request.labels.*.name, '.Team/DevEx') }}"
 
 
           echo "Is master or release: ${IS_MASTER_OR_RELEASE}"

--- a/src/metabase/app_db/cluster_lock.clj
+++ b/src/metabase/app_db/cluster_lock.clj
@@ -32,7 +32,7 @@
    :max-interval-millis 1000
    :retry-on-exception-pred retryable?})
 
-(defn prepare-statement
+(defn- prepare-statement
   "Create a prepared statement to query cache"
   ^PreparedStatement [^Connection conn lock-name-str timeout]
   (let [stmt (.prepareStatement conn ^String (first (mdb.query/compile {:select [:lock.lock_name]


### PR DESCRIPTION
run 3rd tier on devex team label.

Did dumb, mechanical way.

gemini said these might be good as well but they felt a bit off
```
jobs:
  # This job will determine if the tier 3 driver tests should be skipped.
  # It will always run first.
  determine-driver-skips:
    runs-on: ubuntu-latest
    outputs:
      skip: ${{ steps.check_team_and_branch.outputs.skip }}
    steps:
      - name: Checkout repository
        uses: actions/checkout@v4
      - name: Check if tier3 drivers should run
        id: check_team_and_branch
        run: |
          # Define the list of team labels
          TEAM_LABELS='[".Team/Drivers", ".Team/Querying", ".Team/SemanticLayer", ".Team/DevEx"]'

          IS_MASTER_OR_RELEASE="${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') }}"
          
          # Check if any of the pull request labels are in the defined team labels list
          # We use fromJson to convert the string list into an actual array for 'contains'
          HAS_TEAM_LABEL="${{ fromJson(env.TEAM_LABELS) && contains(fromJson(env.TEAM_LABELS), github.event.pull_request.labels.*.name) }}" # This is the ideal but complex way to do list-intersection
          # A simpler way if you just want to check if *any* label matches *any* team label (current logic)
          HAS_TEAM_LABEL_SIMPLIFIED="${{ contains(github.event.pull_request.labels.*.name, '.Team/Drivers') || contains(github.event.pull_request.labels.*.name, '.Team/Querying') || contains(github.event.pull_request.labels.*.name, '.Team/SemanticLayer') || contains(github.event.pull_request.labels.*.name, '.Team/DevEx') }}"
          
          # For your existing logic to work directly, the simplified one is probably better
          # unless you want to iterate over the labels programmatically.
          # Let's stick with the simplest update for now, then show a more advanced one.

          # Original logic updated with .Team/DevEx
          HAS_TEAM_LABEL_UPDATED_ORIGINAL="${{ contains(github.event.pull_request.labels.*.name, '.Team/Drivers') || contains(github.event.pull_request.labels.*.name, '.Team/Querying') || contains(github.event.pull_request.labels.*.name, '.Team/SemanticLayer') || contains(github.event.pull_request.labels.*.name, '.Team/DevEx') }}"

          # Determine if to skip
          SKIP="true"
          if [[ "${IS_MASTER_OR_RELEASE}" == "true" || "${HAS_TEAM_LABEL_UPDATED_ORIGINAL}" == "true" ]]; then
            SKIP="false"
          fi
          echo "IS_MASTER_OR_RELEASE: ${IS_MASTER_OR_RELEASE}"
          echo "HAS_TEAM_LABEL_UPDATED_ORIGINAL: ${HAS_TEAM_LABEL_UPDATED_ORIGINAL}"
          echo "SKIP: ${SKIP}"
          echo "skip=${SKIP}" >> "$GITHUB_OUTPUT"
```