### PR TITLE
feat(simple-embed): parse attributes with json5 to be more permissive…

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -328,7 +328,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         H.visitCustomHtmlPage(`
       ${H.getNewEmbedScriptTag()}
       ${H.getNewEmbedConfigurationScript()}
-      <metabase-question question-id="new" entity-types='["table"]' />
+      <metabase-question question-id="new" entity-types="['table']" />
       `);
 
         H.getSimpleEmbedIframeContent().should("contain", "Orders");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -309,6 +309,34 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
     });
   });
 
+  describe("common checks", () => {
+    describe("should be permissive with json attributes", () => {
+      // NOTE: pay attention if you use initialFilters for these tests, as when the filters are not parsed correctly
+      // we default them to the latest filters used by that user
+      it("should support normal json with strings wrapped in double quotes", () => {
+        H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-question question-id="new" entity-types='["table"]' />
+      `);
+
+        H.getSimpleEmbedIframeContent().should("contain", "Orders");
+        H.getSimpleEmbedIframeContent().should("not.contain", "Orders model");
+      });
+
+      it("should support json5 with strings wrapped in single quotes", () => {
+        H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-question question-id="new" entity-types='["table"]' />
+      `);
+
+        H.getSimpleEmbedIframeContent().should("contain", "Orders");
+        H.getSimpleEmbedIframeContent().should("not.contain", "Orders model");
+      });
+    });
+  });
+
   describe("sync vs async vs defer script loading", () => {
     (
       [

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/webcomponents.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/webcomponents.ts
@@ -1,3 +1,5 @@
+import json5 from "json5";
+
 // Convert kebab-case attribute names to their camelCase setting keys.
 export const attributeToSettingKey = (attr: string): string =>
   attr.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
@@ -31,11 +33,13 @@ export const parseAttributeValue = (value: string | null): unknown => {
   // Attempt to parse JSON arrays/objects for complex attributes
   if (value.startsWith("[") || value.startsWith("{")) {
     try {
-      return JSON.parse(value);
-    } catch {
+      return json5.parse(value);
+    } catch (e) {
       console.error(
-        "Error while trying to parse an attribute as JSON. Complex attributes such as arrays and objects should be valid JSON with keys and values wrapped in double quotes. Received:",
+        "Error while trying to parse an attribute. Received:",
         value,
+        "Caught error:",
+        e,
       );
     }
   }

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/webcomponents.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/webcomponents.unit.spec.ts
@@ -14,11 +14,6 @@ describe("parseAttributeValue should be permissive with json attributes", () => 
       expect(value).toEqual(["value1"]);
     });
 
-    it("should allow for a single leading comma", () => {
-      const value = parseAttributeValue(`["value1", "value2",]`);
-      expect(value).toEqual(["value1", "value2"]);
-    });
-
     it("should allow for a single trailing comma", () => {
       const value = parseAttributeValue(`["value1", "value2",]`);
       expect(value).toEqual(["value1", "value2"]);
@@ -41,7 +36,7 @@ describe("parseAttributeValue should be permissive with json attributes", () => 
       expect(value).toEqual({ key1: "value1" });
     });
 
-    it("should allow for a single leading comma", () => {
+    it("should allow for a single trailing comma", () => {
       const value = parseAttributeValue(
         `{"key1": "value1", "key2": "value2",}`,
       );

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/webcomponents.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/webcomponents.unit.spec.ts
@@ -1,0 +1,58 @@
+import { parseAttributeValue } from "./webcomponents";
+
+// Note, these tests use ` when to wrap strings passed to parseAttributeValue so we can only focus on ' vs " inside the strings
+
+describe("parseAttributeValue should be permissive with json attributes", () => {
+  describe("array attributes", () => {
+    it("should parse normal json with strings wrapped in double quotes", () => {
+      const value = parseAttributeValue(`["value1"]`);
+      expect(value).toEqual(["value1"]);
+    });
+
+    it("should parse json5 with strings wrapped in single quotes", () => {
+      const value = parseAttributeValue(`['value1']`);
+      expect(value).toEqual(["value1"]);
+    });
+
+    it("should allow for a single leading comma", () => {
+      const value = parseAttributeValue(`["value1", "value2",]`);
+      expect(value).toEqual(["value1", "value2"]);
+    });
+
+    it("should allow for a single trailing comma", () => {
+      const value = parseAttributeValue(`["value1", "value2",]`);
+      expect(value).toEqual(["value1", "value2"]);
+    });
+
+    it("should allow for mixed quotes", () => {
+      const value = parseAttributeValue(`['value1', "value2",]`);
+      expect(value).toEqual(["value1", "value2"]);
+    });
+  });
+
+  describe("object attributes", () => {
+    it("should parse normal json with strings wrapped in double quotes", () => {
+      const value = parseAttributeValue(`{"key1": "value1"}`);
+      expect(value).toEqual({ key1: "value1" });
+    });
+
+    it("should parse json5 with strings wrapped in single quotes", () => {
+      const value = parseAttributeValue(`{'key1': 'value1'}`);
+      expect(value).toEqual({ key1: "value1" });
+    });
+
+    it("should allow for a single leading comma", () => {
+      const value = parseAttributeValue(
+        `{"key1": "value1", "key2": "value2",}`,
+      );
+      expect(value).toEqual({ key1: "value1", key2: "value2" });
+    });
+
+    it("should allowed for mixed quotes", () => {
+      const value = parseAttributeValue(
+        `{"key1": 'value1', "key2": "value2",}`,
+      );
+      expect(value).toEqual({ key1: "value1", key2: "value2" });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "inflection": "^1.7.1",
     "inquirer-toggle": "^1.0.1",
     "js-cookie": "^2.1.2",
+    "json5": "^2.2.3",
     "jspdf": "3.0.1",
     "kbar": "^0.1.0-beta.45",
     "leaflet": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "inflection": "^1.7.1",
     "inquirer-toggle": "^1.0.1",
     "js-cookie": "^2.1.2",
-    "json5": "^2.2.3",
+    "json5": "2.2.2",
     "jspdf": "3.0.1",
     "kbar": "^0.1.0-beta.45",
     "leaflet": "^1.2.0",


### PR DESCRIPTION
… with quotes
https://metaboat.slack.com/archives/C063Q3F1HPF/p1753948351633919
https://metaboat.slack.com/archives/C063Q3F1HPF/p1753883019712209

This adds json5 so we can support single quotes and trailing commas in the attributes