### PR TITLE
Add an API endpoint to delete collections

### DIFF
--- a/src/metabase/collections/api.clj
+++ b/src/metabase/collections/api.clj
@@ -1398,12 +1398,8 @@
                     [:id ms/PositiveInt]]]
   (api/check-403 api/*is-superuser?*)
   (let [collection (t2/select-one :model/Collection id)
-        parent-id   (:parent_id (t2/hydrate collection :parent_id))
-        parent (if parent-id
-                 (t2/select-one :model/Collection parent-id)
-                 collection/root-collection)
         old-children-location (collection/children-location collection)
-        new-children-location (collection/children-location parent)]
+        new-children-location (:location collection)]
     (api/check-400 (:archived collection)
                    "Collection must be trashed before deletion.")
     (api/check-400 (nil? (:namespace collection))


### PR DESCRIPTION
This permanently deletes a collection and anything contained inside it.

One "exception" that's not really an exception: say you have A > B > C > D, you trash C, then trash A.

Now you have:

```
Trash > A > B
Trash > C > D
```

(because C was trashed directly).

But internally, we still represent D's location as `/A/B/C/`.

Now you permanently delete A. We need to make sure D's and C's locations get fixed. Therefore, before deleting A, we go through all the *directly*-archived children of A, and move *them* to A's parent. Moving a collection also moves its children, so we'll move the whole `C > D` structure out of `B` into the root collction.

Then we'll delete `A > B`, leaving `C > D` behind.

One note: if you "restore" collection C at this point, it will go into the root collection, where before deleting A it would have gone into B. I think this is a minor enough issue to ignore for now, especially while this is API only. In the longer term we can think about how to resolve this (just mark the collection to make it un-restoreable). (It'd be a bigger issue if collection perms were affected by their parent collection, but they're not.)

Fixes [UXW-398: API endpoint to allow deleting archived collections](https://linear.app/metabase/issue/UXW-398/api-endpoint-to-allow-deleting-archived-collections)

**Note:** I'm OOO until August 15th. Please feel free to merge this while I'm gone, make any changes necessary, etc.