### PR TITLE
Cleanup stacked card background on embed flow preview

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -6,7 +6,7 @@ import "react-resizable/css/styles.css";
 
 import { useUpdateSettingsMutation } from "metabase/api";
 import { useSetting, useToast } from "metabase/common/hooks";
-import { Box, Button, Card, Group, Stack } from "metabase/ui";
+import { Box, Button, Group, Stack } from "metabase/ui";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
 import { useSdkIframeEmbedNavigation } from "../hooks";
@@ -80,12 +80,10 @@ const SdkIframeEmbedSetupContent = () => {
       </SidebarResizer>
 
       <Box className={S.PreviewPanel}>
-        <Card p="md" h="100%">
-          <Stack h="100%">
-            {/** Only show the embed preview once the embedding is auto-enabled, or already enabled. */}
-            {isSimpleEmbeddingEnabled && <SdkIframeEmbedPreview />}
-          </Stack>
-        </Card>
+        <Stack h="100%">
+          {/** Only show the embed preview once the embedding is auto-enabled, or already enabled. */}
+          {isSimpleEmbeddingEnabled && <SdkIframeEmbedPreview />}
+        </Stack>
       </Box>
 
       {showSimpleEmbedTerms && (


### PR DESCRIPTION
Closes EMB-689

Fixes the double card background on embed flow.

<img width="2498" height="1608" alt="CleanShot 2568-08-04 at 16 04 58@2x" src="https://github.com/user-attachments/assets/591335f2-18fc-4e2a-ad3e-e2c9f94fadd3" />
