### PR TITLE
Add `mbql-5-query` macro

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -543,6 +543,7 @@
    metabase.lib.schema.mbql-clause/define-tuple-mbql-clause                                                                  hooks.metabase.lib.schema.mbql-clause/define-mbql-clause
    metabase.lib.test-util.macros/$ids                                                                                        hooks.metabase.test.data/$ids
    metabase.lib.test-util.macros/mbql-query                                                                                  hooks.metabase.test.data/mbql-query
+   metabase.lib.test-util.macros/mbql-5-query                                                                                hooks.metabase.test.data/mbql-query
    metabase.lib.test-util.macros/with-testing-against-standard-queries                                                       hooks.metabase.lib.test-util.macros/with-testing-against-standard-queries
    metabase.model-persistence.api-test/with-persistence-setup!                                                               hooks.common/with-one-top-level-binding
    metabase.model-persistence.api-test/with-setup!                                                                           hooks.common/with-one-top-level-binding

--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -152,6 +152,7 @@
   metabase.lib.join/with-join-alias                                                      [[:default]]
   metabase.lib.join/with-join-conditions                                                 [[:default]]
   metabase.lib.test-util.macros/$ids                                                     [[:inner 0]]
+  metabase.lib.test-util.macros/mbql-5-query                                             [[:inner 0]]
   metabase.lib.test-util.macros/mbql-query                                               [[:inner 0]]
   metabase.lib.util.match/match                                                          [[:inner 0]]
   metabase.lib.util.match/match-one                                                      [[:inner 0]]

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -224,16 +224,35 @@
   (when (map? x)
     (keyword (some #(get x %) [:lib/type "lib/type"]))))
 
+(defn- normalize-stage [stage]
+  (when (map? stage)
+    (let [stage (common/normalize-map stage)]
+      ;; infer stage type
+      (cond
+        (:lib/type stage)
+        stage
+
+        ((some-fn :source-table :source-card) stage)
+        (assoc stage :lib/type :mbql.stage/mbql)
+
+        (:native stage)
+        (assoc stage :lib/type :mbql.stage/native)
+
+        :else
+        stage))))
+
 ;;; TODO -- enforce all kebab-case keys
 (mr/def ::stage
   [:and
-   {:default          {}
-    :decode/normalize common/normalize-map
+   {:default          {:lib/type :mbql.stage/mbql}
+    :decode/normalize normalize-stage
     :encode/serialize #(dissoc %
                                ;; this stuff is all added at runtime by QP middleware.
                                :params
                                :parameters
                                :lib/stage-metadata
+                               ;; wait a minute, `:middleware` is not supposed to be added here, it's supposed to be
+                               ;; added to the top level.
                                :middleware)}
    [:map
     [:lib/type [:ref ::stage.type]]]
@@ -316,9 +335,26 @@
                      (ref-error-for-stages stages))}
    (complement ref-error-for-stages)])
 
+(defn- normalize-stages [stages]
+  (when (sequential? stages)
+    (if (every? :lib/type stages)
+      stages
+      (into [(first stages)]
+            (comp
+             ;; make sure stage has keywordized keys so we can check `:lib/type`
+             (map normalize-stage)
+             ;; subsequent stages have to be MBQL, so add `:lib/type` if it is missing.
+             (map (fn [subsequent-stage]
+                    (cond-> subsequent-stage
+                      (not (:lib/type subsequent-stage)) (assoc :lib/type :mbql.stage/mbql)))))
+            (rest stages)))))
+
 (mr/def ::stages
   [:and
-   [:sequential {:min 1} [:ref ::stage]]
+   [:sequential {:min              1
+                 :decode/normalize normalize-stages
+                 :default          []}
+    [:ref ::stage]]
    [:cat
     [:schema [:ref ::stage.initial]]
     [:* [:schema [:ref ::stage.additional]]]]
@@ -397,4 +433,5 @@
    [:ref ::lib.schema.util/unique-uuids]
    [:fn
     {:error/message ":expressions is not allowed in the top level of a query -- it is only allowed in MBQL stages"}
-    #(not (contains? % :expressions))]])
+    #(not (when (map? %)
+            (contains? % :expressions)))]])

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -13,8 +13,7 @@
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
-   [metabase.util.malli :as mu]
-   [metabase.lib.walk :as lib.walk]))
+   [metabase.util.malli :as mu]))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
@@ -917,47 +916,3 @@
               "Q2__BIRTH_DATE"
               "Q2__count"]
              (mapv :lib/desired-column-alias cols))))))
