### PR TITLE
refactor(sdk): Add `x-metabase-version` header to BE responses

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data/use-init-data.ts
+++ b/enterprise/frontend/src/embedding-sdk/hooks/private/use-init-data/use-init-data.ts
@@ -5,7 +5,10 @@ import _ from "underscore";
 import { getEmbeddingSdkVersion } from "embedding-sdk/config";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk/store";
 import { initAuth } from "embedding-sdk/store/auth";
-import { setFetchRefreshTokenFn } from "embedding-sdk/store/reducer";
+import {
+  setFetchRefreshTokenFn,
+  setMetabaseInstanceVersion,
+} from "embedding-sdk/store/reducer";
 import {
   getFetchRefreshTokenFn,
   getLoginStatus,
@@ -66,6 +69,14 @@ export const useInitData = ({
     api.requestClient = {
       name: EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader,
       version: EMBEDDING_SDK_VERSION,
+    };
+
+    api.onResponseError = ({
+      metabaseVersion,
+    }: {
+      metabaseVersion: string;
+    }) => {
+      dispatch(setMetabaseInstanceVersion(metabaseVersion));
     };
 
     if (allowConsoleLog) {

--- a/enterprise/frontend/src/embedding-sdk/store/reducer.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/reducer.ts
@@ -15,11 +15,15 @@ import { createAsyncThunk } from "metabase/lib/redux";
 import { initAuth, refreshTokenAsync } from "./auth";
 import { getSessionTokenState } from "./selectors";
 
+const SET_METABASE_INSTANCE_VERSION = "sdk/SET_METABASE_INSTANCE_VERSION";
 const SET_METABASE_CLIENT_URL = "sdk/SET_METABASE_CLIENT_URL";
 const SET_LOADER_COMPONENT = "sdk/SET_LOADER_COMPONENT";
 const SET_ERROR_COMPONENT = "sdk/SET_ERROR_COMPONENT";
 const SET_FETCH_REQUEST_TOKEN_FN = "sdk/SET_FETCH_REQUEST_TOKEN_FN";
 
+export const setMetabaseInstanceVersion = createAction<string>(
+  SET_METABASE_INSTANCE_VERSION,
+);
 export const setMetabaseClientUrl = createAction<string>(
   SET_METABASE_CLIENT_URL,
 );
@@ -76,6 +80,7 @@ export const setUsageProblem = createAction<SdkUsageProblem | null>(
 
 const initialState: SdkState = {
   metabaseInstanceUrl: "",
+  metabaseInstanceVersion: null,
   token: {
     token: null,
     loading: false,
@@ -138,6 +143,10 @@ export const sdk = createReducer(initialState, (builder) => {
 
   builder.addCase(setErrorComponent, (state, action) => {
     state.errorComponent = action.payload;
+  });
+
+  builder.addCase(setMetabaseInstanceVersion, (state, action) => {
+    state.metabaseInstanceVersion = action.payload;
   });
 
   builder.addCase(setMetabaseClientUrl, (state, action) => {

--- a/enterprise/frontend/src/embedding-sdk/store/selectors.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/selectors.ts
@@ -1,4 +1,5 @@
 import type { SdkStoreState } from "embedding-sdk/store/types";
+import { getSetting } from "metabase/selectors/settings";
 import type { State } from "metabase-types/store";
 
 export const getLoginStatus = (state: SdkStoreState) => state.sdk?.loginStatus;
@@ -26,6 +27,9 @@ export const getErrorComponent = (state: SdkStoreState) =>
 
 export const getMetabaseInstanceUrl = (state: SdkStoreState) =>
   state.sdk?.metabaseInstanceUrl;
+
+export const getMetabaseInstanceVersion = (state: SdkStoreState) =>
+  state.sdk?.metabaseInstanceVersion ?? getSetting(state, "version")?.tag;
 
 export const getFetchRefreshTokenFn = (state: SdkStoreState) =>
   state.sdk.fetchRefreshTokenFn;

--- a/enterprise/frontend/src/embedding-sdk/store/types.ts
+++ b/enterprise/frontend/src/embedding-sdk/store/types.ts
@@ -24,6 +24,7 @@ export type SdkDispatch = ThunkDispatch<SdkStoreState, void, AnyAction>;
 
 export type SdkState = {
   metabaseInstanceUrl: MetabaseAuthConfig["metabaseInstanceUrl"];
+  metabaseInstanceVersion: string | null;
   token: EmbeddingSessionTokenState;
   loginStatus: LoginStatus;
   plugins: null | MetabasePluginsConfig;

--- a/enterprise/frontend/src/embedding-sdk/test/mocks/state.ts
+++ b/enterprise/frontend/src/embedding-sdk/test/mocks/state.ts
@@ -28,6 +28,7 @@ export const createMockSdkState = ({
 }: Partial<SdkState> = {}): SdkState => {
   return {
     metabaseInstanceUrl: "",
+    metabaseInstanceVersion: null,
     loginStatus: createMockLoginStatusState(),
     token: createMockTokenState(),
     usageProblem: null,

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -10,6 +10,8 @@ const MAX_RETRIES = 10;
 
 // eslint-disable-next-line no-literal-metabase-strings -- Not a user facing string
 const ANTI_CSRF_HEADER = "X-Metabase-Anti-CSRF-Token";
+// eslint-disable-next-line no-literal-metabase-strings -- Not a user facing string
+const METABASE_VERSION_HEADER = "X-Metabase-Version";
 
 let ANTI_CSRF_TOKEN = null;
 
@@ -35,6 +37,7 @@ export class Api extends EventEmitter {
   sessionToken;
 
   onBeforeRequest;
+  onResponseError;
 
   /**
    * @type {string|{name: string, version: string}}
@@ -245,6 +248,10 @@ export class Api extends EventEmitter {
         if (xhr.readyState === XMLHttpRequest.DONE) {
           // getResponseHeader() is case-insensitive
           const antiCsrfToken = xhr.getResponseHeader(ANTI_CSRF_HEADER);
+          const metabaseVersion = xhr.getResponseHeader(
+            METABASE_VERSION_HEADER,
+          );
+
           if (antiCsrfToken) {
             ANTI_CSRF_TOKEN = antiCsrfToken;
           }
@@ -259,12 +266,17 @@ export class Api extends EventEmitter {
           if (status === 202 && body && body._status > 0) {
             status = body._status;
           }
+
           if (status >= 200 && status <= 299) {
             if (options.transformResponse) {
               body = options.transformResponse({ body, data });
             }
             resolve(body);
           } else {
+            if (this.onResponseError) {
+              this.onResponseError({ body, status, metabaseVersion });
+            }
+
             reject({
               status: status,
               data: body,
@@ -323,6 +335,8 @@ export class Api extends EventEmitter {
           }
 
           const token = response.headers.get(ANTI_CSRF_HEADER);
+          const metabaseVersion = response.headers.get(METABASE_VERSION_HEADER);
+
           if (token) {
             ANTI_CSRF_TOKEN = token;
           }
@@ -341,6 +355,10 @@ export class Api extends EventEmitter {
             }
             return body;
           } else {
+            if (this.onResponseError) {
+              this.onResponseError({ body, status, metabaseVersion });
+            }
+
             throw { status: status, data: body };
           }
         });

--- a/src/metabase/server/handler.clj
+++ b/src/metabase/server/handler.clj
@@ -77,6 +77,7 @@
         #'mw.session/wrap-session-key                ; looks for a Metabase Session ID and assoc as :metabase-session-key
         #'mw.auth/wrap-static-api-key                ; looks for a static Metabase API Key on the request and assocs as :metabase-api-key
         #'wrap-cookies                               ; Parses cookies in the request map and assocs as :cookies
+        #'mw.misc/add-version                        ; Adds a X-Metabase-Version header to the response
         #'mw.misc/add-content-type                   ; Adds a Content-Type header for any response that doesn't already have one
         #'mw.misc/disable-streaming-buffering        ; Add header to streaming (async) responses so ngnix doesn't buffer keepalive bytes
         #'wrap-gzip                                  ; GZIP response if client can handle it

--- a/src/metabase/server/middleware/misc.clj
+++ b/src/metabase/server/middleware/misc.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.string :as str]
    [metabase.app-db.core :as mdb]
+   [metabase.config.core :as config]
    [metabase.request.core :as request]
    [metabase.server.streaming-response]
    [metabase.system.core :as system]
@@ -12,6 +13,24 @@
    (metabase.server.streaming_response StreamingResponse)))
 
 (comment metabase.server.streaming-response/keep-me)
+
+(defn- add-version*
+  "Assoc the `x-metabase-version` header onto the response."
+  [response]
+  (assoc-in response
+            [:headers "x-metabase-version"]
+            (:tag config/mb-version-info)))
+
+(defn add-version
+  "Middleware that adds an `x-metabase-version` header (from `:tag mb-version-info`)
+   to all API-call responses. Non-API calls are left untouched."
+  [handler]
+  (fn [request respond raise]
+    (handler request
+             (if-not (request/api-call? request)
+               respond
+               (comp respond add-version*))
+             raise)))
 
 (defn- add-content-type* [{:keys [body], {:strs [Content-Type]} :headers, :as response}]
   (cond-> response

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -233,7 +233,7 @@
         "Vary"                        "Origin"})
      {"Access-Control-Allow-Headers"  "*"
       "Access-Control-Allow-Methods"  "*"
-      "Access-Control-Expose-Headers" "X-Metabase-Anti-CSRF-Token"
+      "Access-Control-Expose-Headers" "X-Metabase-Anti-CSRF-Token, X-Metabase-Version"
       ;; Needed for Embedding SDK. Should cache preflight requests for the specified number of seconds.
       "Access-Control-Max-Age"  "60"})))
 

--- a/test/metabase/server/middleware/misc_test.clj
+++ b/test/metabase/server/middleware/misc_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [medley.core :as m]
+   [metabase.config.core :as config]
    [metabase.server.middleware.misc :as mw.misc]
    [metabase.system.core :as system]
    [metabase.test :as mt]
@@ -48,3 +49,25 @@
         (let [request (mock-request "/" "https://mb2.example.com" nil nil)]
           (maybe-set-site-url request)
           (is (= "https://mb1.example.com" (system/site-url))))))))
+
+(deftest add-version-header-test
+  (testing "x-metabase-version is only added on API calls"
+    (with-redefs [config/mb-version-info {:tag "v42"}]
+      (let [dummy-response {:status 200 :headers {} :body "ok"}
+            handler       (mw.misc/add-version (fn [_ respond _] (respond dummy-response)))]
+        (testing "API call"
+          (let [captured (atom nil)]
+            (handler (ring.mock/request :get "/api/foo")
+                     (fn [resp] (reset! captured resp))
+                     (fn [_] (is false "should not go to raise")))
+            (is (= "v42"
+                   (get-in @captured [:headers "x-metabase-version"]))
+                "header should be set for API calls")))
+        (testing "non-API call"
+          (let [captured (atom nil)]
+            (handler (ring.mock/request :get "/not-api")
+                     (fn [resp] (reset! captured resp))
+                     (fn [_] (is false "should not go to raise")))
+            (is (nil?
+                 (get-in @captured [:headers "x-metabase-version"]))
+                "header should not be set for non-API calls")))))))


### PR DESCRIPTION
The PR adds the `x-metabase-version` for API calls responses.

We need it for the Hosted Bundle project

Our case:
- SDK code is loaded from a MB instance of version N
- everything is fine
- api/setting fetched on SDK load returns version N
- then while a user is staying on a page a MB instance may be updated to version N+1
- now we must show an alert for a user that his SDK code is outdated and a page must be reloaded
- we want to do it when a user performs an API request
- so, any failing API request made from SDK of version N to MB instance of version N + 1 will show an alert.
- to avoid duplicated requests/polling/etc we attach MB version to all API responses

