### PR TITLE
test(embed-js): migrate tests to use custom element api

### DIFF
--- a/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
@@ -1,6 +1,7 @@
 import { match } from "ts-pattern";
 
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme/MetabaseTheme";
+import type { CreateApiKeyResponse } from "metabase-types/api";
 
 import { createApiKey } from "./api";
 import { getIframeBody } from "./e2e-embedding-helpers";
@@ -224,7 +225,7 @@ function setupMockAuthProviders(enabledAuthMethods: EnabledAuthMethods[]) {
     const ADMIN_GROUP_ID = 2;
 
     createApiKey("test iframe sdk embedding", ADMIN_GROUP_ID).then(
-      ({ body }: { body: { unmasked_key: string } }) => {
+      ({ body }: { body: CreateApiKeyResponse }) => {
         cy.wrap(body.unmasked_key).as("apiKey");
       },
     );

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -11,7 +11,10 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     H.prepareSdkIframeEmbedTest({ enabledAuthMethods: [], signOut: true });
 
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
     });
 
     frame.within(() => {
@@ -25,8 +28,13 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     H.prepareSdkIframeEmbedTest({ enabledAuthMethods: [], signOut: false });
 
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
-      useExistingUserSession: true,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
+      metabaseConfig: {
+        useExistingUserSession: true,
+      },
     });
 
     assertDashboardLoaded(frame);
@@ -36,8 +44,13 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     H.prepareSdkIframeEmbedTest({ enabledAuthMethods: [], signOut: false });
 
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
-      useExistingUserSession: false,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
+      metabaseConfig: {
+        useExistingUserSession: false,
+      },
     });
 
     cy.log(
@@ -55,7 +68,10 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     H.prepareSdkIframeEmbedTest({ enabledAuthMethods: ["jwt"], signOut: true });
 
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
     });
 
     assertDashboardLoaded(frame);
@@ -66,7 +82,10 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     H.prepareSdkIframeEmbedTest({ enabledAuthMethods: [], signOut: true });
 
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
       onVisitPage: () => stubWindowOpenForSamlPopup(),
     });
 
@@ -78,7 +97,10 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     H.prepareSdkIframeEmbedTest({ enabledAuthMethods: [], signOut: true });
 
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
       onVisitPage: () => stubWindowOpenForSamlPopup({ isUserValid: false }),
     });
 
@@ -104,9 +126,14 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     cy.log("visit a test page with an origin of example.com using api keys");
     cy.get<string>("@apiKey").then((apiKey) => {
       const frame = H.loadSdkIframeEmbedTestPage({
+        element: "metabase-dashboard",
         origin: "http://example.com",
-        dashboardId: ORDERS_DASHBOARD_ID,
-        apiKey,
+        attributes: {
+          dashboardId: ORDERS_DASHBOARD_ID,
+        },
+        metabaseConfig: {
+          apiKey,
+        },
       });
 
       frame
@@ -127,9 +154,14 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
       "visit a test page with an origin of example.com using the existing user session",
     );
     const frame = H.loadSdkIframeEmbedTestPage({
+      element: "metabase-dashboard",
       origin: "http://example.com",
-      dashboardId: ORDERS_DASHBOARD_ID,
-      useExistingUserSession: true,
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
+      metabaseConfig: {
+        useExistingUserSession: true,
+      },
     });
 
     frame
@@ -149,8 +181,13 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
 
     cy.get<string>("@apiKey").then((apiKey) => {
       const frame = H.loadSdkIframeEmbedTestPage({
-        dashboardId: ORDERS_DASHBOARD_ID,
-        apiKey,
+        element: "metabase-dashboard",
+        attributes: {
+          dashboardId: ORDERS_DASHBOARD_ID,
+        },
+        metabaseConfig: {
+          apiKey,
+        },
       });
 
       assertDashboardLoaded(frame);
@@ -170,8 +207,13 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     });
 
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
-      preferredAuthMethod: "jwt",
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
+      metabaseConfig: {
+        preferredAuthMethod: "jwt",
+      },
     });
 
     cy.wait("@authSso").its("response.body.method").should("eq", "jwt");
