### PR TITLE
Remove semantic HNSW index breaking where clause

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -351,7 +351,6 @@
   [index embedding search-context]
   (let [filters (search-filters search-context)
         embedding-literal (format-embedding embedding)
-        max-cosine-distance 0.7
         base-query {:select [[:id :id]
                              [:model_id :model_id]
                              [:model :model]
@@ -361,7 +360,6 @@
                              [[:raw (str "embedding <=> " embedding-literal)] :semantic_score]
                              [[:raw (str "row_number() OVER (ORDER BY embedding <=> " embedding-literal " ASC)")] :semantic_rank]]
                     :from   [(keyword (:table-name index))]
-                    :where [:<= [:raw (str "embedding <=> " embedding-literal)] max-cosine-distance]
                     :order-by [[:semantic_rank :asc]]
                     :limit  100}]
     (if filters


### PR DESCRIPTION
Search is currently very slow in staging because our HNSW index is not being used. This appears to be because we have cosine distance filtering happening in the semantic search query WHERE clause, which forces a distance calculation and bypasses the index's approximate nearest neighbor optimization.

This may negatively impact the hybrid search results, so a follow up may be necessary.