### PR TITLE
[Release blocker] Revert join custom columns changes

### DIFF
--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -728,9 +728,10 @@
   (lib.util/clause-of-type? lhs-or-rhs :value))
 
 (mu/defn join-condition-lhs-or-rhs-column? :- :boolean
-  "Whether this LHS or RHS expression is a `:field` reference."
+  "Whether this LHS or RHS expression is a `:field` or `:expression` reference."
   [lhs-or-rhs :- [:maybe ::lib.schema.expression/expression]]
-  (lib.util/field-clause? lhs-or-rhs))
+  (or (lib.util/clause-of-type? lhs-or-rhs :field)
+      (lib.util/clause-of-type? lhs-or-rhs :expression)))
 
 (mu/defn filter-args-display-name :- :string
   "Provides a reasonable display name for the `filter-clause` excluding the column-name.

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -811,8 +811,7 @@
                                       (joins query stage-number))]
      (->> (lib.metadata.calculation/visible-columns query stage-number
                                                     (lib.util/query-stage query stage-number)
-                                                    {:include-expressions?         false
-                                                     :include-implicitly-joinable? false})
+                                                    {:include-implicitly-joinable? false})
           (remove (fn [col]
                     (when-let [col-join-alias (lib.join.util/current-join-alias col)]
                       (contains? join-aliases-to-ignore col-join-alias))))

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -817,7 +817,8 @@
                       (contains? join-aliases-to-ignore col-join-alias))))
           (mark-selected-column query
                                 stage-number
-                                (when (lib.util/field-clause? lhs-expression-or-nil)
+                                (when (or (lib.util/clause-of-type? lhs-expression-or-nil :field)
+                                          (lib.util/clause-of-type? lhs-expression-or-nil :expression))
                                   lhs-expression-or-nil))
           sort-join-condition-columns))))
 

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -900,15 +900,18 @@
       (lib/+ rhs-product-price rhs-product-price))))
 
 (deftest ^:parallel join-condition-lhs-or-rhs-column?-test
-  (let [query             (lib/query meta/metadata-provider (meta/table-metadata :orders))
+  (let [query             (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                              (lib/expression "double-total" (lib/* (meta/field-metadata :orders :total) 2)))
         products          (meta/table-metadata :products)
         lhs-columns       (lib/join-condition-lhs-columns query products nil nil)
         lhs-order-tax     (m/find-first (comp #{"TAX"} :name) lhs-columns)
         rhs-columns       (lib/join-condition-rhs-columns query products nil nil)
-        rhs-product-price (m/find-first (comp #{"PRICE"} :name) rhs-columns)]
+        rhs-product-price (m/find-first (comp #{"PRICE"} :name) rhs-columns)
+        lhs-custom-column (m/find-first (comp #{"double-total"} :name) lhs-columns)]
     (are [lhs-or-rhs] (true? (lib.fe-util/join-condition-lhs-or-rhs-column? lhs-or-rhs))
       (lib/ref lhs-order-tax)
-      (lib/ref rhs-product-price))
+      (lib/ref rhs-product-price)
+      (lib/ref lhs-custom-column))
     (are [lhs-or-rhs] (false? (lib.fe-util/join-condition-lhs-or-rhs-column? lhs-or-rhs))
       (lib.expression/value 1)
       (lib/+ lhs-order-tax 1)

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -702,15 +702,16 @@
                 (lib/join-condition-lhs-columns query nil nil rhs)))))))
 
 (deftest ^:parallel join-condition-lhs-columns-expression-test
-  (testing "Should not include expressions in LHS columns"
+  (testing "Should include expressions in LHS columns"
     (let [query (-> (lib.tu/venues-query)
                     (lib/expression "double-price" (lib/* (meta/field-metadata :venues :price) 2)))]
-      (is (=? [{:lib/desired-column-alias "ID"}
-               {:lib/desired-column-alias "CATEGORY_ID"}
-               {:lib/desired-column-alias "NAME"}
-               {:lib/desired-column-alias "LATITUDE"}
-               {:lib/desired-column-alias "LONGITUDE"}
-               {:lib/desired-column-alias "PRICE"}]
+      (is (=? [{:name "ID"}
+               {:name "CATEGORY_ID"}
+               {:name "NAME"}
+               {:name "LATITUDE"}
+               {:name "LONGITUDE"}
+               {:name "PRICE"}
+               {:name "double-price"}]
               (lib/join-condition-lhs-columns query nil nil nil))))))
 
 (deftest ^:parallel join-condition-lhs-columns-with-previous-join-test

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -817,7 +817,7 @@
           lhs-columns       (lib/join-condition-lhs-columns query products nil nil)
           lhs-custom-column (m/find-first (comp #{"expr"} :name) lhs-columns)
           rhs-columns       (lib/join-condition-rhs-columns query products nil nil)
-          rhs-product-price (m/find-first (comp #{"ID"} :name) rhs-columns)
+          rhs-product-price (m/find-first (comp #{"PRICE"} :name) rhs-columns)
           query             (lib/join query (lib/join-clause products [(lib/= lhs-custom-column rhs-product-price)]))]
       (is (=? [{:name "ID"}
                {:name "USER_ID"}

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -811,14 +811,14 @@
                                                    (lib/+ (meta/field-metadata :venues :id) 1)
                                                    (lib/+ (meta/field-metadata :categories :id) 1)))))))
   (testing "should mark custom columns from LHS columns as selected"
-    (let [query       (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                          (lib/expression "expr" (lib/* (meta/field-metadata :orders :total) 2)))
-          products    (meta/table-metadata :products)
-          lhs-columns (lib/join-condition-lhs-columns query products nil nil)
-          lhs-column  (m/find-first (comp #{"expr"} :name) lhs-columns)
-          rhs-columns (lib/join-condition-rhs-columns query products nil nil)
-          rhs-column  (m/find-first (comp #{"ID"} :name) rhs-columns)
-          query       (lib/join query (lib/join-clause products [(lib/= lhs-column rhs-column)]))]
+    (let [query             (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                                (lib/expression "expr" (lib/* (meta/field-metadata :orders :total) 2)))
+          products          (meta/table-metadata :products)
+          lhs-columns       (lib/join-condition-lhs-columns query products nil nil)
+          lhs-custom-column (m/find-first (comp #{"expr"} :name) lhs-columns)
+          rhs-columns       (lib/join-condition-rhs-columns query products nil nil)
+          rhs-product-price (m/find-first (comp #{"ID"} :name) rhs-columns)
+          query             (lib/join query (lib/join-clause products [(lib/= lhs-custom-column rhs-product-price)]))]
       (is (=? [{:name "ID"}
                {:name "USER_ID"}
                {:name "PRODUCT_ID"}
@@ -832,8 +832,8 @@
               (map (partial lib/display-info query)
                    (lib/join-condition-lhs-columns query
                                                    (first (lib/joins query))
-                                                   (lib/ref lhs-column)
-                                                   (lib/ref rhs-column))))))))
+                                                   (lib/ref lhs-custom-column)
+                                                   (lib/ref rhs-product-price))))))))
 
 (deftest ^:parallel join-condition-rhs-columns-join-table-test
   (testing "RHS columns when building a join against a Table"


### PR DESCRIPTION
Partially reverts https://github.com/metabase/metabase/pull/60310
Slack thread https://metaboat.slack.com/archives/C01LQQ2UW03/p1754334712811499

Allows to pick a custom column for a LHS join condition expression.

<img width="1302" height="804" alt="Screenshot 2025-08-05 at 09 16 47" src="https://github.com/user-attachments/assets/7b0f6f07-028f-443a-bb42-4a7ffddd6b50" />
