### PR TITLE
fix(ui/menu): Public link row looks disabled but keeps “Enable” clickable (closes #61518)

### DIFF
--- a/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/PublicLinkMenuItem.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/PublicLinkMenuItem.tsx
@@ -4,7 +4,7 @@ import Link from "metabase/common/components/Link";
 import { useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { Icon, Menu, Stack, Text, Title } from "metabase/ui";
+import { Icon, Menu } from "metabase/ui";
 
 export function PublicLinkMenuItem({
   hasPublicLink,
@@ -21,22 +21,25 @@ export function PublicLinkMenuItem({
       <Menu.Item
         data-testid="embed-menu-public-link-item"
         leftSection={<Icon name="link" aria-hidden />}
+        softDisabled={!isPublicSharingEnabled}
+        rightSection={
+          !isPublicSharingEnabled ? (
+            <Link
+              to="/admin/settings/public-sharing"
+              target="_blank"
+              variant="brand"
+            >
+              {t`Enable`}
+            </Link>
+          ) : undefined
+        }
         onClick={onClick}
       >
-        {isPublicSharingEnabled ? (
-          hasPublicLink ? (
-            t`Public link`
-          ) : (
-            t`Create a public link`
-          )
-        ) : (
-          <Link to="/admin/settings/public-sharing" target="_blank">
-            <Stack gap="xs">
-              <Title order={4}>{t`Public links are off`}</Title>
-              <Text size="sm">{t`Enable them in settings`}</Text>
-            </Stack>
-          </Link>
-        )}
+        {isPublicSharingEnabled
+          ? hasPublicLink
+            ? t`Public link`
+            : t`Create a public link`
+          : t`Public link`}
       </Menu.Item>
     );
   }

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.module.css
@@ -51,3 +51,25 @@
   margin-right: var(--mantine-spacing-sm);
   border-top-color: var(--mb-color-border);
 }
+
+.itemSoftDisabled {
+  cursor: not-allowed;
+}
+
+.itemSoftDisabled:hover {
+  color: var(--mb-color-text-light);
+}
+
+.itemLabelSoftDisabled {
+  color: var(--mb-color-text-light);
+  opacity: 0.6;
+}
+
+.itemSectionLeftSoftDisabled[data-position="left"] {
+  color: var(--mb-color-text-light);
+  opacity: 0.6;
+}
+
+.itemSoftDisabled:hover .itemSection[data-position="right"] {
+  color: inherit;
+}

--- a/frontend/src/metabase/ui/components/overlays/Menu/MenuItem/MenuItem.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Menu/MenuItem/MenuItem.unit.spec.tsx
@@ -1,0 +1,94 @@
+import userEvent from "@testing-library/user-event";
+
+import { render, screen } from "__support__/ui";
+import { Menu } from "metabase/ui";
+
+function renderMenuItem(softDisabled = false) {
+  const onRowClick = jest.fn();
+  const onRightClick = jest.fn();
+
+  render(
+    <Menu opened withinPortal={false}>
+      <Menu.Dropdown>
+        <Menu.Item
+          data-testid="menu-item"
+          onClick={onRowClick}
+          softDisabled={softDisabled}
+          rightSection={
+            <a
+              href="/admin/settings/public-sharing"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="enable"
+              onClick={(e) => {
+                e.preventDefault();
+                onRightClick();
+              }}
+            >
+              Enable
+            </a>
+          }
+        >
+          Public link
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>,
+  );
+
+  const row = screen.getByTestId("menu-item");
+  const enableEl = screen.getByTestId("enable");
+  return { row, enableEl, onRowClick, onRightClick };
+}
+
+describe("MenuItem (softDisabled)", () => {
+  it("suppresses row click but keeps rightSection interactive when softDisabled", async () => {
+    const { row, enableEl, onRowClick, onRightClick } = renderMenuItem(true);
+
+    await userEvent.click(row);
+    expect(onRowClick).not.toHaveBeenCalled();
+
+    await userEvent.click(enableEl);
+    expect(onRightClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("fires onClick when not softDisabled", async () => {
+    const { row, onRowClick } = renderMenuItem(false);
+
+    await userEvent.click(row);
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire row onClick when softDisabled and clicking leftSection", async () => {
+    const onRowClick = jest.fn();
+
+    render(
+      <Menu opened withinPortal={false}>
+        <Menu.Dropdown>
+          <Menu.Item
+            data-testid="menu-item"
+            onClick={onRowClick}
+            softDisabled
+            leftSection={<span data-testid="left">L</span>}
+            rightSection={<a data-testid="enable">Enable</a>}
+          >
+            Public link
+          </Menu.Item>
+        </Menu.Dropdown>
+      </Menu>,
+    );
+
+    await userEvent.click(screen.getByTestId("left"));
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("sets aria-disabled when softDisabled", () => {
+    const { row } = renderMenuItem(true);
+    expect(row).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("does not set aria-disabled when not softDisabled", () => {
+    const { row } = renderMenuItem(false);
+    expect(row).not.toHaveAttribute("aria-disabled");
+  });
+});


### PR DESCRIPTION
**Closes** [https://github.com/metabase/metabase/issues/61518](https://github.com/metabase/metabase/issues/61518)

### Description

Adds support for a `softDisabled` visual state in `<Menu.Item>` to improve UX for menu items that should appear disabled but still allow interaction in the `rightSection`.

This was implemented for the “Public link” menu item in the embed sharing menu when public sharing is disabled. The row appears grayed out and non-clickable, but a call-to-action (like "Enable") remains active.

### How to verify

1. Go to any dashboard as an admin.
2. Open the sharing menu.
3. If public sharing is disabled, you should see the “Public link” row grayed out.
4. Clicking the row itself should do nothing.
5. Clicking the “Enable” link in the right section should navigate you to the settings page.

### Demo

<img width="255" height="184" alt="Screenshot 2568-07-30 at 15 50 20" src="https://github.com/user-attachments/assets/c7d8c0e8-6b18-4bce-867c-055c7106a091" />

### Checklist

* [x] Tests have been added/updated to cover changes in this PR
