### PR TITLE
Optimize search filtering for only personal collections

### DIFF
--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -95,7 +95,9 @@
     "only-mine"
     [:or
      [:= :collection.personal_owner_id current-user-id]
-     [:like :collection.location (format "/%d/%%" (t2/select-one-pk :model/Collection :personal_owner_id [:= current-user-id]))]]
+     [:like :collection.location (format "/%d/%%" (t2/select-one-pk :model/Collection
+                                                                    :personal_owner_id [:= current-user-id]
+                                                                    :location          "/"))]]
 
     "exclude-others"
     (let [with-filter #(personal-collections-where-clause

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -103,7 +103,7 @@
                         collection-id-col)]
       [:or (with-filter "only-mine") (with-filter "exclude")])
 
-    (let [personal-ids   (t2/select-pks-vec :model/Collection :personal_owner_id [:not= nil])
+    (let [personal-ids   (t2/select-pks-vec :model/Collection :personal_owner_id [:not= nil] :location "/")
           child-patterns (for [id personal-ids] (format "/%d/%%" id))]
       (case filter-type
         "only"


### PR DESCRIPTION
I was looking at this code when answering a question from Thomas, and spotted what looks like a performance bug. 

I'm not 100% sure it's an actual problem in practice - I think `personal_owner_id` is only ever set for root collections, but the queries might as well be consistent!

This reminds me of how convenient it would be to have a `top_level_personal_owner_id` column on the rows in the index themselves...