### PR TITLE
Fix pivot tables in static embedding having white cell backgrounds in dark mode

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -1134,9 +1134,11 @@ describe("scenarios > embedding > dashboard appearance", () => {
           );
 
           cy.log("pivot table cell background should be transparent");
-          cy.findAllByTestId("pivot-table-cell")
+          cy.findAllByRole("grid")
             .first()
-            .should("have.css", "background-color", "rgba(0, 0, 0, 0)");
+            .findAllByTestId("pivot-table-cell")
+            .first()
+            .should("have.css", "background-color", "rgba(46, 53, 59, 0.1)");
 
           cy.log("pivot table cell color should be white");
           cy.findByText("Row totals")

--- a/frontend/src/metabase/dashboard/context/context.redux.ts
+++ b/frontend/src/metabase/dashboard/context/context.redux.ts
@@ -55,6 +55,7 @@ import {
   undoDeleteTab,
 } from "metabase/dashboard/actions/tabs";
 import { connect } from "metabase/lib/redux";
+import { getIsEmbeddingIframe } from "metabase/selectors/embed";
 import {
   canManageSubscriptions,
   getUserIsAdmin,
@@ -117,6 +118,7 @@ export const mapStateToProps = (state: State) => ({
   isNavigatingBackToDashboard: getIsNavigatingBackToDashboard(state),
   isLoading: getIsLoading(state),
   isLoadingWithoutCards: getIsLoadingWithoutCards(state),
+  isEmbeddingIframe: getIsEmbeddingIframe(state),
 });
 
 export const mapDispatchToProps = {

--- a/frontend/src/metabase/dashboard/context/context.tsx
+++ b/frontend/src/metabase/dashboard/context/context.tsx
@@ -147,6 +147,7 @@ const DashboardContextProviderInner = forwardRef(
       isLoading,
       isLoadingWithoutCards,
       parameters,
+      isEmbeddingIframe,
 
       // redux actions
       addCardToDashboard,
@@ -194,7 +195,9 @@ const DashboardContextProviderInner = forwardRef(
       setTheme,
     } = useDashboardTheme(initTheme);
 
-    const shouldRenderAsNightMode = Boolean(isNightMode && isFullscreen);
+    const shouldRenderAsNightMode = Boolean(
+      isNightMode && (isFullscreen || isEmbeddingIframe),
+    );
 
     const handleError = useCallback(
       (error: unknown) => {
@@ -402,6 +405,7 @@ const DashboardContextProviderInner = forwardRef(
           isNavigatingBackToDashboard,
           parameters,
           parameterValues,
+          isEmbeddingIframe,
 
           // redux actions
           addCardToDashboard,


### PR DESCRIPTION
Closes #61741
Closes EMB-694

Passes the correct night mode values to the dashboard context, so the underlying viz components are using night mode for their styling. We previously only applied this to fullscreen mode, when it fact it should apply to static embeds too.

## How to verify

- Go into a dashboard that contains a pivot table question
- Go into static embedding preview modal
- It should show a proper dark backgrounds for pivot tables.

## Demo

Before

<img width="2350" height="1722" alt="CleanShot 2568-08-08 at 02 50 09@2x" src="https://github.com/user-attachments/assets/d12886e9-ca0b-4bf7-a6d8-b7edaaf0ee25" />

After

<img width="2340" height="1708" alt="CleanShot 2568-08-08 at 02 52 26@2x" src="https://github.com/user-attachments/assets/70f6e145-8483-4205-816f-d252d8c58d90" />
