### PR TITLE
Rename embed-iframe route to embed-js

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/auto-enable-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/auto-enable-embedding.cy.spec.ts
@@ -16,7 +16,7 @@ describe(suiteTitle, () => {
   });
 
   it("auto-enables the enable-embedding-simple settings", () => {
-    cy.visit("/embed-iframe");
+    cy.visit("/embed-js");
 
     cy.log("simple embedding toast should be shown");
     H.undoToast()

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -28,7 +28,7 @@ export const visitNewEmbedPage = ({
     params.append("locale", locale);
   }
 
-  cy.visit("/embed-iframe?" + params);
+  cy.visit("/embed-js?" + params);
 
   if (dismissEmbedTerms) {
     cy.log("simple embedding terms card should be shown");

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
@@ -102,7 +102,7 @@ const NewItemMenuView = ({
         <Menu.Item
           key="embed"
           component={ForwardRefLink}
-          to="/embed-iframe"
+          to="/embed-js"
           leftSection={<Icon name="embed" />}
           rightSection={<Badge size="xs">{t`Beta`}</Badge>}
         >

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -117,14 +117,12 @@ describe("nav > containers > Navbar > Core App", () => {
     expect(screen.queryByTestId("main-navbar-root")).not.toBeInTheDocument();
   });
 
-  ["question/1", "model/1", "dashboard/1", "embed-iframe"].forEach(
-    (pathname) => {
-      it(`should be hidden on initial load for a ${pathname}`, async () => {
-        await setup({ pathname: `/${pathname}` });
-        await expectNavbarClosed();
-      });
-    },
-  );
+  ["question/1", "model/1", "dashboard/1", "embed-js"].forEach((pathname) => {
+    it(`should be hidden on initial load for a ${pathname}`, async () => {
+      await setup({ pathname: `/${pathname}` });
+      await expectNavbarClosed();
+    });
+  });
 
   it("should hide when visiting a question", async () => {
     const store = await setup({ pathname: "/" });

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -76,7 +76,7 @@ const errorPage = handleActions(
 // regexr.com/7r89i
 // A word boundary is added to /model so it doesn't match /browse/models
 const PATH_WITH_COLLAPSED_NAVBAR =
-  /\/(model\b|question|dashboard|metabot|embed-iframe).*/;
+  /\/(model\b|question|dashboard|metabot|embed-js).*/;
 
 export function isNavbarOpenForPathname(pathname: string, prevState: boolean) {
   return (

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -179,7 +179,7 @@ export const getRoutes = (store) => {
           />
 
           <Route
-            path="embed-iframe"
+            path="embed-js"
             component={PLUGIN_EMBEDDING_IFRAME_SDK_SETUP.SdkIframeEmbedSetup}
           />
 


### PR DESCRIPTION
Closes EMB-693

Renames `/embed-iframe` to `/embed-js` everywhere.