### PR TITLE
remove references to ENTERPRISE_TOKEN

### DIFF
--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -216,11 +216,17 @@ Prior to running Cypress against Metabase® Enterprise Edition™, set `MB_EDITI
 
 **Enterprise instance will start without a premium token!**
 
-If you want to test premium features (feature flags), valid tokens need to be available to all Cypress tests. We achieve this by prefixing environment variables with `CYPRESS_`.
-You should provide two tokens that correspond to the `EE/PRO` self-hosted (all features enabled) and `STARTER` Cloud (no features enabled) Metabase plans. For more information, please see [Metabase pricing page](https://www.metabase.com/pricing/). (note: only a few tests require the no features token)
+If you want to test premium features (feature flags), valid tokens need to be available to all Cypress tests.
+You should provide 4 tokens:
 
-- `CYPRESS_ALL_FEATURES_TOKEN`
-- `CYPRESS_NO_FEATURES_TOKEN`
+- MB_ALL_FEATURES_TOKEN: all feature enabled, including new feature not released yet to customers
+- MB_STARTER_CLOUD_TOKEN: only 'hosting' feature enabled to simulate the starter plan on cloud
+- MB_PRO_CLOUD_TOKEN: PRO features enabled + 'hosting' to simulate the pro plan on cloud
+- MB_PRO_SELF_HOSTED_TOKEN: PRO features but no 'hosting' to simulate the pro self-hosted plan
+
+You can configure these via ENVs or via the `cypress.env.json` file (see `cypress.env.json.example` for an example).
+
+For more information, please see [Metabase pricing page](https://www.metabase.com/pricing/).
 
 ```
 MB_EDITION=ee ENTERPRISE_TOKEN=xxxxxx yarn test-cypress

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -228,10 +228,6 @@ You can configure these via ENVs or via the `cypress.env.json` file (see `cypres
 
 For more information, please see [Metabase pricing page](https://www.metabase.com/pricing/).
 
-```
-MB_EDITION=ee ENTERPRISE_TOKEN=xxxxxx yarn test-cypress
-```
-
 If you navigate to the `/admin/settings/license` page, the license input field should display the active token. Be careful when sharing screenshots!
 
 - If tests start running but the enterprise features are missing: make sure that the token you use has corresponding feature flags enabled.

--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -14,7 +14,6 @@ import { startSampleAppContainers } from "./embedding-sdk/sample-apps/start-samp
 const userOptions = {
   TEST_SUITE: "e2e", // e2e | component
   MB_EDITION: "ee", // ee | oss
-  ENTERPRISE_TOKEN: "",
   START_CONTAINERS: true,
   STOP_CONTAINERS: false,
   BACKEND_PORT: 4000,
@@ -27,7 +26,6 @@ const userOptions = {
 };
 
 const derivedOptions = {
-  CYPRESS_MB_ALL_FEATURES_TOKEN: userOptions.ENTERPRISE_TOKEN,
   QA_DB_ENABLED: userOptions.START_CONTAINERS,
   BUILD_JAR: userOptions.BACKEND_PORT === 4000,
   START_BACKEND: userOptions.BACKEND_PORT === 4000,
@@ -43,9 +41,16 @@ const options = {
 
 process.env = unBooleanify(options);
 
-if (options.MB_EDITION === "ee" && !options.ENTERPRISE_TOKEN) {
+const missingTokens = [
+  "MB_ALL_FEATURES_TOKEN",
+  "MB_STARTER_CLOUD_TOKEN",
+  "MB_PRO_CLOUD_TOKEN",
+  "MB_PRO_SELF_HOSTED_TOKEN",
+].filter((token) => !process.env[token]);
+
+if (options.MB_EDITION === "ee" && missingTokens.length > 0) {
   printBold(
-    "⚠️ ENTERPRISE_TOKEN is not set. Either set it or run with MB_EDITION=oss",
+    `⚠️ Missing tokens: ${missingTokens.join(", ")}. Either set them or run with MB_EDITION=oss`,
   );
   process.exit(FAILURE_EXIT_CODE);
 }
@@ -53,7 +58,6 @@ if (options.MB_EDITION === "ee" && !options.ENTERPRISE_TOKEN) {
 printBold(`Running Cypress with options:
   - TEST_SUITE         : ${options.TEST_SUITE}
   - MB_EDITION         : ${options.MB_EDITION}
-  - ENTERPRISE_TOKEN   : ${options.ENTERPRISE_TOKEN ? "present" : "<missing>"}
   - START_CONTAINERS   : ${options.START_CONTAINERS}
   - STOP_CONTAINERS    : ${options.STOP_CONTAINERS}
   - BUILD_JAR          : ${options.BUILD_JAR}

--- a/enterprise/frontend/src/embedding-sdk/dev.md
+++ b/enterprise/frontend/src/embedding-sdk/dev.md
@@ -45,13 +45,14 @@ Storybook will use the source files and not the built package.
 
 E2e tests for the sdk are currently done with cypress component tests, and located in `e2e/test-component/scenarios/embedding-sdk/`.
 
-
 You'll need to have the following ENVs for running EE E2E tests:
 
 ```bash
 MB_EDITION=ee
-CYPRESS_ALL_FEATURES_TOKEN=  ${usual token from password manager}
-CYPRESS_NO_FEATURES_TOKEN=  ${usual token from password manager}
+MB_ALL_FEATURES_TOKEN=${usual token from password manager}
+MB_STARTER_CLOUD_TOKEN=${usual token from password manager}
+MB_PRO_CLOUD_TOKEN=${usual token from password manager}
+MB_PRO_SELF_HOSTED_TOKEN=${usual token from password manager}
 ```
 
 Cypress will use the built package, so you'll have to build the sdk first (see above).

--- a/enterprise/frontend/src/embedding-sdk/dev.md
+++ b/enterprise/frontend/src/embedding-sdk/dev.md
@@ -72,12 +72,12 @@ In order to check compatibility between Sample Apps and Embedding SDK, we have a
 
 To run these tests locally, run:
 ```
-ENTERPRISE_TOKEN=<token> TEST_SUITE=<sample_app_repo_name>-e2e OPEN_UI=false EMBEDDING_SDK_VERSION=local START_METABASE=false GENERATE_SNAPSHOTS=false START_CONTAINERS=false yarn test-cypress
+TEST_SUITE=<sample_app_repo_name>-e2e OPEN_UI=false EMBEDDING_SDK_VERSION=local START_METABASE=false GENERATE_SNAPSHOTS=false START_CONTAINERS=false yarn test-cypress
 ```
 
 For example for the `metabase-nodejs-react-sdk-embedding-sample`, run:
 ```
-ENTERPRISE_TOKEN=<token> TEST_SUITE=metabase-nodejs-react-sdk-embedding-sample-e2e OPEN_UI=false EMBEDDING_SDK_VERSION=local START_METABASE=false GENERATE_SNAPSHOTS=false START_CONTAINERS=false yarn test-cypress
+TEST_SUITE=metabase-nodejs-react-sdk-embedding-sample-e2e OPEN_UI=false EMBEDDING_SDK_VERSION=local START_METABASE=false GENERATE_SNAPSHOTS=false START_CONTAINERS=false yarn test-cypress
 ```
 
 ##### :warning: Obtaining the Shoppy's Metabase App DB Dump locally


### PR DESCRIPTION
The cypress runner was [exiting](https://github.com/metabase/metabase/pull/61667/files#diff-3d2bcf835645559b2ee649b31b08a4a9cb383315d6bc6bbbff1cdd4736ab1282L50) if `ENTERPRISE_TOKEN` was not passed when 'MB_EDITION=ee'
But we don't really need it, as[ we are only passing it to override `CYPRESS_MB_ALL_FEATURES_TOKEN`](https://github.com/metabase/metabase/pull/61667/files#diff-3d2bcf835645559b2ee649b31b08a4a9cb383315d6bc6bbbff1cdd4736ab1282L30) which should already be set by `MB_ALL_FEATURES_TOKEN`.


This pr:
- removes the check on ENTERPRISE_TOKEN
- adds a check for the tokens we realy need
- updates the docs that still reference the old token names
