### PR TITLE
Throw 404s rather than 403s

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -244,7 +244,7 @@
 
 ;; #### GENERIC 404 RESPONSE HELPERS
 (def ^:private generic-404
-  [404 (tru "You don''t have permissions to do that or it does not exist.")])
+  [404 (deferred-tru "You don''t have permissions to do that or it does not exist.")])
 
 (defn check-404
   "Throw a `404` if `arg` is `false` or `nil`, otherwise return as-is."

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -244,7 +244,7 @@
 
 ;; #### GENERIC 404 RESPONSE HELPERS
 (def ^:private generic-404
-  [404 (deferred-tru "Not found.")])
+  [404 (tru "You don''t have permissions to do that or it does not exist.")])
 
 (defn check-404
   "Throw a `404` if `arg` is `false` or `nil`, otherwise return as-is."
@@ -260,7 +260,7 @@
 ;; #### GENERIC 403 RESPONSE HELPERS
 ;; If you can't be bothered to write a custom error message
 (defn- generic-403 []
-  [403 (tru "You don''t have permissions to do that.")])
+  [404 (tru "You don''t have permissions to do that or it does not exist.")])
 
 (defn check-403
   "Throw a `403` (no permissions) if `arg` is `false` or `nil`, otherwise return as-is."

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -876,8 +876,8 @@
                  {:status-code 422})
 
         (not (mi/can-read? table))
-        (ex-info (tru "You don''t have permissions to do that.")
-                 {:status-code 403}))))
+        (ex-info (tru "You don''t have permissions to do that or it does not exist.")
+                 {:status-code 404}))))
 
 (defn- check-can-update
   "Throws an error if the user cannot upload to the given database and schema."
@@ -900,8 +900,8 @@
                {:status-code 422})
 
       (not (mi/can-write? table))
-      (ex-info (tru "You don''t have permissions to do that.")
-               {:status-code 403}))))
+      (ex-info (tru "You don''t have permissions to do that or it does not exist.")
+               {:status-code 404}))))
 
 (defn- check-can-delete
   "Throws an error if the given table is not an upload, or if the user does not have permission to delete it."


### PR DESCRIPTION
mechanically throw 404s

still a few locations where we do 403s but it is very tangibly about user permissions to an action and not a resource

src/metabase/pulse/models/pulse_channel.clj
201:                              {:status-code 403})))))))))

src/metabase/setup/api.clj
49:            {:status-code 403})))

src/metabase/permissions/util.clj
321:                    {:status-code 403})))
335:                    {:status-code 403})))
349:                    {:status-code 403})))

src/metabase/cloud_migration/models/cloud_migration.clj
71:                      {:status-code 403}))))

src/metabase/actions/execution.clj
77:                     (assoc :status-code 403)

src/metabase/actions/actions.clj
300:              (throw (ex-info (i18n/tru "You don''t have permissions to do that.") {:status-code 403})))

src/metabase/parameters/custom_values.clj
136:                      (throw (ex-info "You don't have permissions to do that." {:status-code 403})))

src/metabase/api/common.clj
276:   (throw (ex-info (tru "You don''t have permissions to do that.") {:status-code 403} e))))

src/metabase/upload/impl.clj
466:               {:status-code 403})
496:                 {:status-code 403})
880:                 {:status-code 403}))))
904:               {:status-code 403}))))
