### PR TITLE
Add MB_SYNC_LEAF_FIELDS_LIMIT setting

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -14,6 +14,7 @@
    [metabase.driver.mongo.parameters :as mongo.params]
    [metabase.driver.mongo.query-processor :as mongo.qp]
    [metabase.driver.mongo.util :as mongo.util]
+   [metabase.driver.settings :as driver.settings]
    [metabase.driver.util :as driver.u]
    [metabase.util :as u]
    [metabase.util.json :as json]
@@ -158,11 +159,6 @@
   ;;  > And that would be definitely ok for most.
   ;;  > If people have problems with that, I think we can make it configurable.
   7)
-
-(def ^:private leaf-fields-limit
-  "Consider at most 1K leaf paths to sync. That combined with [[describe-table-query-depth]] (= 7) gives at most 
-  7K app-db fields per collection."
-  1000)
 
 (defn ^:dynamic *sample-stages*
   "Stages to get sample of a collection in [[describe-table-pipeline]]. Dynamic for testing purposes."
@@ -362,8 +358,8 @@
   Reason for doing this in 2 steps is that for adding database-position the structure has to be fully constructed
   first.
 
-  The resulting structure will hold at most [[leaf-fields-limit]] leaf fields. That translates to at most
-  [[leaf-fields-limit]] * [[describe-table-query-depth]]. That is 7K fields at the time of writing hence safe
+  The resulting structure will hold at most [[driver.settings/mongodb-sync-field-limit]] leaf fields. That translates to at most
+  [[driver.settings/mongodb-sync-field-limit]] * [[describe-table-query-depth]]. That is 7K fields at the time of writing hence safe
   to reside in memory for further operation."
   [dbfields]
   (-> dbfields dbfields->ftree* ftree-reconcile-nodes))
