### PR TITLE
fix search.engine/init! return 

### DIFF
--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -44,7 +44,8 @@
     search-engine))
 
 (defmulti init!
-  "Ensure that the search index exists, and is ready to take search queries."
+  "Ensure that the search index exists, and is ready to take search queries.
+   Returns a map of the number of documents indexed in each model"
   {:arglists '([engine opts])}
   (fn [engine _opts]
     engine))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-300/bad-return-for-searchengineinit

Covered by existing tests in metabase-enterprise.semantic-search.index-test, which now pass
