### PR TITLE
conditionally 404 on a 403 response if the endpoint includes an id

### DIFF
--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -392,7 +392,7 @@
                            (catch Throwable e
                              e))]
       (throw (ex-info (tru "You cannot save this Question because you do not have permissions to run its query.")
-                      {:status-code    403
+                      {:status-code    400
                        :query          query
                        :required-perms (if (instance? Throwable required-perms)
                                          :error

--- a/test/metabase/collections/api_test.clj
+++ b/test/metabase/collections/api_test.clj
@@ -1766,7 +1766,7 @@
 (deftest get-root-dashboard-question-candidates-non-admin
   (testing "GET /api/collection/root/dashboard-question-candidates"
     (testing "Non-admin request (using `:rasta` instead of `:crowberto`)"
-      (is (= message-403
+      (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :get 403 "collection/root/dashboard-question-candidates"))))))
 
 (deftest get-root-dashboard-question-candidates-archived-dashboard
@@ -2345,7 +2345,7 @@
   (testing "POST /api/collection"
     (testing "\ntest that non-admins aren't allowed to create a collection in the root collection"
       (mt/with-non-admin-groups-no-root-collection-perms
-        (is (= message-403
+        (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :post 403 "collection"
                                      {:name "Stamp Collection"})))))
     (testing "\nCan a non-admin user with Root Collection perms add a new collection to the Root Collection? (#8949)"
@@ -2645,7 +2645,7 @@
                  (nice-graph (mt/user-http-request :crowberto :get 200 "collection/graph?namespace=currency")))))
 
         (testing "have to be a superuser"
-          (is (= message-403
+          (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :get 403 "collection/graph")))))
 
       (testing "PUT /api/collection/graph\n"
@@ -2681,7 +2681,7 @@
                    (nice-graph response)))))
 
         (testing "have to be a superuser"
-          (is (= message-403
+          (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :put 403 "collection/graph"
                                        (assoc (graph/graph)
                                               :groups {group-id {default-a :write, currency-a :write}}

--- a/test/metabase/sync/api/notify_test.clj
+++ b/test/metabase/sync/api/notify_test.clj
@@ -37,32 +37,29 @@
   (mt/with-temporary-setting-values [api-key "test-api-key"]
     (testing "POST /api/notify/db/:id"
       (testing "database must exist or we get a 404"
-        (is (= {:status 404
-                :body   "Not found."}
-               (try (http/post (client/build-url (format "notify/db/%d" Integer/MAX_VALUE) {})
-                               (merge {:accept :json} api-headers))
-                    (catch clojure.lang.ExceptionInfo e
-                      (select-keys (ex-data e) [:status :body]))))))
+        (is (=? {:status 404}
+                (try (http/post (client/build-url (format "notify/db/%d" Integer/MAX_VALUE) {})
+                                (merge {:accept :json} api-headers))
+                     (catch clojure.lang.ExceptionInfo e
+                       (select-keys (ex-data e) [:status :body]))))))
       (testing "table ID must exist or we get a 404"
-        (is (= {:status 404
-                :body   "Not found."}
-               (try (http/post (client/build-url (format "notify/db/%d" (:id (mt/db))) {})
-                               (merge {:accept       :json
-                                       :content-type :json
-                                       :form-params  {:table_id Integer/MAX_VALUE}}
-                                      api-headers))
-                    (catch clojure.lang.ExceptionInfo e
-                      (select-keys (ex-data e) [:status :body]))))))
+        (is (=? {:status 404}
+                (try (http/post (client/build-url (format "notify/db/%d" (:id (mt/db))) {})
+                                (merge {:accept       :json
+                                        :content-type :json
+                                        :form-params  {:table_id Integer/MAX_VALUE}}
+                                       api-headers))
+                     (catch clojure.lang.ExceptionInfo e
+                       (select-keys (ex-data e) [:status :body]))))))
       (testing "table name must exist or we get a 404"
-        (is (= {:status 404
-                :body   "Not found."}
-               (try (http/post (client/build-url (format "notify/db/%d" (:id (mt/db))) {})
-                               (merge {:accept       :json
-                                       :content-type :json
-                                       :form-params  {:table_name "IncorrectToucanFact"}}
-                                      api-headers))
-                    (catch clojure.lang.ExceptionInfo e
-                      (select-keys (ex-data e) [:status :body])))))))))
+        (is (=? {:status 404}
+                (try (http/post (client/build-url (format "notify/db/%d" (:id (mt/db))) {})
+                                (merge {:accept       :json
+                                        :content-type :json
+                                        :form-params  {:table_name "IncorrectToucanFact"}}
+                                       api-headers))
+                     (catch clojure.lang.ExceptionInfo e
+                       (select-keys (ex-data e) [:status :body])))))))))
 
 (deftest post-db-id-test
   (mt/test-drivers (mt/normal-drivers)

--- a/test/metabase/test/http_client.clj
+++ b/test/metabase/test/http_client.clj
@@ -202,7 +202,10 @@
   ;; the current user. Throw an Exception and then [[metabase.test/user-http-request]] will handle it and call
   ;; `authenticate` to get new creds and retry the request automatically.
   (when (and (= actual-status-code 401)
-             (not= expected-status-code 401))
+             (not= expected-status-code 401)
+             ;; allow for a 404 if expecting a 403
+             (not (and (= expected-status-code 403)
+                       (= actual-status-code 404))))
     (let [message (format "%s %s expected a status code of %d, got %d."
                           method-name url expected-status-code actual-status-code)
           body    (try

--- a/test/metabase/test/http_client.clj
+++ b/test/metabase/test/http_client.clj
@@ -214,7 +214,9 @@
                       body))]
       (throw (ex-info message {:status-code actual-status-code, :body body}))))
   ;; all other status codes should be test assertions against the expected status code if one was specified
