### PR TITLE
Remove Beta badge from Embedded Analytics JS

### DIFF
--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -16,7 +16,6 @@ import {
 } from "metabase/plugins";
 import {
   Alert,
-  Badge,
   Box,
   Button,
   Flex,
@@ -174,8 +173,6 @@ export function EmbeddingSdkSettings() {
             <Text fz="h3" fw={600} c="text-dark">
               {t`Embedded Analytics JS`}
             </Text>
-
-            <Badge size="sm">{t`Beta`}</Badge>
           </Group>
 
           <Group gap="sm" align="center" justify="space-between" w="100%">

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/simple-embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/simple-embedding.unit.spec.tsx
@@ -30,7 +30,6 @@ describe("EmbeddingSdkSettings (EE with Simple Embedding feature)", () => {
     expect(screen.getByText("SDK for React")).toBeInTheDocument();
 
     expect(screen.getByText("Embedded Analytics JS")).toBeInTheDocument();
-    expect(screen.queryAllByText("Beta")).toHaveLength(1);
   });
 
   it("should show legalese modal when Simple Embedding toggle is enabled", async () => {

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenu.premium.unit.spec.tsx
@@ -67,7 +67,6 @@ describe("NewItemMenu (EE with token)", () => {
     });
 
     expect(await screen.findByText("Embed")).toBeInTheDocument();
-    expect(screen.queryAllByText("Beta")).toHaveLength(1);
   });
 
   it("hides the Embed item when user is non-admin", async () => {

--- a/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
+++ b/frontend/src/metabase/common/components/NewItemMenu/NewItemMenuView.tsx
@@ -8,7 +8,7 @@ import * as Urls from "metabase/lib/urls";
 import { PLUGIN_EMBEDDING_IFRAME_SDK_SETUP } from "metabase/plugins";
 import { setOpenModal } from "metabase/redux/ui";
 import { getSetting } from "metabase/selectors/settings";
-import { Badge, Box, Icon, Menu } from "metabase/ui";
+import { Box, Icon, Menu } from "metabase/ui";
 import type { CollectionId } from "metabase-types/api";
 
 import { trackNewMenuItemClicked } from "./analytics";
@@ -104,7 +104,6 @@ const NewItemMenuView = ({
           component={ForwardRefLink}
           to="/embed-js"
           leftSection={<Icon name="embed" />}
-          rightSection={<Badge size="xs">{t`Beta`}</Badge>}
         >
           {t`Embed`}
         </Menu.Item>,


### PR DESCRIPTION
Closes EMB-704

Removes the `Beta` badge from Embed JS.

Hold until the next point release.