@@ -187,8 +229,13 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     });
 
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
-      preferredAuthMethod: "saml",
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
+      metabaseConfig: {
+        preferredAuthMethod: "saml",
+      },
     });
 
     cy.log("must fail to login via SAML as the SAML endpoint does not exist");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
@@ -13,8 +13,11 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
 
   it("shows a static question with drills=false", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      questionId: ORDERS_QUESTION_ID,
-      drills: false,
+      element: "metabase-question",
+      attributes: {
+        questionId: ORDERS_QUESTION_ID,
+        drills: false,
+      },
     });
 
     cy.wait("@getCardQuery");
@@ -33,9 +36,12 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
 
   it("shows a static question with drills=false, withTitle=true", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      questionId: ORDERS_QUESTION_ID,
-      drills: false,
-      withTitle: true,
+      element: "metabase-question",
+      attributes: {
+        questionId: ORDERS_QUESTION_ID,
+        drills: false,
+        withTitle: true,
+      },
     });
 
     cy.wait("@getCardQuery");
@@ -51,10 +57,13 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
 
   it("shows a static dashboard using drills=false, withTitle=false, withDownloads=true", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
-      drills: false,
-      withTitle: false,
-      withDownloads: true,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+        drills: false,
+        withTitle: false,
+        withDownloads: true,
+      },
     });
 
     cy.wait("@getDashCardQuery");
@@ -77,10 +86,13 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
 
   it("renders an interactive question with drills=true, withTitle=false, withDownloads=true", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      questionId: ORDERS_QUESTION_ID,
-      drills: true,
-      withDownloads: true,
-      withTitle: false,
+      element: "metabase-question",
+      attributes: {
+        questionId: ORDERS_QUESTION_ID,
+        drills: true,
+        withDownloads: true,
+        withTitle: false,
+      },
     });
 
     cy.wait("@getCardQuery");
@@ -104,10 +116,13 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
 
   it("renders an interactive dashboard with drills=true, withDownloads=true, withTitle=false", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
-      drills: true,
-      withDownloads: true,
-      withTitle: false,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+        drills: true,
+        withDownloads: true,
+        withTitle: false,
+      },
     });
 
     cy.wait("@getDashCardQuery");
@@ -137,10 +152,13 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
 
   it("renders the exploration template with isSaveEnabled=true, targetCollection, entityTypes", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      template: "exploration",
-      isSaveEnabled: true,
-      targetCollection: FIRST_COLLECTION_ID,
-      entityTypes: ["table"],
+      element: "metabase-question",
+      attributes: {
+        questionId: "new",
+        isSaveEnabled: true,
+        targetCollection: FIRST_COLLECTION_ID,
+        entityTypes: ["table"],
+      },
     });
 
     frame.within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/missing-tokens.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/missing-tokens.cy.spec.ts
