### PR TITLE
Enable table existence checks for subset of drivers

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -17,15 +17,8 @@
   "Test if the target table of a transform already exists."
   [{:keys [source target] :as _transform}]
   (let [db-id (-> source :query :database)
-        database (t2/select-one :model/Database db-id)
-        driver (:engine database)]
-    (try
-      (-> (driver/describe-table driver database target)
-          :fields
-          seq
-          boolean)
-      (catch Exception e
-        (not (driver/table-known-to-not-exist? driver e))))))
+        {driver :engine :as database} (t2/select-one :model/Database db-id)]
+    (driver/table-exists? driver database target)))
 
 (defn target-table
   "Load the `target` table of a transform from the database specified by `database-id`."

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -749,7 +749,7 @@
                               :set-timezone             true
                               :expression-literals      true
                               :database-routing true
-                              :table-existence-checking true}]
+                              :metadata/table-existence-check true}]
   (defmethod driver/database-supports? [:bigquery-cloud-sdk feature] [_driver _feature _db] supported?))
 
 ;; BigQuery is always in UTC

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -133,6 +133,12 @@
 (def ^:private empty-table-options
   (u/varargs BigQuery$TableOption))
 
+(defn- get-table*
+  [^BigQuery client project-id dataset-id table-id]
+  (if project-id
+    (.getTable client (TableId/of project-id dataset-id table-id) empty-table-options)
+    (.getTable client dataset-id table-id empty-table-options)))
+
 (mu/defn- get-table :- (driver-api/instance-of-class Table)
   (^Table [{{:keys [project-id]} :details, :as database} dataset-id table-id]
    (get-table (database-details->client (:details database)) project-id dataset-id table-id))
@@ -141,9 +147,16 @@
            project-id       :- [:maybe driver-api/schema.common.non-blank-string]
            dataset-id       :- driver-api/schema.common.non-blank-string
            table-id         :- driver-api/schema.common.non-blank-string]
-   (if project-id
-     (.getTable client (TableId/of project-id dataset-id table-id) empty-table-options)
-     (.getTable client dataset-id table-id empty-table-options))))
+   (get-table* client project-id dataset-id table-id)))
+
+(defmethod driver/table-exists? :bigquery-cloud-sdk
+  [_ {:keys [details] :as _database} {table-id :name, dataset-id :schema :as _table}]
+  ;; BigQuery's .getTable returns nil for non-existent tables
+  ;; get-table* call to avoid the non-nil schema enforcement on get-table
+  (let [client     (database-details->client details)
+        project-id (get-project-id details)]
+    (boolean
+     (get-table* client project-id dataset-id table-id))))
 
 (declare ^:dynamic *process-native*)
 
@@ -735,7 +748,8 @@
                               ;; tests expect the converted values.
                               :set-timezone             true
                               :expression-literals      true
-                              :database-routing         true}]
+                              :database-routing true
+                              :table-existence-checking true}]
   (defmethod driver/database-supports? [:bigquery-cloud-sdk feature] [_driver _feature _db] supported?))
 
 ;; BigQuery is always in UTC

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -43,7 +43,8 @@
                               :nested-field-columns      false
                               :test/jvm-timezone-setting false
                               :database-routing          true
-                              :transforms/table          false}]
+                              :transforms/table false
+                              :table-existence-checking true}]
   (defmethod driver/database-supports? [:redshift feature] [_driver _feat _db] supported?))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -44,7 +44,7 @@
                               :test/jvm-timezone-setting false
                               :database-routing          true
                               :transforms/table false
-                              :table-existence-checking true}]
+                              :metadata/table-existence-check true}]
   (defmethod driver/database-supports? [:redshift feature] [_driver _feat _db] supported?))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -65,7 +65,8 @@
                               :split-part                             true
                               :now                                    true
                               :database-routing                       true
-                              :transforms/view                        true}]
+                              :transforms/view true
+                              :table-existence-checking true}]
   (defmethod driver/database-supports? [:snowflake feature] [_driver _feature _db] supported?))
 
 (defmethod driver/humanize-connection-error-message :snowflake
@@ -845,6 +846,10 @@
 
 (defmethod sql-jdbc/impl-query-canceled? :snowflake [_ e]
   (= (sql-jdbc/get-sql-state e) "57014"))
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :snowflake
+  [_ e]
+  (= (sql-jdbc/get-sql-state e) "42S02"))
 
 (defmethod driver/set-database-used! :snowflake [_driver conn db]
   (let [sql (format "USE DATABASE \"%s\"" (db-name db))]

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -66,7 +66,7 @@
                               :now                                    true
                               :database-routing                       true
                               :transforms/view true
-                              :table-existence-checking true}]
+                              :metadata/table-existence-check true}]
   (defmethod driver/database-supports? [:snowflake feature] [_driver _feature _db] supported?))
 
 (defmethod driver/humanize-connection-error-message :snowflake

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -56,7 +56,8 @@
                               :now                                    true
                               :regex                                  false
                               :test/jvm-timezone-setting              false
-                              :transforms/view                        true}]
+                              :transforms/view true
+                              :table-existence-checking true}]
   (defmethod driver/database-supports? [:sqlserver feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:sqlserver :percentile-aggregations]
@@ -931,3 +932,7 @@
   [_driver role]
   ;; REVERT to handle the case where the users role attribute has changed
   (format "REVERT; EXECUTE AS USER = '%s';" role))
