### PR TITLE
fix(sdk): send CORS headers for error messages when embedding is disabled

### DIFF
--- a/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
+++ b/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
@@ -83,7 +83,7 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
 
     getSdkRoot().within(() => {
       cy.findByText(
-        "Unable to connect to instance at http://localhost:4000",
+        "Embedding SDK for React is disabled. Enable it in the embedding settings.",
       ).should("be.visible");
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -17,7 +17,7 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     frame.within(() => {
       cy.findByTestId("sdk-error-container")
         .should("be.visible")
-        .and("contain", "Backend returned an error when refreshing the token.");
+        .and("contain", "SSO has not been enabled and/or configured");
     });
   });
 
@@ -47,7 +47,7 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     frame.within(() => {
       cy.findByTestId("sdk-error-container")
         .should("be.visible")
-        .and("contain", "Backend returned an error when refreshing the token");
+        .and("contain", "SSO has not been enabled and/or configured");
     });
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -192,11 +192,19 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     });
 
     cy.log("must fail to login via SAML as the SAML endpoint does not exist");
+
+    // If the error message returns a 500 (internal server error) status code,
+    // we should show a generic error message.
+    // This happens because the SAML endpoint is not mocked in this test.
     cy.wait("@authSso").its("response.statusCode").should("eq", 500);
+
     frame.within(() => {
       cy.findByTestId("sdk-error-container")
         .should("be.visible")
-        .and("contain", "Backend returned an error when refreshing the token.");
+        .and(
+          "contain",
+          "Unable to connect to instance at http://localhost:4000 (status: 500)",
+        );
     });
   });
 });

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -128,7 +128,7 @@
 (defn- throw-simple-embedding-disabled
   []
   (throw
-   (ex-info (tru "Simple Embedding is disabled. Enable it in the embedding settings.")
+   (ex-info (tru "Embedded Analytics JS is disabled. Enable it in the embedding settings.")
             {:status      "error-embedding-simple-disabled"
              :status-code 402})))
 

--- a/enterprise/frontend/src/embedding-sdk/errors/generic.ts
+++ b/enterprise/frontend/src/embedding-sdk/errors/generic.ts
@@ -10,13 +10,17 @@ export function USER_FETCH_FAILED() {
 export function CANNOT_CONNECT_TO_INSTANCE({
   instanceUrl,
   status,
+  message,
 }: {
   instanceUrl: string;
   status?: number;
+  message?: string;
 }) {
+  const defaultMessage = `Unable to connect to instance at ${instanceUrl}${status ? ` (status: ${status})` : ""}`;
+
   return new MetabaseError(
     "CANNOT_CONNECT_TO_INSTANCE",
-    `Unable to connect to instance at ${instanceUrl}${status ? ` (status: ${status})` : ""}`,
+    message ?? defaultMessage,
     { status },
   );
 }
@@ -34,8 +38,4 @@ export function AUTH_TIMEOUT() {
     "AUTH_TIMEOUT",
     "Authentication has not been completed in time.",
   );
-}
-
-export function SSO_DISABLED({ message }: { message: string }) {
-  return new MetabaseError("SSO_DISABLED", message);
 }

--- a/enterprise/frontend/src/embedding-sdk/errors/generic.ts
+++ b/enterprise/frontend/src/embedding-sdk/errors/generic.ts
@@ -35,3 +35,7 @@ export function AUTH_TIMEOUT() {
     "Authentication has not been completed in time.",
   );
 }
+
+export function SSO_DISABLED({ message }: { message: string }) {
+  return new MetabaseError("SSO_DISABLED", message);
+}

