### PR TITLE
keep report cards and collections in sync

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/reports/models/report.clj
+++ b/enterprise/backend/src/metabase_enterprise/reports/models/report.clj
@@ -1,8 +1,10 @@
 (ns metabase-enterprise.reports.models.report
   (:require
    [metabase.api.common :as api]
+   [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
+   [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -21,3 +23,35 @@
 (doto :model/Report
   (derive :metabase/model)
   (derive :hook/timestamped?))
+
+(defn validate-collection-move-permissions
+  "Validates that the current user has write permissions for both old and new collections
+   when moving a report. Uses the same permission pattern as check-allowed-to-change-collection.
+   Throws 403 exception if permissions are insufficient."
+  [old-collection-id new-collection-id]
+  (when old-collection-id
+    (collection/check-write-perms-for-collection old-collection-id))
+  (when new-collection-id
+    (collection/check-write-perms-for-collection new-collection-id))
+  (when new-collection-id
+    (api/check-400 (t2/exists? :model/Collection :id new-collection-id :archived false))))
+
+(defn sync-report-cards-collection!
+  "Updates all cards associated with a report to match the report's collection_id.
+   Takes a report-id and new-collection-id as parameters.
+   Uses bulk t2/update! operation for efficiency and operates within a transaction.
+   Only updates cards with type = :in_report and matching report_document_id."
+  [report-id new-collection-id]
+  (t2/with-transaction [_conn]
+    (let [updated-count (t2/update! :model/Card
+                                    {:report_document_id report-id
+                                     :type :in_report}
+                                    {:collection_id new-collection-id})]
+      (when (> updated-count 0)
+        (log/debugf "Successfully updated %d cards to collection %s"
+                    updated-count new-collection-id))
+      updated-count)))
+
+(t2/define-after-update :model/Report
+  [{report-id :id new-collection-id :collection_id}]
+  (sync-report-cards-collection! report-id new-collection-id))

--- a/enterprise/backend/test/metabase_enterprise/reports/api/report_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/reports/api/report_test.clj
@@ -6,121 +6,132 @@
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
-(deftest post-report-test
-  (testing "POST /api/ee/report/"
+(deftest post-report-basic-creation-test
+  (testing "POST /api/ee/report/ - basic report creation"
     (mt/with-model-cleanup [:model/Report]
-      (testing "should create a new report"
+      (let [result (mt/user-http-request :crowberto
+                                         :post 200 "ee/report/" {:name "Report 1"
+                                                                 :document "Doc 1"})
+            report-row (t2/select-one :model/Report :id (:id result))
+            report-doc-row (t2/select-one :model/ReportVersion :report_id (:id report-row))]
+        (is (partial= {:name "Report 1" :document "Doc 1"} result))
+        (is (pos? (:id result)))
+
+        (is (partial= {:name "Report 1"} report-row))
+        (is (partial=
+             {:document           "Doc 1"
+              :version_identifier 1}
+             report-doc-row))))))
+
+(deftest post-report-invalid-card-ids-test
+  (testing "POST /api/ee/report/ - should reject invalid card-ids"
+    (mt/with-model-cleanup [:model/Report]
+      (testing "non-integer values"
+        (mt/user-http-request :crowberto
+                              :post 400 "ee/report/"
+                              {:name "Report"
+                               :document "Doc"
+                               :card-ids ["invalid"]}))
+
+      (testing "negative integers"
+        (mt/user-http-request :crowberto
+                              :post 400 "ee/report/"
+                              {:name "Report"
+                               :document "Doc"
+                               :card-ids [-1 2]}))
+
+      (testing "zero values"
+        (mt/user-http-request :crowberto
+                              :post 400 "ee/report/"
+                              {:name "Report"
+                               :document "Doc"
+                               :card-ids [0 1]})))))
+
+(deftest post-report-valid-card-association-test
+  (testing "POST /api/ee/report/ - should associate valid :in_report cards with new report"
+    (mt/with-model-cleanup [:model/Report]
+      (mt/with-temp [:model/Card card1 {:name "Card 1"
+                                        :type :in_report
+                                        :dataset_query (mt/mbql-query venues)}
+                     :model/Card card2 {:name "Card 2"
+                                        :type :in_report
+                                        :dataset_query (mt/mbql-query venues)}]
         (let [result (mt/user-http-request :crowberto
-                                           :post 200 "ee/report/" {:name "Report 1"
-                                                                   :document "Doc 1"})
-              report-row (t2/select-one :model/Report :id (:id result))
-              report-doc-row (t2/select-one :model/ReportVersion :report_id (:id report-row))]
-          (is (partial= {:name "Report 1" :document "Doc 1"} result))
+                                           :post 200 "ee/report/"
+                                           {:name "Report with Valid Cards"
+                                            :document "Doc with valid cards"
+                                            :card-ids [(:id card1) (:id card2)]})
+              updated-card1 (t2/select-one :model/Card :id (:id card1))
+              updated-card2 (t2/select-one :model/Card :id (:id card2))]
           (is (pos? (:id result)))
+          (is (= (:id result) (:report_document_id updated-card1)))
+          (is (= (:id result) (:report_document_id updated-card2))))))))
 
-          (is (partial= {:name "Report 1"} report-row))
-          (is (partial=
-               {:document           "Doc 1"
-                :version_identifier 1}
-               report-doc-row))))
+(deftest post-report-nonexistent-card-ids-test
+  (testing "POST /api/ee/report/ - should reject non-existent card-ids"
+    (mt/with-model-cleanup [:model/Report]
+      (let [non-existent-id 999999]
+        (mt/user-http-request :crowberto
+                              :post 404 "ee/report/"
+                              {:name "Report with Missing Cards"
+                               :document "Doc"
+                               :card-ids [non-existent-id]})))))
 
-      (testing "should reject invalid card-ids"
-        (testing "non-integer values"
-          (mt/user-http-request :crowberto
-                                :post 400 "ee/report/"
-                                {:name "Report"
-                                 :document "Doc"
-                                 :card-ids ["invalid"]}))
-
-        (testing "negative integers"
-          (mt/user-http-request :crowberto
-                                :post 400 "ee/report/"
-                                {:name "Report"
-                                 :document "Doc"
-                                 :card-ids [-1 2]}))
-
-        (testing "zero values"
-          (mt/user-http-request :crowberto
-                                :post 400 "ee/report/"
-                                {:name "Report"
-                                 :document "Doc"
-                                 :card-ids [0 1]})))
-
-      (testing "card association functionality"
-        (mt/with-model-cleanup [:model/Card]
-          (testing "should associate valid :in_report cards with new report"
-            (mt/with-temp [:model/Card card1 {:name "Card 1"
-                                              :type :in_report
-                                              :dataset_query (mt/mbql-query venues)}
-                           :model/Card card2 {:name "Card 2"
-                                              :type :in_report
-                                              :dataset_query (mt/mbql-query venues)}]
-              (let [result (mt/user-http-request :crowberto
-                                                 :post 200 "ee/report/"
-                                                 {:name "Report with Valid Cards"
-                                                  :document "Doc with valid cards"
-                                                  :card-ids [(:id card1) (:id card2)]})
-                    updated-card1 (t2/select-one :model/Card :id (:id card1))
-                    updated-card2 (t2/select-one :model/Card :id (:id card2))]
-                (is (pos? (:id result)))
-                (is (= (:id result) (:report_document_id updated-card1)))
-                (is (= (:id result) (:report_document_id updated-card2))))))
-
-          (testing "should reject non-existent card-ids"
-            (let [non-existent-id 999999]
-              (mt/user-http-request :crowberto
-                                    :post 404 "ee/report/"
-                                    {:name "Report with Missing Cards"
-                                     :document "Doc"
-                                     :card-ids [non-existent-id]})))
-
-          (testing "should reject cards with wrong type"
-            (mt/with-temp [:model/Card wrong-type-card {:name "Wrong Type Card"
-                                                        :type :question
-                                                        :dataset_query (mt/mbql-query venues)}]
-              (is (=? {:message #"The following cards cannot be used in reports because they have the wrong type:.*"}
-                      (mt/user-http-request :crowberto
-                                            :post 400 "ee/report/"
-                                            {:name "Report with Wrong Type Cards"
-                                             :document "Doc"
-                                             :card-ids [(:id wrong-type-card)]})))))
-
-          (testing "should error on nil card-ids"
-            (mt/user-http-request :crowberto
-                                  :post 400 "ee/report/"
-                                  {:name "Report with Nil Cards"
-                                   :document "Doc with nil cards"
-                                   :card-ids nil}))
-
-          (testing "should handle empty card-ids gracefully"
-            (let [result (mt/user-http-request :crowberto
-                                               :post 200 "ee/report/"
-                                               {:name "Report with Empty Cards"
-                                                :document "Doc with empty cards"
-                                                :card-ids []})]
-              (is (pos? (:id result)))))
-
-          (testing "transaction rollback - when card update fails, report creation should be rolled back"
-            ;; This test ensures that if card updates fail, the entire transaction is rolled back
-            (mt/with-temp [:model/Card card {:name "Test Card"
-                                             :type :in_report
-                                             :dataset_query (mt/mbql-query venues)}]
-              ;; Create a scenario where card update might fail by using a mixed set of valid and invalid cards
-              (let [invalid-card-id 999999
-                    initial-reports-count (t2/count :model/Report)]
+(deftest post-report-wrong-card-type-test
+  (testing "POST /api/ee/report/ - should reject cards with wrong type"
+    (mt/with-model-cleanup [:model/Report :model/Card]
+      (mt/with-temp [:model/Card wrong-type-card {:name "Wrong Type Card"
+                                                  :type :question
+                                                  :dataset_query (mt/mbql-query venues)}]
+        (is (=? {:message #"The following cards cannot be used in reports because they have the wrong type:.*"}
                 (mt/user-http-request :crowberto
-                                      :post 404 "ee/report/"
-                                      {:name "Report That Should Rollback"
+                                      :post 400 "ee/report/"
+                                      {:name "Report with Wrong Type Cards"
                                        :document "Doc"
-                                       :card-ids [(:id card) invalid-card-id]})
-                ;; Verify no new report was created due to rollback
-                (is (= initial-reports-count (t2/count :model/Report)))
-                ;; Verify the valid card wasn't updated
-                (let [unchanged-card (t2/select-one :model/Card :id (:id card))]
-                  (is (nil? (:report_document_id unchanged-card))))))))))))
+                                       :card-ids [(:id wrong-type-card)]})))))))
 
-(deftest put-report-test
-  (testing "PUT /api/ee/report/id"
+(deftest post-report-nil-card-ids-test
+  (testing "POST /api/ee/report/ - should error on nil card-ids"
+    (mt/with-model-cleanup [:model/Report]
+      (mt/user-http-request :crowberto
+                            :post 400 "ee/report/"
+                            {:name "Report with Nil Cards"
+                             :document "Doc with nil cards"
+                             :card-ids nil}))))
+
+(deftest post-report-empty-card-ids-test
+  (testing "POST /api/ee/report/ - should handle empty card-ids gracefully"
+    (mt/with-model-cleanup [:model/Report]
+      (let [result (mt/user-http-request :crowberto
+                                         :post 200 "ee/report/"
+                                         {:name "Report with Empty Cards"
+                                          :document "Doc with empty cards"
+                                          :card-ids []})]
+        (is (pos? (:id result)))))))
+
+(deftest post-report-transaction-rollback-test
+  (testing "POST /api/ee/report/ - transaction rollback when card update fails"
+    (mt/with-model-cleanup [:model/Report :model/Card]
+            ;; This test ensures that if card updates fail, the entire transaction is rolled back
+      (mt/with-temp [:model/Card card {:name "Test Card"
+                                       :type :in_report
+                                       :dataset_query (mt/mbql-query venues)}]
+              ;; Create a scenario where card update might fail by using a mixed set of valid and invalid cards
+        (let [invalid-card-id 999999
+              initial-reports-count (t2/count :model/Report)]
+          (mt/user-http-request :crowberto
+                                :post 404 "ee/report/"
+                                {:name "Report That Should Rollback"
+                                 :document "Doc"
+                                 :card-ids [(:id card) invalid-card-id]})
+                ;; Verify no new report was created due to rollback
+          (is (= initial-reports-count (t2/count :model/Report)))
+                ;; Verify the valid card wasn't updated
+          (let [unchanged-card (t2/select-one :model/Card :id (:id card))]
+            (is (nil? (:report_document_id unchanged-card)))))))))
+
+(deftest put-report-basic-update-test
+  (testing "PUT /api/ee/report/id - basic report update"
     (mt/with-temp [:model/Report {report-id :id} {:name "Test Report"}
                    :model/ReportVersion {version-id :id}
                    {:report_id          report-id
@@ -128,95 +139,144 @@
                     :version_identifier 1}]
       (t2/update! :model/Report report-id {:current_version_id version-id})
 
-      (testing "should update an existing report"
-        (let [result (mt/user-http-request :crowberto
-                                           :put 200 (format "ee/report/%s" report-id) {:name "Report 2" :document "Doc 2"})]
-          (is (partial= {:name     "Report 2"
-                         :document "Doc 2"
-                         :version 2} result))))
+      (let [result (mt/user-http-request :crowberto
+                                         :put 200 (format "ee/report/%s" report-id) {:name "Report 2" :document "Doc 2"})]
+        (is (partial= {:name     "Report 2"
+                       :document "Doc 2"
+                       :version 2} result))))))
 
-      (testing "card association functionality"
-        (mt/with-model-cleanup [:model/Card]
-          (testing "should associate valid :in_report cards with existing report"
-            (mt/with-temp [:model/Card card1 {:name "Card 1"
-                                              :type :in_report
-                                              :dataset_query (mt/mbql-query venues)}
-                           :model/Card card2 {:name "Card 2"
-                                              :type :in_report
-                                              :dataset_query (mt/mbql-query venues)}]
-              (let [result (mt/user-http-request :crowberto
-                                                 :put 200 (format "ee/report/%s" report-id)
-                                                 {:name "Updated Report with Cards"
-                                                  :document "Updated doc with cards"
-                                                  :card-ids [(:id card1) (:id card2)]})
-                    updated-card1 (t2/select-one :model/Card :id (:id card1))
-                    updated-card2 (t2/select-one :model/Card :id (:id card2))]
-                (is (= report-id (:id result)))
-                (is (= report-id (:report_document_id updated-card1)))
-                (is (= report-id (:report_document_id updated-card2))))))
+(deftest put-report-associate-valid-cards-test
+  (testing "PUT /api/ee/report/id - should associate valid :in_report cards with existing report"
+    (mt/with-temp [:model/Report {report-id :id} {:name "Test Report"}
+                   :model/ReportVersion {version-id :id}
+                   {:report_id report-id
+                    :document "Initial Doc"
+                    :version_identifier 1}]
+      (t2/update! :model/Report report-id {:current_version_id version-id})
 
-          (testing "should clear existing card associations when updating with new cards"
-            (mt/with-temp [:model/Card old-card {:name "Old Card"
-                                                 :type :in_report
-                                                 :report_document_id report-id
-                                                 :dataset_query (mt/mbql-query venues)}
-                           :model/Card new-card {:name "New Card"
-                                                 :type :in_report
-                                                 :dataset_query (mt/mbql-query venues)}]
-              (mt/user-http-request :crowberto
-                                    :put 200 (format "ee/report/%s" report-id)
-                                    {:card-ids [(:id new-card)]})
-              (let [updated-old-card (t2/select-one :model/Card :id (:id old-card))
-                    updated-new-card (t2/select-one :model/Card :id (:id new-card))]
-                (is (nil? (:report_document_id updated-old-card)))
-                (is (= report-id (:report_document_id updated-new-card))))))
+      (mt/with-model-cleanup [:model/Card]
+        (mt/with-temp [:model/Card card1 {:name "Card 1"
+                                          :type :in_report
+                                          :dataset_query (mt/mbql-query venues)}
+                       :model/Card card2 {:name "Card 2"
+                                          :type :in_report
+                                          :dataset_query (mt/mbql-query venues)}]
+          (let [result (mt/user-http-request :crowberto
+                                             :put 200 (format "ee/report/%s" report-id)
+                                             {:name "Updated Report with Cards"
+                                              :document "Updated doc with cards"
+                                              :card-ids [(:id card1) (:id card2)]})
+                updated-card1 (t2/select-one :model/Card :id (:id card1))
+                updated-card2 (t2/select-one :model/Card :id (:id card2))]
+            (is (= report-id (:id result)))
+            (is (= report-id (:report_document_id updated-card1)))
+            (is (= report-id (:report_document_id updated-card2)))))))))
 
-          (testing "should reject non-existent card-ids"
-            (let [non-existent-id 999999]
-              (is (=? {:message #"The following card IDs do not exist.*"}
-                      (mt/user-http-request :crowberto
-                                            :put 404 (format "ee/report/%s" report-id)
-                                            {:name "Report with Missing Cards"
-                                             :document "Doc"
-                                             :card-ids [non-existent-id]})))))
+(deftest put-report-clear-existing-card-associations-test
+  (testing "PUT /api/ee/report/id - should clear existing card associations when updating with new cards"
+    (mt/with-temp [:model/Report {report-id :id} {:name "Test Report"}
+                   :model/ReportVersion {version-id :id}
+                   {:report_id report-id
+                    :document "Initial Doc"
+                    :version_identifier 1}]
+      (t2/update! :model/Report report-id {:current_version_id version-id})
 
-          (testing "should reject cards with wrong type"
-            (mt/with-temp [:model/Card wrong-type-card {:name "Wrong Type Card"
-                                                        :type :question
-                                                        :dataset_query (mt/mbql-query venues)}]
-              (is (=? {:message #"The following cards cannot be used in reports.*"}
-                      (mt/user-http-request :crowberto
-                                            :put 400 (format "ee/report/%s" report-id)
-                                            {:name "Report with Wrong Type Cards"
-                                             :document "Doc"
-                                             :card-ids [(:id wrong-type-card)]})))))
+      (mt/with-model-cleanup [:model/Card]
+        (mt/with-temp [:model/Card old-card {:name "Old Card"
+                                             :type :in_report
+                                             :report_document_id report-id
+                                             :dataset_query (mt/mbql-query venues)}
+                       :model/Card new-card {:name "New Card"
+                                             :type :in_report
+                                             :dataset_query (mt/mbql-query venues)}]
+          (mt/user-http-request :crowberto
+                                :put 200 (format "ee/report/%s" report-id)
+                                {:card-ids [(:id new-card)]})
+          (let [updated-old-card (t2/select-one :model/Card :id (:id old-card))
+                updated-new-card (t2/select-one :model/Card :id (:id new-card))]
+            (is (= report-id (:report_document_id updated-old-card)))
+            (is (= report-id (:report_document_id updated-new-card)))))))))
 
-          (testing "should handle empty card-ids gracefully"
-            (let [result (mt/user-http-request :crowberto
-                                               :put 200 (format "ee/report/%s" report-id)
-                                               {:name "Report with Empty Cards"
-                                                :document "Doc with empty cards"
-                                                :card-ids []})]
-              (is (= report-id (:id result)))))
+(deftest put-report-reject-nonexistent-card-ids-test
+  (testing "PUT /api/ee/report/id - should reject non-existent card-ids"
+    (mt/with-temp [:model/Report {report-id :id} {:name "Test Report"}
+                   :model/ReportVersion {version-id :id}
+                   {:report_id report-id
+                    :document "Initial Doc"
+                    :version_identifier 1}]
+      (t2/update! :model/Report report-id {:current_version_id version-id})
 
-          (testing "transaction rollback - when card update fails, report update should be rolled back"
-            (let [initial-report (t2/select-one :model/Report :id report-id)
-                  invalid-card-id 999999
-                  initial-versions-count (t2/count :model/ReportVersion :report_id report-id)]
-              (mt/user-http-request :crowberto
-                                    :put 404 (format "ee/report/%s" report-id)
-                                    {:name "Report That Should Rollback"
-                                     :document "Doc that should rollback"
-                                     :card-ids [invalid-card-id]})
-              ;; Verify no new report version was created due to rollback
-              (is (= initial-versions-count (t2/count :model/ReportVersion :report_id report-id)))
-              ;; Verify the report name wasn't updated
-              (let [unchanged-report (t2/select-one :model/Report :id report-id)]
-                (is (= (:name initial-report) (:name unchanged-report))))))))
+      (let [non-existent-id 999999]
+        (is (=? {:message #"The following card IDs do not exist.*"}
+                (mt/user-http-request :crowberto
+                                      :put 404 (format "ee/report/%s" report-id)
+                                      {:name "Report with Missing Cards"
+                                       :document "Doc"
+                                       :card-ids [non-existent-id]})))))))
 
-      (testing "should return 404 for non-existent report"
+(deftest put-report-reject-wrong-card-type-test
+  (testing "PUT /api/ee/report/id - should reject cards with wrong type"
+    (mt/with-temp [:model/Report {report-id :id} {:name "Test Report"}
+                   :model/ReportVersion {version-id :id}
+                   {:report_id report-id
+                    :document "Initial Doc"
+                    :version_identifier 1}]
+      (t2/update! :model/Report report-id {:current_version_id version-id})
+
+      (mt/with-model-cleanup [:model/Card]
+        (mt/with-temp [:model/Card wrong-type-card {:name "Wrong Type Card"
+                                                    :type :question
+                                                    :dataset_query (mt/mbql-query venues)}]
+          (is (=? {:message #"The following cards cannot be used in reports.*"}
+                  (mt/user-http-request :crowberto
+                                        :put 400 (format "ee/report/%s" report-id)
+                                        {:name "Report with Wrong Type Cards"
+                                         :document "Doc"
+                                         :card-ids [(:id wrong-type-card)]}))))))))
+
+(deftest put-report-handle-empty-card-ids-test
+  (testing "PUT /api/ee/report/id - should handle empty card-ids gracefully"
+    (mt/with-temp [:model/Report {report-id :id} {:name "Test Report"}
+                   :model/ReportVersion {version-id :id}
+                   {:report_id report-id
+                    :document "Initial Doc"
+                    :version_identifier 1}]
+      (t2/update! :model/Report report-id {:current_version_id version-id})
+
+      (let [result (mt/user-http-request :crowberto
+                                         :put 200 (format "ee/report/%s" report-id)
+                                         {:name "Report with Empty Cards"
+                                          :document "Doc with empty cards"
+                                          :card-ids []})]
+        (is (= report-id (:id result)))))))
+
+(deftest put-report-transaction-rollback-test
+  (testing "PUT /api/ee/report/id - transaction rollback when card update fails"
+    (mt/with-temp [:model/Report {report-id :id} {:name "Test Report"}
+                   :model/ReportVersion {version-id :id}
+                   {:report_id report-id
+                    :document "Initial Doc"
+                    :version_identifier 1}]
+      (t2/update! :model/Report report-id {:current_version_id version-id})
+
+      (let [initial-report (t2/select-one :model/Report :id report-id)
+            invalid-card-id 999999
+            initial-versions-count (t2/count :model/ReportVersion :report_id report-id)]
         (mt/user-http-request :crowberto
-                              :put 404 "ee/report/99999" {:name "Non-existent Report" :document "Doc"})))))
+                              :put 404 (format "ee/report/%s" report-id)
+                              {:name "Report That Should Rollback"
+                               :document "Doc that should rollback"
+                               :card-ids [invalid-card-id]})
+              ;; Verify no new report version was created due to rollback
+        (is (= initial-versions-count (t2/count :model/ReportVersion :report_id report-id)))
+              ;; Verify the report name wasn't updated
+        (let [unchanged-report (t2/select-one :model/Report :id report-id)]
+          (is (= (:name initial-report) (:name unchanged-report))))))))
+
+(deftest put-report-nonexistent-report-test
+  (testing "PUT /api/ee/report/id - should return 404 for non-existent report"
+    (mt/user-http-request :crowberto
+                          :put 404 "ee/report/99999" {:name "Non-existent Report" :document "Doc"})))
 
 (deftest put-report-with-no-perms-test
   (mt/with-temp [:model/Collection {coll-id :id} {}
@@ -415,3 +475,97 @@
                           (catch Exception e e))]
               (is (= 404 (:status-code (ex-data ex))))
               (is (= [999999] (:missing-card-ids (ex-data ex)))))))))))
