### PR TITLE
dx: add a jsconfig to let IDEs know where to find files

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "target": "esnext",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        "./frontend/src/*",
+        "./frontend/test/*",
+        "./enterprise/frontend/src/*",
+        "./enterprise/frontend/test/*"
+      ],
+      "cljs/*": ["./target/cljs_dev/*"]
+    }
+  },
+  "include": [
+    "frontend/src/**/*.js*",
+    "enterprise/frontend/src/**/*.js*",
+    "frontend/test/**/*.js*",
+    "enterprise/frontend/test/**/*.js*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION

- [x] Not an employee but hoping for a callback on my application, signed the Contributor Agreement

- [x] Closes https://github.com/metabase/metabase/issues/61474

### Description

The app appears to be in transition from typescript-javascript still. For the parts in JS the `metabase/` import is not understood by IDEs like it is for typescript files

this works the same way a ts config does, so now clicking into a metabase/ route will go directly there

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Load base project
2. Try to click into `metabase/` import on a jsx file. 
3. Confirm it only navigates within the file ❌ 
4. Load this branch
5. Try (again) to click into `metabase/` import on a jsx file. (might need to restart your js/ts compiler)
6. Confirm that it takes you to the file ✅ 

### Demo

Before and After are in the [Issue](https://github.com/metabase/metabase/issues/61474)

### Checklist
(No tests needed here)
- [ x ] Tests have been added/updated to cover changes in this PR
