### PR TITLE
fix: zoom on objectid on browser navigation (#55487)

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -269,6 +269,33 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     cy.findByText(`Showing ${EXPECTED_LINKED_ORDERS_COUNT} rows`);
   });
 
+  it("should open, close or update the Object Detail View modal when going back and forth in the browser (metabase#55487)", () => {
+    H.openProductsTable();
+
+    H.openObjectDetail(4);
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText("4134502155718").should("be.visible");
+    });
+
+    cy.go("back");
+    cy.findByTestId("object-detail").should("not.exist");
+
+    cy.go("forward");
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText("4134502155718").should("be.visible");
+    });
+
+    cy.findByTestId("view-previous-object-detail").click();
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText("4966277046676").should("be.visible");
+    });
+
+    cy.go("back");
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText("4134502155718").should("be.visible");
+    });
+  });
+
   it("should fetch linked entities data only once per entity type when reopening the modal (metabase#32720)", () => {
     cy.intercept("POST", "/api/dataset", cy.spy().as("fetchDataset"));
 

--- a/frontend/src/metabase/query_builder/actions/navigation.ts
+++ b/frontend/src/metabase/query_builder/actions/navigation.ts
@@ -28,15 +28,15 @@ export const popState = createThunkAction(
     dispatch(cancelQuery());
 
     const zoomedObjectId = getZoomedObjectId(getState());
-    if (zoomedObjectId) {
-      const { state, query } = getLocation(getState());
-      const previouslyZoomedObjectId = state?.objectId || query?.objectId;
 
-      if (
-        previouslyZoomedObjectId &&
-        zoomedObjectId !== previouslyZoomedObjectId
-      ) {
-        dispatch(zoomInRow({ objectId: previouslyZoomedObjectId }));
+    const { state, query } = getLocation(getState());
+    const objectIdParam = state?.objectId || query?.objectId;
+
+    if (zoomedObjectId !== objectIdParam) {
+      // objectId in location params doesn't match the currently zoomed object
+      // Zoom on new ID, or reset zoom if no ID
+      if (objectIdParam) {
+        dispatch(zoomInRow({ objectId: objectIdParam }));
       } else {
         dispatch(resetRowZoom());
       }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55487

### Description

Pressing the browser's back button would close an ObjectDetailView dialog, but pressing forward would not reopen it.

Updated the `locationChanged` effect in the Query Builder to compare the ID marked as opened (`zoomedRowObjectId`) with the URL param and trigger an open or close action in case they don't match.

There's still some weird behavior if you mix browser navigation with the X button.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Databases -> Sample Database -> Products
2. Click on a entry, dialog opens
3. Click the back button, dialog closes
4. Click the forward button, dialog opens again (it wouldn't before)

### Demo

https://github.com/user-attachments/assets/56a4f56a-ff8e-49f3-a75d-56db30a1a25b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
