### PR TITLE
Add color reset button to embed flow

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -313,7 +313,7 @@ H.describeWithSnowplow(suiteTitle, () => {
     codeBlock().should("contain", 'is-save-enabled="false"');
   });
 
-  it("can change brand color", () => {
+  it("can change brand color and reset colors", () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",
       resourceName: DASHBOARD_NAME,
@@ -323,6 +323,9 @@ H.describeWithSnowplow(suiteTitle, () => {
     getEmbedSidebar().within(() => {
       cy.findByText("Brand Color").should("be.visible");
     });
+
+    cy.log("reset button should not be visible initially");
+    getEmbedSidebar().findByLabelText("Reset colors").should("not.exist");
 
     cy.log("click on brand color picker");
     cy.findByLabelText("#509EE3").click();
@@ -346,11 +349,38 @@ H.describeWithSnowplow(suiteTitle, () => {
       .first()
       .should("have.css", "color", "rgb(255, 0, 0)");
 
+    cy.log("reset button should now be visible");
+    getEmbedSidebar().findByLabelText("Reset colors").should("be.visible");
+
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
 
     codeBlock().should("contain", '"theme": {');
     codeBlock().should("contain", '"colors": {');
     codeBlock().should("contain", '"brand": "#FF0000"');
+
+    cy.log("go back to embed options step");
+    getEmbedSidebar().findByText("Back").click();
+
+    cy.log("click reset button");
+    getEmbedSidebar().findByLabelText("Reset colors").click();
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "embed_wizard_option_changed",
+      event_detail: "theme",
+    });
+
+    cy.log("table header should be back to default blue");
+    H.getSimpleEmbedIframeContent()
+      .findAllByTestId("cell-data")
+      .first()
+      .should("have.css", "color", "rgb(80, 158, 227)");
+
+    cy.log("reset button should be hidden again");
+    getEmbedSidebar().findByLabelText("Reset colors").should("not.exist");
+
+    cy.log("snippet should not contain theme colors");
+    getEmbedSidebar().findByText("Get Code").click();
+    codeBlock().should("not.contain", '"theme": {');
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
@@ -6,24 +6,18 @@ import { useSetting } from "metabase/common/hooks";
 import type { MetabaseColors } from "metabase/embedding-sdk/theme";
 import { colors as defaultMetabaseColors } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
-import {
-  ActionIcon,
-  Card,
-  Group,
-  Icon,
-  Stack,
-  Text,
-  Tooltip,
-} from "metabase/ui";
+import { ActionIcon, Group, Icon, Stack, Text, Tooltip } from "metabase/ui";
 
 interface ColorCustomizationSectionProps {
   theme?: { colors?: Partial<MetabaseColors> };
   onColorChange: (colors: Partial<MetabaseColors>) => void;
+  onColorReset?: () => void;
 }
 
 export const ColorCustomizationSection = ({
   theme,
   onColorChange,
+  onColorReset,
 }: ColorCustomizationSectionProps) => {
   const applicationColors = useSetting("application-colors");
 
@@ -39,15 +33,9 @@ export const ColorCustomizationSection = ({
   );
 
   const resetColors = useCallback(() => {
-    const colors: Record<string, string> = {};
-
-    for (const color of getConfigurableThemeColors()) {
-      colors[color.key] = getOriginalColor(color.originalColorKey);
-    }
-
-    setColorPreviewValues(colors);
-    onColorChange(colors);
-  }, [getOriginalColor, onColorChange]);
+    setColorPreviewValues({});
+    onColorReset?.();
+  }, [onColorReset]);
 
   // Check if any colors have been changed from their defaults
   const hasColorChanged = useMemo(() => {
@@ -61,7 +49,7 @@ export const ColorCustomizationSection = ({
   }, [theme?.colors, getOriginalColor]);
 
   return (
-    <Card p="md">
+    <>
       <Group justify="space-between" align="center" mb="lg">
         <Text size="lg" fw="bold">
           {t`Appearance`}
@@ -83,8 +71,7 @@ export const ColorCustomizationSection = ({
 
       <Group align="start" gap="xl" mb="lg">
         {getConfigurableThemeColors().map(({ key, name, originalColorKey }) => {
-          // Use the default from appearance settings.
-          // If not set, use the default Metabase color.
+          // Use the default from appearance settings. If not set, use the default Metabase color.
           const originalColor = getOriginalColor(originalColorKey);
           const previewValue = colorPreviewValues[key] ?? theme?.colors?.[key];
 
@@ -99,17 +86,14 @@ export const ColorCustomizationSection = ({
                 originalColor={originalColor}
                 previewValue={previewValue}
                 onPreviewChange={(color: string) =>
-                  setColorPreviewValues((prev) => ({
-                    ...prev,
-                    [key]: color,
-                  }))
+                  setColorPreviewValues((prev) => ({ ...prev, [key]: color }))
                 }
               />
             </Stack>
           );
         })}
       </Group>
-    </Card>
+    </>
   );
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
@@ -8,6 +8,8 @@ import { colors as defaultMetabaseColors } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
 import { ActionIcon, Group, Icon, Stack, Text, Tooltip } from "metabase/ui";
 
+import { getConfigurableThemeColors } from "../utils/theme-colors";
+
 interface ColorCustomizationSectionProps {
   theme?: { colors?: Partial<MetabaseColors> };
   onColorChange: (colors: Partial<MetabaseColors>) => void;
@@ -96,28 +98,3 @@ export const ColorCustomizationSection = ({
     </>
   );
 };
-
-const getConfigurableThemeColors = () =>
-  [
-    {
-      name: t`Brand Color`,
-      key: "brand",
-      originalColorKey: "brand",
-    },
-    {
-      name: t`Text Color`,
-      key: "text-primary",
-      originalColorKey: "text-dark",
-    },
-    {
-      name: t`Background Color`,
-      key: "background",
-      originalColorKey: "bg-white",
-    },
-  ] as const satisfies {
-    name: string;
-    key: keyof MetabaseColors;
-
-    // Populate colors from appearance settings.
-    originalColorKey: ColorName;
-  }[];

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { t } from "ttag";
 
 import { ColorPillPicker } from "metabase/common/components/ColorPicker";
 import { useSetting } from "metabase/common/hooks";
 import type { MetabaseColors } from "metabase/embedding-sdk/theme";
 import { colors as defaultMetabaseColors } from "metabase/lib/colors";
-import type { ColorName } from "metabase/lib/colors/types";
 import { ActionIcon, Group, Icon, Stack, Text, Tooltip } from "metabase/ui";
 
 import { getConfigurableThemeColors } from "../utils/theme-colors";
@@ -23,32 +22,19 @@ export const ColorCustomizationSection = ({
 }: ColorCustomizationSectionProps) => {
   const applicationColors = useSetting("application-colors");
 
-  // Undebounced previews to keep color preview fast.
+  // Undebounced color values to keep color selection fast.
   const [colorPreviewValues, setColorPreviewValues] = useState<
     Record<string, string>
   >({});
-
-  const getOriginalColor = useCallback(
-    (colorKey: ColorName) =>
-      applicationColors?.[colorKey] ?? defaultMetabaseColors[colorKey],
-    [applicationColors],
-  );
 
   const resetColors = useCallback(() => {
     setColorPreviewValues({});
     onColorReset?.();
   }, [onColorReset]);
 
-  // Check if any colors have been changed from their defaults
-  const hasColorChanged = useMemo(() => {
-    return getConfigurableThemeColors().some(({ key, originalColorKey }) => {
-      const currentColor = theme?.colors?.[key];
-
-      return (
-        currentColor && currentColor !== getOriginalColor(originalColorKey)
-      );
-    });
-  }, [theme?.colors, getOriginalColor]);
+  // If some of the colors are set, then `theme.colors` would be no longer empty.
+  // This also matches when the `theme` key is shown in the code snippets.
+  const hasColorChanged = !!theme?.colors;
 
   return (
     <>
@@ -74,7 +60,10 @@ export const ColorCustomizationSection = ({
       <Group align="start" gap="xl" mb="lg">
         {getConfigurableThemeColors().map(({ key, name, originalColorKey }) => {
           // Use the default from appearance settings. If not set, use the default Metabase color.
-          const originalColor = getOriginalColor(originalColorKey);
+          const originalColor =
+            applicationColors?.[originalColorKey] ??
+            defaultMetabaseColors[originalColorKey];
+
           const previewValue = colorPreviewValues[key] ?? theme?.colors?.[key];
 
           return (

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useMemo, useState } from "react";
+import { t } from "ttag";
+
+import { ColorPillPicker } from "metabase/common/components/ColorPicker";
+import { useSetting } from "metabase/common/hooks";
+import type { MetabaseColors } from "metabase/embedding-sdk/theme";
+import { colors as defaultMetabaseColors } from "metabase/lib/colors";
+import type { ColorName } from "metabase/lib/colors/types";
+import {
+  ActionIcon,
+  Card,
+  Group,
+  Icon,
+  Stack,
+  Text,
+  Tooltip,
+} from "metabase/ui";
+
+interface ColorCustomizationSectionProps {
+  theme?: { colors?: Partial<MetabaseColors> };
+  onColorChange: (colors: Partial<MetabaseColors>) => void;
+}
+
+export const ColorCustomizationSection = ({
+  theme,
+  onColorChange,
+}: ColorCustomizationSectionProps) => {
+  const applicationColors = useSetting("application-colors");
+
+  // Undebounced previews to keep color preview fast.
+  const [colorPreviewValues, setColorPreviewValues] = useState<
+    Record<string, string>
+  >({});
+
+  const getOriginalColor = useCallback(
+    (colorKey: ColorName) =>
+      applicationColors?.[colorKey] ?? defaultMetabaseColors[colorKey],
+    [applicationColors],
+  );
+
+  const resetColors = useCallback(() => {
+    const colors: Record<string, string> = {};
+
+    for (const color of getConfigurableThemeColors()) {
+      colors[color.key] = getOriginalColor(color.originalColorKey);
+    }
+
+    setColorPreviewValues(colors);
+    onColorChange(colors);
+  }, [getOriginalColor, onColorChange]);
+
+  // Check if any colors have been changed from their defaults
+  const hasColorChanged = useMemo(() => {
+    return getConfigurableThemeColors().some(({ key, originalColorKey }) => {
+      const currentColor = theme?.colors?.[key];
+
+      return (
+        currentColor && currentColor !== getOriginalColor(originalColorKey)
+      );
+    });
+  }, [theme?.colors, getOriginalColor]);
+
+  return (
+    <Card p="md">
+      <Group justify="space-between" align="center" mb="lg">
+        <Text size="lg" fw="bold">
+          {t`Appearance`}
+        </Text>
+
+        {hasColorChanged && (
+          <Tooltip label={t`Reset colors`}>
+            <ActionIcon
+              variant="subtle"
+              size="sm"
+              onClick={resetColors}
+              aria-label={t`Reset colors`}
+            >
+              <Icon name="revert" c="brand" />
+            </ActionIcon>
+          </Tooltip>
+        )}
+      </Group>
+
+      <Group align="start" gap="xl" mb="lg">
+        {getConfigurableThemeColors().map(({ key, name, originalColorKey }) => {
+          // Use the default from appearance settings.
+          // If not set, use the default Metabase color.
+          const originalColor = getOriginalColor(originalColorKey);
+          const previewValue = colorPreviewValues[key] ?? theme?.colors?.[key];
+
+          return (
+            <Stack gap="xs" align="start" key={key}>
+              <Text size="sm" fw="bold">
+                {name}
+              </Text>
+
+              <ColorPillPicker
+                onChange={(color) => onColorChange({ [key]: color })}
+                originalColor={originalColor}
+                previewValue={previewValue}
+                onPreviewChange={(color: string) =>
+                  setColorPreviewValues((prev) => ({
+                    ...prev,
+                    [key]: color,
+                  }))
+                }
+              />
+            </Stack>
+          );
+        })}
+      </Group>
+    </Card>
+  );
+};
+
+const getConfigurableThemeColors = () =>
+  [
+    {
+      name: t`Brand Color`,
+      key: "brand",
+      originalColorKey: "brand",
+    },
+    {
+      name: t`Text Color`,
+      key: "text-primary",
+      originalColorKey: "text-dark",
+    },
+    {
+      name: t`Background Color`,
+      key: "background",
+      originalColorKey: "bg-white",
+    },
+  ] as const satisfies {
+    name: string;
+    key: keyof MetabaseColors;
+
+    // Populate colors from appearance settings.
+    originalColorKey: ColorName;
+  }[];

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -32,9 +32,9 @@ export const SdkIframeEmbedPreview = () => {
   const instanceUrl = useSetting("site-url");
   const applicationColors = useSetting("application-colors");
 
-  // TODO: There is a bug in the SDK where if we set the theme back to undefined,
+  // TODO(EMB-696): There is a bug in the SDK where if we set the theme back to undefined,
   // some color will not be reset to the default (e.g. text color, CSS variables).
-  // We can remove this block once the bug is fixed.
+  // We can remove this block once EMB-696 is fixed.
   const defaultTheme: MetabaseTheme = useMemo(() => {
     const colors = Object.fromEntries(
       getConfigurableThemeColors().map((color) => [

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
@@ -45,11 +45,24 @@ export const SelectEmbedOptionsStep = () => {
     [theme, updateSettings],
   );
 
+  const getOriginalColor = useCallback(
+    (colorKey: ColorName) => {
+      return applicationColors?.[colorKey] ?? defaultMetabaseColors[colorKey];
+    },
+    [applicationColors],
+  );
+
   const resetColors = useCallback(() => {
-    updateSettings({
-      theme: { ...theme, colors: undefined },
-    });
-  }, [theme, updateSettings]);
+    const colors: Record<string, string> = {};
+
+    for (const color of getConfigurableThemeColors()) {
+      colors[color.key] = getOriginalColor(color.originalColorKey);
+    }
+
+    // FIXME: setting the colors to `undefined` does not work here as there is a
+    // visual artifact where the date range picker does not update its background color.
+    updateSettings({ theme: { ...theme, colors } });
+  }, [getOriginalColor, theme, updateSettings]);
 
   const isDashboardOrInteractiveQuestion =
     settings.dashboardId || (settings.questionId && settings.drills);
@@ -127,9 +140,7 @@ export const SelectEmbedOptionsStep = () => {
             ({ key, name, originalColorKey }) => {
               // Use the default from appearance settings.
               // If not set, use the default Metabase color.
-              const originalColor =
-                applicationColors?.[originalColorKey] ??
-                defaultMetabaseColors[originalColorKey];
+              const originalColor = getOriginalColor(originalColorKey);
 
               return (
                 <Stack gap="xs" align="start" key={key}>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
@@ -6,7 +6,17 @@ import { useSetting } from "metabase/common/hooks";
 import type { MetabaseColors } from "metabase/embedding-sdk/theme";
 import { colors as defaultMetabaseColors } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
-import { Card, Checkbox, Divider, Group, Stack, Text } from "metabase/ui";
+import {
+  ActionIcon,
+  Card,
+  Checkbox,
+  Divider,
+  Group,
+  Icon,
+  Stack,
+  Text,
+  Tooltip,
+} from "metabase/ui";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
 
@@ -34,6 +44,12 @@ export const SelectEmbedOptionsStep = () => {
     },
     [theme, updateSettings],
   );
+
+  const resetColors = useCallback(() => {
+    updateSettings({
+      theme: { ...theme, colors: undefined },
+    });
+  }, [theme, updateSettings]);
 
   const isDashboardOrInteractiveQuestion =
     settings.dashboardId || (settings.questionId && settings.drills);
@@ -90,9 +106,21 @@ export const SelectEmbedOptionsStep = () => {
       )}
 
       <Card p="md">
-        <Text size="lg" fw="bold" mb="lg">
-          {t`Appearance`}
-        </Text>
+        <Group justify="space-between" align="center" mb="lg">
+          <Text size="lg" fw="bold">
+            {t`Appearance`}
+          </Text>
+          <Tooltip label={t`Reset colors`}>
+            <ActionIcon
+              variant="subtle"
+              size="sm"
+              onClick={resetColors}
+              aria-label={t`Reset colors`}
+            >
+              <Icon name="refresh" />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
 
         <Group align="start" gap="xl" mb="lg">
           {getConfigurableThemeColors().map(

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { t } from "ttag";
 
 import type { MetabaseColors } from "metabase/embedding-sdk/theme";
-import { Card, Checkbox, Stack, Text } from "metabase/ui";
+import { Card, Checkbox, Divider, Stack, Text } from "metabase/ui";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
 
@@ -84,17 +84,25 @@ export const SelectEmbedOptionsStep = () => {
         </Card>
       )}
 
-      <ColorCustomizationSection theme={theme} onColorChange={updateColors} />
+      <Card p="md">
+        <ColorCustomizationSection
+          theme={theme}
+          onColorChange={updateColors}
+          onColorReset={() => updateSettings({ theme: undefined })}
+        />
 
-      {isQuestionOrDashboardEmbed && (
-        <Card p="md">
-          <Checkbox
-            label={t`Show ${experience} title`}
-            checked={settings.withTitle}
-            onChange={(e) => updateSettings({ withTitle: e.target.checked })}
-          />
-        </Card>
-      )}
+        {isQuestionOrDashboardEmbed && (
+          <>
+            <Divider mb="md" />
+
+            <Checkbox
+              label={t`Show ${experience} title`}
+              checked={settings.withTitle}
+              onChange={(e) => updateSettings({ withTitle: e.target.checked })}
+            />
+          </>
+        )}
+      </Card>
     </Stack>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
@@ -117,7 +117,7 @@ export const SelectEmbedOptionsStep = () => {
               onClick={resetColors}
               aria-label={t`Reset colors`}
             >
-              <Icon name="refresh" />
+              <Icon name="revert" c="brand" />
             </ActionIcon>
           </Tooltip>
         </Group>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
@@ -1,37 +1,17 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { t } from "ttag";
 
-import { ColorPillPicker } from "metabase/common/components/ColorPicker";
-import { useSetting } from "metabase/common/hooks";
 import type { MetabaseColors } from "metabase/embedding-sdk/theme";
-import { colors as defaultMetabaseColors } from "metabase/lib/colors";
-import type { ColorName } from "metabase/lib/colors/types";
-import {
-  ActionIcon,
-  Card,
-  Checkbox,
-  Divider,
-  Group,
-  Icon,
-  Stack,
-  Text,
-  Tooltip,
-} from "metabase/ui";
+import { Card, Checkbox, Stack, Text } from "metabase/ui";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
 
+import { ColorCustomizationSection } from "./ColorCustomizationSection";
 import { ParameterSettings } from "./ParameterSettings";
 
 export const SelectEmbedOptionsStep = () => {
   const { experience, settings, updateSettings } =
     useSdkIframeEmbedSetupContext();
-
-  const applicationColors = useSetting("application-colors");
-
-  // Undebounced previews to keep color selection fast.
-  const [colorPreviewValues, setColorPreviewValues] = useState<
-    Record<string, string>
-  >({});
 
   const { theme } = settings;
 
@@ -41,7 +21,7 @@ export const SelectEmbedOptionsStep = () => {
 
   const isExplorationEmbed = settings.template === "exploration";
 
-  const updateColor = useCallback(
+  const updateColors = useCallback(
     (nextColors: Partial<MetabaseColors>) => {
       updateSettings({
         theme: { ...theme, colors: { ...theme?.colors, ...nextColors } },
@@ -50,42 +30,8 @@ export const SelectEmbedOptionsStep = () => {
     [theme, updateSettings],
   );
 
-  const getOriginalColor = useCallback(
-    (colorKey: ColorName) => {
-      return applicationColors?.[colorKey] ?? defaultMetabaseColors[colorKey];
-    },
-    [applicationColors],
-  );
-
-  const resetColors = useCallback(() => {
-    const colors: Record<string, string> = {};
-
-    for (const color of getConfigurableThemeColors()) {
-      const originalColor = getOriginalColor(color.originalColorKey);
-      colors[color.key] = originalColor;
-    }
-
-    setColorPreviewValues(colors);
-
-    // FIXME: setting the colors to `undefined` does not work here as there is a
-    // visual artifact where the date range picker does not update its background color.
-    updateSettings({ theme: { ...theme, colors } });
-  }, [getOriginalColor, theme, updateSettings]);
-
   const isDashboardOrInteractiveQuestion =
     settings.dashboardId || (settings.questionId && settings.drills);
-
-  // Helper to get current preview value for a color key
-  const getColorPreviewValue = useCallback(
-    (colorKey: keyof MetabaseColors, originalColor: string) => {
-      return (
-        colorPreviewValues[colorKey] ??
-        theme?.colors?.[colorKey] ??
-        originalColor
-      );
-    },
-    [colorPreviewValues, theme?.colors],
-  );
 
   return (
     <Stack gap="md">
@@ -138,90 +84,17 @@ export const SelectEmbedOptionsStep = () => {
         </Card>
       )}
 
-      <Card p="md">
-        <Group justify="space-between" align="center" mb="lg">
-          <Text size="lg" fw="bold">
-            {t`Appearance`}
-          </Text>
-          <Tooltip label={t`Reset colors`}>
-            <ActionIcon
-              variant="subtle"
-              size="sm"
-              onClick={resetColors}
-              aria-label={t`Reset colors`}
-            >
-              <Icon name="revert" c="brand" />
-            </ActionIcon>
-          </Tooltip>
-        </Group>
+      <ColorCustomizationSection theme={theme} onColorChange={updateColors} />
 
-        <Group align="start" gap="xl" mb="lg">
-          {getConfigurableThemeColors().map(
-            ({ key, name, originalColorKey }) => {
-              // Use the default from appearance settings.
-              // If not set, use the default Metabase color.
-              const originalColor = getOriginalColor(originalColorKey);
-
-              return (
-                <Stack gap="xs" align="start" key={key}>
-                  <Text size="sm" fw="bold">
-                    {name}
-                  </Text>
-
-                  <ColorPillPicker
-                    onChange={(color) => updateColor({ [key]: color })}
-                    originalColor={originalColor}
-                    previewValue={getColorPreviewValue(key, originalColor)}
-                    onPreviewChange={(color: string) =>
-                      setColorPreviewValues((prev) => ({
-                        ...prev,
-                        [key]: color,
-                      }))
-                    }
-                  />
-                </Stack>
-              );
-            },
-          )}
-        </Group>
-
-        {isQuestionOrDashboardEmbed && (
-          <>
-            <Divider mb="md" />
-
-            <Checkbox
-              label={t`Show ${experience} title`}
-              checked={settings.withTitle}
-              onChange={(e) => updateSettings({ withTitle: e.target.checked })}
-            />
-          </>
-        )}
-      </Card>
+      {isQuestionOrDashboardEmbed && (
+        <Card p="md">
+          <Checkbox
+            label={t`Show ${experience} title`}
+            checked={settings.withTitle}
+            onChange={(e) => updateSettings({ withTitle: e.target.checked })}
+          />
+        </Card>
+      )}
     </Stack>
   );
 };
-
-const getConfigurableThemeColors = () =>
-  [
-    {
-      name: t`Brand Color`,
-      key: "brand",
-      originalColorKey: "brand",
-    },
-    {
-      name: t`Text Color`,
-      key: "text-primary",
-      originalColorKey: "text-dark",
-    },
-    {
-      name: t`Background Color`,
-      key: "background",
-      originalColorKey: "bg-white",
-    },
-  ] as const satisfies {
-    name: string;
-    key: keyof MetabaseColors;
-
-    // Populate colors from appearance settings.
-    originalColorKey: ColorName;
-  }[];

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/theme-colors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/theme-colors.ts
@@ -1,0 +1,29 @@
+import { t } from "ttag";
+
+import type { MetabaseColors } from "embedding-sdk";
+import type { ColorName } from "metabase/lib/colors/types";
+
+export const getConfigurableThemeColors = () =>
+  [
+    {
+      name: t`Brand Color`,
+      key: "brand",
+      originalColorKey: "brand",
+    },
+    {
+      name: t`Text Color`,
+      key: "text-primary",
+      originalColorKey: "text-dark",
+    },
+    {
+      name: t`Background Color`,
+      key: "background",
+      originalColorKey: "bg-white",
+    },
+  ] as const satisfies {
+    name: string;
+    key: keyof MetabaseColors;
+
+    // Populate colors from appearance settings.
+    originalColorKey: ColorName;
+  }[];

--- a/frontend/src/metabase/common/components/ColorPicker/ColorPillPicker.tsx
+++ b/frontend/src/metabase/common/components/ColorPicker/ColorPillPicker.tsx
@@ -1,5 +1,5 @@
 import { useDebouncedCallback } from "@mantine/hooks";
-import { type Ref, forwardRef, useState } from "react";
+import { type Ref, forwardRef } from "react";
 
 import TippyPopoverWithTrigger from "metabase/common/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import { Group } from "metabase/ui";
@@ -20,11 +20,14 @@ export interface ColorPillPickerProps extends ColorPickerAttributes {
   originalColor: string;
 
   /**
-   * The initial color to display in the color picker.
-   * Useful if the color has been set before e.g. in user settings.
-   * Defaults to the `originalColor`.
+   * Current preview value - this component is always controlled.
    */
-  initialColor?: string;
+  previewValue: string;
+
+  /**
+   * Callback when preview value changes.
+   */
+  onPreviewChange: (color: string) => void;
 
   debounceMs?: number;
 }
@@ -36,15 +39,12 @@ export const ColorPillPicker = forwardRef(function ColorPillPicker(
     onChange,
     debounceMs = COLOR_PICKER_DEBOUNCE_MS,
     originalColor,
-    initialColor,
+    previewValue,
+    onPreviewChange,
     ...props
   }: ColorPillPickerProps,
   ref: Ref<HTMLDivElement>,
 ) {
-  const [previewValue, setPreviewValue] = useState<string>(
-    initialColor ?? originalColor,
-  );
-
   const debouncedUpdate = useDebouncedCallback(onChange, debounceMs);
 
   return (
@@ -62,7 +62,7 @@ export const ColorPillPicker = forwardRef(function ColorPillPicker(
             // Fallback to the original color if the value is cleared.
             const colorWithDefault = nextColor ?? originalColor;
 
-            setPreviewValue(colorWithDefault);
+            onPreviewChange(colorWithDefault);
             debouncedUpdate(colorWithDefault);
           }}
         />

--- a/frontend/src/metabase/common/components/ColorPicker/ColorPillPicker.tsx
+++ b/frontend/src/metabase/common/components/ColorPicker/ColorPillPicker.tsx
@@ -19,9 +19,7 @@ export interface ColorPillPickerProps extends ColorPickerAttributes {
    **/
   originalColor: string;
 
-  /**
-   * Current preview value - this component is always controlled.
-   */
+  /** Undebounced preview value of the color. */
   previewValue: string;
 
   /**
@@ -46,18 +44,19 @@ export const ColorPillPicker = forwardRef(function ColorPillPicker(
   ref: Ref<HTMLDivElement>,
 ) {
   const debouncedUpdate = useDebouncedCallback(onChange, debounceMs);
+  const color = previewValue ?? originalColor;
 
   return (
     <TippyPopoverWithTrigger
       disableContentSandbox
       renderTrigger={({ onClick }) => (
         <Group {...props} ref={ref} wrap="nowrap">
-          <ColorPill color={previewValue} onClick={onClick} />
+          <ColorPill color={color} onClick={onClick} />
         </Group>
       )}
       popoverContent={
         <ColorPickerContent
-          value={previewValue}
+          value={color}
           onChange={(nextColor) => {
             // Fallback to the original color if the value is cleared.
             const colorWithDefault = nextColor ?? originalColor;


### PR DESCRIPTION
Closes EMB-688

## Summary

Adds a reset button to the setup flow that allows users to reset all customized theme colors back to the instance defaults. 

The reset button appears in the appearance section when colors have been customized and provides a quick way to revert all color changes.

## How to verify

1. Go to "New > Embed"
2. Go to the Appearance step.
3. Modify any of the appearance colors (Brand Color, Text Color, or Background Color)
4. Observe that a reset button (revert icon) appears in the top-right of the Appearance section
5. Click the reset button to verify all colors are reset to instance defaults
6. Confirm the reset button disappears after resetting

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
