### PR TITLE
Support switching between :semantic and :appdb engines

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -1,0 +1,19 @@
+(ns metabase-enterprise.semantic-search.core-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.search.core :as search]
+   [metabase.search.engine :as search.engine]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (compose-fixtures
+                     (fixtures/initialize :db)
+                     #'semantic.tu/once-fixture))
+
+(deftest appdb-available-with-semantic
+  (mt/with-premium-features #{:semantic-search}
+    (with-open [_ (semantic.tu/open-temp-index!)]
+      (semantic.tu/cleanup-index-metadata! semantic.tu/db semantic.tu/mock-index-metadata)
+      (search/init-index! {:force-reset? false, :re-populate? false})
+      (is (search.engine/supported-engine? :search.engine/appdb)))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -1,9 +1,11 @@
 (ns metabase-enterprise.semantic-search.core-test
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
-   [metabase.search.core :as search]
-   [metabase.search.engine :as search.engine]
+   [metabase.search.appdb.core :as appdb]
+   [metabase.search.core :as search] [metabase.search.engine :as search.engine]
+   [metabase.search.settings :as search.settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
@@ -13,7 +15,46 @@
 
 (deftest appdb-available-with-semantic
   (mt/with-premium-features #{:semantic-search}
-    (with-open [_ (semantic.tu/open-temp-index!)]
-      (semantic.tu/cleanup-index-metadata! semantic.tu/db semantic.tu/mock-index-metadata)
-      (search/init-index! {:force-reset? false, :re-populate? false})
-      (is (search.engine/supported-engine? :search.engine/appdb)))))
+    (mt/with-temporary-setting-values [search.settings/search-engine "semantic"]
+      (with-open [_ (semantic.tu/open-temp-index!)]
+        (semantic.tu/cleanup-index-metadata! semantic.tu/db semantic.tu/mock-index-metadata)
+        (search/init-index! {:force-reset? false, :re-populate? false})
+        (is (search.engine/supported-engine? :search.engine/appdb))))))
+
+(deftest api-engine-switching-test
+  (mt/with-premium-features #{:semantic-search}
+    (mt/with-temporary-setting-values [search.settings/search-engine "semantic"]
+      (with-open [_ (semantic.tu/open-temp-index!)]
+        (testing "API defaults to semantic engine when configured"
+          (let [semantic-called? (atom false)
+                appdb-called? (atom false)]
+            (with-redefs [semantic.pgvector-api/query
+                          (fn [& _]
+                            (reset! semantic-called? true)
+                            [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0}])
+                          appdb/results
+                          (fn [_]
+                            (reset! appdb-called? true)
+                            [{:id 2 :name "appdb-result" :model "card" :collection_id 1 :score 0.9}])]
+
+              (let [response (mt/user-http-request :crowberto :get 200 "search" :q "test")]
+                (is @semantic-called? "Semantic search should be called by default")
+                (is (not @appdb-called?) "AppDB search should not be called by default")
+                (is (= "search.engine/semantic" (:engine response)))))))
+
+        (testing "API can override engine with search_engine=appdb parameter"
+          (let [semantic-called? (atom false)
+                appdb-called? (atom false)]
+            (with-redefs [semantic.pgvector-api/query
+                          (fn [& _]
+                            (reset! semantic-called? true)
+                            [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0.8}])
+                          appdb/results
+                          (fn [_]
+                            (reset! appdb-called? true)
+                            [{:id 2 :name "appdb-result" :model "card" :collection_id 1 :score 0.9}])]
+
+              (let [response (mt/user-http-request :crowberto :get 200 "search" :q "test" :search_engine "appdb")]
+                (is (not @semantic-called?) "Semantic search should not be called when overridden")
+                (is @appdb-called? "AppDB search should be called when specified")
+                (is (= "search.engine/appdb" (:engine response)))))))))))

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -41,8 +41,10 @@
   #{:postgres :h2})
 
 (defmethod search.engine/supported-engine? :search.engine/appdb [_]
-  (and (or (not config/is-prod?)
-           (= "appdb" (some-> (search.settings/search-engine) name)))
+  (and (or config/is-dev?
+           ;; if the default engine is semantic we want appdb to be available,
+           ;; as we want to mix results
+           (#{"appdb" "semantic"} (some-> (search.settings/search-engine) name)))
        (supported-db? (mdb/db-type))))
 
 (defn- parse-datetime [s]

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -102,7 +102,7 @@
       true (sql.helpers/where (or-null permitted-clause))
       personal-clause (sql.helpers/where (or-null personal-clause)))))
 
-(defmethod search.engine/results :search.engine/appdb
+(defn- results
   [{:keys [search-engine search-string] :as search-ctx}]
   ;; Check whether there is a query-able index.
   (when-not (search.index/active-table)
@@ -152,6 +152,10 @@
       ;; Rule out the error coming from stale index metadata.
       (#'search.index/sync-tracking-atoms!)
       (throw e))))
+
+(defmethod search.engine/results :search.engine/appdb
+  [search-ctx]
+  (results search-ctx))
 
 (defmethod search.engine/model-set :search.engine/appdb
   [search-ctx]


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-276/support-switching-between-semantic-and-appdb-engines