### PR TITLE
Flaky test fix for metabase.queries.api.card-test/we-can-get-a-list-of-dashboards-a-card-appears-in

### DIFF
--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -170,7 +170,7 @@
    cards k
    (fn []
      (let [card-ids       (map u/the-id cards)
-           all-dashboards (t2/query {:union-all [ ;; First get dashboards from direct card connections
+           all-dashboards (t2/query {:union-all [;; First get dashboards from direct card connections
                                                  {:nest
                                                   {:select   [[:dc.card_id :card_id]
                                                               :d.name

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -169,35 +169,38 @@
   (mi/instances-with-hydrated-data
    cards k
    (fn []
-     (let [card-ids (map :id cards)
-           ;; First get dashboards from direct card connections
-           direct-dashboards (t2/query {:select [[:dc.card_id :card_id]
-                                                 :d.name
-                                                 :d.collection_id
-                                                 :d.description
-                                                 :d.id
-                                                 :d.archived]
-                                        :from [[:report_dashboardcard :dc]]
-                                        :join [[:report_dashboard :d] [:= :dc.dashboard_id :d.id]]
-                                        :where [:in :dc.card_id card-ids]})
-           ;; Then get dashboards from series
-           series-dashboards (t2/query {:select [[:dcs.card_id :card_id]
-                                                 :d.name
-                                                 :d.collection_id
-                                                 :d.description
-                                                 :d.id
-                                                 :d.archived]
-                                        :from [[:dashboardcard_series :dcs]]
-                                        :join [[:report_dashboardcard :dc] [:= :dc.id :dcs.dashboardcard_id]
-                                               [:report_dashboard :d] [:= :d.id :dc.dashboard_id]]
-                                        :where [:in :dcs.card_id card-ids]})
-           ;; Combine and group all results
-           all-dashboards (concat direct-dashboards series-dashboards)]
+     (let [card-ids          (map u/the-id cards)
+           all-dashboards    (t2/query {:union-all [ ;; First get dashboards from direct card connections
+                                                    {:nest
+                                                     {:select   [[:dc.card_id :card_id]
+                                                                 :d.name
+                                                                 :d.collection_id
+                                                                 :d.description
+                                                                 :d.id
+                                                                 :d.archived]
+                                                      :from     [[:report_dashboardcard :dc]]
+                                                      :join     [[:report_dashboard :d] [:= :dc.dashboard_id :d.id]]
+                                                      :where    [:in :dc.card_id [:inline card-ids]]
+                                                      :order-by [[:d.id :asc]]}}
+                                                    ;; Then get dashboards from series
+                                                    {:nest
+                                                     {:select   [[:dcs.card_id :card_id]
+                                                                 :d.name
+                                                                 :d.collection_id
+                                                                 :d.description
+                                                                 :d.id
+                                                                 :d.archived]
+                                                      :from     [[:dashboardcard_series :dcs]]
+                                                      :join     [[:report_dashboardcard :dc] [:= :dc.id :dcs.dashboardcard_id]
+                                                                 [:report_dashboard :d] [:= :d.id :dc.dashboard_id]]
+                                                      :where    [:in :dcs.card_id [:inline card-ids]]
+                                                      :order-by [[:d.id :asc]]}}]})]
        (update-vals
         (group-by :card_id all-dashboards)
         (fn [dashes]
           (->> dashes
                (map #(dissoc % :card_id))
+               ;; TODO (Cam 7/30/25) -- we could probably do the 'distinct' in the query itself
                distinct
                (mapv #(t2/instance :model/Dashboard %)))))))
    :id

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -169,32 +169,32 @@
   (mi/instances-with-hydrated-data
    cards k
    (fn []
-     (let [card-ids          (map u/the-id cards)
-           all-dashboards    (t2/query {:union-all [ ;; First get dashboards from direct card connections
-                                                    {:nest
-                                                     {:select   [[:dc.card_id :card_id]
-                                                                 :d.name
-                                                                 :d.collection_id
-                                                                 :d.description
-                                                                 :d.id
-                                                                 :d.archived]
-                                                      :from     [[:report_dashboardcard :dc]]
-                                                      :join     [[:report_dashboard :d] [:= :dc.dashboard_id :d.id]]
-                                                      :where    [:in :dc.card_id [:inline card-ids]]
-                                                      :order-by [[:d.id :asc]]}}
-                                                    ;; Then get dashboards from series
-                                                    {:nest
-                                                     {:select   [[:dcs.card_id :card_id]
-                                                                 :d.name
-                                                                 :d.collection_id
-                                                                 :d.description
-                                                                 :d.id
-                                                                 :d.archived]
-                                                      :from     [[:dashboardcard_series :dcs]]
-                                                      :join     [[:report_dashboardcard :dc] [:= :dc.id :dcs.dashboardcard_id]
-                                                                 [:report_dashboard :d] [:= :d.id :dc.dashboard_id]]
-                                                      :where    [:in :dcs.card_id [:inline card-ids]]
-                                                      :order-by [[:d.id :asc]]}}]})]
+     (let [card-ids       (map u/the-id cards)
+           all-dashboards (t2/query {:union-all [ ;; First get dashboards from direct card connections
+                                                 {:nest
+                                                  {:select   [[:dc.card_id :card_id]
+                                                              :d.name
+                                                              :d.collection_id
+                                                              :d.description
+                                                              :d.id
+                                                              :d.archived]
+                                                   :from     [[:report_dashboardcard :dc]]
+                                                   :join     [[:report_dashboard :d] [:= :dc.dashboard_id :d.id]]
+                                                   :where    [:in :dc.card_id [:inline card-ids]]
+                                                   :order-by [[:d.id :asc]]}}
+                                                 ;; Then get dashboards from series
+                                                 {:nest
+                                                  {:select   [[:dcs.card_id :card_id]
+                                                              :d.name
+                                                              :d.collection_id
+                                                              :d.description
+                                                              :d.id
+                                                              :d.archived]
+                                                   :from     [[:dashboardcard_series :dcs]]
+                                                   :join     [[:report_dashboardcard :dc] [:= :dc.id :dcs.dashboardcard_id]
+                                                              [:report_dashboard :d] [:= :d.id :dc.dashboard_id]]
+                                                   :where    [:in :dcs.card_id [:inline card-ids]]
+                                                   :order-by [[:d.id :asc]]}}]})]
        (update-vals
         (group-by :card_id all-dashboards)
         (fn [dashes]

--- a/test/metabase/queries/api/card_test.clj
+++ b/test/metabase/queries/api/card_test.clj
@@ -4065,20 +4065,22 @@
                    :model/Card {card-id :id} {}]
       (mt/user-http-request :rasta :put 400 (str "card/" card-id) {:dashboard_id dash-id :archived true}))))
 
-(deftest we-can-get-a-list-of-dashboards-a-card-appears-in
+(deftest ^:parallel we-can-get-a-list-of-dashboards-a-card-appears-in
   (testing "a card in one dashboard"
     (mt/with-temp [:model/Dashboard {dash-id :id} {:name "My Dashboard"}
                    :model/Card {card-id :id} {}
                    :model/DashboardCard _ {:dashboard_id dash-id :card_id card-id}]
       (is (= [{:id dash-id
                :name "My Dashboard"}]
-             (mt/user-http-request :rasta :get 200 (str "card/" card-id "/dashboards"))))))
+             (mt/user-http-request :rasta :get 200 (str "card/" card-id "/dashboards")))))))
 
+(deftest ^:parallel we-can-get-a-list-of-dashboards-a-card-appears-in-2
   (testing "card in no dashboards"
     (mt/with-temp [:model/Card {card-id :id} {}]
       (is (= []
-             (mt/user-http-request :rasta :get 200 (str "card/" card-id "/dashboards"))))))
+             (mt/user-http-request :rasta :get 200 (str "card/" card-id "/dashboards")))))))
 
+(deftest ^:parallel we-can-get-a-list-of-dashboards-a-card-appears-in-3
   (testing "card in multiple dashboards"
     (mt/with-temp [:model/Dashboard {dash-id1 :id} {:name "Dashboard One"}
                    :model/Dashboard {dash-id2 :id} {:name "Dashboard Two"}
@@ -4087,27 +4089,31 @@
                    :model/DashboardCard _ {:dashboard_id dash-id2 :card_id card-id}]
       (is (= [{:id dash-id1 :name "Dashboard One"}
               {:id dash-id2 :name "Dashboard Two"}]
-             (mt/user-http-request :rasta :get 200 (str "card/" card-id "/dashboards"))))))
+             (mt/user-http-request :rasta :get 200 (str "card/" card-id "/dashboards")))))))
 
+(deftest ^:parallel we-can-get-a-list-of-dashboards-a-card-appears-in-4
   (testing "card in the same dashboard twice"
     (mt/with-temp [:model/Dashboard {dash-id :id} {:name "My Dashboard"}
                    :model/Card {card-id :id} {}
                    :model/DashboardCard _ {:dashboard_id dash-id :card_id card-id}
                    :model/DashboardCard _ {:dashboard_id dash-id :card_id card-id}]
       (is (= [{:id dash-id :name "My Dashboard"}]
-             (mt/user-http-request :rasta :get 200 (str "card/" card-id "/dashboards"))))))
+             (mt/user-http-request :rasta :get 200 (str "card/" card-id "/dashboards")))))))
 
+(deftest ^:parallel we-can-get-a-list-of-dashboards-a-card-appears-in-5
   (testing "If it's in the dashboard in a series, it's counted as 'in' the dashboard"
     (mt/with-temp [:model/Dashboard {dash-id :id} {:name "My Dashboard"}
                    :model/Card {card-id :id} {}
                    :model/DashboardCard {dc-id :id} {:dashboard_id dash-id}
                    :model/DashboardCardSeries _ {:dashboardcard_id dc-id :card_id card-id}]
       (is (= [{:id dash-id :name "My Dashboard"}]
-             (mt/user-http-request :rasta :get 200 (str "card/" card-id "/dashboards"))))))
+             (mt/user-http-request :rasta :get 200 (str "card/" card-id "/dashboards")))))))
 
+(deftest ^:parallel we-can-get-a-list-of-dashboards-a-card-appears-in-6
   (testing "nonexistent card"
-    (mt/user-http-request :rasta :get 404 "card/invalid-id/dashboards"))
+    (mt/user-http-request :rasta :get 404 "card/invalid-id/dashboards")))
 
+(deftest ^:parallel we-can-get-a-list-of-dashboards-a-card-appears-in-7
   (testing "Don't have permissions on all the dashboards involved"
     (mt/with-temp [:model/Collection {allowed-coll-id :id} {:name "The allowed collection"}
                    :model/Collection {forbidden-coll-id :id} {:name "The forbidden collection"}

--- a/test/metabase/queries/api/card_test.clj
+++ b/test/metabase/queries/api/card_test.clj
@@ -4113,7 +4113,7 @@
   (testing "nonexistent card"
     (mt/user-http-request :rasta :get 404 "card/invalid-id/dashboards")))
 
-(deftest ^:parallel we-can-get-a-list-of-dashboards-a-card-appears-in-7
+(deftest we-can-get-a-list-of-dashboards-a-card-appears-in-7
   (testing "Don't have permissions on all the dashboards involved"
     (mt/with-temp [:model/Collection {allowed-coll-id :id} {:name "The allowed collection"}
                    :model/Collection {forbidden-coll-id :id} {:name "The forbidden collection"}


### PR DESCRIPTION
I saw this test flake here https://github.com/metabase/metabase/actions/runs/16628611112/job/47051852625?pr=61529

```
FAIL in metabase.queries.api.card-test/we-can-get-a-list-of-dashboards-a-card-appears-in (card_test.clj:4088)
card in multiple dashboards 
with temporary :model/Dashboard
 
with temporary :model/Dashboard
 
with temporary :model/Card
 
with temporary :model/DashboardCard
 
with temporary :model/DashboardCard

expected: [{:id 350, :name "Dashboard One"} {:id 351, :name "Dashboard Two"}]
  actual: ({:id 351, :name "Dashboard Two"} {:id 350, :name "Dashboard One"})
```

The order the endpoint returns results was indeterminate, so I changed it to sort by ID so we get consistently ordered results.

I also combined the two separate queries into one query with `union-all` as a nice lil performance improvement, plus inlined the Card IDs (`u/the-id` here ensures they are in fact numbers)

I also split up the mega test with logically separate test cases into several separate tests and marked them `^:parallel` as is our best practice.