@@ -401,7 +397,7 @@
   (let [pipeline (describe-table-pipeline {:collection-name (:name table)
                                            :sample-size (* table-rows-sample/nested-field-sample-limit 2)
                                            :document-sample-depth describe-table-query-depth
-                                           :leaf-limit leaf-fields-limit})
+                                           :leaf-limit (driver.settings/mongodb-sync-field-limit)})
         query {:database (:id database)
                :type     "native"
                :native   {:collection (:name table)

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -358,9 +358,9 @@
   Reason for doing this in 2 steps is that for adding database-position the structure has to be fully constructed
   first.
 
-  The resulting structure will hold at most [[driver.settings/mongodb-sync-field-limit]] leaf fields. That translates to at most
-  [[driver.settings/mongodb-sync-field-limit]] * [[describe-table-query-depth]]. That is 7K fields at the time of writing hence safe
-  to reside in memory for further operation."
+  The resulting structure will hold at most [[driver.settings/sync-leaf-fields-limit]] leaf fields. That translates
+  to at most [[driver.settings/sync-leaf-fields-limit]] * [[describe-table-query-depth]]. That is 7K fields at the 
+  time of writing hence safe to reside in memory for further operation."
   [dbfields]
   (-> dbfields dbfields->ftree* ftree-reconcile-nodes))
 
@@ -397,7 +397,7 @@
   (let [pipeline (describe-table-pipeline {:collection-name (:name table)
                                            :sample-size (* table-rows-sample/nested-field-sample-limit 2)
                                            :document-sample-depth describe-table-query-depth
-                                           :leaf-limit (driver.settings/mongodb-sync-field-limit)})
+                                           :leaf-limit (driver.settings/sync-leaf-fields-limit)})
         query {:database (:id database)
                :type     "native"
                :native   {:collection (:name table)

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -1019,7 +1019,7 @@
     :mongo
     (testing "Ensure _id is present in results"
       ;; Gist: Limit is set to 2 and there, other fields' names that precede the _id when sorted
-      (with-redefs [driver.settings/mongodb-sync-field-limit (constantly 2)]
+      (with-redefs [driver.settings/sync-leaf-fields-limit (constantly 2)]
         (with-describe-table-for-sample
           [{"_id" {"$toObjectId" (org.bson.types.ObjectId.)}
             "__a" 1
@@ -1112,7 +1112,7 @@
                                   {:path "a.b.c.d.e.f.g", :type "array", :indices [1 0 0 0 0 0 0]}
                                   {:path "a.b.c.d.e.f.i", :type "int", :indices [1 0 0 0 0 0 1]}
                                   {:path "a.b.c.d.e.f.h", :type "null", :indices [1 0 0 0 0 0 0]}]]]]
-      (with-redefs [driver.settings/mongodb-sync-field-limit (constantly limit)]
+      (with-redefs [driver.settings/sync-leaf-fields-limit (constantly limit)]
         (with-describe-table-for-sample
           [{"_id" {"$toObjectId" (org.bson.types.ObjectId.)}
             "a" {"b" {"c" {"d" {"e" {"f" {"g" [3 2 1]}}}}}}}

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -12,6 +12,7 @@
    [metabase.driver.mongo.execute :as mongo.execute]
    [metabase.driver.mongo.query-processor :as mongo.qp]
    [metabase.driver.mongo.util :as mongo.util]
+   [metabase.driver.settings :as driver.settings]
    [metabase.driver.util :as driver.u]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
@@ -1018,7 +1019,7 @@
     :mongo
     (testing "Ensure _id is present in results"
       ;; Gist: Limit is set to 2 and there, other fields' names that precede the _id when sorted
-      (with-redefs [mongo/leaf-fields-limit 2]
+      (with-redefs [driver.settings/mongodb-sync-field-limit (constantly 2)]
         (with-describe-table-for-sample
           [{"_id" {"$toObjectId" (org.bson.types.ObjectId.)}
             "__a" 1
@@ -1111,7 +1112,7 @@
                                   {:path "a.b.c.d.e.f.g", :type "array", :indices [1 0 0 0 0 0 0]}
                                   {:path "a.b.c.d.e.f.i", :type "int", :indices [1 0 0 0 0 0 1]}
                                   {:path "a.b.c.d.e.f.h", :type "null", :indices [1 0 0 0 0 0 0]}]]]]
-      (with-redefs [mongo/leaf-fields-limit limit]
+      (with-redefs [driver.settings/mongodb-sync-field-limit (constantly limit)]
         (with-describe-table-for-sample
           [{"_id" {"$toObjectId" (org.bson.types.ObjectId.)}
             "a" {"b" {"c" {"d" {"e" {"f" {"g" [3 2 1]}}}}}}}

--- a/src/metabase/driver/settings.clj
+++ b/src/metabase/driver/settings.clj
@@ -178,8 +178,10 @@
                 ((requiring-resolve 'metabase.driver.util/available-drivers-info)))
   :doc        false)
 
-(defsetting mongodb-sync-field-limit
-  "Maximum number of leaf fields of Mongo collection considered during field sync."
+(defsetting sync-leaf-fields-limit
+  (str "Maximum number of leaf fields synced per collection of document database. Currently relevant for Mongo."
+       " Not to be confused with total number of synced fields. For every chosen leaf field, all intermediate fields"
+       " from root to leaf are synced as well.")
   :visibility :internal
   :export? true
   :setter :none

--- a/src/metabase/driver/settings.clj
+++ b/src/metabase/driver/settings.clj
@@ -177,3 +177,11 @@
   :getter     (fn []
                 ((requiring-resolve 'metabase.driver.util/available-drivers-info)))
   :doc        false)
+
+(defsetting mongodb-sync-field-limit
+  "Maximum number of leaf fields of Mongo collection considered during field sync."
+  :visibility :internal
+  :export? true
+  :setter :none
+  :type :integer
+  :default 1000)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61816
Closes https://linear.app/metabase/issue/QUE-2110/environment-variable-for-mongodb-max-sync-fields