### PR TITLE
Fix CI workflows nesting and artifact download

### DIFF
--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -5,6 +5,14 @@ inputs:
   name:
     description: The name of the artifact to fetch
     required: true
+  output-name:
+    description: Optional custom name for the output jar file (defaults to metabase.jar)
+    required: false
+    default: "metabase.jar"
+  extract-path:
+    description: Directory path where the jar should be extracted (defaults to current directory)
+    required: false
+    default: "."
 
 runs:
   using: "composite"
@@ -45,19 +53,55 @@ runs:
     - name: Move the Uberjar
       shell: bash
       run: | # bash
+        OUTPUT_NAME="${{ inputs.output-name }}"
+        EXTRACT_PATH="${{ inputs.extract-path }}"
+
+        # Create target directory if it doesn't exist
+        if [ "$EXTRACT_PATH" != "." ]; then
+          mkdir -p "$EXTRACT_PATH"
+        fi
+
+        # Find the jar file
         if [ -e "metabase.jar" ]; then
-          echo "metabase.jar is already in the right place"
+          SOURCE_JAR="metabase.jar"
         elif [ -e "target/uberjar/metabase.jar" ]; then
-            echo "moving metabase.jar to current directory"
-          mv target/uberjar/metabase.jar metabase.jar
+          SOURCE_JAR="target/uberjar/metabase.jar"
         else
           echo "Could not find the metabase.jar file"
           exit 1
         fi
 
+        # Move to target path
+        if [ "$EXTRACT_PATH" == "." ]; then
+          # Current directory - use output-name
+          TARGET_PATH="$OUTPUT_NAME"
+        else
+          # Specific directory - always use metabase.jar
+          TARGET_PATH="$EXTRACT_PATH/metabase.jar"
+        fi
+
+        echo "Moving $SOURCE_JAR to $TARGET_PATH"
+        mv "$SOURCE_JAR" "$TARGET_PATH"
+
     - name: Verify that this is a valid JAR file
       shell: bash
-      run: file --mime-type ./metabase.jar
+      run: |
+        EXTRACT_PATH="${{ inputs.extract-path }}"
+        if [ "$EXTRACT_PATH" == "." ]; then
+          JAR_PATH="./${{ inputs.output-name }}"
+        else
+          JAR_PATH="./$EXTRACT_PATH/metabase.jar"
+        fi
+        echo "Verifying JAR at: $JAR_PATH"
+        file --mime-type "$JAR_PATH"
     - name: Reveal its version.properties
       shell: bash
-      run: jar xf metabase.jar version.properties && cat version.properties
+      run: |
+        EXTRACT_PATH="${{ inputs.extract-path }}"
+        if [ "$EXTRACT_PATH" == "." ]; then
+          JAR_PATH="${{ inputs.output-name }}"
+        else
+          JAR_PATH="$EXTRACT_PATH/metabase.jar"
+        fi
+        echo "Extracting version.properties from: $JAR_PATH"
+        jar xf "$JAR_PATH" version.properties && cat version.properties

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -50,18 +50,27 @@ runs:
     - name: unzip uberjar artifact
       shell: bash
       run: unzip mb.zip
-    - name: Move the Uberjar
+    - name: Process the Uberjar
       shell: bash
       run: | # bash
         OUTPUT_NAME="${{ inputs.output-name }}"
         EXTRACT_PATH="${{ inputs.extract-path }}"
+
+        # Function to determine the final JAR path
+        get_jar_path() {
+          if [ "$EXTRACT_PATH" == "." ]; then
+            echo "$OUTPUT_NAME"
+          else
+            echo "$EXTRACT_PATH/metabase.jar"
+          fi
+        }
 
         # Create target directory if it doesn't exist
         if [ "$EXTRACT_PATH" != "." ]; then
           mkdir -p "$EXTRACT_PATH"
         fi
 
-        # Find the jar file
+        # Find the source jar file
         if [ -e "metabase.jar" ]; then
           SOURCE_JAR="metabase.jar"
         elif [ -e "target/uberjar/metabase.jar" ]; then
@@ -71,16 +80,10 @@ runs:
           exit 1
         fi
 
-        # Move to target path
-        if [ "$EXTRACT_PATH" == "." ]; then
-          # Current directory - use output-name
-          TARGET_PATH="$OUTPUT_NAME"
-        else
-          # Specific directory - always use metabase.jar
-          TARGET_PATH="$EXTRACT_PATH/metabase.jar"
-        fi
+        # Get the target path
+        TARGET_PATH=$(get_jar_path)
 
