### PR TITLE
Prg-108-add-gem-icon-and-free-trial-cta-in-interactive-embedding

### DIFF
--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -206,30 +206,34 @@ describe("embed modal display", () => {
   });
 
   describe("when the user has an OSS instance", () => {
-    it("should display a link to the product page for embedded analytics", () => {
-      cy.signInAsAdmin();
-      H.visitDashboard("@dashboardId");
-      H.openSharingMenu("Embed");
+    it(
+      "should display a link to the product page for embedded analytics",
+      { tags: "@OSS" },
+      () => {
+        cy.signInAsAdmin();
+        H.visitDashboard("@dashboardId");
+        H.openSharingMenu("Embed");
 
-      H.getEmbedModalSharingPane().within(() => {
-        cy.findByText("Static embedding").should("be.visible");
-        cy.findByText("Interactive embedding").should("be.visible");
+        H.getEmbedModalSharingPane().within(() => {
+          cy.findByText("Static embedding").should("be.visible");
+          cy.findByText("Interactive embedding").should("be.visible");
 
-        cy.findByRole("link", { name: "Interactive embedding" }).should(
-          "have.attr",
-          "href",
-          "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=upsell&utm_campaign=embedding-interactive&utm_content=static-embed-popover&source_plan=oss",
-        );
+          cy.findByRole("link", { name: "Interactive embedding" }).should(
+            "have.attr",
+            "href",
+            "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=upsell&utm_campaign=embedding-interactive&utm_content=static-embed-popover&source_plan=oss",
+          );
 
-        cy.findByRole("article", { name: "Interactive embedding" }).within(
-          () => {
-            cy.findByText("Learn more").should("be.visible");
-            cy.findByText("Disabled.").should("not.exist");
-            cy.findByText("Enable in admin settings").should("not.exist");
-          },
-        );
-      });
-    });
+          cy.findByRole("article", { name: "Interactive embedding" }).within(
+            () => {
+              cy.findByText("Learn more").should("be.visible");
+              cy.findByText("Disabled.").should("not.exist");
+              cy.findByText("Enable in admin settings").should("not.exist");
+            },
+          );
+        });
+      },
+    );
   });
 });
 

--- a/frontend/src/metabase/admin/upsells/UpsellEmbeddingButton.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellEmbeddingButton.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
 
