### PR TITLE
[Semantic Search] Embedding generation support for OpenAI compatible APIs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/llm/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/settings.clj
@@ -12,7 +12,7 @@
   :doc "This feature is experimental.")
 
 (defsetting ee-openai-api-base-url
-  (deferred-tru "The OpenAI API Key used in Metabase Enterprise.")
+  (deferred-tru "The OpenAI embeddings base URL used in Metabase Enterprise.")
   :encryption :no
   :visibility :settings-manager
   :export? false

--- a/enterprise/backend/src/metabase_enterprise/llm/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/settings.clj
@@ -11,6 +11,13 @@
   :export? false
   :doc "This feature is experimental.")
 
+(defsetting ee-openai-api-base-url
+  (deferred-tru "The OpenAI API Key used in Metabase Enterprise.")
+  :encryption :no
+  :visibility :settings-manager
+  :export? false
+  :doc "This feature is experimental.")
+
 (defsetting ee-openai-api-key
   (deferred-tru "The OpenAI API Key used in Metabase Enterprise.")
   :encryption :no

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -14,13 +14,14 @@
 (def ^:private ollama-supported-models
   "Map of supported Ollama models to their embedding dimensions."
   {"mxbai-embed-large" 1024
+   "snowflake-arctic-embed2:568m" 1024
    "nomic-embed-text" 768
    "all-minilm" 384})
 
 (def ^:private openai-supported-models
   "Map of supported OpenAI models to their embedding dimensions."
   {"text-embedding-3-small" 1536
-   "text-embedding-3-large" 3072
+   "Snowflake/snowflake-arctic-embed-l-v2.0" 1024
    "text-embedding-ada-002" 1536})
 
 ;;; Token Counting for OpenAI Models
@@ -149,7 +150,7 @@
 
 (defn- openai-get-embeddings-batch [model-name texts]
   (let [api-key (semantic-settings/openai-api-key)
-        endpoint "https://api.openai.com/v1/embeddings"]
+        endpoint (str (semantic-settings/openai-api-base-url) "/v1/embeddings")]
     (when-not api-key
       (throw (ex-info "OpenAI API key not configured" {:setting "ee-openai-api-key"})))
     (try

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -13,16 +13,26 @@
 
 (def ^:private ollama-supported-models
   "Map of supported Ollama models to their embedding dimensions."
-  {"mxbai-embed-large" 1024
-   "snowflake-arctic-embed2:568m" 1024
+  {"all-minilm" 384
+   "mxbai-embed-large" 1024
    "nomic-embed-text" 768
-   "all-minilm" 384})
+   "snowflake-arctic-embed2:568m" 1024})
 
 (def ^:private openai-supported-models
   "Map of supported OpenAI models to their embedding dimensions."
-  {"text-embedding-3-small" 1536
-   "Snowflake/snowflake-arctic-embed-l-v2.0" 1024
-   "text-embedding-ada-002" 1536})
+  {"text-embedding-ada-002" 1536
+   "text-embedding-3-small" 1536
+   "Snowflake/snowflake-arctic-embed-l-v2.0" 1024})
+
+(def model->abbrev
+  "Map of supported models to a unique abbreviation for use in index names."
+  {"all-minilm" "all_minilm"
+   "mxbai-embed-large" "mxbai_embed_lg"
+   "nomic-embed-text" "nomic_embed_txt"
+   "snowflake-arctic-embed2:568m" "snwflk_arc_embed2_568m"
+   "text-embedding-ada-002" "txt_embed_ada_2"
+   "text-embedding-3-small" "txt_embed_3_sm"
+   "Snowflake/snowflake-arctic-embed-l-v2.0" "snwflk_arc_embedl2"})
 
 ;;; Token Counting for OpenAI Models
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -160,7 +160,7 @@
   "Returns the default index spec for a model."
   [embedding-model]
   (let [{:keys [model-name provider vector-dimensions]} embedding-model
-        sanitized-model-name (clojure.string/replace model-name #"[/:.]" "_")
+        sanitized-model-name (str/replace model-name #"[/:.]" "_")
         table-name (str "index_table_" provider "_" sanitized-model-name "_" vector-dimensions)]
     {:embedding-model embedding-model
      :table-name table-name

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -161,7 +161,7 @@
   [embedding-model]
   (let [{:keys [model-name provider vector-dimensions]} embedding-model
         sanitized-model-name (clojure.string/replace model-name #"[/:.]" "_")
-        table-name (str "index_table__" provider "_" sanitized-model-name "_" vector-dimensions)]
+        table-name (str "index_table_" provider "_" sanitized-model-name "_" vector-dimensions)]
     {:embedding-model embedding-model
      :table-name table-name
      :version 0}))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -160,8 +160,9 @@
   "Returns the default index spec for a model."
   [embedding-model]
   (let [{:keys [model-name provider vector-dimensions]} embedding-model
-        sanitized-model-name (str/replace (last (str/split model-name #"/")) #"[/:.]" "_")
-        table-name (str "index_table_" provider "_" sanitized-model-name "_" vector-dimensions)]
+        ;; This is a hack to ensure we don't exceed postgres' limit of 63 chars for identifier names.
+        abbreviated-model-name (embedding/model->abbrev model-name model-name)
+        table-name (str "index_table_" provider "_" abbreviated-model-name "_" vector-dimensions)]
     {:embedding-model embedding-model
      :table-name table-name
      :version 0}))
@@ -211,7 +212,6 @@
 
 ;; We can't use full column names in the various index names, because otherwise we overflow postgres' max name length.
 ;; NOTE If you add a new index, add it to index-embedding-name-length-test as well
-;; TODO Maybe we should also abbreviate the model / provider names in the :table-name to give some breathing room.
 (defn- index-name
   "Returns the name for an index for the given index configuration, column, and index type."
   [index suffix]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -161,7 +161,7 @@
   [embedding-model]
   (let [{:keys [model-name provider vector-dimensions]} embedding-model
         sanitized-model-name (clojure.string/replace model-name #"[/:.]" "_")
-        table-name (str "index_table__" provider "__" sanitized-model-name "__" vector-dimensions)]
+        table-name (str "index_table__" provider "_" sanitized-model-name "_" vector-dimensions)]
     {:embedding-model embedding-model
      :table-name table-name
      :version 0}))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -160,7 +160,8 @@
   "Returns the default index spec for a model."
   [embedding-model]
   (let [{:keys [model-name provider vector-dimensions]} embedding-model
-        table-name (str "index_table_" provider "_" model-name "_" vector-dimensions)]
+        sanitized-model-name (clojure.string/replace model-name #"[/:.]" "_")
+        table-name (str "index_table__" provider "__" sanitized-model-name "__" vector-dimensions)]
     {:embedding-model embedding-model
      :table-name table-name
      :version 0}))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -160,7 +160,7 @@
   "Returns the default index spec for a model."
   [embedding-model]
   (let [{:keys [model-name provider vector-dimensions]} embedding-model
-        sanitized-model-name (str/replace model-name #"[/:.]" "_")
+        sanitized-model-name (str/replace (last (str/split model-name #"/")) #"[/:.]" "_")
         table-name (str "index_table_" provider "_" sanitized-model-name "_" vector-dimensions)]
     {:embedding-model embedding-model
      :table-name table-name

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -22,6 +22,11 @@
   :export? false
   :doc "This feature is experimental. Leave empty to use provider defaults.")
 
+(defn openai-api-base-url
+  "Get the OpenAI API base url from the existing LLM settings."
+  []
+  (llm-settings/ee-openai-api-base-url))
+
 (defn openai-api-key
   "Get the OpenAI API key from the existing LLM settings."
   []

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -115,3 +115,15 @@
           batches (#'embedding/create-batches 5 #'embedding/count-tokens texts)]
       ;; Should skip the long text and batch the short ones
       (is (= [["Short" "Also short"]] batches)))))
+
+(deftest ^:parallel model->abbrev-test
+  (mt/with-premium-features #{:semantic-search}
+    (testing "all models have an abbreviation defined"
+      (doseq [provider (keys embedding/supported-models-for-provider)
+              [model _] (get embedding/supported-models-for-provider provider)]
+        (testing (str "\n" provider " " model)
+          (is (some? (embedding/model->abbrev model))))))
+    (testing "all abbreviations are unique"
+      (doseq [[abbrev frequency] (frequencies (vals embedding/model->abbrev))]
+        (testing abbrev
+          (is (= 1 frequency)))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -43,8 +43,8 @@
       (is (= 768 (:vector-dimensions (embedding/get-configured-model)))))
 
     (mt/with-temporary-setting-values [ee-embedding-provider "openai"
-                                       ee-embedding-model "text-embedding-3-large"]
-      (is (= 3072 (:vector-dimensions (embedding/get-configured-model)))))))
+                                       ee-embedding-model "text-embedding-ada-002"]
+      (is (= 1536 (:vector-dimensions (embedding/get-configured-model)))))))
 
 (deftest test-default-models
   (testing "Provider defaults are used when no override is set"
@@ -67,8 +67,8 @@
 
   (testing "get-model uses override when specified"
     (mt/with-temporary-setting-values [ee-embedding-provider "openai"
-                                       ee-embedding-model "text-embedding-3-large"]
-      (is (= "text-embedding-3-large" (:model-name (embedding/get-configured-model)))))))
+                                       ee-embedding-model "text-embedding-ada-002"]
+      (is (= "text-embedding-ada-002" (:model-name (embedding/get-configured-model)))))))
 
 (deftest test-openai-provider-validation
   (testing "OpenAIProvider throws when API key not configured"


### PR DESCRIPTION
### Description

This PR makes it so that we can start pointing our dev instance to our internal embedding service. Ideally we can get this merged into our integration branch and make it nicer in follow up PRs. In detail, the follow changes were made:
- Allows the base url for the OpenAI provider to be configured (similar to how the python client works), allow us to send requests to an OpenAI compatible API
- Adds support for the `snowflake-arctic-embed` models
- Sanitizes the model names as they can have `/`, `.`, and `:` in the names

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
