### PR TITLE
add LIVE_BACKEND option to test-cypress

### DIFF
--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -8,84 +8,70 @@ const path = require("path");
 
 const { delay } = require("./cypress-runner-utils");
 
-const CypressBackend = {
-  server: null,
+class BaseBackend {
+  constructor() {
+    this.server = null;
+  }
+
   createServer(port = process.env.BACKEND_PORT || 4000) {
     const generateTempDbPath = () =>
       path.join(os.tmpdir(), `metabase-test-${process.pid}.db`);
 
-    const server = {
+    this.server = {
       dbFile: generateTempDbPath(),
       host: `http://localhost:${port}`,
       port,
     };
+  }
 
-    this.server = server;
-  },
+  // subclasses must return { cmd, args }
+  getCommand() {
+    throw new Error("buildCommand() not implemented in base class");
+  }
+
+  getEnv() {
+    return {
+      MB_DB_TYPE: "h2",
+      MB_DB_FILE: this.server.dbFile,
+      MB_JETTY_HOST: "0.0.0.0",
+      MB_JETTY_PORT: this.server.port,
+      MB_ENABLE_TEST_ENDPOINTS: "true",
+      MB_DANGEROUS_UNSAFE_ENABLE_TESTING_H2_CONNECTIONS_DO_NOT_ENABLE: "true",
+      MB_LAST_ANALYTICS_CHECKSUM: "-1",
+      MB_DB_CONNECTION_URI: "",
+      MB_CONFIG_FILE_PATH: "__cypress__",
+    };
+  }
+
   async start() {
     if (!this.server) {
       this.createServer();
     }
+
     if (!this.server.process) {
-      const javaFlags = [
-        "-XX:+IgnoreUnrecognizedVMOptions", // ignore options not recognized by this Java version (e.g. Java 8 should ignore Java 9 options)
-        "-Dh2.bindAddress=localhost", // fix H2 randomly not working (?)
-        "-Djava.awt.headless=true", // when running on macOS prevent little Java icon from popping up in Dock
-        "-Dmail.smtps.ssl.trust=*", // trust self signed certs for testing
-        "-Duser.timezone=US/Pacific",
-        process.env.SHOW_BACKEND_LOGS === "true"
-          ? null
-          : `-Dlog4j.configurationFile=file:${__dirname}/../../frontend/test/__runner__/log4j2.xml`,
-      ].filter(Boolean);
+      const { cmd, args } = this.getCommand();
 
-      const metabaseConfig = {
-        MB_DB_TYPE: "h2",
-        MB_DB_FILE: this.server.dbFile,
-        MB_JETTY_HOST: "0.0.0.0",
-        MB_JETTY_PORT: this.server.port,
-        MB_ENABLE_TEST_ENDPOINTS: "true",
-        MB_DANGEROUS_UNSAFE_ENABLE_TESTING_H2_CONNECTIONS_DO_NOT_ENABLE: "true",
-        MB_LAST_ANALYTICS_CHECKSUM: "-1",
-        MB_DB_CONNECTION_URI: "", // ignore connection URI in favor of the db file
-        MB_CONFIG_FILE_PATH: "__cypress__", // ignore config.yml
-      };
-
-      /**
-       * This ENV is used for Cloud instances only, and is subject to change.
-       * As such, it is not documented anywhere in the code base!
-       *
-       * WARNING:
-       * Changing values here will break the related E2E test.
-       */
-      const userDefaults = {
-        MB_USER_DEFAULTS: JSON.stringify({
-          token: "123456",
-          user: {
-            first_name: "Testy",
-            last_name: "McTestface",
-            email: "testy@metabase.test",
-            site_name: "Epic Team",
-          },
-        }),
-      };
-
-      this.server.process = spawn(
-        "java",
-        [...javaFlags, "-jar", "target/uberjar/metabase.jar"],
-        {
-          env: {
-            ...process.env,
-            ...metabaseConfig,
-            ...userDefaults,
-          },
-          stdio:
-            process.env["DISABLE_LOGGING"] ||
-            process.env["DISABLE_LOGGING_BACKEND"]
-              ? "ignore"
-              : "inherit",
-          detached: true,
+      this.server.process = spawn(cmd, args, {
+        env: {
+          ...process.env,
+          ...this.getEnv(),
+          MB_USER_DEFAULTS: JSON.stringify({
+            token: "123456",
+            user: {
+              first_name: "Testy",
+              last_name: "McTestface",
+              email: "testy@metabase.test",
+              site_name: "Epic Team",
+            },
+          }),
         },
-      );
+        stdio:
+          process.env["DISABLE_LOGGING"] ||
+          process.env["DISABLE_LOGGING_BACKEND"]
+            ? "ignore"
+            : "inherit",
+        detached: true,
+      });
     }
 
     if (!(await isReady(this.server.host))) {
@@ -93,8 +79,7 @@ const CypressBackend = {
         `Waiting for backend (host=${this.server.host}, dbFile=${this.server.dbFile})`,
       );
       while (!(await isReady(this.server.host))) {
-        if (!process.env["CI"]) {
-          // disable for CI since it breaks CircleCI's no_output_timeout
+        if (!process.env.CI) {
           process.stdout.write(".");
         }
         await delay(500);
@@ -107,40 +92,35 @@ const CypressBackend = {
     );
 
     if (process.env.CI) {
-      this.server.process.unref(); // detach console
+      this.server.process.unref();
     }
 
     async function isReady(host) {
-      // This is needed until we can use NodeJS native `fetch`.
-      function request(url) {
-        return new Promise((resolve, reject) => {
+      const reqJson = (url) =>
+        new Promise((resolve, reject) => {
           const req = http.get(url, (res) => {
             let body = "";
-
-            res.on("data", (chunk) => {
-              body += chunk;
-            });
-
+            res.on("data", (c) => (body += c));
             res.on("end", () => {
-              resolve(JSON.parse(body));
+              try {
+                resolve(JSON.parse(body));
+              } catch {
+                resolve({});
+              }
             });
           });
-
-          req.on("error", (e) => {
-            reject(e);
-          });
+          req.on("error", reject);
         });
-      }
 
       try {
-        const { status } = await request(`${host}/api/health`);
-        if (status === "ok") {
-          return true;
-        }
-      } catch (e) {}
-      return false;
+        const { status } = await reqJson(`${host}/api/health`);
+        return status === "ok";
+      } catch {
+        return false;
+      }
     }
-  },
+  }
+
   async stop() {
     if (this?.server?.process) {
       this.server.process.kill("SIGKILL");
@@ -152,8 +132,40 @@ const CypressBackend = {
       if (this?.server?.dbFile) {
         fs.unlinkSync(`${this.server.dbFile}.mv.db`);
       }
-    } catch (e) {}
-  },
-};
+    } catch {}
+  }
+}
 
-module.exports = CypressBackend;
+class JarBackend extends BaseBackend {
+  getCommand() {
+    const javaFlags = [
+      "-XX:+IgnoreUnrecognizedVMOptions", // ignore options not recognized by this Java version
+      "-Dh2.bindAddress=localhost",
+      "-Djava.awt.headless=true",
+      "-Dmail.smtps.ssl.trust=*",
+      "-Duser.timezone=US/Pacific",
+      process.env.SHOW_BACKEND_LOGS === "true"
+        ? null
+        : `-Dlog4j.configurationFile=file:${__dirname}/../../frontend/test/__runner__/log4j2.xml`,
+    ].filter(Boolean);
+
+    return {
+      cmd: "java",
+      args: [...javaFlags, "-jar", "target/uberjar/metabase.jar"],
+    };
+  }
+}
+
+class LiveBackend extends BaseBackend {
+  getCommand() {
+    const mbEdition = process.env.MB_EDITION || "ee";
+    const alias = mbEdition === "oss" ? "-M:dev:run" : "-M:dev:run:ee";
+    return { cmd: "clojure", args: [alias] };
+  }
+}
+
+const jarBackend = new JarBackend();
+const liveBackend = new LiveBackend();
+Object.assign(jarBackend, { JarBackend: jarBackend, LiveBackend: liveBackend });
+
+module.exports = jarBackend;

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -38,8 +38,8 @@ class BaseBackend {
       MB_ENABLE_TEST_ENDPOINTS: "true",
       MB_DANGEROUS_UNSAFE_ENABLE_TESTING_H2_CONNECTIONS_DO_NOT_ENABLE: "true",
       MB_LAST_ANALYTICS_CHECKSUM: "-1",
-      MB_DB_CONNECTION_URI: "",
-      MB_CONFIG_FILE_PATH: "__cypress__",
+      MB_DB_CONNECTION_URI: "", // ignore connection URI in favor of the db file
+      MB_CONFIG_FILE_PATH: "__cypress__", // ignore config.yml
     };
   }
 
@@ -90,7 +90,7 @@ class BaseBackend {
         `Waiting for backend (host=${this.server.host}, dbFile=${this.server.dbFile})`,
       );
       while (!(await isReady(this.server.host))) {
-        if (!process.env.CI) {
+        if (!process.env["CI"]) {
           // disable for CI since it breaks CircleCI's no_output_timeout
           process.stdout.write(".");
         }
@@ -104,7 +104,7 @@ class BaseBackend {
     );
 
     if (process.env.CI) {
-      this.server.process.unref();
+      this.server.process.unref(); // detach console
     }
 
     async function isReady(host) {

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -164,8 +164,4 @@ class LiveBackend extends BaseBackend {
   }
 }
 
-const jarBackend = new JarBackend();
-const liveBackend = new LiveBackend();
-Object.assign(jarBackend, { JarBackend: jarBackend, LiveBackend: liveBackend });
-
-module.exports = jarBackend;
+module.exports = { JarBackend, LiveBackend };

--- a/e2e/runner/run_cypress_ci.js
+++ b/e2e/runner/run_cypress_ci.js
@@ -1,5 +1,5 @@
 const { FAILURE_EXIT_CODE } = require("./constants/exit-code");
-const CypressBackend = require("./cypress-runner-backend");
+const { JarBackend } = require("./cypress-runner-backend");
 const runCypress = require("./cypress-runner-run-tests");
 const { printBold } = require("./cypress-runner-utils");
 
@@ -28,7 +28,8 @@ if (
 
 const startServer = async () => {
   printBold("Starting backend");
-  await CypressBackend.start();
+  const backend = new JarBackend();
+  await backend.start();
 };
 
 const runTests = async (testSuite) => {

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -1,5 +1,5 @@
 import { FAILURE_EXIT_CODE, SUCCESS_EXIT_CODE } from "./constants/exit-code";
-import Backends from "./cypress-runner-backend";
+import { JarBackend, LiveBackend } from "./cypress-runner-backend";
 import runCypress from "./cypress-runner-run-tests";
 import {
   booleanify,
@@ -67,8 +67,9 @@ printBold(`Running Cypress with options:
   - TZ                 : ${options.TZ}
 `);
 
-const { JarBackend, LiveBackend } = Backends as any;
-const CypressBackend = options.LIVE_BACKEND ? LiveBackend : JarBackend;
+const CypressBackend = options.LIVE_BACKEND
+  ? new LiveBackend()
+  : new JarBackend();
 
 const init = async () => {
   if (options.START_CONTAINERS) {

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -78,43 +78,28 @@ const init = async () => {
   }
 
   if (options.BUILD_JAR) {
-    printBold("⏳ Building backend");
+    printBold("⏳ Building backend (uberjar)");
     shell("./bin/build-for-test");
+  }
 
-    if (options.START_BACKEND) {
-      const isBackendRunning = shell(
-        `lsof -ti:${options.BACKEND_PORT} || echo ""`,
-        { quiet: true },
+  if (options.START_BACKEND) {
+    const isBackendRunning = shell(
+      `lsof -ti:${options.BACKEND_PORT} || echo ""`,
+      { quiet: true },
+    );
+    if (isBackendRunning) {
+      printBold(
+        "⚠️ Your backend is already running, you may want to kill pid " +
+          isBackendRunning,
       );
-      if (isBackendRunning) {
-        printBold(
-          "⚠️ Your backend is already running, you may want to kill pid " +
-            isBackendRunning,
-        );
-        process.exit(FAILURE_EXIT_CODE);
-      }
-
-      printBold("⏳ Starting backend (jar mode)");
-      await CypressBackend.start();
+      process.exit(FAILURE_EXIT_CODE);
     }
-  } else if (options.LIVE_BACKEND) {
-    if (options.START_BACKEND) {
-      const isBackendRunning = shell(
-        `lsof -ti:${options.BACKEND_PORT} || echo ""`,
-        { quiet: true },
-      );
-      if (isBackendRunning) {
-        printBold(
-          "⚠️ Your backend is already running, you may want to kill pid " +
-            isBackendRunning,
-        );
-        process.exit(FAILURE_EXIT_CODE);
-      }
 
-      printBold("⏳ Starting backend (live mode)");
-      await CypressBackend.start();
-    }
-  } else {
+    const modeLabel = options.LIVE_BACKEND ? "live" : "jar";
+    printBold(`⏳ Starting backend (${modeLabel} mode)`);
+    await CypressBackend.start();
+  } else if (!options.BUILD_JAR) {
+    // Not building jar and not starting backend – assume external server
     printBold(
       `Not building a jar, expecting metabase to be running on port ${options.BACKEND_PORT}. Make sure your metabase instance is running with an h2 app db and the following environment variables:
   - MB_ENABLE_TEST_ENDPOINTS=true


### PR DESCRIPTION
This PR adds a `LIVE_BACKEND` env that we can pass to `yarn test-cypress` to make it skip the uberjar step and instead run a backend instance with `clojure -M:dev:run:ee` and the appropriate ENVs.

This can be used for a quicker start up and/or to have live backend ~, but in my specific case I needed it to work around a limitation we have in the embedding team, specifically EMB-668:
we have a `embed.js` file that's used for the new "simple embedding" that needs to be served by the instance but it also requires some custom rspack configuration, when running cypress and build-hot that file isn't hot-reloaded and ugly things happens~