-        # Check if source and target are the same
+        # Move the jar if source and target differ
         if [ "$SOURCE_JAR" == "$TARGET_PATH" ]; then
           echo "Jar is already at the correct location: $TARGET_PATH"
         else
@@ -88,25 +91,17 @@ runs:
           mv "$SOURCE_JAR" "$TARGET_PATH"
         fi
 
+        # Export the path for subsequent steps
+        echo "JAR_PATH=$TARGET_PATH" >> $GITHUB_ENV
+
     - name: Verify that this is a valid JAR file
       shell: bash
       run: |
-        EXTRACT_PATH="${{ inputs.extract-path }}"
-        if [ "$EXTRACT_PATH" == "." ]; then
-          JAR_PATH="./${{ inputs.output-name }}"
-        else
-          JAR_PATH="./$EXTRACT_PATH/metabase.jar"
-        fi
         echo "Verifying JAR at: $JAR_PATH"
         file --mime-type "$JAR_PATH"
+        
     - name: Reveal its version.properties
       shell: bash
       run: |
-        EXTRACT_PATH="${{ inputs.extract-path }}"
-        if [ "$EXTRACT_PATH" == "." ]; then
-          JAR_PATH="${{ inputs.output-name }}"
-        else
-          JAR_PATH="$EXTRACT_PATH/metabase.jar"
-        fi
         echo "Extracting version.properties from: $JAR_PATH"
         jar xf "$JAR_PATH" version.properties && cat version.properties

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -80,8 +80,13 @@ runs:
           TARGET_PATH="$EXTRACT_PATH/metabase.jar"
         fi
 
-        echo "Moving $SOURCE_JAR to $TARGET_PATH"
-        mv "$SOURCE_JAR" "$TARGET_PATH"
+        # Check if source and target are the same
+        if [ "$SOURCE_JAR" == "$TARGET_PATH" ]; then
+          echo "Jar is already at the correct location: $TARGET_PATH"
+        else
+          echo "Moving $SOURCE_JAR to $TARGET_PATH"
+          mv "$SOURCE_JAR" "$TARGET_PATH"
+        fi
 
     - name: Verify that this is a valid JAR file
       shell: bash

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -99,7 +99,7 @@ runs:
       run: |
         echo "Verifying JAR at: $JAR_PATH"
         file --mime-type "$JAR_PATH"
-        
+
     - name: Reveal its version.properties
       shell: bash
       run: |

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -61,7 +61,7 @@ runs:
           if [ "$EXTRACT_PATH" == "." ]; then
             echo "$OUTPUT_NAME"
           else
-            echo "$EXTRACT_PATH/metabase.jar"
+            echo "$EXTRACT_PATH/$OUTPUT_NAME.jar"
           fi
         }
 

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -61,7 +61,7 @@ runs:
           if [ "$EXTRACT_PATH" == "." ]; then
             echo "$OUTPUT_NAME"
           else
-            echo "$EXTRACT_PATH/$OUTPUT_NAME.jar"
+            echo "$EXTRACT_PATH/$OUTPUT_NAME"
           fi
         }
 

--- a/.github/actions/get-docker-info/action.yml
+++ b/.github/actions/get-docker-info/action.yml
@@ -40,16 +40,16 @@ runs:
           const branch = '${{ inputs.branch }}';
           const edition = '${{ inputs.edition }}';
           const owner = '${{ inputs.owner }}';
-          
+
           console.log(`Determining Docker info for branch: ${branch}, edition: ${edition}`);
-          
+
           let repo, tag, editions;
