### PR TITLE
[SEMANTIC] base64 embeddings and better logging

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -107,4 +107,11 @@
                   {:model "dashboard"
                    :id "3"
                    :searchable_text "This is a test dashboard"}])
-  (delete-from-index! "card" ["1" "2"]))
+  (delete-from-index! "card" ["1" "2"])
+
+  ;; reindex! testing
+  (require '[metabase.search.ingestion :as search.ingestion])
+  (def all-docs (search.ingestion/searchable-documents))
+  (def subset-docs (eduction (take 2000) all-docs))
+  (reindex! subset-docs {})
+  (reindex! all-docs {}))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -232,7 +232,7 @@
      :min (apply min counts)
      :max (apply max counts)
      :sum (reduce + counts)
-     :avg (Double/parseDouble (format "%.2f" (double avg-raw)))}))
+     :avg (parse-double (format "%.2f" (double avg-raw)))}))
 
 (defn process-embeddings-streaming
   "Process texts in provider-appropriate batches, calling process-fn for each batch. process-fn will be called with

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -226,12 +226,13 @@
 
 (defn- calc-token-metrics
   [texts]
-  (let [counts (map count-tokens texts)]
+  (let [counts  (map count-tokens texts)
+        avg-raw (/ (reduce + counts) (count counts))]
     {:n   (count texts)
      :min (apply min counts)
      :max (apply max counts)
      :sum (reduce + counts)
-     :avg (double (/ (reduce + counts) (count counts)))}))
+     :avg (Double/parseDouble (format "%.2f" (double avg-raw)))}))
 
 (defn process-embeddings-streaming
   "Process texts in provider-appropriate batches, calling process-fn for each batch. process-fn will be called with


### PR DESCRIPTION
Primary changes:
  - Request base64 encoded embedding vectors from the openai API
    - Results in 50% faster embedding pipeline runtime
  - Reworked & added some logging to embedding generation & index update pipeline

<details>
<summary>Float encoded (before)</summary>

```
2025-08-04 19:50:55,701 INFO semantic.core :: Initializing semantic search engine 
2025-08-04 19:50:55,720 INFO semantic-search.db :: Initializing semantic search connection pool with properties: {idleConnectionTestPeriod 60, maxIdleTimeExcessConnections 600, maxConnectionAge 1800, maxPoolSize 5, minPoolSize 1, initialPoolSize 1, dataSourceName metabase-semantic-search-db} 
2025-08-04 19:50:55,756 INFO semantic-search.index-metadata :: Creating metadata table if not exists index_metadata (0) 
2025-08-04 19:50:55,758 INFO semantic-search.index-metadata :: Creating control table if not exists index_control (0) 
2025-08-04 19:50:56,351 INFO semantic-search.index :: Populating semantic search index with 10263 documents 
2025-08-04 19:51:01,192 INFO semantic-search.index :: semantic search processed 622 total documents with frequencies {indexed-entity 595, dashboard 9, table 8, collection 4, database 2, dataset 4} 
2025-08-04 19:51:08,916 INFO semantic-search.index :: semantic search processed 575 total documents with frequencies {indexed-entity 575} 
2025-08-04 19:51:13,317 INFO semantic-search.index :: semantic search processed 573 total documents with frequencies {indexed-entity 573} 
2025-08-04 19:51:19,464 INFO semantic-search.index :: semantic search processed 579 total documents with frequencies {indexed-entity 579} 
2025-08-04 19:51:27,686 INFO semantic-search.index :: semantic search processed 1038 total documents with frequencies {indexed-entity 1038} 
2025-08-04 19:51:35,045 INFO semantic-search.index :: semantic search processed 856 total documents with frequencies {indexed-entity 856} 
2025-08-04 19:51:40,370 INFO semantic-search.index :: semantic search processed 708 total documents with frequencies {indexed-entity 708} 
2025-08-04 19:51:49,240 INFO semantic-search.index :: semantic search processed 1101 total documents with frequencies {indexed-entity 1101} 
2025-08-04 19:52:00,158 INFO semantic-search.index :: semantic search processed 1238 total documents with frequencies {indexed-entity 1238} 
2025-08-04 19:52:08,752 INFO semantic-search.index :: semantic search processed 947 total documents with frequencies {indexed-entity 947} 
2025-08-04 19:52:17,646 INFO semantic-search.index :: semantic search processed 1207 total documents with frequencies {indexed-entity 1207} 
2025-08-04 19:52:26,944 INFO semantic-search.index :: semantic search processed 1225 total documents with frequencies {indexed-entity 1225} 
2025-08-04 19:52:32,881 INFO semantic-search.index :: semantic search processed 907 total documents with frequencies {indexed-entity 871, card 34, metric 2} 
2025-08-04 19:52:32,900 INFO search.core :: Index initialized in 100565ms (["indexed-entity" 10200] ["card" 34] ["dashboard" 9] ["table" 8] ["dataset" 4] ["collection" 4] ["database" 2] ["metric" 2]) 
```

</details>

<details>
<summary>Base64</summary>

```
2025-08-04 19:43:43,355 INFO semantic.core :: Initializing semantic search engine 
2025-08-04 19:43:43,373 INFO semantic-search.db :: Initializing semantic search connection pool with properties: {idleConnectionTestPeriod 60, maxIdleTimeExcessConnections 600, maxConnectionAge 1800, maxPoolSize 5, minPoolSize 1, initialPoolSize 1, dataSourceName metabase-semantic-search-db} 
2025-08-04 19:43:43,408 INFO semantic-search.index-metadata :: Creating metadata table if not exists index_metadata (0) 
2025-08-04 19:43:43,410 INFO semantic-search.index-metadata :: Creating control table if not exists index_control (0) 
2025-08-04 19:43:45,667 INFO metabase.util ::    ⮦ Embedding batch 1/13 {:n 622, :min 1, :max 47, :sum 3994, :avg 6.42} took 1.5 s 
2025-08-04 19:43:48,263 INFO metabase.util ::    ⮦ Semantic index database update of 622 documents {"indexed-entity" 595, "dashboard" 9, "table" 8, "collection" 4, "database" 2, "dataset" 4} took 2.6 s 
2025-08-04 19:43:49,373 INFO metabase.util ::    ⮦ Embedding batch 2/13 {:n 575, :min 4, :max 11, :sum 3993, :avg 6.94} took 1.1 s 
2025-08-04 19:43:51,912 INFO metabase.util ::    ⮦ Semantic index database update of 575 documents {"indexed-entity" 575} took 2.5 s 
2025-08-04 19:43:53,074 INFO metabase.util ::    ⮦ Embedding batch 3/13 {:n 573, :min 5, :max 11, :sum 3994, :avg 6.97} took 1.2 s 
2025-08-04 19:43:54,678 INFO metabase.util ::    ⮦ Semantic index database update of 573 documents {"indexed-entity" 573} took 1.6 s 
2025-08-04 19:43:55,615 INFO metabase.util ::    ⮦ Embedding batch 4/13 {:n 579, :min 5, :max 10, :sum 3995, :avg 6.9} took 936.8 ms 
2025-08-04 19:43:57,858 INFO metabase.util ::    ⮦ Semantic index database update of 579 documents {"indexed-entity" 579} took 2.2 s 
2025-08-04 19:43:59,156 INFO metabase.util ::    ⮦ Embedding batch 5/13 {:n 842, :min 1, :max 11, :sum 4000, :avg 4.75} took 1.3 s 
2025-08-04 19:44:02,913 INFO metabase.util ::    ⮦ Semantic index database update of 1038 documents {"indexed-entity" 1038} took 3.8 s 
2025-08-04 19:44:04,258 INFO metabase.util ::    ⮦ Embedding batch 6/13 {:n 750, :min 1, :max 14, :sum 3998, :avg 5.33} took 1.3 s 
2025-08-04 19:44:06,522 INFO metabase.util ::    ⮦ Semantic index database update of 856 documents {"indexed-entity" 856} took 2.3 s 
2025-08-04 19:44:07,963 INFO metabase.util ::    ⮦ Embedding batch 7/13 {:n 706, :min 2, :max 12, :sum 3993, :avg 5.66} took 1.4 s 
2025-08-04 19:44:09,536 INFO metabase.util ::    ⮦ Semantic index database update of 708 documents {"indexed-entity" 708} took 1.6 s 
2025-08-04 19:44:11,210 INFO metabase.util ::    ⮦ Embedding batch 8/13 {:n 951, :min 1, :max 13, :sum 4000, :avg 4.21} took 1.7 s 
2025-08-04 19:44:14,329 INFO metabase.util ::    ⮦ Semantic index database update of 1101 documents {"indexed-entity" 1101} took 3.1 s 
2025-08-04 19:44:15,844 INFO metabase.util ::    ⮦ Embedding batch 9/13 {:n 1009, :min 1, :max 10, :sum 4000, :avg 3.96} took 1.5 s 
2025-08-04 19:44:19,191 INFO metabase.util ::    ⮦ Semantic index database update of 1238 documents {"indexed-entity" 1238} took 3.3 s 
2025-08-04 19:44:20,951 INFO metabase.util ::    ⮦ Embedding batch 10/13 {:n 936, :min 2, :max 9, :sum 3998, :avg 4.27} took 1.8 s 
2025-08-04 19:44:24,446 INFO metabase.util ::    ⮦ Semantic index database update of 947 documents {"indexed-entity" 947} took 3.5 s 
2025-08-04 19:44:26,155 INFO metabase.util ::    ⮦ Embedding batch 11/13 {:n 1017, :min 1, :max 12, :sum 3999, :avg 3.93} took 1.7 s 
2025-08-04 19:44:28,704 INFO metabase.util ::    ⮦ Semantic index database update of 1207 documents {"indexed-entity" 1207} took 2.5 s 
2025-08-04 19:44:30,740 INFO metabase.util ::    ⮦ Embedding batch 12/13 {:n 992, :min 1, :max 12, :sum 3996, :avg 4.03} took 2.0 s 
2025-08-04 19:44:33,933 INFO metabase.util ::    ⮦ Semantic index database update of 1225 documents {"indexed-entity" 1225} took 3.2 s 
2025-08-04 19:44:34,997 INFO metabase.util ::    ⮦ Embedding batch 13/13 {:n 711, :min 1, :max 23, :sum 3359, :avg 4.72} took 1.1 s 
2025-08-04 19:44:37,158 INFO metabase.util ::    ⮦ Semantic index database update of 907 documents {"indexed-entity" 871, "card" 34, "metric" 2} took 2.2 s 
2025-08-04 19:44:37,171 INFO metabase.util ::  ⮦ Generating embeddings {:model "text-embedding-3-small", :dimenions 1536, :texts {:n 10263, :min 1, :max 47, :sum 51319, :avg 5.0}} took 53.1 s 
2025-08-04 19:44:37,172 INFO metabase.util :: Semantic search embedding generation and db update for {:docs 10263, :texts 10263} took 53.1 s 
2025-08-04 19:44:37,176 INFO search.core :: Index initialized in 57270ms (["indexed-entity" 10200] ["card" 34] ["dashboard" 9] ["table" 8] ["dataset" 4] ["collection" 4] ["database" 2] ["metric" 2]) 
```

</details>

<details>
<summary>Base64 & 512 dimension length (from 1536)</summary>

```
2025-08-04 19:47:19,220 INFO semantic.core :: Initializing semantic search engine 
2025-08-04 19:47:19,238 INFO semantic-search.db :: Initializing semantic search connection pool with properties: {idleConnectionTestPeriod 60, maxIdleTimeExcessConnections 600, maxConnectionAge 1800, maxPoolSize 5, minPoolSize 1, initialPoolSize 1, dataSourceName metabase-semantic-search-db} 
2025-08-04 19:47:19,275 INFO semantic-search.index-metadata :: Creating metadata table if not exists index_metadata (0) 
2025-08-04 19:47:19,276 INFO semantic-search.index-metadata :: Creating control table if not exists index_control (0)  
2025-08-04 19:47:21,105 INFO metabase.util ::    ⮦ Embedding batch 1/13 {:n 622, :min 1, :max 47, :sum 3994, :avg 6.42} took 1.0 s 
2025-08-04 19:47:21,885 INFO metabase.util ::    ⮦ Semantic index database update of 622 documents {"indexed-entity" 595, "dashboard" 9, "table" 8, "collection" 4, "database" 2, "dataset" 4} took 777.5 ms 
2025-08-04 19:47:22,958 INFO metabase.util ::    ⮦ Embedding batch 2/13 {:n 575, :min 4, :max 11, :sum 3993, :avg 6.94} took 1.1 s 
2025-08-04 19:47:23,661 INFO metabase.util ::    ⮦ Semantic index database update of 575 documents {"indexed-entity" 575} took 702.8 ms 
2025-08-04 19:47:24,564 INFO metabase.util ::    ⮦ Embedding batch 3/13 {:n 573, :min 5, :max 11, :sum 3994, :avg 6.97} took 901.7 ms 
2025-08-04 19:47:25,066 INFO metabase.util ::    ⮦ Semantic index database update of 573 documents {"indexed-entity" 573} took 501.9 ms 
2025-08-04 19:47:26,294 INFO metabase.util ::    ⮦ Embedding batch 4/13 {:n 579, :min 5, :max 10, :sum 3995, :avg 6.9} took 1.2 s 
2025-08-04 19:47:27,194 INFO metabase.util ::    ⮦ Semantic index database update of 579 documents {"indexed-entity" 579} took 899.2 ms 
2025-08-04 19:47:29,395 INFO metabase.util ::    ⮦ Embedding batch 5/13 {:n 842, :min 1, :max 11, :sum 4000, :avg 4.75} took 2.2 s 
2025-08-04 19:47:30,599 INFO metabase.util ::    ⮦ Semantic index database update of 1038 documents {"indexed-entity" 1038} took 1.2 s 
2025-08-04 19:47:31,559 INFO metabase.util ::    ⮦ Embedding batch 6/13 {:n 750, :min 1, :max 14, :sum 3998, :avg 5.33} took 959.9 ms 
2025-08-04 19:47:32,487 INFO metabase.util ::    ⮦ Semantic index database update of 856 documents {"indexed-entity" 856} took 927.3 ms 
2025-08-04 19:47:33,246 INFO metabase.util ::    ⮦ Embedding batch 7/13 {:n 706, :min 2, :max 12, :sum 3993, :avg 5.66} took 758.5 ms 
2025-08-04 19:47:34,336 INFO metabase.util ::    ⮦ Semantic index database update of 708 documents {"indexed-entity" 708} took 1.1 s 
2025-08-04 19:47:36,628 INFO metabase.util ::    ⮦ Embedding batch 8/13 {:n 951, :min 1, :max 13, :sum 4000, :avg 4.21} took 2.3 s 
2025-08-04 19:47:38,139 INFO metabase.util ::    ⮦ Semantic index database update of 1101 documents {"indexed-entity" 1101} took 1.5 s 
2025-08-04 19:47:39,252 INFO metabase.util ::    ⮦ Embedding batch 9/13 {:n 1009, :min 1, :max 10, :sum 4000, :avg 3.96} took 1.1 s 
2025-08-04 19:47:40,554 INFO metabase.util ::    ⮦ Semantic index database update of 1238 documents {"indexed-entity" 1238} took 1.3 s 
2025-08-04 19:47:41,699 INFO metabase.util ::    ⮦ Embedding batch 10/13 {:n 936, :min 2, :max 9, :sum 3998, :avg 4.27} took 1.1 s 
2025-08-04 19:47:43,299 INFO metabase.util ::    ⮦ Semantic index database update of 947 documents {"indexed-entity" 947} took 1.6 s 
2025-08-04 19:47:44,784 INFO metabase.util ::    ⮦ Embedding batch 11/13 {:n 1017, :min 1, :max 12, :sum 3999, :avg 3.93} took 1.5 s 
2025-08-04 19:47:46,691 INFO metabase.util ::    ⮦ Semantic index database update of 1207 documents {"indexed-entity" 1207} took 1.9 s 
2025-08-04 19:47:47,903 INFO metabase.util ::    ⮦ Embedding batch 12/13 {:n 992, :min 1, :max 12, :sum 3996, :avg 4.03} took 1.2 s 
2025-08-04 19:47:49,395 INFO metabase.util ::    ⮦ Semantic index database update of 1225 documents {"indexed-entity" 1225} took 1.5 s 
2025-08-04 19:47:50,513 INFO metabase.util ::    ⮦ Embedding batch 13/13 {:n 711, :min 1, :max 23, :sum 3359, :avg 4.72} took 1.1 s 
2025-08-04 19:47:51,616 INFO metabase.util ::    ⮦ Semantic index database update of 907 documents {"indexed-entity" 871, "card" 34, "metric" 2} took 1.1 s 
2025-08-04 19:47:51,630 INFO metabase.util ::  ⮦ Generating embeddings {:model "text-embedding-3-small", :dimenions 512, :texts {:n 10263, :min 1, :max 47, :sum 51319, :avg 5.0}} took 31.8 s 
2025-08-04 19:47:51,630 INFO metabase.util :: Semantic search embedding generation and db update for {:docs 10263, :texts 10263} took 31.8 s 
2025-08-04 19:47:51,632 INFO search.core :: Index initialized in 35806ms (["indexed-entity" 10200] ["card" 34] ["dashboard" 9] ["table" 8] ["dataset" 4] ["collection" 4] ["database" 2] ["metric" 2]) 
```

</details>