### PR TITLE
Temporarily replace docs and quickstart with "Try it out"

### DIFF
--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -28,6 +28,7 @@ import {
 
 import { SettingHeader } from "../../SettingHeader";
 import { AdminSettingInput } from "../../widgets/AdminSettingInput";
+import { LinkButton } from "../EmbeddingOption/LinkButton";
 import { EmbeddingToggle } from "../EmbeddingToggle";
 
 import S from "./EmbeddingSdkSettings.module.css";
@@ -189,27 +190,14 @@ export function EmbeddingSdkSettings() {
 
             {isSimpleEmbedFeatureEnabled ? (
               <Group gap="md">
-                <Button
+                <LinkButton
                   size="compact-xs"
                   variant="outline"
-                  component={ExternalLink}
-                  href={quickStartUrl}
-                  rightSection={<Icon size={12} name="external" />}
+                  to="/embed-js"
                   fz="sm"
                 >
-                  {t`Quick start`}
-                </Button>
-
-                <Button
-                  size="compact-xs"
-                  variant="outline"
-                  component={ExternalLink}
-                  href={documentationUrl}
-                  rightSection={<Icon size={12} name="external" />}
-                  fz="sm"
-                >
-                  {t`Documentation`}
-                </Button>
+                  {t`Try it out`}
+                </LinkButton>
               </Group>
             ) : (
               <UpsellEmbeddingButton


### PR DESCRIPTION
Closes EMB-705

Replaces "Documentation" and "Quickstart" with "Try it out" which opens the embed flow, until we have the full docs up and running on the website.

<img width="2514" height="1756" alt="CleanShot 2568-08-07 at 21 15 21@2x" src="https://github.com/user-attachments/assets/c9845231-4cd8-47c9-a779-d469378a2911" />