-          
+
           if (branch === 'master') {
             // Master builds both editions with specific repos
             editions = ['ee', 'oss'];
             tag = 'latest';
-            
+
             if (edition === 'ee') {
               repo = `${owner}/metabase-enterprise-head`;
             } else {
@@ -61,14 +61,14 @@ runs:
             tag = branch.replaceAll('/', '-'); // slashes make docker sad
             repo = `${owner}/metabase-dev`;
           }
-          
+
           const fullImage = `${repo}:${tag}`;
-          
+
           // Set outputs
           core.setOutput('repo', repo);
           core.setOutput('tag', tag);
           core.setOutput('full_image', fullImage);
           core.setOutput('editions', JSON.stringify(editions));
-          
+
           console.log(`Docker image: ${fullImage}`);
           console.log(`Editions: ${JSON.stringify(editions)}`);

--- a/.github/actions/get-docker-info/action.yml
+++ b/.github/actions/get-docker-info/action.yml
@@ -1,0 +1,74 @@
+name: Get Docker Info
+description: Determines Docker repository and tag based on branch and edition
+
+inputs:
+  branch:
+    description: Branch name (defaults to current branch)
+    required: false
+    default: ${{ github.head_ref || github.ref_name }}
+  edition:
+    description: Edition (ee or oss)
+    required: false
+    default: ee
+  owner:
+    description: Repository owner (defaults to current repo owner)
+    required: false
+    default: ${{ github.repository_owner }}
+
+outputs:
+  repo:
+    description: Docker repository name
+    value: ${{ steps.docker-info.outputs.repo }}
+  tag:
+    description: Docker tag
+    value: ${{ steps.docker-info.outputs.tag }}
+  full_image:
+    description: Full Docker image name (repo:tag)
+    value: ${{ steps.docker-info.outputs.full_image }}
+  editions:
+    description: JSON array of editions to build
+    value: ${{ steps.docker-info.outputs.editions }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Determine Docker info
+      id: docker-info
+      uses: actions/github-script@v7
+      with:
+        script: | # js
+          const branch = '${{ inputs.branch }}';
+          const edition = '${{ inputs.edition }}';
+          const owner = '${{ inputs.owner }}';
+          
+          console.log(`Determining Docker info for branch: ${branch}, edition: ${edition}`);
+          
+          let repo, tag, editions;
+          
+          if (branch === 'master') {
+            // Master builds both editions with specific repos
+            editions = ['ee', 'oss'];
+            tag = 'latest';
+            
+            if (edition === 'ee') {
+              repo = `${owner}/metabase-enterprise-head`;
+            } else {
+              repo = `${owner}/metabase-head`;
+            }
+          } else {
+            // All other branches only build EE to metabase-dev
+            editions = ['ee'];
+            tag = branch.replaceAll('/', '-'); // slashes make docker sad
+            repo = `${owner}/metabase-dev`;
+          }
+          
+          const fullImage = `${repo}:${tag}`;
+          
+          // Set outputs
+          core.setOutput('repo', repo);
+          core.setOutput('tag', tag);
+          core.setOutput('full_image', fullImage);
+          core.setOutput('editions', JSON.stringify(editions));
+          
+          console.log(`Docker image: ${fullImage}`);
+          console.log(`Editions: ${JSON.stringify(editions)}`);

--- a/.github/workflows/containerize-uberjar.yml
+++ b/.github/workflows/containerize-uberjar.yml
@@ -10,45 +10,41 @@ jobs:
     timeout-minutes: 5
     name: Get container info
     outputs:
-      editions: ${{ toJson(fromJson(steps.info.outputs.result).editions) }}
-      ee: ${{ toJson(fromJson(steps.info.outputs.result).ee) }}
-      oss: ${{ toJson(fromJson(steps.info.outputs.result).oss) }}
+      editions: ${{ steps.ee-info.outputs.editions }}
+      ee: ${{ toJson(fromJson(steps.build-matrix.outputs.result).ee) }}
+      oss: ${{ toJson(fromJson(steps.build-matrix.outputs.result).oss) }}
     steps:
-      - name: Get docker repo and tag
-        id: info
+      - name: Check out the code
+        uses: actions/checkout@v4
+      - name: Get EE Docker info
+        id: ee-info
+        uses: ./.github/actions/get-docker-info
+        with:
+          edition: ee
+      - name: Get OSS Docker info
+        id: oss-info
+        uses: ./.github/actions/get-docker-info
+        with:
+          edition: oss
+      - name: Build matrix info
+        id: build-matrix
         uses: actions/github-script@v7
         with:
           script: | # js
-            const branch = '${{ github.head_ref || github.ref_name }}';
-            const owner = '${{ github.repository_owner }}';
-
-            console.log(`Branch: ${branch}`);
-
-            if (branch === "master") {
-              return {
-                editions: ["ee", "oss"],
-                ee: {
-                  repo: `${owner}/metabase-enterprise-head`,
-                  tag: "latest"
-                },
-                oss: {
-                  repo: `${owner}/metabase-head`,
-                  tag: "latest"
-                }
-              };
-            }
-
-            return {
-              editions: ["ee"],
+            const editions = JSON.parse('${{ steps.ee-info.outputs.editions }}');
+            const result = {
+              editions: editions,
               ee: {
-                repo: `${owner}/metabase-dev`,
-                tag: branch.replaceAll("/", "-"), // slashes make docker sad
+                repo: '${{ steps.ee-info.outputs.repo }}',
+                tag: '${{ steps.ee-info.outputs.tag }}'
               },
+              oss: {
+                repo: '${{ steps.oss-info.outputs.repo }}',
+                tag: '${{ steps.oss-info.outputs.tag }}'
+              }
             };
-
-      - name: Print output
-        run: |
-          echo "${{ steps.info.outputs.result }}"
+            console.log('Build matrix:', result);
+            return result;
 
   containerize:
     needs: [get-container-info]

--- a/.github/workflows/containerize-uberjar.yml
+++ b/.github/workflows/containerize-uberjar.yml
@@ -1,0 +1,96 @@
+name: Containerize Uberjar
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  get-container-info:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    name: Get container info
+    outputs:
+      editions: ${{ toJson(fromJson(steps.info.outputs.result).editions) }}
+      ee: ${{ toJson(fromJson(steps.info.outputs.result).ee) }}
+      oss: ${{ toJson(fromJson(steps.info.outputs.result).oss) }}
+    steps:
+      - name: Get docker repo and tag
+        id: info
+        uses: actions/github-script@v7
+        with:
+          script: | # js
+            const branch = '${{ github.head_ref || github.ref_name }}';
+            const owner = '${{ github.repository_owner }}';
+
+            console.log(`Branch: ${branch}`);
+
+            if (branch === "master") {
+              return {
+                editions: ["ee", "oss"],
+                ee: {
+                  repo: `${owner}/metabase-enterprise-head`,
+                  tag: "latest"
+                },
+                oss: {
+                  repo: `${owner}/metabase-head`,
+                  tag: "latest"
+                }
+              };
+            }
+
+            return {
+              editions: ["ee"],
+              ee: {
+                repo: `${owner}/metabase-dev`,
+                tag: branch.replaceAll("/", "-"), // slashes make docker sad
+              },
+            };
+
+      - name: Print output
+        run: |
+          echo "${{ steps.info.outputs.result }}"
+
+  containerize:
+    needs: [get-container-info]
+    if: needs.get-container-info.result == 'success'
+    strategy:
+      matrix:
+        edition: ${{ fromJson(needs.get-container-info.outputs.editions) }}
+    uses: ./.github/workflows/containerize-jar.yml
+    secrets: inherit
+    with:
+      artifact-name: metabase-${{ matrix.edition }}-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
+      commit: ${{ github.event.inputs.commit || github.sha }}
+      repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
+      tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
+      release: "false"
+      build-args: |
+        GIT_COMMIT_SHA=${{ github.event.inputs.commit || github.sha }}
+
+  run-trivy:
+    needs: [get-container-info, containerize]
+    strategy:
+      matrix:
+        edition: ${{ fromJson(needs.get-container-info.outputs.editions) }}
+    runs-on: ubuntu-22.04
+    name: Run Trivy vulnerability scanner
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit || github.sha }}
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.29.0
+        env:
+          TRIVY_OFFLINE_SCAN: true
+          repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
+          tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
+        with:
+          image-ref: docker.io/${{ env.repo }}:${{ env.tag }}
+          format: sarif
+          output: trivy-results.sarif
+          version: "v0.57.1"
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"

--- a/.github/workflows/containerize-uberjar.yml
+++ b/.github/workflows/containerize-uberjar.yml
@@ -90,3 +90,37 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
+
+  post-comment:
+    needs: [get-container-info, containerize]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    name: Post PR comment
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+      - name: Get Docker info for comment
+        id: docker-info
+        uses: ./.github/actions/get-docker-info
+        with:
+          branch: ${{ github.head_ref || github.ref_name }}
+          edition: ee
+
+      - name: Post PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docker-build-status
+          message: |
+            ✅ Docker build completed for commit ${{ github.event.pull_request.head.sha || github.sha }}
+
+            The uberjar has been built and containerized successfully.
+
+            **Branch:** `${{ github.head_ref || github.ref_name }}`
+            **Docker Image:** `${{ steps.docker-info.outputs.full_image }}`
+            **Docker Hub:** [View on Docker Hub](https://hub.docker.com/r/${{ steps.docker-info.outputs.repo }}/tags?name=${{ steps.docker-info.outputs.tag }})
+            **Triggered by:** @${{ github.actor }}
+
+            Pull the image:
+            ```bash
+            docker pull ${{ steps.docker-info.outputs.full_image }}
+            ```

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -79,9 +79,10 @@ jobs:
         uses: ./.github/actions/run-embedding-sdk-storybook
 
       - name: Retrieve uberjar artifact for ${{ inputs.edition }}
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/fetch-artifact
         with:
           name: metabase-${{ inputs.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          extract-path: "target/uberjar"
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -89,11 +89,10 @@ jobs:
           done
           echo "run_id=$(jq -r '.workflow_runs[0].id' e2e-tests.json)" >> $GITHUB_OUTPUT
       - name: Retrieve uberjar artifact for ee
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/fetch-artifact
         with:
           name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ inputs.wait_for_uberjar && steps.wait_for_uberjar.outputs.run_id || github.run_id }}
+          extract-path: "target/uberjar"
       - name: Move uberjar to bin/docker
         run: |
           jar xf target/uberjar/metabase.jar

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -27,9 +27,10 @@ jobs:
         with:
           registries: "${{ secrets.PR_ENV_AWS_ACCOUNT_ID }}"
       - name: Retrieve uberjar artifact for ee
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/fetch-artifact
         with:
           name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
+          extract-path: "target/uberjar"
       - name: Move uberjar to bin/docker
         run: |
           jar xf target/uberjar/metabase.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,8 +190,8 @@ jobs:
         sparse-checkout: release
     - name: prepare release scripts
       run: cd release && yarn && yarn build
-    - name: Retrieve uberjar artifact
-      uses: ./.github/actions/fetch-artifact
+    - uses: actions/download-artifact@v4
+      name: Retrieve uberjar artifact
       with:
         name: metabase-${{ matrix.edition }}-uberjar
     - name: Determine the upload path ## EE is always v1.x.y, OSS is always v0.x.y
@@ -227,10 +227,8 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
-    - name: Check out the code
-      uses: actions/checkout@v4
-    - name: Retrieve uberjar artifact
-      uses: ./.github/actions/fetch-artifact
+    - uses: actions/download-artifact@v4
+      name: Retrieve uberjar artifact
       with:
         name: metabase-${{ matrix.edition }}-uberjar
     - name: Determine the download path ## EE is always v1.x.y, OSS is always v0.x.y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,8 +190,8 @@ jobs:
         sparse-checkout: release
     - name: prepare release scripts
       run: cd release && yarn && yarn build
-    - uses: actions/download-artifact@v4
-      name: Retrieve uberjar artifact
+    - name: Retrieve uberjar artifact
+      uses: ./.github/actions/fetch-artifact
       with:
         name: metabase-${{ matrix.edition }}-uberjar
     - name: Determine the upload path ## EE is always v1.x.y, OSS is always v0.x.y
@@ -227,8 +227,10 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
-    - uses: actions/download-artifact@v4
-      name: Retrieve uberjar artifact
+    - name: Check out the code
+      uses: actions/checkout@v4
+    - name: Retrieve uberjar artifact
+      uses: ./.github/actions/fetch-artifact
       with:
         name: metabase-${{ matrix.edition }}-uberjar
     - name: Determine the download path ## EE is always v1.x.y, OSS is always v0.x.y

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -135,7 +135,9 @@ jobs:
     needs: [uberjar]
     if: |
       !cancelled() &&
-      github.event_name == 'push' &&
-      contains(fromJson('["master", "metabot-v3-main", "internal-tools"]'), github.ref_name)
+      (
+        (github.event_name == 'push' && contains(fromJson('["master", "metabot-v3-main", "internal-tools"]'), github.ref_name)) ||
+        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-docker-uberjar'))
+      )
     uses: ./.github/workflows/containerize-uberjar.yml
     secrets: inherit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -130,3 +130,12 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'PR-Env')
     uses: ./.github/workflows/pr-env.yml
     secrets: inherit
+
+  containerize:
+    needs: [uberjar]
+    if: |
+      !cancelled() &&
+      github.event_name == 'push' &&
+      contains(fromJson('["master", "metabot-v3-main", "internal-tools"]'), github.ref_name)
+    uses: ./.github/workflows/containerize-uberjar.yml
+    secrets: inherit

--- a/.github/workflows/uberjar-containerize-labeled.yml
+++ b/.github/workflows/uberjar-containerize-labeled.yml
@@ -27,13 +27,14 @@ jobs:
     needs: [uberjar, containerize]
     runs-on: ubuntu-22.04
     steps:
-      - name: Generate Docker Hub URL
-        id: docker-url
-        run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          # Replace slashes with dashes for Docker tag (same logic as containerize-uberjar.yml)
-          DOCKER_TAG="${BRANCH//\//-}"
-          echo "docker_tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
+      - name: Check out the code
+        uses: actions/checkout@v4
+      - name: Get Docker info
+        id: docker-info
+        uses: ./.github/actions/get-docker-info
+        with:
+          branch: ${{ github.event.pull_request.head.ref }}
+          edition: ee
           
       - name: Post PR comment
         uses: marocchino/sticky-pull-request-comment@v2
@@ -45,10 +46,11 @@ jobs:
             The uberjar has been built and containerized successfully.
 
             **Branch:** `${{ github.event.pull_request.head.ref }}`
-            **Docker Tag:** `${{ steps.docker-url.outputs.docker_tag }}`
-            **Docker Hub:** [metabase/metabase-dev:${{ steps.docker-url.outputs.docker_tag }}](https://hub.docker.com/r/metabase/metabase-dev/tags?name=${{ steps.docker-url.outputs.docker_tag }})
+            **Docker Image:** `${{ steps.docker-info.outputs.full_image }}`
+            **Docker Hub:** [View on Docker Hub](https://hub.docker.com/r/${{ steps.docker-info.outputs.repo }}/tags?name=${{ steps.docker-info.outputs.tag }})
             **Triggered by:** @${{ github.actor }}
             
+            Pull the image:
             ```bash
-            docker pull metabase/metabase-dev:${{ steps.docker-url.outputs.docker_tag }}
+            docker pull ${{ steps.docker-info.outputs.full_image }}
             ```

--- a/.github/workflows/uberjar-containerize-labeled.yml
+++ b/.github/workflows/uberjar-containerize-labeled.yml
@@ -21,36 +21,3 @@ jobs:
     if: ${{ github.event.label.name == 'build-docker-uberjar' }}
     uses: ./.github/workflows/containerize-uberjar.yml
     secrets: inherit
-
-  post-comment:
-    if: ${{ github.event.label.name == 'build-docker-uberjar' }}
-    needs: [uberjar, containerize]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out the code
-        uses: actions/checkout@v4
-      - name: Get Docker info
-        id: docker-info
-        uses: ./.github/actions/get-docker-info
-        with:
-          branch: ${{ github.event.pull_request.head.ref }}
-          edition: ee
-          
-      - name: Post PR comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: docker-build-status
-          message: |
-            ✅ Docker build completed for commit ${{ github.event.pull_request.head.sha }}
-
-            The uberjar has been built and containerized successfully.
-
-            **Branch:** `${{ github.event.pull_request.head.ref }}`
-            **Docker Image:** `${{ steps.docker-info.outputs.full_image }}`
-            **Docker Hub:** [View on Docker Hub](https://hub.docker.com/r/${{ steps.docker-info.outputs.repo }}/tags?name=${{ steps.docker-info.outputs.tag }})
-            **Triggered by:** @${{ github.actor }}
-            
-            Pull the image:
-            ```bash
-            docker pull ${{ steps.docker-info.outputs.full_image }}
-            ```

--- a/.github/workflows/uberjar-containerize-labeled.yml
+++ b/.github/workflows/uberjar-containerize-labeled.yml
@@ -1,0 +1,40 @@
+name: Uberjar Containerize labeled
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  uberjar:
+    if: ${{ github.event.label.name == 'build-docker-uberjar' }}
+    uses: ./.github/workflows/uberjar.yml
+    secrets: inherit
+    with:
+      source_changed: false
+
+  containerize:
+    needs: [uberjar]
+    if: ${{ github.event.label.name == 'build-docker-uberjar' }}
+    uses: ./.github/workflows/containerize-uberjar.yml
+    secrets: inherit
+
+  post-comment:
+    if: ${{ github.event.label.name == 'build-docker-uberjar' }}
+    needs: [uberjar, containerize]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Post PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docker-build-status
+          message: |
+            ✅ Docker build completed for commit ${{ github.event.pull_request.head.sha }}
+
+            The uberjar has been built and containerized successfully.
+
+            **Branch:** `${{ github.event.pull_request.head.ref }}`
+            **Triggered by:** @${{ github.actor }}

--- a/.github/workflows/uberjar-containerize-labeled.yml
+++ b/.github/workflows/uberjar-containerize-labeled.yml
@@ -27,6 +27,14 @@ jobs:
     needs: [uberjar, containerize]
     runs-on: ubuntu-22.04
     steps:
+      - name: Generate Docker Hub URL
+        id: docker-url
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          # Replace slashes with dashes for Docker tag (same logic as containerize-uberjar.yml)
+          DOCKER_TAG="${BRANCH//\//-}"
+          echo "docker_tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
+          
       - name: Post PR comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
@@ -37,4 +45,10 @@ jobs:
             The uberjar has been built and containerized successfully.
 
             **Branch:** `${{ github.event.pull_request.head.ref }}`
+            **Docker Tag:** `${{ steps.docker-url.outputs.docker_tag }}`
+            **Docker Hub:** [metabase/metabase-dev:${{ steps.docker-url.outputs.docker_tag }}](https://hub.docker.com/r/metabase/metabase-dev/tags?name=${{ steps.docker-url.outputs.docker_tag }})
             **Triggered by:** @${{ github.actor }}
+            
+            ```bash
+            docker pull metabase/metabase-dev:${{ steps.docker-url.outputs.docker_tag }}
+            ```

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -1,4 +1,4 @@
-name: Build + Docker Uberjar
+name: Build Uberjar
 
 # This workflow builds an uberjar and pushes it to dockerhub for any branch, either on-demand,
 # or automatically for the listed branches
@@ -43,19 +43,23 @@ jobs:
       oss_exists: ${{ steps.check-oss.outcome == 'success' }}
       should_build: ${{ steps.decide.outputs.should_build }}
     steps:
-      - name: Try to download existing EE artifact
+      - name: Check out the code
+        uses: actions/checkout@v4
+      - name: Try to fetch existing EE artifact
         id: check-ee
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/fetch-artifact
         with:
           name: metabase-ee-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
+          output-name: metabase-ee.jar
 
-      - name: Try to download existing OSS artifact
+      - name: Try to fetch existing OSS artifact
         id: check-oss
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/fetch-artifact
         with:
           name: metabase-oss-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
+          output-name: metabase-oss.jar
 
       - name: Decide if build is needed
         id: decide
@@ -110,63 +114,17 @@ jobs:
               node_version: requirements.node,
             };
 
-  get-container-info:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 5
-    name: Get container info
-    # Skip if this is a PR without the build-docker-uberjar label
-    if: github.ref_name == 'master' || contains(github.event.pull_request.labels.*.name, 'build-docker-uberjar')
-    outputs:
-      editions: ${{ toJson(fromJson(steps.info.outputs.result).editions) }}
-      ee: ${{ toJson(fromJson(steps.info.outputs.result).ee) }}
-      oss: ${{ toJson(fromJson(steps.info.outputs.result).oss) }}
-    steps:
-      - name: Get docker repo and tag
-        id: info
-        uses: actions/github-script@v7
-        with:
-          script: | # js
-            const branch = '${{ github.head_ref || github.ref_name }}';
-            const owner = '${{ github.repository_owner }}';
-
-            console.log(`Branch: ${branch}`);
-
-            if (branch === "master") {
-              return {
-                editions: ["ee", "oss"],
-                ee: {
-                  repo: `${owner}/metabase-enterprise-head`,
-                  tag: "latest"
-                },
-                oss: {
-                  repo: `${owner}/metabase-head`,
-                  tag: "latest"
-                }
-              };
-            }
-
-            return {
-              editions: ["ee"],
-              ee: {
-                repo: `${owner}/metabase-dev`,
-                tag: branch.replaceAll("/", "-"), // slashes make docker sad
-              },
-            };
-
-      - name: Print output
-        run: |
-          echo "${{ steps.info.outputs.result }}"
 
   build:
     needs:
-      [check-existing-artifacts, get-build-requirements, get-container-info]
+      [check-existing-artifacts, get-build-requirements]
     if: always() && !cancelled() && needs.check-existing-artifacts.outputs.should_build == 'true' && (needs.get-build-requirements.result == 'success' || needs.get-build-requirements.result == 'skipped')
     name: Build MB ${{ matrix.edition }}
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       matrix:
-        edition: ${{ needs.get-container-info.result == 'success' && fromJson(needs.get-container-info.outputs.editions) || fromJson('["ee", "oss"]') }}
+        edition: ["ee", "oss"]
     env:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
@@ -195,14 +153,16 @@ jobs:
   check-jar-health:
     runs-on: ubuntu-22.04
     name: Is ${{ matrix.edition }} (java ${{ matrix.java-version }}) healthy?
-    needs: [build, check-existing-artifacts, get-container-info]
+    needs: [build, check-existing-artifacts]
     if: always() && !cancelled() && (needs.build.result == 'success' || (needs.check-existing-artifacts.outputs.should_build == 'false' && needs.check-existing-artifacts.outputs.ee_exists == 'true' && needs.check-existing-artifacts.outputs.oss_exists == 'true'))
     timeout-minutes: 10
     strategy:
       matrix:
-        edition: ${{ needs.get-container-info.result == 'success' && fromJson(needs.get-container-info.outputs.editions) || fromJson('["ee", "oss"]') }}
+        edition: ["ee", "oss"]
         java-version: [21]
     steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
       - name: Prepare JRE (Java Run-time Environment)
         uses: actions/setup-java@v4
         with:
@@ -210,57 +170,12 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: "temurin"
       - run: java -version
-      - uses: actions/download-artifact@v4
-        name: Retrieve uberjar artifact
+      - name: Retrieve uberjar artifact
+        uses: ./.github/actions/fetch-artifact
         with:
           name: metabase-${{ matrix.edition }}-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
       - name: Launch uberjar
         run: >-
-          java --add-opens java.base/java.nio=ALL-UNNAMED -jar ./target/uberjar/metabase.jar &
+          java --add-opens java.base/java.nio=ALL-UNNAMED -jar ./metabase.jar &
       - name: Wait for Metabase to start
         run: while ! curl 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-
-  containerize:
-    needs: [check-jar-health, get-container-info, build]
-    if: needs.get-container-info.result == 'success' && needs.build.result == 'success'
-    strategy:
-      matrix:
-        edition: ${{ fromJson(needs.get-container-info.outputs.editions) }}
-    uses: ./.github/workflows/containerize-jar.yml
-    secrets: inherit
-    with:
-      artifact-name: metabase-${{ matrix.edition }}-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
-      commit: ${{ github.event.inputs.commit || github.sha }}
-      repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
-      tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
-      release: "false"
-      build-args: |
-        GIT_COMMIT_SHA=${{ github.event.inputs.commit || github.sha }}
-
-  run-trivy:
-    needs: [get-container-info, containerize]
-    strategy:
-      matrix:
-        edition: ${{ fromJson(needs.get-container-info.outputs.editions) }}
-    runs-on: ubuntu-22.04
-    name: Run Trivy vulnerability scanner
-    steps:
-      - name: Check out the code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.commit || github.sha }}
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
-        env:
-          TRIVY_OFFLINE_SCAN: true
-          repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}
-          tag: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).tag }}
-        with:
-          image-ref: docker.io/${{ env.repo }}:${{ env.tag }}
-          format: sarif
-          output: trivy-results.sarif
-          version: "v0.57.1"
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
# Fix Uberjar Containerization and Refactor GitHub Actions Workflows

