### PR TITLE
change rspack to allow testing custom domains locally easier

### DIFF
--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -39,6 +39,14 @@ const PORT = process.env.PORT || 8080;
 const isDevMode = IS_DEV_MODE;
 const shouldEnableHotRefresh = WEBPACK_BUNDLE === "hot";
 
+// If you want to test metabase locally with a custom domain, either use
+// `metabase.local` or add your custom domain via the `MB_TEST_CUSTOM_DOMAINS`
+// environment variable so that rspack will allow requests from them.
+const TEST_CUSTOM_DOMAINS =
+  process.env.MB_TEST_CUSTOM_DOMAINS?.split(",")
+    .map((domain) => domain.trim())
+    .filter(Boolean) ?? [];
+
 const BABEL_LOADER = { loader: "babel-loader", options: BABEL_CONFIG };
 
 const SWC_LOADER = {
@@ -323,6 +331,7 @@ if (shouldEnableHotRefresh) {
     headers: {
       "Access-Control-Allow-Origin": "*",
     },
+    allowedHosts: ["localhost", "metabase.local", ...TEST_CUSTOM_DOMAINS],
     // tweak stats to make the output in the console more legible
     devMiddleware: {
       stats: { preset: "errors-warnings", timings: true },


### PR DESCRIPTION
Closes EMB-686


This makes testing custom domains locally easier, which is useful as the embedding team, just in the last months, found two issues caused in staging right before releasing that were not showing up locally because of special behaviour of localhost.

This adds a default of `company.local` and enables us to specify extra domains via an env

How to test:
point a domain to localhost in /etc/hosts and visit it, for example `company.local:3000`, everything (including hot reload) should work