### PR TITLE
Add thread pool for embedding requests

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -408,6 +408,7 @@
   clojure.test.check.clojure-test/defspec                                               clojure.test/deftest
   clojure.test.check.properties/for-all                                                 clojure.core/let
   clojurewerkz.quartzite.jobs/defjob                                                    clojure.core/defn
+  com.climate.claypoole/with-shutdown!                                                  clojure.core/let
   instaparse.core/defparser                                                             clojure.core/def
   metabase-enterprise.action-v2.test-util/with-test-tables!                             clojure.core/let
   metabase-enterprise.serialization.test-util/with-dbs                                  clojure.core/fn

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,12 +74,12 @@ jobs:
     with:
       skip: ${{ needs.files-changed.outputs.backend_all != 'true' && needs.static-viz-files-changed.outputs.static_viz != 'true' }}
 
-  # semantic-search-tests:
-  #   needs: files-changed
-  #   uses: ./.github/workflows/semantic-search.yml
-  #   secrets: inherit
-  #   with:
-  #     skip: ${{ needs.files-changed.outputs.backend_all != 'true' }}
+  semantic-search-tests:
+    needs: files-changed
+    uses: ./.github/workflows/semantic-search.yml
+    secrets: inherit
+    with:
+      skip: ${{ needs.files-changed.outputs.backend_all != 'true' }}
 
   app-db-tests:
     needs: files-changed

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -50,7 +50,7 @@
       (semantic.pgvector-api/index-documents!
        pgvector
        index-metadata
-       (vec document-reducible)))))
+       document-reducible))))
 
 (defenterprise delete-from-index!
   "Enterprise implementation of semantic index deletion."
@@ -64,7 +64,7 @@
        pgvector
        index-metadata
        model
-       (vec ids)))))
+       ids))))
 
 ;; TODO: add reindexing/table-swapping logic when index is detected as stale
 (defenterprise init!
@@ -76,7 +76,7 @@
         embedding-model (get-configured-embedding-model)]
     (jdbc/with-transaction [tx pgvector]
       (semantic.pgvector-api/init-semantic-search! tx index-metadata embedding-model))
-    (semantic.pgvector-api/index-documents! pgvector index-metadata (vec searchable-documents))))
+    (semantic.pgvector-api/index-documents! pgvector index-metadata searchable-documents)))
 
 (defenterprise reindex!
   "Reindex the semantic search index."
@@ -88,7 +88,7 @@
     ;; todo force a new index
     (jdbc/with-transaction [tx pgvector]
       (semantic.pgvector-api/init-semantic-search! tx index-metadata embedding-model))
-    (semantic.pgvector-api/index-documents! pgvector index-metadata (vec searchable-documents))))
+    (semantic.pgvector-api/index-documents! pgvector index-metadata searchable-documents)))
 
 ;; TODO: implement
 (defenterprise reset-tracking!

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -109,7 +109,7 @@
   [items process-fn]
   (if (seq items)
     (cp/with-shutdown! [pool (cp/threadpool (semantic-settings/embedding-concurrency-limit) :name "embedding-request-thread-pool")]
-      (cp/pmap pool process-fn items))
+      (doall (cp/pmap pool process-fn items)))
     []))
 
 ;;;; Provider SPI

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -126,13 +126,14 @@
 
 (defn- batch-update!
   [connectable table-name records->sql documents embeddings]
-  (u/prog1 (->> documents (map :model) frequencies)
-    (u/profile (str "Semantic index database update of " (count documents) " documents " <>)
-      (doseq [batch (->> (map vector documents embeddings)
-                         (map (fn [[doc embedding]] (doc->db-record embedding doc)))
-                         (partition-all *batch-size*))]
-        (jdbc/execute! connectable (records->sql batch)))
-      (analytics-set-index-size! connectable table-name))))
+  (when (seq documents)
+    (u/prog1 (->> documents (map :model) frequencies)
+      (u/profile (str "Semantic index database update of " (count documents) " documents " <>)
+        (doseq [batch (->> (map vector documents embeddings)
+                           (map (fn [[doc embedding]] (doc->db-record embedding doc)))
+                           (partition-all *batch-size*))]
+          (jdbc/execute! connectable (records->sql batch)))
+        (analytics-set-index-size! connectable table-name)))))
 
 (defn- batch-delete-ids!
   [connectable table-name model ids->sql ids]
@@ -144,9 +145,10 @@
                                                      "documents with model type" model)))))
                            +
                            ids)]
