### PR TITLE
Check for simple embedding's enabled settings and token feature

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/auto-enable-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/auto-enable-embedding.cy.spec.ts
@@ -1,0 +1,34 @@
+const { H } = cy;
+
+const suiteTitle =
+  "scenarios > embedding > sdk iframe embed setup > auto enable embedding settings";
+
+describe(suiteTitle, () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+    H.updateSetting("enable-embedding-simple", false);
+
+    cy.intercept("GET", "/api/dashboard/*").as("dashboard");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("GET", "/api/activity/recents?*").as("recentActivity");
+  });
+
+  it("auto-enables the enable-embedding-simple settings", () => {
+    cy.visit("/embed-iframe");
+
+    cy.log("simple embedding toast should be shown");
+    H.undoToast()
+      .should("be.visible")
+      .findByText(/Embedded Analytics JS is enabled/)
+      .should("be.visible");
+
+    H.waitForSimpleEmbedIframesToLoad();
+
+    cy.log("embed preview should be visible");
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByText("Orders in a dashboard").should("be.visible");
+    });
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx
@@ -1,0 +1,130 @@
+import userEvent from "@testing-library/user-event";
+
+import {
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { screen, within } from "__support__/ui";
+import { renderWithSDKProviders } from "embedding-sdk/test/__support__/ui";
+import { createMockSdkConfig } from "embedding-sdk/test/mocks/config";
+import { createMockSdkState } from "embedding-sdk/test/mocks/state";
+import {
+  createMockSettings,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+const TEST_USER = createMockUser();
+
+jest.mock("metabase/visualizations/register", () => jest.fn(() => {}));
+
+const mockSdkDispatchFn = jest.fn();
+jest.mock("embedding-sdk/store", () => ({
+  ...jest.requireActual("embedding-sdk/store"),
+  useSdkDispatch: () => mockSdkDispatchFn,
+}));
+
+jest.mock("metabase/embedding-sdk/config", () => ({
+  ...jest.requireActual("metabase/embedding-sdk/config"),
+  EMBEDDING_SDK_CONFIG: {
+    isEmbeddingSdk: true,
+    metabaseClientRequestHeader: "embedding-simple",
+    enableEmbeddingSettingKey: "enable-embedding-simple",
+    tokenFeatureKey: "embedding_simple",
+  },
+  EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG: {
+    isSdkIframeEmbedAuth: true,
+    useExistingUserSession: false,
+  },
+}));
+
+interface Options {
+  hasSimpleEmbeddingFeature?: boolean;
+  isSimpleEmbeddingEnabled?: boolean;
+}
+
+const setup = (options: Options) => {
+  const tokenFeatures = createMockTokenFeatures({
+    embedding_simple: options.hasSimpleEmbeddingFeature ?? true,
+  });
+
+  const settingValues = createMockSettings({
+    "token-features": tokenFeatures,
+    "enable-embedding-simple": options.isSimpleEmbeddingEnabled ?? true,
+  });
+
+  const state = createMockState({
+    settings: mockSettings(settingValues),
+    currentUser: TEST_USER,
+    sdk: createMockSdkState(),
+  });
+
+  setupSettingsEndpoints([]);
+  setupPropertiesEndpoints(settingValues);
+
+  return renderWithSDKProviders(<div>hello!</div>, {
+    sdkProviderProps: { authConfig: createMockSdkConfig() },
+    storeInitialState: state,
+  });
+};
+
+const PROBLEM_CARD_TEST_ID = "sdk-usage-problem-card";
+const PROBLEM_INDICATOR_TEST_ID = "sdk-usage-problem-indicator";
+
+describe("SdkUsageProblemDisplay (simple embedding)", () => {
+  it("does not show an error when a license exists and is enabled", async () => {
+    await setup({
+      hasSimpleEmbeddingFeature: true,
+      isSimpleEmbeddingEnabled: true,
+    });
+
+    expect(
+      screen.queryByTestId(PROBLEM_INDICATOR_TEST_ID),
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByTestId(PROBLEM_CARD_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it("shows an error when used without a license", async () => {
+    await setup({
+      hasSimpleEmbeddingFeature: false,
+    });
+
+    await userEvent.click(screen.getByTestId(PROBLEM_INDICATOR_TEST_ID));
+
+    const card = screen.getByTestId(PROBLEM_CARD_TEST_ID);
+    expect(within(card).getByText("Error")).toBeInTheDocument();
+
+    expect(
+      within(card).getByText(
+        /Attempting to use this in other ways is in breach of our usage policy/,
+      ),
+    ).toBeInTheDocument();
+
+    const docsLink = within(card).getByRole("link", {
+      name: /Documentation/,
+    });
+
+    expect(docsLink).toHaveAttribute(
+      "href",
+      "https://www.metabase.com/upgrade",
+    );
+  });
+
+  it("shows an error when simple embedding is disabled", async () => {
+    await setup({
+      hasSimpleEmbeddingFeature: true,
+      isSimpleEmbeddingEnabled: false,
+    });
+
+    await userEvent.click(screen.getByTestId(PROBLEM_INDICATOR_TEST_ID));
+
+    const card = screen.getByTestId(PROBLEM_CARD_TEST_ID);
+
+    expect(
+      within(card).getByText(/not enabled for this instance/),
+    ).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx
@@ -35,7 +35,7 @@ jest.mock("metabase/embedding-sdk/config", () => ({
     tokenFeatureKey: "embedding_simple",
   },
   EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG: {
-    isSdkIframeEmbedAuth: true,
+    isSimpleEmbedding: true,
     useExistingUserSession: false,
   },
 }));

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
@@ -117,10 +117,6 @@ describe("SdkUsageProblemDisplay", () => {
     const card = screen.getByTestId(PROBLEM_CARD_TEST_ID);
 
     expect(
-      within(card).getByText("This embed is powered by the Metabase SDK."),
-    ).toBeInTheDocument();
-
-    expect(
       within(card).getByText(
         /This is intended for evaluation purposes and works only on localhost. To use on other sites, implement SSO./,
       ),
@@ -175,7 +171,7 @@ describe("SdkUsageProblemDisplay", () => {
 
     expect(
       within(card).getByText(
-        /The embedding SDK is not enabled for this instance. Please enable it in settings to start using the SDK./,
+        /Embedding is not enabled for this instance. Please enable it in settings./,
       ),
     ).toBeInTheDocument();
 

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
@@ -117,6 +117,10 @@ describe("SdkUsageProblemDisplay", () => {
     const card = screen.getByTestId(PROBLEM_CARD_TEST_ID);
 
     expect(
+      within(card).getByText("This embed is powered by the Metabase SDK."),
+    ).toBeInTheDocument();
+
+    expect(
       within(card).getByText(
         /This is intended for evaluation purposes and works only on localhost. To use on other sites, implement SSO./,
       ),

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-usage-problem.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-usage-problem.ts
@@ -33,7 +33,7 @@ export function useSdkUsageProblem({
       return true;
     }
 
-    return getTokenFeature(state, "embedding_sdk");
+    return getTokenFeature(state, EMBEDDING_SDK_CONFIG.tokenFeatureKey);
   });
 
   const isDevelopmentMode = useSdkSelector((state) => {

--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-usage-problem.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-sdk-usage-problem.ts
@@ -6,6 +6,7 @@ import { getSdkUsageProblem } from "embedding-sdk/lib/usage-problem";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import { setUsageProblem } from "embedding-sdk/store/reducer";
 import { useSetting } from "metabase/common/hooks";
+import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
 import { getTokenFeature } from "metabase/setup/selectors";
 
 export function useSdkUsageProblem({
@@ -22,7 +23,8 @@ export function useSdkUsageProblem({
   // When the setting haven't been loaded or failed to query, we assume that the
   // feature is _enabled_ first. Otherwise, when a user's instance is temporarily down,
   // their customer would see an alarming error message on production.
-  const isEnabled = useSetting("enable-embedding-sdk") ?? true;
+  const isEnabled =
+    useSetting(EMBEDDING_SDK_CONFIG.enableEmbeddingSettingKey) ?? true;
 
   const hasTokenFeature = useSdkSelector((state) => {
     // We also assume that the feature is enabled if the token-features are missing.

--- a/enterprise/frontend/src/embedding-sdk/lib/usage-problem.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/usage-problem.ts
@@ -5,6 +5,7 @@ import type {
   SdkUsageProblem,
   SdkUsageProblemKey,
 } from "embedding-sdk/types/usage-problem";
+import { EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG } from "metabase/embedding-sdk/config";
 
 import { getIsLocalhost } from "./is-localhost";
 
@@ -16,14 +17,12 @@ interface SdkProblemOptions {
 }
 
 export const USAGE_PROBLEM_MESSAGES = {
-  API_KEYS_WITHOUT_LICENSE: `The embedding SDK is using API keys. This is intended for evaluation purposes and works only on localhost. To use on other sites, a license is required and you need to implement SSO.`,
-  API_KEYS_WITH_LICENSE: `The embedding SDK is using API keys. This is intended for evaluation purposes and works only on localhost. To use on other sites, implement SSO.`,
+  API_KEYS_WITHOUT_LICENSE: `This embed is using API keys. This is intended for evaluation purposes and works only on localhost. To use on other sites, a license is required and you need to implement SSO.`,
+  API_KEYS_WITH_LICENSE: `This embed is using API keys. This is intended for evaluation purposes and works only on localhost. To use on other sites, implement SSO.`,
   SSO_WITHOUT_LICENSE: `Usage without a valid license for this feature is only allowed for evaluation purposes, using API keys and only on localhost. Attempting to use this in other ways is in breach of our usage policy.`,
-  JWT_PROVIDER_URI_DEPRECATED: `The jwtProviderUri and authProviderUri config properties have been removed. Configure your authProviderUri within your instance settings.`,
-  JWT_AUTH_CONFIG_NOT_VALID: `The JWT Provider URI is not set. Please set it in the instance settings. Alternatively, you can set a fetchRequestToken function in the embedding SDK config.`,
 
   // This message only works on localhost at the moment, as we cannot detect if embedding is disabled due to CORS restrictions on /api/session/properties.
-  EMBEDDING_SDK_NOT_ENABLED: `The embedding SDK is not enabled for this instance. Please enable it in settings to start using the SDK.`,
+  EMBEDDING_SDK_NOT_ENABLED: `Embedding is not enabled for this instance. Please enable it in settings.`,
 
   // eslint-disable-next-line no-literal-metabase-strings -- only shown in development.
   DEVELOPMENT_MODE_CLOUD_INSTANCE: `This Metabase is in development mode intended exclusively for testing. Using this Metabase for everyday BI work or when embedding in production is considered unfair usage.`,
@@ -44,8 +43,6 @@ export const USAGE_PROBLEM_DOC_URLS: Record<SdkUsageProblemKey, string> = {
   API_KEYS_WITHOUT_LICENSE: METABASE_UPGRADE_URL,
   API_KEYS_WITH_LICENSE: SDK_AUTH_DOCS_URL,
   SSO_WITHOUT_LICENSE: METABASE_UPGRADE_URL,
-  JWT_PROVIDER_URI_DEPRECATED: SDK_AUTH_DOCS_URL,
-  JWT_AUTH_CONFIG_NOT_VALID: SDK_AUTH_DOCS_URL,
   EMBEDDING_SDK_NOT_ENABLED: SDK_INTRODUCTION_DOCS_URL,
   DEVELOPMENT_MODE_CLOUD_INSTANCE: METABASE_UPGRADE_URL,
 } as const;
@@ -124,7 +121,17 @@ const toWarning = (type: SdkUsageProblemKey): SdkUsageProblem => ({
   type,
   severity: "warning",
   // eslint-disable-next-line no-literal-metabase-strings -- only shown in development.
-  title: "This embed is powered by the Metabase SDK.",
+  title: getTitle(),
   message: USAGE_PROBLEM_MESSAGES[type],
   documentationUrl: USAGE_PROBLEM_DOC_URLS[type],
 });
+
+const getTitle = () => {
+  if (EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.isSimpleEmbedding) {
+    // eslint-disable-next-line no-literal-metabase-strings -- only shown in development or config error.
+    return "This embed is powered by the Metabase Embedded Analytics JS";
+  }
+
+  // eslint-disable-next-line no-literal-metabase-strings -- only shown in development or config error.
+  return "This embed is powered by the Metabase SDK.";
+};

--- a/enterprise/frontend/src/embedding-sdk/lib/usage-problem.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/usage-problem.ts
@@ -120,7 +120,6 @@ const toError = (type: SdkUsageProblemKey): SdkUsageProblem => ({
 const toWarning = (type: SdkUsageProblemKey): SdkUsageProblem => ({
   type,
   severity: "warning",
-  // eslint-disable-next-line no-literal-metabase-strings -- only shown in development.
   title: getTitle(),
   message: USAGE_PROBLEM_MESSAGES[type],
   documentationUrl: USAGE_PROBLEM_DOC_URLS[type],

--- a/enterprise/frontend/src/embedding-sdk/store/auth/auth.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/auth/auth.ts
@@ -117,7 +117,7 @@ export const refreshTokenAsync = createAsyncThunk(
   ): Promise<MetabaseEmbeddingSessionToken | null> => {
     const state = getState() as SdkStoreState;
 
-    if (EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.isSdkIframeEmbedAuth) {
+    if (EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.isSimpleEmbedding) {
       return requestSessionTokenFromEmbedJs();
     }
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -38,13 +38,13 @@ const SdkIframeEmbedSetupContent = () => {
   const acceptSimpleEmbedTerms = () =>
     updateSettings({ "show-simple-embed-terms": false });
 
-  // Automatically enable the embedding SDK if it's not already enabled.
+  // Automatically enable embedding if it's not already enabled.
   useEffect(() => {
     if (!isSimpleEmbeddingEnabled) {
       updateSettings({ "enable-embedding-simple": true });
 
       sendToast({
-        message: t`Simple embedding is enabled. You can configure it in admin settings.`,
+        message: t`Embedded Analytics JS is enabled. You can configure it in admin settings.`,
       });
     }
   }, [isSimpleEmbeddingEnabled, sendToast, updateSettings]);

--- a/frontend/src/metabase/app-embed-sdk.tsx
+++ b/frontend/src/metabase/app-embed-sdk.tsx
@@ -11,6 +11,7 @@ import {
 EMBEDDING_SDK_CONFIG.isEmbeddingSdk = true;
 EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader = "embedding-simple";
 EMBEDDING_SDK_CONFIG.enableEmbeddingSettingKey = "enable-embedding-simple";
+EMBEDDING_SDK_CONFIG.tokenFeatureKey = "embedding_simple";
 
 // Use the iframe embedding auth flow instead of the regular auth flow.
 EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.isSdkIframeEmbedAuth = true;

--- a/frontend/src/metabase/app-embed-sdk.tsx
+++ b/frontend/src/metabase/app-embed-sdk.tsx
@@ -5,10 +5,12 @@ import {
   EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG,
 } from "metabase/embedding-sdk/config";
 
-// Enable SDK mode for new iframe embedding.
-// Note that this is also defined in the SDK's entry point.
+/**
+ * Configuration overrides for simple embedding.
+ */
 EMBEDDING_SDK_CONFIG.isEmbeddingSdk = true;
 EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader = "embedding-simple";
+EMBEDDING_SDK_CONFIG.enableEmbeddingSettingKey = "enable-embedding-simple";
 
 // Use the iframe embedding auth flow instead of the regular auth flow.
 EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.isSdkIframeEmbedAuth = true;

--- a/frontend/src/metabase/app-embed-sdk.tsx
+++ b/frontend/src/metabase/app-embed-sdk.tsx
@@ -14,7 +14,7 @@ EMBEDDING_SDK_CONFIG.enableEmbeddingSettingKey = "enable-embedding-simple";
 EMBEDDING_SDK_CONFIG.tokenFeatureKey = "embedding_simple";
 
 // Use the iframe embedding auth flow instead of the regular auth flow.
-EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.isSdkIframeEmbedAuth = true;
+EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.isSimpleEmbedding = true;
 
 // load the embedding_iframe_sdk EE plugin
 import "sdk-iframe-embedding-ee-plugins";

--- a/frontend/src/metabase/app-embed-sdk.tsx
+++ b/frontend/src/metabase/app-embed-sdk.tsx
@@ -8,13 +8,11 @@ import {
 /**
  * Configuration overrides for simple embedding.
  */
+EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.isSimpleEmbedding = true;
 EMBEDDING_SDK_CONFIG.isEmbeddingSdk = true;
 EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader = "embedding-simple";
 EMBEDDING_SDK_CONFIG.enableEmbeddingSettingKey = "enable-embedding-simple";
 EMBEDDING_SDK_CONFIG.tokenFeatureKey = "embedding_simple";
-
-// Use the iframe embedding auth flow instead of the regular auth flow.
-EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.isSimpleEmbedding = true;
 
 // load the embedding_iframe_sdk EE plugin
 import "sdk-iframe-embedding-ee-plugins";

--- a/frontend/src/metabase/embedding-sdk/config.ts
+++ b/frontend/src/metabase/embedding-sdk/config.ts
@@ -1,4 +1,4 @@
-import type { SettingKey } from "metabase-types/api";
+import type { SettingKey, TokenFeature } from "metabase-types/api";
 
 export const EMBEDDING_SDK_ROOT_ELEMENT_ID = "metabase-sdk-root";
 export const EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID = "metabase-sdk-portal-root";
@@ -7,6 +7,7 @@ type InternalSdkConfig = {
   isEmbeddingSdk: boolean;
   metabaseClientRequestHeader: "embedding-sdk-react" | "embedding-simple";
   enableEmbeddingSettingKey: "enable-embedding-sdk" | "enable-embedding-simple";
+  tokenFeatureKey: "embedding_sdk" | "embedding_simple";
 };
 
 export const EMBEDDING_SDK_CONFIG: InternalSdkConfig = {
@@ -25,6 +26,11 @@ export const EMBEDDING_SDK_CONFIG: InternalSdkConfig = {
    * Which setting indicates whether the embedding is enabled?
    */
   enableEmbeddingSettingKey: "enable-embedding-sdk" satisfies SettingKey,
+
+  /**
+   * Which token feature indicates whether the embedding is available?
+   */
+  tokenFeatureKey: "embedding_sdk" satisfies TokenFeature,
 };
 
 export const EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG = {

--- a/frontend/src/metabase/embedding-sdk/config.ts
+++ b/frontend/src/metabase/embedding-sdk/config.ts
@@ -1,7 +1,15 @@
+import type { SettingKey } from "metabase-types/api";
+
 export const EMBEDDING_SDK_ROOT_ELEMENT_ID = "metabase-sdk-root";
 export const EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID = "metabase-sdk-portal-root";
 
-export const EMBEDDING_SDK_CONFIG = {
+type InternalSdkConfig = {
+  isEmbeddingSdk: boolean;
+  metabaseClientRequestHeader: "embedding-sdk-react" | "embedding-simple";
+  enableEmbeddingSettingKey: "enable-embedding-sdk" | "enable-embedding-simple";
+};
+
+export const EMBEDDING_SDK_CONFIG: InternalSdkConfig = {
   /**
    * Whether we are in the Embedding SDK or its derivatives
    * such as sdk-based iframe embedding.
@@ -12,6 +20,11 @@ export const EMBEDDING_SDK_CONFIG = {
    * Which X-Metabase-Client header to use for requests to the Metabase instance?
    */
   metabaseClientRequestHeader: "embedding-sdk-react",
+
+  /**
+   * Which setting indicates whether the embedding is enabled?
+   */
+  enableEmbeddingSettingKey: "enable-embedding-sdk" satisfies SettingKey,
 };
 
 export const EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG = {

--- a/frontend/src/metabase/embedding-sdk/config.ts
+++ b/frontend/src/metabase/embedding-sdk/config.ts
@@ -34,8 +34,8 @@ export const EMBEDDING_SDK_CONFIG: InternalSdkConfig = {
 };
 
 export const EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG = {
-  /** Whether the iframe embedding auth flow should be used. */
-  isSdkIframeEmbedAuth: false,
+  /** Whether we are in the simple embedding environment. */
+  isSimpleEmbedding: false,
 
   /** Whether we should use the existing user session (i.e. admin user's cookie) */
   useExistingUserSession: false,


### PR DESCRIPTION
Closes EMB-671

We should use `enable-embedding-simple` in place of `enable-embedding-sdk` in the usage problem hook to check if embedding is enabled in simple embedding. Same as `embedding_simple` in place of `embedding_sdk`.

### How to verify

- Disable simple embedding and SDK embedding in admin settings
- Go to "new > embed"
- It should auto flip embedding
- Embed preview should work now!

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - unit and e2e
