### PR TITLE
Incorporate metadata into semantic search result ranking

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1026,13 +1026,13 @@
   search
   {:team "Admin Webapp"
    :api #{metabase.search.api
-          metabase.search.appdb.scoring
           metabase.search.config
           metabase.search.core
           metabase.search.engine
           metabase.search.in-place.scoring
           metabase.search.ingestion
           metabase.search.init
+          metabase.search.scoring
           metabase.search.spec}
    :uses #{analytics
            api

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1026,6 +1026,7 @@
   search
   {:team "Admin Webapp"
    :api #{metabase.search.api
+          metabase.search.appdb.scoring
           metabase.search.config
           metabase.search.core
           metabase.search.engine

--- a/enterprise/backend/src/metabase_enterprise/search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/search/scoring.clj
@@ -1,14 +1,14 @@
 (ns metabase-enterprise.search.scoring
   (:require
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
-   [metabase.search.appdb.scoring :as appdb.scoring]
    [metabase.search.config :as search.config]
-   [metabase.search.in-place.scoring :as scoring]))
+   [metabase.search.in-place.scoring :as scoring]
+   [metabase.search.scoring :as search.scoring]))
 
 (def ^:private enterprise-scorers
-  {:official-collection {:expr (appdb.scoring/truthy :official_collection)
+  {:official-collection {:expr (search.scoring/truthy :official_collection)
                          :pred #(premium-features/has-feature? :official-collections)}
-   :verified            {:expr (appdb.scoring/truthy :verified)
+   :verified            {:expr (search.scoring/truthy :verified)
                          :pred #(premium-features/has-feature? :content-verification)}})
 
 (defn- additional-scorers
@@ -24,7 +24,7 @@
   "Return the select-item expressions used to calculate the score for each search result."
   :feature :none
   [search-ctx]
-  (merge (appdb.scoring/base-scorers search-ctx) (additional-scorers)))
+  (merge (search.scoring/base-scorers search-ctx) (additional-scorers)))
 
 ;; ------------ LEGACY ----------
 

--- a/enterprise/backend/src/metabase_enterprise/search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/search/scoring.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.search.scoring
   (:require
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
+   [metabase.search.appdb.scoring :as appdb.scoring]
    [metabase.search.config :as search.config]
    [metabase.search.in-place.scoring :as scoring]
    [metabase.search.scoring :as search.scoring]))
@@ -24,7 +25,7 @@
   "Return the select-item expressions used to calculate the score for each search result."
   :feature :none
   [search-ctx]
-  (merge (search.scoring/base-scorers search-ctx) (additional-scorers)))
+  (merge (appdb.scoring/base-scorers search-ctx) (additional-scorers)))
 
 ;; ------------ LEGACY ----------
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -50,16 +50,21 @@
      [:model_created_at :timestamp-with-time-zone]
      [:last_editor_id :int]
      [:model_updated_at :timestamp-with-time-zone]
+     [:pinned :boolean]
      [:archived :boolean [:default false]]
      [:verified :boolean]
      [:official_collection :boolean]
      [:database_id :int]
      [:collection_id :int]
      [:display_type :text]
+     [:dashboardcard_count :int]
+     [:view_count :int]
+     [:last_viewed_at :timestamp-with-time-zone]
      [:legacy_input :jsonb]
      [:embedding [:raw (format "vector(%d)" vector-dimensions)] :not-null]
      [:text_search_vector :tsvector :not-null]
      [:text_search_with_native_query_vector :tsvector :not-null]
+     [:name :text :not-null]
      [:content :text :not-null]
      [:metadata :jsonb]
      [[:constraint unique-constraint-name]
@@ -79,20 +84,26 @@
 (defn- doc->db-record
   "Convert a document to a database record with a provided embedding."
   [embedding-vec {:keys [model id searchable_text created_at creator_id updated_at
-                         last_editor_id archived verified official_collection database_id collection_id display_type legacy_input] :as doc}]
+                         last_editor_id archived verified official_collection database_id collection_id display_type legacy_input
+                         pinned dashboardcard_count view_count last_viewed_at] :as doc}]
   {:model               model
    :model_id            id
    :creator_id          creator_id
    :model_created_at    created_at
    :last_editor_id      last_editor_id
    :model_updated_at    updated_at
+   :pinned              pinned
    :archived            archived
    :verified            verified
    :official_collection official_collection
    :database_id         database_id
    :collection_id       collection_id
+   :dashboardcard_count dashboardcard_count
+   :view_count          view_count
+   :last_viewed_at      last_viewed_at
    :display_type        display_type
    :embedding           [:raw (format-embedding embedding-vec)]
+   :name                (:name doc)
    :content             searchable_text
    :text_search_vector (if (:name doc)
                          [:||

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -409,6 +409,7 @@
    [:display_type :display_type]
    [:model_created_at :model_created_at]
    [:model_updated_at :model_updated_at]
+   [:official_collection :official_collection]
    [:collection_id :collection_id]])
 
 (defn- keyword-search-query [index search-context]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -74,3 +74,8 @@
   [search-ctx scorers qry]
   (-> (search.scoring/with-scores search-ctx scorers qry)
       (sql.helpers/order-by [:total_score :desc])))
+
+(defn all-scores
+  "Score stats for each scorer"
+  [weights scorers index-row]
+  (search.scoring/all-scores weights scorers index-row))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -1,0 +1,67 @@
+(ns metabase-enterprise.semantic-search.scoring
+  (:require
+   [clojure.walk :as walk]
+   [honey.sql.helpers :as sql.helpers]
+   [metabase.search.scoring :as search.scoring]))
+
+(def ^:private index-table-columns
+  ;; TODO move metabase-enterprise.semantic-search.index/index-table-schema into new namespace to break dep cycle and
+  ;; compute this set from the index-table-schema.
+  #{:id
+    :model
+    :model_id
+    :database_id
+    :collection_id
+    :creator_id
+    :last_editor_id
+    :archived
+    :verified
+    :official_collection
+    :pinned
+    :dashboardcard_count
+    :view_count
+    :display_type
+    :created_at
+    :last_viewed_at
+    :model_created_at
+    :model_updated_at
+    :legacy_input
+    :metadata
+    :content
+    :text_search_vector
+    :text_search_with_native_query_vector
+    :embedding})
+
+(def ^:private index-col->hybrid-expr
+  "Map from an index table column name to an expression that can be used to reference that column in the outer hybrid search query.
+
+  E.g. {:model [:coalesce :v.model :t.model] ...}"
+  (let [prefixed #(keyword (str %1 (name %2)))]
+    (into {}
+          (mapcat (fn [col-name]
+                    (let [hybrid-expr [:coalesce (prefixed "v." col-name) (prefixed "t." col-name)]]
+                      [[col-name hybrid-expr]
+                       [(prefixed "search_index." col-name) hybrid-expr]])))
+          index-table-columns)))
+
+(defn- replace-columns-with-hybrid-exprs
+  [scorer-expr]
+  (walk/postwalk-replace index-col->hybrid-expr scorer-expr))
+
+(defn scorers
+  "Return the select-item expressions used to calculate the score for semantic search results."
+  [search-ctx]
+  (-> (search.scoring/scorers search-ctx)
+      (update-vals replace-columns-with-hybrid-exprs)))
+
+(defn with-scores
+  "Add a bunch of SELECT columns for the individual and total scores, and a corresponding ORDER BY."
+  [search-ctx scorers qry]
+  (let [rrf-weight 100
+        score-weight 1]
+    (-> (search.scoring/with-scores search-ctx scorers qry)
+        (sql.helpers/select [[:+
+                              [:* rrf-weight :rrf_rank]
+                              [:* score-weight :total_score]]
+                             :rrf_total_score])
+        (sql.helpers/order-by [:rrf_total_score :desc]))))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -27,15 +27,13 @@
 
 (def ^:private rrf-rank-exp
   (let [k 60
-        scale 100
         keyword-weight 0.51
         semantic-weight 0.49]
-    [:* scale
-     [:+
-      [:* [:cast semantic-weight :float]
-       [:coalesce [:/ 1.0 [:+ k [:. :v :semantic_rank]]] 0]]
-      [:* [:cast keyword-weight :float]
-       [:coalesce [:/ 1.0 [:+ k [:. :t :keyword_rank]]] 0]]]]))
+    [:+
+     [:* [:cast semantic-weight :float]
+      [:coalesce [:/ 1.0 [:+ k [:. :v :semantic_rank]]] 0]]
+     [:* [:cast keyword-weight :float]
+      [:coalesce [:/ 1.0 [:+ k [:. :t :keyword_rank]]] 0]]]))
 
 (defn base-scorers
   "The default constituents of the search ranking scores."

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -1,67 +1,76 @@
 (ns metabase-enterprise.semantic-search.scoring
   (:require
-   [clojure.walk :as walk]
    [honey.sql.helpers :as sql.helpers]
-   [metabase.search.scoring :as search.scoring]))
+   [metabase.search.config :as search.config]
+   [metabase.search.scoring :as search.scoring]
+   [toucan2.util :as u]))
 
