### PR TITLE
bump hive to 4.1.0

### DIFF
--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.0.1"}}}
+ {org.apache.hive/hive-jdbc$standalone {:mvn/version "4.1.0"}}}


### PR DESCRIPTION
solves:
https://github.com/metabase/metabase/security/code-scanning/305 https://github.com/metabase/metabase/security/code-scanning/304 https://github.com/metabase/metabase/security/code-scanning/301 https://github.com/metabase/metabase/security/code-scanning/302

does not solve:
https://github.com/metabase/metabase/security/code-scanning/490