+
+(deftest report-collection-sync-integration-test
+  (testing "End-to-end collection synchronization through API"
+    (mt/with-temp [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+                   :model/Collection {new-collection-id :id} {:name "New Collection"}
+                   :model/Report {report-id :id} {:collection_id old-collection-id :name "Integration Test Report"}
+                   :model/ReportVersion {version-id :id} {:report_id report-id
+                                                          :document "Integration test doc"
+                                                          :version_identifier 1}]
+      (t2/update! :model/Report report-id {:current_version_id version-id})
+
+      ;; Create cards associated with the report
+      (mt/with-temp [:model/Card {card1-id :id} {:name "Integration Card 1"
+                                                 :type :in_report
+                                                 :report_document_id report-id
+                                                 :collection_id old-collection-id
+                                                 :dataset_query (mt/mbql-query venues)}
+                     :model/Card {card2-id :id} {:name "Integration Card 2"
+                                                 :type :in_report
+                                                 :report_document_id report-id
+                                                 :collection_id old-collection-id
+                                                 :dataset_query (mt/mbql-query venues)}
+                     ;; This card should NOT be affected (different type)
+                     :model/Card {other-card-id :id} {:name "Other Card"
+                                                      :type :question
+                                                      :collection_id old-collection-id
+                                                      :dataset_query (mt/mbql-query venues)}]
+
+        (testing "PUT /api/ee/report/:id with collection change syncs cards"
+          ;; Update report through API to move to new collection
+          (let [response (mt/user-http-request :crowberto
+                                               :put 200 (format "ee/report/%s" report-id)
+                                               {:collection_id new-collection-id})]
+            (is (= new-collection-id (:collection_id response)))
+
+            ;; Verify report was moved
+            (is (= new-collection-id (:collection_id (t2/select-one :model/Report :id report-id))))
+
+            ;; Verify associated cards were moved
+            (is (= new-collection-id (:collection_id (t2/select-one :model/Card :id card1-id))))
+            (is (= new-collection-id (:collection_id (t2/select-one :model/Card :id card2-id))))
+
+            ;; Verify other card was NOT moved
+            (is (= old-collection-id (:collection_id (t2/select-one :model/Card :id other-card-id))))))
+
+        (testing "Moving to root collection (nil) works"
+          (let [response (mt/user-http-request :crowberto
+                                               :put 200 (format "ee/report/%s" report-id)
+                                               {:collection_id nil})]
+            (is (nil? (:collection_id response)))
+
+            ;; Verify all associated cards moved to root
+            (is (nil? (:collection_id (t2/select-one :model/Card :id card1-id))))
+            (is (nil? (:collection_id (t2/select-one :model/Card :id card2-id))))
+
+            ;; Other card should still be in old collection
+            (is (= old-collection-id (:collection_id (t2/select-one :model/Card :id other-card-id))))))))))
+
+(deftest api-permission-edge-cases-test
+  (testing "API permission validation edge cases"
+    (mt/with-temp [:model/User {user-id :id} {:first_name "Test" :last_name "User" :email "test@integration.com"}
+                   :model/Collection {collection1-id :id} {:name "Permission Collection 1"}
+                   :model/Collection {collection2-id :id} {:name "Permission Collection 2"}
+                   :model/Report {report-id :id} {:collection_id collection1-id :name "Permission Test Report"}
+                   :model/ReportVersion {version-id :id} {:report_id report-id
+                                                          :document "Permission test doc"
+                                                          :version_identifier 1}]
+      (t2/update! :model/Report report-id {:current_version_id version-id})
+
+      ;; Create cards in the original collection
+      (mt/with-temp [:model/Card {card-id :id} {:name "Permission Test Card"
+                                                :type :in_report
+                                                :report_document_id report-id
+                                                :collection_id collection1-id
+                                                :dataset_query (mt/mbql-query venues)}]
+
+        (testing "regular user without permissions cannot move report"
+          ;; Should fail with 403
+          (mt/user-http-request user-id
+                                :put 403 (format "ee/report/%s" report-id)
+                                {:collection_id collection2-id})
+
+          ;; Verify nothing changed
+          (is (= collection1-id (:collection_id (t2/select-one :model/Report :id report-id))))
+          (is (= collection1-id (:collection_id (t2/select-one :model/Card :id card-id)))))
+
+        (testing "moving to non-existent collection fails gracefully"
+          (mt/user-http-request :crowberto
+                                :put 400 (format "ee/report/%s" report-id)
+                                {:collection_id 99999})
+
+          ;; Verify nothing changed
+          (is (= collection1-id (:collection_id (t2/select-one :model/Report :id report-id))))
+          (is (= collection1-id (:collection_id (t2/select-one :model/Card :id card-id)))))))))