-    (log/info "semantic search deleted" deleted "total documents with model type" model)
-    (analytics-set-index-size! connectable table-name)
-    {model deleted}))
+    (when (pos? deleted)
+      (log/info "semantic search deleted" deleted "total documents with model type" model)
+      (analytics-set-index-size! connectable table-name)
+      {model deleted})))
 
 (defn- db-records->update-set
   [db-records]
@@ -167,33 +169,34 @@
 
 (defn- upsert-index-batch!
   [connectable index documents]
-  (let [text->docs         (group-by :searchable_text documents)
-        searchable-texts   (keys text->docs)]
-    (u/profile (str "Semantic search embedding generation and db update for " {:docs (count documents) :texts (count searchable-texts)})
-      (embedding/process-embeddings-streaming
-       (:embedding-model index)
-       searchable-texts
-       (fn [text->embedding]
-         (let [batch-documents
-               (mapcat (fn [text]
-                         (if-let [embedding (text->embedding text)]
-                           (map #(assoc % :embedding embedding) (get text->docs text))
-                           (when-let [docs (get text->docs text)]
-                             (log/warn "No embedding found for" (count docs) "documents with searchable text:"
-                                       {:searchable_text text
-                                        :document_count (count docs)}))))
-                       (keys text->embedding))]
-           (batch-update!
-            connectable
-            (:table-name index)
-            (fn [db-records]
-              (-> (sql.helpers/insert-into (keyword (:table-name index)))
-                  (sql.helpers/values db-records)
-                  (sql.helpers/on-conflict :model :model_id)
-                  (sql.helpers/do-update-set (db-records->update-set db-records))
-                  sql-format-quoted))
-            batch-documents
-            (map :embedding batch-documents))))))))
+  (when (seq documents)
+    (let [text->docs         (group-by :searchable_text documents)
+          searchable-texts   (keys text->docs)]
+      (u/profile (str "Semantic search embedding generation and db update for " {:docs (count documents) :texts (count searchable-texts)})
+        (embedding/process-embeddings-streaming
+         (:embedding-model index)
+         searchable-texts
+         (fn [text->embedding]
+           (let [batch-documents
+                 (mapcat (fn [text]
+                           (if-let [embedding (text->embedding text)]
+                             (map #(assoc % :embedding embedding) (get text->docs text))
+                             (when-let [docs (get text->docs text)]
+                               (log/warn "No embedding found for" (count docs) "documents with searchable text:"
+                                         {:searchable_text text
+                                          :document_count (count docs)}))))
+                         (keys text->embedding))]
+             (batch-update!
+              connectable
+              (:table-name index)
+              (fn [db-records]
+                (-> (sql.helpers/insert-into (keyword (:table-name index)))
+                    (sql.helpers/values db-records)
+                    (sql.helpers/on-conflict :model :model_id)
+                    (sql.helpers/do-update-set (db-records->update-set db-records))
+                    sql-format-quoted))
+              batch-documents
+              (map :embedding batch-documents)))))))))
 
 (defn upsert-index!
   "Inserts or updates documents in the index table. If a document with the same

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -672,7 +672,7 @@
      (-> (sql.helpers/delete-from (keyword (:table-name index)))
          (sql.helpers/where [:and
                              [:= :model model]
-                             [:in :model_id batch-ids]])
+                             [:in :model_id (map str batch-ids)]])
          sql-format-quoted))
    model-ids))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -168,7 +168,7 @@
 (defn- upsert-index-batch!
   [connectable index documents]
   (let [text->docs         (group-by :searchable_text documents)
-        searchable-texts   (map :searchable_text documents)]
+        searchable-texts   (keys text->docs)]
     (u/profile (str "Semantic search embedding generation and db update for " {:docs (count documents) :texts (count searchable-texts)})
       (embedding/process-embeddings-streaming
        (:embedding-model index)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -51,3 +51,12 @@
   :export? false
   :visibility :internal
   :description "Maximum number of texts per batch for embedding.")
+
+(defsetting embedding-concurrency-limit
+  (deferred-tru "Maximum number of concurrent embedding requests to process in parallel.")
+  :type :integer
+  :default 2
+  :encryption :no
+  :export? false
+  :visibility :internal
+  :description "Controls how many embedding requests can be processed concurrently. Higher values increase throughput but use more resources.")

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -49,8 +49,7 @@
   :default 4000
   :encryption :no
   :export? false
-  :visibility :internal
-  :description "Maximum number of texts per batch for embedding.")
+  :visibility :internal)
 
 (defsetting embedding-concurrency-limit
   (deferred-tru "Maximum number of concurrent embedding requests to process in parallel.")
@@ -58,5 +57,4 @@
   :default 2
   :encryption :no
   :export? false
-  :visibility :internal
-  :description "Controls how many embedding requests can be processed concurrently. Higher values increase throughput but use more resources.")
+  :visibility :internal)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.analytics.core :as analytics]
@@ -216,6 +217,50 @@
                        :content "Tiger Conservation"
                        :embedding (semantic.tu/get-mock-embedding "Tiger Conservation")}]
                      (semantic.tu/query-embeddings {:model "card" :model_id "3"}))))))))))
