### PR TITLE
Remove quotes around UUIDs in XLSX downloads

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -27,6 +27,7 @@
     OffsetDateTime
     OffsetTime
     ZonedDateTime)
+   (java.util UUID)
    (org.apache.poi.ss.usermodel
     Cell
     DataConsolidateFunction
@@ -315,6 +316,10 @@
   {:arglists '([cell value styles typed-styles])}
   (fn [^Cell _cell value _styles _typed-styles]
     (type value)))
+
+(defmethod set-cell! UUID
+  [^Cell cell ^UUID uuid _styles _typed-styles]
+  (.setCellValue cell (str uuid)))
 
 ;; Temporal values in Excel are just NUMERIC cells that are stored in a floating-point format and have some cell
 ;; styles applied that dictate how to format them


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57719
I'm ignoring `styles` and `typed-styles` here just like the `Object` implementation or the `String` implementation.

Fixes [UXW-145: Quotation marks appear around UUIDs in .xlsx downloads](https://linear.app/metabase/issue/UXW-145/quotation-marks-appear-around-uuids-in-xlsx-downloads)