--- a/enterprise/backend/test/metabase_enterprise/reports/models/report_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/reports/models/report_test.clj
@@ -1,0 +1,373 @@
+(ns metabase-enterprise.reports.models.report-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.reports.models.report :as report]
+   [metabase.collections.models.collection :as collection]
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
+
+(deftest sync-report-cards-collection-matching-cards-test
+  (testing "should only update cards with matching report_document_id and :in_report type"
+    (mt/with-temp [:model/Collection {collection-id :id} {:name "Target Collection"}
+                   :model/Report {report-id :id} {:name "Test Report"}
+                   :model/Card {card1-id :id} {:name "Report Card 1"
+                                               :type :in_report
+                                               :report_document_id report-id
+                                               :collection_id nil
+                                               :dataset_query (mt/mbql-query venues)}
+                   :model/Card {card2-id :id} {:name "Report Card 2"
+                                               :type :in_report
+                                               :report_document_id report-id
+                                               :collection_id nil
+                                               :dataset_query (mt/mbql-query venues)}
+                   :model/Card {other-card-id :id} {:name "Other Card"
+                                                    :type :question
+                                                    :collection_id nil
+                                                    :dataset_query (mt/mbql-query venues)}]
+      (let [updated-count (report/sync-report-cards-collection! report-id collection-id)]
+        ;; Should update exactly 2 cards
+        (is (= 2 updated-count))
+
+        ;; Verify the report cards were updated
+        (let [updated-card1 (t2/select-one :model/Card :id card1-id)
+              updated-card2 (t2/select-one :model/Card :id card2-id)
+              other-card (t2/select-one :model/Card :id other-card-id)]
+          (is (= collection-id (:collection_id updated-card1)))
+          (is (= collection-id (:collection_id updated-card2)))
+          ;; Other card should not be affected
+          (is (nil? (:collection_id other-card))))))))
+
+(deftest sync-report-cards-collection-nil-report-document-id-test
+  (testing "should not affect cards with nil report_document_id"
+    (mt/with-temp [:model/Collection {collection-id :id} {:name "Target Collection"}
+                   :model/Report {report-id :id} {:name "Test Report"}
+                   :model/Card {nil-report-card-id :id} {:name "Nil Report Card"
+                                                         :type :in_report
+                                                         :report_document_id nil
+                                                         :collection_id nil
+                                                         :dataset_query (mt/mbql-query venues)}]
+      (let [updated-count (report/sync-report-cards-collection! report-id collection-id)]
+        ;; Should update 0 cards since no cards have matching report_document_id
+        (is (= 0 updated-count))
+
+        ;; Verify the card with nil report_document_id was not affected
+        (let [unchanged-card (t2/select-one :model/Card :id nil-report-card-id)]
+          (is (nil? (:collection_id unchanged-card))))))))
+
+(deftest sync-report-cards-collection-large-numbers-test
+  (testing "should handle large numbers of cards efficiently"
+    (mt/with-model-cleanup [:model/Card]
+      (mt/with-temp [:model/Collection {collection-id :id} {:name "Target Collection"}
+                     :model/Report {report-id :id} {:name "Test Report with Many Cards"}]
+        ;; Create 50 cards associated with the report
+        (let [card-ids (doall
+                        (for [i (range 50)]
+                          (:id (t2/insert-returning-pks! :model/Card
+                                                         (merge (mt/with-temp-defaults :model/Card)
+                                                                {:type :in_report
+                                                                 :report_document_id report-id
+                                                                 :collection_id nil
+                                                                 :dataset_query (mt/mbql-query venues)})))))]
+          (let [updated-count (report/sync-report-cards-collection! report-id collection-id)]
+            ;; Should update all 50 cards
+            (is (= 50 updated-count))
+
+            ;; Verify all cards were updated (check a few samples)
+            (let [sample-cards (t2/select :model/Card :id [:in card-ids] {:limit 5})]
+              (is (every? #(= collection-id (:collection_id %)) sample-cards)))))))))
+
+(deftest sync-report-cards-collection-transaction-boundaries-test
+  (testing "should work within transaction boundaries"
+    (mt/with-temp [:model/Collection {collection-id :id} {:name "Target Collection"}
+                   :model/Report {report-id :id} {:name "Transaction Test Report"}
+                   :model/Card {card-id :id} {:name "Transaction Test Card"
+                                              :type :in_report
+                                              :report_document_id report-id
+                                              :collection_id nil
+                                              :dataset_query (mt/mbql-query venues)}]
+      ;; Test that function works correctly within a transaction
+      (t2/with-transaction [_conn]
+        (let [updated-count (report/sync-report-cards-collection! report-id collection-id)]
+          (is (= 1 updated-count))
+
+          ;; Verify card was updated within the transaction
+          (let [updated-card (t2/select-one :model/Card :id card-id)]
+            (is (= collection-id (:collection_id updated-card))))))
+
+      ;; Verify the update persisted after transaction
+      (let [final-card (t2/select-one :model/Card :id card-id)]
+        (is (= collection-id (:collection_id final-card)))))))
+
+(deftest sync-report-cards-collection-empty-result-sets-test
+  (testing "should handle empty result sets gracefully"
+    (mt/with-temp [:model/Collection {collection-id :id} {:name "Target Collection"}
+                   :model/Report {report-id :id} {:name "Empty Report"}]
+      ;; No cards associated with this report
+      (let [updated-count (report/sync-report-cards-collection! report-id collection-id)]
+        ;; Should return 0 for no updates
+        (is (= 0 updated-count))))))
+
+(deftest sync-report-cards-collection-transaction-rollback-test
+  (testing "transaction rollback if any card update fails"
+    (mt/with-temp [:model/Collection {collection-id :id} {:name "Target Collection"}
+                   :model/Report {report-id :id} {:name "Transaction Rollback Test"}
+                   :model/Card {card-id :id} {:name "Test Card"
+                                              :type :in_report
+                                              :report_document_id report-id
+                                              :collection_id nil
+                                              :dataset_query (mt/mbql-query venues)}]
+      ;; This test verifies that the function uses proper transaction boundaries
+      ;; If the transaction fails, all changes should be rolled back
+      (testing "cards are updated within transaction boundaries"
+        (let [updated-count (report/sync-report-cards-collection! report-id collection-id)]
+          (is (= 1 updated-count))
+
+          ;; Verify the card was updated
+          (let [updated-card (t2/select-one :model/Card :id card-id)]
+            (is (= collection-id (:collection_id updated-card))))))
+
+      (testing "function operates atomically"
+        ;; This test demonstrates that the sync operation is atomic
+        ;; All cards are updated in a single transaction
+        (let [original-collection-id (:collection_id (t2/select-one :model/Card :id card-id))]
+          (is (= collection-id original-collection-id))
+
+          ;; Create a second collection for moving back
+          (mt/with-temp [:model/Collection {new-collection-id :id} {:name "New Target Collection"}]
+            (let [updated-count (report/sync-report-cards-collection! report-id new-collection-id)]
+              (is (= 1 updated-count))
+
+              ;; Verify the card was moved to the new collection
+              (let [final-card (t2/select-one :model/Card :id card-id)]
+                (is (= new-collection-id (:collection_id final-card)))))))))))
+
+(deftest report-collection-sync-hook-triggers-on-collection-change-test
+  (testing "Hook is called when report collection_id changes"
+    (mt/with-temp
+      [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+       :model/Collection {new-collection-id :id} {:name "New Collection"}
+       :model/Report {report-id :id} {:collection_id old-collection-id
+                                      :name "Test Report"}
+       :model/Card {card1-id :id} {:name "Card 1"
+                                   :type :in_report
+                                   :report_document_id report-id
+                                   :collection_id old-collection-id}
+       :model/Card {card2-id :id} {:name "Card 2"
+                                   :type :in_report
+                                   :report_document_id report-id
+                                   :collection_id old-collection-id}]
+
+      ;; Update the report's collection_id
+      (t2/update! :model/Report report-id {:collection_id new-collection-id})
+
+      ;; Verify that associated cards were updated to match the new collection
+      (is (= new-collection-id (:collection_id (t2/select-one :model/Card :id card1-id))))
+      (is (= new-collection-id (:collection_id (t2/select-one :model/Card :id card2-id)))))))
+
+(deftest report-collection-sync-hook-handles-nil-collections-test
+  (testing "Hook correctly handles nil collection values"
+    (mt/with-temp
+      [:model/Collection {collection-id :id} {:name "Test Collection"}
+       :model/Report {report-id :id} {:collection_id collection-id
+                                      :name "Test Report"}
+       :model/Card {card-id :id} {:name "Card"
+                                  :type :in_report
+                                  :report_document_id report-id
+                                  :collection_id collection-id}]
+
+      ;; Move report to no collection (nil)
+      (t2/update! :model/Report report-id {:collection_id nil})
+
+      ;; Verify that the card's collection_id was updated to nil
+      (is (nil? (:collection_id (t2/select-one :model/Card :id card-id)))))))
+
+(deftest report-collection-sync-hook-only-affects-in-report-cards-test
+  (testing "Hook only updates cards with type :in_report and matching report_document_id"
+    (mt/with-temp
+      [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+       :model/Collection {new-collection-id :id} {:name "New Collection"}
+       :model/Report {report-id :id} {:collection_id old-collection-id
+                                      :name "Test Report"}
+       ;; Card that should be updated (correct type and report_document_id)
+       :model/Card {in-report-card-id :id} {:name "In-Report Card"
+                                            :type :in_report
+                                            :report_document_id report-id
+                                            :collection_id old-collection-id}
+       ;; Card that should NOT be updated (wrong type)
+       :model/Card {question-card-id :id} {:name "Question Card"
+                                           :type :question
+                                           :collection_id old-collection-id}
+       ;; Card that should NOT be updated (no report_document_id)
+       :model/Card {regular-card-id :id} {:name "Regular Card"
+                                          :type :in_report
+                                          :collection_id old-collection-id}]
+
+      ;; Update the report's collection_id
+      (t2/update! :model/Report report-id {:collection_id new-collection-id})
+
+      ;; Verify only the correct card was updated
+      (is (= new-collection-id (:collection_id (t2/select-one :model/Card :id in-report-card-id))))
+
+      ;; Verify other cards were NOT updated
+      (is (= old-collection-id (:collection_id (t2/select-one :model/Card :id question-card-id))))
+      (is (= old-collection-id (:collection_id (t2/select-one :model/Card :id regular-card-id)))))))
+
+(deftest personal-collection-edge-cases-test
+  (testing "Personal collection handling"
+    (binding [collection/*allow-deleting-personal-collections* true]
+      (mt/with-temp [:model/User {user-id :id} {:first_name "Test" :last_name "User" :email "test@example.com"}
+                     :model/Collection {personal-collection-id :id} {:name "Personal Collection"
+                                                                     :personal_owner_id user-id}
+                     :model/Collection {regular-collection-id :id} {:name "Regular Collection"}
+                     :model/Report {report-id :id} {:collection_id regular-collection-id
+                                                    :name "Personal Test Report"}
+                     :model/Card {card-id :id} {:name "Personal Card"
+                                                :type :in_report
+                                                :report_document_id report-id
+                                                :collection_id regular-collection-id
+                                                :dataset_query (mt/mbql-query venues)}]
+
+        (testing "moving report to personal collection moves associated cards"
+          (mt/with-current-user user-id
+          ;; As the personal collection owner, update should succeed
+            (t2/update! :model/Report report-id {:collection_id personal-collection-id})
+
+          ;; Verify both report and card moved to personal collection
+            (is (= personal-collection-id (:collection_id (t2/select-one :model/Report :id report-id))))
+            (is (= personal-collection-id (:collection_id (t2/select-one :model/Card :id card-id))))))
+
+        (testing "moving report from personal collection works"
+          (mt/with-current-user user-id
+          ;; Move back to regular collection
+            (t2/update! :model/Report report-id {:collection_id regular-collection-id})
+
+          ;; Verify both report and card moved back
+            (is (= regular-collection-id (:collection_id (t2/select-one :model/Report :id report-id))))
+            (is (= regular-collection-id (:collection_id (t2/select-one :model/Card :id card-id))))))))))
+
+(deftest validate-collection-move-permissions-allows-move-with-both-permissions-test
+  (testing "allows move when user has write permissions for both collections"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+                     :model/Collection {new-collection-id :id} {:name "New Collection"}
+                     :model/User {user-id :id} {}]
+        (mt/with-current-user user-id
+          ;; Grant write permissions to both collections
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) old-collection-id)
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) new-collection-id)
+
+          ;; Should not throw any exception
+          (is (true? (report/validate-collection-move-permissions old-collection-id new-collection-id))))))))
+
+(deftest validate-collection-move-permissions-throws-403-missing-old-permission-test
+  (testing "throws 403 when user lacks write permission for old collection"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+                     :model/Collection {new-collection-id :id} {:name "New Collection"}
+                     :model/User {user-id :id} {}]
+        (mt/with-current-user user-id
+          ;; Grant write permission only to new collection
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) new-collection-id)
+
+          ;; Should throw 403 exception
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You do not have curate permissions for this Collection."
+                                (report/validate-collection-move-permissions old-collection-id new-collection-id))))))))
+
+(deftest validate-collection-move-permissions-throws-403-missing-new-permission-test
+  (testing "throws 403 when user lacks write permission for new collection"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+                     :model/Collection {new-collection-id :id} {:name "New Collection"}
+                     :model/User {user-id :id} {}]
+        (mt/with-current-user user-id
+          ;; Grant write permission only to old collection
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) old-collection-id)
+
+          ;; Should throw 403 exception
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You do not have curate permissions for this Collection."
+                                (report/validate-collection-move-permissions old-collection-id new-collection-id))))))))
+
+(deftest validate-collection-move-permissions-throws-403-no-permissions-test
+  (testing "throws 403 when user lacks write permissions for both collections"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+                     :model/Collection {new-collection-id :id} {:name "New Collection"}
+                     :model/User {user-id :id} {}]
+        (mt/with-current-user user-id
+          ;; No permissions granted
+
+          ;; Should throw 403 exception
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You do not have curate permissions for this Collection."
+                                (report/validate-collection-move-permissions old-collection-id new-collection-id))))))))
+
+(deftest validate-collection-move-permissions-allows-move-from-root-test
+  (testing "allows move when old collection is nil (moving from root)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {new-collection-id :id} {:name "New Collection"}
+                     :model/User {user-id :id} {}]
+        (mt/with-current-user user-id
+          ;; Grant write permission to new collection
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) new-collection-id)
+
+          ;; Should not throw any exception when old collection is nil
+          (is (true? (report/validate-collection-move-permissions nil new-collection-id))))))))
+
+(deftest validate-collection-move-permissions-allows-move-to-root-test
+  (testing "allows move when new collection is nil (moving to root)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+                     :model/User {user-id :id} {}]
+        (mt/with-current-user user-id
+          ;; Grant write permission to old collection
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) old-collection-id)
+
+          ;; Should not throw any exception when new collection is nil
+          (is (nil? (report/validate-collection-move-permissions old-collection-id nil))))))))
+
+(deftest validate-collection-move-permissions-allows-move-both-nil-test
+  (testing "allows move when both collections are nil"
+    (mt/with-temp [:model/User {user-id :id} {}]
+      (mt/with-current-user user-id
+        ;; Should not throw any exception when both collections are nil
+        (is (nil? (report/validate-collection-move-permissions nil nil)))))))
+
+(deftest validate-collection-move-permissions-throws-400-nonexistent-collection-test
+  (testing "throws 400 when new collection does not exist"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+                     :model/User {user-id :id} {}]
+        (mt/with-current-user user-id
+          ;; Grant write permission to old collection
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) old-collection-id)
+
+          ;; Use a non-existent collection ID
+          (let [non-existent-id 999999]
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You do not have curate permissions for this Collection."
+                                  (report/validate-collection-move-permissions old-collection-id non-existent-id)))))))))
+
+(deftest validate-collection-move-permissions-throws-400-archived-collection-test
+  (testing "throws 400 when new collection is archived"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+                     :model/Collection {archived-collection-id :id} {:name "Archived Collection" :archived true}
+                     :model/User {user-id :id} {}]
+        (mt/with-current-user user-id
+          ;; Grant write permissions to both collections
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) old-collection-id)
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) archived-collection-id)
+
+          ;; Should throw 400 exception for archived collection
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid"
+                                (report/validate-collection-move-permissions old-collection-id archived-collection-id))))))))
+
+(deftest validate-collection-move-permissions-superuser-test
+  (testing "superuser can move between any collections"
+    (mt/with-temp [:model/Collection {old-collection-id :id} {:name "Old Collection"}
+                   :model/Collection {new-collection-id :id} {:name "New Collection"}]
+      (mt/with-current-user (mt/user->id :crowberto)
+        ;; Superuser should be able to move without explicit permissions
+        (is (true? (report/validate-collection-move-permissions old-collection-id new-collection-id)))))))


### PR DESCRIPTION
### Description

Sync collection ids of in_report cards with the report's collection. 

Add checks for collection permissions (irrelevant as long as this is restricted to super users).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
