### PR TITLE
Format scalar currencies correctly in alerts

### DIFF
--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -71,14 +71,14 @@
 
 ;;; --------------------------------------------------- Formatting ---------------------------------------------------
 
-(mu/defn- format-cell
+(mu/defn- format-scalar-value
   [timezone-id :- [:maybe :string] value col visualization-settings]
   (cond
     (types/temporal-field? col)
     ((formatter/make-temporal-str-formatter timezone-id col {}) value)
 
     (number? value)
-    (formatter/format-number value col visualization-settings)
+    (formatter/format-scalar-number value col visualization-settings)
 
     :else
     (str value)))
@@ -153,7 +153,7 @@
       (query-results->row-seq timezone-id remapping-lookup cols (take row-limit rows) viz-settings)))))
 
 (defn- strong-limit-text [number]
-  [:strong {:style (style/style {:color style/color-gray-3})} (h (formatter/format-number number))])
+  [:strong {:style (style/style {:color style/color-gray-3})} (h (formatter/format-scalar-number number))])
 
 (defn- render-truncation-warning
   [row-limit row-count]
@@ -408,7 +408,7 @@
                           [0 (first cols)])
         row           (first rows)
         raw-value     (get row row-idx)
-        value         (format-cell timezone-id raw-value col viz-settings)]
+        value         (format-scalar-value timezone-id raw-value col viz-settings)]
     {:attachments
      nil
 
@@ -481,8 +481,8 @@
           {:keys [last-value previous-value unit last-change] :as _insight}
           (where (comp #{(:name metric-col)} :col) insights)]
       (if (and last-value previous-value unit last-change)
-        (let [value                (format-cell timezone-id last-value metric-col viz-settings)
-              previous             (format-cell timezone-id previous-value metric-col viz-settings)
+        (let [value                (format-scalar-value timezone-id last-value metric-col viz-settings)
+              previous             (format-scalar-value timezone-id previous-value metric-col viz-settings)
               delta-statement      (cond
                                      (= last-value previous-value)
                                      (tru "No change")
@@ -515,7 +515,7 @@
                                                  :font-weight   700
                                                  :padding-right :16px})}
                         (trs "Nothing to compare to.")]]
-         :render/text (str (format-cell timezone-id last-value metric-col viz-settings)
+         :render/text (str (format-scalar-value timezone-id last-value metric-col viz-settings)
                            "\n" (trs "Nothing to compare to."))}))))
 
 (defn- all-unique?

--- a/src/metabase/formatter/core.clj
+++ b/src/metabase/formatter/core.clj
@@ -14,7 +14,7 @@
   coerce-bignum-to-int
   create-formatter
   format-geographic-coordinates
-  format-number
+  format-scalar-number
   graphing-column-row-fns
   make-temporal-str-formatter
   map->NumericWrapper

--- a/src/metabase/formatter/impl.clj
+++ b/src/metabase/formatter/impl.clj
@@ -117,7 +117,8 @@
   format string once and then apply it over many values."
   [{:keys  [semantic_type effective_type base_type]
     col-id :id field-ref :field_ref col-name :name col-settings :settings :as col}
-   viz-settings]
+   viz-settings
+   & [scalar?]]
   (let [global-type-settings (try
                                (streaming.common/global-type-settings col viz-settings)
                                (catch Exception _e
@@ -191,7 +192,9 @@
                                       fmtr))]
           (->NumericWrapper
            (let [inline-currency? (and currency?
-                                       (false? (::mb.viz/currency-in-header column-settings)))
+                                       (or
+                                        scalar?
+                                        (false? (::mb.viz/currency-in-header column-settings))))
                  sb               (StringBuilder.)]
              ;; Using explicit StringBuilder to avoid touching the slow `clojure.core/str` multi-arity.
              (when prefix (.append sb prefix))
@@ -214,7 +217,7 @@
            value))
         value))))
 
-(mu/defn format-number :- (ms/InstanceOfClass NumericWrapper)
+(mu/defn format-scalar-number :- (ms/InstanceOfClass NumericWrapper)
   "Format a number `n` and return it as a NumericWrapper; this type is used to do special formatting in other
   `pulse.render` namespaces."
   ([n :- number?]
@@ -222,7 +225,7 @@
                          :num-value n}))
 
   ([value column viz-settings]
-   (let [fmttr (number-formatter column viz-settings)]
+   (let [fmttr (number-formatter column viz-settings true)]
      (fmttr value))))
 
 (defn graphing-column-row-fns

--- a/test/metabase/formatter/impl_test.clj
+++ b/test/metabase/formatter/impl_test.clj
@@ -268,3 +268,19 @@
         (testing "Should use column-specific GBP currency, not global AUD currency"
           (is (str/starts-with? result "£")
               (str "Expected GBP symbol (£) but got: " result)))))))
+
+(deftest scalar-flag-inserts-currency-inline
+  (testing "When the scalar flag is passed to `number-formatter` it puts the currency inline"
+    (let [column {:id 1
+                  :name "SUBTOTAL"
+                  :field_ref [:field 1 nil]
+                  :effective_type :type/Currency}
+          viz-settings {::mb.viz/column-settings
+                        {{::mb.viz/field-id 1} {::mb.viz/currency "GBP"
+                                                ::mb.viz/currency-style "symbol"
+                                                ::mb.viz/number-style "currency"}}}
+          formatter-fn (formatter/number-formatter column viz-settings true)
+          result (str (formatter-fn 1234.56))]
+      (testing "Should use column-specific GBP currency, not global AUD currency"
+        (is (str/starts-with? result "£")
+            (str "Expected GBP symbol (£) but got: " result))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57468
Previously we were treating all currency formatting as if we were in a table, and only adding the currency symbol if `currency-in-header` were explicitly set to `false` for the column.

When formatting a scalar value, though, we want to always add the currency symbol inline (since there is no header in this case).

I found that `metabase.channel.render.body/format-cell` and `metabase.formatter.core/format-number` were actually only used to format *scalar* cells and *scalar* numbers (as opposed to cells in a table), so I renamed them for a bit more clarity and added a new optional argument, `scalar?`, to
`metabase.formatter.core/number-formatter`. When passed (and truthy) the currency symbol will be splatted into the formatted number even if `:currency-in-header` is not `false`.

Fixes [UXW-150: Slack and email alert doesn't render currency symbols.](https://linear.app/metabase/issue/UXW-150/slack-and-email-alert-doesnt-render-currency-symbols)

Before:
<img width="477" height="420" alt="Screenshot 2025-07-31 at 06 14 51" src="https://github.com/user-attachments/assets/1bea4668-de85-4143-9b2b-1816948d806d" />

After:
<img width="477" height="420" alt="Screenshot 2025-07-31 at 05 50 40" src="https://github.com/user-attachments/assets/7921b36c-434c-4575-be55-05d39f1d6c57" />

Tables are unaffected, still printing the currency in the header or in the table rows themselves as the user specifies.