### PR TITLE
Draft: Fix: UXW-42 Fix issues related to visualization layout jumping

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
@@ -91,6 +91,8 @@ interface ViewMainContainerProps {
   parameters: UiParameter[];
 
   updateQuestion: (question: Question, opts?: { run?: boolean }) => void;
+
+  visualizationSettings: unknown;
 }
 
 export const ViewMainContainer = (props: ViewMainContainerProps) => {
@@ -102,7 +104,6 @@ export const ViewMainContainer = (props: ViewMainContainerProps) => {
     showRightSidebar,
     parameters,
     setParameterValue,
-    isLiveResizable,
     updateQuestion,
   } = props;
 
@@ -136,7 +137,8 @@ export const ViewMainContainer = (props: ViewMainContainerProps) => {
 
       <DebouncedFrame
         className={ViewMainContainerS.StyledDebouncedFrame}
-        enabled={!isLiveResizable}
+        enabled
+        resetKey={props.visualizationSettings}
       >
         <QueryVisualization
           {...props}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54147
Closes UXW-42

### Description

Tweaks DebouncedFrame so it accepts a resetKey prop which can be used to trigger an immediate update rather than a debounced one without remounting.

### How to verify

See https://github.com/metabase/metabase/issues/54147 for repro steps.

Check for resize regressions anywhere DebouncedFrame is used.

### Demo

**BEFORE**

https://github.com/user-attachments/assets/423c55b1-c8a2-45d9-b4ad-ff6dbd69fa23

**AFTER**

https://github.com/user-attachments/assets/b0b5f5dd-59d0-4a7e-b178-30b499b4ba3a

**BEFORE (dashboards)**

https://github.com/user-attachments/assets/c7b88e08-6475-4ab5-8a03-4363d42c75a5

**AFTER (dashboards)**

https://github.com/user-attachments/assets/eb0cf688-7cfb-4316-86e4-70d657297c51

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
