### PR TITLE
Add `backend-sources` as triggers to SDK compatibility tests

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -132,6 +132,7 @@ e2e_embedding_sdk_compatibility:
   - *default
   - *frontend_embedding_sdk_ci
   - *frontend_sources
+  - *backend_sources
   - "e2e/embedding-sdk-host-apps/**"
   - "e2e/runner/embedding-sdk/**"
   - "e2e/test-host-app/**/*.cy.*.{js,ts}"


### PR DESCRIPTION
Context:
https://metaboat.slack.com/archives/C063Q3F1HPF/p1753891699842649?thread_ts=1753887741.103769&cid=C063Q3F1HPF