### PR TITLE
Thread pool for semantic search index batch updates

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -408,6 +408,7 @@
   clojure.test.check.clojure-test/defspec                                               clojure.test/deftest
   clojure.test.check.properties/for-all                                                 clojure.core/let
   clojurewerkz.quartzite.jobs/defjob                                                    clojure.core/defn
+  com.climate.claypoole/with-shutdown!                                                  clojure.core/let
   instaparse.core/defparser                                                             clojure.core/def
   metabase-enterprise.action-v2.test-util/with-test-tables!                             clojure.core/let
   metabase-enterprise.serialization.test-util/with-dbs                                  clojure.core/fn

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -293,11 +293,12 @@
   model + model_id already exists, it will be replaced. Parallelizes batch insertion
   using a thread pool with a configurable thread count (default: 2)."
   [connectable index documents-reducible]
-  (cp/with-shutdown! [pool (cp/threadpool (semantic-settings/embedding-thread-count))]
-    (->> documents-reducible
-         (partition-all *batch-size*)
-         (cp/pmap pool #(upsert-index-batch! connectable index %))
-         (reduce (partial merge-with +) {}))))
+  (not-empty
+   (cp/with-shutdown! [pool (cp/threadpool (semantic-settings/index-update-thread-count))]
+     (->> documents-reducible
+          (partition-all *batch-size*)
+          (cp/pmap pool #(upsert-index-batch! connectable index %))
+          (reduce (partial merge-with +) {})))))
 
 (defn- drop-index-table-sql
   [{:keys [table-name]}]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -329,9 +329,7 @@
   "Inserts or updates documents in the index table. If a document with the same
   model + model_id already exists, it will be replaced. Parallelizes batch insertion
   using a shared thread pool with a configurable thread count (default: 2)."
-  ([connectable index documents-reducible]
-   (upsert-index! connectable index documents-reducible {}))
-  ([connectable index documents-reducible {:keys [serial?] :or {serial? false}}]
+  ([connectable index documents-reducible & {:keys [serial?] :or {serial? false}}]
    (not-empty
     (let [pool @index-update-executor
           results (transduce

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -293,11 +293,17 @@
   model + model_id already exists, it will be replaced. Parallelizes batch insertion
   using a thread pool with a configurable thread count (default: 2)."
   [connectable index documents-reducible]
-  (cp/with-shutdown! [pool (cp/threadpool (semantic-settings/embedding-thread-count))]
-    (->> documents-reducible
-         (partition-all *batch-size*)
-         (cp/pmap pool #(upsert-index-batch! connectable index %))
-         (reduce (partial merge-with +) {}))))
+  (cp/with-shutdown! [pool (cp/threadpool (semantic-settings/index-update-thread-count))]
+    (transduce
+     (comp
+      (partition-all *batch-size*)
+      (map #(cp/future pool (upsert-index-batch! connectable index %))))
+     (completing
+      (fn [acc f]
+        (let [result @f]
+          (merge-with + acc result))))
+     {}
+     documents-reducible)))
 
 (defn- drop-index-table-sql
   [{:keys [table-name]}]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
@@ -86,7 +86,7 @@
   `documents` is a logical collection, but can be reducible to save memory usage."
   [pgvector index-metadata documents]
   (let [{:keys [index]} (ensure-active-index-state pgvector index-metadata)]
-    (semantic.index/upsert-index! pgvector index documents {})))
+    (semantic.index/upsert-index! pgvector index documents)))
 
 (defn gate-updates!
   "Stages document updates through the gate table to enable async indexing. See gate.clj.

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
@@ -86,7 +86,7 @@
   `documents` is a logical collection, but can be reducible to save memory usage."
   [pgvector index-metadata documents]
   (let [{:keys [index]} (ensure-active-index-state pgvector index-metadata)]
-    (semantic.index/upsert-index! pgvector index documents)))
+    (semantic.index/upsert-index! pgvector index documents {})))
 
 (defn gate-updates!
   "Stages document updates through the gate table to enable async indexing. See gate.clj.

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -78,3 +78,12 @@
   :export? false
   :visibility :internal
   :doc "Minimum number of semantic search results required before falling back to other engines.")
+
+(defsetting embedding-thread-count
+  (deferred-tru "Number of threads to use for parallel embedding generation.")
+  :type :integer
+  :default 2
+  :encryption :no
+  :export? false
+  :visibility :internal
+  :doc "Number of threads to use for parallel embedding generation. Higher values can improve indexing performance but may increase API costs and resource usage.")

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -79,11 +79,11 @@
   :visibility :internal
   :doc "Minimum number of semantic search results required before falling back to other engines.")
 
-(defsetting embedding-thread-count
-  (deferred-tru "Number of threads to use for parallel embedding generation.")
+(defsetting index-update-thread-count
+  (deferred-tru "Number of threads to use for batched index updates, including embedding requests")
   :type :integer
   :default 2
   :encryption :no
   :export? false
   :visibility :internal
-  :doc "Number of threads to use for parallel embedding generation. Higher values can improve indexing performance but may increase API costs and resource usage.")
+  :doc "Number of threads to use for batched index updates, including embedding requests")

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -166,7 +166,7 @@
             (semantic.tu/check-index-has-no-mock-docs)
 
             (testing "upsert-index!"
-              (with-redefs [semantic.index/upsert-index-batch! (only-first-call realized @#'semantic.index/upsert-index-batch!)]
+              (with-redefs [semantic.index/upsert-index-pooled! (only-first-call realized @#'semantic.index/upsert-index-pooled!)]
                 (is (= {"card" 2} (semantic.tu/upsert-index! mock-docs))))
               (semantic.tu/check-index-has-mock-card))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -282,7 +282,7 @@
                             (when (seq (second ret))
                               (reset! inter-batch-cache-hit? true))
                             ret)))]
-          (semantic.tu/upsert-index! test-documents {:serial? serial?}))
+          (semantic.tu/upsert-index! test-documents :serial? serial?))
         (is (= inter-batch? @inter-batch-cache-hit?))
         (is (= 1 (count @calls)))
         (is (= ["Dog Training Guide" "Elephant Migration"]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
@@ -86,7 +86,7 @@
           (with-redefs [semantic.index/upsert-index! proxy]
             (testing "check proxies correct args and ret is untouched"
               (let [ret (sut pgvector index-metadata documents)]
-                (is (= [{:args [pgvector @index-ref documents]
+                (is (= [{:args [pgvector @index-ref documents {}]
                          :ret  ret}]
                        @calls))))
 
@@ -94,7 +94,7 @@
               (reset! calls [])
               (let [new-index (semantic.pgvector-api/init-semantic-search! pgvector index-metadata model2)
                     ret       (sut pgvector index-metadata documents)]
-                (is (= [{:args [pgvector new-index documents]
+                (is (= [{:args [pgvector new-index documents {}]
                          :ret  ret}]
                        @calls))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
@@ -86,7 +86,7 @@
           (with-redefs [semantic.index/upsert-index! proxy]
             (testing "check proxies correct args and ret is untouched"
               (let [ret (sut pgvector index-metadata documents)]
-                (is (= [{:args [pgvector @index-ref documents {}]
+                (is (= [{:args [pgvector @index-ref documents]
                          :ret  ret}]
                        @calls))))
 
@@ -94,7 +94,7 @@
               (reset! calls [])
               (let [new-index (semantic.pgvector-api/init-semantic-search! pgvector index-metadata model2)
                     ret       (sut pgvector index-metadata documents)]
-                (is (= [{:args [pgvector new-index documents {}]
+                (is (= [{:args [pgvector new-index documents]
                          :ret  ret}]
                        @calls))))))))))
 
@@ -214,10 +214,10 @@
                                  (.interrupt thread)
                                  (when-not (.join thread (Duration/ofSeconds 30))
                                    (log/fatal "Indexing loop thread not exiting during test!")))))))]
-    (with-redefs [semantic.indexer/sleep         (fn [_])   ; do not slow down
-                  semantic.indexer/poll-limit    4          ; important to test poll / paging (not many docs in test-data)
-                  semantic.indexer/lag-tolerance Duration/ZERO ; if too high will slow the test down significantly
-                  ]
+    (with-redefs [semantic.indexer/sleep         (fn [_])       ; do not slow down
+                  semantic.indexer/poll-limit    4              ; important to test poll / paging (not many docs in test-data)
+                  semantic.indexer/lag-tolerance Duration/ZERO] ; if too high will slow the test down significantly
+
       (with-open [index-ref  (open-semantic-search! pgvector index-metadata embedding-model)
                   job-thread (open-job-thread pgvector index-metadata)]
         (let [index @index-ref

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -115,7 +115,7 @@
   (semantic.index/query-index db mock-index search-context))
 
 (defn upsert-index! [documents & opts]
-  (semantic.index/upsert-index! db mock-index documents opts))
+  (apply semantic.index/upsert-index! db mock-index documents opts))
 
 (defn delete-from-index! [model ids]
   (semantic.index/delete-from-index! db mock-index model ids))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -114,8 +114,8 @@
 (defn query-index [search-context]
   (semantic.index/query-index db mock-index search-context))
 
-(defn upsert-index! [documents]
-  (semantic.index/upsert-index! db mock-index documents))
+(defn upsert-index! [documents & opts]
+  (semantic.index/upsert-index! db mock-index documents opts))
 
 (defn delete-from-index! [model ids]
   (semantic.index/delete-from-index! db mock-index model ids))

--- a/src/metabase/permissions/models/collection/graph.clj
+++ b/src/metabase/permissions/models/collection/graph.clj
@@ -87,7 +87,6 @@
 
 (defn- calculate-perm-groups [collection-namespace group-id->perms collection-ids]
   (into {}
-        #_:clj-kondo/ignore
         (cp/with-shutdown! [pool (+ 2 (cp/ncpus))]
           (doall (cp/upmap pool
                            (fn [group-id]


### PR DESCRIPTION
Second stab at https://github.com/metabase/metabase/pull/61836 after the feature branch diverged.

It was a bit trickier than I expected to ensure we process batches concurrently while also respecting the reducible and not realizing more documents than we need at once. I experimented with using `cp/pmap`, which works for seqable inputs, but `reducible-documents` is generated from `u/rconcat` and only implements `CollReduce`.

Ultimately I switched to creating a ThreadPoolExecutor with the `CallerRunsPolicy` rejection policy (via [this SO thread](https://stackoverflow.com/questions/4521983/java-executorservice-that-blocks-on-submission-after-a-certain-queue-size)) so that a job rejected from the pool gets run on the submitter thread, blocking the transduction and ensuring we're still not realizing the entire reducible at once. I've also ensured we're testing both the concurrency and the lazy evaluation, and added a serial mode that other test cases can use for convenience when concurrency is irrelevant.

Not in love with this solution so can be talked out of it if anyone has opinions, but it does seem to work as expected.