### PR TITLE
feat(sdk): Add "SDK incompatibility with instance" banner

### DIFF
--- a/docs/embedding/sdk/snippets/appearance/customizing-loader-and-components.tsx
+++ b/docs/embedding/sdk/snippets/appearance/customizing-loader-and-components.tsx
@@ -18,13 +18,13 @@ const Example = () => {
       loaderComponent={() => <div>Analytics is loading...</div>}
       errorComponent={({ type, message, onClose }) => {
         switch (type) {
-          case "floating":
+          case "fixed":
             return (
               <div style={{ position: "fixed", left: 0, right: 0, bottom: 0 }}>
                 There was an error: {message}. <span onClick={onClose}>X</span>
               </div>
             );
-          case "default":
+          case "relative":
           default:
             return <div>There was an error: {message}</div>;
         }

--- a/docs/embedding/sdk/snippets/appearance/customizing-loader-and-components.tsx
+++ b/docs/embedding/sdk/snippets/appearance/customizing-loader-and-components.tsx
@@ -16,7 +16,19 @@ const Example = () => {
       authConfig={authConfig}
       // [<endignore>]
       loaderComponent={() => <div>Analytics is loading...</div>}
-      errorComponent={({ message }) => <div>There was an error: {message}</div>}
+      errorComponent={({ type, message, onClose }) => {
+        switch (type) {
+          case "floating":
+            return (
+              <div style={{ position: "fixed", left: 0, right: 0, bottom: 0 }}>
+                There was an error: {message}. <span onClick={onClose}>X</span>
+              </div>
+            );
+          case "default":
+          default:
+            return <div>There was an error: {message}</div>;
+        }
+      }}
     >
       <StaticDashboard dashboardId={1} />
     </MetabaseProvider>

--- a/e2e/test-component/scenarios/embedding-sdk/incompatibility-with-instance-banner.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/incompatibility-with-instance-banner.cy.spec.tsx
@@ -1,0 +1,136 @@
+import {
+  InteractiveQuestion,
+  MetabaseProvider,
+} from "@metabase/embedding-sdk-react";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import * as H from "e2e/support/helpers";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { DEFAULT_SDK_AUTH_PROVIDER_CONFIG } from "e2e/support/helpers/embedding-sdk-component-testing";
+import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
+import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > embedding-sdk > incompatibility-with-instance-banner", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+
+    signInAsAdminAndEnableEmbeddingSdk();
+
+    H.createDashboardWithQuestions({
+      questions: [
+        {
+          name: "Test Question",
+          display: "table",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+          },
+          visualization_settings: {
+            "graph.dimensions": ["CREATED_AT", "STATE"],
+            "graph.metrics": ["count", "sum"],
+          },
+        },
+      ],
+      cards: [{ col: 0, row: 0, size_x: 24, size_y: 6 }],
+    }).then(({ dashboard, questions }) => {
+      cy.wrap(dashboard.id).as("dashboardId");
+      cy.wrap(questions[0].id).as("questionId");
+    });
+
+    cy.signOut();
+
+    mockAuthProviderAndJwtSignIn();
+  });
+
+  describe("when the SDK is incompatible with an instance", () => {
+    it("should show an error with a close button", () => {
+      cy.mount(
+        <MetabaseProvider authConfig={DEFAULT_SDK_AUTH_PROVIDER_CONFIG}>
+          <InteractiveQuestion questionId={1} />
+        </MetabaseProvider>,
+      );
+
+      getSdkRoot().within(() => {
+        cy.findByTestId("notebook-button").click();
+
+        cy.intercept("POST", "*", (req) => {
+          req.reply({
+            statusCode: 500,
+            headers: {
+              "X-Metabase-Version": "v0.0.0", // incompatible version
+            },
+            body: req.body,
+          });
+        });
+
+        cy.findByText("Visualize").click();
+      });
+
+      cy.findByTestId("sdk-error-container").should(
+        "contain.text",
+        "The analytics server is undergoing maintenance",
+      );
+
+      cy.findByTestId("sdk-error-container").within(() => {
+        cy.findByTestId("alert-close-button").click();
+
+        cy.findByTestId("sdk-error-container").should("not.exist");
+      });
+    });
+
+    it("should show a custom error with a close button", () => {
+      cy.mount(
+        <MetabaseProvider
+          authConfig={DEFAULT_SDK_AUTH_PROVIDER_CONFIG}
+          errorComponent={({
+            message,
+            onClose,
+          }: {
+            message: string;
+            onClose: () => void;
+          }) => (
+            <div>
+              <span>Custom error: {message}</span>
+              <div data-testid="custom-alert-close-icon" onClick={onClose}>
+                x
+              </div>
+            </div>
+          )}
+        >
+          <InteractiveQuestion questionId={1} />
+        </MetabaseProvider>,
+      );
+
+      getSdkRoot().within(() => {
+        cy.findByTestId("notebook-button").click();
+
+        cy.intercept("POST", "*", (req) => {
+          req.reply({
+            statusCode: 500,
+            headers: {
+              "X-Metabase-Version": "v0.0.0", // incompatible version
+            },
+            body: req.body,
+          });
+        });
+
+        cy.findByText("Visualize").click();
+      });
+
+      cy.findByTestId("sdk-error-container").should(
+        "contain.text",
+        "The analytics server is undergoing maintenance",
+      );
+
+      cy.findByTestId("sdk-error-container").within(() => {
+        cy.findByTestId("custom-alert-close-icon").click();
+
+        cy.findByTestId("sdk-error-container").should("not.exist");
+      });
+    });
+  });
+});

