### PR TITLE
Fix nested array queries

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -617,11 +617,17 @@
   [_ rs _ i]
   (get-object-of-class-thunk rs i java.time.LocalDateTime))
 
+(defn- arrays->vectors
+  [obj]
+  (if (.isArray (class obj))
+    (mapv arrays->vectors obj)
+    obj))
+
 (defmethod read-column-thunk [:sql-jdbc Types/ARRAY]
   [_driver ^java.sql.ResultSet rs _rsmeta ^Integer i]
   (fn []
-    (when-let [obj (.getObject rs i)]
-      (vec (.getArray ^java.sql.Array obj)))))
+    (when-let [sql-arr (.getObject rs i)]
+      (arrays->vectors (.getArray ^java.sql.Array sql-arr)))))
 
 (defmethod read-column-thunk [:sql-jdbc Types/TIMESTAMP_WITH_TIMEZONE]
   [_ rs _ i]

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -23,6 +23,7 @@
    [metabase.settings.core :as setting]
    [metabase.test :as mt]
    [metabase.test.data.env :as tx.env]
+   [metabase.test.data.interface :as tx]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli.registry :as mr]))
@@ -1363,3 +1364,62 @@
              (h2x/unwrap-typed-honeysql-form
               (sql.qp/coerce-integer :sql
                                      (h2x/with-database-type-info value type))))))))
+
+(defmulti native-nested-array-query
+  {:arglists '([driver])}
+  tx/dispatch-on-driver-with-test-extensions
+  :hierarchy #'driver/hierarchy)
+
+(defmethod native-nested-array-query :default
+  [_driver]
+  "select array[array[array['a', 'b'], array['c', 'd'] ], array[array['w', 'x'], array['y', 'z'] ]];")
+
+(doseq [driver [:mysql :sqlite]]
+  (defmethod native-nested-array-query driver
+    [_driver]
+    "select json_array(json_array(json_array('a', 'b'), json_array('c', 'd')), json_array(json_array('w', 'x'), json_array('y', 'z')));"))
+
+(doseq [driver [:redshift :databricks]]
+  (defmethod native-nested-array-query driver
+    [_driver]
+    "select array(array(array('a', 'b'), array('c', 'd')), array(array('w', 'x'), array('y', 'z')));"))
+
+(defmethod native-nested-array-query :snowflake
+  [_driver]
+  "select array_construct(array_construct(array_construct('a', 'b'), array_construct('c', 'd')), array_construct(array_construct('w', 'x'), array_construct('y', 'z')));")
+
+(defmulti native-nested-array-results
+  {:arglists '([driver])}
+  tx/dispatch-on-driver-with-test-extensions
+  :hierarchy #'driver/hierarchy)
+
+(defmethod native-nested-array-results :default
+  [_driver]
+  [[["a" "b"] ["c" "d"]] [["w" "x"] ["y" "z"]]])
+
+(doseq [driver [:sqlite :databricks :redshift]]
+  (defmethod native-nested-array-results driver
+    [_driver]
+    "[[[\"a\",\"b\"],[\"c\",\"d\"]],[[\"w\",\"x\"],[\"y\",\"z\"]]]"))
+
+(defmethod native-nested-array-results :mysql
+  [_driver]
+  "[[[\"a\", \"b\"], [\"c\", \"d\"]], [[\"w\", \"x\"], [\"y\", \"z\"]]]")
+
+(defmethod native-nested-array-results :snowflake
+  [_driver]
+  "[\n  [\n    [\n      \"a\",\n      \"b\"\n    ],\n    [\n      \"c\",\n      \"d\"\n    ]\n  ],\n  [\n    [\n      \"w\",\n      \"x\"\n    ],\n    [\n      \"y\",\n      \"z\"\n    ]\n  ]\n]")
+
+(doseq [driver [:postgres :vertica :mysql :sqlite :redshift :databricks :snowflake]]
+  (defmethod driver/database-supports? [driver :test/nested-arrays]
+    [_driver _feature _database]
+    true))
+
+(deftest ^:parallel nested-array-query-test
+  (testing "A nested array query should be returned in a readable format"
+    (mt/test-drivers (mt/driver-select {:+features [:test/nested-arrays]})
+      (mt/dataset test-data
+        (is (= [[(native-nested-array-results driver/*driver*)]]
+               (->> (mt/native-query {:query (native-nested-array-query driver/*driver*)})
+                    mt/process-query
+                    mt/rows)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61819

### Description

We convert SQL arrays to vectors to ensure that they're displayed and cached correctly. But we were just converting them to vectors and assuming they were 1D. Change is to recursively convert the arrays to vectors to handle nested SQL arrays. 

### How to verify

1. Run this query from the native editor:
`select array[array[array['a', 'b'], array['c', 'd'] ], array[array['w', 'x'], array['y', 'z']]];`
2. You should get back `[[["a","b"],["c","d"]],[["w","x"],["y","x"]]]`

### Demo

https://github.com/user-attachments/assets/ccf85ee8-1b65-441c-ae7d-4e779b6ede1c

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
