### PR TITLE
fix(timeseries): prevent automatic coarsening of monthly ticks when there’s capacity (closes #60475)

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/util.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/util.ts
@@ -1,4 +1,8 @@
 import type { OptionsType } from "metabase/lib/formatting/types";
+import {
+  expectedTickCount,
+  maxTicksForChartWidth,
+} from "metabase/visualizations/echarts/cartesian/utils/timeseries";
 import type {
   ComputedVisualizationSettings,
   RemappingHydratedDatasetColumn,
@@ -10,7 +14,11 @@ import {
   POSITIVE_BAR_DATA_LABEL_KEY_SUFFIX,
 } from "../constants/dataset";
 
-import type { DataKey } from "./types";
+import type {
+  DataKey,
+  TimeSeriesAxisFormatter,
+  TimeSeriesInterval,
+} from "./types";
 
 export function getBarSeriesDataLabelKey(dataKey: DataKey, sign: "+" | "-") {
   if (sign === "+") {
@@ -31,4 +39,15 @@ export function getColumnScaling(
     settings.column?.(column) ?? getColumnSettings(settings, column);
   const scale = columnSettings?.scale;
   return Number.isFinite(scale) ? (scale as number) : 1;
+}
+
+export function shouldPinInterval(
+  interval: TimeSeriesInterval,
+  timeRangeMs: number,
+  chartWidth: number,
+  formatter: TimeSeriesAxisFormatter,
+) {
+  const capacity = maxTicksForChartWidth(chartWidth, formatter);
+  const tickCount = expectedTickCount(interval, timeRangeMs);
+  return tickCount <= capacity;
 }

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/util.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/util.ts
@@ -2,7 +2,7 @@ import type { OptionsType } from "metabase/lib/formatting/types";
 import {
   expectedTickCount,
   maxTicksForChartWidth,
-} from "metabase/visualizations/echarts/cartesian/utils/timeseries";
+} from "../utils/timeseries";
 import type {
   ComputedVisualizationSettings,
   RemappingHydratedDatasetColumn,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/util.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/util.ts
@@ -1,8 +1,4 @@
 import type { OptionsType } from "metabase/lib/formatting/types";
-import {
-  expectedTickCount,
-  maxTicksForChartWidth,
-} from "../utils/timeseries";
 import type {
   ComputedVisualizationSettings,
   RemappingHydratedDatasetColumn,
@@ -13,6 +9,7 @@ import {
   NEGATIVE_BAR_DATA_LABEL_KEY_SUFFIX,
   POSITIVE_BAR_DATA_LABEL_KEY_SUFFIX,
 } from "../constants/dataset";
+import { expectedTickCount, maxTicksForChartWidth } from "../utils/timeseries";
 
 import type {
   DataKey,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/ticks.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/ticks.ts
@@ -1,6 +1,7 @@
 import type { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 
+import { shouldPinInterval } from "metabase/visualizations/echarts/cartesian/model/util";
 import type { ContinuousDomain } from "metabase/visualizations/shared/types/scale";
 
 import type {
@@ -51,6 +52,7 @@ export const getTicksOptions = (
   ];
   const paddedMin = dayjs(xDomainPadded[0]);
   const paddedMax = dayjs(xDomainPadded[1]);
+  const timeRangeMs = xDomain[1] - xDomain[0];
 
   // Compute ticks interval based on the X-axis range, original interval, and the chart width.
   const computedInterval = computeTimeseriesTicksInterval(
@@ -102,6 +104,16 @@ export const getTicksOptions = (
       count: 1,
       unit: effectiveTicksUnit,
     });
+  }
+
+  if (
+    interval.unit === "month" &&
+    interval.count === 1 &&
+    shouldPinInterval(interval, timeRangeMs, chartWidth, xAxisModel.formatter)
+  ) {
+    const dur = getTimeSeriesIntervalDuration(interval);
+    minInterval = dur;
+    maxInterval = dur;
   }
 
   if (!maxInterval) {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/ticks.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/ticks.ts
@@ -1,13 +1,13 @@
 import type { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 
-import { shouldPinInterval } from "../model/util";
 import type { ContinuousDomain } from "metabase/visualizations/shared/types/scale";
 
 import type {
   TimeSeriesAxisFormatter,
   TimeSeriesXAxisModel,
 } from "../model/types";
+import { shouldPinInterval } from "../model/util";
 import {
   computeTimeseriesTicksInterval,
   getLargestInterval,
@@ -109,6 +109,8 @@ export const getTicksOptions = (
   if (
     interval.unit === "month" &&
     interval.count === 1 &&
+    computedInterval.unit === "month" &&
+    computedInterval.count === 1 &&
     shouldPinInterval(interval, timeRangeMs, chartWidth, xAxisModel.formatter)
   ) {
     const dur = getTimeSeriesIntervalDuration(interval);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/ticks.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/ticks.ts
@@ -1,7 +1,7 @@
 import type { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 
-import { shouldPinInterval } from "metabase/visualizations/echarts/cartesian/model/util";
+import { shouldPinInterval } from "../model/util";
 import type { ContinuousDomain } from "metabase/visualizations/shared/types/scale";
 
 import type {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/utils.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/utils.ts
@@ -1,4 +1,10 @@
-import type { BaseCartesianChartModel, DataKey } from "../model/types";
+import dayjs from "dayjs";
+
+import type {
+  BaseCartesianChartModel,
+  DataKey,
+  TimeSeriesInterval,
+} from "../model/types";
 
 export function getSeriesYAxisIndex(
   dataKey: DataKey,
@@ -13,3 +19,25 @@ export function getSeriesYAxisIndex(
 
   return leftAxisModel.seriesKeys.includes(dataKey) ? 0 : 1;
 }
+
+export const coerceYear = (iv: TimeSeriesInterval): TimeSeriesInterval =>
+  iv.unit === "month" && iv.count === 12 ? { unit: "year", count: 1 } : iv;
+
+export const coerceAnnualFromMonthly = (
+  dates: Date[],
+  iv: TimeSeriesInterval,
+): TimeSeriesInterval => {
+  if (iv.unit !== "month" || iv.count !== 1 || dates.length < 2) {
+    return iv;
+  }
+
+  const months = dates.map((d) => dayjs(d).month());
+  const days = dates.map((d) => dayjs(d).date());
+  const years = dates.map((d) => dayjs(d).year());
+
+  const sameMonth = months.every((m) => m === months[0]);
+  const sameDay = days.every((dd) => dd === days[0]);
+  const multiYear = new Set(years).size > 1;
+
+  return sameMonth && sameDay && multiYear ? { unit: "year", count: 1 } : iv;
+};

--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/timeseries.ts
@@ -55,7 +55,10 @@ export const TIMESERIES_INTERVALS: (TimeSeriesInterval & {
   { unit: "day", count: 1, testFn: (d: Dayjs) => d.hour() }, // (13) 1 day
   { unit: "week", count: 1, testFn: (d: Dayjs) => d.day() }, // (14) 1 week
   { unit: "month", count: 1, testFn: (d: Dayjs) => d.date() }, // (15) 1 month
-  { unit: "quarter", count: 1, testFn: (d: Dayjs) => d.month() % 3 }, // (16) 3 months / 1 quarter
+  { unit: "month", count: 2, testFn: (d: Dayjs) => d.month() % 2 }, // (16) 2 months
+  { unit: "quarter", count: 1, testFn: (d: Dayjs) => d.month() % 3 }, // (17) 3 months / 1 quarter
+  { unit: "month", count: 4, testFn: (d: Dayjs) => d.month() % 4 }, // (18) 4 months
+  { unit: "month", count: 6, testFn: (d: Dayjs) => d.month() % 6 }, // (19) 6 months
   { unit: "year", count: 1, testFn: (d: Dayjs) => d.month() }, // (17) 1 year
   { unit: "year", count: 2, testFn: (d: Dayjs) => d.year() % 2 }, // (18) 2 year
   { unit: "year", count: 10, testFn: (d: Dayjs) => d.year() % 10 }, // (19) 10 year
@@ -144,7 +147,7 @@ export function getTimeSeriesIntervalDuration(interval: TimeSeriesInterval) {
 
 /// Return the number of ticks we can expect to see over a time range using the TIMESERIES_INTERVALS entry interval.
 /// for example a "5 seconds" interval over a time range of a minute should have an expected tick count of 20.
-function expectedTickCount(
+export function expectedTickCount(
   interval: TimeSeriesInterval,
   timeRangeMilliseconds: number,
 ) {
@@ -200,7 +203,7 @@ function timeseriesTicksInterval(
 }
 
 /// return the maximum number of ticks to show for a timeseries chart of a given width
-function maxTicksForChartWidth(
+export function maxTicksForChartWidth(
   chartWidth: number,
   tickFormat: (value: RowValue) => string,
 ) {


### PR DESCRIPTION
Closes [https://github.com/metabase/metabase/issues/60475](https://github.com/metabase/metabase/issues/60475)

## Description

On time series charts with a 1-month bucket over roughly a year, ECharts was automatically coarsening the tick interval (e.g., showing every 2 months / 6 labels) even when there was enough horizontal space for all 12 monthly labels. This change adds a heuristic in `getTicksOptions` to detect the exact 1-month interval with sufficient capacity (>=12) and pins both `minInterval` and `maxInterval` to the one-month duration so that ECharts cannot coarsen it. When space allows, all 12 months are shown; when space is constrained it still degrades to coarser intervals.

## How to verify

1. Run the frontend locally and open a new question on the Sample Dataset (e.g., Orders).
2. Bucket the x-axis by "Created At: Month" covering a 12-month span (e.g., Jan–Dec).
3. View it as a bar/time-series chart.
4. With the chart wide enough, verify that all 12 month labels (Jan through Dec) appear on the x-axis.
5. Shrink the chart width and confirm that it gracefully degrades (e.g., drops to fewer labels like 6) when there isn’t space.
6. Verify other time ranges (shorter than 12 months) still behave reasonably and don’t regress.

## Demo

*Before*: Monthly buckets were coarsened to every 2 months even when the chart was wide enough.
<img width="1679" height="964" alt="Screenshot 2568-07-31 at 12 34 37" src="https://github.com/user-attachments/assets/10e9dfdf-a142-4f5a-ab1d-811865e5d032" />

*After*: All 12 month ticks are shown when capacity allows.
<img width="1680" height="949" alt="Screenshot 2568-07-31 at 16 27 06" src="https://github.com/user-attachments/assets/2c6a1e92-5e77-43f6-abe5-539ed2997be9" />
<img width="1679" height="960" alt="Screenshot 2568-07-31 at 16 27 18" src="https://github.com/user-attachments/assets/dcd60941-6f6e-4604-8fd2-c6a05b41fd7f" />


## Checklist

* [ ] Tests have been added/updated to cover changes in this PR
  *Note: No existing test coverage for this code path; none were added in this change because the file and environment are large to validate locally. Will add if requested by reviewer.*
