### PR TITLE
Send CORS headers for localhost regardless of whether SDK is enabled or not

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -516,6 +516,7 @@
            public-sharing
            queries
            query-processor
+           server
            settings
            tiles
            util}}
@@ -1097,6 +1098,7 @@
    :api  #{metabase.server.core
            metabase.server.init
            metabase.server.middleware.session
+           metabase.server.settings
            metabase.server.streaming-response} ; TODO -- too many API namespaces
    :uses #{analytics
            api

--- a/docs/configuring-metabase/config-template.md
+++ b/docs/configuring-metabase/config-template.md
@@ -134,7 +134,7 @@ config:
     email-smtp-username: null
     email-smtp-username-override: null
     embedding-app-origins-interactive: null
-    embedding-app-origins-sdk: localhost:*
+    embedding-app-origins-sdk: ""
     embedding-homepage: hidden
     embedding-secret-key: null
     enable-embedding-interactive: false

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -562,7 +562,7 @@ Allow these space delimited origins to embed Metabase interactive.
 > Only available on Metabase [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.
 
 - Type: string
-- Default: `localhost:*`
+- Default: `""`
 - [Configuration file name](./config-file.md): `embedding-app-origins-sdk`
 
 Allow Metabase SDK access to these space delimited origins.

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -220,6 +220,7 @@ export const createMockSettings = (
   "help-link-custom-destination": "",
   "deprecation-notice-version": undefined,
   "development-mode?": false,
+  "disable-cors-on-localhost": false,
   "ee-ai-features-enabled": false,
   "ee-openai-model": "",
   "ee-openai-api-key": "",

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -430,6 +430,7 @@ interface AdminSettings {
   "active-users-count"?: number;
   "custom-geojson-enabled": boolean;
   "deprecation-notice-version"?: string;
+  "disable-cors-on-localhost": boolean;
   "embedding-secret-key"?: string;
   "redirect-all-requests-to-https": boolean;
   "query-caching-min-ttl": number;

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -44,6 +44,7 @@ export function EmbeddingSdkSettings() {
 
   const isReactSdkEnabled = useSetting("enable-embedding-sdk");
   const isReactSdkFeatureEnabled = PLUGIN_EMBEDDING_SDK.isEnabled();
+  const isLocalhostCorsDisabled = useSetting("disable-cors-on-localhost");
 
   const isSimpleEmbedEnabled = useSetting("enable-embedding-simple");
   const isSimpleEmbedFeatureEnabled =
@@ -128,6 +129,10 @@ export function EmbeddingSdkSettings() {
           .jt`You can test Embedded analytics SDK on localhost quickly by using API keys. To use the SDK on other sites, ${ImplementJwtLink}.`,
     )
     .otherwise(() => null);
+
+  const corsHintText = isLocalhostCorsDisabled
+    ? t`Separate values with a space. Localhost is not allowed. Changes will take effect within one minute.`
+    : t`Separate values with a space. Localhost is automatically included. Changes will take effect within one minute.`;
 
   return (
     <SettingsPageWrapper title={t`Modular embedding`}>
@@ -245,7 +250,7 @@ export function EmbeddingSdkSettings() {
                   <HoverCard.Dropdown>
                     <Box p="md" w={270}>
                       <Text lh="lg" c="text-medium">
-                        {t`Separate values with a space. Localhost is automatically included. Changes will take effect within one minute.`}
+                        {corsHintText}
                       </Text>
                     </Box>
                   </HoverCard.Dropdown>

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -145,7 +145,8 @@
    ;; We no longer add "localhost:*" as a default origin as of Metabase 56, as it is always allowed,
    ;; but we still filter it out in stats for compatibility with migrated instances.
    :embedding_app_origin_sdk_set         (boolean (let [sdk-origins (setting/get :embedding-app-origins-sdk)]
-                                                    (and sdk-origins (not= "localhost:*" sdk-origins))))
+                                                    (and (not (str/blank? sdk-origins))
+                                                         (not= "localhost:*" sdk-origins))))
    :embedding_app_origin_interactive_set (setting/get :embedding-app-origins-interactive)
    :appearance_site_name                 (not= (appearance/site-name) "Metabase")
    :appearance_help_link                 (appearance/help-link)

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -142,6 +142,8 @@
    :embedding_app_origin_set             (boolean
                                           #_{:clj-kondo/ignore [:deprecated-var]}
                                           (setting/get :embedding-app-origin))
+   ;; We no longer add "localhost:*" as a default origin as of Metabase 56, as it is always allowed,
+   ;; but we still filter it out in stats for compatibility with migrated instances.
    :embedding_app_origin_sdk_set         (boolean (let [sdk-origins (setting/get :embedding-app-origins-sdk)]
                                                     (and sdk-origins (not= "localhost:*" sdk-origins))))
    :embedding_app_origin_interactive_set (setting/get :embedding-app-origins-interactive)

--- a/src/metabase/embedding/settings.clj
+++ b/src/metabase/embedding/settings.clj
@@ -66,7 +66,9 @@
                                                                 (or (setting/get-value-of-type :string :embedding-app-origin)
                                                                     (setting/get-value-of-type :string :embedding-app-origins-interactive)
                                                                     (let [sdk-origins (setting/get-value-of-type :string :embedding-app-origins-sdk)]
-                                                                      (and sdk-origins (not= "localhost:*" sdk-origins)))))
+                                                                      ;; Don't track "localhost:*" as a meaningful origin since it was
+                                                                      ;; the old default and may still exist in migrated instances
+                                                                      (and sdk-origins (not (str/blank? sdk-origins)) (not= "localhost:*" sdk-origins)))))
                                    :number-embedded-questions  (t2/count :model/Card :enable_embedding true)
                                    :number-embedded-dashboards (t2/count :model/Dashboard :enable_embedding true)}))))))
 
