### PR TITLE
feat(sdk): add translation context and aria-label to embedding sdk settings

### DIFF
--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -139,6 +139,7 @@ export function EmbeddingSdkSettings() {
             label={t`Enabled`}
             settingKey="enable-embedding-sdk"
             labelPosition="right"
+            aria-label={t`SDK for React toggle`}
           />
 
           <Group gap="md">
@@ -183,6 +184,7 @@ export function EmbeddingSdkSettings() {
               labelPosition="right"
               settingKey="enable-embedding-simple"
               disabled={!isSimpleEmbedFeatureEnabled}
+              aria-label={t`Embedded Analytics JS toggle`}
             />
 
             {isSimpleEmbedFeatureEnabled ? (

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -1,6 +1,6 @@
 import cx from "classnames";
 import { match } from "ts-pattern";
-import { jt, t } from "ttag";
+import { c, jt, t } from "ttag";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { UpsellDevInstances } from "metabase/admin/upsells";
@@ -102,17 +102,24 @@ export function EmbeddingSdkSettings() {
     .with(
       { needsToSwitchBinaries: true },
       () =>
-        jt`You can test Embedded analytics SDK on localhost quickly by using API keys. To use the SDK on other sites, ${SwitchBinariesLink}, ${(<UpsellSdkLink key="upsell-sdk-link" />)} and ${ImplementJwtLink}.`,
+        c(
+          "{0} is the link to switch binaries. {1} is the link to upsell the SDK. {2} is the link to implement JWT or SAML authentication.",
+        )
+          .jt`You can test Embedded analytics SDK on localhost quickly by using API keys. To use the SDK on other sites, ${SwitchBinariesLink}, ${(<UpsellSdkLink key="upsell-sdk-link" />)} and ${ImplementJwtLink}.`,
     )
     .with(
       { needsToUpgrade: true },
       () =>
-        jt`You can test Embedded analytics SDK on localhost quickly by using API keys. To use the SDK on other sites, ${(<UpsellSdkLink key="upsell-sdk-link" />)} and ${ImplementJwtLink}.`,
+        c(
+          "{0} is the link to upsell the SDK. {1} is the link to implement JWT or SAML authentication.",
+        )
+          .jt`You can test Embedded analytics SDK on localhost quickly by using API keys. To use the SDK on other sites, ${(<UpsellSdkLink key="upsell-sdk-link" />)} and ${ImplementJwtLink}.`,
     )
     .with(
       { needsToImplementJwt: true },
       () =>
-        jt`You can test Embedded analytics SDK on localhost quickly by using API keys. To use the SDK on other sites, ${ImplementJwtLink}.`,
+        c("{0} is the link to implement JWT or SAML authentication.")
+          .jt`You can test Embedded analytics SDK on localhost quickly by using API keys. To use the SDK on other sites, ${ImplementJwtLink}.`,
     )
     .otherwise(() => null);
 

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/common.unit.spec.tsx
@@ -40,7 +40,9 @@ describe("EmbeddingSdkSettings (OSS)", () => {
         });
 
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-        await userEvent.click(screen.getAllByRole("switch")[0]);
+        await userEvent.click(
+          screen.getByRole("switch", { name: "SDK for React toggle" }),
+        );
         assertLegaleseModal();
 
         await userEvent.click(screen.getByText("Agree and continue"));
@@ -63,7 +65,9 @@ describe("EmbeddingSdkSettings (OSS)", () => {
         });
 
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-        await userEvent.click(screen.getAllByRole("switch")[0]);
+        await userEvent.click(
+          screen.getByRole("switch", { name: "SDK for React toggle" }),
+        );
         assertLegaleseModal();
 
         await userEvent.click(screen.getByText("Decline and go back"));
@@ -83,7 +87,9 @@ describe("EmbeddingSdkSettings (OSS)", () => {
         });
 
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-        await userEvent.click(screen.getAllByRole("switch")[0]);
+        await userEvent.click(
+          screen.getByRole("switch", { name: "SDK for React toggle" }),
+        );
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
         const puts = await findRequests("PUT");


### PR DESCRIPTION
Follow-up changes to EMB-692. This addresses @npretto's review [comments](https://github.com/metabase/metabase/pull/61802#discussion_r2256246846) by adding translation contexts and aria-label for accessibility and nicer test locators.