### PR TITLE
fix annoying tooltip on cartesian charts, pie, sankey

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
+++ b/frontend/src/metabase/visualizations/echarts/tooltip/index.tsx
@@ -19,6 +19,7 @@ import type { PieChartModel, SliceTreeNode } from "../pie/model/types";
 import { getArrayFromMapValues } from "../pie/util";
 
 export const TOOLTIP_POINTER_MARGIN = 10;
+export const ECHARTS_TOOLTIP_CONTAINER_CLASS = "echarts-tooltip-container";
 
 export const getTooltipPositionFn =
   (containerRef: React.RefObject<HTMLDivElement>) =>
@@ -72,7 +73,7 @@ export const getTooltipBaseOption = (
     enterable: true,
     className: TooltipStyles.ChartTooltipRoot,
     appendTo: () => {
-      const echartsTooltipContainerSelector = ".echarts-tooltip-container";
+      const echartsTooltipContainerSelector = `.${ECHARTS_TOOLTIP_CONTAINER_CLASS}`;
       const containerSelector = !isEmbeddingSdk()
         ? echartsTooltipContainerSelector
         : `#${EMBEDDING_SDK_PORTAL_ROOT_ELEMENT_ID} ${echartsTooltipContainerSelector}`;
@@ -83,7 +84,7 @@ export const getTooltipBaseOption = (
 
       if (!container) {
         container = document.createElement("div");
-        container.classList.add("echarts-tooltip-container");
+        container.classList.add(ECHARTS_TOOLTIP_CONTAINER_CLASS);
         container.style.setProperty("overflow", "hidden");
         container.style.setProperty("position", "fixed");
         container.style.setProperty("inset", "0");

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -123,6 +123,7 @@ function _CartesianChart(props: VisualizationProps) {
 
   const { onSelectSeries, onOpenQuestion, eventHandlers } = useChartEvents(
     chartRef,
+    containerRef,
     chartModel,
     timelineEventsModel,
     option,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -39,6 +39,7 @@ import {
 import { getVisualizerSeriesCardIndex } from "metabase/visualizer/utils";
 import type { CardId } from "metabase-types/api";
 
+import { useTooltipMouseLeave } from "./use-tooltip-mouse-leave";
 import {
   getHoveredEChartsSeriesDataKeyAndIndex,
   getHoveredSeriesDataKey,
@@ -46,6 +47,7 @@ import {
 
 export const useChartEvents = (
   chartRef: React.MutableRefObject<EChartsType | undefined>,
+  containerRef: React.RefObject<HTMLDivElement>,
   chartModel: BaseCartesianChartModel,
   timelineEventsModel: TimelineEventsModel | null,
   option: EChartsCoreOption,
@@ -70,6 +72,7 @@ export const useChartEvents = (
   }: VisualizationProps,
 ) => {
   const isBrushing = useRef<boolean>();
+  useTooltipMouseLeave(chartRef, onHoverChange, containerRef);
 
   const onOpenQuestion = useCallback(
     (cardId?: CardId) => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-tooltip-mouse-leave.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-tooltip-mouse-leave.ts
@@ -1,0 +1,59 @@
+import type { EChartsType } from "echarts/core";
+import { useEffect, useRef } from "react";
+import _ from "underscore";
+
+import { ECHARTS_TOOLTIP_CONTAINER_CLASS } from "metabase/visualizations/echarts/tooltip";
+import type { VisualizationProps } from "metabase/visualizations/types";
+
+const ECHARTS_TOOLTIP_SELECTOR = `.${ECHARTS_TOOLTIP_CONTAINER_CLASS} > div`;
+const MOUSEMOVE_THROTTLE_MS = 50;
+
+export const useTooltipMouseLeave = (
+  chartRef?: React.MutableRefObject<EChartsType | undefined>,
+  onHoverChange?: VisualizationProps["onHoverChange"],
+  containerRef?: React.RefObject<HTMLDivElement>,
+) => {
+  const isMouseOverTooltipRef = useRef(false);
+
+  useEffect(() => {
+    if (!onHoverChange) {
+      return;
+    }
+
+    const handleGlobalMouseMove = _.throttle((e: MouseEvent) => {
+      try {
+        const target = e.target as HTMLElement;
+        const tooltipElement = target.closest(
+          ECHARTS_TOOLTIP_SELECTOR,
+        ) as HTMLElement;
+
+        if (tooltipElement) {
+          if (!isMouseOverTooltipRef.current) {
+            isMouseOverTooltipRef.current = true;
+          }
+        } else if (isMouseOverTooltipRef.current) {
+          isMouseOverTooltipRef.current = false;
+
+          onHoverChange(null);
+          if (chartRef?.current && !chartRef.current.isDisposed()) {
+            chartRef.current.dispatchAction({
+              type: "hideTip",
+            });
+            chartRef.current.dispatchAction({
+              type: "downplay",
+            });
+          }
+        }
+      } catch (error) {
+        console.error("Error in tooltip mouse leave handler:", error);
+      }
+    }, MOUSEMOVE_THROTTLE_MS);
+
+    document.addEventListener("mousemove", handleGlobalMouseMove, true);
+
+    return () => {
+      document.removeEventListener("mousemove", handleGlobalMouseMove, true);
+      handleGlobalMouseMove.cancel();
+    };
+  }, [chartRef, onHoverChange, containerRef]);
+};

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.tsx
@@ -17,6 +17,7 @@ import {
 } from "metabase/visualizations/echarts/tooltip";
 import { useBrowserRenderingContext } from "metabase/visualizations/hooks/use-browser-rendering-context";
 import type { VisualizationProps } from "metabase/visualizations/types";
+import { useTooltipMouseLeave } from "metabase/visualizations/visualizations/CartesianChart/use-tooltip-mouse-leave";
 
 import { PIE_CHART_DEFINITION } from "./chart-definition";
 import { useChartEvents } from "./use-chart-events";
@@ -171,6 +172,7 @@ export function PieChart(props: VisualizationProps) {
   };
 
   useCloseTooltipOnScroll(chartRef);
+  useTooltipMouseLeave(chartRef, onHoverChange, containerRef);
 
   return (
     <ChartWithLegend

--- a/frontend/src/metabase/visualizations/visualizations/SankeyChart/SankeyChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SankeyChart/SankeyChart.tsx
@@ -13,6 +13,7 @@ import {
 } from "metabase/visualizations/echarts/tooltip";
 import { useBrowserRenderingContext } from "metabase/visualizations/hooks/use-browser-rendering-context";
 import type { VisualizationProps } from "metabase/visualizations/types";
+import { useTooltipMouseLeave } from "metabase/visualizations/visualizations/CartesianChart/use-tooltip-mouse-leave";
 
 import { SANKEY_CHART_DEFINITION } from "./chart-definition";
 import { useChartEvents } from "./events";
@@ -25,6 +26,7 @@ export const SankeyChart = ({
   width,
   height,
   onVisualizationClick,
+  onHoverChange,
 }: VisualizationProps) => {
   const rawSeriesWithRemappings = useMemo(
     () => extractRemappings(rawSeries),
@@ -65,6 +67,7 @@ export const SankeyChart = ({
   );
 
   useCloseTooltipOnScroll(chartRef);
+  useTooltipMouseLeave(chartRef, onHoverChange, containerRef);
 
   const sankeyColorsCss = useSankeyChartColorsClasses(chartModel);
 


### PR DESCRIPTION
### Description

[Slack report](https://metaboat.slack.com/archives/C099QV2SLE4/p1754495931284049)

ECharts visualizations may appear stuck in an element hovered state in the following scenario:
- hover an element close to chart boundary so the tooltip appears
- enter the tooltip with mouse
- from tooltip move cursor to the ourside of chart boundary

This does not trigger ECharts mouseout event so charts get stuck in hovered state.
Can be reproduced on all cartesian charts except the row chart, pie chart, sankey chart.

### Demo

Before: https://www.loom.com/share/aefe56830db64b4398157750d78fc38c?sid=8230920d-b40e-44e6-b134-a8a167b856aa
After: https://www.loom.com/share/2be1efcf400a4709b25e7532b296866b?sid=62f338e3-3af2-46f6-ac41-ed05f8f256f9

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
