### PR TITLE
Fix navigate forwards to a Details modal for QB

### DIFF
--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -363,8 +363,9 @@ describe("scenarios > models metadata", () => {
         cy.findByTestId("object-detail").within(() => {
           cy.findByText("68883"); // zip
           cy.findAllByText("Hudson Borer");
-          cy.icon("close").click();
         });
+
+        cy.go("back"); // close Object Details view
 
         cy.go("back"); // navigate away from drilled table
         cy.wait("@dataset");

--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -1097,3 +1097,30 @@ describe("issue 56416", () => {
     H.assertQueryBuilderRowCount(1);
   });
 });
+
+describe("issue 55487", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should be able open object details on browser forward navigation (metabase#55487)", () => {
+    H.visitQuestion(ORDERS_QUESTION_ID);
+
+    cy.findByTestId("table-body")
+      .get("[data-index='4']")
+      .within(() => {
+        cy.get("[data-column-id='ID']").click();
+      });
+
+    cy.findByTestId("object-detail").should("be.visible");
+
+    cy.go("back");
+
+    cy.findByTestId("object-detail").should("not.exist");
+
+    cy.go("forward");
+
+    cy.findByTestId("object-detail").should("be.visible");
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -166,8 +166,12 @@ export const navigateToNewCardInsideQB = createThunkAction(
           // to start building a new ad-hoc question based on a dataset
           dispatch(setCardAndRun({ ...card, type: "question" }));
         }
+
         if (objectId !== undefined) {
-          dispatch(zoomInRow({ objectId }));
+          // TODO: this should happen after we navigated to a new card, but in reality we open details view before navigation, which adds one more item in browser history
+          setTimeout(() => {
+            dispatch(zoomInRow({ objectId }));
+          });
         }
       }
     };

--- a/frontend/src/metabase/query_builder/actions/navigation.ts
+++ b/frontend/src/metabase/query_builder/actions/navigation.ts
@@ -81,6 +81,10 @@ export const popState = createThunkAction(
         }),
       );
     }
+
+    if (location.state.objectId) {
+      await dispatch(zoomInRow({ objectId: location.state.objectId }));
+    }
   },
 );
 

--- a/frontend/src/metabase/query_builder/actions/object-detail.ts
+++ b/frontend/src/metabase/query_builder/actions/object-detail.ts
@@ -28,7 +28,8 @@ import { zoomInRow } from "./zoom";
 export const RESET_ROW_ZOOM = "metabase/qb/RESET_ROW_ZOOM";
 export const resetRowZoom = () => (dispatch: Dispatch) => {
   dispatch({ type: RESET_ROW_ZOOM });
-  dispatch(updateUrl());
+
+  dispatch(updateUrl(null, { preserveParameters: false }));
 };
 
 function filterByFk(


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/55487 / UXW-38

### Description

Fixes forward navigation in Query Builder into object id

### Demo


https://github.com/user-attachments/assets/dbbbd441-7bff-4563-a7bd-7c692ac0e9b1


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
