### PR TITLE
refactor(sdk): Prepare e2e code for Hosted Bundle

### DIFF
--- a/e2e/support/component-cypress.js
+++ b/e2e/support/component-cypress.js
@@ -1,0 +1,5 @@
+import "./cypress";
+
+beforeEach(() => {
+  // Add SDK-specific commands here
+});

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -249,10 +249,12 @@ const stressTestConfig = {
 
 const embeddingSdkComponentTestConfig = {
   ...defaultConfig,
+  defaultCommandTimeout: 10000,
+  requestTimeout: 10000,
   video: false,
   specPattern: "e2e/test-component/scenarios/embedding-sdk/**/*.cy.spec.tsx",
   indexHtmlFile: "e2e/support/component-index.html",
-  supportFile: "e2e/support/cypress.js",
+  supportFile: "e2e/support/component-cypress.js",
 
   reporter: mainConfig.reporter,
   reporterOptions: mainConfig.reporterOptions,

--- a/e2e/support/helpers/e2e-embedding-sdk-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-sdk-helpers.ts
@@ -1,4 +1,6 @@
 export const EMBEDDING_SDK_STORY_HOST = "http://localhost:6006/iframe.html";
 
-export const getSdkRoot = () =>
-  cy.get("#metabase-sdk-root").should("be.visible");
+export const getSdkRoot = () => cy.get("[data-cy-root]").should("be.visible");
+
+export const getStorybookSdkRoot = () =>
+  cy.get("#storybook-root").should("be.visible");

--- a/e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers.tsx
+++ b/e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers.tsx
@@ -15,11 +15,16 @@ export const DEFAULT_SDK_AUTH_PROVIDER_CONFIG = {
 export interface MountSdkContentOptions {
   sdkProviderProps?: Partial<MetabaseProviderProps>;
   strictMode?: boolean;
+  waitForUser?: boolean;
 }
 
 export function mountSdkContent(
   children: JSX.Element,
-  { sdkProviderProps, strictMode = false }: MountSdkContentOptions = {},
+  {
+    sdkProviderProps,
+    strictMode = false,
+    waitForUser = true,
+  }: MountSdkContentOptions = {},
 ) {
   cy.intercept("GET", "/api/user/current").as("getUser");
 
@@ -43,7 +48,9 @@ export function mountSdkContent(
     cy.mount(reactNode);
   }
 
-  cy.wait("@getUser").then(({ response }) => {
-    expect(response?.statusCode).to.equal(200);
-  });
+  if (waitForUser) {
+    cy.wait("@getUser").then(({ response }) => {
+      expect(response?.statusCode).to.equal(200);
+    });
+  }
 }

--- a/e2e/support/helpers/embedding-sdk-testing/index.ts
+++ b/e2e/support/helpers/embedding-sdk-testing/index.ts
@@ -1,1 +1,1 @@
-export * from ".//embedding-sdk-helpers";
+export * from "./embedding-sdk-helpers";

--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -59,7 +59,7 @@ describe("scenarios > embedding-sdk > styles", () => {
         expect(response?.statusCode).to.equal(200);
       });
 
-      getSdkRoot().children().should("have.attr", "dir", "ltr");
+      getSdkRoot().get(".mb-wrapper").should("have.attr", "dir", "ltr");
     });
   });
 

--- a/e2e/test-host-app/shared/compatibility.cy.spec.js
+++ b/e2e/test-host-app/shared/compatibility.cy.spec.js
@@ -97,5 +97,5 @@ describe("Embedding SDK: shared Host Apps compatibility tests", () => {
 });
 
 function sdkRoot() {
-  return cy.get("#metabase-sdk-root");
+  return cy.get(".mb-wrapper").first();
 }

--- a/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
+++ b/e2e/test/scenarios/embedding-sdk/static-dashboard-cors.cy.spec.js
@@ -8,7 +8,7 @@ import { AUTH_PROVIDER_URL } from "e2e/support/helpers";
 import { visitFullAppEmbeddingUrl } from "e2e/support/helpers/e2e-embedding-helpers";
 import {
   EMBEDDING_SDK_STORY_HOST,
-  getSdkRoot,
+  getStorybookSdkRoot,
 } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import {
   JWT_SHARED_SECRET,
@@ -81,7 +81,7 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
       });
     });
 
-    getSdkRoot().within(() => {
+    getStorybookSdkRoot().within(() => {
       cy.findByText(
         "Unable to connect to instance at http://localhost:4000",
       ).should("be.visible");
@@ -112,7 +112,7 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
       expect(response?.statusCode).to.equal(200);
     });
 
-    getSdkRoot().within(() => {
+    getStorybookSdkRoot().within(() => {
       cy.findByText("Embedding Sdk Test Dashboard").should("be.visible"); // dashboard title
 
       cy.findByText("Text text card").should("be.visible"); // text card content
@@ -141,7 +141,7 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
       });
     });
 
-    getSdkRoot().within(() => {
+    getStorybookSdkRoot().within(() => {
       cy.findByText(
         "Unable to connect to instance at http://localhost:4000",
       ).should("be.visible");
@@ -173,7 +173,7 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
       expect(response?.statusCode).to.equal(200);
     });
 
-    getSdkRoot().within(() => {
+    getStorybookSdkRoot().within(() => {
       cy.findByText("Embedding Sdk Test Dashboard").should("be.visible"); // dashboard title
 
       cy.findByText("Text text card").should("be.visible"); // text card content


### PR DESCRIPTION
Prepare e2e code for Hosted Bundle

We can't use SDK-root element selector anymore, because MetabaseProvider won't add such DOM node anymore.
Depending on use-case different other selectors are used.