### PR TITLE
fix: jwt auth doesn't wipe login_attributes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -32,7 +32,6 @@
               :last_name        last-name
               :email            email
               :sso_source       :jwt
-              :login_attributes {}
               :jwt_attributes   user-attributes}]
     (or (sso-utils/fetch-and-update-login-attributes! user (sso-settings/jwt-user-provisioning-enabled?))
         (sso-utils/check-user-provisioning :jwt)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -29,7 +29,7 @@
    ;; TODO - we should avoid hardcoding this to make it easier to add new integrations. Maybe look at something like
    ;; the keys of `(methods sso/sso-get)`
    [:sso_source       [:enum :saml :jwt]]
-   [:login_attributes [:maybe :map]]
+   [:login_attributes {:optional true} [:maybe :map]]
    [:jwt_attributes   {:optional true} [:maybe :map]]])
 
 (defn- maybe-throw-user-provisioning

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -530,7 +530,45 @@
                                                            :first_name "New"
                                                            :last_name  "User"}
                                                           default-jwt-secret))]
-            (is (saml-test/successful-login? response))))))))
+            (is (saml-test/successful-login? response))))))
+
+    (testing "Existing user login attributes are not changed on subsequent logins"
+      (with-jwt-default-setup!
+        (with-users-with-email-deleted "existinguser@metabase.com"
+          ;; Create user with initial login attributes
+          (let [response (client/client-real-response :get 302 "/auth/sso"
+                                                      {:request-options {:redirect-strategy :none}}
+                                                      :return_to default-redirect-uri
+                                                      :jwt
+                                                      (jwt/sign
+                                                       {:email      "existinguser@metabase.com"
+                                                        :first_name "Existing"
+                                                        :last_name  "User"
+                                                        :department "Engineering"
+                                                        :role       "Developer"}
+                                                       default-jwt-secret))]
+            (is (saml-test/successful-login? response))
+            (testing "initial login attributes are stored"
+              (is (= nil
+                     (t2/select-one-fn :login_attributes :model/User :email "existinguser@metabase.com")))))
+
+          ;; Log in again with different attributes
+          (let [response (client/client-real-response :get 302 "/auth/sso"
+                                                      {:request-options {:redirect-strategy :none}}
+                                                      :return_to default-redirect-uri
+                                                      :jwt
+                                                      (jwt/sign
+                                                       {:email      "existinguser@metabase.com"
+                                                        :first_name "Existing"
+                                                        :last_name  "User"
+                                                        :department "Marketing"
+                                                        :role       "Manager"
+                                                        :location   "Remote"}
+                                                       default-jwt-secret))]
+            (is (saml-test/successful-login? response))
+            (testing "login attributes remain unchanged from initial login"
+              (is (= nil
+                     (t2/select-one-fn :login_attributes :model/User :email "existinguser@metabase.com"))))))))))
 
 (deftest login-update-account-test
   (testing "An existing user will be reactivated upon login"

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.tsx
@@ -178,6 +178,7 @@ const getFormValues = (
     "jwt-user-provisioning-enabled?",
     "jwt-identity-provider-uri",
     "jwt-shared-secret",
+    "jwt-group-sync",
     "jwt-attribute-email",
     "jwt-attribute-firstname",
     "jwt-attribute-lastname",


### PR DESCRIPTION

### Description

Missed this from the big remerge, where login attributes were being reset to an empty value on jwt login. Also fixed not including the jwt-group-sync on the initial formik state.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
