### PR TITLE
fix: snyk set org and repo for open source limits 

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         continue-on-error: true
-        run: snyk test --file=${{ matrix.project.file }} --package-manager=${{ matrix.project.package-manager }} --sarif-file-output=snyk-${{ matrix.project.category }}.sarif
+        run: snyk test --org="metabase-AnD9iS4Wfu4eBYMsG2DZ5N" --remote-repo-url="https://github.com/metabase/metabase" --file=${{ matrix.project.file }} --package-manager=${{ matrix.project.package-manager }} --sarif-file-output=snyk-${{ matrix.project.category }}.sarif
       - name: Upload results
         uses: github/codeql-action/upload-sarif@v3
         with:
@@ -159,7 +159,8 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         continue-on-error: true
-        run: snyk test --file=${{ matrix.project.file }} --package-manager=maven --sarif-file-output=snyk-${{ matrix.project.category }}.sarif
+        run: snyk test --org="metabase-AnD9iS4Wfu4eBYMsG2DZ5N" --remote-repo-url="https://github.com/metabase/metabase" --file=${{ matrix.project.file }} --package-manager=maven --sarif-file-output=snyk-${{ matrix.project.category }}.sarif
+
       - name: Upload results
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
### Description

Fix our snyk test command to set our repo url and organization so we have the open source unlimited tests applied to our CI

Successful run [here](https://github.com/metabase/metabase/actions/runs/16630608718/job/47058896679)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
