### PR TITLE
docs(sdk): missing documentation for question components

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -36,6 +36,13 @@ export type InteractiveQuestionProps = Omit<
   SdkQuestionProps,
   "getClickActionMode" | "navigateToNewCard" | "backToDashboard"
 >;
+
+/**
+ * A question component with drill-downs enabled.
+ *
+ * @function
+ * @category InteractiveQuestion
+ */
 export const _InteractiveQuestion = (props: InteractiveQuestionProps) => (
   <SdkQuestion {...props} />
 );

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -15,7 +15,7 @@ import {
   QuestionSettingsDropdown,
   QuestionVisualization,
   SaveButton,
-  type SdkSaveQuestionForm,
+  SdkSaveQuestionForm,
   Summarize,
   SummarizeDropdown,
   Title,
@@ -25,7 +25,6 @@ import {
   SdkQuestion,
   type SdkQuestionProps,
 } from "embedding-sdk/components/public/SdkQuestion/SdkQuestion";
-import { SaveQuestionForm } from "metabase/common/components/SaveQuestionForm";
 
 /**
  * @interface
@@ -88,7 +87,7 @@ InteractiveQuestion.Editor = Editor;
 InteractiveQuestion.NotebookButton = EditorButton;
 InteractiveQuestion.EditorButton = EditorButton;
 InteractiveQuestion.QuestionVisualization = QuestionVisualization;
-InteractiveQuestion.SaveQuestionForm = SaveQuestionForm;
+InteractiveQuestion.SaveQuestionForm = SdkSaveQuestionForm;
 InteractiveQuestion.SaveButton = SaveButton;
 InteractiveQuestion.ChartTypeSelector = ChartTypeSelector;
 InteractiveQuestion.QuestionSettings = QuestionSettings;

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -37,16 +37,16 @@ export type InteractiveQuestionProps = Omit<
   "getClickActionMode" | "navigateToNewCard" | "backToDashboard"
 >;
 
+export const _InteractiveQuestion = (props: InteractiveQuestionProps) => (
+  <SdkQuestion {...props} />
+);
+
 /**
  * A question component with drill-downs enabled.
  *
  * @function
  * @category InteractiveQuestion
  */
-export const _InteractiveQuestion = (props: InteractiveQuestionProps) => (
-  <SdkQuestion {...props} />
-);
-
 export const InteractiveQuestion =
   _InteractiveQuestion as typeof _InteractiveQuestion & {
     BackButton: typeof BackButton;

--- a/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -1,7 +1,31 @@
 import {
+  BackButton,
+  Breakout,
+  BreakoutDropdown,
+  ChartTypeDropdown,
+  ChartTypeSelector,
+  DownloadWidget,
+  DownloadWidgetDropdown,
+  Editor,
+  EditorButton,
+  Filter,
+  FilterDropdown,
+  QuestionResetButton,
+  QuestionSettings,
+  QuestionSettingsDropdown,
+  QuestionVisualization,
+  SaveButton,
+  type SdkSaveQuestionForm,
+  Summarize,
+  SummarizeDropdown,
+  Title,
+  VisualizationButton,
+} from "embedding-sdk/components/private/SdkQuestion/components";
+import {
   SdkQuestion,
   type SdkQuestionProps,
 } from "embedding-sdk/components/public/SdkQuestion/SdkQuestion";
+import { SaveQuestionForm } from "metabase/common/components/SaveQuestionForm";
 
 /**
  * @interface
@@ -18,54 +42,53 @@ export const _InteractiveQuestion = (props: InteractiveQuestionProps) => (
 
 export const InteractiveQuestion =
   _InteractiveQuestion as typeof _InteractiveQuestion & {
-    BackButton: typeof SdkQuestion.BackButton;
-    Filter: typeof SdkQuestion.Filter;
-    FilterDropdown: typeof SdkQuestion.FilterDropdown;
-    ResetButton: typeof SdkQuestion.ResetButton;
-    Title: typeof SdkQuestion.Title;
-    Summarize: typeof SdkQuestion.Summarize;
-    SummarizeDropdown: typeof SdkQuestion.SummarizeDropdown;
+    BackButton: typeof BackButton;
+    Filter: typeof Filter;
+    FilterDropdown: typeof FilterDropdown;
+    ResetButton: typeof QuestionResetButton;
+    Title: typeof Title;
+    Summarize: typeof Summarize;
+    SummarizeDropdown: typeof SummarizeDropdown;
     /** @deprecated Use `InteractiveQuestion.Editor` instead */
-    Notebook: typeof SdkQuestion.Editor;
-    Editor: typeof SdkQuestion.Editor;
+    Notebook: typeof Editor;
+    Editor: typeof Editor;
     /** @deprecated Use `InteractiveQuestion.EditorButton` instead */
-    NotebookButton: typeof SdkQuestion.EditorButton;
-    EditorButton: typeof SdkQuestion.EditorButton;
-    QuestionVisualization: typeof SdkQuestion.QuestionVisualization;
-    VisualizationButton: typeof SdkQuestion.VisualizationButton;
-    SaveQuestionForm: typeof SdkQuestion.SaveQuestionForm;
-    SaveButton: typeof SdkQuestion.SaveButton;
-    ChartTypeSelector: typeof SdkQuestion.ChartTypeSelector;
-    ChartTypeDropdown: typeof SdkQuestion.ChartTypeDropdown;
-    QuestionSettings: typeof SdkQuestion.QuestionSettings;
-    QuestionSettingsDropdown: typeof SdkQuestion.QuestionSettingsDropdown;
-    Breakout: typeof SdkQuestion.Breakout;
-    BreakoutDropdown: typeof SdkQuestion.BreakoutDropdown;
-    DownloadWidget: typeof SdkQuestion.DownloadWidget;
-    DownloadWidgetDropdown: typeof SdkQuestion.DownloadWidgetDropdown;
+    NotebookButton: typeof EditorButton;
+    EditorButton: typeof EditorButton;
+    QuestionVisualization: typeof QuestionVisualization;
+    VisualizationButton: typeof VisualizationButton;
+    SaveQuestionForm: typeof SdkSaveQuestionForm;
+    SaveButton: typeof SaveButton;
+    ChartTypeSelector: typeof ChartTypeSelector;
+    ChartTypeDropdown: typeof ChartTypeDropdown;
+    QuestionSettings: typeof QuestionSettings;
+    QuestionSettingsDropdown: typeof QuestionSettingsDropdown;
+    Breakout: typeof Breakout;
+    BreakoutDropdown: typeof BreakoutDropdown;
+    DownloadWidget: typeof DownloadWidget;
+    DownloadWidgetDropdown: typeof DownloadWidgetDropdown;
   };
 
-InteractiveQuestion.BackButton = SdkQuestion.BackButton;
-InteractiveQuestion.Filter = SdkQuestion.Filter;
-InteractiveQuestion.FilterDropdown = SdkQuestion.FilterDropdown;
-InteractiveQuestion.ResetButton = SdkQuestion.ResetButton;
-InteractiveQuestion.Title = SdkQuestion.Title;
-InteractiveQuestion.Summarize = SdkQuestion.Summarize;
-InteractiveQuestion.SummarizeDropdown = SdkQuestion.SummarizeDropdown;
-InteractiveQuestion.Notebook = SdkQuestion.Editor;
-InteractiveQuestion.Editor = SdkQuestion.Editor;
-InteractiveQuestion.NotebookButton = SdkQuestion.EditorButton;
-InteractiveQuestion.EditorButton = SdkQuestion.EditorButton;
-InteractiveQuestion.QuestionVisualization = SdkQuestion.QuestionVisualization;
-InteractiveQuestion.SaveQuestionForm = SdkQuestion.SaveQuestionForm;
-InteractiveQuestion.SaveButton = SdkQuestion.SaveButton;
-InteractiveQuestion.ChartTypeSelector = SdkQuestion.ChartTypeSelector;
-InteractiveQuestion.QuestionSettings = SdkQuestion.QuestionSettings;
-InteractiveQuestion.QuestionSettingsDropdown =
-  SdkQuestion.QuestionSettingsDropdown;
-InteractiveQuestion.BreakoutDropdown = SdkQuestion.BreakoutDropdown;
-InteractiveQuestion.Breakout = SdkQuestion.Breakout;
-InteractiveQuestion.ChartTypeDropdown = SdkQuestion.ChartTypeDropdown;
-InteractiveQuestion.DownloadWidget = SdkQuestion.DownloadWidget;
-InteractiveQuestion.DownloadWidgetDropdown = SdkQuestion.DownloadWidgetDropdown;
-InteractiveQuestion.VisualizationButton = SdkQuestion.VisualizationButton;
+InteractiveQuestion.BackButton = BackButton;
+InteractiveQuestion.Filter = Filter;
+InteractiveQuestion.FilterDropdown = FilterDropdown;
+InteractiveQuestion.ResetButton = QuestionResetButton;
+InteractiveQuestion.Title = Title;
+InteractiveQuestion.Summarize = Summarize;
+InteractiveQuestion.SummarizeDropdown = SummarizeDropdown;
+InteractiveQuestion.Notebook = Editor;
+InteractiveQuestion.Editor = Editor;
+InteractiveQuestion.NotebookButton = EditorButton;
+InteractiveQuestion.EditorButton = EditorButton;
+InteractiveQuestion.QuestionVisualization = QuestionVisualization;
+InteractiveQuestion.SaveQuestionForm = SaveQuestionForm;
+InteractiveQuestion.SaveButton = SaveButton;
+InteractiveQuestion.ChartTypeSelector = ChartTypeSelector;
+InteractiveQuestion.QuestionSettings = QuestionSettings;
+InteractiveQuestion.QuestionSettingsDropdown = QuestionSettingsDropdown;
+InteractiveQuestion.BreakoutDropdown = BreakoutDropdown;
+InteractiveQuestion.Breakout = Breakout;
+InteractiveQuestion.ChartTypeDropdown = ChartTypeDropdown;
+InteractiveQuestion.DownloadWidget = DownloadWidget;
+InteractiveQuestion.DownloadWidgetDropdown = DownloadWidgetDropdown;
+InteractiveQuestion.VisualizationButton = VisualizationButton;

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
@@ -1,6 +1,23 @@
 import type { PropsWithChildren } from "react";
 
 import { FlexibleSizeComponent } from "embedding-sdk/components/private/FlexibleSizeComponent";
+import {
+  Breakout,
+  BreakoutDropdown,
+  ChartTypeDropdown,
+  ChartTypeSelector,
+  DownloadWidget,
+  DownloadWidgetDropdown,
+  Filter,
+  FilterDropdown,
+  QuestionResetButton,
+  QuestionSettings,
+  QuestionSettingsDropdown,
+  QuestionVisualization,
+  Summarize,
+  SummarizeDropdown,
+  Title,
+} from "embedding-sdk/components/private/SdkQuestion/components";
 import { DefaultViewTitle } from "embedding-sdk/components/private/SdkQuestionDefaultView/DefaultViewTitle";
 import {
   SdkQuestion,
@@ -103,35 +120,35 @@ const _StaticQuestion = ({
 };
 
 export const StaticQuestion = _StaticQuestion as typeof _StaticQuestion & {
-  Filter: typeof SdkQuestion.Filter;
-  FilterDropdown: typeof SdkQuestion.FilterDropdown;
-  ResetButton: typeof SdkQuestion.ResetButton;
-  Title: typeof SdkQuestion.Title;
-  Summarize: typeof SdkQuestion.Summarize;
-  SummarizeDropdown: typeof SdkQuestion.SummarizeDropdown;
-  QuestionVisualization: typeof SdkQuestion.QuestionVisualization;
-  ChartTypeSelector: typeof SdkQuestion.ChartTypeSelector;
-  ChartTypeDropdown: typeof SdkQuestion.ChartTypeDropdown;
-  QuestionSettings: typeof SdkQuestion.QuestionSettings;
-  QuestionSettingsDropdown: typeof SdkQuestion.QuestionSettingsDropdown;
-  Breakout: typeof SdkQuestion.Breakout;
-  BreakoutDropdown: typeof SdkQuestion.BreakoutDropdown;
-  DownloadWidget: typeof SdkQuestion.DownloadWidget;
-  DownloadWidgetDropdown: typeof SdkQuestion.DownloadWidgetDropdown;
+  Filter: typeof Filter;
+  FilterDropdown: typeof FilterDropdown;
+  ResetButton: typeof QuestionResetButton;
+  Title: typeof Title;
+  Summarize: typeof Summarize;
+  SummarizeDropdown: typeof SummarizeDropdown;
+  QuestionVisualization: typeof QuestionVisualization;
+  ChartTypeSelector: typeof ChartTypeSelector;
+  ChartTypeDropdown: typeof ChartTypeDropdown;
+  QuestionSettings: typeof QuestionSettings;
+  QuestionSettingsDropdown: typeof QuestionSettingsDropdown;
+  Breakout: typeof Breakout;
+  BreakoutDropdown: typeof BreakoutDropdown;
+  DownloadWidget: typeof DownloadWidget;
+  DownloadWidgetDropdown: typeof DownloadWidgetDropdown;
 };
 
-StaticQuestion.Filter = SdkQuestion.Filter;
-StaticQuestion.FilterDropdown = SdkQuestion.FilterDropdown;
-StaticQuestion.ResetButton = SdkQuestion.ResetButton;
-StaticQuestion.Title = SdkQuestion.Title;
-StaticQuestion.Summarize = SdkQuestion.Summarize;
-StaticQuestion.SummarizeDropdown = SdkQuestion.SummarizeDropdown;
-StaticQuestion.QuestionVisualization = SdkQuestion.QuestionVisualization;
-StaticQuestion.ChartTypeSelector = SdkQuestion.ChartTypeSelector;
-StaticQuestion.QuestionSettings = SdkQuestion.QuestionSettings;
-StaticQuestion.QuestionSettingsDropdown = SdkQuestion.QuestionSettingsDropdown;
-StaticQuestion.BreakoutDropdown = SdkQuestion.BreakoutDropdown;
-StaticQuestion.Breakout = SdkQuestion.Breakout;
-StaticQuestion.ChartTypeDropdown = SdkQuestion.ChartTypeDropdown;
-StaticQuestion.DownloadWidget = SdkQuestion.DownloadWidget;
-StaticQuestion.DownloadWidgetDropdown = SdkQuestion.DownloadWidgetDropdown;
+StaticQuestion.Filter = Filter;
+StaticQuestion.FilterDropdown = FilterDropdown;
+StaticQuestion.ResetButton = QuestionResetButton;
+StaticQuestion.Title = Title;
+StaticQuestion.Summarize = Summarize;
+StaticQuestion.SummarizeDropdown = SummarizeDropdown;
+StaticQuestion.QuestionVisualization = QuestionVisualization;
+StaticQuestion.ChartTypeSelector = ChartTypeSelector;
+StaticQuestion.QuestionSettings = QuestionSettings;
+StaticQuestion.QuestionSettingsDropdown = QuestionSettingsDropdown;
+StaticQuestion.BreakoutDropdown = BreakoutDropdown;
+StaticQuestion.Breakout = Breakout;
+StaticQuestion.ChartTypeDropdown = ChartTypeDropdown;
+StaticQuestion.DownloadWidget = DownloadWidget;
+StaticQuestion.DownloadWidgetDropdown = DownloadWidgetDropdown;

--- a/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/StaticQuestion/StaticQuestion.tsx
@@ -49,12 +49,6 @@ export type StaticQuestionProps = PropsWithChildren<
   >
 >;
 
-/**
- * A component that renders a static question.
- *
- * @function
- * @category StaticQuestion
- */
 const _StaticQuestion = ({
   questionId: initialQuestionId,
   withChartTypeSelector,
@@ -119,6 +113,12 @@ const _StaticQuestion = ({
   );
 };
 
+/**
+ * A question component without drill-downs.
+ *
+ * @function
+ * @category StaticQuestion
+ */
 export const StaticQuestion = _StaticQuestion as typeof _StaticQuestion & {
   Filter: typeof Filter;
   FilterDropdown: typeof FilterDropdown;


### PR DESCRIPTION
Closes EMB-676

These [links in the SDK docs](https://www.metabase.com/docs/latest/embedding/sdk/questions#interactive-question-components) are all dead now. We need to restore them.