### PR TITLE
Amendments due to parallel permission implementation

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -160,6 +160,8 @@
        [:scope ::types/scope.raw]
        [:params {:optional true} :map]
        [:input {:optional true} :map]]]
+  ;; This check should be redundant in practice with the permission checks within perform-action!
+  ;; Since test coverage is light and the logic is so simple, we've decided to be extra cautious for now.
   (api/check-superuser)
   {:outputs (execute!* action scope params [input])})
 
@@ -187,6 +189,8 @@
        [:scope ::types/scope.raw]
        [:inputs [:sequential {:min 1} :map]]
        [:params {:optional true} [:map-of :keyword :any]]]]
+  ;; This check should be redundant in practice with the permission checks within perform-action!
+  ;; Since test coverage is light and the logic is so simple, we've decided to be extra cautious for now.
   (api/check-superuser)
   {:outputs (execute!* action scope params inputs)})
 
@@ -197,6 +201,8 @@
    {}
    ;; TODO support for bulk actions
    {:keys [action scope input]}] :- ::execute-form
+  ;; This check should be redundant in practice with the permission checks within perform-action!
+  ;; Since test coverage is light and the logic is so simple, we've decided to be extra cautious for now.
   (api/check-superuser)
   (let [scope         (actions/hydrate-scope scope)
         unified       (fetch-unified-action scope action)

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -42,8 +42,6 @@
 (defn create-rows!
   ([table-id rows]
    (create-rows! table-id :crowberto 200 rows))
-  ([table-id response-code rows]
-   (create-rows! table-id :crowberto response-code rows))
   ([table-id user response-code rows]
    (mt/user-http-request user :post response-code execute-bulk-url
                          {:action :data-grid.row/create
@@ -53,8 +51,8 @@
 (defn- update-rows!
   ([table-id rows]
    (update-rows! table-id :crowberto 200 rows))
-  ([table-id response-code rows]
-   (update-rows! table-id :crowberto response-code rows))
+  ([table-id rows params]
+   (update-rows! table-id :crowberto 200 rows params))
   ([table-id user response-code rows & [params]]
    (mt/user-http-request user :post response-code execute-bulk-url
                          (cond->
@@ -66,8 +64,6 @@
 (defn- delete-rows!
   ([table-id rows]
    (delete-rows! table-id :crowberto 200 rows))
-  ([table-id response-code rows]
-   (delete-rows! table-id :crowberto response-code rows))
   ([table-id user response-code rows]
    (mt/user-http-request user :post response-code execute-bulk-url
                          {:action :data-grid.row/delete
@@ -122,7 +118,7 @@
                    {:op "updated", :table-id table-id, :row {:id 2, :name "Speacolumn", :song "The Star-Spangled Banner"}}}
                  (set
                   (:outputs
-                   (update-rows! table-id :crowberto 200 [{:id 1} {:id 2}] {:song "The Star-Spangled Banner"})))))
+                   (update-rows! table-id [{:id 1} {:id 2}] {:song "The Star-Spangled Banner"})))))
 
           (is (= #{[1 "Pidgey" "The Star-Spangled Banner"]
                    [2 "Speacolumn" "The Star-Spangled Banner"]
@@ -185,7 +181,7 @@
                      {:op "updated", :table-id table-id, :row {:id (str id-2), :name "Speacolumn", :song "The Star-Spangled Banner"}}}
                    (set
                     (:outputs
-                     (update-rows! table-id :crowberto 200
+                     (update-rows! table-id
                                    [{:id id-1}
                                     {:id id-2}]
                                    {:song "The Star-Spangled Banner"})))))
@@ -250,7 +246,7 @@
                    {:op "updated", :table-id table-id, :row {:id_1 2, :id_2 0, :name "Speacolumn", :song "The Star-Spangled Banner"}}}
                  (set
                   (:outputs
-                   (update-rows! table-id :crowberto 200
+                   (update-rows! table-id
                                  [{:id_1 1, :id_2 0}
                                   {:id_1 2, :id_2 0}]
                                  {:song "The Star-Spangled Banner"})))))


### PR DESCRIPTION
Since 31b6fc564cbc15b273d00e78081e8724fd30ed10 was implemented in parallel to 31b6fc564cbc15b273d00e78081e8724fd30ed10 there is some redundancy. This cleans things up slightly, but leaves the redundant api-level and action-level checks. 
