### PR TITLE
Add the Beta badge to "New > Embed" menu

### DIFF
--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
@@ -58,5 +58,6 @@ describe("NewItemMenu (EE with token)", () => {
     await setup({ tokenFeatures: { embedding_simple: true } });
 
     expect(await screen.findByText("Embed")).toBeInTheDocument();
+    expect(screen.queryAllByText("Beta")).toHaveLength(1);
   });
 });

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
@@ -8,7 +8,7 @@ import * as Urls from "metabase/lib/urls";
 import { PLUGIN_EMBEDDING_IFRAME_SDK_SETUP } from "metabase/plugins";
 import { setOpenModal } from "metabase/redux/ui";
 import { getSetting } from "metabase/selectors/settings";
-import { Box, Icon, Menu } from "metabase/ui";
+import { Badge, Box, Icon, Menu } from "metabase/ui";
 import type { CollectionId } from "metabase-types/api";
 
 import { trackNewMenuItemClicked } from "./analytics";
@@ -98,6 +98,7 @@ const NewItemMenuView = ({
           component={ForwardRefLink}
           to="/embed-iframe"
           leftSection={<Icon name="embed" />}
+          rightSection={<Badge size="xs">{t`Beta`}</Badge>}
         >
           {t`Embed`}
         </Menu.Item>,


### PR DESCRIPTION
Closes EMB-672

Adds the Beta badge to `New > Embed` menu.

<img width="400" alt="CleanShot 2568-07-30 at 17 48 07@2x" src="https://github.com/user-attachments/assets/71a10b7c-ff59-4d7f-90f0-c95c325645bf" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