-
-(deftest ^:parallel join-source-query-join-test
-  (testing "lib/returned-columns calculates incorrect :source-column-aliases for columns coming from nested joins (QUE-1373)"
-    (let [query         (lib/query
-                         meta/metadata-provider
-                         (lib.tu.macros/mbql-5-query orders
-                           {:stages [{:joins  [{:alias     "Q2"
-                                                :stages    [{:source-table $$reviews
-                                                             :aggregation  [[:avg {:name "avg"} $reviews.rating]]
-                                                             :breakout     [&P2.products.category]
-                                                             :joins        [{:alias      "P2"
-                                                                             :strategy   :left-join
-                                                                             :stages     [{:source-table $$products}]
-                                                                             :conditions [[:= {}
-                                                                                           $reviews.product-id
-                                                                                           &P2.products.id]]}]}]
-                                                :strategy  :left-join
-                                                :condition [:= {} &Q2.products.category 1]}]
-                                      ;; busted field ref, should probably be something like
-                                      ;;
-                                      ;;    [:field {:join-alias "Q2", :base-type :type/Integer} "P2__CATEGORY"]
-                                      ;;
-                                      ;; but we should still be able to resolve it correctly.
-                                      :fields [[:field {:join-alias "Q2"} (meta/id :products :category)]
-                                               [:field {:base-type :type/Integer, :join-alias "Q2"} "avg"]]}]}))
-          relevant-keys (fn [cols]
-                          (map #(select-keys % [:name
-                                                :lib/source
-                                                :metabase.lib.join/join-alias
-                                                :lib/source-column-alias
-                                                :lib/desired-column-alias])
-                               cols))]
-      (testing "query (last stage) returned columns"
-        (is (= [{:name                         "CATEGORY"
-                 :lib/source                   :source/joins
-                 :metabase.lib.join/join-alias "Q2"
-                 :lib/source-column-alias      "P2__CATEGORY"
-                 :lib/desired-column-alias     "Q2__P2__CATEGORY"}
-                {:name                         "avg"
-                 :lib/source                   :source/joins
-                 :metabase.lib.join/join-alias "Q2"
-                 :lib/source-column-alias      "avg"
-                 :lib/desired-column-alias     "Q2__avg"}]
-               (relevant-keys (lib/returned-columns query))))))))

--- a/test/metabase/lib/test_util/macros.clj
+++ b/test/metabase/lib/test_util/macros.clj
@@ -2,7 +2,9 @@
   (:require
    [clojure.test :refer [testing]]
    [metabase.lib.test-util.macros.impl :as lib.tu.macros.impl]
-   [metabase.test.data.mbql-query-impl :as mbql-query-impl]))
+   [metabase.test.data.mbql-query-impl :as mbql-query-impl]
+   [metabase.util :as u]
+   [metabase.util.malli :as mu]))
 
 (defn- do-with-bindings [thunk]
   (binding [mbql-query-impl/*id-fn-symb*              'metabase.lib.test-metadata/id
@@ -36,6 +38,48 @@
        (mbql-query-impl/parse-tokens table-name <>)
        (mbql-query-impl/maybe-add-source-table <> table-name)
        (mbql-query-impl/wrap-inner-query <>)))))
+
+(mu/defn- maybe-add-source-table-mbql-5 :- :map
+  [query :- :map
+   table-name]
+  (cond
+    ;; `table-name` is not specified: return query as is
+    (not table-name)
+    query
+
+    ;; already has source table/card in the first stage: return query as is
+    ((some-fn :source-table :source-card) (get-in query [:stages 0]))
+    query
+
+    ;; query is missing `:stages`: add empty vector and recur
+    (not (:stages query))
+    (recur (assoc query :stages [])
+           table-name)
+
+    ;; query is missing first stage: add empty first stage and recur
+    (not (first (:stages query)))
+    (recur (update query :stages #(conj (vec %) {:lib/type :mbql.stage/mbql}))
+           table-name)
+
+    ;; otherwise we're good to go. Add `(meta/id ...)` form for `:source-table` to the first stage
+    :else
+    (assoc-in query [:stages 0 :source-table] (list 'metabase.lib.test-metadata/id (keyword table-name)))))
+
+(defmacro mbql-5-query
+  "Like [[mbql-query]] but for use with MBQL 5 queries. Currently experimental, and maybe need bugfixes!"
+  {:style/indent :defn}
+  ([table-name]
+   `(mbql-5-query ~table-name {}))
+
+  ([table-name query]
+   {:pre [(map? query)]}
+   (do-with-bindings
+    (fn []
+      (binding [mbql-query-impl/*mbql-version* 5]
+        (as-> query <>
+          (mbql-query-impl/parse-tokens table-name <>)
+          (u/assoc-default <> :lib/type :mbql/query, :database '(metabase.lib.test-metadata/id))
+          (maybe-add-source-table-mbql-5 <> table-name)))))))
 
 (defmacro with-testing-against-standard-queries
   "Tests against a number of named expressions that all produce the same columns through different methods."


### PR DESCRIPTION
Add `lib.tu/mbql-5-query` to (eventually) replace `lib.tu/mbql-query` and allow writing out MBQL 5 queries by hand in tests (yes, it is better to use the Lib to build the queries, but for copying failing tests from QP tests or whatever writing MBQL by hand is usually the easiest path forward -- having the option to use `:stages` instead of nesting source queries a million times is nice). This uses `lib/normalize` to add UUIDs automatically. It can now also infer stage types automatically based on the keys inside them. Nice!

This macro does actually work correctly (used in new tests #61767) even if this PR itself doesn't contain tests that use it