### PR TITLE
fix: issues generating valid urls for map tiles

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -132,6 +132,48 @@ describe("scenarios > visualizations > maps", () => {
     cy.findByText("171 Olive Oyle Lane"); // Address in the first row
   });
 
+  it("should display a pins when a breakout column sets a base-type (metabase#59984)", () => {
+    cy.intercept("/app/tiles/**").as("tiles");
+    H.visitQuestionAdhoc({
+      display: "map",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "query",
+        query: {
+          "source-table": PEOPLE_ID,
+          aggregation: ["count"],
+          breakout: [
+            [
+              "field",
+              PEOPLE.LONGITUDE,
+              {
+                "base-type": "text/Float",
+              },
+            ],
+            [
+              "field",
+              PEOPLE.LATITUDE,
+              {
+                "base-type": "text/Float",
+              },
+            ],
+          ],
+          limit: 1,
+        },
+      },
+      visualization_settings: {
+        "map.type": "pin",
+        "table.pivot_column": "LATITUDE",
+        "table.cell_column": "LONGITUDE",
+      },
+    });
+
+    // this should not create a 400 error
+    cy.wait("@dataset").then((xhr) => {
+      expect(xhr.response.statusCode).to.equal(200);
+    });
+  });
+
   it("should display a tooltip for a grid map without a metric column (metabase#17940)", () => {
     H.visitQuestionAdhoc({
       display: "map",

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -133,13 +133,8 @@ describe("scenarios > visualizations > maps", () => {
   });
 
   it("should display a pins when a breakout column sets a base-type (metabase#59984)", () => {
-    cy.intercept("/app/tiles/**").as("tiles");
-    
-    // this should not create a 400 error
-    cy.wait("@tiles").then((xhr) => {
-      expect(xhr.response.statusCode).to.equal(200);
-    });
-    
+    cy.intercept("/api/tiles/**").as("tiles");
+
     H.visitQuestionAdhoc({
       display: "map",
       dataset_query: {
@@ -153,25 +148,29 @@ describe("scenarios > visualizations > maps", () => {
               "field",
               PEOPLE.LONGITUDE,
               {
-                "base-type": "text/Float",
+                "base-type": "type/Float",
               },
             ],
             [
               "field",
               PEOPLE.LATITUDE,
               {
-                "base-type": "text/Float",
+                "base-type": "type/Float",
               },
             ],
           ],
-          limit: 1,
         },
       },
       visualization_settings: {
         "map.type": "pin",
-        "table.pivot_column": "LATITUDE",
-        "table.cell_column": "LONGITUDE",
+        "map.latitude_column": "LATITUDE",
+        "map.longitude_column": "LONGITUDE",
       },
+    });
+
+    // this should not create a 400 error
+    cy.wait("@tiles").then((xhr) => {
+      expect(xhr.response.statusCode).to.equal(200);
     });
   });
 

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -134,6 +134,12 @@ describe("scenarios > visualizations > maps", () => {
 
   it("should display a pins when a breakout column sets a base-type (metabase#59984)", () => {
     cy.intercept("/app/tiles/**").as("tiles");
+    
+    // this should not create a 400 error
+    cy.wait("@tiles").then((xhr) => {
+      expect(xhr.response.statusCode).to.equal(200);
+    });
+    
     H.visitQuestionAdhoc({
       display: "map",
       dataset_query: {
@@ -166,11 +172,6 @@ describe("scenarios > visualizations > maps", () => {
         "table.pivot_column": "LATITUDE",
         "table.cell_column": "LONGITUDE",
       },
-    });
-
-    // this should not create a 400 error
-    cy.wait("@tiles").then((xhr) => {
-      expect(xhr.response.statusCode).to.equal(200);
     });
   });
 

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -169,7 +169,7 @@ describe("scenarios > visualizations > maps", () => {
     });
 
     // this should not create a 400 error
-    cy.wait("@dataset").then((xhr) => {
+    cy.wait("@tiles").then((xhr) => {
       expect(xhr.response.statusCode).to.equal(200);
     });
   });

--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
@@ -5,13 +5,15 @@ import { getTileUrl } from "../lib/map";
 import LeafletMap from "./LeafletMap";
 
 // When base-type is present in the field ref (usually due to a breakout) the call to get
-// tiles will fail because its value of text/Float (for example) gets encoded as test%2FFloat
+// tiles will fail because its value of type/Float (for example) gets encoded as test%2FFloat
 // Jetty URL decodes this to `/` before attempting to parse the URI which results in Jetty
 // reporting an ambiguous path identifier.
 //
 // There may be other problematic field ref options, but this one causes the immediate bug
-const stringifyFieldRef = ([type, key, { ["base-type"]: _, ...restOpts }]) =>
-  encodeURIComponent(JSON.stringify([type, key, restOpts]));
+const stringifyFieldRef = ([type, key, opts]) => {
+  const { ["base-type"]: _, ...restOpts } = !opts ? {} : opts;
+  return encodeURIComponent(JSON.stringify([type, key, restOpts]));
+};
 
 export default class LeafletTilePinMap extends LeafletMap {
   componentDidMount() {

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -7,7 +7,7 @@ interface TileCoordinate {
 
 interface TileUrlParams {
   cardId?: number;
-  dashboardId?: number;
+  dashboardId?: number | string;
   dashcardId?: number;
   zoom: string | number;
   coord: TileCoordinate;
@@ -39,6 +39,10 @@ export function getTileUrl(params: TileUrlParams): string {
   const isDashboard = dashboardId && dashcardId && cardId;
 
   if (isDashboard) {
+    // isAutoDashboard
+    if (typeof dashboardId === "string" && dashboardId.startsWith("/auto")) {
+      return adhocQueryTileUrl(zoom, coord, latField, lonField, datasetQuery);
+    }
     const isPublicDashboard = uuid;
 
     if (isPublicDashboard) {

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -43,6 +43,10 @@ export function getTileUrl(params: TileUrlParams): string {
     if (typeof dashboardId === "string" && dashboardId.startsWith("/auto")) {
       return adhocQueryTileUrl(zoom, coord, latField, lonField, datasetQuery);
     }
+
+    if (typeof dashboardId === "string") {
+      throw Error("dashboardId must be an int");
+    }
     const isPublicDashboard = uuid;
 
     if (isPublicDashboard) {

--- a/frontend/src/metabase/visualizations/lib/map.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/map.unit.spec.ts
@@ -89,6 +89,30 @@ describe("map", () => {
         );
       });
 
+      it("should handle an x-ray dashboard", () => {
+        const datasetQuery: JsonQuery = {
+          database: 1,
+          type: "query",
+          query: { "source-table": 1 },
+        } as JsonQuery;
+        const encodedQuery = encodeURIComponent(JSON.stringify(datasetQuery));
+
+        const url = getTileUrl({
+          dashboardId: "/auto/dashboard/table/5",
+          dashcardId: 20,
+          cardId: 30,
+          zoom,
+          coord,
+          latField,
+          lonField,
+          datasetQuery,
+        });
+
+        expect(url).toBe(
+          `/api/tiles/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?query=${encodedQuery}`,
+        );
+      });
+
       it("should generate url for dashboard with parameters", () => {
         const datasetResult = createMockDataset({
           json_query: {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59984
### Description

Fixes to issues generating map tiles, one is on x-ray dashboards we need to check that we're not in a real dashboard and send an ad hoc tile request.

Second if the field ref sent in the request has options we need to remove the 'base-type' option because the type will be encoded as something like test%2FFloat and the way Jetty decodes URLs before parsing turns it into a '/' in a position a path separator cannot be: https://github.com/jetty/jetty.project/issues/7713\

### How to verify

Navigate to the Sample Database Accounts X-Ray and see that the pins render correctly

### Demo

<img width="432" height="395" alt="Screenshot 2025-07-30 at 3 42 50 PM" src="https://github.com/user-attachments/assets/63779bf2-e6e3-4012-987b-550937d488e9" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
