### PR TITLE
[Semantic Search] Remove disable semantic search filter

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -191,7 +191,7 @@ describe("scenarios > visualizations > table", () => {
   it("should preserve set widths after reordering (VIZ-439)", () => {
     cy.intercept(
       "GET",
-      "/api/search?search_engine=appdb&models=dataset&models=table&table_db_id=*",
+      "/api/search?models=dataset&models=table&table_db_id=*",
     ).as("getSearchResults");
     H.startNewNativeQuestion({
       query: 'select 1 "first_column", 2 "second_column"',

--- a/frontend/src/metabase/api/search.ts
+++ b/frontend/src/metabase/api/search.ts
@@ -10,12 +10,7 @@ export const searchApi = Api.injectEndpoints({
       query: (params) => ({
         method: "GET",
         url: "/api/search",
-        params: {
-          // default FE to using app db for search to so it
-          // can be enabled only in specific features
-          search_engine: "appdb",
-          ...params,
-        },
+        params,
       }),
       providesTags: (response, error, { models }) =>
         provideSearchItemListTags(response?.data ?? [], models),

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
@@ -201,7 +201,6 @@ describe("LinkedEntityPicker", () => {
           expect(urlSearchParamsToObject(urlObject.searchParams)).toEqual({
             context: "entity-picker",
             models: "dashboard",
-            search_engine: "appdb",
             q: typedText,
             filter_items_in_personal_collection: "exclude",
           });
@@ -263,7 +262,6 @@ describe("LinkedEntityPicker", () => {
           expect(urlSearchParamsToObject(urlObject.searchParams)).toEqual({
             context: "entity-picker",
             models: "dashboard",
-            search_engine: "appdb",
             q: typedText,
           });
         });
@@ -330,7 +328,7 @@ describe("LinkedEntityPicker", () => {
             await screen.findByPlaceholderText(/search/i),
             typedText,
           );
-          await userEvent.click(screen.getByText("Everywhere"));
+          await userEvent.click(await screen.findByText("Everywhere"));
 
           expect(
             await screen.findByText(questionSearchResult.name),
@@ -349,7 +347,6 @@ describe("LinkedEntityPicker", () => {
             models: ["card", "dataset"],
             q: typedText,
             filter_items_in_personal_collection: "exclude",
-            search_engine: "appdb",
           });
         });
       });
@@ -407,7 +404,6 @@ describe("LinkedEntityPicker", () => {
           expect(urlSearchParamsToObject(urlObject.searchParams)).toEqual({
             context: "entity-picker",
             models: ["card", "dataset"],
-            search_engine: "appdb",
             q: typedText,
           });
         });

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -78,7 +78,6 @@ export const useCommandPalette = ({
       context: "command-palette",
       include_dashboard_questions: true,
       limit: 20,
-      search_engine: "semantic",
     },
     {
       skip: !debouncedSearchText || !isSearchTypeaheadEnabled,

--- a/frontend/src/metabase/query_builder/components/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -555,7 +555,6 @@ describe("AddToDashSelectDashModal", () => {
       expect(Object.fromEntries(urlObject.searchParams.entries())).toEqual({
         context: "entity-picker",
         models: "dashboard",
-        search_engine: "appdb",
         q: typedText,
         filter_items_in_personal_collection: "only",
       });
@@ -586,7 +585,6 @@ describe("AddToDashSelectDashModal", () => {
       expect(Object.fromEntries(urlObject.searchParams.entries())).toEqual({
         context: "entity-picker",
         models: "dashboard",
-        search_engine: "appdb",
         q: typedText,
       });
     });

--- a/frontend/src/metabase/search/components/SearchSidebar/SearchSidebar.tsx
+++ b/frontend/src/metabase/search/components/SearchSidebar/SearchSidebar.tsx
@@ -1,4 +1,3 @@
-import { t } from "ttag";
 import _ from "underscore";
 
 import { PLUGIN_CONTENT_VERIFICATION } from "metabase/plugins";
@@ -15,7 +14,6 @@ import { SearchFilterKeys } from "metabase/search/constants";
 import type {
   FilterTypeKeys,
   SearchFilterComponent,
-  SearchFilterToggle,
   SearchQueryParamValue,
   URLSearchFilterQueryParams,
 } from "metabase/search/types";
@@ -27,14 +25,6 @@ type SearchSidebarProps = {
 };
 
 export const SearchSidebar = ({ value, onChange }: SearchSidebarProps) => {
-  // TODO: don't ship this to prod
-  const DisableSemanticSearchFilter: SearchFilterToggle = {
-    label: () => t`Disable semantic search`,
-    type: "toggle",
-    fromUrl: (value) => value === "true",
-    toUrl: (value: boolean) => (value ? "true" : null),
-  };
-
   const filterMap: Record<FilterTypeKeys, SearchFilterComponent> = {
     [SearchFilterKeys.Type]: TypeFilter,
     [SearchFilterKeys.CreatedBy]: CreatedByFilter,
@@ -42,7 +32,6 @@ export const SearchSidebar = ({ value, onChange }: SearchSidebarProps) => {
     [SearchFilterKeys.LastEditedBy]: LastEditedByFilter,
     [SearchFilterKeys.LastEditedAt]: LastEditedAtFilter,
     [SearchFilterKeys.Verified]: PLUGIN_CONTENT_VERIFICATION.VerifiedFilter,
-    [SearchFilterKeys.DisableSemanticSearch]: DisableSemanticSearchFilter,
     [SearchFilterKeys.NativeQuery]: NativeQueryFilter,
     [SearchFilterKeys.SearchTrashedItems]: SearchTrashedItemsFilter,
   };
@@ -101,7 +90,6 @@ export const SearchSidebar = ({ value, onChange }: SearchSidebarProps) => {
         {getFilter(SearchFilterKeys.LastEditedAt)}
       </Stack>
       {getFilter(SearchFilterKeys.Verified)}
-      {getFilter(SearchFilterKeys.DisableSemanticSearch)}
       {getFilter(SearchFilterKeys.NativeQuery)}
       {getFilter(SearchFilterKeys.SearchTrashedItems)}
     </Stack>

--- a/frontend/src/metabase/search/constants.ts
+++ b/frontend/src/metabase/search/constants.ts
@@ -9,7 +9,6 @@ export const SearchFilterKeys = {
   LastEditedAt: "last_edited_at",
   NativeQuery: "search_native_query",
   SearchTrashedItems: "archived",
-  DisableSemanticSearch: "disable_semantic_search",
 } as const;
 
 export const enabledSearchTypes: EnabledSearchModel[] = [

--- a/frontend/src/metabase/search/containers/SearchApp.jsx
+++ b/frontend/src/metabase/search/containers/SearchApp.jsx
@@ -49,18 +49,12 @@ function SearchApp({ location }) {
 
   const query = {
     q: searchText,
-    ..._.omit(searchFilters, [
-      SearchFilterKeys.Type,
-      SearchFilterKeys.DisableSemanticSearch,
-    ]),
+    ..._.omit(searchFilters, SearchFilterKeys.Type),
     models: models && (Array.isArray(models) ? models : [models]),
     limit: PAGE_SIZE,
     offset: PAGE_SIZE * page,
     context: SearchContextTypes.SEARCH_APP,
     include_dashboard_questions: true,
-    search_engine: searchFilters[SearchFilterKeys.DisableSemanticSearch]
-      ? "appdb"
-      : "semantic",
   };
 
   const onChangeLocation = useCallback(

--- a/frontend/src/metabase/search/types.ts
+++ b/frontend/src/metabase/search/types.ts
@@ -29,8 +29,6 @@ export type VerifiedFilterProps = true | null;
 export type NativeQueryFilterProps = true | null;
 export type SearchTrashedItemsFilterProps = true | undefined;
 
-export type SemanticSearchFilterProps = true | undefined;
-
 export type SearchFilterPropTypes = {
   [SearchFilterKeys.Type]: TypeFilterProps;
   [SearchFilterKeys.Verified]: VerifiedFilterProps;
@@ -40,7 +38,6 @@ export type SearchFilterPropTypes = {
   [SearchFilterKeys.LastEditedAt]: LastEditedAtFilterProps;
   [SearchFilterKeys.NativeQuery]: NativeQueryFilterProps;
   [SearchFilterKeys.SearchTrashedItems]: SearchTrashedItemsFilterProps;
-  [SearchFilterKeys.DisableSemanticSearch]: SemanticSearchFilterProps;
 };
 
 export type FilterTypeKeys = keyof SearchFilterPropTypes;


### PR DESCRIPTION
### Description

Remove the temp filter for disabling the semantic search feature and make it the default everywhere in the app if it's enabled.

### How to verify

- Search on search page, command palette, and also no things like the entity picker

### Checklist

- [x] Tests have been added/updated to cover changes in this PR