### PR TITLE
Fix empty latest Docker version in docs

### DIFF
--- a/docs/installation-and-operation/activating-the-enterprise-edition.md
+++ b/docs/installation-and-operation/activating-the-enterprise-edition.md
@@ -49,7 +49,7 @@ To get all the features available when upgrading to a _self-hosted_ [Pro or Ente
 Assuming you've been using a [production application database](../installation-and-operation/configuring-application-database.md), you'll want to:
 
 1. [Back up your application database](./backing-up-metabase-application-data.md).
-2. Download the Enterprise Edition version that corresponds with your current Metabase version. So if you're running the Docker image for {{site.data.latest_version}}, you should switch to the Docker image for {{site.data.latest_enterprise}}. To see a list of available versions for both the Open Source and Enterprise Editions, check out [Metabase releases](https://github.com/metabase/metabase/releases).
+2. Download the Enterprise Edition version that corresponds with your current Metabase version. So if you're running the Docker image for {{site.latest_version}}, you should switch to the Docker image for {{site.latest_enterprise}}. To see a list of available versions for both the Open Source and Enterprise Editions, check out [Metabase releases](https://github.com/metabase/metabase/releases).
 3. Stop your current Metabase Open Source edition.
 4. Swap in the Enterprise Edition Docker image or jar that you downloaded.
 5. Start your Metabase like you normally would using the new Enterprise Edition image or jar. You don't need to do anything with your application database (which you've backed up in step one, right?).


### PR DESCRIPTION
### Description

Fixes an incorrect reference to a Docker version in https://www.metabase.com/docs/latest/installation-and-operation/activating-the-enterprise-edition#upgrading-from-a-self-hosted-metabase-open-source-edition-to-a-pro-or-enterprise-plan, which renders as blank.

> So if you’re running the Docker image for , you should switch to the Docker image for .

Not been able to validate this locally yet.