### PR TITLE
Hide Embed menu from "New" button if the user is not an admin

### DIFF
--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
@@ -23,7 +23,6 @@ type SetupOpts = {
   hasModels?: boolean;
   tokenFeatures?: Partial<TokenFeatures>;
   isAdmin?: boolean;
-  isSimpleEmbeddingEnabled?: boolean;
 };
 
 const SAMPLE_DATABASE = createSampleDatabase();
@@ -32,11 +31,9 @@ async function setup({
   databases = [SAMPLE_DATABASE],
   tokenFeatures,
   isAdmin = true,
-  isSimpleEmbeddingEnabled = false,
 }: SetupOpts = {}) {
   const settings = mockSettings({
     "token-features": createMockTokenFeatures(tokenFeatures),
-    "enable-embedding-simple": isSimpleEmbeddingEnabled,
   });
 
   setupDatabasesEndpoints(databases);
@@ -63,41 +60,20 @@ describe("NewItemMenu (EE with token)", () => {
     jest.restoreAllMocks();
   });
 
-  it.each([
-    {
-      description: "user is admin and embedding is disabled",
+  it("shows the Embed item when user is an admin", async () => {
+    await setup({
+      tokenFeatures: { embedding_simple: true },
       isAdmin: true,
-      isSimpleEmbeddingEnabled: false,
-    },
-    {
-      description: "user is non-admin and embedding is enabled",
-      isAdmin: false,
-      isSimpleEmbeddingEnabled: true,
-    },
-    {
-      description: "user is admin and embedding is enabled",
-      isAdmin: true,
-      isSimpleEmbeddingEnabled: true,
-    },
-  ])(
-    "shows the Embed item when $description",
-    async ({ isAdmin, isSimpleEmbeddingEnabled }) => {
-      await setup({
-        tokenFeatures: { embedding_simple: true },
-        isAdmin,
-        isSimpleEmbeddingEnabled,
-      });
+    });
 
-      expect(await screen.findByText("Embed")).toBeInTheDocument();
-      expect(screen.queryAllByText("Beta")).toHaveLength(1);
-    },
-  );
+    expect(await screen.findByText("Embed")).toBeInTheDocument();
+    expect(screen.queryAllByText("Beta")).toHaveLength(1);
+  });
 
-  it("hides the Embed item when user is non-admin and embedding is disabled", async () => {
+  it("hides the Embed item when user is non-admin", async () => {
     await setup({
       tokenFeatures: { embedding_simple: true },
       isAdmin: false,
-      isSimpleEmbeddingEnabled: false,
     });
 
     expect(screen.queryByText("Embed")).not.toBeInTheDocument();

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.tsx
@@ -9,7 +9,6 @@ import {
   getHasDatabaseWithJsonEngine,
   getHasNativeWrite,
 } from "metabase/selectors/data";
-import { getSetting } from "metabase/selectors/settings";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { State } from "metabase-types/store";
@@ -28,7 +27,6 @@ const mapStateToProps = (
   hasNativeWrite: getHasNativeWrite(databases),
   hasDatabaseWithJsonEngine: getHasDatabaseWithJsonEngine(databases),
   isAdmin: getUserIsAdmin(state),
-  isSimpleEmbeddingEnabled: getSetting(state, "enable-embedding-simple"),
 });
 
 const mapDispatchToProps = {

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.tsx
@@ -9,6 +9,8 @@ import {
   getHasDatabaseWithJsonEngine,
   getHasNativeWrite,
 } from "metabase/selectors/data";
+import { getSetting } from "metabase/selectors/settings";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { State } from "metabase-types/store";
 
@@ -25,6 +27,8 @@ const mapStateToProps = (
   hasDataAccess: getHasDataAccess(databases),
   hasNativeWrite: getHasNativeWrite(databases),
   hasDatabaseWithJsonEngine: getHasDatabaseWithJsonEngine(databases),
+  isAdmin: getUserIsAdmin(state),
+  isSimpleEmbeddingEnabled: getSetting(state, "enable-embedding-simple"),
 });
 
 const mapDispatchToProps = {

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
@@ -24,7 +24,6 @@ export interface NewItemMenuProps {
   hasDatabaseWithJsonEngine: boolean;
   onCloseNavbar: () => void;
   isAdmin: boolean;
-  isSimpleEmbeddingEnabled?: boolean;
 }
 
 const NewItemMenuView = ({
@@ -34,7 +33,6 @@ const NewItemMenuView = ({
   hasNativeWrite,
   hasDatabaseWithJsonEngine,
   isAdmin,
-  isSimpleEmbeddingEnabled,
 }: NewItemMenuProps) => {
   const dispatch = useDispatch();
 
@@ -95,10 +93,10 @@ const NewItemMenuView = ({
     );
 
     // This is a non-standard way of feature gating, akin to using hasPremiumFeature. Do not do this for more complex setups.
-    // We hide the "Embed" menu item if the user is not an admin and simple embedding is disabled.
+    // We hide the "Embed" menu item if the user is not an admin
     if (
       PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.shouldShowEmbedInNewItemMenu() &&
-      (isAdmin || isSimpleEmbeddingEnabled)
+      isAdmin
     ) {
       items.push(
         <Menu.Item
@@ -118,7 +116,6 @@ const NewItemMenuView = ({
     hasDataAccess,
     hasNativeWrite,
     isAdmin,
-    isSimpleEmbeddingEnabled,
     collectionId,
     lastUsedDatabaseId,
     hasDatabaseWithJsonEngine,

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
@@ -23,6 +23,8 @@ export interface NewItemMenuProps {
   hasNativeWrite: boolean;
   hasDatabaseWithJsonEngine: boolean;
   onCloseNavbar: () => void;
+  isAdmin: boolean;
+  isSimpleEmbeddingEnabled?: boolean;
 }
 
 const NewItemMenuView = ({
@@ -31,6 +33,8 @@ const NewItemMenuView = ({
   hasDataAccess,
   hasNativeWrite,
   hasDatabaseWithJsonEngine,
+  isAdmin,
+  isSimpleEmbeddingEnabled,
 }: NewItemMenuProps) => {
   const dispatch = useDispatch();
 
@@ -91,7 +95,11 @@ const NewItemMenuView = ({
     );
 
     // This is a non-standard way of feature gating, akin to using hasPremiumFeature. Do not do this for more complex setups.
-    if (PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.shouldShowEmbedInNewItemMenu()) {
+    // We hide the "Embed" menu item if the user is not an admin and simple embedding is disabled.
+    if (
+      PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.shouldShowEmbedInNewItemMenu() &&
+      (isAdmin || isSimpleEmbeddingEnabled)
+    ) {
       items.push(
         <Menu.Item
           key="embed"
@@ -109,9 +117,11 @@ const NewItemMenuView = ({
   }, [
     hasDataAccess,
     hasNativeWrite,
+    isAdmin,
+    isSimpleEmbeddingEnabled,
     collectionId,
-    hasDatabaseWithJsonEngine,
     lastUsedDatabaseId,
+    hasDatabaseWithJsonEngine,
     dispatch,
   ]);
 


### PR DESCRIPTION
Closes EMB-680

Hides the "Embed" menu from "New" button if the user is not an admin

### How to verify

- Use a normal non-admin user
- The "Embed" button should be gone.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
