### PR TITLE
Fix native models e2e test

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -1805,7 +1805,12 @@ describe("issue 45063", { tags: "@flaky" }, () => {
     });
   }
 
-  function verifyListFilter({ fieldDisplayName, fieldValue, fieldValueLabel }) {
+  function verifyListFilter({
+    fieldDisplayName,
+    filterHeaderName,
+    fieldValue,
+    fieldValueLabel,
+  }) {
     H.tableHeaderClick(fieldDisplayName);
     H.popover().findByText("Filter by this column").click();
     H.popover().within(() => {
@@ -1814,13 +1819,14 @@ describe("issue 45063", { tags: "@flaky" }, () => {
       cy.button("Add filter").click();
     });
     cy.findByTestId("qb-filters-panel")
-      .findByText(`${fieldDisplayName} is ${fieldValue}`)
+      .findByText(`${filterHeaderName || fieldDisplayName} is ${fieldValue}`)
       .click();
     H.popover().findByLabelText(fieldValueLabel).should("be.checked");
   }
 
   function verifySearchFilter({
     fieldDisplayName,
+    filterHeaderName,
     fieldPlaceholder,
     fieldValue,
     fieldValueLabel,
@@ -1834,7 +1840,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
       .button("Add filter")
       .click();
     cy.findByTestId("qb-filters-panel")
-      .findByText(`${fieldDisplayName} is ${fieldValue}`)
+      .findByText(`${filterHeaderName || fieldDisplayName} is ${fieldValue}`)
       .should("be.visible");
   }
 
@@ -1842,6 +1848,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
     visitCard,
     fieldId,
     fieldDisplayName,
+    filterHeaderName,
     fieldPlaceholder,
     fieldValue,
     fieldValueLabel,
@@ -1852,7 +1859,12 @@ describe("issue 45063", { tags: "@flaky" }, () => {
     setListValues({ fieldId });
     cy.signInAsNormalUser();
     visitCard();
-    verifyListFilter({ fieldDisplayName, fieldValue, fieldValueLabel });
+    verifyListFilter({
+      fieldDisplayName,
+      filterHeaderName,
+      fieldValue,
+      fieldValueLabel,
+    });
     H.assertQueryBuilderRowCount(expectedRowCount);
 
     cy.log("search values");
@@ -1862,6 +1874,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
     visitCard();
     verifySearchFilter({
       fieldDisplayName,
+      filterHeaderName,
       fieldPlaceholder,
       fieldValue,
       fieldValueLabel,
@@ -1966,6 +1979,7 @@ describe("issue 45063", { tags: "@flaky" }, () => {
         visitCard: () => cy.get("@modelId").then(H.visitModel),
         fieldId: ORDERS.PRODUCT_ID,
         fieldDisplayName: "Product ID",
+        filterHeaderName: "PRODUCT_ID", // the title case version doesn't get picked up in filters
         fieldPlaceholder: "Search by Title or enter an ID",
         fieldValue: 1,
         fieldValueLabel: "Rustic Paper Wallet",


### PR DESCRIPTION
closes dev-720

### Description

This test was totally broken. A change to foreign field handling changed the casing of the product id field to be title case in some places but SCREAMING_SNAKE_CASE in others. This extends the test framework to support this.

<img width="867" height="519" alt="CleanShot 2025-07-31 at 15 34 54" src="https://github.com/user-attachments/assets/d9e8c4bc-c159-44d3-a60e-b082ee2b5670" />
