### PR TITLE
[Semantic Search] Add AI Service as an embeddings providers

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1699,6 +1699,7 @@
   enterprise/metabot-v3
   {:team "Metabot"
    :api #{metabase-enterprise.metabot-v3.api
+          metabase-enterprise.metabot-v3.client
           metabase-enterprise.metabot-v3.core
           metabase-enterprise.metabot-v3.init
           metabase-enterprise.metabot-v3.tools.api}
@@ -1796,7 +1797,8 @@
            search
            settings
            util
-           enterprise/llm}}
+           enterprise/llm
+           enterprise/metabot-v3}}
 
   enterprise/serialization
   {:team "Workflows"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -91,6 +91,9 @@
 (defn- example-question-generation-endpoint []
   (str (metabot-v3.settings/ai-service-base-url) "/v1/example-question-generation/batch"))
 
+(defn- generate-embeddings-endpoint []
+  (str (metabot-v3.settings/ai-service-base-url) "/v1/embeddings"))
+
 (mu/defn request :- ::metabot-v3.client.schema/ai-service.response
   "Make a V2 request to the AI Service."
   [{:keys [context messages profile-id conversation-id session-id state]}
@@ -369,4 +372,20 @@
       (throw (ex-info (format "Error in generate-example-questions request to AI service: unexpected status: %d %s"
                               (:status response) (:reason-phrase response))
                       {:request (assoc options :body payload)
+                       :response response})))))
+
+(defn generate-embeddings
+  "Generate vector embeddings for a batch of inputs questions for the given models and metrics."
+  [model-name texts]
+  (let [url (generate-embeddings-endpoint)
+        body {:model model-name
+              :input texts
+              :encoding_format "base64"}
+        options (build-request-options body)
+        response (post! url options)]
+    (if (= (:status response) 200)
+      (:body response)
+      (throw (ex-info (format "Error in generate-embeddings request to AI service: unexpected status: %d %s"
+                              (:status response) (:reason-phrase response))
+                      {:request (assoc options :body body)
                        :response response})))))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -172,11 +172,11 @@
     (log/debug "Calling AI Service embeddings API" {:documents (count texts) :tokens (count-tokens-batch texts)})
     (let [response (metabot-v3.client/generate-embeddings model-name texts)]
       (analytics/inc! :metabase-search/semantic-embedding-tokens
-                      {:provider "openai", :model model-name}
+                      {:provider "ai-service", :model model-name}
                       (->> response :usage :total_tokens))
       (extract-base64-response-embeddings response))
     (catch Exception e
-      (log/error e "OpenAI embeddings API call failed" {:documents (count texts) :tokens (count-tokens-batch texts)})
+      (log/error e "AI Service embeddings API call failed" {:documents (count texts) :tokens (count-tokens-batch texts)})
       (throw e))))
 
 (defn- ai-service-get-embedding [model-name text]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -3,7 +3,6 @@
    [clj-http.client :as http]
    [clojure.string :as str]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
-   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
    [metabase-enterprise.semantic-search.settings :as semantic-settings]
    [metabase.analytics.core :as analytics]
    [metabase.util :as u]
@@ -26,17 +25,26 @@
 (def ^:private model-abbreviations {"small" "sm" "medium" "md" "large" "lg" "tiny" "tn"})
 
 (defn abbrev-model-name
-  "Abbreviate long model names for use in index names. Does not ensure uniqueness."
-  [model-name max-len]
-  (let [clean-model-name (clean-model-name model-name)]
-    (if (<= (count clean-model-name) max-len)
+  "Abbreviate long model names for use in index names."
+  [model-name]
+  (-> model-name
       clean-model-name
-      (-> clean-model-name
-          (str/replace #"embedding|embed" "")
-          ((fn [s] (reduce-kv str/replace s model-abbreviations)))
-          (str/replace #"_{2,}" "_")
-          (#(subs % 0 (min (count %) max-len)))
-          (str/replace #"^_+|_+$" "")))))
+      (str/replace #"embedding|embed" "")
+      ((fn [s] (reduce-kv str/replace s model-abbreviations)))
+      (str/replace #"_{2,}" "_")
+      (str/replace #"^_+|_+$" "")))
+
+(defn clean-provider-name
+  "Clean up a provider names for use in index names."
+  [provider-name]
+  (str/replace provider-name #"[-:.]" "_"))
+
+(defn abbrev-provider-name
+  "Abbreviate long provider names for use in index names."
+  [provider-name]
+  (if (= provider-name "ai-service")
+    "ais"
+    (clean-provider-name provider-name)))
 
 ;;; Token Counting for OpenAI Models
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -28,13 +28,15 @@
 (defn abbrev-model-name
   "Abbreviate long model names for use in index names. Does not ensure uniqueness."
   [model-name max-len]
-  (-> model-name
+  (let [clean-model-name (clean-model-name model-name)]
+    (if (<= (count clean-model-name) max-len)
       clean-model-name
-      (str/replace #"embedding|embed" "")
-      ((fn [s] (reduce-kv str/replace s model-abbreviations)))
-      (str/replace #"_{2,}" "_")
-      (#(subs % 0 (min (count %) max-len)))
-      (str/replace #"^_+|_+$" "")))
+      (-> clean-model-name
+          (str/replace #"embedding|embed" "")
+          ((fn [s] (reduce-kv str/replace s model-abbreviations)))
+          (str/replace #"_{2,}" "_")
+          (#(subs % 0 (min (count %) max-len)))
+          (str/replace #"^_+|_+$" "")))))
 
 ;;; Token Counting for OpenAI Models
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -161,10 +161,12 @@
   [embedding-model]
   (let [{:keys [model-name provider vector-dimensions]} embedding-model
         provider-name (str/replace provider #"[-:.]" "_")
+        table-name-prefix (str "index_table_" provider-name "_")
+        table-name-suffix (str "_" vector-dimensions)
         ;; calculate remaining space to ensure we don't exceed postgres' limit of 63 chars for identifier names.
-        model-max-name-len (- 63 14 (count provider-name) (count (str vector-dimensions)))
+        model-max-name-len (- 63 (count table-name-prefix) (count table-name-suffix))
         abbreviated-model-name (embedding/abbrev-model-name model-name model-max-name-len)
-        table-name (str "index_table_" provider-name "_" abbreviated-model-name "_" vector-dimensions)]
+        table-name (str table-name-prefix abbreviated-model-name table-name-suffix)]
     {:embedding-model embedding-model
      :table-name table-name
      :version 0}))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -156,17 +156,28 @@
         excluded-kw (fn [column] (keyword (str "excluded." (name column))))]
     (zipmap update-keys (map excluded-kw update-keys))))
 
+(defn- throw-if-max-pg-len
+  [resource-name msg]
+  (when (> (count resource-name) 63)
+    (throw (ex-info msg
+                    {:table-name resource-name
+                     :length (count resource-name)
+                     :limit 63}))))
+
+(defn model-table-name
+  "Returns the table name for a model."
+  [embedding-model]
+  (let [{:keys [model-name provider vector-dimensions]} embedding-model
+        provider-name (embedding/abbrev-provider-name provider)
+        abbrev-model-name (embedding/abbrev-model-name model-name)
+        result (str "index_table_" provider-name "_" abbrev-model-name "_" vector-dimensions)]
+    (throw-if-max-pg-len result "Table name exceeds PostgreSQL limit")
+    result))
+
 (defn default-index
   "Returns the default index spec for a model."
   [embedding-model]
-  (let [{:keys [model-name provider vector-dimensions]} embedding-model
-        provider-name (str/replace provider #"[-:.]" "_")
-        table-name-prefix (str "index_table_" provider-name "_")
-        table-name-suffix (str "_" vector-dimensions)
-        ;; calculate remaining space to ensure we don't exceed postgres' limit of 63 chars for identifier names.
-        model-max-name-len (- 63 (count table-name-prefix) (count table-name-suffix))
-        abbreviated-model-name (embedding/abbrev-model-name model-name model-max-name-len)
-        table-name (str table-name-prefix abbreviated-model-name table-name-suffix)]
+  (let [table-name (model-table-name embedding-model)]
     {:embedding-model embedding-model
      :table-name table-name
      :version 0}))
@@ -219,7 +230,9 @@
 (defn- index-name
   "Returns the name for an index for the given index configuration, column, and index type."
   [index suffix]
-  (str (:table-name index) suffix))
+  (let [result (str (:table-name index) suffix)]
+    (throw-if-max-pg-len result "Index name exceeds PostgreSQL limit")
+    result))
 
 (defn hnsw-index-name
   "Returns the name for a HNSW database index for the given semantic search index configuration."

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -160,9 +160,11 @@
   "Returns the default index spec for a model."
   [embedding-model]
   (let [{:keys [model-name provider vector-dimensions]} embedding-model
-        ;; This is a hack to ensure we don't exceed postgres' limit of 63 chars for identifier names.
-        abbreviated-model-name (embedding/model->abbrev model-name model-name)
-        table-name (str "index_table_" provider "_" abbreviated-model-name "_" vector-dimensions)]
+        provider-name (str/replace provider #"[-:.]" "_")
+        ;; calculate remaining space to ensure we don't exceed postgres' limit of 63 chars for identifier names.
+        model-max-name-len (- 63 14 (count provider-name) (count (str vector-dimensions)))
+        abbreviated-model-name (embedding/abbrev-model-name model-name model-max-name-len)
+        table-name (str "index_table_" provider-name "_" abbreviated-model-name "_" vector-dimensions)]
     {:embedding-model embedding-model
      :table-name table-name
      :version 0}))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -6,21 +6,30 @@
    [metabase.util.i18n :refer [deferred-tru]]))
 
 (defsetting ee-embedding-provider
-  (deferred-tru "The embedding provider to use (:openai or :ollama)")
+  (deferred-tru "The embedding provider to use (:openai, :ollama, or :ai-service)")
   :encryption :no
   :visibility :settings-manager
-  :default "ollama"
+  :default "ai-service"
   :type :string
   :export? false
   :doc "This feature is experimental.")
 
 (defsetting ee-embedding-model
-  (deferred-tru "Override the default embedding model for the selected provider")
+  (deferred-tru "Set the embedding model for the selected provider")
   :encryption :no
   :visibility :settings-manager
-  :default nil
+  :default "Snowflake/snowflake-arctic-embed-l-v2.0"
   :export? false
-  :doc "This feature is experimental. Leave empty to use provider defaults.")
+  :doc "This feature is experimental.")
+
+(defsetting ee-embedding-model-dimensions
+  (deferred-tru "Set the dimension size for the selected embedding model")
+  :encryption :no
+  :visibility :settings-manager
+  :default 1024
+  :type :positive-integer
+  :export? false
+  :doc "This feature is experimental.")
 
 (defn openai-api-base-url
   "Get the OpenAI API base url from the existing LLM settings."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -47,6 +47,7 @@
       (is (= 1536 (:vector-dimensions (embedding/get-configured-model)))))))
 
 (deftest test-default-models
+  ;; TODO fix
   (testing "Provider defaults are used when no override is set"
     (is (= "text-embedding-3-small" (#'embedding/default-model-for-provider "openai")))
     (is (= "mxbai-embed-large" (#'embedding/default-model-for-provider "ollama")))
@@ -116,6 +117,7 @@
       ;; Should skip the long text and batch the short ones
       (is (= [["Short" "Also short"]] batches)))))
 
+;; TODO: fix this test
 (deftest ^:parallel model->abbrev-test
   (mt/with-premium-features #{:semantic-search}
     (testing "all models have an abbreviation defined"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -8,43 +8,38 @@
 
 (deftest test-get-provider
   (testing "get-active-model returns based on setting"
-    (mt/with-temporary-setting-values [ee-embedding-provider "ollama"]
+    (mt/with-temporary-setting-values [ee-embedding-provider "ai-service"
+                                       ee-embedding-model "mxbai-embed-large"
+                                       ee-embedding-model-dimensions 1024]
+      (is (= {:provider "ai-service"
+              :model-name "mxbai-embed-large"
+              :vector-dimensions 1024}
+             (embedding/get-configured-model))))
+
+    (mt/with-temporary-setting-values [ee-embedding-provider "ollama"
+                                       ee-embedding-model "mxbai-embed-large"
+                                       ee-embedding-model-dimensions 1024]
       (is (= {:provider "ollama"
               :model-name "mxbai-embed-large"
               :vector-dimensions 1024}
              (embedding/get-configured-model))))
 
-    (mt/with-temporary-setting-values [ee-embedding-provider "openai"]
+    (mt/with-temporary-setting-values [ee-embedding-provider "openai"
+                                       ee-embedding-model "text-embedding-3-small"
+                                       ee-embedding-model-dimensions 1536]
       (is (= {:provider "openai"
               :model-name "text-embedding-3-small"
               :vector-dimensions 1536}
-             (embedding/get-configured-model)))))
-
-  (testing "get-provider throws on unknown provider"
-    (mt/with-temporary-setting-values [ee-embedding-provider "unknown"]
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"Unknown embedding provider: unknown"
-           (embedding/get-configured-model))))))
+             (embedding/get-configured-model))))))
 
 (deftest test-model-dimensions-with-settings
-  (testing "model-dimensions uses provider defaults when override is nil"
-    (mt/with-temporary-setting-values [ee-embedding-provider "ollama"
-                                       ee-embedding-model nil]
-      (is (= 1024 (:vector-dimensions (embedding/get-configured-model)))))
-
-    (mt/with-temporary-setting-values [ee-embedding-provider "openai"
-                                       ee-embedding-model nil]
-      (is (= 1536 (:vector-dimensions (embedding/get-configured-model))))))
+  (testing "model-dimensions uses setting defaults when override is nil"
+    (mt/with-temporary-setting-values [ee-embedding-model-dimensions nil]
+      (is (= 1024 (:vector-dimensions (embedding/get-configured-model))))))
 
   (testing "model-dimensions uses override when specified"
-    (mt/with-temporary-setting-values [ee-embedding-provider "ollama"
-                                       ee-embedding-model "nomic-embed-text"]
-      (is (= 768 (:vector-dimensions (embedding/get-configured-model)))))
-
-    (mt/with-temporary-setting-values [ee-embedding-provider "openai"
-                                       ee-embedding-model "text-embedding-ada-002"]
-      (is (= 1536 (:vector-dimensions (embedding/get-configured-model)))))))
+    (mt/with-temporary-setting-values [ee-embedding-model-dimensions 768]
+      (is (= 768 (:vector-dimensions (embedding/get-configured-model)))))))
 
 (deftest test-openai-provider-validation
   (testing "OpenAIProvider throws when API key not configured"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
@@ -5,21 +5,3 @@
    [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase.test :as mt]))
-
-(deftest ^:parallel index-embedding-name-length-test
-  (mt/with-premium-features #{:semantic-search}
-    (testing "index names never exceed 63 bytes for any embedding model"
-      ;; Postgres truncates indentifier names to 63 bytes (+ 1 byte for a terminating NULL). Ensure that none of the
-      ;; index names exceed this limit for any embedding provider + model combination.
-      (doseq [provider (keys semantic.embedding/supported-models-for-provider)
-              [model vector-dimensions] (get semantic.embedding/supported-models-for-provider provider)
-              name-func [:table-name
-                         #'semantic.index/hnsw-index-name
-                         #'semantic.index/fts-index-name
-                         #'semantic.index/fts-native-index-name]]
-        (testing (str "\n" provider " " model " " vector-dimensions "\n" name-func)
-          (let [index (-> {:provider provider
-                           :model-name model
-                           :vector-dimensions vector-dimensions}
-                          semantic.index/default-index)]
-            (is (>= 63 (-> index name-func count)))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
@@ -5,3 +5,52 @@
    [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase.test :as mt]))
+
+(def ^:private test-provider "ai-service")
+(def ^:private test-short-model-name "short-model")
+(def ^:private test-long-model-name "some-really-really-really-really-really-long-model-name-that-will-exceed-the-limit")
+(def ^:private test-vector-dimensions 1024)
+(def ^:private pg-limit-error-pattern #"exceeds PostgreSQL limit")
+
+;; Postgres truncates indentifier names to 63 bytes (+ 1 byte for a terminating NULL). Ensure that errors are thrown
+;; if a resource name would exceed the limit for any embedding provider + model combination.
+(deftest ^:parallel index-embedding-name-length-test
+  (mt/with-premium-features #{:semantic-search}
+    (testing "Throws if index name would be longer than the 63 byte Postgres limit"
+      (doseq [name-func [#'semantic.index/hnsw-index-name
+                         #'semantic.index/fts-index-name
+                         #'semantic.index/fts-native-index-name]]
+        (testing (str name-func)
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                pg-limit-error-pattern
+                                (-> {:provider test-provider
+                                     :model-name test-long-model-name
+                                     :vector-dimensions test-vector-dimensions}
+                                    semantic.index/default-index))))))
+    (testing "Succeeds if index name would be less than the 63 byte Postgres limit"
+      (let [index (-> {:provider test-provider
+                       :model-name test-short-model-name
+                       :vector-dimensions test-vector-dimensions}
+                      semantic.index/default-index)]
+        (doseq [name-func [#'semantic.index/hnsw-index-name
+                           #'semantic.index/fts-index-name
+                           #'semantic.index/fts-native-index-name]]
+          (testing (str name-func)
+            (is (string? (name-func index)))
+            (is (< (count (name-func index)) 64))))))))
+
+(deftest ^:parallel table-name-length-test
+  (mt/with-premium-features #{:semantic-search}
+    (testing "Throws if table name exceeds 63 byte Postgres limit"
+      (let [embedding-model {:provider test-provider
+                             :model-name test-long-model-name
+                             :vector-dimensions test-vector-dimensions}]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Table name exceeds PostgreSQL limit"
+                              (semantic.index/model-table-name embedding-model)))))
+    (testing "Succeeds if table name would be less than the 63 byte Postgres limit"
+      (let [embedding-model {:provider test-provider
+                             :model-name test-short-model-name
+                             :vector-dimensions test-vector-dimensions}]
+        (is (string? (semantic.index/model-table-name embedding-model)))
+        (is (< (count (semantic.index/model-table-name embedding-model)) 64))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_embedding_test.clj
@@ -2,7 +2,6 @@
   "Tests for things at the intersection of the index and embedding namespaces."
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase.test :as mt]))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -93,7 +93,7 @@
 
 (defn unique-index-metadata
   []
-  (let [uniq-id (subs (u/generate-nano-id) 0 17)
+  (let [uniq-id (subs (u/generate-nano-id) 0 11)
         fmt     (str "mock_%s_" uniq-id "_")]
     {:version               "0"
      :metadata-table-name   (format fmt "index_metadata")

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -89,7 +89,7 @@
   {:version               "0"
    :metadata-table-name   "mock_index_metadata"
    :control-table-name    "mock_index_control"
-   :index-table-qualifier "mock_%s"})
+   :index-table-qualifier "%s"})
 
 (defn unique-index-metadata
   []

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -89,12 +89,12 @@
   {:version               "0"
    :metadata-table-name   "mock_index_metadata"
    :control-table-name    "mock_index_control"
-   :index-table-qualifier "%s"})
+   :index-table-qualifier "_%s"})
 
 (defn unique-index-metadata
   []
-  (let [nano-id (u/generate-nano-id)
-        fmt     (str "mock_%s_" nano-id "_")]
+  (let [uniq-id (subs (u/generate-nano-id) 0 17)
+        fmt     (str "mock_%s_" uniq-id "_")]
     {:version               "0"
      :metadata-table-name   (format fmt "index_metadata")
      :control-table-name    (format fmt "index_control")


### PR DESCRIPTION
Closes [BOT-275](https://linear.app/metabase/issue/BOT-275/create-a-metabase-service-for-generating-embeddings)

### Description

This is pt. 1 of my plan to make dynamically swapping models possible ([slack message](https://metaboat.slack.com/archives/C07SJT1P0ET/p1754429609574029)).

Adds AI Service as an embeddings provider. [ai-service#288](https://github.com/metabase/ai-service/pull/288) adds a new OpenAI compatible `/v1/embeddings` endpoint for generating embeddings. This PR makes it so that ai-service and our suggested embedding model are the defaults. This means that so long as AI Service has been configured and `MB_SEARCH_ENGINE=semantic` for metabase, everything should work out of the box without configuration from us. 

### How to verify

- setup AI service correctly (see [ai-service#288](https://github.com/metabase/ai-service/pull/288) for details)
- start up you BE service, you should should see your db be indexed by ai service

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
