### PR TITLE
Derive theme-aware colors in embed flow from 3 base colors

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -428,10 +428,7 @@ H.describeWithSnowplow(suiteTitle, () => {
     // derived-colors-for-embed-flow.unit.spec.ts contains the tests for other derived colors.
     cy.log("dark mode colors should be derived");
     codeBlock().should("contain", '"background-hover": "rgb(27, 27, 27)"');
-    codeBlock().should(
-      "contain",
-      '"text-secondary": "rgba(241, 241, 241, 0.7)"',
-    );
+    codeBlock().should("contain", '"text-secondary": "rgb(169, 169, 169)"');
     codeBlock().should("contain", '"brand-hover": "rgba(189, 81, 253, 0.5)"');
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -392,4 +392,46 @@ H.describeWithSnowplow(suiteTitle, () => {
     getEmbedSidebar().findByText("Get Code").click();
     codeBlock().should("not.contain", '"theme": {');
   });
+
+  it("derives colors for dark theme palette", () => {
+    navigateToEmbedOptionsStep({
+      experience: "dashboard",
+      resourceName: DASHBOARD_NAME,
+    });
+
+    cy.log("change brand color");
+    cy.findByLabelText("#509EE3").click();
+    H.popover().within(() => {
+      cy.findByDisplayValue("#509EE3").clear().type("#BD51FD");
+    });
+
+    cy.log("change primary text color");
+    cy.findByLabelText("#4C5773").click();
+    H.popover().within(() => {
+      cy.findByDisplayValue("#4C5773").clear().type("#F1F1F1");
+    });
+
+    cy.log("change background color");
+    cy.findByLabelText("#FFFFFF").click();
+    H.popover().within(() => {
+      cy.findByDisplayValue("#FFFFFF").clear().type("#121212");
+    });
+
+    cy.log("verify the preview reflects the dark theme");
+    H.getSimpleEmbedIframeContent()
+      .findByTestId("dashboard")
+      .should("have.css", "background-color", "rgb(18, 18, 18)");
+
+    cy.log("check that derived colors are applied to snippet");
+    getEmbedSidebar().findByText("Get Code").click();
+
+    // derived-colors-for-embed-flow.unit.spec.ts contains the tests for other derived colors.
+    cy.log("dark mode colors should be derived");
+    codeBlock().should("contain", '"background-hover": "rgb(27, 27, 27)"');
+    codeBlock().should(
+      "contain",
+      '"text-secondary": "rgba(241, 241, 241, 0.7)"',
+    );
+    codeBlock().should("contain", '"brand-hover": "rgba(189, 81, 253, 0.5)"');
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -10,6 +10,7 @@ import { Card } from "metabase/ui";
 import type { SdkIframeEmbedBaseSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
+import { getDerivedDefaultColorsForEmbedFlow } from "../utils/derived-colors-for-embed-flow";
 import { getConfigurableThemeColors } from "../utils/theme-colors";
 
 import S from "./SdkIframeEmbedPreview.module.css";
@@ -39,28 +40,34 @@ export const SdkIframeEmbedPreview = () => {
     [],
   );
 
-  // TODO(EMB-696): There is a bug in the SDK where if we set the theme back to undefined,
-  // some color will not be reset to the default (e.g. text color, CSS variables).
-  // We can remove this block once EMB-696 is fixed.
-  const defaultTheme: MetabaseTheme = useMemo(() => {
-    const colors = Object.fromEntries(
-      getConfigurableThemeColors().map((color) => [
-        color.key,
-        applicationColors?.[color.originalColorKey] ??
-          defaultMetabaseColors[color.originalColorKey],
-      ]),
+  const derivedTheme = useMemo(() => {
+    // TODO(EMB-696): There is a bug in the SDK where if we set the theme back to undefined,
+    // some color will not be reset to the default (e.g. text color, CSS variables).
+    // We can remove this block once EMB-696 is fixed.
+    const defaultTheme: MetabaseTheme = {
+      colors: Object.fromEntries(
+        getConfigurableThemeColors().map((color) => [
+          color.key,
+          applicationColors?.[color.originalColorKey] ??
+            defaultMetabaseColors[color.originalColorKey],
+        ]),
+      ),
+    };
+
+    return getDerivedDefaultColorsForEmbedFlow(
+      settings.theme ?? defaultTheme,
+      applicationColors ?? undefined,
     );
-    return { colors };
-  }, [applicationColors]);
+  }, [applicationColors, settings.theme]);
 
   const metabaseConfig = useMemo(
     () => ({
       instanceUrl,
       useExistingUserSession: true,
-      theme: settings.theme ?? defaultTheme,
+      theme: derivedTheme,
       ...(localeOverride ? { locale: localeOverride } : {}),
     }),
-    [instanceUrl, localeOverride, settings.theme, defaultTheme],
+    [instanceUrl, localeOverride, derivedTheme],
   );
 
   // initial configuration, needed so that the element finds the config on first render

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/hooks/use-sdk-iframe-embed-snippet.ts
@@ -3,14 +3,27 @@ import { useMemo } from "react";
 import { useSetting } from "metabase/common/hooks";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
+import { getDerivedDefaultColorsForEmbedFlow } from "../utils/derived-colors-for-embed-flow";
 import { getEmbedSnippet } from "../utils/embed-snippet";
 
 export function useSdkIframeEmbedSnippet() {
   const instanceUrl = useSetting("site-url");
+  const applicationColors = useSetting("application-colors");
   const { settings, experience } = useSdkIframeEmbedSetupContext();
 
-  return useMemo(
-    () => getEmbedSnippet({ settings, instanceUrl, experience }),
-    [instanceUrl, settings, experience],
-  );
+  return useMemo(() => {
+    // Apply derived colors to the settings for the code snippet
+    const derivedTheme =
+      settings.theme &&
+      getDerivedDefaultColorsForEmbedFlow(
+        settings.theme,
+        applicationColors ?? undefined,
+      );
+
+    return getEmbedSnippet({
+      settings: { ...settings, theme: derivedTheme },
+      instanceUrl,
+      experience,
+    });
+  }, [instanceUrl, settings, experience, applicationColors]);
 }

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/derived-colors-for-embed-flow.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/derived-colors-for-embed-flow.ts
@@ -22,7 +22,7 @@ export function getDerivedDefaultColorsForEmbedFlow(
 ): MetabaseTheme {
   const userColors = theme.colors ?? {};
 
-  const getSourceColor = (colorName: MetabaseColor): string => {
+  const getSourceColor = (colorName: MetabaseColor): string | null => {
     // Chart colors consists of 8 colors, so they can't be derived.
     if (colorName === "charts") {
       throw new Error("chart color must not be used as a source color");
@@ -45,8 +45,16 @@ export function getDerivedDefaultColorsForEmbedFlow(
       }
     }
 
-    // As a last resort, fallback to the default Metabase color object
-    return colors[colorName as ColorName];
+    // Fallback to the default Metabase color object.
+    for (const appColorName of appColorNames) {
+      const defaultColor = colors[appColorName as ColorName];
+
+      if (defaultColor) {
+        return defaultColor;
+      }
+    }
+
+    return null;
   };
 
   const backgroundColor = getSourceColor("background");
@@ -76,6 +84,11 @@ export function getDerivedDefaultColorsForEmbedFlow(
     }
 
     const sourceColor = getSourceColor(operation.source);
+
+    if (sourceColor === null) {
+      continue;
+    }
+
     const derivedColor = applyColorOperation(sourceColor, operation);
 
     derivedColors[colorKey] = derivedColor;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/derived-colors-for-embed-flow.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/derived-colors-for-embed-flow.unit.spec.ts
@@ -1,0 +1,83 @@
+import type { MetabaseTheme } from "embedding-sdk";
+
+import { getDerivedDefaultColorsForEmbedFlow } from "./derived-colors-for-embed-flow";
+
+describe("getDerivedDefaultColorsForEmbedFlow", () => {
+  it("derives colors for light theme", () => {
+    const theme: MetabaseTheme = {
+      colors: {
+        background: "#ffffff",
+        "text-primary": "#333333",
+        brand: "#509ee3",
+        border: "#d9d9d9",
+      },
+    };
+
+    const { colors } = getDerivedDefaultColorsForEmbedFlow(theme);
+
+    expect(colors?.background).toBe("#ffffff");
+    expect(colors?.["text-primary"]).toBe("#333333");
+    expect(colors?.["background-hover"]).toBe("rgb(252, 252, 252)");
+    expect(colors?.["background-disabled"]).toBe("rgb(247, 247, 247)");
+    expect(colors?.["text-secondary"]).toBe("rgba(51, 51, 51, 0.7)");
+    expect(colors?.["text-tertiary"]).toBe("rgba(51, 51, 51, 0.5)");
+  });
+
+  it("derives colors for dark theme", () => {
+    const theme: MetabaseTheme = {
+      colors: {
+        background: "#1a1a1a",
+        "text-primary": "#ffffff",
+        brand: "#509ee3",
+      },
+    };
+
+    const { colors } = getDerivedDefaultColorsForEmbedFlow(theme);
+
+    expect(colors?.background).toBe("#1a1a1a");
+    expect(colors?.["text-primary"]).toBe("#ffffff");
+    expect(colors?.["background-hover"]).toBe("rgb(39, 39, 39)");
+    expect(colors?.["background-disabled"]).toBe("rgb(31, 31, 31)");
+    expect(colors?.["text-secondary"]).toBe("rgba(255, 255, 255, 0.7)");
+    expect(colors?.["text-tertiary"]).toBe("rgba(255, 255, 255, 0.5)");
+  });
+
+  it("should not override existing colors", () => {
+    const theme: MetabaseTheme = {
+      colors: {
+        background: "#ffffff",
+        "text-primary": "#333333",
+        "background-hover": "#existing-color",
+      },
+    };
+
+    const { colors } = getDerivedDefaultColorsForEmbedFlow(theme);
+
+    expect(colors?.background).toBe("#ffffff");
+    expect(colors?.["text-primary"]).toBe("#333333");
+    expect(colors?.["background-hover"]).toBe("#existing-color");
+  });
+
+  it("derives color from white-labeled colors", () => {
+    const theme: MetabaseTheme = {};
+
+    const appColors = {
+      "bg-white": "#2d3030",
+      "text-dark": "#eee",
+    };
+
+    const { colors } = getDerivedDefaultColorsForEmbedFlow(theme, appColors);
+
+    expect(colors?.["background-hover"]).toBe("rgb(68, 72, 72)");
+  });
+
+  it("derives default colors for empty themes", () => {
+    const theme: MetabaseTheme = {};
+
+    const { colors } = getDerivedDefaultColorsForEmbedFlow(theme);
+
+    expect(colors).toBeDefined();
+    expect(colors?.["background-hover"]).toBeDefined();
+    expect(colors?.["text-secondary"]).toBeDefined();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/derived-colors-for-embed-flow.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/derived-colors-for-embed-flow.unit.spec.ts
@@ -42,6 +42,17 @@ describe("getDerivedDefaultColorsForEmbedFlow", () => {
     expect(colors?.["text-tertiary"]).toBe("rgba(255, 255, 255, 0.5)");
   });
 
+  it("uses the default text-primary color if only background is defined", () => {
+    const theme: MetabaseTheme = {
+      colors: {
+        background: "#1a1a1a",
+      },
+    };
+
+    const { colors } = getDerivedDefaultColorsForEmbedFlow(theme);
+    expect(colors?.["text-primary"]).toBe("#4C5773");
+  });
+
   it("should not override existing colors", () => {
     const theme: MetabaseTheme = {
       colors: {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/derived-colors-for-embed-flow.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/derived-colors-for-embed-flow.unit.spec.ts
@@ -83,9 +83,7 @@ describe("getDerivedDefaultColorsForEmbedFlow", () => {
   });
 
   it("derives default colors for empty themes", () => {
-    const theme: MetabaseTheme = {};
-
-    const { colors } = getDerivedDefaultColorsForEmbedFlow(theme);
+    const { colors } = getDerivedDefaultColorsForEmbedFlow({});
 
     expect(colors).toBeDefined();
     expect(colors?.["background-hover"]).toBeDefined();

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/derived-colors-for-embed-flow.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/derived-colors-for-embed-flow.unit.spec.ts
@@ -19,8 +19,8 @@ describe("getDerivedDefaultColorsForEmbedFlow", () => {
     expect(colors?.["text-primary"]).toBe("#333333");
     expect(colors?.["background-hover"]).toBe("rgb(252, 252, 252)");
     expect(colors?.["background-disabled"]).toBe("rgb(247, 247, 247)");
-    expect(colors?.["text-secondary"]).toBe("rgba(51, 51, 51, 0.7)");
-    expect(colors?.["text-tertiary"]).toBe("rgba(51, 51, 51, 0.5)");
+    expect(colors?.["text-secondary"]).toBe("rgb(66, 66, 66)");
+    expect(colors?.["text-tertiary"]).toBe("rgb(82, 82, 82)");
   });
 
   it("derives colors for dark theme", () => {
@@ -38,8 +38,8 @@ describe("getDerivedDefaultColorsForEmbedFlow", () => {
     expect(colors?.["text-primary"]).toBe("#ffffff");
     expect(colors?.["background-hover"]).toBe("rgb(39, 39, 39)");
     expect(colors?.["background-disabled"]).toBe("rgb(31, 31, 31)");
-    expect(colors?.["text-secondary"]).toBe("rgba(255, 255, 255, 0.7)");
-    expect(colors?.["text-tertiary"]).toBe("rgba(255, 255, 255, 0.5)");
+    expect(colors?.["text-secondary"]).toBe("rgb(179, 179, 179)");
+    expect(colors?.["text-tertiary"]).toBe("rgb(102, 102, 102)");
   });
 
   it("uses the default text-primary color if only background is defined", () => {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/dynamic-sdk-color-defaults.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/dynamic-sdk-color-defaults.ts
@@ -1,0 +1,41 @@
+import type { EmbedFlowDerivedDefaultColorConfig } from "./types";
+
+/**
+ * Define theme-aware color defaults for the embedding SDK.
+ * These will be applied when the user hasn't defined these colors explicitly.
+ */
+export const EMBED_FLOW_DERIVED_COLORS_CONFIG: EmbedFlowDerivedDefaultColorConfig =
+  {
+    "background-hover": {
+      light: { source: "background", darken: 0.01 },
+      dark: { source: "background", lighten: 0.5 },
+    },
+    "background-disabled": {
+      light: { source: "background", darken: 0.03 },
+      dark: { source: "background", lighten: 0.2 },
+    },
+    "background-secondary": {
+      light: { source: "background", darken: 0.05 },
+      dark: { source: "background", lighten: 0.5 },
+    },
+    "text-secondary": {
+      light: { source: "text-primary", alpha: 0.7 },
+      dark: { source: "text-primary", alpha: 0.7 },
+    },
+    "text-tertiary": {
+      light: { source: "text-primary", alpha: 0.5 },
+      dark: { source: "text-primary", alpha: 0.5 },
+    },
+    border: {
+      light: { source: "border", alpha: 0.7 },
+      dark: { source: "border", alpha: 0.7 },
+    },
+    "brand-hover": {
+      light: { source: "brand", lighten: 0.4 },
+      dark: { source: "brand", alpha: 0.5 },
+    },
+    "brand-hover-light": {
+      light: { source: "brand", lighten: 0.6 },
+      dark: { source: "brand", alpha: 0.3 },
+    },
+  };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/dynamic-sdk-color-defaults.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/dynamic-sdk-color-defaults.ts
@@ -19,15 +19,14 @@ export const EMBED_FLOW_DERIVED_COLORS_CONFIG: EmbedFlowDerivedDefaultColorConfi
       dark: { source: "background", lighten: 0.5 },
     },
     "text-secondary": {
-      light: { source: "text-primary", alpha: 0.7 },
-      dark: { source: "text-primary", alpha: 0.7 },
+      light: { source: "text-primary", lighten: 0.3 },
+      dark: { source: "text-primary", darken: 0.3 },
     },
     "text-tertiary": {
-      light: { source: "text-primary", alpha: 0.5 },
-      dark: { source: "text-primary", alpha: 0.5 },
+      light: { source: "text-primary", lighten: 0.6 },
+      dark: { source: "text-primary", darken: 0.6 },
     },
     border: {
-      light: { source: "border", alpha: 0.7 },
       dark: { source: "border", alpha: 0.7 },
     },
     "brand-hover": {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/types.ts
@@ -1,0 +1,11 @@
+import type { MetabaseColor } from "metabase/embedding-sdk/theme";
+import type { DynamicColorDefinition } from "metabase/embedding-sdk/types/private/css-variables";
+
+/**
+ * A mapping of SDK color names to their dynamic color definition.
+ *
+ * This is currently only used in the embed flow to provide better out-of-the-box defaults.
+ **/
+export type EmbedFlowDerivedDefaultColorConfig = Partial<
+  Record<MetabaseColor, DynamicColorDefinition>
+>;

--- a/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/RecentsTab.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/RecentsTab/RecentsTab.tsx
@@ -31,7 +31,7 @@ export const RecentsTab = <
   }
 
   return (
-    <Stack h="100%" bg="bg-light">
+    <Stack h="100%" bg="var(--mb-color-bg-light)">
       {recentItems.length > 0 ? (
         <GroupedRecentsList
           items={recentItems}

--- a/frontend/src/metabase/embedding-sdk/theme/apply-color-operation.unit.spec.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/apply-color-operation.unit.spec.ts
@@ -1,0 +1,45 @@
+import { applyColorOperation } from "./dynamic-css-vars";
+
+describe("applyColorOperation", () => {
+  it("applies lighten operation", () => {
+    const result = applyColorOperation("#ff0000", {
+      source: "brand",
+      lighten: 0.2,
+    });
+
+    expect(result).toBe("rgb(255, 51, 51)");
+  });
+
+  it("applies darken operation", () => {
+    const result = applyColorOperation("#ff0000", {
+      source: "brand",
+      darken: 0.2,
+    });
+
+    expect(result).toBe("rgb(204, 0, 0)");
+  });
+
+  it("applies alpha operation", () => {
+    const result = applyColorOperation("#ff0000", {
+      source: "brand",
+      alpha: 0.5,
+    });
+
+    expect(result).toBe("rgba(255, 0, 0, 0.5)");
+  });
+
+  it("does nothing if no operation exists", () => {
+    expect(applyColorOperation("#00ff00", { source: "brand" })).toBe("#00ff00");
+  });
+
+  it("should handle all operations together", () => {
+    const result = applyColorOperation("#333333", {
+      source: "brand",
+      lighten: 0.3,
+      darken: 0.1,
+      alpha: 0.7,
+    });
+
+    expect(result).toBe("rgba(59, 59, 59, 0.7)");
+  });
+});

--- a/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars-config.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars-config.ts
@@ -1,25 +1,26 @@
 import type { DynamicCssVarConfig } from "../types/private/css-variables";
 
 /**
- * These CSS variables are dynamically generated based on the theme.
+ * Custom CSS variables that don't correspond to SDK color mappings.
+ * These are always applied and can't be overridden by user-defined colors.
  */
 export const DYNAMIC_CSS_VARIABLES: DynamicCssVarConfig = {
   "--mb-color-bg-sdk-question-toolbar": {
-    light: { source: "bg-white", darken: 0.04 },
-    dark: { source: "bg-white", lighten: 0.5 },
+    light: { source: "background", darken: 0.04 },
+    dark: { source: "background", lighten: 0.5 },
   },
   "--mb-color-notebook-step-bg": {
-    light: { source: "bg-white", darken: 0.05 },
-    dark: { source: "bg-white", lighten: 0.5 },
+    light: { source: "background", darken: 0.05 },
+    dark: { source: "background", lighten: 0.5 },
   },
   "--mb-color-notebook-step-bg-hover": {
-    light: { source: "bg-white", darken: 0.1 },
-    dark: { source: "bg-white", lighten: 0.4 },
+    light: { source: "background", darken: 0.1 },
+    dark: { source: "background", lighten: 0.4 },
   },
   "--mb-color-background-hover": {
-    dark: { source: "bg-white", lighten: 0.5 },
+    dark: { source: "background", lighten: 0.5 },
   },
   "--mb-color-bg-error": {
-    dark: { source: "error", alpha: 0.3 },
+    dark: { source: "negative", alpha: 0.1 },
   },
 };

--- a/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars.ts
@@ -1,22 +1,48 @@
 // eslint-disable-next-line no-restricted-imports
 import { css } from "@emotion/react";
+import Color from "color";
 
-import { alpha, darken, isDark, isLight, lighten } from "metabase/lib/colors";
-import type { MantineTheme } from "metabase/ui";
+import { isDark, isLight } from "metabase/lib/colors";
+import type { MantineTheme, MantineThemeOverride } from "metabase/ui";
 
 import type { ColorOperation } from "../types/private/css-variables";
 
 import { DYNAMIC_CSS_VARIABLES } from "./dynamic-css-vars-config";
+import { SDK_TO_MAIN_APP_COLORS_MAPPING } from "./embedding-color-palette";
 
-const isColorDefined = (color: string) =>
-  color && color !== "transparent" && color !== "unset";
+const isColorDefined = (color?: string): color is string =>
+  !!color && color !== "transparent" && color !== "unset";
+
+/**
+ * Applies color operations (lighten, darken, alpha) to a base color.
+ */
+export function applyColorOperation(
+  baseColor: string,
+  operation: ColorOperation,
+): string {
+  let mappedColor = baseColor;
+
+  if (operation.lighten !== undefined) {
+    mappedColor = Color(mappedColor).lighten(operation.lighten).rgb().string();
+  }
+
+  if (operation.darken !== undefined) {
+    mappedColor = Color(mappedColor).darken(operation.darken).rgb().string();
+  }
+
+  if (operation.alpha !== undefined) {
+    mappedColor = Color(mappedColor).alpha(operation.alpha).rgb().string();
+  }
+
+  return mappedColor;
+}
 
 /**
  * Determine if the current color scheme is dark based on the palette.
  */
-export function getIsDarkThemeFromPalette(theme: MantineTheme) {
-  const backgroundColor = theme.fn.themeColor("background");
-  const foregroundColor = theme.fn.themeColor("text-dark");
+export function getIsDarkThemeFromPalette(theme: MantineThemeOverride) {
+  const backgroundColor = theme.fn?.themeColor?.("background");
+  const foregroundColor = theme.fn?.themeColor?.("text-dark");
 
   // Dark background color indicates a dark theme.
   if (isColorDefined(backgroundColor)) {
@@ -49,23 +75,21 @@ export function getDynamicCssVariables(theme: MantineTheme) {
       }
 
       // Do not define the CSS variable if the source color or operation is not defined.
-      if (!operation) {
+      // In addition, do not use chart color as source color to sample from.
+      if (!operation || operation?.source === "charts") {
         return [cssVar, null];
       }
 
-      let mappedColor = theme.fn.themeColor(operation.source);
+      // One SDK color will be mapped to multiple main app colors.
+      // All of those colors will have the same value, so we sample from the first one.
+      const colorKeys = SDK_TO_MAIN_APP_COLORS_MAPPING[operation.source];
 
-      if (operation.lighten) {
-        mappedColor = lighten(mappedColor, operation.lighten);
+      if (!colorKeys) {
+        return [cssVar, null];
       }
 
-      if (operation.darken) {
-        mappedColor = darken(mappedColor, operation.darken);
-      }
-
-      if (operation.alpha) {
-        mappedColor = alpha(mappedColor, operation.alpha);
-      }
+      const baseColor = theme.fn.themeColor(colorKeys?.[0]);
+      const mappedColor = applyColorOperation(baseColor, operation);
 
       return [cssVar, mappedColor];
     })

--- a/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
@@ -24,6 +24,7 @@ export type SemanticColorKey =
   | "text-brand"
   | "text-white"
   | "background"
+  | "background-hover"
   | "background-selected"
   | "background-disabled"
   | "background-inverse"
@@ -49,7 +50,7 @@ export const SDK_TO_MAIN_APP_COLORS_MAPPING: Record<
   "text-secondary": ["text-medium", "text-secondary"],
   "text-tertiary": ["text-light", "text-tertiary"],
   background: ["bg-white", "background"],
-  "background-hover": ["bg-light"],
+  "background-hover": ["bg-light", "background-hover"],
   "background-secondary": ["bg-medium"],
   "background-disabled": ["background-disabled"],
   shadow: ["shadow"],

--- a/frontend/src/metabase/embedding-sdk/types/private/css-variables.ts
+++ b/frontend/src/metabase/embedding-sdk/types/private/css-variables.ts
@@ -1,11 +1,8 @@
-import type { SemanticColorKey } from "metabase/embedding-sdk/theme/embedding-color-palette";
-import type { ColorName } from "metabase/lib/colors/types";
-
-export type SourceColorKey = ColorName | SemanticColorKey;
+import type { MetabaseColor } from "metabase/embedding-sdk/theme";
 
 export type ColorOperation = {
   /** The color to use as a source for generating the CSS variable. **/
-  source: SourceColorKey;
+  source: MetabaseColor;
 
   /** Lightens the color by the given amount. **/
   lighten?: number;
@@ -20,9 +17,9 @@ export type ColorOperation = {
 /**
  * Applies different color operations to light and dark themes.
  */
-export type DynamicCssVarColorDefinition = {
+export type DynamicColorDefinition = {
   light?: ColorOperation;
   dark?: ColorOperation;
 };
 
-export type DynamicCssVarConfig = Record<string, DynamicCssVarColorDefinition>;
+export type DynamicCssVarConfig = Record<string, DynamicColorDefinition>;


### PR DESCRIPTION
Closes EMB-710

This PR makes it so that by defining 3 theme colors (`brand`, `background` and `text-primary`) on the embed flow, the rest of the embed flow colors are derived automatically depending on whether their background is light or dark. This will only affect the embed flow's code snippets and the theme colors.

### How to verify

- Go to the embed flow "+ New > Embed".
- Tweak the colors around. Try both dark mode and light mode.
- The app should not have ugly colors, or at least a minimal number of ugly colors.
- The code snippet should reflect

### Known Problems

- Changing the theme color lacks a smooth transition. I tried adding the transitions class to the card but that causes the background transitions to be slightly out-of-sync in the iframe and in the embed preview. Removing the card padding didn't help as static questions does not have padding. Adding a padding might be an answer.

### Demo

<img width="2684" height="1580" alt="CleanShot 2568-08-13 at 22 22 06@2x" src="https://github.com/user-attachments/assets/0573c2c8-f940-427e-8abf-a2c3383a4ba8" />

https://www.loom.com/share/6d5193570f0e46eabfd12d59199f0e6e?sid=16f15c65-656c-42ae-8d58-d222dd242cb9

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