+
+(deftest upsert-index-batched-embeddings-dedupe-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-open [_ (semantic.tu/open-temp-index!)]
+      (testing "Documents with identical searchable texts lead to deduped embedding calc"
+        (let [test-documents [{:model "card"
+                               :id "1"
+                               :searchable_text "Dog Training Guide"
+                               :creator_id 1
+                               :legacy_input {:model "card" :id "1"}
+                               :metadata {}}
+                              {:model "card"
+                               :id "2"
+                               :searchable_text "Elephant Migration"
+                               :creator_id 2
+                               :legacy_input {:model "card" :id "2"}
+                               :metadata {}}
+                              {:model "card"
+                               :id "3"
+                               :searchable_text "Dog Training Guide"
+                               :creator_id 3
+                               :legacy_input {:model "card" :id "3"}
+                               :metadata {}}]]
+          (binding [semantic.index/*batch-size* 5]
+            (let [{:keys [calls proxy]} (semantic.tu/spy semantic.embedding/process-embeddings-streaming)]
+              (with-redefs [semantic.embedding/process-embeddings-streaming proxy]
+                (semantic.tu/upsert-index! test-documents))
+              (is (= 1 (count @calls)))
+              (is (= ["Dog Training Guide" "Elephant Migration"]
+                     (second (:args (first @calls))))))
+            (is (= [{:model "card" :model_id "1" :creator_id 1
+                     :content "Dog Training Guide"
+                     :embedding (semantic.tu/get-mock-embedding "Dog Training Guide")}]
+                   (semantic.tu/query-embeddings {:model "card" :model_id "1"})))
+
+            (is (= [{:model "card" :model_id "2" :creator_id 2
+                     :content "Elephant Migration"
+                     :embedding (semantic.tu/get-mock-embedding "Elephant Migration")}]
+                   (semantic.tu/query-embeddings {:model "card" :model_id "2"})))
+
+            (is (= [{:model "card" :model_id "3" :creator_id 3
+                     :content "Dog Training Guide"
+                     :embedding (semantic.tu/get-mock-embedding "Dog Training Guide")}]
+                   (semantic.tu/query-embeddings {:model "card" :model_id "3"})))))))))
 
 (deftest prometheus-metrics-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
@@ -65,14 +65,6 @@
     ;; not defined specific exception behaviour here yet, but best not to return empty or something silly like that
     (is (thrown? Exception (apply sut args)))))
 
-(defn- spy [f]
-  (let [calls (atom [])]
-    {:calls calls
-     :proxy (fn [& args]
-              (let [ret (apply f args)]
-                (swap! calls conj {:args args, :ret ret})
-                ret))}))
-
 (deftest index-documents!-test
   (let [pgvector       semantic.tu/db
         index-metadata (semantic.tu/unique-index-metadata)
@@ -83,7 +75,7 @@
     (with-open [index-ref (open-semantic-search! pgvector index-metadata model1)]
       ;; no specific behaviour, only proxies the active index to the index search
       (testing "is only a proxy for the active index call"
-        (let [{:keys [proxy calls]} (spy semantic.index/upsert-index!)
+        (let [{:keys [proxy calls]} (semantic.tu/spy semantic.index/upsert-index!)
               documents (semantic.tu/mock-documents)]
           (with-redefs [semantic.index/upsert-index! proxy]
             (testing "check proxies correct args and ret is untouched"
@@ -115,7 +107,7 @@
       ;; no specific behaviour, only proxies the active index to the index search
       (testing "is only a proxy for the active index call"
         (semantic.pgvector-api/index-documents! pgvector index-metadata documents)
-        (let [{:keys [calls proxy]} (spy semantic.index/delete-from-index!)]
+        (let [{:keys [calls proxy]} (semantic.tu/spy semantic.index/delete-from-index!)]
           (with-redefs [semantic.index/delete-from-index! proxy]
             (testing "check proxies correct args and ret is untouched"
               (let [ret1 (sut pgvector index-metadata dash dash-ids)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -381,3 +381,11 @@
 (defn check-index-has-mock-docs []
   (check-index-has-mock-card)
   (check-index-has-mock-dashboard))
+
+(defn spy [f]
+  (let [calls (atom [])]
+    {:calls calls
+     :proxy (fn [& args]
+              (let [ret (apply f args)]
+                (swap! calls conj {:args args, :ret ret})
+                ret))}))

--- a/src/metabase/permissions/models/collection/graph.clj
+++ b/src/metabase/permissions/models/collection/graph.clj
@@ -87,7 +87,6 @@
 
 (defn- calculate-perm-groups [collection-namespace group-id->perms collection-ids]
   (into {}
-        #_:clj-kondo/ignore
         (cp/with-shutdown! [pool (+ 2 (cp/ncpus))]
           (doall (cp/upmap pool
                            (fn [group-id]

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -143,7 +143,11 @@
        (eduction (map #(assoc % :model search-model)))))
 
 (defn- search-items-reducible []
-  (reduce u/rconcat [] (map spec-index-reducible search.spec/search-models)))
+  (let [models search.spec/search-models
+        sorted-models (cond-> models
+                        (contains? models "indexed-entity")
+                        (-> (disj "indexed-entity") (concat ["indexed-entity"])))]
+    (reduce u/rconcat [] (map spec-index-reducible sorted-models))))
 
 (defn- query->documents [query-reducible]
   (->> query-reducible


### PR DESCRIPTION
Adds support for temporary thread pools for embedding requests during semantic search indexing to enable parallel requests. Defaults the thread count to 2, but configurable by a setting.

WIP - I'm not sure yet how much this will need to change if we stop realizing the document list up-front. 