### PR TITLE
Adjust semantic search query to favor HNSW index over seq scans

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -383,8 +383,7 @@
                              [:distance :semantic_score]]
                     :from [:vector_candidates]
                     :where [:<= :distance max-cosine-distance]
-                    :order-by [[:semantic_rank :asc]]
-                    :limit 100}]
+                    :order-by [[:semantic_rank :asc]]}]
     (if filters
       (update base-query :where #(into [:and] [% filters]))
       base-query)))
@@ -583,13 +582,6 @@
 (defn query-index
   "Query the index for documents similar to the search string."
   [db index search-context]
-  (try
-    ;; Incentivize HNSW index scans over seqscans by reducing cost factor from default 4.0
-    ;; TODO: there's definitely a better way of doing this
-    (jdbc/execute! db ["SET random_page_cost = 1.0"])
-    (catch Exception e
-      (log/warn e "Failed to apply random_page_cost optimization")))
-
   (let [{:keys [embedding-model]} index
         search-string (:search-string search-context)]
     (when-not (str/blank? search-string)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -347,21 +347,44 @@
      :limit 100}))
 
 (defn- semantic-search-query
-  "Build a semantic search query using vector similarity."
+  "Build a semantic search query using vector similarity with post-filtering to enable HNSW index usage."
   [index embedding search-context]
   (let [filters (search-filters search-context)
         embedding-literal (format-embedding embedding)
-        base-query {:select [[:id :id]
+        max-cosine-distance 0.7
+        ;; Inner query: pure vector search to better trigger HNSW index vs. seqscan
+        ;; TODO: only pull in necessary extra columns from configured filters
+        hnsw-query {:select [[:id :id]
                              [:model_id :model_id]
                              [:model :model]
                              [:content :content]
                              [:verified :verified]
                              [:metadata :metadata]
-                             [[:raw (str "embedding <=> " embedding-literal)] :semantic_score]
-                             [[:raw (str "row_number() OVER (ORDER BY embedding <=> " embedding-literal " ASC)")] :semantic_rank]]
+                             [:archived :archived]
+                             [:creator_id :creator_id]
+                             [:last_editor_id :last_editor_id]
+                             [:database_id :database_id]
+                             [:display_type :display_type]
+                             [:model_created_at :model_created_at]
+                             [:model_updated_at :model_updated_at]
+                             [:collection_id :collection_id]
+                             [[:raw (str "embedding <=> " embedding-literal)] :distance]]
                     :from   [(keyword (:table-name index))]
+                    :order-by [[[:raw (str "embedding <=> " embedding-literal)] :asc]]
+                    :limit  100}
+        base-query {:with [[:vector_candidates hnsw-query]]
+                    :select [[:id :id]
+                             [:model_id :model_id]
+                             [:model :model]
+                             [:content :content]
+                             [:verified :verified]
+                             [:metadata :metadata]
+                             [[:raw "row_number() OVER (ORDER BY distance ASC)"] :semantic_rank]
+                             [:distance :semantic_score]]
+                    :from [:vector_candidates]
+                    :where [:<= :distance max-cosine-distance]
                     :order-by [[:semantic_rank :asc]]
-                    :limit  100}]
+                    :limit 100}]
     (if filters
       (update base-query :where #(into [:and] [% filters]))
       base-query)))
