### PR TITLE
submit init function, not results

### DIFF
--- a/src/metabase/search/task/search_index.clj
+++ b/src/metabase/search/task/search_index.clj
@@ -43,7 +43,7 @@
   (search/reindex!))
 
 (defmethod startup/def-startup-logic! ::SearchIndexInit [_]
-  (quick-task/submit-task! (init!)))
+  (quick-task/submit-task! init!))
 
 (defmethod task/init! ::SearchIndexReindex [_]
   (let [job         (jobs/build


### PR DESCRIPTION
was blocking on startup
stacktrace below is representative. has a few other things like reveal but shows that we get into a huge loop over all cards and you end up waiting for the instance to be ready for a long time
```
	at metabase.lib.card$fn__77290$fn__77297.invoke(card.cljc:71)
	at metabase.lib.card$fn__77302$__GT_card_metadata_columns77301__77303$fn__77304.invoke(card.cljc:141)
	at clojure.core$mapv$fn__8569.invoke(core.clj:7059)
	at clojure.lang.PersistentVector.reduce(PersistentVector.java:418)
	at clojure.core$reduce.invokeStatic(core.clj:6964)
	at clojure.core$mapv.invokeStatic(core.clj:7050)
	at clojure.core$mapv.invoke(core.clj:7050)
	at metabase.lib.card$fn__77302$__GT_card_metadata_columns77301__77303.invoke(card.cljc:141)
	at metabase.lib.card$fn__77302$fn__77308.invoke(card.cljc:120)
	at metabase.lib.card$fn__77316$card_cols_STAR_77315__77317.invoke(card.cljc:163)
	at metabase.lib.card$fn__77316$fn__77322.invoke(card.cljc:157)
	at metabase.lib.card$fn__77350$card_metadata_columns77349__77351.invoke(card.cljc:223)
	at metabase.lib.card$fn__77350$fn__77354.invoke(card.cljc:217)
	at metabase.lib.card$eval77367$_AMPERSAND_f__77368.invoke(card.cljc:257)
	at metabase.lib.card$eval77367$fn__77372.invoke(card.cljc:242)
	at clojure.lang.MultiFn.invoke(MultiFn.java:244)
	at metabase.lib.metadata.calculation$fn__74776$returned_columns74775__74777$fn__74778.invoke(calculation.cljc:524)
	at metabase.lib.metadata.cache$fn__74548$do_with_cached_value74547__74549.invoke(cache.cljc:104)
	at metabase.lib.metadata.cache$fn__74548$fn__74555.invoke(cache.cljc:92)
	at metabase.lib.metadata.calculation$fn__74776$returned_columns74775__74777.invoke(calculation.cljc:523)
	at metabase.lib.metadata.calculation$fn__74776$fn__74781.invoke(calculation.cljc:503)
	at metabase.lib.metadata.calculation$fn__74776$returned_columns74775__74777.invoke(calculation.cljc:516)
	at metabase.lib.metadata.calculation$fn__74776$fn__74781.invoke(calculation.cljc:503)
	at metabase.lib.field.resolution$fn__80775$resolve_in_card_returned_columns80774__80776.invoke(resolution.cljc:352)
	at metabase.lib.field.resolution$fn__80775$fn__80784.invoke(resolution.cljc:346)
	at metabase.lib.field.resolution$fn__80788$resolve_in_card_or_stage_metadata80787__80789.invoke(resolution.cljc:365)
	at metabase.lib.field.resolution$fn__80788$fn__80801.invoke(resolution.cljc:358)
	at metabase.lib.field.resolution$resolve_from_previous_stage_or_source_STAR_.invokeStatic(resolution.cljc:410)
	at metabase.lib.field.resolution$resolve_from_previous_stage_or_source_STAR_.invoke(resolution.cljc:390)
	at metabase.lib.field.resolution$fn__80844$resolve_from_previous_stage_or_source80843__80845.invoke(resolution.cljc:440)
	at metabase.lib.field.resolution$fn__80844$fn__80861.invoke(resolution.cljc:434)
	at metabase.lib.field.resolution$fn__80865$resolve_field_ref80864__80867.invoke(resolution.cljc:471)
	at metabase.lib.field.resolution$fn__80865$fn__80878.invoke(resolution.cljc:457)
	at metabase.lib.field$eval80922$_AMPERSAND_f__80923.invoke(field.cljc:62)
	at metabase.lib.field$eval80922$fn__80925.invoke(field.cljc:60)
	at clojure.lang.MultiFn.invoke(MultiFn.java:239)
	at metabase.lib.metadata.calculation$fn__74679$metadata74678__74680$fn__74681.invoke(calculation.cljc:287)
	at metabase.lib.metadata.cache$fn__74548$do_with_cached_value74547__74549.invoke(cache.cljc:104)
	at metabase.lib.metadata.cache$fn__74548$fn__74555.invoke(cache.cljc:92)
	at metabase.lib.metadata.calculation$fn__74679$metadata74678__74680.invoke(calculation.cljc:286)
	at metabase.lib.metadata.calculation$fn__74679$fn__74684.invoke(calculation.cljc:275)
	at metabase.lib.breakout$fn__80328$breakouts_metadata80327__80329$fn__80331.invoke(breakout.cljc:43)
	at clojure.core$mapv$fn__8569.invoke(core.clj:7059)
	at clojure.lang.PersistentVector.reduce(PersistentVector.java:418)
	at clojure.core$reduce.invokeStatic(core.clj:6964)
	at clojure.core$mapv.invokeStatic(core.clj:7050)
	at clojure.core$mapv.invoke(core.clj:7050)
	at metabase.lib.breakout$fn__80328$breakouts_metadata80327__80329.invoke(breakout.cljc:42)
	at metabase.lib.breakout$fn__80328$fn__80334.invoke(breakout.cljc:35)
	at metabase.lib.stage$fn__81784$breakouts_columns81783__81785.invoke(stage.cljc:59)
	at metabase.lib.stage$fn__81784$fn__81787.invoke(stage.cljc:55)
	at metabase.lib.stage$fn__81843$summary_columns81842__81844.invoke(stage.cljc:92)
	at metabase.lib.stage$fn__81843$fn__81846.invoke(stage.cljc:86)
	at metabase.lib.stage$eval81986$_AMPERSAND_f__81988.invoke(stage.cljc:290)
	at metabase.lib.stage$eval81986$fn__81996.invoke(stage.cljc:283)
	at clojure.lang.MultiFn.invoke(MultiFn.java:244)
	at metabase.lib.metadata.calculation$fn__74776$returned_columns74775__74777$fn__74778.invoke(calculation.cljc:524)
	at metabase.lib.metadata.cache$fn__74548$do_with_cached_value74547__74549.invoke(cache.cljc:104)
	at metabase.lib.metadata.cache$fn__74548$fn__74555.invoke(cache.cljc:92)
	at metabase.lib.metadata.calculation$fn__74776$returned_columns74775__74777.invoke(calculation.cljc:523)
	at metabase.lib.metadata.calculation$fn__74776$fn__74781.invoke(calculation.cljc:503)
	at metabase.lib.metadata.calculation$fn__74776$returned_columns74775__74777.invoke(calculation.cljc:516)
	at metabase.lib.metadata.calculation$fn__74776$fn__74781.invoke(calculation.cljc:503)
	at metabase.lib.metadata.calculation$fn__74776$returned_columns74775__74777.invoke(calculation.cljc:513)
	at metabase.lib.metadata.calculation$fn__74776$fn__74781.invoke(calculation.cljc:503)
	at metabase.lib.metadata.calculation$fn__74776$returned_columns74775__74777.invoke(calculation.cljc:510)
	at metabase.lib.metadata.calculation$fn__74776$fn__74781.invoke(calculation.cljc:503)
	at metabase.queries.models.card$dataset_query__GT_dimensions.invokeStatic(card.clj:1270)
	at metabase.queries.models.card$dataset_query__GT_dimensions.invoke(card.clj:1262)
	at metabase.queries.models.card$extract_non_temporal_dimension_ids.invokeStatic(card.clj:1277)
	at metabase.queries.models.card$extract_non_temporal_dimension_ids.invoke(card.clj:1274)
	at metabase.search.ingestion$execute_function_attr.invokeStatic(ingestion.clj:68)
	at metabase.search.ingestion$execute_function_attr.invoke(ingestion.clj:63)
	at metabase.search.ingestion$execute_all_function_attrs$fn__131886.invoke(ingestion.clj:80)
	at clojure.lang.PersistentHashMap$NodeSeq.kvreduce(PersistentHashMap.java:1309)
	at clojure.lang.PersistentHashMap$BitmapIndexedNode.kvreduce(PersistentHashMap.java:804)
	at clojure.lang.PersistentHashMap$NodeSeq.kvreduce(PersistentHashMap.java:1314)
	at clojure.lang.PersistentHashMap$BitmapIndexedNode.kvreduce(PersistentHashMap.java:804)
	at clojure.lang.PersistentHashMap.kvreduce(PersistentHashMap.java:238)
	at clojure.core$fn__8559.invokeStatic(core.clj:6987)
	at clojure.core$fn__8559.invoke(core.clj:6967)
	at clojure.core.protocols$fn__8287$G__8282__8296.invoke(protocols.clj:174)
	at clojure.core$reduce_kv.invokeStatic(core.clj:6998)
	at clojure.core$reduce_kv.invoke(core.clj:6989)
	at metabase.search.ingestion$execute_all_function_attrs.invokeStatic(ingestion.clj:76)
	at metabase.search.ingestion$execute_all_function_attrs.invoke(ingestion.clj:73)
	at metabase.search.ingestion$__GT_document.invokeStatic(ingestion.clj:87)
	at metabase.search.ingestion$__GT_document.invoke(ingestion.clj:85)
	at clojure.core$map$fn__5952$fn__5953.invoke(core.clj:2759)
	at medley.core$distinct_by$fn__15232$fn__15233.invoke(core.cljc:290)
	at clojure.core$map$fn__5952$fn__5953.invoke(core.clj:2759)
	at clojure.core$completing$fn__8562.invoke(core.clj:7010)
	at clojure.core$map$fn__5952$fn__5953.invoke(core.clj:2759)
	at toucan2.pipeline$with_init$fn__51829.invoke(pipeline.clj:327)
	at clojure.core$completing$fn__8562.invoke(core.clj:7010)
	at toucan2.jdbc.result_set$reduce_result_set.invokeStatic(result_set.clj:156)
	at toucan2.jdbc.result_set$reduce_result_set.invoke(result_set.clj:125)
	at toucan2.jdbc.query$reduce_jdbc_query.invokeStatic(query.clj:51)
	at toucan2.jdbc.query$reduce_jdbc_query.invoke(query.clj:22)
	at toucan2.jdbc.pipeline$transduce_execute_with_connection_primary_method_java_sql_Connection_default_default.invokeStatic(pipeline.clj:19)
	at toucan2.jdbc.pipeline$transduce_execute_with_connection_primary_method_java_sql_Connection_default_default.invoke(pipeline.clj:9)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:15)
	at methodical.impl.combo.threaded$combine_methods_thread_last$fn__23165$combined_method_thread_last__23166.invoke(threaded.clj:64)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:65)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:216)
	at toucan2.pipeline$transduce_execute$with_connection_STAR___51727.invoke(pipeline.clj:78)
	at toucan2.connection$bind_current_connectable_fn$fn__51305.invoke(connection.clj:104)
	at toucan2.connection$bind_current_connectable_fn$fn__51305.invoke(connection.clj:104)
	at toucan2.jdbc.connection$do_with_connection_primary_method_java_sql_Connection.invokeStatic(connection.clj:13)
	at toucan2.jdbc.connection$do_with_connection_primary_method_java_sql_Connection.invoke(connection.clj:11)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invokeStatic(connection.clj:118)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invoke(connection.clj:106)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:55)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:210)
	at toucan2.connection$do_with_connection_primary_method_.invokeStatic(connection.clj:204)
	at toucan2.connection$do_with_connection_primary_method_.invoke(connection.clj:194)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invokeStatic(connection.clj:118)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invoke(connection.clj:106)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:55)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:210)
	at toucan2.pipeline$transduce_execute.invokeStatic(pipeline.clj:77)
	at toucan2.pipeline$transduce_execute.invoke(pipeline.clj:64)
	at clojure.lang.Var.invoke(Var.java:401)
	at toucan2.pipeline$transduce_compiled_query.invokeStatic(pipeline.clj:244)
	at toucan2.pipeline$transduce_compiled_query.invoke(pipeline.clj:240)
	at toucan2.pipeline$transduce_built_query.invokeStatic(pipeline.clj:252)
	at toucan2.pipeline$transduce_built_query.invoke(pipeline.clj:246)
	at toucan2.pipeline$transduce_query_primary_method_default.invokeStatic(pipeline.clj:272)
	at toucan2.pipeline$transduce_query_primary_method_default.invoke(pipeline.clj:269)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:15)
	at methodical.impl.combo.threaded$combine_methods_thread_last$fn__23165$combined_method_thread_last__23166.invoke(threaded.clj:64)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:65)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:216)
	at toucan2.pipeline$transduce_query_STAR_.invokeStatic(pipeline.clj:278)
	at toucan2.pipeline$transduce_query_STAR_.invoke(pipeline.clj:274)
	at toucan2.pipeline$transduce_with_model.invokeStatic(pipeline.clj:293)
	at toucan2.pipeline$transduce_with_model.invoke(pipeline.clj:280)
	at toucan2.pipeline$transduce_parsed.invokeStatic(pipeline.clj:309)
	at toucan2.pipeline$transduce_parsed.invoke(pipeline.clj:295)
	at clojure.lang.AFn.applyToHelper(AFn.java:160)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.core$apply.invokeStatic(core.clj:669)
	at clojure.core$apply.invoke(core.clj:662)
	at toucan2.pipeline$reducible_fn$reify__51862.reduce(pipeline.clj:404)
	at clojure.core$transduce.invokeStatic(core.clj:7025)
	at clojure.core.Eduction.reduce(core.clj:7874)
	at clojure.core$reduce.invokeStatic(core.clj:6964)
	at clojure.core$reduce.invoke(core.clj:6947)
	at metabase.util$rconcat$reify__16182.coll_reduce(util.cljc:1188)
	at clojure.core$transduce.invokeStatic(core.clj:7026)
	at clojure.core.Eduction.reduce(core.clj:7874)
	at clojure.core$transduce.invokeStatic(core.clj:7025)
	at clojure.core$transduce.invokeStatic(core.clj:7021)
	at clojure.core$transduce.invoke(core.clj:7012)
	at metabase.search.appdb.index$index_docs_BANG_.invokeStatic(index.clj:279)
	at metabase.search.appdb.index$index_docs_BANG_.invoke(index.clj:275)
	at metabase.search.appdb.core$populate_index_BANG_.invokeStatic(core.clj:169)
	at metabase.search.appdb.core$populate_index_BANG_.invoke(core.clj:168)
	at metabase.search.appdb.core$eval132669$fn__132671.invoke(core.clj:182)
	at clojure.lang.MultiFn.invoke(MultiFn.java:234)
	at metabase.search.core$init_index_BANG_$iter__133794__133798$fn__133799.invoke(core.clj:91)
	at clojure.lang.LazySeq.force(LazySeq.java:50)
	at clojure.lang.LazySeq.realize(LazySeq.java:89)
	at clojure.lang.LazySeq.seq(LazySeq.java:106)
	at clojure.lang.RT.seq(RT.java:555)
	at clojure.core$seq__5488.invokeStatic(core.clj:139)
	at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:24)
	at clojure.core.protocols$fn__8266.invokeStatic(protocols.clj:74)
	at clojure.core.protocols$fn__8266.invoke(protocols.clj:74)
	at clojure.core.protocols$fn__8207$G__8202__8220.invoke(protocols.clj:13)
	at clojure.core$reduce.invokeStatic(core.clj:6965)
	at clojure.core$reduce.invoke(core.clj:6947)
	at metabase.search.core$init_index_BANG_.invokeStatic(core.clj:88)
	at metabase.search.core$init_index_BANG_.doInvoke(core.clj:80)
	at clojure.lang.RestFn.invoke(RestFn.java:411)
	at metabase.search.task.search_index$init_BANG_$fn__173098.invoke(search_index.clj:38)
	at metabase.app_db.cluster_lock$do_with_cluster_lock_STAR_$with_connection_STAR___126394$with_transaction_STAR___126395.invoke(cluster_lock.clj:61)
	at toucan2.connection$bind_current_connectable_fn$fn__51305.invoke(connection.clj:104)
	at metabase.app_db.connection$do_transaction$thunk__61025.invoke(connection.clj:145)
	at metabase.app_db.connection$do_transaction.invokeStatic(connection.clj:164)
	at metabase.app_db.connection$do_transaction.invoke(connection.clj:141)
	at metabase.app_db.connection$do_with_transaction_primary_method_java_sql_Connection.invokeStatic(connection.clj:201)
	at metabase.app_db.connection$do_with_transaction_primary_method_java_sql_Connection.invoke(connection.clj:174)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:13)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at toucan2.connection$do_with_transaction_around_method_toucan2_connection_default.invokeStatic(connection.clj:249)
	at toucan2.connection$do_with_transaction_around_method_toucan2_connection_default.invoke(connection.clj:245)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:13)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:58)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:212)
	at metabase.app_db.cluster_lock$do_with_cluster_lock_STAR_$with_connection_STAR___126394.invoke(cluster_lock.clj:53)
	at toucan2.connection$bind_current_connectable_fn$fn__51305.invoke(connection.clj:104)
	at toucan2.connection$bind_current_connectable_fn$fn__51305.invoke(connection.clj:104)
	at toucan2.connection$bind_current_connectable_fn$fn__51305.invoke(connection.clj:104)
	at toucan2.jdbc.connection$do_with_connection_primary_method_javax_sql_DataSource.invokeStatic(connection.clj:18)
	at toucan2.jdbc.connection$do_with_connection_primary_method_javax_sql_DataSource.invoke(connection.clj:15)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invokeStatic(connection.clj:118)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invoke(connection.clj:106)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:55)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:210)
	at metabase.app_db.connection$do_with_connection_primary_method_default.invokeStatic(connection.clj:132)
	at metabase.app_db.connection$do_with_connection_primary_method_default.invoke(connection.clj:130)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invokeStatic(connection.clj:118)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invoke(connection.clj:106)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:55)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:210)
	at toucan2.connection$do_with_connection_primary_method_.invokeStatic(connection.clj:204)
	at toucan2.connection$do_with_connection_primary_method_.invoke(connection.clj:194)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invokeStatic(connection.clj:118)
	at toucan2.connection$do_with_connection_around_method_toucan2_connection_default.invoke(connection.clj:106)
	at methodical.impl.combo.common$partial_STAR_$fn__22829.invoke(common.clj:12)
	at methodical.util.FnWithMeta.invoke(util.clj:46)
	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:55)
	at methodical.impl.standard$invoke_multifn.invoke(standard.clj:47)
	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:210)
	at metabase.app_db.cluster_lock$do_with_cluster_lock_STAR_.invokeStatic(cluster_lock.clj:53)
	at metabase.app_db.cluster_lock$do_with_cluster_lock_STAR_.invoke(cluster_lock.clj:51)
	at metabase.app_db.cluster_lock$fn__126406$do_with_cluster_lock126405__126407$do_with_cluster_lock_STAR__STAR___126409.invoke(cluster_lock.clj:78)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$apply.invoke(core.clj:662)
	at metabase.util.retry$decorate$fn$reify__126370.call(retry.clj:110)
	at io.github.resilience4j.retry.Retry.lambda$decorateCallable$5(Retry.java:306)
	at metabase.util.retry$decorate$fn__126369.doInvoke(retry.clj:111)
	at clojure.lang.RestFn.invoke(RestFn.java:400)
	at metabase.util.retry$fn__126375$make126374__126376$fn__126377.invoke(retry.clj:120)
	at metabase.app_db.cluster_lock$fn__126406$do_with_cluster_lock126405__126407.invoke(cluster_lock.clj:82)
	at metabase.app_db.cluster_lock$fn__126406$fn__126412.invoke(cluster_lock.clj:63)
	at metabase.app_db.cluster_lock$fn__126406$do_with_cluster_lock126405__126407.invoke(cluster_lock.clj:75)
	at metabase.app_db.cluster_lock$fn__126406$fn__126412.invoke(cluster_lock.clj:63)
	at metabase.search.task.search_index$init_BANG_.invokeStatic(search_index.clj:37)
	at metabase.search.task.search_index$init_BANG_.invoke(search_index.clj:33)
	at metabase.search.task.search_index$eval173156$fn__173157.invoke(search_index.clj:46)
	at metabase.startup.core$run_startup_logic_BANG_$fn__173079.invoke(core.clj:30)
	at metabase.startup.core$run_startup_logic_BANG_.invokeStatic(core.clj:28)
	at metabase.startup.core$run_startup_logic_BANG_.invoke(core.clj:24)
	at metabase.core.core$init_BANG__STAR_.invokeStatic(core.clj:181)
	at metabase.core.core$init_BANG__STAR_.invoke(core.clj:117)
	at metabase.core.core$init_BANG_.invokeStatic(core.clj:194)
	at metabase.core.core$init_BANG_.invoke(core.clj:189)
	at dev$init_BANG_.invokeStatic(dev.clj:143)
	at dev$init_BANG_.invoke(dev.clj:139)
	at dev$start_BANG_.invokeStatic(dev.clj:180)
	at dev$start_BANG_.invoke(dev.clj:176)
	at dev$eval206099.invokeStatic(NO_SOURCE_FILE:1)
	at dev$eval206099.invoke(NO_SOURCE_FILE:1)
	at clojure.lang.Compiler.eval(Compiler.java:7739)
	at clojure.lang.Compiler.eval(Compiler.java:7729)
	at clojure.lang.Compiler.eval(Compiler.java:7694)
	at clojure.core$eval.invokeStatic(core.clj:3232)
	at clojure.core$eval.invoke(core.clj:3228)
	at vlaaad.reveal.repl$wrap_eval$fn__37945.invoke(repl.clj:90)
	at clojure.main$repl$read_eval_print__9248$fn__9251.invoke(main.clj:437)
	at clojure.main$repl$read_eval_print__9248.invoke(main.clj:437)
	at clojure.main$repl$fn__9257.invoke(main.clj:459)
	at clojure.main$repl.invokeStatic(main.clj:459)
	at clojure.main$repl.doInvoke(main.clj:368)
	at clojure.lang.RestFn.applyTo(RestFn.java:140)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$apply.invoke(core.clj:662)
```

> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