--- a/enterprise/frontend/src/embedding-sdk/errors/generic.ts
+++ b/enterprise/frontend/src/embedding-sdk/errors/generic.ts
@@ -16,13 +16,16 @@ export function CANNOT_CONNECT_TO_INSTANCE({
   status?: number;
   message?: string;
 }) {
-  const defaultMessage = `Unable to connect to instance at ${instanceUrl}${status ? ` (status: ${status})` : ""}`;
+  // If error status is 500 (internal server error) or no message is provided,
+  // we provide a generic error message.
+  const errorMessage =
+    !message || status === 500
+      ? `Unable to connect to instance at ${instanceUrl}${status ? ` (status: ${status})` : ""}`
+      : message;
 
-  return new MetabaseError(
-    "CANNOT_CONNECT_TO_INSTANCE",
-    message ?? defaultMessage,
-    { status },
-  );
+  return new MetabaseError("CANNOT_CONNECT_TO_INSTANCE", errorMessage, {
+    status,
+  });
 }
 
 export function INVALID_AUTH_METHOD({ method }: { method: string }) {

--- a/enterprise/frontend/src/embedding-sdk/errors/jwt.ts
+++ b/enterprise/frontend/src/embedding-sdk/errors/jwt.ts
@@ -26,11 +26,7 @@ export function REFRESH_TOKEN_BACKEND_ERROR(params: {
   status?: string;
   message?: string;
 }) {
-  return new MetabaseError(
-    "BACKEND_ERROR_STATUS",
-    `Backend returned an error when refreshing the token. Status: ${params.status ?? "unknown"}${params.message ? ", Message: " + params.message : ""}.`,
-    params,
-  );
+  return new MetabaseError("BACKEND_ERROR_STATUS", params.message, params);
 }
 
 export function CUSTOM_FETCH_REQUEST_TOKEN_ERROR(params: {

--- a/enterprise/frontend/src/embedding-sdk/errors/jwt.ts
+++ b/enterprise/frontend/src/embedding-sdk/errors/jwt.ts
@@ -27,7 +27,7 @@ export function REFRESH_TOKEN_BACKEND_ERROR(params: {
   message?: string;
 }) {
   const errorMessage =
-    params.message ??
+    params.message ||
     `Backend returned an error when refreshing the token.${params.status ? ` Status: ${params.status}` : ""}`;
 
   return new MetabaseError("BACKEND_ERROR_STATUS", errorMessage, params);

--- a/enterprise/frontend/src/embedding-sdk/errors/jwt.ts
+++ b/enterprise/frontend/src/embedding-sdk/errors/jwt.ts
@@ -26,7 +26,13 @@ export function REFRESH_TOKEN_BACKEND_ERROR(params: {
   status?: string;
   message?: string;
 }) {
-  return new MetabaseError("BACKEND_ERROR_STATUS", params.message, params);
+  const defaultMessage = `Backend returned an error when refreshing the token. Status: ${params.status ?? "unknown"}.`;
+
+  return new MetabaseError(
+    "BACKEND_ERROR_STATUS",
+    params.message ?? defaultMessage,
+    params,
+  );
 }
 
 export function CUSTOM_FETCH_REQUEST_TOKEN_ERROR(params: {

--- a/enterprise/frontend/src/embedding-sdk/errors/jwt.ts
+++ b/enterprise/frontend/src/embedding-sdk/errors/jwt.ts
@@ -26,13 +26,11 @@ export function REFRESH_TOKEN_BACKEND_ERROR(params: {
   status?: string;
   message?: string;
 }) {
-  const defaultMessage = `Backend returned an error when refreshing the token. Status: ${params.status ?? "unknown"}.`;
+  const errorMessage =
+    params.message ??
+    `Backend returned an error when refreshing the token.${params.status ? ` Status: ${params.status}` : ""}`;
 
-  return new MetabaseError(
-    "BACKEND_ERROR_STATUS",
-    params.message ?? defaultMessage,
-    params,
-  );
+  return new MetabaseError("BACKEND_ERROR_STATUS", errorMessage, params);
 }
 
 export function CUSTOM_FETCH_REQUEST_TOKEN_ERROR(params: {

--- a/enterprise/frontend/src/embedding/auth-common/connect-to-instance-auth-sso.ts
+++ b/enterprise/frontend/src/embedding/auth-common/connect-to-instance-auth-sso.ts
@@ -32,11 +32,10 @@ export async function connectToInstanceAuthSso(
 
     if (!urlResponse.ok) {
       let errorData;
+
       try {
         errorData = await urlResponse.json();
-      } catch {
-        // If JSON parsing fails, errorData will be undefined
-      }
+      } catch {}
 
       throw MetabaseError.CANNOT_CONNECT_TO_INSTANCE({
         instanceUrl: url,

--- a/enterprise/frontend/src/embedding/auth-common/connect-to-instance-auth-sso.ts
+++ b/enterprise/frontend/src/embedding/auth-common/connect-to-instance-auth-sso.ts
@@ -31,17 +31,17 @@ export async function connectToInstanceAuthSso(
     const urlResponse = await fetch(ssoUrl, { headers });
 
     if (!urlResponse.ok) {
-      const errorData = await urlResponse.json();
-
-      if (errorData.status === "error-sso-disabled") {
-        throw MetabaseError.SSO_DISABLED({
-          message: errorData.message,
-        });
+      let errorData;
+      try {
+        errorData = await urlResponse.json();
+      } catch {
+        // If JSON parsing fails, errorData will be undefined
       }
 
       throw MetabaseError.CANNOT_CONNECT_TO_INSTANCE({
         instanceUrl: url,
         status: urlResponse.status,
+        message: errorData?.message,
       });
     }
     return await urlResponse.json();

--- a/enterprise/frontend/src/embedding/auth-common/connect-to-instance-auth-sso.ts
+++ b/enterprise/frontend/src/embedding/auth-common/connect-to-instance-auth-sso.ts
@@ -29,7 +29,16 @@ export async function connectToInstanceAuthSso(
 
   try {
     const urlResponse = await fetch(ssoUrl, { headers });
+
     if (!urlResponse.ok) {
+      const errorData = await urlResponse.json();
+
+      if (errorData.status === "error-sso-disabled") {
+        throw MetabaseError.SSO_DISABLED({
+          message: errorData.message,
+        });
+      }
+
       throw MetabaseError.CANNOT_CONNECT_TO_INSTANCE({
         instanceUrl: url,
         status: urlResponse.status,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -383,8 +383,6 @@ class MetabaseEmbed {
           error,
         });
       }
-
-      throw error;
     }
   }
 

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -270,10 +270,12 @@
                  :nonce          (:nonce request)
                  :allow-iframes? ((some-fn request/public? request/embed?) request)
                  :allow-cache?   (request/cacheable? request))
-        ;; Add CORS headers for /auth/sso endpoint with 402 status (embedding disabled errors)
-        ;; This allows frontend to read error messages when embedding SDK is not set up
+        ;; Add CORS headers for /auth/sso endpoint
+        ;; - For OPTIONS requests (preflight) to allow CORS
+        ;; - For 402 status (embedding disabled errors) to allow frontend to read error messages
         cors-headers (when (and (= (:uri request) "/auth/sso")
-                                (= (:status response) 402))
+                                (or (= (:request-method request) :options)
+                                    (= (:status response) 402)))
                        {"Access-Control-Allow-Origin" "*"
                         "Access-Control-Allow-Headers" "*"
                         "Access-Control-Allow-Methods" "*"})]

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -272,10 +272,10 @@
                  :allow-cache?   (request/cacheable? request))
         ;; Add CORS headers for /auth/sso endpoint
         ;; - For OPTIONS requests (preflight) to allow CORS
-        ;; - For 402 status (embedding disabled errors) to allow frontend to read error messages
+        ;; - For 400/402 status (client/embedding errors) to allow frontend to read error messages
         cors-headers (when (and (= (:uri request) "/auth/sso")
                                 (or (= (:request-method request) :options)
-                                    (= (:status response) 402)))
+                                    (contains? #{400 402} (:status response))))
                        {"Access-Control-Allow-Origin" "*"
                         "Access-Control-Allow-Headers" "*"
                         "Access-Control-Allow-Methods" "*"})]

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -82,6 +82,8 @@
    ;; ^/api/health -> Health Check Endpoint
    (GET "/api/health" [] health-handler)
 
+   ;; Handle CORS preflight requests for auth routes
+   (OPTIONS "/auth/*" [] {:status 200 :body ""})
    (OPTIONS "/api/*" [] {:status 200 :body ""})
 
    ;; ^/api/ -> All other API routes

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -470,30 +470,4 @@
                                       identity
                                       identity)]
         (is (nil? (get-in response [:headers "Access-Control-Allow-Origin"]))
-            (format "Should not set CORS headers for /auth/sso with %d status" status)))))
-
-  (testing "Should not add CORS headers for OPTIONS requests to other endpoints"
-    (let [wrapped-handler (mw.security/add-security-headers
-                           (fn [_request respond _raise]
-                             (respond {:status 200
-                                       :headers {}
-                                       :body ""})))
-          response (wrapped-handler {:request-method :options
-                                     :uri "/api/some-other-endpoint"
-                                     :headers {"origin" "https://example.com"}}
-                                    identity
-                                    identity)]
-      (is (nil? (get-in response [:headers "Access-Control-Allow-Origin"]))
-          "Should not set CORS headers for OPTIONS requests to other endpoints")))
-
-  (testing "Should not add CORS headers for other endpoints with 402 status"
-    (let [wrapped-handler (mw.security/add-security-headers
-                           (fn [_request respond _raise]
-                             (respond {:status 402
-                                       :headers {"Content-Type" "application/json"}
-                                       :body "{\"status\": \"error\"}"})))
-          response (wrapped-handler {:uri "/api/some-other-endpoint" :headers {"origin" "https://example.com"}}
-                                    identity
-                                    identity)]
-      (is (nil? (get-in response [:headers "Access-Control-Allow-Origin"]))
-          "Should not set CORS headers for other endpoints with 402 status"))))
+            (format "Should not set CORS headers for /auth/sso with %d status" status))))))


