### PR TITLE
do not throw on empty query for /search

### DIFF
--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -171,7 +171,7 @@
     non-temporal-dim-ids                :non_temporal_dim_ids
     has-temporal-dim                    :has_temporal_dim}
    :- [:map
-       [:q                                   {:optional true} [:maybe ms/NonBlankString]]
+       [:q                                   {:optional true} [:maybe :string]]
        [:context                             {:optional true} [:maybe :keyword]]
        [:archived                            {:default false} [:maybe :boolean]]
        [:table_db_id                         {:optional true} [:maybe ms/PositiveInt]]
@@ -214,7 +214,7 @@
                 :offset                              (request/offset)
                 :search-engine                       search-engine
                 :search-native-query                 search-native-query
-                :search-string                       q
+                :search-string                       (some-> q str/trim not-empty)
                 :table-db-id                         table-db-id
                 :verified                            verified
                 :ids                                 (set ids)

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -1826,7 +1826,7 @@
           (is (= 0 (count (filter #{:metabase-search/response-error} @calls)))))
 
         (testing "Bad request (400)"
-          (mt/user-http-request :crowberto :get 400 "/search" :q " ")
+          (mt/user-http-request :crowberto :get 400 "/search" :archived "meow")
           (is (= 1 (count (filter #{:metabase-search/response-ok} @calls))))
           ;; We do not treat client side errors as errors for our alerts.
           (is (= 0 (count (filter #{:metabase-search/response-error} @calls)))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60944
instead just pass `(not-empty q)` to the search subsystem, which will convert it to `nil` if it's empty and pass it unchanged if it's not.

I still don't think this is probably the ideal user experience when you navigate to `/search` but it's not an error at least.

Fixes [UXW-338: /search errors when not provided a search term](https://linear.app/metabase/issue/UXW-338/search-errors-when-not-provided-a-search-term)