### PR TITLE
Fix: UXW-382 - Public Links menu item within sharing menu is too large

### DIFF
--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -133,8 +133,8 @@ const { H } = cy;
             H.openSharingMenu();
 
             H.sharingMenu().within(() => {
-              cy.findByText("Public links are off").should("be.visible");
-              cy.findByText("Enable them in settings").should("be.visible");
+              cy.findByText("Public link").should("be.visible");
+              cy.findByText("Enable").should("be.visible");
             });
 
             cy.findByTestId("embed-menu-embed-modal-item").click();

--- a/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/PublicLinkMenuItem.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/PublicLinkMenuItem.tsx
@@ -1,4 +1,3 @@
-import cx from "classnames";
 import { t } from "ttag";
 
 import Link from "metabase/common/components/Link";
@@ -47,7 +46,9 @@ export function PublicLinkMenuItem({
               h="auto"
               lh="inherit"
               ml="sm"
-              className={cx(CS.floatRight, CS.borderless, CS.p0)}
+              p={0}
+              bd={0}
+              className={CS.floatRight}
             >
               {t`Enable`}
             </Button>

--- a/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/PublicLinkMenuItem.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/PublicLinkMenuItem.tsx
@@ -1,10 +1,13 @@
+import cx from "classnames";
 import { t } from "ttag";
 
 import Link from "metabase/common/components/Link";
 import { useSetting } from "metabase/common/hooks";
+import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { Icon, Menu, Stack, Text, Title } from "metabase/ui";
+import { Button, Icon, Menu } from "metabase/ui";
+import MenuStyles from "metabase/ui/components/overlays/Menu/Menu.module.css";
 
 export function PublicLinkMenuItem({
   hasPublicLink,
@@ -22,6 +25,11 @@ export function PublicLinkMenuItem({
         data-testid="embed-menu-public-link-item"
         leftSection={<Icon name="link" aria-hidden />}
         onClick={onClick}
+        {...(!isPublicSharingEnabled && {
+          onClick: undefined,
+          component: "div",
+          className: cx(MenuStyles.ignoreHover, CS.textLight),
+        })}
       >
         {isPublicSharingEnabled ? (
           hasPublicLink ? (
@@ -30,12 +38,21 @@ export function PublicLinkMenuItem({
             t`Create a public link`
           )
         ) : (
-          <Link to="/admin/settings/public-sharing" target="_blank">
-            <Stack gap="xs">
-              <Title order={4}>{t`Public links are off`}</Title>
-              <Text size="sm">{t`Enable them in settings`}</Text>
-            </Stack>
-          </Link>
+          <>
+            {t`Public link`}
+            <Button
+              component={Link}
+              to="/admin/settings/public-sharing"
+              target="_blank"
+              variant="subtle"
+              h="auto"
+              lh="inherit"
+              ml="sm"
+              className={cx(CS.floatRight, CS.borderless, CS.p0)}
+            >
+              {t`Enable`}
+            </Button>
+          </>
         )}
       </Menu.Item>
     );

--- a/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/PublicLinkMenuItem.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/MenuItems/PublicLinkMenuItem.tsx
@@ -7,7 +7,6 @@ import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Button, Icon, Menu } from "metabase/ui";
-import MenuStyles from "metabase/ui/components/overlays/Menu/Menu.module.css";
 
 export function PublicLinkMenuItem({
   hasPublicLink,
@@ -28,7 +27,7 @@ export function PublicLinkMenuItem({
         {...(!isPublicSharingEnabled && {
           onClick: undefined,
           component: "div",
-          className: cx(MenuStyles.ignoreHover, CS.textLight),
+          disabled: true,
         })}
       >
         {isPublicSharingEnabled ? (

--- a/frontend/src/metabase/embedding/components/SharingMenu/test/DashboardSharingMenu.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/test/DashboardSharingMenu.unit.spec.tsx
@@ -163,13 +163,14 @@ describe("DashboardSharingMenu", () => {
         ).not.toBeInTheDocument();
       });
 
-      it("should show a 'public links are off' menu item if public sharing is disabled", async () => {
+      it('should show an "Enable" link if public sharing is disabled', async () => {
         setupDashboardSharingMenu({
           isAdmin: true,
           isPublicSharingEnabled: false,
         });
         await openMenu();
-        expect(screen.getByText("Public links are off")).toBeInTheDocument();
+        expect(screen.getByText("Public link")).toBeInTheDocument();
+        expect(screen.getByText("Enable")).toBeInTheDocument();
         expect(
           screen.queryByText("Create a public link"),
         ).not.toBeInTheDocument();

--- a/frontend/src/metabase/embedding/components/SharingMenu/test/QuestionSharingMenu.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/components/SharingMenu/test/QuestionSharingMenu.unit.spec.tsx
@@ -158,13 +158,14 @@ describe("QuestionSharingMenu", () => {
         ).not.toBeInTheDocument();
       });
 
-      it("should show a 'public links are off' menu item if public sharing is disabled", async () => {
+      it('should show an "Enable" link if public sharing is disabled', async () => {
         setupQuestionSharingMenu({
           isAdmin: true,
           isPublicSharingEnabled: false,
         });
         await openMenu();
-        expect(screen.getByText("Public links are off")).toBeInTheDocument();
+        expect(screen.getByText("Public link")).toBeInTheDocument();
+        expect(screen.getByText("Enable")).toBeInTheDocument();
         expect(
           screen.queryByText("Create a public link"),
         ).not.toBeInTheDocument();

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.module.css
@@ -12,15 +12,12 @@
   line-height: var(--mantine-line-height-lg);
   padding: var(--mantine-spacing-sm);
 
-  &:disabled {
+  &[data-disabled="true"] {
     color: var(--mb-color-text-light);
+    opacity: 1;
   }
 
-  &.ignoreHover {
-    cursor: default;
-  }
-
-  &:hover:not(.ignoreHover) {
+  &:hover:not([data-disabled="true"]) {
     color: var(--mb-color-text-hover);
     background-color: var(--mb-color-background-hover);
 

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.module.css
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.module.css
@@ -16,7 +16,11 @@
     color: var(--mb-color-text-light);
   }
 
-  &:hover {
+  &.ignoreHover {
+    cursor: default;
+  }
+
+  &:hover:not(.ignoreHover) {
     color: var(--mb-color-text-hover);
     background-color: var(--mb-color-background-hover);
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61518
Closes UXW-382

### Description

Updates "Public link" menu item for admins when public links aren't enabled so it doesn't look obviously broken.

### How to verify

See https://github.com/metabase/metabase/issues/61518 for repro steps.

No changes will be made to the non-admin state for this bugfix ([Slack thread](https://metaboat.slack.com/archives/C096M2BBGHH/p1753901002600299?thread_ts=1753899755.848609&cid=C096M2BBGHH)).

### Demo

https://github.com/user-attachments/assets/4e42ae3a-719d-47aa-ad9e-9ba0fce5ed33

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