--- a/e2e/test-component/scenarios/embedding-sdk/incompatibility-with-instance-banner.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/incompatibility-with-instance-banner.cy.spec.tsx
@@ -3,14 +3,11 @@ import {
   MetabaseProvider,
 } from "@metabase/embedding-sdk-react";
 
-import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import * as H from "e2e/support/helpers";
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { DEFAULT_SDK_AUTH_PROVIDER_CONFIG } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
-
-const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > embedding-sdk > incompatibility-with-instance-banner", () => {
   beforeEach(() => {
@@ -19,27 +16,6 @@ describe("scenarios > embedding-sdk > incompatibility-with-instance-banner", () 
     );
 
     signInAsAdminAndEnableEmbeddingSdk();
-
-    H.createDashboardWithQuestions({
-      questions: [
-        {
-          name: "Test Question",
-          display: "table",
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [["count"]],
-          },
-          visualization_settings: {
-            "graph.dimensions": ["CREATED_AT", "STATE"],
-            "graph.metrics": ["count", "sum"],
-          },
-        },
-      ],
-      cards: [{ col: 0, row: 0, size_x: 24, size_y: 6 }],
-    }).then(({ dashboard, questions }) => {
-      cy.wrap(dashboard.id).as("dashboardId");
-      cy.wrap(questions[0].id).as("questionId");
-    });
 
     cy.signOut();
 
@@ -50,7 +26,7 @@ describe("scenarios > embedding-sdk > incompatibility-with-instance-banner", () 
     it("should show an error with a close button", () => {
       cy.mount(
         <MetabaseProvider authConfig={DEFAULT_SDK_AUTH_PROVIDER_CONFIG}>
-          <InteractiveQuestion questionId={1} />
+          <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />
         </MetabaseProvider>,
       );
 
@@ -101,7 +77,7 @@ describe("scenarios > embedding-sdk > incompatibility-with-instance-banner", () 
             </div>
           )}
         >
-          <InteractiveQuestion questionId={1} />
+          <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />
         </MetabaseProvider>,
       );
 

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
@@ -1,4 +1,5 @@
-import { type CSSProperties, type PropsWithChildren, useState } from "react";
+import { useDisclosure } from "@mantine/hooks";
+import type { CSSProperties, PropsWithChildren } from "react";
 import { jt, t } from "ttag";
 
 import { useSdkSelector } from "embedding-sdk/store";
@@ -11,9 +12,10 @@ import { Box, Center, Code, Flex, Portal } from "metabase/ui";
 
 export const SdkError = ({
   message,
-  type = "default",
-}: SdkErrorComponentProps) => {
-  const [visible, setVisible] = useState(true);
+  type = "relative",
+  withCloseButton = false,
+}: Omit<SdkErrorComponentProps, "onClose">) => {
+  const [visible, { close }] = useDisclosure(true);
 
   const CustomError = useSdkSelector(getErrorComponent);
 
@@ -22,7 +24,7 @@ export const SdkError = ({
   }
 
   const handleBannerClose = () => {
-    setVisible(false);
+    close();
   };
 
   const ErrorMessageComponent = CustomError || DefaultErrorMessage;
@@ -32,7 +34,7 @@ export const SdkError = ({
       <ErrorMessageComponent
         type={type}
         message={message}
-        {...(type === "floating" && {
+        {...(withCloseButton && {
           onClose: handleBannerClose,
         })}
       />
@@ -41,16 +43,16 @@ export const SdkError = ({
 
   return (
     <>
-      {type === "default" && errorMessageElement}
+      {type === "relative" && errorMessageElement}
 
-      {type === "floating" && (
-        <SdkFloatingErrorWrapper>{errorMessageElement}</SdkFloatingErrorWrapper>
+      {type === "fixed" && (
+        <SdkPortalErrorWrapper>{errorMessageElement}</SdkPortalErrorWrapper>
       )}
     </>
   );
 };
 
-export function SdkFloatingErrorWrapper({ children }: PropsWithChildren) {
+export function SdkPortalErrorWrapper({ children }: PropsWithChildren) {
   return (
     <Portal target={`#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}`}>
       <Flex

--- a/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/PublicComponentWrapper/SdkError.tsx
@@ -1,23 +1,71 @@
+import { type CSSProperties, type PropsWithChildren, useState } from "react";
 import { jt, t } from "ttag";
 
 import { useSdkSelector } from "embedding-sdk/store";
 import { getErrorComponent } from "embedding-sdk/store/selectors";
 import type { SdkErrorComponentProps } from "embedding-sdk/types";
 import Alert from "metabase/common/components/Alert";
+import { EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID } from "metabase/embedding-sdk/config";
 import { color } from "metabase/lib/colors";
-import { Box, Center, Code } from "metabase/ui";
+import { Box, Center, Code, Flex, Portal } from "metabase/ui";
 
-export const SdkError = ({ message }: SdkErrorComponentProps) => {
+export const SdkError = ({
+  message,
+  type = "default",
+}: SdkErrorComponentProps) => {
+  const [visible, setVisible] = useState(true);
+
   const CustomError = useSdkSelector(getErrorComponent);
+
+  if (!visible) {
+    return null;
+  }
+
+  const handleBannerClose = () => {
+    setVisible(false);
+  };
 
   const ErrorMessageComponent = CustomError || DefaultErrorMessage;
 
-  return (
+  const errorMessageElement = (
     <Center h="100%" w="100%" mx="auto" data-testid="sdk-error-container">
-      <ErrorMessageComponent message={message} />
+      <ErrorMessageComponent
+        type={type}
+        message={message}
+        {...(type === "floating" && {
+          onClose: handleBannerClose,
+        })}
+      />
     </Center>
   );
+
+  return (
+    <>
+      {type === "default" && errorMessageElement}
+
+      {type === "floating" && (
+        <SdkFloatingErrorWrapper>{errorMessageElement}</SdkFloatingErrorWrapper>
+      )}
+    </>
+  );
 };
+
+export function SdkFloatingErrorWrapper({ children }: PropsWithChildren) {
+  return (
+    <Portal target={`#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID}`}>
+      <Flex
+        pos="fixed"
+        bottom="1rem"
+        left="1rem"
+        right="1rem"
+        style={{ zIndex: 500 }}
+        align="center"
+      >
+        {children}
+      </Flex>
+    </Portal>
+  );
+}
 
 const FORCE_DARK_TEXT_COLOR = {
   // The Alert component has a light background, we need to force a dark text
@@ -25,11 +73,11 @@ const FORCE_DARK_TEXT_COLOR = {
   // is a light color, making the text un-readable
   "--mb-color-text-dark": color("text-dark"),
   "--mb-color-text-medium": color("text-medium"),
-} as React.CSSProperties;
+} as CSSProperties;
 
-const DefaultErrorMessage = ({ message }: SdkErrorComponentProps) => (
+const DefaultErrorMessage = ({ message, onClose }: SdkErrorComponentProps) => (
   <Box p="sm" style={FORCE_DARK_TEXT_COLOR}>
-    <Alert variant="error" icon="warning">
+    <Alert variant="error" icon="warning" onClose={onClose}>
       {message}
     </Alert>
   </Box>

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkVersionCompatibilityHandler/SdkIncompatibilityWithInstanceBanner.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkVersionCompatibilityHandler/SdkIncompatibilityWithInstanceBanner.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { jt, t } from "ttag";
+import { c, t } from "ttag";
 
 import { SdkError } from "embedding-sdk/components/private/PublicComponentWrapper";
 import { getEmbeddingSdkVersion } from "embedding-sdk/config";
@@ -41,9 +41,11 @@ export function SdkIncompatibilityWithInstanceBanner() {
 
   return (
     <SdkError
-      type="floating"
+      type="fixed"
+      withCloseButton
       message={
-        <span>{jt`The analytics server is undergoing maintenance. ${(
+        <span>{c("{0} is the button to reload the page")
+          .jt`The analytics server is undergoing maintenance. ${(
           <Anchor
             key="reload-page-button"
             data-testid="reload-page-button"

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkVersionCompatibilityHandler/SdkIncompatibilityWithInstanceBanner.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkVersionCompatibilityHandler/SdkIncompatibilityWithInstanceBanner.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+import { jt, t } from "ttag";
+
+import { SdkError } from "embedding-sdk/components/private/PublicComponentWrapper";
+import { getEmbeddingSdkVersion } from "embedding-sdk/config";
+import {
+  isInvalidMetabaseVersion,
+  isSdkVersionCompatibleWithMetabaseVersion,
+} from "embedding-sdk/lib/version-utils";
+import { useSdkSelector } from "embedding-sdk/store";
+import { getMetabaseInstanceVersion } from "embedding-sdk/store/selectors";
+import { Anchor } from "metabase/ui";
+
+export function SdkIncompatibilityWithInstanceBanner() {
+  const mbVersion = useSdkSelector(getMetabaseInstanceVersion);
+  const sdkVersion = getEmbeddingSdkVersion();
+
+  const isSdkCompatibleWithInstance = useMemo(() => {
+    if (!mbVersion || sdkVersion === "unknown") {
+      // If we don't have the Metabase version, we can't determine compatibility.
+      return true;
+    }
+
+    if (isInvalidMetabaseVersion(mbVersion)) {
+      return true;
+    }
+
+    return isSdkVersionCompatibleWithMetabaseVersion({
+      mbVersion,
+      sdkVersion,
+    });
+  }, [mbVersion, sdkVersion]);
+
+  if (isSdkCompatibleWithInstance) {
+    return null;
+  }
+
+  const handlePageReload = () => {
+    window.location.reload();
+  };
+
+  return (
+    <SdkError
+      type="floating"
+      message={
+        <span>{jt`The analytics server is undergoing maintenance. ${(
+          <Anchor
+            key="reload-page-button"
+            data-testid="reload-page-button"
+            onClick={handlePageReload}
+          >{t`Reload the page`}</Anchor>
+        )}.`}</span>
+      }
+    />
+  );
+}

--- a/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/MetabaseProvider.tsx
@@ -3,6 +3,7 @@ import type { Action, Store } from "@reduxjs/toolkit";
 import { type JSX, type ReactNode, memo, useEffect, useRef } from "react";
 
 import { SdkThemeProvider } from "embedding-sdk/components/private/SdkThemeProvider";
+import { SdkIncompatibilityWithInstanceBanner } from "embedding-sdk/components/private/SdkVersionCompatibilityHandler/SdkIncompatibilityWithInstanceBanner";
 import { useInitData } from "embedding-sdk/hooks";
 import { getSdkStore } from "embedding-sdk/store";
 import {
@@ -144,7 +145,10 @@ export const MetabaseProviderInternal = ({
           <Box className={className} id={EMBEDDING_SDK_ROOT_ELEMENT_ID}>
             <LocaleProvider locale={locale || instanceLocale}>
               {children}
+
+              <SdkIncompatibilityWithInstanceBanner />
             </LocaleProvider>
+
             <SdkUsageProblemDisplay
               authConfig={authConfig}
               allowConsoleLog={allowConsoleLog}

--- a/enterprise/frontend/src/embedding-sdk/lib/version-utils.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/version-utils.ts
@@ -1,5 +1,14 @@
 import { versionToNumericComponents } from "metabase/lib/utils";
 
+// They are mostly used for local development
+export const isInvalidMetabaseVersion = (mbVersion: string) => {
+  return (
+    mbVersion === "vLOCAL_DEV" ||
+    mbVersion === "vUNKNOWN" ||
+    mbVersion.endsWith("-SNAPSHOT")
+  );
+};
+
 export const isSdkVersionCompatibleWithMetabaseVersion = ({
   mbVersion,
   sdkVersion,

--- a/enterprise/frontend/src/embedding-sdk/lib/version-utils.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk/lib/version-utils.unit.spec.ts
@@ -1,4 +1,7 @@
-import { isSdkVersionCompatibleWithMetabaseVersion } from "./version-utils";
+import {
+  isInvalidMetabaseVersion,
+  isSdkVersionCompatibleWithMetabaseVersion,
+} from "./version-utils";
 
 const expectCompatibility = ({
   mbVersion,
@@ -19,74 +22,107 @@ const expectCompatibility = ({
   });
 };
 
-describe('sdk version utils, naming used: "{0,1}.{major}.{minor}"', () => {
-  describe('should return true only if the "major" version is the same', () => {
-    expectCompatibility({
-      mbVersion: "v0.52.10",
-      sdkVersion: "0.52.10",
-      expected: true,
-    });
-    expectCompatibility({
-      mbVersion: "v1.50.10",
-      sdkVersion: "0.51.10",
-      expected: false,
-    });
-    expectCompatibility({
-      mbVersion: "v1.50.10",
-      sdkVersion: "0.53.10",
-      expected: false,
-    });
-  });
-
-  describe('should ignore "minors"', () => {
-    expectCompatibility({
-      mbVersion: "v1.50.10",
-      sdkVersion: "0.50.11",
-      expected: true,
-    });
-
-    expectCompatibility({
-      mbVersion: "v1.50.10",
-      sdkVersion: "0.50.9",
-      expected: true,
-    });
-  });
-
-  describe("sdk version 0.xx.yy should be compatible both with MB 0.xx.yy (OSS) and 1.xx.yy (EE)", () => {
-    expectCompatibility({
-      mbVersion: "v0.52.10",
-      sdkVersion: "0.52.10",
-      expected: true,
-    });
-
-    expectCompatibility({
-      mbVersion: "v1.52.10",
-      sdkVersion: "0.52.10",
-      expected: true,
+describe("sdk version utils", () => {
+  describe.each([
+    {
+      version: "vLOCAL_DEV",
+      expectedResult: true,
+    },
+    {
+      version: "vUNKNOWN",
+      expectedResult: true,
+    },
+    {
+      version: "v0.52.10-SNAPSHOT",
+      expectedResult: true,
+    },
+    {
+      version: "v1.50.10",
+      expectedResult: false,
+    },
+    {
+      version: "v1.50.10-rc",
+      expectedResult: false,
+    },
+    {
+      version: "v1.50.10-alpha",
+      expectedResult: false,
+    },
+  ])("isInvalidMetabaseVersion", ({ version, expectedResult }) => {
+    it(`should return ${expectedResult} for ${version}`, () => {
+      expect(isInvalidMetabaseVersion(version)).toBe(expectedResult);
     });
   });
 
-  describe("should ignore build tags like snapshot, alpha, beta, rc", () => {
-    for (const tag of ["snapshot", "alpha", "beta", "rc", "X-NOT-EXISTING"]) {
+  describe('isSdkVersionCompatibleWithMetabaseVersion, naming used: "{0,1}.{major}.{minor}"', () => {
+    describe('should return true only if the "major" version is the same', () => {
       expectCompatibility({
-        mbVersion: `v0.52.10-${tag}`,
+        mbVersion: "v0.52.10",
         sdkVersion: "0.52.10",
         expected: true,
       });
-    }
-  });
-
-  describe("should handle versions of the sdk wrapped in double quotes (metabase#50014)", () => {
-    expectCompatibility({
-      mbVersion: "v1.55.0",
-      sdkVersion: '"0.55.0"',
-      expected: true,
+      expectCompatibility({
+        mbVersion: "v1.50.10",
+        sdkVersion: "0.51.10",
+        expected: false,
+      });
+      expectCompatibility({
+        mbVersion: "v1.50.10",
+        sdkVersion: "0.53.10",
+        expected: false,
+      });
     });
 
-    expectCompatibility({
-      mbVersion: "v1.55.0",
-      sdkVersion: '"0.54.0"',
-      expected: false,
+    describe('should ignore "minors"', () => {
+      expectCompatibility({
+        mbVersion: "v1.50.10",
+        sdkVersion: "0.50.11",
+        expected: true,
+      });
+
+      expectCompatibility({
+        mbVersion: "v1.50.10",
+        sdkVersion: "0.50.9",
+        expected: true,
+      });
+    });
+
+    describe("sdk version 0.xx.yy should be compatible both with MB 0.xx.yy (OSS) and 1.xx.yy (EE)", () => {
+      expectCompatibility({
+        mbVersion: "v0.52.10",
+        sdkVersion: "0.52.10",
+        expected: true,
+      });
+
+      expectCompatibility({
+        mbVersion: "v1.52.10",
+        sdkVersion: "0.52.10",
+        expected: true,
+      });
+    });
+
+    describe("should ignore build tags like snapshot, alpha, beta, rc", () => {
+      for (const tag of ["snapshot", "alpha", "beta", "rc", "X-NOT-EXISTING"]) {
+        expectCompatibility({
+          mbVersion: `v0.52.10-${tag}`,
+          sdkVersion: "0.52.10",
+          expected: true,
+        });
+      }
+    });
+
+    describe("should handle versions of the sdk wrapped in double quotes (metabase#50014)", () => {
+      expectCompatibility({
+        mbVersion: "v1.55.0",
+        sdkVersion: '"0.55.0"',
+        expected: true,
+      });
+
+      expectCompatibility({
+        mbVersion: "v1.55.0",
+        sdkVersion: '"0.54.0"',
+        expected: false,
+      });
     });
   });
 });

--- a/enterprise/frontend/src/embedding-sdk/types/ui.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/ui.ts
@@ -10,8 +10,9 @@ export type {
 export type { MetabaseFontFamily } from "metabase/embedding-sdk/theme/fonts";
 
 export type SdkErrorComponentProps = {
-  type?: "default" | "floating";
+  type?: "relative" | "fixed";
   message: ReactNode;
+  withCloseButton?: boolean;
   onClose?: () => void;
 };
 

--- a/enterprise/frontend/src/embedding-sdk/types/ui.ts
+++ b/enterprise/frontend/src/embedding-sdk/types/ui.ts
@@ -10,9 +10,12 @@ export type {
 export type { MetabaseFontFamily } from "metabase/embedding-sdk/theme/fonts";
 
 export type SdkErrorComponentProps = {
+  type?: "default" | "floating";
   message: ReactNode;
+  onClose?: () => void;
 };
 
 export type SdkErrorComponent = ({
+  type,
   message,
 }: SdkErrorComponentProps) => JSX.Element;


### PR DESCRIPTION
The PR adds the "SDK incompatibility with instance" banner

Context:
https://metaboat.slack.com/archives/C063Q3F1HPF/p1753969983469469

<img width="900" height="567" alt="image" src="https://github.com/user-attachments/assets/07e3f95b-755e-4b80-beb1-da833dfadfa9" />

How to validate:
- it is tested via e2e