-(def ^:private index-table-columns
-  ;; TODO move metabase-enterprise.semantic-search.index/index-table-schema into new namespace to break dep cycle and
-  ;; compute this set from the index-table-schema.
-  #{:id
-    :model
-    :model_id
-    :database_id
-    :collection_id
-    :creator_id
-    :last_editor_id
-    :archived
-    :verified
-    :official_collection
-    :pinned
-    :dashboardcard_count
-    :view_count
-    :display_type
-    :created_at
-    :last_viewed_at
-    :model_created_at
-    :model_updated_at
-    :legacy_input
-    :metadata
-    :content
-    :text_search_vector
-    :text_search_with_native_query_vector
-    :embedding})
+(defn- ->col-expr
+  "For a given `col-name` return a :coalesce expression to reference it from the outer hybrid search query.
 
-(def ^:private index-col->hybrid-expr
-  "Map from an index table column name to an expression that can be used to reference that column in the outer hybrid search query.
+   (->col-expr :model_id) -> [:coalesce :v.model_id :t.model_id]"
+  [col-name]
+  (let [prefix #(keyword (str %1 (name %2)))]
+    [:coalesce (prefix "v." col-name) (prefix "t." col-name)]))
 
-  E.g. {:model [:coalesce :v.model :t.model] ...}"
-  (let [prefixed #(keyword (str %1 (name %2)))]
-    (into {}
-          (mapcat (fn [col-name]
-                    (let [hybrid-expr [:coalesce (prefixed "v." col-name) (prefixed "t." col-name)]]
-                      [[col-name hybrid-expr]
-                       [(prefixed "search_index." col-name) hybrid-expr]])))
-          index-table-columns)))
+(defn- model-rank-exp [{:keys [context]}]
+  (let [search-order search.config/models-search-order
+        n            (double (count search-order))
+        cases        (map-indexed (fn [i sm]
+                                    [[:= (->col-expr :model) sm]
+                                     (or (search.config/scorer-param context :model sm)
+                                         [:inline (/ (- n i) n)])])
+                                  search-order)]
+    (-> (into [:case] cat (concat cases))
+        ;; if you're not listed, get a very poor score
+        (into [:else [:inline 0.01]]))))
 
-(defn- replace-columns-with-hybrid-exprs
-  [scorer-expr]
-  (walk/postwalk-replace index-col->hybrid-expr scorer-expr))
+(def ^:private rrf-rank-exp
+  (let [k 60
+        scale 100
+        keyword-weight 0.51
+        semantic-weight 0.49]
+    [:* scale
+     [:+
+      [:* [:cast semantic-weight :float]
+       [:coalesce [:/ 1.0 [:+ k [:. :v :semantic_rank]]] 0]]
+      [:* [:cast keyword-weight :float]
+       [:coalesce [:/ 1.0 [:+ k [:. :t :keyword_rank]]] 0]]]]))
 
-(defn scorers
+(defn base-scorers
+  "The default constituents of the search ranking scores."
+  [{:keys [search-string limit-int] :as search-ctx}]
+  (if (and limit-int (zero? limit-int))
+    {:model       [:inline 1]}
+    ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
+    ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
+    {:rrf          rrf-rank-exp
+     :pinned       (search.scoring/truthy (->col-expr :pinned))
+     :recency      (search.scoring/inverse-duration [:coalesce
+                                                     (->col-expr :last_viewed_at)
+                                                     (->col-expr :model_updated_at)]
+                                                    [:now]
+                                                    search.config/stale-time-in-days)
+     :dashboard    (search.scoring/size (->col-expr :dashboardcard_count) search.config/dashboard-count-ceiling)
+     :model        (model-rank-exp search-ctx)
+     :mine         (search.scoring/equal (->col-expr :creator_id) (:current-user-id search-ctx))
+     :exact        (if search-string
+                     ;; perform the lower casing within the database, in case it behaves differently to our helper
+                     (search.scoring/equal [:lower (->col-expr :name)] [:lower search-string])
+                     [:inline 0])
+     :prefix       (if search-string
+                     ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
+                     (search.scoring/prefix [:lower (->col-expr :name)] (u/lower-case-en search-string))
+                     [:inline 0])}))
+
+;; TODO EE version
+(defn semantic-scorers
   "Return the select-item expressions used to calculate the score for semantic search results."
   [search-ctx]
-  (-> (search.scoring/scorers search-ctx)
-      (update-vals replace-columns-with-hybrid-exprs)))
+  (base-scorers search-ctx))
 
 (defn with-scores
   "Add a bunch of SELECT columns for the individual and total scores, and a corresponding ORDER BY."
   [search-ctx scorers qry]
-  (let [rrf-weight 100
-        score-weight 1]
-    (-> (search.scoring/with-scores search-ctx scorers qry)
-        (sql.helpers/select [[:+
-                              [:* rrf-weight :rrf_rank]
-                              [:* score-weight :total_score]]
-                             :rrf_total_score])
-        (sql.helpers/order-by [:rrf_total_score :desc]))))
+  (-> (search.scoring/with-scores search-ctx scorers qry)
+      (sql.helpers/order-by [:total_score :desc])))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -182,18 +182,21 @@
       (testing "Documents with different searchable texts get associated with their correct embeddings"
         (let [test-documents [{:model "card"
                                :id "1"
+                               :name "Dog Training Guide"
                                :searchable_text "Dog Training Guide"
                                :creator_id 1
                                :legacy_input {:model "card" :id "1"}
                                :metadata {}}
                               {:model "card"
                                :id "2"
+                               :name "Elephant Migration"
                                :searchable_text "Elephant Migration"
                                :creator_id 2
                                :legacy_input {:model "card" :id "2"}
                                :metadata {}}
                               {:model "card"
                                :id "3"
+                               :name "Tiger Conservation"
                                :searchable_text "Tiger Conservation"
                                :creator_id 3
                                :legacy_input {:model "card" :id "3"}
@@ -221,18 +224,21 @@
 (defn- embedding-reuse-with-batch-size! [batch-size & {:keys [inter-batch?]}]
   (let [test-documents [{:model "card"
                          :id "1"
+                         :name "Dog Training Guide"
                          :searchable_text "Dog Training Guide"
                          :creator_id 1
                          :legacy_input {:model "card" :id "1"}
                          :metadata {}}
                         {:model "card"
                          :id "2"
+                         :name "Elephant Migration"
                          :searchable_text "Elephant Migration"
                          :creator_id 2
                          :legacy_input {:model "card" :id "2"}
                          :metadata {}}
                         {:model "card"
                          :id "3"
+                         :name "Dog Training Guide"
                          :searchable_text "Dog Training Guide"
                          :creator_id 3
                          :legacy_input {:model "card" :id "3"}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
@@ -137,16 +137,18 @@
           index-metadata (semantic.tu/unique-index-metadata)
           model1         semantic.tu/mock-embedding-model
           model2         (assoc semantic.tu/mock-embedding-model :model-name "judge-embedd")
+          remove-scores  (fn [rows] (mapv #(dissoc % :score :all-scores) rows)) ; scores have time-sensitives components
           sut*           semantic.pgvector-api/query
-          sut            #(mt/as-admin (apply sut* %&))     ; see notes below about perms
-          search-string  "insect patterns"                  ; specifics of search will be handled under index tests
-          _              (assert semantic.tu/mock-embeddings "search string should have test embedding")
+          sut            #(remove-scores (mt/as-admin (apply sut* %&))) ; see notes below about perms
+          search-string  "insect patterns"              ; specifics of search will be handled under index tests
+          _              (assert (semantic.tu/mock-embeddings search-string)
+                                 "search string should have test embedding")
           search         {:search-string search-string}]
       (test-not-initialized sut pgvector index-metadata search)
       (with-open [index-ref (open-semantic-search! pgvector index-metadata model1)]
         (semantic.pgvector-api/index-documents! pgvector index-metadata (vec (search.ingestion/searchable-documents)))
         (testing "search results are the same as direct index query"
-          (let [index-results (mt/as-admin (semantic.index/query-index pgvector @index-ref search))
+          (let [index-results (remove-scores (mt/as-admin (semantic.index/query-index pgvector @index-ref search)))
                 api-results   (sut pgvector index-metadata search)]
             (testing "sanity check the test is setup correctly" (is (seq api-results)))
             (is (= api-results index-results))))
@@ -174,7 +176,7 @@
               ;; can actually change
               (is (seq (sut pgvector index-metadata search))))
             (testing "querying previous index directly still works"
-              (is (= current-results (mt/as-admin (semantic.index/query-index pgvector @index-ref search)))))))
+              (is (= current-results (remove-scores (mt/as-admin (semantic.index/query-index pgvector @index-ref search))))))))
         (testing "throws exception when no active index exists"
           ;; corrupt the control table
           (jdbc/execute! pgvector (sql/format {:delete-from (keyword (:control-table-name index-metadata))}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -257,8 +257,8 @@
         (binding [semantic.index/*batch-size* 1]
           (semantic.tu/with-index!
             (testing "Horse-related query finds horse content"
-              (let [results (semantic.tu/query-index {:search-string "equine"})]
-                (is (= "Horse Racing Analysis" (-> results first :name)))))
+              (let [results (semantic.tu/query-index {:search-string "marine mammal"})]
+                (is (= "Whale Communication" (-> results first :name)))))
 
             (testing "Tiger-related query finds tiger content"
               (let [results (semantic.tu/query-index {:search-string "endangered species"})]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -1,0 +1,175 @@
+(ns metabase-enterprise.semantic-search.scoring-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.search.appdb.scoring-test :refer [with-weights]]
+   [metabase.test :as mt])
+  (:import
+   (java.time Instant)
+   (java.time.temporal ChronoUnit)))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once #'semantic.tu/once-fixture)
+
+(defn- add-doc-defaults
+  [doc]
+  (merge {:id 123
+          :searchable_text (:name doc)
+          :created_at #t "2025-01-01T12:00:00Z"
+          :creator_id (mt/user->id :rasta)
+          :archived false
+          :legacy_input {:id (or (:id doc) 123)
+                         :model (:model doc)
+                         :name (:name doc)}
+          :metadata {:title (:name doc)}}
+         doc))
+
+(defmacro with-index-contents!
+  "Populate the index with the given documents."
+  {:style/indent :defn}
+  [documents & body]
+  `(with-open [_# (semantic.tu/open-temp-index!)]
+     (semantic.tu/upsert-index! (map add-doc-defaults ~documents))
+     ~@body))
+
+(defn search-results*
+  [search-string & {:as raw-ctx}]
+  (mapv (juxt :model :id :name)
+        (mt/as-admin ; side-step permissions for these tests
+          (semantic.tu/query-index (merge {:search-string search-string
+                                           :search-engine "semantic"
+                                           :current-user-id (mt/user->id :rasta)}
+                                          raw-ctx)))))
+
+(defn search-results
+  "Like search-results* but with a sanity check that search without weights returns a different result."
+  [ranker-key search-string & {:as raw-ctx}]
+  (let [result   (with-weights {ranker-key 1} (search-results* search-string raw-ctx))
+        inverted (with-weights {ranker-key -1} (search-results* search-string raw-ctx))]
+    ;; note that this may not be a strict reversal, due to ties.
+    (is (not= inverted result)
+        "sanity check: search-no-weights should be different")
+    result))
+
+(deftest rrf-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-index-contents!
+      [{:model "card" :id 1 :name "orders"}
+       {:model "card" :id 2 :name "unrelated"}
+       {:model "card" :id 3 :name "classified" :searchable_text "available only by court order"}
+       {:model "card" :id 4 :name "order"}
+       {:model "card" :id 5 :name "orders, invoices, other stuff", :searchable_text "a verbose description"}
+       {:model "card" :id 6 :name "ordering"}]
+      (with-redefs [semantic.tu/mock-embeddings {"order"      [0.11 -0.33  0.56 -0.77]
+                                                 "orders"     [0.12 -0.34  0.57 -0.78]
+                                                 "ordering"   [0.13 -0.35  0.58 -0.79]
+                                                 "unrelated"  [-0.1 -0.2 -0.3 -0.4]
+                                                 "classified" [0.11 0.22 0.33 0.44]
+                                                 "orders, invoices, other stuff" [0.17 -0.39  0.62 -0.83]
+                                                 "available only by court order" [-0.11 -0.22 -0.33 -0.44]}]
+        (testing "Preferences according to textual matches"
+          ;; Note that, ceteris paribus, the ordering in the database is currently stable - this might change!
+          ;; Due to stemming, we do not distinguish between exact matches and those that differ slightly.
+          (is (= [["card" 1 "orders"]
+                  ["card" 4 "order"]
+                  ["card" 6 "ordering"]
+                  ["card" 5 "orders, invoices, other stuff"]
+                  ;; If the match is only in a secondary field, it is less preferred.
+                  ["card" 3 "classified"]]
+                 (search-results :rrf "order"))))))))
+
+(deftest exact-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-index-contents!
+      [{:model "card" :id 1 :name "the any most of stop words very"}
+       {:model "card" :id 2 :name "stop words"}]
+      (testing "Preferences according to exact name matches, including stop words"
+        (is (= [["card" 1 "the any most of stop words very"]
+                ["card" 2 "stop words"]]
+               (search-results :exact "the any most of stop words very")))))))
+
+(deftest prefix-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-index-contents!
+      [{:model "card" :id 1 :name "this is a prefix of something longer"}
+       {:model "card" :id 2 :name "a prefix this is not, unfortunately"}]
+      (testing "We can boost exact prefix matches"
+        (is (= [["card" 1 "this is a prefix of something longer"]
+                ["card" 2 "a prefix this is not, unfortunately"]]
+               (search-results :prefix "this is a prefix")))))))
+
+(deftest pinned-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-index-contents!
+      [{:model "card" :id 1 :name "not pinned" :pinned false}
+       {:model "card" :id 2 :name "yes pinned" :pinned true}]
+      (is (= [["card" 2 "yes pinned"]
+              ["card" 1 "not pinned"]]
+             (search-results :pinned "pinned"))))))
+
+(deftest mine-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-index-contents!
+      [{:model "card" :id 1 :name "crowberto" :creator_id (mt/user->id :crowberto)}
+       {:model "card" :id 2 :name "rasta" :creator_id (mt/user->id :rasta)}]
+      (is (= [["card" 2 "rasta"]
+              ["card" 1 "crowberto"]]
+             (search-results :mine "mine" {:current-user-id (mt/user->id :rasta)}))))))
+
+(deftest model-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-index-contents!
+      [{:model "dataset" :id 1 :name "card ancient"}
+       {:model "card"    :id 2 :name "card recent"}
+       {:model "metric"  :id 3 :name "card old"}]
+      (testing "There is a preferred ordering in which different models are returned"
+        (is (= [["metric"  3 "card old"]
+                ["card"    2 "card recent"]
+                ["dataset" 1 "card ancient"]]
+               (search-results :model "card"))))
+      (testing "We can override this order with weights"
+        (is (= [["dataset" 1 "card ancient"]
+                ["metric"  3 "card old"]
+                ["card"    2 "card recent"]]
+               (with-weights {:model 1.0 :model/dataset 1.0}
+                 (search-results* "card"))))))))
+
+(deftest recency-test
+  (mt/with-premium-features #{:semantic-search}
+    (let [right-now   (Instant/now)
+          long-ago    (.minus right-now 1 ChronoUnit/DAYS)
+          forever-ago (.minus right-now 10 ChronoUnit/DAYS)]
+      (with-index-contents!
+        [{:model "card" :id 1 :name "card ancient" :last_viewed_at forever-ago}
+         {:model "card" :id 2 :name "card recent" :last_viewed_at right-now}
+         {:model "card" :id 3 :name "card old" :last_viewed_at long-ago}]
+        (testing "More recently viewed results are preferred"
+          (is (= [["card" 2 "card recent"]
+                  ["card" 3 "card old"]
+                  ["card" 1 "card ancient"]]
+                 (search-results :recency "card"))))))))
+
+(deftest dashboard-count-test
+  (mt/with-premium-features #{:semantic-search}
+    (testing "cards used in dashboard have higher rank"
+      (with-index-contents!
+        [{:model "card" :id 1 :name "card no used" :dashboardcard_count 2}
+         {:model "card" :id 2 :name "card used" :dashboardcard_count 3}]
+        (is (= [["card" 2 "card used"]
+                ["card" 1 "card no used"]]
+               (search-results :dashboard "card")))))))
+
+(defn indifferent?
+  "Check that the results and their order do not depend on the given ranker."
+  [ranker-key search-string & {:as raw-ctx}]
+  (= (with-weights {ranker-key 1} (search-results* search-string raw-ctx))
+     (with-weights {ranker-key -1} (search-results* search-string raw-ctx))))
+
+(deftest dashboard-count-test-2
+  (mt/with-premium-features #{:semantic-search}
+    (testing "it has a ceiling, more than the ceiling is considered to be equal"
+      (with-index-contents!
+        [{:model "card" :id 1 :name "card popular" :dashboardcard_count 200}
+         {:model "card" :id 2 :name "card" :dashboardcard_count 201}]
+        (is (indifferent? :dashboard "card"))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.semantic-search.scoring-test
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.search.appdb.scoring-test :refer [with-weights]]
    [metabase.test :as mt])
@@ -36,7 +37,8 @@
 (defn search-results*
   [search-string & {:as raw-ctx}]
   (mapv (juxt :model :id :name)
-        (mt/as-admin ; side-step permissions for these tests
+        ;; side-step permissions for these tests
+        (mt/with-dynamic-fn-redefs [semantic.index/filter-read-permitted identity]
           (semantic.tu/query-index (merge {:search-string search-string
                                            :search-engine "semantic"
                                            :current-user-id (mt/user->id :rasta)}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -130,6 +130,7 @@
   (let [native-query-json (dog-training-native-query-json)]
     [{:model "card"
       :id 123
+      :name "Dog Training Guide"
       :searchable_text "Dog Training Guide"
       :created_at #t "2025-01-01T12:00:00Z"
       :creator_id 1
@@ -143,6 +144,7 @@
                  :native-query native-query-json}}
      {:model "dashboard"
       :id 456
+      :name "Elephant Migration"
       :searchable_text "Elephant Migration"
       :created_at #t "2025-02-01T12:00:00Z"
       :creator_id 2

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -122,12 +122,8 @@
 (defn dog-training-native-query []
   (mt/native-query {:query "SELECT AVG(tricks) FROM dogs WHERE age > 7 GROUP BY breed"}))
 
-(defn dog-training-native-query-json []
-  (-> (dog-training-native-query)
-      json/encode))
-
 (defn mock-documents []
-  (let [native-query-json (dog-training-native-query-json)]
+  (let [native-query-json (-> (dog-training-native-query) json/encode)]
     [{:model "card"
       :id 123
       :name "Dog Training Guide"

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -8,13 +8,14 @@
    [metabase.config.core :as config]
    [metabase.events.core :as events]
    [metabase.search.appdb.index :as search.index]
-   [metabase.search.appdb.scoring :as search.scoring]
+   [metabase.search.appdb.scoring :as appdb.scoring]
    [metabase.search.appdb.specialization.postgres :as specialization.postgres]
    [metabase.search.config :as search.config]
    [metabase.search.engine :as search.engine]
    [metabase.search.filter :as search.filter]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.permissions :as search.permissions]
+   [metabase.search.scoring :as search.scoring]
    [metabase.search.settings :as search.settings]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
@@ -146,7 +147,7 @@
       (->> (search.index/search-query search-string search-ctx [:legacy_input])
            (add-collection-join-and-where-clauses search-ctx)
            (add-table-where-clauses search-ctx)
-           (search.scoring/with-scores search-ctx scorers)
+           (appdb.scoring/with-scores search-ctx scorers)
            (search.filter/with-filters search-ctx)
            t2/query
            (map (partial rehydrate weights (keys scorers)))))

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -61,15 +61,7 @@
        ;; ideally we would make per-user computed attributes part of the spec itself.
        :bookmark   (pos? (:bookmarked index-row 0))
        :score      (:total_score index-row 1)
-       :all-scores (mapv (fn [k]
-                           ;; we shouldn't get null scores, but just in case (i.e., because there are bugs)
-                           (let [score  (or (get index-row k) 0)
-                                 weight (or (weights k) 0)]
-                             {:score        score
-                              :name         k
-                              :weight       weight
-                              :contribution (* weight score)}))
-                         active-scorers))
+       :all-scores (search.scoring/all-scores weights active-scorers index-row))
       (update :created_at parse-datetime)
       (update :updated_at parse-datetime)
       (update :last_edited_at parse-datetime)))

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -8,14 +8,13 @@
    [metabase.config.core :as config]
    [metabase.events.core :as events]
    [metabase.search.appdb.index :as search.index]
-   [metabase.search.appdb.scoring :as appdb.scoring]
+   [metabase.search.appdb.scoring :as search.scoring]
    [metabase.search.appdb.specialization.postgres :as specialization.postgres]
    [metabase.search.config :as search.config]
    [metabase.search.engine :as search.engine]
    [metabase.search.filter :as search.filter]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.permissions :as search.permissions]
-   [metabase.search.scoring :as search.scoring]
    [metabase.search.settings :as search.settings]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
@@ -147,7 +146,7 @@
       (->> (search.index/search-query search-string search-ctx [:legacy_input])
            (add-collection-join-and-where-clauses search-ctx)
            (add-table-where-clauses search-ctx)
-           (appdb.scoring/with-scores search-ctx scorers)
+           (search.scoring/with-scores search-ctx scorers)
            (search.filter/with-filters search-ctx)
            t2/query
            (map (partial rehydrate weights (keys scorers)))))

--- a/src/metabase/search/appdb/scoring.clj
+++ b/src/metabase/search/appdb/scoring.clj
@@ -11,6 +11,11 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
+(defn all-scores
+  "Score stats for each scorer"
+  [weights scorers index-row]
+  (search.scoring/all-scores weights scorers index-row))
+
 ;; TODO move these to the spec definitions
 (def ^:private bookmarked-models [:card :collection :dashboard])
 

--- a/src/metabase/search/appdb/scoring.clj
+++ b/src/metabase/search/appdb/scoring.clj
@@ -1,78 +1,15 @@
 (ns metabase.search.appdb.scoring
   (:require
    [clojure.core.memoize :as memoize]
-   [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
    [metabase.config.core :as config]
-   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.search.appdb.index :as search.index]
    [metabase.search.appdb.specialization.api :as specialization]
    [metabase.search.config :as search.config]
+   [metabase.search.engine :as search.engine]
+   [metabase.search.scoring :as search.scoring]
    [metabase.util :as u]
    [toucan2.core :as t2]))
-
-(def ^:private seconds-in-a-day 86400)
-
-(defn truthy
-  "Prefer it when a (potentially nullable) boolean is true."
-  [column]
-  [:coalesce [:cast column :integer] [:inline 0]])
-
-(defn equal
-  "Prefer it when it matches a specific (non-null) value"
-  [column value]
-  [:coalesce [:case [:= column value] [:inline 1] :else [:inline 0]] [:inline 0]])
-
-(defn prefix
-  "Prefer it when the given value is a completion of a specific (non-null) value"
-  [column value]
-  [:coalesce [:case [:like column (str (str/replace value "%" "%%") "%")] [:inline 1] :else [:inline 0]] [:inline 0]])
-
-(defn size
-  "Prefer items whose value is larger, up to some saturation point. Items beyond that point are equivalent."
-  [column ceiling]
-  [:least
-   [:inline 1]
-   [:/
-    [:coalesce column [:inline 0]]
-    ;; protect against div / 0
-    [:greatest
-     [:inline 1]
-     (if (number? ceiling)
-       [:inline (double ceiling)]
-       [:cast ceiling :float])]]])
-
-(defn inverse-duration
-  "Score at item based on the duration between two dates, where less is better."
-  [from-column to-column ceiling-in-days]
-  (let [ceiling [:inline ceiling-in-days]]
-    [:/
-     [:greatest
-      [:- ceiling
-       [:/
-        ;; Use seconds for granularity in the fraction.
-        ;; TODO will probably need to specialize this based on (mdb/db-type)
-        [[:raw "EXTRACT(epoch FROM (" [:- to-column from-column] [:raw "))"]]]
-        [:inline (double seconds-in-a-day)]]]
-      [:inline 0]]
-     ceiling]))
-
-(defn- sum-columns [column-names]
-  (if (seq column-names)
-    (reduce (fn [expr col] [:+ expr col])
-            (first column-names)
-            (rest column-names))
-    [:inline 1]))
-
-(defn- weighted-score [context [column-alias expr]]
-  [:* [:inline (search.config/weight context column-alias)] expr])
-
-(defn- select-items [context scorers]
-  (concat
-   (for [[column-alias expr] scorers]
-     [expr column-alias])
-   [[(sum-columns (map (partial weighted-score context) scorers))
-     :total_score]]))
 
 ;; TODO move these to the spec definitions
 (def ^:private bookmarked-models [:card :collection :dashboard])
@@ -87,18 +24,6 @@
                                [:!= nil (keyword (str m "_bookmark." m "_id"))]]
                               [:inline 1]])]
     (into [:case] (concat (mapcat (comp match-clause name) bookmarked-models) [:else [:inline 0]]))))
-
-(defn- user-recency-expr [{:keys [current-user-id]}]
-  {:select [[[:max :recent_views.timestamp] :last_viewed_at]]
-   :from   [:recent_views]
-   :where  [:and
-            [:= :recent_views.user_id current-user-id]
-            [:= [:cast :recent_views.model_id :text] :search_index.model_id]
-            [:= :recent_views.model
-             [:case
-              [:= :search_index.model [:inline "dataset"]] [:inline "card"]
-              [:= :search_index.model [:inline "metric"]] [:inline "card"]
-              :else :search_index.model]]]})
 
 (defn- view-count-percentiles*
   [p-value]
@@ -119,54 +44,21 @@
   (let [views (view-count-percentiles percentile)
         cases (for [[sm v] views]
                 [[:= :search_index.model [:inline (name sm)]] (max (or v 0) 1)])]
-    (size :view_count (if (seq cases)
-                        (into [:case] cat cases)
-                        1))))
+    (search.scoring/size :view_count (if (seq cases)
+                                       (into [:case] cat cases)
+                                       1))))
 
-(defn- model-rank-exp [{:keys [context]}]
-  (let [search-order search.config/models-search-order
-        n            (double (count search-order))
-        cases        (map-indexed (fn [i sm]
-                                    [[:= :search_index.model sm]
-                                     (or (search.config/scorer-param context :model sm)
-                                         [:inline (/ (- n i) n)])])
-                                  search-order)]
-    (-> (into [:case] cat (concat cases))
-        ;; if you're not listed, get a very poor score
-        (into [:else [:inline 0.01]]))))
-
-(defn base-scorers
-  "The default constituents of the search ranking scores."
-  [{:keys [search-string limit-int] :as search-ctx}]
-  (if (and limit-int (zero? limit-int))
-    {:model       [:inline 1]}
-    ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
-    ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
-    {:text         (specialization/text-score)
-     :view-count   (view-count-expr search.config/view-count-scaling-percentile)
-     :pinned       (truthy :pinned)
-     :bookmarked   bookmark-score-expr
-     :recency      (inverse-duration [:coalesce :last_viewed_at :model_updated_at] [:now] search.config/stale-time-in-days)
-     :user-recency (inverse-duration (user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)
-     :dashboard    (size :dashboardcard_count search.config/dashboard-count-ceiling)
-     :model        (model-rank-exp search-ctx)
-     :mine         (equal :search_index.creator_id (:current-user-id search-ctx))
-     :exact        (if search-string
-                     ;; perform the lower casing within the database, in case it behaves differently to our helper
-                     (equal [:lower :search_index.name] [:lower search-string])
-                     [:inline 0])
-     :prefix       (if search-string
-                     ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
-                     (prefix [:lower :search_index.name] (u/lower-case-en search-string))
-                     [:inline 0])}))
-
-(defenterprise scorers
-  "Return the select-item expressions used to calculate the score for each search result."
-  metabase-enterprise.search.scoring
-  [search-ctx]
-  (base-scorers search-ctx))
-
-(defn- scorer-select-items [search-ctx scorers] (select-items (:context search-ctx) scorers))
+(defmethod search.engine/scorers :search.engine/appdb
+  [{:keys [limit-int] :as search-ctx}]
+  (merge
+   (search.scoring/base-scorers search-ctx)
+   (if (and limit-int (zero? limit-int))
+     {:model       [:inline 1]}
+     ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
+     ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
+     {:text         (specialization/text-score)
+      :view-count   (view-count-expr search.config/view-count-scaling-percentile)
+      :bookmarked   bookmark-score-expr})))
 
 (defn- bookmark-join [model user-id]
   (let [model-name (name model)
@@ -185,6 +77,6 @@
 (defn with-scores
   "Add a bunch of SELECT columns for the individual and total scores, and a corresponding ORDER BY."
   [{:keys [current-user-id] :as search-ctx} scorers qry]
-  (-> (apply sql.helpers/select qry (scorer-select-items search-ctx scorers))
+  (-> (search.scoring/with-scores search-ctx scorers qry)
       (join-bookmarks current-user-id)
       (sql.helpers/order-by [:total_score :desc])))

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -85,7 +85,8 @@
     :text                5
     :mine                1
     :exact               5
-    :prefix              0}
+    :prefix              0
+    :rrf                 5}
    :command-palette
    {:prefix               5
     :model/collection     1

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -86,7 +86,8 @@
     :mine                1
     :exact               5
     :prefix              0
-    :rrf                 5}
+    ;; TODO figure out a better way to blend these scorers with wildly different scale.
+    :rrf                 5000}
    :command-palette
    {:prefix               5
     :model/collection     1

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -34,6 +34,12 @@
   {:result (dissoc result :score)
    :score  (:score result)})
 
+(defmulti scorers
+  "Return the select-item expressions used to calculate the score for each search result for this engine."
+  {:arglists '([search-context])}
+  (fn [{engine :search-engine}]
+    engine))
+
 (defmulti update!
   "Updates the existing search index by consuming the documents from the given reducible.
   Returns a map of the number of documents indexed in each model"

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -34,12 +34,6 @@
   {:result (dissoc result :score)
    :score  (:score result)})
 
-(defmulti scorers
-  "Return the select-item expressions used to calculate the score for each search result for this engine."
-  {:arglists '([search-context])}
-  (fn [{engine :search-engine}]
-    engine))
-
 (defmulti update!
   "Updates the existing search index by consuming the documents from the given reducible.
   Returns a map of the number of documents indexed in each model"

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -2,9 +2,7 @@
   (:require
    [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
-   [metabase.premium-features.core :refer [defenterprise]]
-   [metabase.search.config :as search.config]
-   [metabase.util :as u]))
+   [metabase.search.config :as search.config]))
 
 (def ^:private seconds-in-a-day 86400)
 
@@ -52,78 +50,30 @@
       [:inline 0]]
      ceiling]))
 
-(defn- sum-columns [column-names]
+(defn sum-columns
+  "Sum the columns in `column-names`."
+  [column-names]
   (if (seq column-names)
     (reduce (fn [expr col] [:+ expr col])
             (first column-names)
             (rest column-names))
     [:inline 1]))
 
-(defn- weighted-score [context [column-alias expr]]
+(defn weighted-score
+  "Multiply a score by its weight."
+  [context [column-alias expr]]
   [:* [:inline (search.config/weight context column-alias)] expr])
 
-(defn- select-items [context scorers]
+(defn select-items
+  "Select expressions for each scorer, plus a :total_score that is the weighted sum of the `scorers`."
+  [context scorers]
   (concat
    (for [[column-alias expr] scorers]
      [expr column-alias])
    [[(sum-columns (map (partial weighted-score context) scorers))
      :total_score]]))
 
-(defn- user-recency-expr [{:keys [current-user-id]}]
-  {:select [[[:max :recent_views.timestamp] :last_viewed_at]]
-   :from   [:recent_views]
-   :where  [:and
-            [:= :recent_views.user_id current-user-id]
-            [:= [:cast :recent_views.model_id :text] :search_index.model_id]
-            [:= :recent_views.model
-             [:case
-              [:= :search_index.model [:inline "dataset"]] [:inline "card"]
-              [:= :search_index.model [:inline "metric"]] [:inline "card"]
-              :else :search_index.model]]]})
-
-(defn- model-rank-exp [{:keys [context]}]
-  (let [search-order search.config/models-search-order
-        n            (double (count search-order))
-        cases        (map-indexed (fn [i sm]
-                                    [[:= :search_index.model sm]
-                                     (or (search.config/scorer-param context :model sm)
-                                         [:inline (/ (- n i) n)])])
-                                  search-order)]
-    (-> (into [:case] cat (concat cases))
-        ;; if you're not listed, get a very poor score
-        (into [:else [:inline 0.01]]))))
-
-(defn base-scorers
-  "The default constituents of the search ranking scores."
-  [{:keys [search-string limit-int] :as search-ctx}]
-  (if (and limit-int (zero? limit-int))
-    {:model       [:inline 1]}
-    ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
-    ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
-    {:pinned       (truthy :pinned)
-     :recency      (inverse-duration [:coalesce :last_viewed_at :model_updated_at] [:now] search.config/stale-time-in-days)
-     :user-recency (inverse-duration (user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)
-     :dashboard    (size :dashboardcard_count search.config/dashboard-count-ceiling)
-     :model        (model-rank-exp search-ctx)
-     :mine         (equal :search_index.creator_id (:current-user-id search-ctx))
-     :exact        (if search-string
-                     ;; perform the lower casing within the database, in case it behaves differently to our helper
-                     (equal [:lower :search_index.name] [:lower search-string])
-                     [:inline 0])
-     :prefix       (if search-string
-                     ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
-                     (prefix [:lower :search_index.name] (u/lower-case-en search-string))
-                     [:inline 0])}))
-
-(defenterprise scorers
-  "Return the select-item expressions used to calculate the score for each search result."
-  metabase-enterprise.search.scoring
-  [search-ctx]
-  (base-scorers search-ctx))
-
-(defn- scorer-select-items [search-ctx scorers] (select-items (:context search-ctx) scorers))
-
 (defn with-scores
   "Add a bunch of SELECT columns for the individual and total scores."
   [search-ctx scorers qry]
-  (apply sql.helpers/select qry (scorer-select-items search-ctx scorers)))
+  (apply sql.helpers/select qry (select-items (:context search-ctx) scorers)))

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -77,3 +77,16 @@
   "Add a bunch of SELECT columns for the individual and total scores."
   [search-ctx scorers qry]
   (apply sql.helpers/select qry (select-items (:context search-ctx) scorers)))
+
+(defn all-scores
+  "Scoring stats for each `index-row`."
+  [weights scorers index-row]
+  (mapv (fn [k]
+          ;; we shouldn't get null scores, but just in case (i.e., because there are bugs)
+          (let [score  (or (get index-row k) 0)
+                weight (or (weights k) 0)]
+            {:score        score
+             :name         k
+             :weight       weight
+             :contribution (* weight score)}))
+        scorers))

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -1,0 +1,130 @@
+(ns metabase.search.scoring
+  (:require
+   [clojure.string :as str]
+   [honey.sql.helpers :as sql.helpers]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.search.config :as search.config]
+   [metabase.search.engine :as search.engine]
+   [metabase.util :as u]))
+
+(def ^:private seconds-in-a-day 86400)
+
+(defn truthy
+  "Prefer it when a (potentially nullable) boolean is true."
+  [column]
+  [:coalesce [:cast column :integer] [:inline 0]])
+
+(defn equal
+  "Prefer it when it matches a specific (non-null) value"
+  [column value]
+  [:coalesce [:case [:= column value] [:inline 1] :else [:inline 0]] [:inline 0]])
+
+(defn prefix
+  "Prefer it when the given value is a completion of a specific (non-null) value"
+  [column value]
+  [:coalesce [:case [:like column (str (str/replace value "%" "%%") "%")] [:inline 1] :else [:inline 0]] [:inline 0]])
+
+(defn size
+  "Prefer items whose value is larger, up to some saturation point. Items beyond that point are equivalent."
+  [column ceiling]
+  [:least
+   [:inline 1]
+   [:/
+    [:coalesce column [:inline 0]]
+    ;; protect against div / 0
+    [:greatest
+     [:inline 1]
+     (if (number? ceiling)
+       [:inline (double ceiling)]
+       [:cast ceiling :float])]]])
+
+(defn inverse-duration
+  "Score at item based on the duration between two dates, where less is better."
+  [from-column to-column ceiling-in-days]
+  (let [ceiling [:inline ceiling-in-days]]
+    [:/
+     [:greatest
+      [:- ceiling
+       [:/
+        ;; Use seconds for granularity in the fraction.
+        ;; TODO will probably need to specialize this based on (mdb/db-type)
+        [[:raw "EXTRACT(epoch FROM (" [:- to-column from-column] [:raw "))"]]]
+        [:inline (double seconds-in-a-day)]]]
+      [:inline 0]]
+     ceiling]))
+
+(defn- sum-columns [column-names]
+  (if (seq column-names)
+    (reduce (fn [expr col] [:+ expr col])
+            (first column-names)
+            (rest column-names))
+    [:inline 1]))
+
+(defn- weighted-score [context [column-alias expr]]
+  [:* [:inline (search.config/weight context column-alias)] expr])
+
+(defn- select-items [context scorers]
+  (concat
+   (for [[column-alias expr] scorers]
+     [expr column-alias])
+   [[(sum-columns (map (partial weighted-score context) scorers))
+     :total_score]]))
+
+(defn- user-recency-expr [{:keys [current-user-id]}]
+  {:select [[[:max :recent_views.timestamp] :last_viewed_at]]
+   :from   [:recent_views]
+   :where  [:and
+            [:= :recent_views.user_id current-user-id]
+            [:= [:cast :recent_views.model_id :text] :search_index.model_id]
+            [:= :recent_views.model
+             [:case
+              [:= :search_index.model [:inline "dataset"]] [:inline "card"]
+              [:= :search_index.model [:inline "metric"]] [:inline "card"]
+              :else :search_index.model]]]})
+
+(defn- model-rank-exp [{:keys [context]}]
+  (let [search-order search.config/models-search-order
+        n            (double (count search-order))
+        cases        (map-indexed (fn [i sm]
+                                    [[:= :search_index.model sm]
+                                     (or (search.config/scorer-param context :model sm)
+                                         [:inline (/ (- n i) n)])])
+                                  search-order)]
+    (-> (into [:case] cat (concat cases))
+        ;; if you're not listed, get a very poor score
+        (into [:else [:inline 0.01]]))))
+
+(defn base-scorers
+  "The default constituents of the search ranking scores."
+  [{:keys [search-string limit-int] :as search-ctx}]
+  (if (and limit-int (zero? limit-int))
+    {:model       [:inline 1]}
+    ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
+    ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
+    {:pinned       (truthy :pinned)
+     :recency      (inverse-duration [:coalesce :last_viewed_at :model_updated_at] [:now] search.config/stale-time-in-days)
+     :user-recency (inverse-duration (user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)
+     :dashboard    (size :dashboardcard_count search.config/dashboard-count-ceiling)
+     :model        (model-rank-exp search-ctx)
+     :mine         (equal :search_index.creator_id (:current-user-id search-ctx))
+     :exact        (if search-string
+                     ;; perform the lower casing within the database, in case it behaves differently to our helper
+                     (equal [:lower :search_index.name] [:lower search-string])
+                     [:inline 0])
+     :prefix       (if search-string
+                     ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
+                     (prefix [:lower :search_index.name] (u/lower-case-en search-string))
+                     [:inline 0])}))
+
+(defenterprise scorers
+  "Return the select-item expressions used to calculate the score for each search result."
+  metabase-enterprise.search.scoring
+  [search-ctx]
+  (search.engine/scorers search-ctx))
+
+(defn- scorer-select-items [search-ctx scorers] (select-items (:context search-ctx) scorers))
+
+(defn with-scores
+  "Add a bunch of SELECT columns for the individual and total scores."
+  [search-ctx scorers qry]
+  (apply sql.helpers/select qry (scorer-select-items search-ctx scorers)))

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -4,7 +4,6 @@
    [honey.sql.helpers :as sql.helpers]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.search.config :as search.config]
-   [metabase.search.engine :as search.engine]
    [metabase.util :as u]))
 
 (def ^:private seconds-in-a-day 86400)
@@ -120,7 +119,7 @@
   "Return the select-item expressions used to calculate the score for each search result."
   metabase-enterprise.search.scoring
   [search-ctx]
-  (search.engine/scorers search-ctx))
+  (base-scorers search-ctx))
 
 (defn- scorer-select-items [search-ctx scorers] (select-items (:context search-ctx) scorers))
 

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -10,7 +10,6 @@
    [metabase.search.config :as search.config]
    [metabase.search.core :as search]
    [metabase.search.ingestion :as search.ingestion]
-   [metabase.search.scoring :as search.scoring]
    [metabase.search.spec :as search.spec]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
@@ -74,8 +73,8 @@
                                    (map (comp keyword u/->kebab-case-en name second))
                                    ;; Remove db-specific fields
                                    (remove #{:search-vector :query}))
-                             (vals (search.scoring/scorers {:search-engine :search.engine/appdb
-                                                            :search-string ""})))
+                             (vals (scoring/scorers {:search-engine :search.engine/appdb
+                                                     :search-string ""})))
                        (set (cons :model (keys search.spec/attr-types))))))))
 
 ;; ---- index-ony rankers ----

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -10,6 +10,7 @@
    [metabase.search.config :as search.config]
    [metabase.search.core :as search]
    [metabase.search.ingestion :as search.ingestion]
+   [metabase.search.scoring :as search.scoring]
    [metabase.search.spec :as search.spec]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
@@ -73,7 +74,8 @@
                                    (map (comp keyword u/->kebab-case-en name second))
                                    ;; Remove db-specific fields
                                    (remove #{:search-vector :query}))
-                             (vals (scoring/scorers {:search-string ""})))
+                             (vals (search.scoring/scorers {:search-engine :search.engine/appdb
+                                                            :search-string ""})))
                        (set (cons :model (keys search.spec/attr-types))))))))
 
 ;; ---- index-ony rankers ----


### PR DESCRIPTION
Closes BOT-264

### Description

Add metadata scorers to the semantic search results. The basic approach is similar to the appdb implementation. Scorers define a set of sql expressions that gets added to the outer hybrid query's select list. The total score is a weighted sum of these expressions, with the (weighted) rrf score as one component of the sum.

Worth pointing out: the above approach means that we are essentially just re-ranking whatever results come out of the semantic and keyword search queries based on the additional metadata, rather than letting the metadata bubble up new candidates that would not otherwise match based on keyword / semantic score. Chatting with wotbrew, there are efficiency concerns if we try to do it the other way, but possibly we could revisit this approach if re-ranking the final hybrid results isn't enough.

Loaded up the stats DB locally. Verified that the new query still appears to be using index scans for the semantic and ts vectors. Query latency seems roughly comparable to fiery-blue. Search results hard to gauge since there are other changes in my local branch, but also seem roughly on par with fiery-blue (not noticeably better or worse).

```
->  Index Scan using index_table_ollama_mxbai_embed_lg_1024_embed_hnsw_idx on index_table_ollama_mxbai_embed_lg_1024  (cost=1837.67..422729.26 rows=140863 width=199) (actual time=0.784..2.624 rows=220 loops=1)
...
->  Bitmap Index Scan on index_table_ollama_mxbai_embed_lg_1024_tsv_gin_idx  (cost=0.00..331.75 rows=17 width=0) (actual time=4.203..4.203 rows=207 loops=1)
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