@@ -147,24 +149,20 @@
        (str/join " ")
        str/trim))
 
-(mu/defn- add-localhost :- :string [s :- [:maybe :string]]
-  (->> s ignore-localhost (str "localhost:* ") str/trim))
-
 (defn- -embedding-app-origins-sdk []
-  (add-localhost (setting/get-value-of-type :string :embedding-app-origins-sdk)))
+  (setting/get-value-of-type :string :embedding-app-origins-sdk))
 
 (defn- -embedding-app-origins-sdk!
   "The setter for [[embedding-app-origins-sdk]].
 
   Checks that we have SDK embedding feature and that it's enabled, then sets the value accordingly."
   [new-value]
-  (add-localhost ;; return the same value that is returned from the getter
-   (->> new-value
-        ignore-localhost
-        ;; Why ignore-localhost?, because localhost:* will always be allowed, so we don't need to store it, if we
-        ;; were to store it, and the value was set N times, it would have localhost:* prefixed N times. Also, we
-        ;; should not store localhost:port, since it's covered by localhost:* (which is the minumum value).
-        (setting/set-value-of-type! :string :embedding-app-origins-sdk))))
+  (->> new-value
+       ignore-localhost
+       ;; Why ignore-localhost?, because localhost:* will always be allowed, so we don't need to store it, if we
+       ;; were to store it, and the value was set N times, it would have localhost:* prefixed N times. Also, we
+       ;; should not store localhost:port, since it's covered by localhost:* (which is the minumum value).
+       (setting/set-value-of-type! :string :embedding-app-origins-sdk)))
 
 (defsetting embedding-app-origins-sdk
   (deferred-tru "Allow Metabase SDK access to these space delimited origins.")
@@ -172,7 +170,7 @@
   :export?    false
   :visibility :public
   :feature    :embedding-sdk
-  :default    "localhost:*"
+  :default    ""
   :encryption :no
   :audit      :getter
   :getter     #'-embedding-app-origins-sdk

--- a/src/metabase/embedding/settings.clj
+++ b/src/metabase/embedding/settings.clj
@@ -161,7 +161,7 @@
        ignore-localhost
        ;; Why ignore-localhost?, because localhost:* will always be allowed, so we don't need to store it, if we
        ;; were to store it, and the value was set N times, it would have localhost:* prefixed N times. Also, we
-       ;; should not store localhost:port, since it's covered by localhost:* (which is the minumum value).
+       ;; should not store localhost:port, since it's covered by localhost:* (which is the minimum value).
        (setting/set-value-of-type! :string :embedding-app-origins-sdk)))
 
 (defsetting embedding-app-origins-sdk

--- a/src/metabase/embedding/settings.clj
+++ b/src/metabase/embedding/settings.clj
@@ -160,7 +160,7 @@
              (seq origins-string)
              (re-find #"localhost" origins-string))
     (throw (ex-info
-            "Localhost origins are not allowed on this instance."
+            "Localhost is not allowed because DISABLE_CORS_ON_LOCALHOST is set."
             {:status-code 400}))))
 
 (defn- -embedding-app-origins-sdk!

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -215,7 +215,7 @@
   (when raw-origin
     (let [origin (parse-url raw-origin)]
       (and origin
-           (= (:domain origin) "localhost")))))
+           (= (str/lower-case (:domain origin)) "localhost")))))
 
 (mu/defn approved-origin?
   "Returns true if `origin` should be allowed for CORS based on the `approved-origins`"

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -226,7 +226,7 @@
    (or
     ;; Allow localhost origins unless explicitly disallowed
     (and (localhost-origin? raw-origin)
-         (not (server.settings/disallow-cors-on-localhost)))
+         (not (server.settings/disable-cors-on-localhost)))
     ;; Check against approved origins list
     (when (and (seq raw-origin) (seq approved-origins-raw))
       (let [approved-list (parse-approved-origins approved-origins-raw)
@@ -241,7 +241,7 @@
 (defn access-control-headers
   "Returns headers for CORS requests"
   [origin enabled? approved-origins]
-  (let [localhost-allowed? (and (localhost-origin? origin) (not (server.settings/disallow-cors-on-localhost)))]
+  (let [localhost-allowed? (and (localhost-origin? origin) (not (server.settings/disable-cors-on-localhost)))]
     (when (or enabled? localhost-allowed?)
       (merge
        (when (approved-origin? origin approved-origins)

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -11,6 +11,7 @@
    [metabase.server.settings :as server.settings]
 
    [metabase.settings.core :as setting]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [ring.util.codec :refer [base64-encode]])
@@ -215,7 +216,7 @@
   (when raw-origin
     (let [origin (parse-url raw-origin)]
       (and origin
-           (= (str/lower-case (:domain origin)) "localhost")))))
+           (= (u/lower-case-en (:domain origin)) "localhost")))))
 
 (mu/defn approved-origin?
   "Returns true if `origin` should be allowed for CORS based on the `approved-origins`"

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -60,3 +60,10 @@ x.com")
   :default    true
   :visibility :internal
   :export?    false)
+
+(defsetting disallow-cors-on-localhost
+  (deferred-tru "Disallow CORS requests from localhost origins.")
+  :type       :boolean
+  :default    false
+  :visibility :internal
+  :export?    true)

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -61,8 +61,8 @@ x.com")
   :visibility :internal
   :export?    false)
 
-(defsetting disallow-cors-on-localhost
-  (deferred-tru "Disallow CORS requests from localhost origins.")
+(defsetting disable-cors-on-localhost
+  (deferred-tru "Prevents the server from sending CORS headers for requests originating from localhost.")
   :type       :boolean
   :default    false
   :visibility :internal

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -65,5 +65,5 @@ x.com")
   (deferred-tru "Prevents the server from sending CORS headers for requests originating from localhost.")
   :type       :boolean
   :default    false
-  :visibility :internal
+  :visibility :admin
   :export?    true)

--- a/test/metabase/embedding/settings_test.clj
+++ b/test/metabase/embedding/settings_test.clj
@@ -74,12 +74,12 @@
     (mt/with-temporary-setting-values [enable-embedding-sdk true]
       (let [origin-value "localhost:*"]
         (embed.settings/embedding-app-origins-sdk! origin-value)
-        (testing "All localhosty origins should be ignored, so the result should be \"localhost:*\""
+        (testing "All localhosty origins should be ignored, so the result should be empty"
           (embed.settings/embedding-app-origins-sdk! (str origin-value " localhost:8080"))
-          (is (= "localhost:*" (embed.settings/embedding-app-origins-sdk))))
+          (is (= "" (embed.settings/embedding-app-origins-sdk))))
         (testing "Normal ips are added to the list"
           (embed.settings/embedding-app-origins-sdk! (str origin-value " " other-ip))
-          (is (= (str "localhost:* " other-ip) (embed.settings/embedding-app-origins-sdk))))))))
+          (is (= other-ip (embed.settings/embedding-app-origins-sdk))))))))
 
 (deftest enable-embedding-SDK-false-returns-nothing
   (mt/with-premium-features #{:embedding :embedding-sdk}
@@ -185,13 +185,13 @@
         (= expected-behavior :no-op)
         (do (is (= (:embedding-app-origins-interactive unsyncd-setting)
                    (embed.settings/embedding-app-origins-interactive)))
-            (is (= (#'embed.settings/add-localhost (:embedding-app-origins-sdk unsyncd-setting))
+            (is (= (:embedding-app-origins-sdk unsyncd-setting)
                    (embed.settings/embedding-app-origins-sdk))))
 
         (= expected-behavior :sets-both)
         (do (is (= (:mb-embedding-app-origin env)
                    (embed.settings/embedding-app-origins-interactive)))
-            (is (= (#'embed.settings/add-localhost (:mb-embedding-app-origin env))
+            (is (= (:mb-embedding-app-origin env)
                    (embed.settings/embedding-app-origins-sdk))))
 
         :else (throw (ex-info "Invalid expected-behavior in test-origin-sync." {:expected-behavior expected-behavior}))))))

--- a/test/metabase/embedding/settings_test.clj
+++ b/test/metabase/embedding/settings_test.clj
@@ -228,17 +228,17 @@
         (testing "localhost:* should be rejected"
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"Localhost origins are not allowed on this instance."
+               #"Localhost is not allowed because DISABLE_CORS_ON_LOCALHOST is set."
                (embed.settings/embedding-app-origins-sdk! "localhost:*"))))
         (testing "localhost:3000 should be rejected"
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"Localhost origins are not allowed on this instance."
+               #"Localhost is not allowed because DISABLE_CORS_ON_LOCALHOST is set."
                (embed.settings/embedding-app-origins-sdk! "localhost:3000"))))
         (testing "localhost mixed with other origins should be rejected"
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"Localhost origins are not allowed on this instance."
+               #"Localhost is not allowed because DISABLE_CORS_ON_LOCALHOST is set."
                (embed.settings/embedding-app-origins-sdk! "https://example.com localhost:3000")))))))
 
   (testing "Should allow localhost origins when disable-cors-on-localhost is disabled"

--- a/test/metabase/embedding/settings_test.clj
+++ b/test/metabase/embedding/settings_test.clj
@@ -7,7 +7,6 @@
    [metabase.embedding.settings :as embed.settings]
    [metabase.premium-features.token-check :as token-check]
    [metabase.premium-features.token-check-test :as token-check-test]
-   [metabase.server.settings :refer [disable-cors-on-localhost]]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -201,7 +201,7 @@
   (testing "Should handle invalid origins"
     (is (mw.security/approved-origin? "http://example.com" "  fpt://something ://123 4 http://example.com"))))
 
