### PR TITLE
Add table link to metadata page

### DIFF
--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -22,6 +22,7 @@ export const DataModel = {
     get: getTableSection,
     getNameInput: getTableNameInput,
     getDescriptionInput: getTableDescriptionInput,
+    getQueryBuilderLink: getTableQueryBuilderLink,
     getSortButton: getTableSortButton,
     getSortDoneButton: getTableSortDoneButton,
     getSortOrderInput: getTableSortOrderInput,
@@ -212,6 +213,10 @@ function getTableSection() {
 
 function getTableNameInput() {
   return getTableSection().findByPlaceholderText("Give this table a name");
+}
+
+function getTableQueryBuilderLink() {
+  return getTableSection().findByLabelText("Explore this table");
 }
 
 function getTableDescriptionInput() {

--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -216,7 +216,7 @@ function getTableNameInput() {
 }
 
 function getTableQueryBuilderLink() {
-  return getTableSection().findByLabelText("Explore this table");
+  return getTableSection().findByLabelText("Go to this table");
 }
 
 function getTableDescriptionInput() {

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -855,6 +855,16 @@ describe("scenarios > admin > datamodel", () => {
       );
     });
 
+    it("should be able to preview the table in the query builder", () => {
+      H.DataModel.visit({
+        databaseId: SAMPLE_DB_ID,
+        schemaId: SAMPLE_DB_SCHEMA_ID,
+        tableId: ORDERS_ID,
+      });
+      TableSection.getQueryBuilderLink().click();
+      H.queryBuilderHeader().findByText("Orders").should("be.visible");
+    });
+
     it("should be able to see details of a table", () => {
       H.DataModel.visit({ databaseId: SAMPLE_DB_ID });
 

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
@@ -1,4 +1,5 @@
 import { useElementSize } from "@mantine/hooks";
+import type { ReactNode } from "react";
 
 import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { Box, Group, Icon, type IconName, Text, rem } from "metabase/ui";
@@ -15,9 +16,9 @@ interface Props {
   nameMaxLength?: number;
   namePlaceholder: string;
   namePrefix?: string;
+  nameRightSection?: ReactNode;
   onDescriptionChange: (description: string) => void;
   onNameChange: (name: string) => void;
-  rightSection?: React.ReactNode;
 }
 
 export const NameDescriptionInput = ({
@@ -28,9 +29,9 @@ export const NameDescriptionInput = ({
   nameMaxLength,
   namePlaceholder,
   namePrefix,
+  nameRightSection,
   onDescriptionChange,
   onNameChange,
-  rightSection,
 }: Props) => {
   const { ref, width } = useElementSize();
   const { ref: sectionRef, width: sectionWidth } = useElementSize();
@@ -102,8 +103,7 @@ export const NameDescriptionInput = ({
         maxLength={nameMaxLength}
         placeholder={namePlaceholder}
         required
-        rightSection={rightSection}
-        rightSectionWidth={rightSection ? 40 : 0}
+        rightSection={nameRightSection}
         size="lg"
         styles={{
           section: {

--- a/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
+++ b/frontend/src/metabase/metadata/components/NameDescriptionInput/NameDescriptionInput.tsx
@@ -17,6 +17,7 @@ interface Props {
   namePrefix?: string;
   onDescriptionChange: (description: string) => void;
   onNameChange: (name: string) => void;
+  rightSection?: React.ReactNode;
 }
 
 export const NameDescriptionInput = ({
@@ -29,6 +30,7 @@ export const NameDescriptionInput = ({
   namePrefix,
   onDescriptionChange,
   onNameChange,
+  rightSection,
 }: Props) => {
   const { ref, width } = useElementSize();
   const { ref: sectionRef, width: sectionWidth } = useElementSize();
@@ -100,6 +102,8 @@ export const NameDescriptionInput = ({
         maxLength={nameMaxLength}
         placeholder={namePlaceholder}
         required
+        rightSection={rightSection}
+        rightSectionWidth={rightSection ? 40 : 0}
         size="lg"
         styles={{
           section: {

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -171,7 +171,7 @@ const TableSectionBase = ({ params, table, onSyncOptionsClick }: Props) => {
                 color="text-light"
                 size="sm"
                 mr="sm"
-                aria-label={t`Explore this table`}
+                aria-label={t`Go to this table`}
               >
                 <Icon name="external" size={16} />
               </ActionIcon>

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -1,4 +1,5 @@
 import { memo, useState } from "react";
+import { Link } from "react-router";
 import { t } from "ttag";
 
 import {
@@ -6,7 +7,6 @@ import {
   useUpdateTableMutation,
 } from "metabase/api";
 import EmptyState from "metabase/common/components/EmptyState";
-import Link from "metabase/common/components/Link";
 import {
   FieldOrderPicker,
   NameDescriptionInput,
@@ -23,8 +23,6 @@ import {
   Text,
   Tooltip,
 } from "metabase/ui";
-import Question from "metabase-lib/v1/Question";
-import * as ML_Urls from "metabase-lib/v1/urls";
 import type { FieldId, Table, TableFieldOrder } from "metabase-types/api";
 
 import type { RouteParams } from "../../types";
@@ -145,12 +143,6 @@ const TableSectionBase = ({ params, table, onSyncOptionsClick }: Props) => {
     }
   };
 
-  const question = Question.create({
-    databaseId: table.db_id,
-    tableId: table.id,
-  });
-  const questionUrl = ML_Urls.getUrl(question);
-
   return (
     <Stack data-testid="table-section" gap={0} pb="xl">
       <Stack
@@ -170,24 +162,24 @@ const TableSectionBase = ({ params, table, onSyncOptionsClick }: Props) => {
           nameIcon="table2"
           nameMaxLength={254}
           namePlaceholder={t`Give this table a name`}
-          onDescriptionChange={handleDescriptionChange}
-          onNameChange={handleNameChange}
-          rightSection={
-            <div style={{ marginRight: 16 }}>
-              <Link to={questionUrl}>
-                <Tooltip label={t`Go to this table`} position="top">
-                  <ActionIcon
-                    aria-label={t`Explore this table`}
-                    color="text-light"
-                    size="sm"
-                    variant="subtle"
-                  >
-                    <Icon name="external" size={16} />
-                  </ActionIcon>
-                </Tooltip>
-              </Link>
-            </div>
+          nameRightSection={
+            <Tooltip label={t`Go to this table`} position="top">
+              <ActionIcon
+                component={Link}
+                to={getQueryBuilderUrl(table)}
+                target="_blank"
+                variant="subtle"
+                color="text-light"
+                size="sm"
+                mr="sm"
+                aria-label={t`Explore this table`}
+              >
+                <Icon name="external" size={16} />
+              </ActionIcon>
+            </Tooltip>
           }
+          onNameChange={handleNameChange}
+          onDescriptionChange={handleDescriptionChange}
         />
 
         <Group
@@ -275,5 +267,9 @@ const TableSectionBase = ({ params, table, onSyncOptionsClick }: Props) => {
     </Stack>
   );
 };
+
+function getQueryBuilderUrl(table: Table) {
+  return `/question#?db=${table.db_id}&table=${table.id}`;
+}
 
 export const TableSection = memo(TableSectionBase);

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -6,6 +6,7 @@ import {
   useUpdateTableMutation,
 } from "metabase/api";
 import EmptyState from "metabase/common/components/EmptyState";
+import Link from "metabase/common/components/Link";
 import {
   FieldOrderPicker,
   NameDescriptionInput,
@@ -13,7 +14,17 @@ import {
 } from "metabase/metadata/components";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { getRawTableFieldId } from "metabase/metadata/utils/field";
-import { Group, Loader, Stack, Text } from "metabase/ui";
+import {
+  ActionIcon,
+  Group,
+  Icon,
+  Loader,
+  Stack,
+  Text,
+  Tooltip,
+} from "metabase/ui";
+import Question from "metabase-lib/v1/Question";
+import * as ML_Urls from "metabase-lib/v1/urls";
 import type { FieldId, Table, TableFieldOrder } from "metabase-types/api";
 
 import type { RouteParams } from "../../types";
@@ -134,6 +145,12 @@ const TableSectionBase = ({ params, table, onSyncOptionsClick }: Props) => {
     }
   };
 
+  const question = Question.create({
+    databaseId: table.db_id,
+    tableId: table.id,
+  });
+  const questionUrl = ML_Urls.getUrl(question);
+
   return (
     <Stack data-testid="table-section" gap={0} pb="xl">
       <Stack
@@ -155,6 +172,22 @@ const TableSectionBase = ({ params, table, onSyncOptionsClick }: Props) => {
           namePlaceholder={t`Give this table a name`}
           onDescriptionChange={handleDescriptionChange}
           onNameChange={handleNameChange}
+          rightSection={
+            <div style={{ marginRight: 16 }}>
+              <Link to={questionUrl}>
+                <Tooltip label={t`Go to this table`} position="top">
+                  <ActionIcon
+                    aria-label={t`Explore this table`}
+                    color="text-light"
+                    size="sm"
+                    variant="subtle"
+                  >
+                    <Icon name="external" size={16} />
+                  </ActionIcon>
+                </Tooltip>
+              </Link>
+            </div>
+          }
         />
 
         <Group

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.tsx
@@ -167,7 +167,6 @@ const TableSectionBase = ({ params, table, onSyncOptionsClick }: Props) => {
               <ActionIcon
                 component={Link}
                 to={getQueryBuilderUrl(table)}
-                target="_blank"
                 variant="subtle"
                 color="text-light"
                 size="sm"

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.unit.spec.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "__support__/ui";
+import type { Table } from "metabase-types/api";
+
+import { TableSection } from "./TableSection";
+
+const mockTable = {
+  id: 1,
+  name: "test_table",
+  display_name: "Test Table",
+  description: "Test table description",
+  db_id: 1,
+  schema: "public",
+  field_order: "database",
+  active: true,
+  visibility_type: null,
+  initial_sync_status: "complete",
+  is_upload: false,
+  created_at: "2023-01-01T00:00:00Z",
+  updated_at: "2023-01-01T00:00:00Z",
+  fields: [
+    {
+      id: 1,
+      name: "id",
+      display_name: "ID",
+      base_type: "type/Integer",
+      semantic_type: "type/PK",
+      table_id: 1,
+      description: null,
+      database_type: "INTEGER",
+      active: true,
+      visibility_type: "normal",
+      has_field_values: "none",
+      settings: null,
+      fk_target_field_id: null,
+      custom_position: 0,
+      effective_type: "type/Integer",
+      coercion_strategy: null,
+      nfc_path: null,
+      created_at: "2023-01-01T00:00:00Z",
+      updated_at: "2023-01-01T00:00:00Z",
+      preview_display: "text",
+      position: 0,
+      json_unfolding: null,
+      fingerprint: null,
+      last_analyzed: "2023-01-01T00:00:00Z",
+    },
+  ],
+} as Table;
+
+const mockParams = {
+  databaseId: "1",
+  schemaName: "public",
+  tableId: "1",
+  fieldId: "1",
+};
+
+describe("TableSection", () => {
+  it("should render the external ActionIcon in the table name input", () => {
+    const onSyncOptionsClick = jest.fn();
+
+    render(
+      <TableSection
+        params={mockParams}
+        table={mockTable}
+        onSyncOptionsClick={onSyncOptionsClick}
+      />,
+    );
+
+    // Check that the external icon is rendered
+    const externalIcon = screen.getByLabelText("Explore this table");
+    expect(externalIcon).toBeInTheDocument();
+
+    // Check that the external icon is present
+    const externalIconElement = screen.getByLabelText("external icon");
+    expect(externalIconElement).toBeInTheDocument();
+  });
+
+  it("should render the table name input with the correct name", () => {
+    const onSyncOptionsClick = jest.fn();
+
+    render(
+      <TableSection
+        params={mockParams}
+        table={mockTable}
+        onSyncOptionsClick={onSyncOptionsClick}
+      />,
+    );
+
+    // Check that the table name input is rendered with the correct value
+    const nameInput = screen.getByDisplayValue("Test Table");
+    expect(nameInput).toBeInTheDocument();
+  });
+
+  it("should render the table description input with the correct description", () => {
+    const onSyncOptionsClick = jest.fn();
+
+    render(
+      <TableSection
+        params={mockParams}
+        table={mockTable}
+        onSyncOptionsClick={onSyncOptionsClick}
+      />,
+    );
+
+    // Check that the description input is rendered with the correct value
+    const descriptionInput = screen.getByDisplayValue("Test table description");
+    expect(descriptionInput).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.unit.spec.tsx
@@ -1,109 +1,61 @@
-import { render, screen } from "__support__/ui";
+import { Route } from "react-router";
+
+import { renderWithProviders, screen } from "__support__/ui";
 import type { Table } from "metabase-types/api";
+import { createMockTable } from "metabase-types/api/mocks";
+
+import type { RouteParams } from "../../types";
 
 import { TableSection } from "./TableSection";
 
-const mockTable = {
-  id: 1,
-  name: "test_table",
-  display_name: "Test Table",
-  description: "Test table description",
-  db_id: 1,
-  schema: "public",
-  field_order: "database",
-  active: true,
-  visibility_type: null,
-  initial_sync_status: "complete",
-  is_upload: false,
-  created_at: "2023-01-01T00:00:00Z",
-  updated_at: "2023-01-01T00:00:00Z",
-  fields: [
-    {
-      id: 1,
-      name: "id",
-      display_name: "ID",
-      base_type: "type/Integer",
-      semantic_type: "type/PK",
-      table_id: 1,
-      description: null,
-      database_type: "INTEGER",
-      active: true,
-      visibility_type: "normal",
-      has_field_values: "none",
-      settings: null,
-      fk_target_field_id: null,
-      custom_position: 0,
-      effective_type: "type/Integer",
-      coercion_strategy: null,
-      nfc_path: null,
-      created_at: "2023-01-01T00:00:00Z",
-      updated_at: "2023-01-01T00:00:00Z",
-      preview_display: "text",
-      position: 0,
-      json_unfolding: null,
-      fingerprint: null,
-      last_analyzed: "2023-01-01T00:00:00Z",
-    },
-  ],
-} as Table;
-
-const mockParams = {
-  databaseId: "1",
-  schemaName: "public",
-  tableId: "1",
-  fieldId: "1",
+type SetupOpts = {
+  table?: Table;
+  params?: RouteParams;
 };
 
+function setup({
+  table = createMockTable(),
+  params = createMockRouteParams(),
+}: SetupOpts = {}) {
+  const onSyncOptionsClick = jest.fn();
+
+  renderWithProviders(
+    <Route
+      path="/"
+      component={() => (
+        <TableSection
+          table={table}
+          params={params}
+          onSyncOptionsClick={onSyncOptionsClick}
+        />
+      )}
+    />,
+    { withRouter: true },
+  );
+
+  return { onSyncOptionsClick };
+}
+
+function createMockRouteParams(opts?: Partial<RouteParams>): RouteParams {
+  return {
+    databaseId: "1",
+    schemaId: "1:public",
+    tableId: "1",
+    fieldId: "1",
+    ...opts,
+  };
+}
+
 describe("TableSection", () => {
-  it("should render the external ActionIcon in the table name input", () => {
-    const onSyncOptionsClick = jest.fn();
+  it("should render the link to explore this table in the query builder", () => {
+    const table = createMockTable();
+    setup({ table });
 
-    render(
-      <TableSection
-        params={mockParams}
-        table={mockTable}
-        onSyncOptionsClick={onSyncOptionsClick}
-      />,
+    const tableLink = screen.getByLabelText("Explore this table");
+    expect(tableLink).toBeInTheDocument();
+    expect(tableLink).toHaveAttribute(
+      "href",
+      `/question#?db=${table.db_id}&table=${table.id}`,
     );
-
-    // Check that the external icon is rendered
-    const externalIcon = screen.getByLabelText("Explore this table");
-    expect(externalIcon).toBeInTheDocument();
-
-    // Check that the external icon is present
-    const externalIconElement = screen.getByLabelText("external icon");
-    expect(externalIconElement).toBeInTheDocument();
-  });
-
-  it("should render the table name input with the correct name", () => {
-    const onSyncOptionsClick = jest.fn();
-
-    render(
-      <TableSection
-        params={mockParams}
-        table={mockTable}
-        onSyncOptionsClick={onSyncOptionsClick}
-      />,
-    );
-
-    // Check that the table name input is rendered with the correct value
-    const nameInput = screen.getByDisplayValue("Test Table");
-    expect(nameInput).toBeInTheDocument();
-  });
-
-  it("should render the table description input with the correct description", () => {
-    const onSyncOptionsClick = jest.fn();
-
-    render(
-      <TableSection
-        params={mockParams}
-        table={mockTable}
-        onSyncOptionsClick={onSyncOptionsClick}
-      />,
-    );
-
-    // Check that the description input is rendered with the correct value
-    const descriptionInput = screen.getByDisplayValue("Test table description");
-    expect(descriptionInput).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/TableSection.unit.spec.tsx
@@ -51,7 +51,7 @@ describe("TableSection", () => {
     const table = createMockTable();
     setup({ table });
 
-    const tableLink = screen.getByLabelText("Explore this table");
+    const tableLink = screen.getByLabelText("Go to this table");
     expect(tableLink).toBeInTheDocument();
     expect(tableLink).toHaveAttribute(
       "href",


### PR DESCRIPTION
### Description

Adds a simple way for you to go visit a table from its corresponding Table Metadata page.

<img width="1201" height="864" alt="image" src="https://github.com/user-attachments/assets/2a3f886e-430a-4818-9122-b4b45e8a6a8f" />

Clicking it takes you to the table in "chill mode:"

<img width="1317" height="438" alt="image" src="https://github.com/user-attachments/assets/15b7d8e9-f68f-485b-b606-918e39edccaf" />

### How to verify


1. Go to Admin -> Table Metadata
2. Open up a table in the sidebar
3. Click on the link icon button next to the table's name
4. Make sure you end up looking at the table in chill mode


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
