### PR TITLE
fix: login_attrs -> jwt_attrs for jwt users

### DIFF
--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -229,9 +229,11 @@ databaseChangeLog:
            UPDATE core_user
            SET jwt_attributes = login_attributes, login_attributes = '{}'
            WHERE sso_source = 'jwt';
-      rollback: # there is not a clean way to roll this change back but if an
-                # instance is downgraded on the next jwt login login_attributes
-                # will be set the attributes from the jwt anyway.
+      rollback: >-
+        - sql:
+           UPDATE core_user
+           SET login_attributes = jwt_attributes
+           WHERE sso_source = 'jwt';
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -217,6 +217,22 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  - changeSet:
+      id: v56.2025-07-17T20:11:56
+      author: edpaget
+      comment: |
+        Add sync login_attributes with jwt_attributes, we need to replace jwt_attributes
+        with login attributes for users with sso_source jwt so that they will get the new
+        behavior where login_attributes can override jwt_attributes
+      changes:
+        - sql: >-
+           UPDATE core_user
+           SET jwt_attributes = login_attributes, login_attributes = '{}'
+           WHERE sso_source = 'jwt';
+      rollback: # there is not a clean way to roll this change back but if an
+                # instance is downgraded on the next jwt login login_attributes
+                # will be set the attributes from the jwt anyway.
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -229,8 +229,8 @@ databaseChangeLog:
            UPDATE core_user
            SET jwt_attributes = login_attributes, login_attributes = '{}'
            WHERE sso_source = 'jwt';
-      rollback: >-
-        - sql:
+      rollback:
+        - sql: >-
            UPDATE core_user
            SET login_attributes = jwt_attributes
            WHERE sso_source = 'jwt';


### PR DESCRIPTION
### Description

Enables the new behavior where login attributes persist between jwt logins for existing jwt-based users. We need to copy existing login_attributes to jwt_attributes so that the current jwt-managed attributes can be reset on the next jwt-based login. Any future edits to login_attributes will persist between jwt-sessions.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