@@ -560,6 +583,13 @@
 (defn query-index
   "Query the index for documents similar to the search string."
   [db index search-context]
+  (try
+    ;; Incentivize HNSW index scans over seqscans by reducing cost factor from default 4.0
+    ;; TODO: there's definitely a better way of doing this
+    (jdbc/execute! db ["SET random_page_cost = 1.0"])
+    (catch Exception e
+      (log/warn e "Failed to apply random_page_cost optimization")))
+
   (let [{:keys [embedding-model]} index
         search-string (:search-string search-context)]
     (when-not (str/blank? search-string)
@@ -626,3 +656,40 @@
   (require '[metabase.test :as mt])
   (mt/with-test-user :crowberto
     (doall (query-index db index {:search-string "Copper knife"}))))
+
+(comment
+  ;; Query performance analysis with EXPLAIN ANALYZE
+  ;; Run this to debug query performance and execution plans
+  (defn explain-analyze-query
+    [db sql-with-params]
+    (let [[sql & params] sql-with-params
+          explain-sql (str "EXPLAIN (ANALYZE true, BUFFERS true, FORMAT text) " sql)]
+      (jdbc/execute! db (into [explain-sql] params))))
+
+  ((requiring-resolve 'metabase-enterprise.semantic-search.db/init-db!))
+  (def db @@(requiring-resolve 'metabase-enterprise.semantic-search.db/data-source))
+  (jdbc/execute! db ["SHOW random_page_cost;"])      ; makes index scans appear cheaper
+  (jdbc/execute! db ["SHOW seq_page_cost;"])         ; default 1
+  (jdbc/execute! db ["SHOW hnsw.ef_search;"])
+  (jdbc/execute! db ["SET random_page_cost = 1.0;"]) ; Default 4, should set to seq_page_cost (default 1)
+  (jdbc/execute! db ["SET enable_seqscan = ON;"])    ; ON|OFF - Disable seq scan to force index scan
+
+  (def embedding-model (embedding/get-configured-model))
+  (def index (default-index embedding-model))
+  (def search-string "product orders")
+  (def search-context {:search-string search-string
+                       :models ["card" "dashboard"]
+                       :archived? false
+                       :verified nil})
+  (def search-context {:search-string search-string})
+
+  (def embedding (embedding/get-embedding (:embedding-model index) search-string))
+
+  ;; Format queries for execution
+  (def semantic-sql (sql-format-quoted (semantic-search-query index embedding search-context)))
+  (def keyword-sql (sql-format-quoted (keyword-search-query index search-context)))
+  (def hybrid-sql (sql-format-quoted (hybrid-search-query index embedding search-context)))
+  ;; do in repl ->
+  #_(explain-analyze-query db semantic-sql)
+  #_(explain-analyze-query db keyword-sql)
+  #_(explain-analyze-query db hybrid-sql))


### PR DESCRIPTION
Related to BOT-277

After noticing very slow search results in the most recent deploy of our semantic staging instance and local `EXPLAIN ANALYZE ...` testing, it would appear that our semantic search queries are not utilizing the HNSW index and instead fall back to sequential scans which severely underperform. [Slack context](https://metaboat.slack.com/archives/C07SJT1P0ET/p1754088387962289?thread_ts=1754081471.676639&cid=C07SJT1P0ET)

#61765 failed to address the root problem and search became even slower as a result (~30 seconds for search result -> over 3 minutes per my anecdotal experience)

This PR is a better attempt at addressing the issue:
  - Restructures `semantic-search-query` to use a two-stage CTE approach
    - Stage 1 is a pure vector search with importantly no `row_number()` calls or filters enabled, allowing the use of the HNSW index
    - Stage 2 is where we apply post index scan filters and result ranking that is consumed by the hybrid RRF implementation
  - [OUTDATED] ~~We set `random_page_cost = 1.0` on the db connection prior to hybrid search execution~~
    - From local `EXPLAIN ANALYZE` testing and manually disabling seq scans we can see that even with the above adjustments the index scan query cost is significant, so the plan falls back to the perceived better option of seq scan
    - Apparently this is a known problem when attempting to use HNSW indexes in pgvector
    - By reducing `random_page_cost` from its default value of 4, we reduce the estimated cost of the index scans and thus more reliably hit the HNSW index
  - Also added some query debugging helper stuff in the comment block which proved quite useful while looking into this

We reverted the changing of `random_page_cost` since the wildly inaccurate cost analysis of HNSW index scans seems to have been addressed in pgvector 0.8 which is what we're running.

NOTE: We should do further testing of query performance given different permutations of possible API filters

## Some data
This is from running locally with an appdb with ~10k indexed docs (mostly indexed entities)

<details>
<summary> -- BEFORE --> `(explain-analyze-query db semantic-sql-old)`</summary>

```
[{:QUERY PLAN
  "Limit  (cost=2676.57..2676.82 rows=100 width=81) (actual time=57.722..57.728 rows=100 loops=1)"}
 {:QUERY PLAN "  Buffers: shared hit=20673 read=16518"}
 {:QUERY PLAN
  "  ->  Sort  (cost=2676.57..2702.23 rows=10263 width=81) (actual time=57.719..57.722 rows=100 loops=1)"}
 {:QUERY PLAN "        Sort Key: (row_number() OVER (?))"}
 {:QUERY PLAN "        Sort Method: top-N heapsort  Memory: 42kB"}
 {:QUERY PLAN "        Buffers: shared hit=20673 read=16518"}
 {:QUERY PLAN
  "        ->  WindowAgg  (cost=2079.07..2284.33 rows=10263 width=81) (actual time=55.242..56.820 rows=10263 loops=1)"}
 {:QUERY PLAN "              Buffers: shared hit=20673 read=16518"}
 {:QUERY PLAN
  "              ->  Sort  (cost=2079.07..2104.73 rows=10263 width=73) (actual time=55.236..55.665 rows=10263 loops=1)"}
 {:QUERY PLAN
  "                    Sort Key: ((embedding <=> '[...]'::vector))"}
 {:QUERY PLAN
  "                    Sort Method: quicksort  Memory: 1396kB"}
 {:QUERY PLAN
  "                    Buffers: shared hit=20673 read=16518"}
 {:QUERY PLAN
  "                    ->  Seq Scan on index_table_openai_txt_embed_3_sm_1536  (cost=0.00..1395.29 rows=10263 width=73) (actual time=0.138..52.725 rows=10263 loops=1)"}
 {:QUERY PLAN
  "                          Buffers: shared hit=20673 read=16518"}
 {:QUERY PLAN "Planning:"}
 {:QUERY PLAN "  Buffers: shared hit=1"}
 {:QUERY PLAN "Planning Time: 0.191 ms"}
 {:QUERY PLAN "Execution Time: 57.817 ms"}]
```

</details>

<details>
<summary> -- AFTER --> `(explain-analyze-query db semantic-sql)`</summary>

```
[{:QUERY PLAN
  "Limit  (cost=1310.47..1310.55 rows=33 width=81) (actual time=1.983..1.990 rows=37 loops=1)"}
 {:QUERY PLAN "  Buffers: shared hit=570"}
 {:QUERY PLAN
  "  ->  Sort  (cost=1310.47..1310.55 rows=33 width=81) (actual time=1.981..1.984 rows=37 loops=1)"}
 {:QUERY PLAN "        Sort Key: (row_number() OVER (?))"}
 {:QUERY PLAN "        Sort Method: quicksort  Memory: 33kB"}
 {:QUERY PLAN "        Buffers: shared hit=570"}
 {:QUERY PLAN
  "        ->  WindowAgg  (cost=1103.71..1309.64 rows=33 width=81) (actual time=1.162..1.935 rows=37 loops=1)"}
 {:QUERY PLAN "              Buffers: shared hit=570"}
 {:QUERY PLAN
  "              ->  Subquery Scan on vector_candidates  (cost=1103.71..1309.14 rows=33 width=73) (actual time=1.139..1.892 rows=37 loops=1)"}
 {:QUERY PLAN
  "                    Filter: (vector_candidates.distance <= '0.7'::double precision)"}
 {:QUERY PLAN "                    Rows Removed by Filter: 4"}
 {:QUERY PLAN "                    Buffers: shared hit=570"}
 {:QUERY PLAN
  "                    ->  Limit  (cost=1103.71..1307.89 rows=100 width=138) (actual time=1.136..1.882 rows=41 loops=1)"}
 {:QUERY PLAN "                          Buffers: shared hit=570"}
 {:QUERY PLAN
  "                          ->  Index Scan using index_table_openai_txt_embed_3_sm_1536_embed_hnsw_idx on index_table_openai_txt_embed_3_sm_1536  (cost=1103.71..22059.26 rows=10263 width=138) (actual time=1.135..1.876 rows=41 loops=1)"}
 {:QUERY PLAN
  "                                Order By: (embedding <=> '[...]'::vector)"}
 {:QUERY PLAN
  "                                Buffers: shared hit=570"}
 {:QUERY PLAN "Planning:"}
 {:QUERY PLAN "  Buffers: shared hit=1"}
 {:QUERY PLAN "Planning Time: 0.327 ms"}
 {:QUERY PLAN "Execution Time: 2.083 ms"}]
```

</details>