### PR TITLE
enable cider middleware in dev-start

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -238,7 +238,8 @@
   ;;    (dev/start!)
   :dev
   {:extra-deps
-   {clj-http-fake/clj-http-fake  {:mvn/version "1.0.4"
+   {cider/cider-nrepl            {:mvn/version "0.57.0"}                    ; nREPL server for CIDER
+    clj-http-fake/clj-http-fake  {:mvn/version "1.0.4"
                                   :exclusions  [slingshot/slingshot]}
     clj-kondo/clj-kondo          {:mvn/version "2025.04.07"}                ; included here mainly to facilitate working on the stuff in `.clj-kondo/src`
     cloverage/cloverage          {:mvn/version "1.2.4"}
@@ -248,7 +249,6 @@
     {:mvn/version "0.4.0"}                     ; Enables easy memory measurement
     com.gfredericks/test.chuck   {:mvn/version "0.2.15"}                    ; generating strings from regexes (useful with malli)
     criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
-    cider/cider-nrepl            {:mvn/version "0.57.0"}                    ; nREPL server for CIDER
     dev.weavejester/hashp        {:mvn/version "0.4.0"}                     ; debugging/spying utility
     djblue/portal                {:mvn/version "0.59.2"}                    ; ui for inspecting values
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}                     ; cleaner test output

--- a/deps.edn
+++ b/deps.edn
@@ -262,6 +262,7 @@
     peridot/peridot              {:git/url "https://github.com/piranha/peridot.git"
                                   :sha "db627c627db3b527a63caf472f0422e4cbfdf574"} ; mocking Ring requests; waiting for upstream release of commit 0fc7c01 (explicit charset)
     pjstadig/humane-test-output  {:mvn/version "0.11.0"}
+    refactor-nrepl/refactor-nrepl {:mvn/version "3.11.0"}                   ; refactoring helpers for cider
     reifyhealth/specmonstah      {:mvn/version "2.1.0"
                                   :exclusions  [org.clojure/clojure
                                                 org.clojure/clojurescript]} ; lets you write test fixtures that are clear, concise, and easy to maintain (clojure.spec)

--- a/deps.edn
+++ b/deps.edn
@@ -248,6 +248,7 @@
     {:mvn/version "0.4.0"}                     ; Enables easy memory measurement
     com.gfredericks/test.chuck   {:mvn/version "0.2.15"}                    ; generating strings from regexes (useful with malli)
     criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
+    cider/cider-nrepl            {:mvn/version "0.57.0"}                    ; nREPL server for CIDER
     dev.weavejester/hashp        {:mvn/version "0.4.0"}                     ; debugging/spying utility
     djblue/portal                {:mvn/version "0.59.2"}                    ; ui for inspecting values
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}                     ; cleaner test output

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -8,13 +8,15 @@
    [metabase.classloader.core :as classloader]
    [metabase.core.bootstrap]
    [metabase.util :as u]
-   [nrepl.server :as nrepl-server]))
+   [nrepl.server :as nrepl-server]
+   [refactor-nrepl.middleware]))
 
 (set! *warn-on-reflection* true)
 
 (comment
   metabase.core.bootstrap/keep-me
-  hashp.preload/keep-me)
+  hashp.preload/keep-me
+  refactor-nrepl.middleware/keep-me)
 
 ;; Load all user.clj files (including the system-wide one).
 (when *file* ; Ensure we don't load ourselves recursively, just in case.
@@ -94,6 +96,7 @@
        :port port
        :bind "0.0.0.0"
        ;; this handler has cider middlewares installed:
-       :handler cider-nrepl/cider-nrepl-handler)))
+       :handler (apply nrepl-server/default-handler
+                       (conj cider-nrepl/cider-middleware 'refactor-nrepl.middleware/wrap-refactor)))))
   ((requiring-resolve 'dev/start!))
   (deref (promise)))


### PR DESCRIPTION
```
$ clj -M:dev:ee:ee-dev:drivers:drivers-dev:dev-start --help
Warning: environ value /Users/bcm/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/bcm/.sdkman/candidates/java/21.0.7-tem
2025-07-31 16:34:49,143 INFO metabase.util :: Maximum memory available to JVM: 16.0 GB
Usage: clj -M:dev:dev-start:drivers:drivers-dev:ee:ee-dev [options]
Options:
  -h, --help              Show this help text
  -H, --hot               Enable hot reloading
  -p, --port PORT  50605  Port to run the nREPL server on
  
$ clj -M:dev:ee:ee-dev:drivers:drivers-dev:dev-start --port 7778
Warning: environ value /Users/bcm/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/bcm/.sdkman/candidates/java/21.0.7-tem
2025-07-31 16:35:00,082 INFO metabase.util :: Maximum memory available to JVM: 16.0 GB
Starting Metabase cider repl on port 7778
... server continues starting as normal ...
```