### PR TITLE
Collapse indexed-entity ids in semantic search results

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -528,7 +528,8 @@
 (defn- filter-can-read-indexed-entity
   "Check permissions for indexed entities by resolving to their parent model / card"
   [indexed-entity-docs]
-  (let [model-index-ids (into #{} (map #(-> % :id (str/split #":") first parse-long) indexed-entity-docs))
+  (let [->model-index-id #(-> % :id search/indexed-entity-id->model-index-id)
+        model-index-ids (into #{} (map ->model-index-id indexed-entity-docs))
         model-indexes (when (seq model-index-ids)
                         (t2/select :model/ModelIndex :id [:in model-index-ids]))
         index-id->card (when (seq model-indexes)
@@ -540,7 +541,7 @@
                                         [(:id model-index) (get cards-by-id (:model_id model-index))])
                                       model-indexes))))]
     (filterv (fn [doc]
-               (when-let [model-index-id (-> doc :id (str/split #":") first parse-long)]
+               (when-let [model-index-id (-> doc ->model-index-id)]
                  (when-let [parent-card (get index-id->card model-index-id)]
                    (mi/can-read? parent-card))))
              indexed-entity-docs)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -658,7 +658,7 @@
 
 (defn- apply-collection-filter
   "Apply personal collection filtering with logging."
-  [docs search-context]
+  [search-context docs]
   (let [filter-type (:filter-items-in-personal-collection search-context)]
     (if (or (nil? filter-type) (= filter-type "all"))
       docs
@@ -693,9 +693,10 @@
             raw-results (into [] xform reducible)
             db-query-time-ms (u/since-ms db-timer)
 
-            filtered-results (-> raw-results
-                                 filter-read-permitted
-                                 (apply-collection-filter search-context))
+            filtered-results (->> raw-results
+                                  filter-read-permitted
+                                  (apply-collection-filter search-context)
+                                  (mapv search/collapse-id))
 
             total-time-ms (u/since-ms timer)]
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
@@ -135,7 +135,7 @@
   (let [pgvector         semantic.tu/db
         embedding-model1 semantic.tu/mock-embedding-model
         embedding-model2 (assoc semantic.tu/mock-embedding-model
-                                :model-name "mock-harder")
+                                :model-name "mock2")
         sut              semantic.index-metadata/find-best-index!
         ;; warning: the setup-scenario can currently only set up a happy path
         ;; other variables include:

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -478,3 +478,55 @@
           (testing "handles non-existent model indexes"
             (let [non-existent-docs [{:id "99999:123" :model "indexed-entity" :content "Non-existent"}]]
               (is (= [] (#'semantic.index/filter-can-read-indexed-entity non-existent-docs))))))))))
+
+(deftest indexed-entity-collapse-id-test
+  (mt/with-premium-features #{:semantic-search}
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Card model-1 (assoc (mt/card-with-source-metadata-for-query
+                                               (mt/mbql-query products {:fields [$id $title]
+                                                                        :limit 1}))
+                                              :type "model"
+                                              :name "Fish Tank Setup"
+                                              :database_id (mt/id)
+                                              :collection_id coll-id)
+                   :model/ModelIndex model-index-1 {:model_id (:id model-1)
+                                                    :pk_ref (mt/$ids :products $id)
+                                                    :value_ref (mt/$ids :products $title)
+                                                    :schedule "0 0 0 * * *"
+                                                    :state "initial"
+                                                    :creator_id (mt/user->id :rasta)}]
+      (let [docs [{:model "dataset"
+                   :id (:id model-1)
+                   :name (:name model-1)
+                   :searchable_text (:name model-1)
+                   :created_at #t "2025-01-01T12:00:00Z"
+                   :creator_id (mt/user->id :crowberto)
+                   :archived false
+                   :collection_id coll-id
+                   :legacy_input {:id (:id model-1)
+                                  :model "dataset"
+                                  :dataset_query (:dataset_query model-1)}
+                   :metadata {:title (:name model-1)}}
+                  {:id (str (:id model-index-1) ":1234")
+                   :name "Antarctic wildlife"
+                   :model "indexed-entity"
+                   :archived false
+                   :collection_id coll-id
+                   :searchable_text "Antarctic wildlife"
+                   :legacy_input {:id (str (:id model-index-1) ":1234")
+                                  :name "Antarctic wildlife"
+                                  :model "indexed-entity"}
+                   :metadata {:title "Antarctic wildlife"}}]]
+        (with-open [_ (semantic.tu/open-temp-index!)]
+          (testing "indexed-entity can be inserted into index"
+            (is (=
+                 {"indexed-entity" 1, "dataset" 1}
+                 (semantic.tu/upsert-index! docs))))
+          (testing "indexed-entity has id collapsed"
+            (is (= {:id 1234
+                    :name "Antarctic wildlife"
+                    :model "indexed-entity"}
+                   (mt/as-admin
+                     (-> (semantic.tu/query-index {:search-string "Antarctic wildlife"})
+                         first
+                         (select-keys [:id :name :model])))))))))))

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.appdb.core
   (:require
-   [clojure.string :as str]
    [environ.core :as env]
    [honey.sql.helpers :as sql.helpers]
    [java-time.api :as t]
@@ -16,6 +15,7 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.permissions :as search.permissions]
    [metabase.search.settings :as search.settings]
+   [metabase.search.util :as search.util]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
@@ -50,12 +50,9 @@
 (defn- parse-datetime [s]
   (when s (OffsetDateTime/parse s)))
 
-(defn- collapse-id [{:keys [id] :as row}]
-  (assoc row :id (if (number? id) id (parse-long (last (str/split (:id row) #":"))))))
-
 (defn- rehydrate [weights active-scorers index-row]
   (-> (json/decode+kw (:legacy_input index-row))
-      collapse-id
+      search.util/collapse-id
       (assoc
        ;; this relies on the corresponding scorer, which is not great coupling.
        ;; ideally we would make per-user computed attributes part of the spec itself.

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -49,6 +49,7 @@
   define-spec]
 
  [search.util
+  collapse-id
   tsv-language
   to-tsquery-expr
   weighted-tsvector])

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -50,6 +50,8 @@
 
  [search.util
   collapse-id
+  indexed-entity-id->model-index-id
+  indexed-entity-id->model-pk
   tsv-language
   to-tsquery-expr
   weighted-tsvector])

--- a/src/metabase/search/util.clj
+++ b/src/metabase/search/util.clj
@@ -22,10 +22,29 @@
       :or  (every? impossible-condition? (rest where))
       false)))
 
+(defn- explode-multipart-ids
+  "Split integer IDs from a `multi-part-id-string` like \"123:456\" => (\"123\" \"456\")"
+  [multi-part-id-string]
+  (str/split multi-part-id-string #":"))
+
+(defn indexed-entity-id->model-index-id
+  "Extract the model-index-id from a composite indexed-entity id like <model-index-id>:<model-pk>"
+  [indexed-entity-id]
+  (-> (explode-multipart-ids indexed-entity-id)
+      first
+      parse-long))
+
+(defn indexed-entity-id->model-pk
+  "Extract the model-pk from a composite indexed-entity id like <model-index-id>:<model-pk>"
+  [indexed-entity-id]
+  (-> (explode-multipart-ids indexed-entity-id)
+      last
+      parse-long))
+
 (defn collapse-id
   "Collapse the id of search results that may contain multiple ids (like indexed-entities)."
   [{:keys [id] :as row}]
-  (assoc row :id (if (number? id) id (parse-long (last (str/split id #":"))))))
+  (assoc row :id (if (number? id) id (indexed-entity-id->model-pk id))))
 
 ;;; ============================================================================
 ;;; Postgres-specific utilities

--- a/src/metabase/search/util.clj
+++ b/src/metabase/search/util.clj
@@ -22,6 +22,11 @@
       :or  (every? impossible-condition? (rest where))
       false)))
 
+(defn collapse-id
+  "Collapse the id of search results that may contain multiple ids (like indexed-entities)."
+  [{:keys [id] :as row}]
+  (assoc row :id (if (number? id) id (parse-long (last (str/split id #":"))))))
+
 ;;; ============================================================================
 ;;; Postgres-specific utilities
 ;;; ============================================================================


### PR DESCRIPTION
Closes BOT-306

### Description

The indexed-entity results have composite ids like `model-index-id:model-pk`. We need to extract the `model-pk` and attach that as the `:id` on the results. Otherwise, the links generated by the frontend are invalid like
`/model/12345-blah/1234:62681`

### How to verify

See repro steps in ticket:

https://linear.app/metabase/issue/BOT-306/fix-indexed-entity-ids-in-search-results#comment-7b3d6f4b

Result: on fiery-blue you get an error like "We're a little lost...We couldn't find that record"


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
