### PR TITLE
Fix: UXW-314 - Button hover state inconsistencies

### DIFF
--- a/frontend/src/metabase/css/components/buttons.module.css
+++ b/frontend/src/metabase/css/components/buttons.module.css
@@ -122,14 +122,14 @@
 }
 
 .ButtonOnlyIcon {
-  border-color: transparent;
+  border: none;
   background: transparent;
   color: var(--mb-color-text-dark);
   padding: 0;
 }
 
 .ButtonOnlyIcon:focus {
-  border-color: var(--mb-color-background);
+  border: none;
   outline-color: var(--mb-color-brand);
 }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61322
Closes UXW-314

### Description

Basically just reverts the border change to `.ButtonOnlyIcon` made in https://github.com/metabase/metabase/pull/60175

### How to verify

See https://github.com/metabase/metabase/issues/61322 for repro steps

### Demo

https://github.com/user-attachments/assets/4adb14e3-dda7-49d1-9f04-e0e3f0713461

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
