### PR TITLE
allow setting the default cypress browser via env CYPRESS_BROWSER

### DIFF
--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -24,7 +24,7 @@ const getEmbeddingSdkAppE2eConfig = async ({
   };
 
   const defaultConfig = {
-    browser: "chrome",
+    browser: process.env.CYPRESS_BROWSER ?? "chrome",
     project,
     configFile: "e2e/support/cypress.config.js",
     config: {
@@ -75,7 +75,7 @@ const getHostAppE2eConfig = (suite) => ({
 const configs = {
   e2e: async () => {
     const defaultConfig = {
-      browser: "chrome",
+      browser: process.env.CYPRESS_BROWSER ?? "chrome",
       configFile: "e2e/support/cypress.config.js",
       config: {
         baseUrl: getHost(),
@@ -103,7 +103,7 @@ const configs = {
     const { browser } = await parseArguments(args);
 
     const snapshotConfig = {
-      browser: browser ?? "chrome",
+      browser: process.env.CYPRESS_BROWSER ?? browser ?? "chrome",
       configFile: "e2e/support/cypress-snapshots.config.js",
       config: {
         baseUrl: getHost(),
@@ -118,7 +118,7 @@ const configs = {
     const { browser } = await parseArguments(args);
 
     const sdkComponentConfig = {
-      browser: browser ?? "chrome",
+      browser: process.env.CYPRESS_BROWSER ?? browser ?? "chrome",
       configFile: "e2e/support/cypress-embedding-sdk-component-test.config.js",
       config: {
         baseUrl: getHost(),

--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -103,7 +103,7 @@ const configs = {
     const { browser } = await parseArguments(args);
 
     const snapshotConfig = {
-      browser: process.env.CYPRESS_BROWSER ?? browser ?? "chrome",
+      browser: browser ?? process.env.CYPRESS_BROWSER ?? "chrome",
       configFile: "e2e/support/cypress-snapshots.config.js",
       config: {
         baseUrl: getHost(),
@@ -118,7 +118,7 @@ const configs = {
     const { browser } = await parseArguments(args);
 
     const sdkComponentConfig = {
-      browser: process.env.CYPRESS_BROWSER ?? browser ?? "chrome",
+      browser: browser ?? process.env.CYPRESS_BROWSER ?? "chrome",
       configFile: "e2e/support/cypress-embedding-sdk-component-test.config.js",
       config: {
         baseUrl: getHost(),


### PR DESCRIPTION
Trying to use chrome locally means having it crash even on small to medium files, and it seems people are already using electron most of the times locally.

Right now, as far as I know, we don't have a way to default cypress to electron and we can only choose it by passing `--browser electron`.

This adds an ENV so that we can set it once instead of having to always pass it