### PR TITLE
docs(sdk): manual backport of changelog entry for 56

### DIFF
--- a/docs/embedding/sdk/introduction.md
+++ b/docs/embedding/sdk/introduction.md
@@ -100,6 +100,7 @@ You can find the [Embedded analytics SDK source code in the Metabase repo](https
 
 View the SDK's changelog:
 
+- [56-stable](https://github.com/metabase/metabase/blob/release-x.56.x/enterprise/frontend/src/embedding-sdk/CHANGELOG.md)
 - [55-stable](https://github.com/metabase/metabase/blob/release-x.55.x/enterprise/frontend/src/embedding-sdk/CHANGELOG.md)
 - [54-stable](https://github.com/metabase/metabase/blob/release-x.54.x/enterprise/frontend/src/embedding-sdk/CHANGELOG.md)
 - [53-stable](https://github.com/metabase/metabase/blob/release-x.53.x/enterprise/frontend/src/embedding-sdk/CHANGELOG.md)


### PR DESCRIPTION
https://metaboat.slack.com/archives/C063Q3F1HPF/p1754568212215369?thread_ts=1753992624.846439&cid=C063Q3F1HPF

We need to backport this to 56 as the live docs are from the release branch