-(deftest ^:parallel test-disallow-cors-on-localhost-approved-origin
+(deftest test-disallow-cors-on-localhost-approved-origin
   (testing "Should approve localhost origins when disallow-cors-on-localhost is false"
     (mt/with-temporary-setting-values [disallow-cors-on-localhost false]
       (is (mw.security/approved-origin? "http://localhost" ""))
@@ -454,7 +454,7 @@
                   response (wrapped-handler {:headers {"origin" request-origin} :uri request-uri} identity identity)]
               [enable-embedding-sdk embedding-app-origins-sdk request-origin request-uri (-> response :headers (get "Access-Control-Allow-Origin"))])))))
 
-(deftest ^:parallel add-cors-headers-for-auth-sso-test
+(deftest add-cors-headers-for-auth-sso-test
   (testing "Should add CORS headers for /auth/sso endpoint with 402 status (embedding disabled errors)"
     (let [wrapped-handler (mw.security/add-security-headers
                            (fn [_request respond _raise]

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -201,6 +201,38 @@
   (testing "Should handle invalid origins"
     (is (mw.security/approved-origin? "http://example.com" "  fpt://something ://123 4 http://example.com"))))
 
+(deftest ^:parallel test-disallow-cors-on-localhost-approved-origin
+  (testing "Should approve localhost origins when disallow-cors-on-localhost is false"
+    (mt/with-temporary-setting-values [disallow-cors-on-localhost false]
+      (is (mw.security/approved-origin? "http://localhost" ""))
+      (is (mw.security/approved-origin? "http://localhost:3000" ""))))
+  (testing "Should reject localhost origins when disallow-cors-on-localhost is true"
+    (mt/with-temporary-setting-values [disallow-cors-on-localhost true]
+      (is (not (mw.security/approved-origin? "http://localhost" "")))
+      (is (not (mw.security/approved-origin? "http://localhost:3000" "")))))
+  (testing "Should allow localhost origins when explicitly added to approved origins even with disallow-cors-on-localhost true"
+    (mt/with-temporary-setting-values [disallow-cors-on-localhost true]
+      (is (mw.security/approved-origin? "http://localhost" "localhost"))
+      (is (mw.security/approved-origin? "http://localhost:3000" "localhost:*")))))
+
+(deftest test-disallow-cors-on-localhost-access-control-headers
+  (testing "Should allow CORS headers for localhost when disallow-cors-on-localhost is false"
+    (mt/with-temporary-setting-values [disallow-cors-on-localhost false
+                                       enable-embedding-sdk false]
+      (is (= "http://localhost:8080" (get (mw.security/access-control-headers
+                                           "http://localhost:8080"
+                                           false
+                                           "")
+                                          "Access-Control-Allow-Origin")))))
+  (testing "Should block CORS headers for localhost when disallow-cors-on-localhost is true and embedding disabled"
+    (mt/with-temporary-setting-values [disallow-cors-on-localhost true
+                                       enable-embedding-sdk false]
+      (is (= nil (get (mw.security/access-control-headers
+                       "http://localhost:8080"
+                       false
+                       "")
+                      "Access-Control-Allow-Origin"))))))
+
 (deftest test-access-control-headers
   (mt/with-premium-features #{:embedding-sdk}
     (testing "Should allow localhost even when enable-embedding-sdk is disabled"

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -201,31 +201,31 @@
   (testing "Should handle invalid origins"
     (is (mw.security/approved-origin? "http://example.com" "  fpt://something ://123 4 http://example.com"))))
 
-(deftest test-disallow-cors-on-localhost-approved-origin
-  (testing "Should approve localhost origins when disallow-cors-on-localhost is false"
-    (mt/with-temporary-setting-values [disallow-cors-on-localhost false]
+(deftest test-disable-cors-on-localhost-approved-origin
+  (testing "Should approve localhost origins when disable-cors-on-localhost is false"
+    (mt/with-temporary-setting-values [disable-cors-on-localhost false]
       (is (mw.security/approved-origin? "http://localhost" ""))
       (is (mw.security/approved-origin? "http://localhost:3000" ""))))
-  (testing "Should reject localhost origins when disallow-cors-on-localhost is true"
-    (mt/with-temporary-setting-values [disallow-cors-on-localhost true]
+  (testing "Should reject localhost origins when disable-cors-on-localhost is true"
+    (mt/with-temporary-setting-values [disable-cors-on-localhost true]
       (is (not (mw.security/approved-origin? "http://localhost" "")))
       (is (not (mw.security/approved-origin? "http://localhost:3000" "")))))
-  (testing "Should allow localhost origins when explicitly added to approved origins even with disallow-cors-on-localhost true"
-    (mt/with-temporary-setting-values [disallow-cors-on-localhost true]
+  (testing "Should allow localhost origins when explicitly added to approved origins even with disable-cors-on-localhost true"
+    (mt/with-temporary-setting-values [disable-cors-on-localhost true]
       (is (mw.security/approved-origin? "http://localhost" "localhost"))
       (is (mw.security/approved-origin? "http://localhost:3000" "localhost:*")))))
 
-(deftest test-disallow-cors-on-localhost-access-control-headers
-  (testing "Should allow CORS headers for localhost when disallow-cors-on-localhost is false"
-    (mt/with-temporary-setting-values [disallow-cors-on-localhost false
+(deftest test-disable-cors-on-localhost-access-control-headers
+  (testing "Should allow CORS headers for localhost when disable-cors-on-localhost is false"
+    (mt/with-temporary-setting-values [disable-cors-on-localhost false
                                        enable-embedding-sdk false]
       (is (= "http://localhost:8080" (get (mw.security/access-control-headers
                                            "http://localhost:8080"
                                            false
                                            "")
                                           "Access-Control-Allow-Origin")))))
-  (testing "Should block CORS headers for localhost when disallow-cors-on-localhost is true and embedding disabled"
-    (mt/with-temporary-setting-values [disallow-cors-on-localhost true
+  (testing "Should block CORS headers for localhost when disable-cors-on-localhost is true and embedding disabled"
+    (mt/with-temporary-setting-values [disable-cors-on-localhost true
                                        enable-embedding-sdk false]
       (is (= nil (get (mw.security/access-control-headers
                        "http://localhost:8080"

--- a/test_resources/serialization_baseline/settings.yaml
+++ b/test_resources/serialization_baseline/settings.yaml
@@ -14,6 +14,7 @@ custom-formatting: null
 custom-geojson: null
 custom-geojson-enabled: null
 default-maps-enabled: null
+disable-cors-on-localhost: null
 email-max-recipients-per-second: null
 embedding-homepage: null
 enable-embedding: null


### PR DESCRIPTION
Closes EMB-660

This is a companion PR to https://github.com/metabase/metabase/pull/61808

We want to **always** send CORS headers if we are in a **localhost** origin, regardless of whether Embedding SDK is enabled or not. Today, we already always enable `localhost:*` if the Embedding SDK toggle is enabled. This PR just makes it so that it does not depend on whether the SDK toggle is enabled or not.

The purpose is to enable better error messages and reduce friction for API keys users who are trying out the Embedding SDK, even if they forgot to enable the Embedding SDK.

In addition, it removes the `"localhost:*"` default from the text field per Alberto's feedback, as we are giving users a false impression that removing `localhost:*` actually removes it from the allowed origins. That is not the case today.

### How to verify

- Disable the Embedding SDK toggle in the admin settings "Modular Embedding > Embedding SDK"
- Create an API key
- Pass an API key as `apiKey: "..."` to your test Metabase instance at localhost. Using Storybook might work as well.
- You should see the usage problem banner on the bottom left now says "Embedding is not enabled for this instance. Please enable it in settings" instead of a generic "Cannot connect to instance" error.

### Demo

When you load the page on localhost and you forgot to turn on SDK embedding, it should display a helpful message from the backend, now that CORS is always enabled on localhost.

<img width="1198" height="860" alt="CleanShot 2568-08-06 at 00 14 59@2x" src="https://github.com/user-attachments/assets/b7a2321e-f718-40e7-a1f3-2b6a74531919" />

When you click "Hide error", you can also get the page to load. This intentionally bypasses the warning on localhost.

<img width="2502" height="1502" alt="CleanShot 2568-08-06 at 00 14 33@2x" src="https://github.com/user-attachments/assets/72700dd6-8e82-4721-be73-88d56a05a13a" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
