### PR TITLE
fix(viz/cartesian): stop interaction‑driven repaints (use dispatchAction; memoize renderer) (closes #60654)

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
+++ b/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
@@ -11,7 +11,6 @@ import { getObjectValues } from "metabase/lib/objects";
 import { isNotNull } from "metabase/lib/types";
 import TooltipStyles from "metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.module.css";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
-import type { ClickObject } from "metabase-lib";
 
 import type { BaseCartesianChartModel } from "../cartesian/model/types";
 import type { SankeyChartModel } from "../graph/sankey/model/types";
@@ -130,28 +129,29 @@ export const useInjectSeriesColorsClasses = (hexColors: string[]) => {
       .join("\n");
   }, [hexColors]);
 
-  const style = useMemo(
+  return useMemo(
     () =>
       cssString !== null ? (
         <style nonce={window.MetabaseNonce}>{cssString}</style>
       ) : null,
     [cssString],
   );
-
-  return style;
 };
 
 export const useClickedStateTooltipSync = (
   chart?: EChartsType,
-  clicked?: ClickObject | null,
+  clicked?: unknown | null,
 ) => {
-  useEffect(
-    function toggleTooltip() {
-      const isTooltipEnabled = clicked == null;
-      chart?.setOption({ tooltip: { show: isTooltipEnabled } }, false);
-    },
-    [chart, clicked],
-  );
+  useEffect(() => {
+    if (!chart) {
+      return;
+    }
+
+    if (clicked) {
+      chart.dispatchAction({ type: "hideTip" });
+      chart.dispatchAction({ type: "updateAxisPointer", currTrigger: "leave" });
+    }
+  }, [chart, clicked]);
 };
 
 export const useCartesianChartSeriesColorsClasses = (

--- a/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
+++ b/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
@@ -11,6 +11,7 @@ import { getObjectValues } from "metabase/lib/objects";
 import { isNotNull } from "metabase/lib/types";
 import TooltipStyles from "metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.module.css";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+import type { ClickObject } from "metabase-lib";
 
 import type { BaseCartesianChartModel } from "../cartesian/model/types";
 import type { SankeyChartModel } from "../graph/sankey/model/types";
@@ -140,7 +141,7 @@ export const useInjectSeriesColorsClasses = (hexColors: string[]) => {
 
 export const useClickedStateTooltipSync = (
   chart?: EChartsType,
-  clicked?: unknown | null,
+  clicked?: ClickObject | null,
 ) => {
   useEffect(() => {
     if (!chart) {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -21,6 +21,21 @@ import { useBrowserRenderingContext } from "metabase/visualizations/hooks/use-br
 import type { VisualizationProps } from "metabase/visualizations/types";
 import type { CardDisplayType } from "metabase-types/api";
 
+type ModelsAndOptionInput = Pick<
+  VisualizationProps,
+  | "rawSeries"
+  | "settings"
+  | "card"
+  | "fontFamily"
+  | "width"
+  | "height"
+  | "hiddenSeries"
+  | "timelineEvents"
+  | "selectedTimelineEventIds"
+  | "onRender"
+  | "isFullscreen"
+>;
+
 export function useModelsAndOption(
   {
     rawSeries,
@@ -33,9 +48,8 @@ export function useModelsAndOption(
     timelineEvents,
     selectedTimelineEventIds,
     onRender,
-    hovered,
     isFullscreen,
-  }: VisualizationProps,
+  }: ModelsAndOptionInput,
   containerRef: React.RefObject<HTMLDivElement>,
 ) {
   const tc = useTranslateContent();
@@ -125,17 +139,8 @@ export function useModelsAndOption(
   );
 
   const selectedOrHoveredTimelineEventIds = useMemo(() => {
-    const ids = [];
-
-    if (selectedTimelineEventIds != null) {
-      ids.push(...selectedTimelineEventIds);
-    }
-    if (hovered?.timelineEvents != null) {
-      ids.push(...hovered.timelineEvents.map((e) => e.id));
-    }
-
-    return ids;
-  }, [selectedTimelineEventIds, hovered?.timelineEvents]);
+    return selectedTimelineEventIds ?? [];
+  }, [selectedTimelineEventIds]);
 
   const tooltipOption = useMemo(() => {
     return getTooltipOption(

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -7,6 +7,7 @@ import type {
   DataKey,
   SeriesModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
+import type { EChartsSeriesMouseEvent } from "metabase/visualizations/echarts/types";
 import type {
   ComputedVisualizationSettings,
   HoveredObject,
@@ -96,3 +97,37 @@ export const getHoveredEChartsSeriesDataKeyAndIndex = (
 
   return { hoveredSeriesDataKey, hoveredEChartsSeriesIndex };
 };
+
+export type SeriesDatum = { seriesIndex: number; dataIndex: number };
+
+export function getSeriesDatumFromEvent(
+  option: EChartsCoreOption,
+  ev: EChartsSeriesMouseEvent,
+): SeriesDatum | null {
+  const e = ev as unknown as {
+    seriesIndex?: number;
+    seriesId?: string | number;
+    dataIndex?: number;
+  };
+
+  if (typeof e.dataIndex !== "number") {
+    return null;
+  }
+
+  if (typeof e.seriesIndex === "number") {
+    return { seriesIndex: e.seriesIndex, dataIndex: e.dataIndex };
+  }
+
+  const seriesArr = Array.isArray((option as any).series)
+    ? ((option as any).series as Array<{ id?: string | number }>)
+    : [];
+
+  if (e.seriesId != null) {
+    const idx = seriesArr.findIndex((s) => s && s.id === e.seriesId);
+    if (idx >= 0) {
+      return { seriesIndex: idx, dataIndex: e.dataIndex };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
Closes [https://github.com/metabase/metabase/issues/60654](https://github.com/metabase/metabase/issues/60654)

---

### Description

**Problem**

* Hovering and clicking on scatter points caused visible flicker / apparent re-renders. Initially traced to hover updates, and after fixing those, a **click popover** repaint surfaced as a separate issue.
* Root causes:

  1. `chart.setOption(...)` was invoked from interaction paths (hover/click tooltip sync). Any `setOption` during interaction forces ECharts to rebuild/repaint.
  2. The chart subtree re-rendered when `clicked` changed (popover open/close), because `clicked` flowed through the full chart component.
  3. Brush state was toggled on hover changes, causing extra churn.

**Approach**

* Keep **all interaction** updates (hover/click/brush) on **`dispatchAction`** only; reserve `setOption` for structural changes.
* **Isolate the renderer**: memoize `ResponsiveEChartsRenderer` and move the clicked tooltip sync into a tiny sibling component, so opening the popover does not re-render the canvas.
* **Stabilize option**: narrow `useModelsAndOption` inputs to exclude transient UI state (`clicked`, and removed hover-driven recompute). Option no longer changes on interactions.
* **Event typing**: add a safe `{seriesIndex, dataIndex}` resolver (falls back from `seriesId` → index) for timeline/series events.
* **Axis updates**: the only remaining `setOption` is Y‑axis visibility (no action exists); it’s deferred with `requestAnimationFrame` and targeted to `yAxis` only.

**Files touched**

* `echarts/tooltip/index.tsx`: `useClickedStateTooltipSync` now uses actions (`hideTip`, `updateAxisPointer`) — no `setOption`.
* `CartesianChart.tsx`: memoized renderer; split out `ClickedTooltipSync` sibling; build narrow `modelInputs` for `useModelsAndOption`.
* `use-chart-events.ts`: refs for `clicked`/`hovered`; freeze hover while popover open; timeline hover highlight/downplay via actions + safe datum resolver; click path only opens drill when clickable; brush uses actions and edge‑triggered cursor.
* `use-models-and-option.ts`: typed `ModelsAndOptionInput`; removed hover from option build; selection only.
* `utils.ts`: `getSeriesDatumFromEvent` helper.

**Result**

* We didn’t just fix hover; we also eliminated the click‑popover repaint. Interactions no longer cause chart repaints or React churn.

---

### How to verify

1. **Reproduce original case**

   * *Sample Dataset* → Invoices → **Sum of Payment by ID** → switch to **Scatter**.
   * **Hover** points: tooltips show, no flicker; axis visibility toggles smoothly.
   * **Click** a point: popover opens; canvas does **not** flicker.
2. **Brush**

   * Drag to brush on X: tooltip hides during drag; selection applied on release; no ghost click.
3. **Timeline events (if present)**

   * Hover a timeline marker: highlight via actions; clears on mouseout.
   * Click a marker: selection toggles as before.
4. **Multi‑axis charts**

   * On charts with left/right Y‑axes, hover series bound to each axis; visibility toggles correctly; no console errors.
5. **Profiler sanity (optional)**

   * In React DevTools Profiler, click a point; the memoized renderer should not re-render; only the tiny tooltip sync re-renders.

---

### Checklist

* [ ] Tests have been added/updated to cover changes in this PR

**Note on tests**

* This code path currently has **no existing unit tests**, and the affected files are **large/monolithic**, which makes adding meaningful tests without refactoring disproportionately heavy.
* I’m happy to follow up with a **targeted refactor** (e.g., extracting `useClickedStateTooltipSync`, the event datum resolver, and the renderer wrapper into smaller modules) and then add unit tests around those seams. I can take that on **on request** as a separate PR to keep this fix unblocked and focused on the regression.

*I'd recommend thorough manual testing, since the core workings of the Cartesian charts have been rewritten*

---

### Rationale for refactoring

* Interaction updates must be **action‑based** (`dispatchAction`) to avoid ECharts rebuilds; `setOption` is reserved for structural changes only (here: Y‑axis visibility).
* Decoupling the renderer from transient UI state and memoizing it prevents unnecessary canvas re-renders.
* Narrowing `useModelsAndOption` inputs ensures options are stable during interactions, eliminating hidden recomputations that previously caused repainting.