-import S from "./components/Upsells.module.css";
+import S from "./components/UpsellCta.module.css";
 import { useUpsellLink } from "./components/use-upsell-link";
 
 export const UpsellEmbeddingButton = ({

--- a/frontend/src/metabase/admin/upsells/UpsellSdkCta.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellSdkCta.tsx
@@ -1,4 +1,5 @@
 import { useSelector } from "metabase/lib/redux";
+import { isEEBuild } from "metabase/lib/utils";
 import { PLUGIN_ADMIN_SETTINGS, PLUGIN_EMBEDDING } from "metabase/plugins";
 import { Box } from "metabase/ui";
 
@@ -43,6 +44,10 @@ export function useUpsellSdkCta() {
 export function UpsellSdkCta() {
   const { url, internalLink, triggerUpsellFlow, trackUpsell } =
     useUpsellSdkCta();
+
+  if (!isEEBuild()) {
+    return null;
+  }
 
   return (
     <Box>

--- a/frontend/src/metabase/admin/upsells/UpsellSdkCta.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellSdkCta.tsx
@@ -1,0 +1,59 @@
+import { useSelector } from "metabase/lib/redux";
+import { PLUGIN_ADMIN_SETTINGS, PLUGIN_EMBEDDING } from "metabase/plugins";
+import { Box } from "metabase/ui";
+
+import { UpsellCta } from "./components/UpsellCta";
+import { trackUpsellClicked } from "./components/analytics";
+import { useUpsellLink } from "./components/use-upsell-link";
+
+export function useUpsellSdkCta() {
+  const campaign = "embedding-interactive";
+  const location = "static-embed-popover";
+
+  const isInteractiveEmbeddingEnabled = useSelector(
+    PLUGIN_EMBEDDING.isInteractiveEmbeddingEnabled,
+  );
+
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
+
+  const trackUpsell = () => trackUpsellClicked({ location, campaign });
+
+  const url = useUpsellLink({
+    url: `https://www.metabase.com/product/embedded-analytics`,
+    campaign,
+    location,
+  });
+
+  if (isInteractiveEmbeddingEnabled) {
+    return {
+      internalLink: "/admin/settings/embedding-in-other-applications/full-app",
+    };
+  }
+
+  return {
+    url,
+    triggerUpsellFlow,
+    trackUpsell,
+  };
+}
+
+export function UpsellSdkCta() {
+  const { url, internalLink, triggerUpsellFlow, trackUpsell } =
+    useUpsellSdkCta();
+
+  return (
+    <Box>
+      <UpsellCta
+        onClick={triggerUpsellFlow}
+        internalLink={internalLink}
+        buttonText="Try it now"
+        url={url}
+        onClickCapture={() => trackUpsell?.()}
+        size="large"
+      />
+    </Box>
+  );
+}

--- a/frontend/src/metabase/admin/upsells/UpsellSdkCta.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellSdkCta.tsx
@@ -1,3 +1,5 @@
+import { t } from "ttag";
+
 import { useSelector } from "metabase/lib/redux";
 import { isEEBuild } from "metabase/lib/utils";
 import { PLUGIN_ADMIN_SETTINGS, PLUGIN_EMBEDDING } from "metabase/plugins";
@@ -54,7 +56,7 @@ export function UpsellSdkCta() {
       <UpsellCta
         onClick={triggerUpsellFlow}
         internalLink={internalLink}
-        buttonText="Try it now"
+        buttonText={t`Try for free`}
         url={url}
         onClickCapture={() => trackUpsell?.()}
         size="large"

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
@@ -62,7 +62,7 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
   onClick,
   ...props
 }: UpsellBannerProps) => {
-  const url = useUpsellLink({
+  const urlWithParams = useUpsellLink({
     url: buttonLink ?? UPGRADE_URL,
     campaign,
     location,
@@ -101,10 +101,9 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
       <Flex align="center" gap="md">
         <UpsellCta
           onClick={onClick}
-          buttonLink={buttonLink}
+          url={buttonLink ? urlWithParams : undefined}
           internalLink={internalLink}
           buttonText={buttonText}
-          url={url}
           onClickCapture={() => trackUpsellClicked({ location, campaign })}
         />
 

--- a/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBanner.tsx
@@ -1,10 +1,7 @@
 import cx from "classnames";
 import { useMount } from "react-use";
-import { P, match } from "ts-pattern";
 import { t } from "ttag";
 
-import ExternalLink from "metabase/common/components/ExternalLink";
-import Link from "metabase/common/components/Link";
 import {
   Box,
   Flex,
@@ -21,6 +18,7 @@ import {
   type DismissibleProps,
   UpsellWrapperDismissible,
 } from "./UpsellBannerDismissible";
+import { UpsellCta } from "./UpsellCta";
 import { UpsellGem } from "./UpsellGem";
 import { UpsellWrapper } from "./UpsellWrapper";
 import S from "./Upsells.module.css";
@@ -101,62 +99,14 @@ export const _UpsellBanner: React.FC<UpsellBannerProps> = ({
       </Flex>
 
       <Flex align="center" gap="md">
-        {match({ onClick, buttonLink, internalLink })
-          .with(
-            {
-              onClick: P.nonNullable,
-              buttonLink: P.any,
-              internalLink: P.nullish,
-            },
-            (args) => (
-              <UnstyledButton
-                onClick={() => {
-                  trackUpsellClicked({ location, campaign });
-                  args.onClick();
-                }}
-                className={S.UpsellCTALink}
-              >
-                {buttonText}
-              </UnstyledButton>
-            ),
-          )
-          .with(
-            {
-              onClick: P.any,
-              buttonLink: P.nonNullable,
-              internalLink: P.nullish,
-            },
-            () => (
-              <ExternalLink
-                onClickCapture={() =>
-                  trackUpsellClicked({ location, campaign })
-                }
-                href={url}
-                className={S.UpsellCTALink}
-              >
-                {buttonText}
-              </ExternalLink>
-            ),
-          )
-          .with(
-            {
-              onClick: P.any,
-              buttonLink: P.any,
-              internalLink: P.nonNullable,
-            },
-            (args) => (
-              <Link
-                onClickCapture={() =>
-                  trackUpsellClicked({ location, campaign })
-                }
-                to={args.internalLink}
-                className={S.UpsellCTALink}
-              >
-                {buttonText}
-              </Link>
-            ),
-          )
-          .otherwise(() => null)}
+        <UpsellCta
+          onClick={onClick}
+          buttonLink={buttonLink}
+          internalLink={internalLink}
+          buttonText={buttonText}
+          url={url}
+          onClickCapture={() => trackUpsellClicked({ location, campaign })}
+        />
 
         {dismissible && (
           <UnstyledButton

--- a/frontend/src/metabase/admin/upsells/components/UpsellBigCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellBigCard.tsx
@@ -6,6 +6,7 @@ import { Box, Flex, Image, Stack, Text, Title } from "metabase/ui";
 
 import { UPGRADE_URL } from "../constants";
 
+import StylesUpsellCtaLink from "./UpsellCta.module.css";
 import { UpsellGem } from "./UpsellGem";
 import { UpsellWrapper } from "./UpsellWrapper";
 import S from "./Upsells.module.css";
@@ -75,7 +76,7 @@ export const _UpsellBigCard: React.FC<UpsellBigCardProps> = ({
             .with(P.nonNullable, () => (
               <Box
                 component="button"
-                className={S.UpsellCTALink}
+                className={StylesUpsellCtaLink.UpsellCTALink}
                 onClickCapture={() =>
                   trackUpsellClicked({ location, campaign })
                 }
@@ -86,7 +87,7 @@ export const _UpsellBigCard: React.FC<UpsellBigCardProps> = ({
             ))
             .otherwise(() => (
               <ExternalLink
-                className={S.UpsellCTALink}
+                className={StylesUpsellCtaLink.UpsellCTALink}
                 href={url}
                 onClickCapture={() =>
                   trackUpsellClicked({ location, campaign })

--- a/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
@@ -60,7 +60,7 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
   onClick,
   ...props
 }: UpsellCardProps) => {
-  const url = useUpsellLink({
+  const urlWithParams = useUpsellLink({
     url: buttonLink ?? UPGRADE_URL,
     campaign,
     location,
@@ -100,10 +100,9 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
           <Box mx="md" mb="lg">
             <UpsellCta
               onClick={onClick}
-              buttonLink={buttonLink}
+              url={buttonLink ? urlWithParams : undefined}
               internalLink={internalLink}
               buttonText={buttonText}
-              url={url}
               onClickCapture={() => trackUpsellClicked({ location, campaign })}
             />
           </Box>

--- a/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCard.tsx
@@ -1,21 +1,11 @@
 import cx from "classnames";
 import { useMount } from "react-use";
-import { P, match } from "ts-pattern";
 
-import ExternalLink from "metabase/common/components/ExternalLink";
-import Link from "metabase/common/components/Link";
-import {
-  Box,
-  Flex,
-  Image,
-  Stack,
-  Text,
-  Title,
-  UnstyledButton,
-} from "metabase/ui";
+import { Box, Flex, Image, Stack, Text, Title } from "metabase/ui";
 
 import { UPGRADE_URL } from "../constants";
 
+import { UpsellCta } from "./UpsellCta";
 import { UpsellGem } from "./UpsellGem";
 import { UpsellWrapper } from "./UpsellWrapper";
 import S from "./Upsells.module.css";
@@ -108,62 +98,14 @@ export const _UpsellCard: React.FC<UpsellCardProps> = ({
             {children}
           </Text>
           <Box mx="md" mb="lg">
-            {match({ onClick, buttonLink, internalLink })
-              .with(
-                {
-                  onClick: P.nonNullable,
-                  buttonLink: P.any,
-                  internalLink: P.nullish,
-                },
-                (args) => (
-                  <UnstyledButton
-                    onClick={() => {
-                      trackUpsellClicked({ location, campaign });
-                      args.onClick();
-                    }}
-                    className={S.UpsellCTALink}
-                  >
-                    {buttonText}
-                  </UnstyledButton>
-                ),
-              )
-              .with(
-                {
-                  onClick: P.nullish,
-                  buttonLink: P.nonNullable,
-                  internalLink: P.nullish,
-                },
-                () => (
-                  <ExternalLink
-                    onClickCapture={() =>
-                      trackUpsellClicked({ location, campaign })
-                    }
-                    href={url}
-                    className={S.UpsellCTALink}
-                  >
-                    {buttonText}
-                  </ExternalLink>
-                ),
-              )
-              .with(
-                {
-                  onClick: P.any,
-                  buttonLink: P.any,
-                  internalLink: P.nonNullable,
-                },
-                (args) => (
-                  <Link
-                    onClickCapture={() =>
-                      trackUpsellClicked({ location, campaign })
-                    }
-                    to={args.internalLink}
-                    className={S.UpsellCTALink}
-                  >
-                    {buttonText}
-                  </Link>
-                ),
-              )
-              .otherwise(() => null)}
+            <UpsellCta
+              onClick={onClick}
+              buttonLink={buttonLink}
+              internalLink={internalLink}
+              buttonText={buttonText}
+              url={url}
+              onClickCapture={() => trackUpsellClicked({ location, campaign })}
+            />
           </Box>
         </Stack>
       </Stack>

--- a/frontend/src/metabase/admin/upsells/components/UpsellCta.module.css
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCta.module.css
@@ -1,0 +1,27 @@
+@import "./Upsells.base.module.css";
+
+.UpsellCTALink {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: center;
+  flex-grow: 0;
+  font-weight: bold;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 2rem;
+  color: var(--mb-color-upsell-primary);
+  background-color: var(--mb-color-upsell-secondary);
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--mb-color-upsell-primary);
+    color: var(--mb-color-text-white);
+  }
+
+  &.Large {
+    font-size: 0.875rem;
+    padding: 0.75rem 1rem;
+  }
+}

--- a/frontend/src/metabase/admin/upsells/components/UpsellCta.stories.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCta.stories.tsx
@@ -1,3 +1,5 @@
+import { action } from "@storybook/addon-actions";
+
 import { UpsellCta } from "./UpsellCta";
 
 export default {
@@ -7,22 +9,31 @@ export default {
 
 export const CtaButton = () => (
   <UpsellCta
-    onClick={() => {}}
-    buttonLink=""
-    internalLink=""
+    onClick={action("clicked")}
+    internalLink={undefined}
     buttonText="Try it now"
-    url=""
+    url={undefined}
     onClickCapture={() => {}}
+  />
+);
+
+export const CtaButtonLarge = () => (
+  <UpsellCta
+    onClick={action("clicked")}
+    internalLink={undefined}
+    buttonText="Try it now"
+    url={undefined}
+    onClickCapture={() => {}}
+    size="large"
   />
 );
 
 export const CtaExternalLink = () => (
   <UpsellCta
     onClick={undefined}
-    buttonLink="https://store.metabase.com"
+    url="https://store.metabase.com"
     internalLink={undefined}
     buttonText="Try it now"
-    url=""
     onClickCapture={() => {}}
   />
 );
@@ -30,10 +41,9 @@ export const CtaExternalLink = () => (
 export const CtaInternalLink = () => (
   <UpsellCta
     onClick={undefined}
-    buttonLink={undefined}
     internalLink="/admin/settings/embed"
     buttonText="Try it now"
-    url=""
+    url={undefined}
     onClickCapture={() => {}}
   />
 );

--- a/frontend/src/metabase/admin/upsells/components/UpsellCta.stories.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCta.stories.tsx
@@ -1,0 +1,39 @@
+import { UpsellCta } from "./UpsellCta";
+
+export default {
+  title: "Patterns/Upsells/UpsellCta",
+  component: UpsellCta,
+};
+
+export const CtaButton = () => (
+  <UpsellCta
+    onClick={() => {}}
+    buttonLink=""
+    internalLink=""
+    buttonText="Try it now"
+    url=""
+    onClickCapture={() => {}}
+  />
+);
+
+export const CtaExternalLink = () => (
+  <UpsellCta
+    onClick={undefined}
+    buttonLink="https://store.metabase.com"
+    internalLink={undefined}
+    buttonText="Try it now"
+    url=""
+    onClickCapture={() => {}}
+  />
+);
+
+export const CtaInternalLink = () => (
+  <UpsellCta
+    onClick={undefined}
+    buttonLink={undefined}
+    internalLink="/admin/settings/embed"
+    buttonText="Try it now"
+    url=""
+    onClickCapture={() => {}}
+  />
+);

--- a/frontend/src/metabase/admin/upsells/components/UpsellCta.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCta.tsx
@@ -1,0 +1,78 @@
+import { P, match } from "ts-pattern";
+
+import ExternalLink from "metabase/common/components/ExternalLink";
+import Link from "metabase/common/components/Link";
+import { UnstyledButton } from "metabase/ui";
+
+import S from "./Upsells.module.css";
+
+type UpsellCtaProps = {
+  onClick: (() => void) | undefined;
+  buttonLink: string | undefined;
+  internalLink: string | undefined;
+  buttonText: string;
+  url: string | undefined;
+  onClickCapture: () => void;
+};
+
+export function UpsellCta({
+  onClick,
+  onClickCapture,
+  buttonLink,
+  internalLink,
+  buttonText,
+  url,
+}: UpsellCtaProps) {
+  return match({ onClick, buttonLink, internalLink })
+    .with(
+      {
+        onClick: P.nonNullable,
+        buttonLink: P.any,
+        internalLink: P.nullish,
+      },
+      (args) => (
+        <UnstyledButton
+          onClick={() => {
+            args.onClick();
+            onClickCapture?.();
+          }}
+          className={S.UpsellCTALink}
+        >
+          {buttonText}
+        </UnstyledButton>
+      ),
+    )
+    .with(
+      {
+        onClick: P.any,
+        buttonLink: P.nonNullable,
+        internalLink: P.nullish,
+      },
+      () => (
+        <ExternalLink
+          onClickCapture={onClickCapture}
+          href={url}
+          className={S.UpsellCTALink}
+        >
+          {buttonText}
+        </ExternalLink>
+      ),
+    )
+    .with(
+      {
+        onClick: P.any,
+        buttonLink: P.any,
+        internalLink: P.nonNullable,
+      },
+      (args) => (
+        <Link
+          onClickCapture={onClickCapture}
+          to={args.internalLink}
+          className={S.UpsellCTALink}
+        >
+          {buttonText}
+        </Link>
+      ),
+    )
+    .otherwise(() => null);
+}

--- a/frontend/src/metabase/admin/upsells/components/UpsellCta.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCta.tsx
@@ -1,33 +1,38 @@
+import cx from "classnames";
 import { P, match } from "ts-pattern";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
 import Link from "metabase/common/components/Link";
 import { UnstyledButton } from "metabase/ui";
 
-import S from "./Upsells.module.css";
+import S from "./UpsellCta.module.css";
 
 type UpsellCtaProps = {
   onClick: (() => void) | undefined;
-  buttonLink: string | undefined;
   internalLink: string | undefined;
   buttonText: string;
   url: string | undefined;
   onClickCapture: () => void;
+  size?: "default" | "large";
 };
 
 export function UpsellCta({
   onClick,
   onClickCapture,
-  buttonLink,
   internalLink,
   buttonText,
   url,
+  size = "default",
 }: UpsellCtaProps) {
-  return match({ onClick, buttonLink, internalLink })
+  const className = cx(S.UpsellCTALink, {
+    [S.Large]: size === "large",
+  });
+
+  return match({ onClick, url, internalLink })
     .with(
       {
         onClick: P.nonNullable,
-        buttonLink: P.any,
+        url: P.any,
         internalLink: P.nullish,
       },
       (args) => (
@@ -36,7 +41,7 @@ export function UpsellCta({
             args.onClick();
             onClickCapture?.();
           }}
-          className={S.UpsellCTALink}
+          className={className}
         >
           {buttonText}
         </UnstyledButton>
@@ -45,14 +50,14 @@ export function UpsellCta({
     .with(
       {
         onClick: P.any,
-        buttonLink: P.nonNullable,
+        url: P.nonNullable,
         internalLink: P.nullish,
       },
       () => (
         <ExternalLink
           onClickCapture={onClickCapture}
           href={url}
-          className={S.UpsellCTALink}
+          className={className}
         >
           {buttonText}
         </ExternalLink>
@@ -61,14 +66,14 @@ export function UpsellCta({
     .with(
       {
         onClick: P.any,
-        buttonLink: P.any,
+        url: P.any,
         internalLink: P.nonNullable,
       },
       (args) => (
         <Link
           onClickCapture={onClickCapture}
           to={args.internalLink}
-          className={S.UpsellCTALink}
+          className={className}
         >
           {buttonText}
         </Link>

--- a/frontend/src/metabase/admin/upsells/components/UpsellCta.unit.spec.tsx
+++ b/frontend/src/metabase/admin/upsells/components/UpsellCta.unit.spec.tsx
@@ -1,0 +1,133 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { UpsellCta } from "./UpsellCta";
+
+function setup({
+  buttonText,
+  url,
+  internalLink,
+  onClick,
+}: {
+  buttonText: string;
+  url?: string;
+  internalLink?: string;
+  onClick?: () => void;
+}) {
+  const user = userEvent.setup();
+  const mockOnClick = jest.fn();
+  const mockOnClickCapture = jest.fn();
+
+  renderWithProviders(
+    <>
+      <Route path="/admin/settings" component={() => <div>Settings</div>} />
+      <Route
+        path="/"
+        component={() => (
+          <UpsellCta
+            onClick={onClick}
+            onClickCapture={mockOnClickCapture}
+            buttonText={buttonText}
+            url={url}
+            internalLink={internalLink}
+          />
+        )}
+      />
+    </>,
+    {
+      withRouter: true,
+      initialRoute: "/",
+    },
+  );
+
+  return {
+    user,
+    mockOnClick,
+    mockOnClickCapture,
+  };
+}
+
+describe("UpsellCta", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("onClick variant", () => {
+    it("should render as UnstyledButton when onClick is provided", async () => {
+      const mockOnClick = jest.fn();
+
+      const { mockOnClickCapture, user } = setup({
+        onClick: mockOnClick,
+        buttonText: "Click me",
+      });
+
+      const button = screen.getByRole("button", { name: "Click me" });
+      await user.click(button);
+
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+      expect(mockOnClickCapture).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("external URL variant", () => {
+    it("should render as ExternalLink when url is provided", async () => {
+      const { mockOnClickCapture, user } = setup({
+        buttonText: "External link",
+        url: "https://example.com",
+      });
+
+      const link = screen.getByRole("link", { name: "External link" });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "https://example.com");
+      await user.click(link);
+
+      expect(mockOnClickCapture).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("internal link variant", () => {
+    it("should render as Link when internalLink is provided", async () => {
+      const { mockOnClickCapture, user } = setup({
+        buttonText: "Internal link",
+        internalLink: "/admin/settings",
+      });
+
+      const link = screen.getByText("Internal link");
+      expect(link).toBeInTheDocument();
+      expect(link.tagName).toBe("A");
+
+      await user.click(link);
+
+      expect(mockOnClickCapture).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("priority handling", () => {
+    it("should prioritize onClick over url when both are provided", () => {
+      setup({
+        onClick: jest.fn(),
+        buttonText: "Priority test",
+        url: "https://example.com",
+      });
+      const button = screen.getByRole("button", { name: "Priority test" });
+      expect(button).toBeInTheDocument();
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+
+    it("should prioritize url over internalLink when both are provided", () => {
+      setup({
+        buttonText: "Priority test",
+        url: "https://example.com",
+        internalLink: "/admin/settings",
+      });
+
+      // Based on the current implementation, when both url and internalLink are provided,
+      // the internalLink pattern matches first, so it renders an internal Link
+      const link = screen.getByText("Priority test");
+      expect(link).toBeInTheDocument();
+      expect(link.tagName).toBe("A");
+    });
+  });
+});

--- a/frontend/src/metabase/admin/upsells/components/Upsells.base.module.css
+++ b/frontend/src/metabase/admin/upsells/components/Upsells.base.module.css
@@ -1,0 +1,9 @@
+/**
+ * The upsell color palette is designed to function in harmony with the original Metabase set of Blues, Grays and Purples
+ * but with a twist. All three colors are new and should not be used elsewhere in the product experience.
+ */
+:root {
+  --mb-color-upsell-primary: #005999;
+  --mb-color-upsell-secondary: #bff4ff;
+  --mb-color-upsell-gem: #00d4ff;
+}

--- a/frontend/src/metabase/admin/upsells/components/Upsells.module.css
+++ b/frontend/src/metabase/admin/upsells/components/Upsells.module.css
@@ -1,12 +1,4 @@
-/**
- * The upsell color palette is designed to function in harmony with the original Metabase set of Blues, Grays and Purples
- * but with a twist. All three colors are new and should not be used elsewhere in the product experience.
- */
-:root {
-  --mb-color-upsell-primary: #005999;
-  --mb-color-upsell-secondary: #bff4ff;
-  --mb-color-upsell-gem: #00d4ff;
-}
+@import "./Upsells.base.module.css";
 
 .UpsellGem {
   color: var(--mb-color-upsell-gem);

--- a/frontend/src/metabase/admin/upsells/components/Upsells.module.css
+++ b/frontend/src/metabase/admin/upsells/components/Upsells.module.css
@@ -5,32 +5,6 @@
   flex-shrink: 0;
 }
 
-.UpsellCTALink {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  justify-content: center;
-  flex-grow: 0;
-  font-weight: bold;
-  font-size: 0.75rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 2rem;
-  color: var(--mb-color-upsell-primary);
-  background-color: var(--mb-color-upsell-secondary);
-  text-decoration: none;
-  cursor: pointer;
-
-  &:hover {
-    background-color: var(--mb-color-upsell-primary);
-    color: var(--mb-color-text-white);
-  }
-}
-
-.UpsellCTALink.Large {
-  font-size: 0.875rem;
-  padding: 0.75rem 1rem;
-}
-
 .UpsellBannerComponent {
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/admin/upsells/components/index.ts
+++ b/frontend/src/metabase/admin/upsells/components/index.ts
@@ -2,3 +2,4 @@ export * from "./UpsellBanner";
 export * from "./UpsellBigCard";
 export * from "./UpsellCard";
 export * from "./UpsellPill";
+export { UpsellGem } from "./UpsellGem";

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/tests/EmbedModalContent.enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/tests/EmbedModalContent.enterprise.unit.spec.tsx
@@ -6,6 +6,7 @@ function setupEnterprise(opts?: Partial<SetupOpts>) {
   setup({
     ...opts,
     hasEnterprisePlugins: true,
+    isHosted: false,
   });
 }
 
@@ -19,7 +20,7 @@ describe("EmbedModalContent", () => {
 
         // The card is clickable
         expect(
-          screen.queryByRole("link", { name: INTERACTIVE_EMBEDDING_TITLE }),
+          screen.queryByRole("link", { name: "Learn more" }),
         ).toHaveProperty(
           "href",
           "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=upsell&utm_campaign=embedding-interactive&utm_content=static-embed-popover&source_plan=oss",
@@ -40,6 +41,10 @@ describe("EmbedModalContent", () => {
             "Enable in admin settings",
           ),
         ).not.toBeInTheDocument();
+
+        expect(
+          screen.getByRole("button", { name: "Try for free" }),
+        ).toBeInTheDocument();
       });
     });
 
@@ -49,7 +54,7 @@ describe("EmbedModalContent", () => {
 
         // The card is clickable
         expect(
-          screen.queryByRole("link", { name: INTERACTIVE_EMBEDDING_TITLE }),
+          screen.queryByRole("link", { name: "Learn more" }),
         ).toHaveProperty(
           "href",
           "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=upsell&utm_campaign=embedding-interactive&utm_content=static-embed-popover&source_plan=oss",

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/tests/EmbedModalContent.premium.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/tests/EmbedModalContent.premium.unit.spec.tsx
@@ -9,6 +9,7 @@ function setupPremium(opts?: Partial<SetupOpts>) {
     ...opts,
     hasEnterprisePlugins: true,
     tokenFeatures: createMockTokenFeatures({ embedding: true }),
+    isHosted: true,
   });
 }
 

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/tests/setup.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/tests/setup.tsx
@@ -21,6 +21,7 @@ export interface SetupOpts {
   props?: Partial<EmbedModalContentProps>;
   hasEnterprisePlugins?: boolean;
   tokenFeatures?: TokenFeatures;
+  isHosted?: boolean;
 }
 
 export function setup(
@@ -48,6 +49,7 @@ export function setup(
     } = {},
     hasEnterprisePlugins,
     tokenFeatures,
+    isHosted,
   }: SetupOpts = {
     props: {},
   },
@@ -58,7 +60,7 @@ export function setup(
     "enable-embedding-interactive": enableEmbeddingInteractive,
     "enable-embedding-sdk": enableEmbeddingSdk,
     "embedding-secret-key": "my_super_secret_key",
-    "is-hosted?": hasEnterprisePlugins,
+    "is-hosted?": isHosted ?? false,
   });
 
   if (hasEnterprisePlugins) {

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/tests/setup.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/tests/setup.tsx
@@ -58,6 +58,7 @@ export function setup(
     "enable-embedding-interactive": enableEmbeddingInteractive,
     "enable-embedding-sdk": enableEmbeddingSdk,
     "embedding-secret-key": "my_super_secret_key",
+    "is-hosted?": hasEnterprisePlugins,
   });
 
   if (hasEnterprisePlugins) {

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -2,12 +2,12 @@ import cx from "classnames";
 import { type ComponentProps, useState } from "react";
 import { t } from "ttag";
 
+import { UpsellGem } from "metabase/admin/upsells/components";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import Link from "metabase/common/components/Link";
 import { useDocsUrl, useSetting, useUrlWithUtm } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import type { ExportFormatType } from "metabase/embedding/components/PublicLinkPopover/types";
-import { Badge } from "metabase/home/components/EmbedHomepage/Badge";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_EMBEDDING } from "metabase/plugins";
 import { trackPublicLinkRemoved } from "metabase/public/lib/analytics";
@@ -133,7 +133,7 @@ export function SelectEmbedTypePane({
         >
           <SharingPaneButton
             title={t`Interactive embedding`}
-            badge={<Badge color="brand">{t`Pro`}</Badge>}
+            badge={<UpsellGem />}
             illustration={<InteractiveEmbeddingIllustration />}
             isDisabled={
               isInteractiveEmbeddingAvailable && !isInteractiveEmbeddingEnabled
@@ -167,11 +167,7 @@ export function SelectEmbedTypePane({
         >
           <SharingPaneButton
             title={t`Embedded analytics SDK`}
-            badge={
-              <>
-                <Badge color="brand">{t`Pro`}</Badge>
-              </>
-            }
+            badge={<UpsellGem />}
             illustration={<SdkIllustration />}
             isDisabled={!isEmbeddingSdkEnabled}
             disabledLink={"/admin/settings/embedding-in-other-applications/sdk"}

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -47,6 +47,7 @@ export function SelectEmbedTypePane({
   getPublicUrl,
   goToNextStep,
 }: SelectEmbedTypePaneProps) {
+  const { url } = useUpsellSdkCta();
   const hasPublicLink = resource.public_uuid != null;
 
   const utmTags = {
@@ -147,7 +148,7 @@ export function SelectEmbedTypePane({
               <List.Item>{t`Let people click to explore.`}</List.Item>
               <List.Item>
                 {t`Customize appearance with your logo, font, and colors.`}{" "}
-                {!isInteractiveEmbeddingAvailable && <LearnMore />}
+                {!isInteractiveEmbeddingAvailable && <LearnMore url={url} />}
               </List.Item>
             </List>
             {!isInteractiveEmbeddingAvailable && <UpsellSdkCta />}
@@ -206,9 +207,16 @@ export function SelectEmbedTypePane({
   );
 }
 
-function LearnMore() {
+function LearnMore({ url }: { url: string | undefined }) {
+  if (!url) {
+    return null;
+  }
+
   return (
-    <ExternalLink style={{ fontWeight: "bold" }}>{t`Learn more`}</ExternalLink>
+    <ExternalLink
+      href={url}
+      style={{ fontWeight: "bold" }}
+    >{t`Learn more`}</ExternalLink>
   );
 }
 

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -10,7 +10,7 @@ import {
 import { UpsellGem } from "metabase/admin/upsells/components";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import Link from "metabase/common/components/Link";
-import { useDocsUrl, useSetting, useUrlWithUtm } from "metabase/common/hooks";
+import { useDocsUrl, useSetting } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import type { ExportFormatType } from "metabase/embedding/components/PublicLinkPopover/types";
 import { useSelector } from "metabase/lib/redux";
@@ -220,33 +220,6 @@ function LearnMore({ url }: { url: string | undefined }) {
   );
 }
 
-export const useInteractiveEmbeddingCta = () => {
-  const isInteractiveEmbeddingEnabled = useSelector(
-    PLUGIN_EMBEDDING.isInteractiveEmbeddingEnabled,
-  );
-
-  const url = useUrlWithUtm(
-    `https://www.metabase.com/product/embedded-analytics`,
-    {
-      utm_source: "product",
-      utm_medium: "upsell",
-      utm_campaign: "embedding-interactive",
-      utm_content: "static-embed-popover",
-    },
-  );
-
-  if (isInteractiveEmbeddingEnabled) {
-    return {
-      url: "/admin/settings/embedding-in-other-applications/full-app",
-    };
-  }
-
-  return {
-    url,
-    target: "_blank",
-  };
-};
-
 interface MaybeLinkInteractiveEmbeddingProps {
   shouldRenderLink?: boolean;
   children: React.ReactNode;
@@ -301,6 +274,7 @@ function MaybeLinkInteractiveEmbedding({
 interface MaybeLinkProps extends ComponentProps<typeof Link> {
   shouldRenderLink?: boolean;
 }
+
 function MaybeLink({ shouldRenderLink, ...props }: MaybeLinkProps) {
   if (shouldRenderLink) {
     return <Link {...props} />;

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SharingPaneButton/SharingPaneButton.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SharingPaneButton/SharingPaneButton.tsx
@@ -45,8 +45,8 @@ export const SharingPaneButton = ({
       <Stack pb={isDisabled ? "md" : undefined}>
         <Center mb={32}>{illustration}</Center>
         <Group align="center" gap="sm">
-          <Title order={2}>{title}</Title>
           {badge}
+          <Title order={2}>{title}</Title>
         </Group>
         {children}
       </Stack>


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-108/add-gem-icon-and-free-trial-cta-in-interactive-embedding-block

### Description

Two main things were done here:
- Replacing "pro plan` badges with Gem icons
- Adding the new upsell flow for EE builds with embedding not available
- Refactors:
    - Extracting `<UpsellCta>` component
    - Moving upsell logic to a separate hook and component
 

### Demo

https://www.loom.com/share/c9761d485d7a4eefaab37cb39b49a1d2?sid=844203bb-a582-4fca-b3f4-dee4603f2a3b

https://metaboat.slack.com/archives/C08N6CX5EMQ/p1754318807250499?thread_ts=1754053681.078399&cid=C08N6CX5EMQ

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