@@ -17,9 +17,14 @@ describe("scenarios > embedding > sdk iframe embedding > without token features"
 
     cy.get<string>("@apiKey").then((apiKey) => {
       const frame = H.loadSdkIframeEmbedTestPage({
+        element: "metabase-question",
         origin: "http://example.com",
-        template: "exploration",
-        apiKey,
+        attributes: {
+          questionId: "new",
+        },
+        metabaseConfig: {
+          apiKey,
+        },
       });
 
       frame
@@ -31,8 +36,13 @@ describe("scenarios > embedding > sdk iframe embedding > without token features"
   it("does not show an error if the token features are missing and the parent page is localhost", () => {
     cy.get<string>("@apiKey").then((apiKey) => {
       const frame = H.loadSdkIframeEmbedTestPage({
-        template: "exploration",
-        apiKey,
+        element: "metabase-question",
+        attributes: {
+          questionId: "new",
+        },
+        metabaseConfig: {
+          apiKey,
+        },
       });
 
       frame

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -221,7 +221,7 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
       cy.findByText("Orders").should("be.visible");
     });
 
-    cy.log("2. call embed.updateSettings to show the title");
+    cy.log("2. call setAttribute to show the title");
     frame.window().then((win) => {
       const element = win.document!.querySelector("metabase-dashboard")!;
       element.setAttribute("with-title", "true");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -22,7 +22,10 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
 
   it("uses the embedding-simple client request header", () => {
     H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
     });
 
     cy.wait("@getDashCardQuery").then(({ request }) => {
@@ -34,7 +37,10 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
 
   it("displays a dashboard", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
     });
 
     cy.wait("@getDashCardQuery");
@@ -48,7 +54,10 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
 
   it("displays a question", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      questionId: ORDERS_QUESTION_ID,
+      element: "metabase-question",
+      attributes: {
+        questionId: ORDERS_QUESTION_ID,
+      },
     });
 
     cy.wait("@getCardQuery");
@@ -60,7 +69,10 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
 
   it("displays a dashboard using entity id", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ENTITY_ID,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ENTITY_ID,
+      },
     });
 
     cy.wait("@getDashCardQuery");
@@ -74,7 +86,10 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
 
   it("displays a question using entity id", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      questionId: ORDERS_QUESTION_ENTITY_ID,
+      element: "metabase-question",
+      attributes: {
+        questionId: ORDERS_QUESTION_ENTITY_ID,
+      },
     });
 
     cy.wait("@getCardQuery");
@@ -85,7 +100,12 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
   });
 
   it("displays the exploration template", () => {
-    const frame = H.loadSdkIframeEmbedTestPage({ template: "exploration" });
+    const frame = H.loadSdkIframeEmbedTestPage({
+      element: "metabase-question",
+      attributes: {
+        questionId: "new",
+      },
+    });
 
     frame.within(() => {
       H.assertSdkNotebookEditorUsable(frame);
@@ -97,8 +117,13 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
 
   it("applies the provided locale", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      locale: "de",
-      dashboardId: ORDERS_DASHBOARD_ID,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
+      metabaseConfig: {
+        locale: "de",
+      },
     });
 
     frame.within(() => {
@@ -106,36 +131,22 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
     });
   });
 
-  it("destroys the iframe when embed.destroy is called", () => {
+  it("updates the question id with embed.setAttribute", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      questionId: ORDERS_QUESTION_ID,
-    });
-
-    cy.wait("@getCardQuery");
-    cy.get("iframe").should("be.visible");
-
-    cy.log("1. we call embed.destroy to remove the iframe");
-    frame.window().then((win) => {
-      // @ts-expect-error -- this is within the iframe
-      win.embed.destroy();
-    });
-
-    cy.log("2. iframe should be removed");
-    cy.get("iframe").should("not.exist");
-  });
-
-  it("updates the question id with embed.updateSettings", () => {
-    const frame = H.loadSdkIframeEmbedTestPage({
-      questionId: ORDERS_QUESTION_ID,
+      element: "metabase-question",
+      attributes: {
+        questionId: ORDERS_QUESTION_ID,
+      },
     });
 
     cy.wait("@getCardQuery");
     frame.findByText("Orders, Count").should("not.exist");
 
-    cy.log("1. call embed.updateSettings to update the question id");
+    cy.log("1. call embed.setAttribute to update the question id");
     frame.window().then((win) => {
-      // @ts-expect-error -- this is within the iframe
-      win.embed.updateSettings({ questionId: ORDERS_COUNT_QUESTION_ID });
+      win
+        .document!.querySelector("metabase-question")!
+        .setAttribute("question-id", ORDERS_COUNT_QUESTION_ID.toString());
     });
 
     cy.wait("@getCardQuery");
@@ -155,67 +166,37 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
       });
   });
 
-  it("does not allow changing the value of instanceUrl via embed.updateSettings", () => {
-    const frame = H.loadSdkIframeEmbedTestPage({
-      questionId: ORDERS_QUESTION_ID,
-    });
-
-    cy.wait("@getCardQuery");
-
-    cy.log("1. get the original iframe source");
-    cy.get("iframe")
-      .should("be.visible")
-      .invoke("attr", "src")
-      .as("originalSrc");
-
-    cy.log("2. try to update instanceUrl via embed.updateSettings");
-    frame.window().then((win) => {
-      try {
-        // @ts-expect-error -- this is within the iframe
-        win.embed.updateSettings({
-          instanceUrl: "http://some-other-site.com",
-        });
-      } catch (err: any) {
-        cy.wrap(err.message).as("updateSettingsError");
-      }
-    });
-
-    cy.log("3. expect an error to be thrown");
-    cy.get("@updateSettingsError").should(
-      "eq",
-      "instanceUrl cannot be updated after the embed is created",
-    );
-
-    cy.log("4. wait a moment to allow any iframe reloads (should not happen)");
-    cy.wait(200);
-
-    cy.log("5. assert that the iframe source has not changed");
-    cy.get("@originalSrc").then((originalSrc) => {
-      cy.get("iframe").invoke("attr", "src").should("eq", originalSrc);
-    });
-  });
-
   it("fires ready event after iframe is loaded", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      questionId: ORDERS_QUESTION_ID,
+      element: "metabase-question",
+      attributes: {
+        questionId: ORDERS_QUESTION_ID,
+      },
       onVisitPage: () => {
         cy.window().then((win) => {
-          // @ts-expect-error -- this is within the iframe
-          win.embed.addEventListener("ready", () => {
-            win.document.body.setAttribute("data-iframe-is-ready", "true");
+          const element = win.document!.querySelector("metabase-question")!;
+          element.addEventListener("ready", () => {
+            win.document!.body.setAttribute(
+              "data-consumer-event-triggered",
+              "true",
+            );
           });
         });
       },
     });
 
     cy.log("ready event should not be fired before the page loads");
-    cy.get("body").should("not.have.attr", "data-iframe-is-ready", "true");
+    cy.get("body").should(
+      "not.have.attr",
+      "data-consumer-event-triggered",
+      "true",
+    );
 
     cy.wait("@getCardQuery");
 
     cy.log("ready event should be fired after the page loads");
     cy.get("iframe").should("be.visible");
-    cy.get("body").should("have.attr", "data-iframe-is-ready", "true");
+    cy.get("body").should("have.attr", "data-consumer-event-triggered", "true");
 
     cy.log("iframe content should now be loaded");
     frame.within(() => {
@@ -225,8 +206,11 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
 
   it("shows dashboard title when updateSettings({ withTitle: true }) is called", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
-      withTitle: false,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+        withTitle: false,
+      },
     });
 
     cy.wait("@getDashCardQuery");
@@ -239,8 +223,8 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
 
     cy.log("2. call embed.updateSettings to show the title");
     frame.window().then((win) => {
-      // @ts-expect-error -- this is within the iframe
-      win.embed.updateSettings({ withTitle: true });
+      const element = win.document!.querySelector("metabase-dashboard")!;
+      element.setAttribute("with-title", "true");
     });
 
     cy.log("3. dashboard title should now be visible");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/theming.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/theming.cy.spec.ts
@@ -33,8 +33,13 @@ describe("scenarios > embedding > sdk iframe embedding > theming", () => {
 
   it("should apply custom themes", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
-      theme: DARK_THEME,
-      dashboardId: ORDERS_DASHBOARD_ID,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
+      metabaseConfig: {
+        theme: DARK_THEME,
+      },
     });
 
     cy.wait("@getDashboard");
@@ -72,18 +77,23 @@ describe("scenarios > embedding > sdk iframe embedding > theming", () => {
         const DARK_THEME = ${JSON.stringify(DARK_THEME)};
 
         function setLightTheme() {
-          embed.updateSettings({ theme: LIGHT_THEME });
+          defineMetabaseConfig({ theme: LIGHT_THEME });
         }
 
         function setDarkTheme() {
-          embed.updateSettings({ theme: DARK_THEME });
+          defineMetabaseConfig({ theme: DARK_THEME });
         }
       </script>
     `;
 
     const frame = H.loadSdkIframeEmbedTestPage({
-      dashboardId: ORDERS_DASHBOARD_ID,
-      theme: LIGHT_THEME,
+      element: "metabase-dashboard",
+      attributes: {
+        dashboardId: ORDERS_DASHBOARD_ID,
+      },
+      metabaseConfig: {
+        theme: LIGHT_THEME,
+      },
       insertHtml: { beforeEmbed: THEME_SWITCHER_HTML },
     });
 


### PR DESCRIPTION
Closes EMB-653

This moves the tests to use the new api so we can drop MetabaseEmbed in a follow up PR