### PR TITLE
[drill-thru] Fix bucketed date ranges in `underlying-records`

### DIFF
--- a/test/metabase/lib/drill_thru/automatic_insights_test.cljc
+++ b/test/metabase/lib/drill_thru/automatic_insights_test.cljc
@@ -82,7 +82,7 @@
             (lib/drill-thru query -1 nil drill)))))
 
 (deftest ^:parallel automatic-insights-apply-test
-  (let [filters [[:= {} [:field {} (meta/id :orders :created-at)] "2023-12-01"]]]
+  (let [filters [[:between {} [:field {} (meta/id :orders :created-at)] "2023-12-01" "2023-12-31"]]]
     (testing "breakouts are turned to filters, aggregations dropped"
       (auto-insights (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                          (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
@@ -109,7 +109,7 @@
                        (lib/breakout (lib/with-temporal-bucket
                                        (meta/field-metadata :orders :created-at)
                                        :month)))
-                   [[:= {} [:field {} (meta/id :orders :created-at)] "2023-12-01"]
+                   [[:between {} [:field {} (meta/id :orders :created-at)] "2023-12-01" "2023-12-31"]
                     [:= {} [:field {} (meta/id :products :category)] "Doohickey"]])))
 
 (deftest ^:parallel automatic-insights-apply-test-3
@@ -129,7 +129,7 @@
                          (lib/breakout (lib/with-temporal-bucket
                                          (meta/field-metadata :orders :created-at)
                                          :month)))
-                     [[:= {} [:field {} (meta/id :orders :created-at)] "2023-12-01"]]))))
+                     [[:between {} [:field {} (meta/id :orders :created-at)] "2023-12-01" "2023-12-31"]]))))
 
 (deftest ^:parallel binned-column-test
   (testing "Automatic insights for a binned column should generate filters for current bin's min/max values"

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -604,7 +604,7 @@
   (testing "date(time) truncation units"
     (are [unit lo hi] (=? [[:between {}
                             [:field {:temporal-unit unit} (meta/id :orders :created-at)]
-                            (str lo) (str hi)]]
+                            lo hi]]
                           (let [created-at (-> (meta/field-metadata :orders :created-at)
                                                (lib/with-temporal-bucket  unit))]
                             (#'lib.drill-thru.underlying-records/filter-clauses-with-possible-bucketing
@@ -617,8 +617,10 @@
       :week    "2024-05-12" "2024-05-18"
       :day     "2024-05-15" "2024-05-15"
       ;; Datetimes
-      :hour    "2024-05-15T12:00:00.000" "2024-05-15T12:59:59.999"
-      :minute  "2024-05-15T12:34:00.000" "2024-05-15T12:34:59.999")))
+      ;; TODO: This CLJ/CLJS difference is dumb and should be fixed in `metabase.util.time`. It's supposed to produce
+      ;; identical results in both environments.
+      :hour    #?(:clj "2024-05-15T12:00:00.000" :cljs "2024-05-15T12:00") "2024-05-15T12:59:59.999"
+      :minute  #?(:clj "2024-05-15T12:34:00.000" :cljs "2024-05-15T12:34") "2024-05-15T12:34:59.999")))
 
 (deftest ^:parallel filter-clauses-with-possible-bucketing-test-extraction-units
   (testing "date(time) extraction units"


### PR DESCRIPTION
Closes #12496.

### Description

Previously `underlying-records` drills were generating `=` filters, rather than
`:between`. The filter chip was correct (eg. `Created At: Week is May 12-18, 2024`)
but the filter widget was messed up (showing `On` rather than `Between`).

Turning a truncated unit like `:week` into a `:between` filter makes
both the filter chip and widget work correctly.

### How to verify

Follow the steps in #12496.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
