### PR TITLE
prepare the sdk workflow for 56 release

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -16,6 +16,7 @@ on:
           - release-x.53.x
           - release-x.54.x
           - release-x.55.x
+          - release-x.56.x
           - esbuild-main
 
 concurrency:
@@ -393,7 +394,16 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
-          npm publish --tag ${{fromJson('{"master": "nightly", "release-x.51.x": "51-stable", "release-x.52.x": "52-stable", "release-x.53.x": "53-stable", "release-x.54.x": "54-stable", "release-x.55.x": "55-stable", "esbuild-main": "56-esbuild"}')[inputs.branch]}}
+          npm publish --tag ${{fromJson('{
+           "master": "nightly",
+           "release-x.51.x": "51-stable",
+           "release-x.52.x": "52-stable",
+           "release-x.53.x": "53-stable",
+           "release-x.54.x": "54-stable",
+           "release-x.55.x": "55-stable",
+           "release-x.56.x": "56-nightly",
+           "esbuild-main": "56-esbuild"
+           }')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.55.x`) deployment
         if: ${{ inputs.branch == 'release-x.55.x' }}


### PR DESCRIPTION
https://www.notion.so/metabase/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d
The template already has 56 in it: https://github.com/metabase/metabase/blob/e51666eea6cd73793b886422fc675f53d0f4395c/enterprise/frontend/src/embedding-sdk/package.template.json#L3-L4