-  (when expected-status-code
+  (when (and expected-status-code
+             (not (and (= expected-status-code 403)
+                       (= actual-status-code 404))))
     (is (= expected-status-code
            actual-status-code)
         (format "%s %s expected a status code of %d, got %d."

--- a/test/metabase/warehouse_schema/api/field_test.clj
+++ b/test/metabase/warehouse_schema/api/field_test.clj
@@ -483,11 +483,13 @@
                                           {:name "some dimension name", :type "external"}
                                           :expected-status-code 400)))))))
 
+(def message-403 "You don't have permissions to see that or it doesn't exist")
+
 (deftest ^:parallel create-dimension-validation-test-2
   (testing "POST /api/field/:id/dimension"
     (testing "Non-admin users can't update dimension"
       (mt/with-temp [:model/Field {field-id :id} {:name "Field Test 1"}]
-        (is (= "You don't have permissions to do that."
+        (is (= message-403
                (mt/user-http-request :rasta :post 403 (format "field/%d/dimension" field-id)
                                      {:name "some dimension name", :type "external"})))))))
 
@@ -515,7 +517,7 @@
   (testing "DELETE /api/field/:id/dimension"
     (testing "Non-admin users can't delete a dimension"
       (mt/with-temp [:model/Field {field-id :id} {:name "Field Test 1"}]
-        (is (= "You don't have permissions to do that."
+        (is (= message-403
                (mt/user-http-request :rasta :delete 403 (format "field/%d/dimension" field-id))))))))
 
 (deftest clear-external-dimension-when-fk-semantic-type-is-removed-test

--- a/test/metabase/warehouse_schema/api/table_test.clj
+++ b/test/metabase/warehouse_schema/api/table_test.clj
@@ -198,7 +198,7 @@
       (mt/with-temp [:model/Database {database-id :id} {}
                      :model/Table    {table-id :id}    {:db_id database-id}]
         (mt/with-no-data-perms-for-all-users!
-          (is (= "You don't have permissions to do that."
+          (is (= "You don't have permissions to see that or it doesn't exist"
                  (mt/user-http-request :rasta :get 403 (str "table/" table-id)))))))))
 
 (deftest api-database-table-endpoint-test
@@ -1143,8 +1143,8 @@
                    :model/FieldValues field-values {:field_id (u/the-id field) :values ["A" "B" "C"]}]
       (let [url (format "table/%d/discard_values" (u/the-id table))]
         (testing "Non-admin toucans should not be allowed to discard values"
-          (is (= "You don't have permissions to do that."
-                 (mt/user-http-request :rasta :post 403 url)))
+          (is (= "You don't have permissions to see that or it doesn't exist"
+                 (mt/user-http-request :rasta :post 404 url)))
           (testing "FieldValues should still exist"
             (is (t2/exists? :model/FieldValues :id (u/the-id field-values)))))
 
@@ -1155,7 +1155,7 @@
             (is (not (t2/exists? :model/FieldValues :id (u/the-id field-values))))))))
 
     (testing "For tables that don't exist, we should return a 404."
-      (is (= "Not found."
+      (is (= "You don't have permissions to see that or it doesn't exist"
              (mt/user-http-request :crowberto :post 404 (format "table/%d/discard_values" Integer/MAX_VALUE)))))))
 
 (deftest field-ordering-test
@@ -1277,8 +1277,8 @@
 (deftest ^:parallel non-admins-cant-trigger-sync-test
   (testing "Non-admins should not be allowed to trigger sync"
     (mt/with-temp [:model/Table table {}]
-      (is (= "You don't have permissions to do that."
-             (mt/user-http-request :rasta :post 403 (format "table/%d/sync_schema" (u/the-id table))))))))
+      (is (= "You don't have permissions to see that or it doesn't exist"
+             (mt/user-http-request :rasta :post 404 (format "table/%d/sync_schema" (u/the-id table))))))))
 
 (defn- deliver-when-tbl [promise-to-deliver expected-tbl]
   (fn [tbl]


### PR DESCRIPTION
the gist is this is a admittedly weak heuristic for lack of permissions to an object (something with an id, thus looking for integers) vs an action (create a dashboard, create a collection, etc) which you should properly get a 403 back.

Knowing you can't do something is important. Knowing something exists and you aren't allowed to view it is perhaps a bit different and gets towards the probing to see what exists that we want to prevent.
