### PR TITLE
Fix creator list UI on search page

### DIFF
--- a/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.tsx
+++ b/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.tsx
@@ -78,7 +78,6 @@ export const SearchUserPicker = ({
         <SearchUserSelectBox gap={0}>
           <SearchUserItemContainer
             data-testid="search-user-select-box"
-            gap="xs"
             p="xs"
             mah="30vh"
           >

--- a/frontend/src/metabase/search/components/UserListElement/UserListElement.module.css
+++ b/frontend/src/metabase/search/components/UserListElement/UserListElement.module.css
@@ -1,4 +1,6 @@
 .Root {
+  flex-shrink: 0;
+
   &:hover {
     background-color: var(--mb-color-brand-lighter) !important;
   }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61903

### Description

This fixes broken UI for Creator dropdown list on Search page

Before | After
---|---
<img width="341" height="762" alt="Screenshot 2025-08-07 at 19 29 20" src="https://github.com/user-attachments/assets/c7b8d3a2-81cb-4af3-b4b2-f1963cd06244" />
  |  
<img width="345" height="766" alt="Screenshot 2025-08-07 at 19 29 32" src="https://github.com/user-attachments/assets/c5fa2f4a-448d-4c08-a4a7-98c25719a82d" />


### How to verify

on any Metabase instance with a lot of users (>50):

Press cmd+k to open search interface
Enter any search term (e.g. "dashboard")
Click on "View X results" to get to /search page
On the /search page, click on the "Creator" selector to open a dropdown

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
