### PR TITLE
Always set connection role for Redshift

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -272,12 +272,13 @@
    db-or-id-or-spec
    options
    (fn [^Connection conn]
+     (let [db (cond (integer? db-or-id-or-spec) (driver-api/with-metadata-provider db-or-id-or-spec
+                                                  (driver-api/database (driver-api/metadata-provider)))
+                    (u/id db-or-id-or-spec)     db-or-id-or-spec)]
+       (sql-jdbc.execute/set-role-if-supported! driver conn db))
      (when-not (sql-jdbc.execute/recursive-connection?)
        (sql-jdbc.execute/set-best-transaction-level! driver conn)
        (sql-jdbc.execute/set-time-zone-if-supported! driver conn session-timezone)
-       (sql-jdbc.execute/set-role-if-supported! driver conn (cond (integer? db-or-id-or-spec) (driver-api/with-metadata-provider db-or-id-or-spec
-                                                                                                (driver-api/database (driver-api/metadata-provider)))
-                                                                  (u/id db-or-id-or-spec)     db-or-id-or-spec))
        (try
          (.setHoldability conn ResultSet/CLOSE_CURSORS_AT_COMMIT)
          (catch Throwable e


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

https://metaboat.slack.com/archives/C0645JP1W81/p1754484537697919

Two issues:
1. Redshift wasn't always setting the role on connections, only if the connection was non-recursive
2. This caused tests to flake due to a bad implementation of test helper `do-on-all-connection-in-pool`

Solution is to always set the role on redshift connections and to use the `do-on-all-connection-in-pool` implementation from @dpsutton in the slack thread above.

### How to verify

1. All the tests should pass

### Demo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
