### PR TITLE
chore(sdk): bump minimum react version to 18

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -27,7 +27,7 @@
   },
   "types": "./dist/index.d.ts",
   "peerDependencies": {
-    "react": ">=17 <=19",
-    "react-dom": ">=17 <=19"
+    "react": ">=18 <=19",
+    "react-dom": ">=18 <=19"
   }
 }


### PR DESCRIPTION
The last version of the sdk that supports react 17 is 53: https://metaboat.slack.com/archives/C063Q3F1HPF/p1754055392741539

This updates the package.json to reflect taht

Triple backport because:
backport: 56
double: 55
triple: 54