### PR TITLE
Design cleanup for embedding sdk settings page

### DIFF
--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -79,6 +79,7 @@ export function EmbeddingSdkSettings() {
     <ExternalLink
       key="switch-metabase-binaries"
       href={switchMetabaseBinariesUrl}
+      className={cx(CS.link, CS.textBold)}
     >
       {t`switch Metabase binaries`}
     </ExternalLink>
@@ -265,13 +266,19 @@ export function EmbeddingSdkSettings() {
         bg="none"
         bd="1px solid var(--mb-color-border)"
       >
-        <Group gap="sm">
-          <Icon color="var(--mb-color-text-secondary)" name="info_filled" />
+        <Flex gap="sm">
+          <Box>
+            <Icon
+              color="var(--mb-color-text-secondary)"
+              name="info_filled"
+              mt="2px"
+            />
+          </Box>
 
-          <Text size="sm" c="text-medium" lh="lg">
+          <Text c="text-medium" lh="lg">
             {apiKeyBannerText}
           </Text>
-        </Group>
+        </Flex>
       </Alert>
     </SettingsPageWrapper>
   );

--- a/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellDevInstances.tsx
@@ -25,7 +25,7 @@ export function UpsellDevInstances({ location }: { location: LOCATION }) {
       location={location}
       dismissible
     >
-      <Text size="sm">
+      <Text c="text-medium" lh="md">
         {t`Test out code in staging in a separate Metabase instance before deploying to production.`}
       </Text>
     </UpsellBanner>

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
@@ -79,7 +79,6 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
       ? props
       : { dismissible: false, onDismiss: () => {} };
   const gemSize = large ? 24 : undefined;
-  const contentAlignment = large ? "flex-start" : "center";
 
   return (
     <Box
@@ -88,8 +87,9 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
       bg="bg-white"
       {...domProps}
     >
-      <Flex align={contentAlignment} gap="md" wrap="nowrap">
-        <UpsellGem size={gemSize} />
+      <Flex align="flex-start" gap="sm" wrap="nowrap">
+        <UpsellGem size={gemSize} mt="1px" />
+
         <Stack gap="xs">
           <Title lh={1.25} order={3} size="md">
             {title}

--- a/frontend/src/metabase/admin/upsells/components/Upsells.module.css
+++ b/frontend/src/metabase/admin/upsells/components/Upsells.module.css
@@ -39,7 +39,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 1rem;
+  padding: 1.25rem 2rem;
   overflow: hidden;
   border: 1px solid var(--mb-color-border);
   border-radius: 0.5rem;


### PR DESCRIPTION
Closes EMB-677

> From Alessio: The info card looks different than in Figma (see screenshot from the branch vs [Figma](https://www.figma.com/design/Y4kNKVA1xlHNWKjhsySeyo/SDK-Embedding--admin-settings---embed-flow--Copy-?node-id=13052-1365&t=wxxCjfgb6xh4hGp7-0) and the Upsell card should have the same alignment as the info card (I don't see this in the branch so I couldn't actually review this). Text in both of these should be size 14, while right now is size 12. This is so we harmonize more the font sizes across the various cards.

- Fix alignment and visual in upsell banner. Applies to every upsell banners.
- Fix alignment and visual in alert in the settings page

### Demo

<img width="2518" height="1766" alt="CleanShot 2568-07-31 at 16 54 45@2x" src="https://github.com/user-attachments/assets/5cc36323-0369-4588-b7ff-08299183fdd4" />

<img width="2518" height="1768" alt="CleanShot 2568-07-31 at 16 55 11@2x" src="https://github.com/user-attachments/assets/4eedf364-da95-4aad-9b81-72ab19ee0854" />

<img width="2518" height="1766" alt="CleanShot 2568-07-31 at 16 58 46@2x" src="https://github.com/user-attachments/assets/ebbfae9b-36cd-4d10-ace0-e0890172f040" />
