### PR TITLE
Assign correct MB version metadata to data-editing functions

### DIFF
--- a/src/metabase/actions/actions.clj
+++ b/src/metabase/actions/actions.clj
@@ -27,7 +27,7 @@
 
 (defmulti default-mapping
   "Allow actions to dynamically generating a :mapping, in none has been configured."
-  {:arglists '([action-kw scope]), :added "0.56.0"}
+  {:arglists '([action-kw scope]), :added "0.57.0"}
   (fn [action-kw _scope]
     action-kw))
 

--- a/src/metabase/actions/args.clj
+++ b/src/metabase/actions/args.clj
@@ -21,7 +21,7 @@
 
 (defmulti validate-inputs!
   "Check whether the given action is supported for the given inputs, and if not throw an error."
-  {:arglists '([action inputs]), :added "0.56.0"}
+  {:arglists '([action inputs]), :added "0.57.0"}
   (fn [action _inputs]
     (keyword action)))
 

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -271,7 +271,7 @@
   "Does the Metabase Cloud instance have ETL connections with PG?"
   :etl-connections-pg)
 
-(define-premium-feature table-data-editing?
+(define-premium-feature ^{:added "0.57.0"} table-data-editing?
   "Should we allow users to edit the data within tables?"
   :table-data-editing)
 


### PR DESCRIPTION
We missed the boat for the 56 release.