### PR DESCRIPTION
Closes EMB-645

## Summary

This PR adds CORS support for error messages on the `/auth/sso` endpoint, enabling the frontend to properly handle and display server error messages when embedding is configured. This improves error handling for the embedding SDK by allowing cross-origin access to error responses.

## Changes Made

### Backend Changes

**CORS Middleware** (`src/metabase/server/middleware/security.clj`)
- Added CORS headers for `/auth/sso` endpoint in two scenarios:
  - OPTIONS requests (preflight) for proper CORS support
  - 400/402 status responses to allow frontend access to error messages
- Supports both client errors (400) and embedding disabled errors (402)

**Route Handler** (`src/metabase/server/routes.clj`)
- Added `OPTIONS "/auth/*"` route to handle CORS preflight requests
- Returns 200 OK with empty body for OPTIONS requests

### Frontend Changes

**Error Handling** (`enterprise/frontend/src/embedding/auth-common/connect-to-instance-auth-sso.ts`)
- Conditionally uses server error message when available
- Falls back to generic error message when JSON parsing fails

**Error Types** (`enterprise/frontend/src/embedding-sdk/errors/generic.ts`)
- `CANNOT_CONNECT_TO_INSTANCE` accepts optional `message` parameter
- Uses server message when provided, falls back to default message

## Demos

- Specific server messages are now shown directly:
  - "SSO has not been enabled and/or configured"
  - "Simple Embedding is disabled. Enable it in the embedding settings."
  - "The auth/sso endpoint only exists in enterprise builds"

<img width="1392" height="714" alt="CleanShot 2568-08-05 at 02 58 06@2x" src="https://github.com/user-attachments/assets/196946ca-ceed-4736-8827-6ad636154f79" />

<img width="1114" height="582" alt="CleanShot 2568-08-05 at 02 59 50@2x" src="https://github.com/user-attachments/assets/7b6dae78-4e3d-49e5-bc31-29923d1d5a71" />
