### PR TITLE
[CLJS] Clean up CLJS warnings from accidental `mu/fn` usage

### DIFF
--- a/src/metabase/util/malli.cljc
+++ b/src/metabase/util/malli.cljc
@@ -150,11 +150,11 @@
   (mc/walk
    schema
    (mc/schema-walker
-    (fn [schema]
+    (core/fn [schema]
       (case (mc/type schema)
         :map
         (mc/-set-children schema
-                          (mapv (fn [[k p s]]
+                          (mapv (core/fn [[k p s]]
                                   [k (dissoc p :optional) s]) (mc/children schema)))
         :maybe
         (first (mc/children schema))
@@ -166,10 +166,10 @@
   [schema]
   (mc/walk
    schema
-   (mc/schema-walker (fn [schema]
+   (mc/schema-walker (core/fn [schema]
                        (if (= :map (mc/type schema))
                          (mc/-set-children schema
-                                           (mapv (fn [[k p s]]
+                                           (mapv (core/fn [[k p s]]
                                                    [(u/->snake_case_en k) p s]) (mc/children schema)))
 
                          schema)))))


### PR DESCRIPTION
### Description

Recent changes in `metabase.util.malli` used `fn` internally, which is `mu/fn` in (at least) CLJS
which was generating warnings about unused vars and undefined references. I tweaked those calls to
be `core/fn` calls instead, which fixes the warnings and doesn't change the behaviour since no schemas
are specified for these calls.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
