### PR TITLE
exlucde apache commons lang3

### DIFF
--- a/modules/drivers/clickhouse/deps.edn
+++ b/modules/drivers/clickhouse/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src" "resources"]
  :deps
- {com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.4"}
+ {com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.4"
+                                  :exclusions [org.apache.commons/commons-lang3]}
   org.lz4/lz4-java {:mvn/version "1.8.0"}}}


### PR DESCRIPTION
solves https://github.com/metabase/metabase/security/code-scanning/493

but this is actually not an issue at all. When we build the driver jars we remove deps provided by metabase itself. Metabase itself relies on

```
org.apache.commons/commons-lang3          {:mvn/version "3.18.0"}
```

```clojure
(defn- remove-provided-libs [basis driver edition]
  (let [provided-lib->provider (into {}
                                     (filter (fn [[lib]]
                                               (get-in basis [:libs lib])))
                                     (provided-libs driver edition))]
    ;; log which libs we're including and excluding.
    (doseq [lib (sort (keys (:libs basis)))]
      (u/announce (if-let [provider (get provided-lib->provider lib)]
                    (format "SKIP    %%s (provided by %s)" provider)
                    "INCLUDE %s")
                  (colorize/yellow lib)))
    ;; now remove the provide libs from `:classpath`, `:classpath-roots`, and `:libs`
    (let [provided-libs-set  (into #{} (keys provided-lib->provider))
          provided-paths-set (into #{} (mapcat #(get-in basis [:libs % :paths])) provided-libs-set)]
      (-> basis
          (update :classpath-roots #(vec (remove provided-paths-set %)))
          (update :libs            #(into {} (remove (fn [[lib]] (provided-libs-set lib))) %))
          (update :classpath       #(into {} (remove (fn [[path]] (provided-paths-set path))) %))))))
```

That output looks like:

```
    Write :clickhouse :ee uberjar -> /home/runner/work/metabase/metabase/resources/modules/clickhouse.metabase-driver.jar
         SKIP    org.clojure/clojure (provided by metabase-core)
          SKIP    org.clojure/core.specs.alpha (provided by metabase-core)
          SKIP    org.clojure/spec.alpha (provided by metabase-core)
          INCLUDE com.clickhouse/clickhouse-client
          INCLUDE com.clickhouse/clickhouse-data
          INCLUDE com.clickhouse/clickhouse-http-client
          INCLUDE com.clickhouse/clickhouse-jdbc
          INCLUDE com.clickhouse/client-v2
          INCLUDE com.clickhouse/jdbc-v2
          SKIP    com.fasterxml.jackson.core/jackson-core (provided by metabase-core)
          SKIP    com.google.errorprone/error_prone_annotations (provided by metabase-core)
          SKIP    com.google.guava/failureaccess (provided by metabase-core)
          SKIP    com.google.guava/guava (provided by metabase-core)
          SKIP    com.google.guava/listenablefuture (provided by metabase-core)
          SKIP    com.google.j2objc/j2objc-annotations (provided by metabase-core)
          SKIP    commons-codec/commons-codec (provided by metabase-core)
          SKIP    commons-io/commons-io (provided by metabase-core)
          SKIP    org.apache.commons/commons-compress (provided by metabase-core)
          SKIP    org.apache.commons/commons-lang3 (provided by metabase-core) <------------------
          SKIP    org.apache.httpcomponents.client5/httpclient5 (provided by metabase-core)
          SKIP    org.apache.httpcomponents.core5/httpcore5 (provided by metabase-core)
          SKIP    org.apache.httpcomponents.core5/httpcore5-h2 (provided by metabase-core)
          SKIP    org.clojure/clojure (provided by metabase-core)
          SKIP    org.clojure/core.specs.alpha (provided by metabase-core)
          SKIP    org.clojure/spec.alpha (provided by metabase-core)
          SKIP    org.jspecify/jspecify (provided by metabase-core)
          INCLUDE org.lz4/lz4-java
          SKIP    org.ow2.asm/asm (provided by metabase-core)
          INCLUDE org.roaringbitmap/RoaringBitmap
          INCLUDE org.roaringbitmap/shims
          SKIP    org.slf4j/slf4j-api (provided by metabase-core)
```

But this is included here in the hopes that it appeases snyk