## 🎯 Problem

The uberjar containerization was failing in multiple scenarios:
1. **PR Label Trigger**: Adding `build-docker-uberjar` label to PRs wasn't triggering containerization
2. **Manual Dispatch**: Workflow dispatch wasn't properly containerizing uberjars
3. **GitHub Limitations**: Hit 4-level workflow nesting limit when running containerize
4. **Cross-workflow Artifacts**: Standard `download-artifact` action couldn't fetch artifacts from different workflow runs

## 🔧 Solution

This PR implements a comprehensive refactoring of our containerization workflows to fix all issues while improving maintainability.

### Key Changes

#### 1. **New Custom Actions** (DRY principle)
- **`fetch-artifact`**: Cross-workflow artifact fetching with flexible path extraction
  - Replaces GitHub's `download-artifact` for cross-workflow compatibility
  - `extract-path` parameter for flexible jar placement (e.g., `"."`, `"target/uberjar"`, custom paths)
  - Smart path detection to avoid moving files to themselves
  
- **`get-docker-info`**: Centralized Docker naming logic
  - Single source of truth for Docker repository and tag determination
  - Handles master vs PR branch logic (metabase-head vs metabase-dev)
  - Returns repo, tag, and full image name

#### 2. **New Workflows**
- **`containerize-uberjar.yml`**: Orchestrates containerization (avoids nesting)
  - Calls `containerize-jar.yml` with proper matrix strategy
  - Includes Trivy security scanning
  - Supports both `workflow_call` and `workflow_dispatch`

- **`uberjar-containerize-labeled.yml`**: PR label handler
  - Triggered by `build-docker-uberjar` label
  - Orchestrates uberjar build + containerization
  - Posts PR comment with Docker Hub link and pull command

#### 3. **Workflow Refactoring**
- **`uberjar.yml`**: Removed all containerization logic (117 lines removed)
  - Now focused solely on building uberjars
  - Checks for existing artifacts to avoid rebuilds
  
- **`run-tests.yml`**: Added containerization job for master pushes
  - Runs containerization in parallel, not nested
  
- **Updated workflows** to use new actions:
  - `e2e-test.yml`, `pr-env.yml`, `perf-test.yml` → use `fetch-artifact` with `extract-path`
