### PR TITLE
Tag an embed flow test "persists chart embed options" as flaky

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/user-settings-persistence.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/user-settings-persistence.cy.spec.ts
@@ -61,7 +61,7 @@ describe("scenarios > embedding > sdk iframe embed setup > user settings persist
     });
   });
 
-  it("persists chart embed options", () => {
+  it("persists chart embed options", { tags: "@flaky" }, () => {
     navigateToEmbedOptionsStep({
       experience: "chart",
       resourceName: QUESTION_NAME,


### PR DESCRIPTION
Tag a flaky embed flow test according to Trunk: https://app.trunk.io/metabase/flaky-tests/test/c0a542ad-e2eb-5581-8b17-7925f71e753f?repo=metabase%2Fmetabase&intervalDays=1

This one seems to be getting flakier this past days. I will take a look today.