### PR TITLE
Include columns that are not specifically excluded

### DIFF
--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -43,7 +43,7 @@
        cols
        (mbql.u/uniquify-names (map :name cols))))
 
-(defn- validate-table-columms
+(defn- validate-table-columns
   "Validate that all of the columns in `table-columns` correspond to actual columns in `cols`, correlating them by
   field ref or name. Returns `nil` if any do not, so that we fall back to using `cols` directly for the export (#19465).
   Otherwise returns `table-columns`."
@@ -54,6 +54,29 @@
                                       (col-names (::mb.viz/table-column-name table-col))))
                   table-columns)
       table-columns)))
+
+(defn- not-explicitly-excluded-columns
+  "If a column is not explicitly excluded (it doesn't have a row in `table-columns` that marks it as disabled), we
+  should include it. This way, if e.g. the query has changed from `SELECT id FROM ...` to `SELECT id, created_at FROM
+  ...`, we'll include the new columns. (This is the same behavior as the UI.)"
+  [table-columns cols]
+  (let [{:keys [name->table field-ref->table]} (reduce (fn [m {n ::mb.viz/table-column-name
+                                                               fr ::mb.viz/table-column-field-ref
+                                                               :as table}]
+                                                         (cond-> m
+                                                           true (assoc-in [:name->table n] table)
+                                                           fr (assoc-in [:field-ref->table fr] table)))
+                                                       {}
+                                                       table-columns)]
+    (for [col cols
+          :when (and (not (get name->table (:name col)))
+                     (not (get field-ref->table (:field_ref col))))
+          :let [col-name (:name col)
+                id-or-name (or (:id col) col-name)
+                field-ref (:field_ref col)]]
+      {::mb.viz/table-column-field-ref (or field-ref [:field id-or-name nil])
+       ::mb.viz/table-column-enabled   true
+       ::mb.viz/table-column-name      col-name})))
 
 (defn- pivot-grouping-exists?
   "Returns `true` if there's a column with the :name \"pivot-grouping\",
@@ -71,7 +94,10 @@
     ;; If the columns contain a pivot-grouping, we're exporting a pivot and the cols order is not used,
     ;; so we can just pass the indices in order.
     (range (count cols))
-    (let [table-columns'     (or (validate-table-columms table-columns cols)
+    (let [table-columns'     (or (when-let [tcs (seq (validate-table-columns table-columns cols))]
+                                   (concat
+                                    (filter ::mb.viz/table-column-enabled tcs)
+                                    (not-explicitly-excluded-columns table-columns cols)))
                                  ;; If table-columns is not provided (e.g. for saved cards), we can construct a fake one
                                  ;; that retains the original column ordering in `cols`
                                  (for [col cols]
@@ -81,7 +107,6 @@
                                      {::mb.viz/table-column-field-ref (or field-ref [:field id-or-name nil])
                                       ::mb.viz/table-column-enabled   true
                                       ::mb.viz/table-column-name      col-name})))
-          enabled-table-cols (filter ::mb.viz/table-column-enabled table-columns')
           cols-vector        (into [] cols)
           ;; cols-index is a map from keys representing fields to their indices into `cols`
           cols-index         (reduce-kv (fn [m i col]
@@ -106,7 +131,7 @@
 
                   (not remapped-from-name)
                   index)))
-            enabled-table-cols)
+            table-columns')
            (remove nil?)))))
 
 (defn order-cols

--- a/test/metabase/channel/render/table_test.clj
+++ b/test/metabase/channel/render/table_test.clj
@@ -131,7 +131,8 @@
                               {:name "A" :enabled true}
                               {:name "C" :enabled false}
                               {:name "D" :enabled false}
-                              {:name "E" :enabled false}]}
+                              {:name "E" :enabled false}
+                              {:name "F" :enabled false}]}
           expected-img-cell {:type :element,
                              :attrs
                              {:src "https://example.com/image.jpg",


### PR DESCRIPTION
Fixes [UXW-147: SQL question missing new columns when downloading results](https://linear.app/metabase/issue/UXW-147/sql-question-missing-new-columns-when-downloading-results)

<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61337
When streaming data for a query, we were only including columns if a) the viz settings for the column were completely empty, or if b) the viz settings for the columns included specifically enabling that column.

The problem occurs most clearly for things like native SQL queries.

If you construct a query like

```
SELECT id FROM venues;
```

and then set the column viz settings to *something* non-empty (most easy way: just hide the `id` column and then show it again), and then save the card, then change the query to:

```
SELECT id, name FROM venues;
```

then if you download the CSV for this card (even after saving it!) you'll get a result that only contains `id` and not `name`.

A few tests needed to change here because they were implicitly assuming the old behavior, but I don't think that's entirely intentional. This behavior was different than the behavior in the Metabase application proper, where UI results would show all the columns (in the above example, they'd immediately show `id` *and* `name`).

**Note:** I'm OOO until August 15th. Feel free to merge this while I'm gone, it should be good to go pending review. (And if it's not approved, please feel free to modify it before merging.)