+
+(defmethod sql-jdbc/impl-table-known-to-not-exist? :sqlserver
+  [_ e]
+  (= (sql-jdbc/get-sql-state e) "S0002"))

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -58,7 +58,7 @@
                               :regex                                  false
                               :test/jvm-timezone-setting              false
                               :transforms/view true
-                              :table-existence-checking true}]
+                              :metadata/table-existence-check true}]
   (defmethod driver/database-supports? [:sqlserver feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:sqlserver :percentile-aggregations]

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -72,7 +72,8 @@
                               :uploads                   true
                               :database-routing          true
                               :transforms/table          true
-                              :transforms/view           true}]
+                              :transforms/view true
+                              :table-existence-checking true}]
   (defmethod driver/database-supports? [:h2 feature]
     [_driver _feature _database]
     supported?))

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -73,7 +73,7 @@
                               :database-routing          true
                               :transforms/table          true
                               :transforms/view true
-                              :table-existence-checking true}]
+                              :metadata/table-existence-check true}]
   (defmethod driver/database-supports? [:h2 feature]
     [_driver _feature _database]
     supported?))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -89,7 +89,8 @@
                               :expression-literals                    true
                               :database-routing                       true
                               :transforms/table                       true
-                              :transforms/view                        true}]
+                              :transforms/view true
+                              :table-existence-checking true}]
   (defmethod driver/database-supports? [:mysql feature] [_driver _feature _db] supported?))
 
 ;; This is a bit of a lie since the JSON type was introduced for MySQL since 5.7.8.

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -90,7 +90,7 @@
                               :database-routing                       true
                               :transforms/table                       true
                               :transforms/view true
-                              :table-existence-checking true}]
+                              :metadata/table-existence-check true}]
   (defmethod driver/database-supports? [:mysql feature] [_driver _feature _db] supported?))
 
 ;; This is a bit of a lie since the JSON type was introduced for MySQL since 5.7.8.

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -78,7 +78,8 @@
                               :expressions/date         true
                               :database-routing         true
                               :transforms/table         true
-                              :transforms/view          true}]
+                              :transforms/view true
+                              :table-existence-checking true}]
   (defmethod driver/database-supports? [:postgres feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:postgres :nested-field-columns]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -79,7 +79,7 @@
                               :database-routing         true
                               :transforms/table         true
                               :transforms/view true
-                              :table-existence-checking true}]
+                              :metadata/table-existence-check true}]
   (defmethod driver/database-supports? [:postgres feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:postgres :nested-field-columns]

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -256,7 +256,7 @@
 
 (deftest ^:parallel table-exists-test
   (testing "Make sure checking for table existence works"
-    (mt/test-drivers (mt/normal-drivers-with-feature :table-existence-checking)
+    (mt/test-drivers (mt/normal-drivers-with-feature :metadata/table-existence-check)
       (let [venues-table (t2/select-one :model/Table :id (mt/id :venues))
             fake-table {:name "fake_table_xyz123" :schema (:schema venues-table)}]
         (is (driver/table-exists? driver/*driver* (mt/db) venues-table)

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -254,6 +254,16 @@
                                :native   (-> (qp.compile/compile (mt/mbql-query orders {:limit 1}))
                                              (update :query (partial driver/prettify-native-form driver/*driver*)))})))))
 
+(deftest ^:parallel table-exists-test
+  (testing "Make sure checking for table existence works"
+    (mt/test-drivers (mt/normal-drivers-with-feature :table-existence-checking)
+      (let [venues-table (t2/select-one :model/Table :id (mt/id :venues))
+            fake-table {:name "fake_table_xyz123" :schema (:schema venues-table)}]
+        (is (driver/table-exists? driver/*driver* (mt/db) venues-table)
+            (str "Driver " driver/*driver* " should detect that venues table exists"))
+        (is (not (driver/table-exists? driver/*driver* (mt/db) fake-table))
+            (str "Driver " driver/*driver* " should detect that fake table doesn't exist"))))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Begin tests for `describe-*` methods used in sync
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Ensures there is an implementation of `transforms.util/target-table-exists?` for:
- Postgres
- MySQL
- BigQuery
- Snowflake
- SQL Server
- Redshift (untested)

Provides a default implementation like what was there before: attempt a `describe-table`, catch an exception, see if it's due to a table being missing. But also provides more direct implementations per driver. Adds a `:table-existence-check` driver feature to limit testing to just these drivers.