### PR TITLE
feat(new-embed): log an error when the parsing of a json attribute fails

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/webcomponents.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/webcomponents.ts
@@ -33,7 +33,10 @@ export const parseAttributeValue = (value: string | null): unknown => {
     try {
       return JSON.parse(value);
     } catch {
-      /* swallow parse errors and fall through */
+      console.error(
+        "Error while trying ot parse an attribute as JSON. Complex attributes such as arrays and objects should be valid JSON with keys and values wrapped in double quotes. Received:",
+        value,
+      );
     }
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/webcomponents.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/webcomponents.ts
@@ -34,7 +34,7 @@ export const parseAttributeValue = (value: string | null): unknown => {
       return JSON.parse(value);
     } catch {
       console.error(
-        "Error while trying ot parse an attribute as JSON. Complex attributes such as arrays and objects should be valid JSON with keys and values wrapped in double quotes. Received:",
+        "Error while trying to parse an attribute as JSON. Complex attributes such as arrays and objects should be valid JSON with keys and values wrapped in double quotes. Received:",
         value,
       );
     }


### PR DESCRIPTION
https://metaboat.slack.com/archives/C063Q3F1HPF/p1753883019712209
This used to fail silently, this adds a log

<img width="758" height="93" alt="image" src="https://github.com/user-attachments/assets/15e181b3-7196-4a99-ba42-97ba4ff943eb" />
