### PR TITLE
Docs: fix examples in timezone docs

### DIFF
--- a/docs/questions/query-builder/expressions/converttimezone.md
+++ b/docs/questions/query-builder/expressions/converttimezone.md
@@ -135,8 +135,8 @@ The Metabase report time zone only applies to `timestamp with time zone` or `tim
 
 | Raw timestamp in your database           | Data type                     | Report time zone | Displayed as           |
 | ---------------------------------------- | ----------------------------- | ---------------- | ---------------------- |
-| `2022-12-28T12:00:00 AT TIME ZONE 'CST'` | `timestamp with time zone`    | 'Canada/Eastern' | Dec 28, 2022, 7:00 AM  |
-| `2022-12-28T12:00:00-06:00`              | `timestamp with offset`       | 'Canada/Eastern' | Dec 28, 2022, 7:00 AM  |
+| `2022-12-28T12:00:00 AT TIME ZONE 'CST'` | `timestamp with time zone`    | 'Canada/Eastern' | Dec 28, 2022, 1:00 PM  |
+| `2022-12-28T12:00:00-06:00`              | `timestamp with offset`       | 'Canada/Eastern' | Dec 28, 2022, 1:00 PM  |
 | `2022-12-28T12:00:00`                    | `timestamp without time zone` | 'Canada/Eastern' | Dec 28, 2022, 12:00 AM |
 
 The Metabase report time zone will not apply to the output of a `convertTimezone` expression. For example:


### PR DESCRIPTION
Fixes docs timestamp example as per this feedback:
https://discourse.metabase.com/t/timezone-documentation-seems-incorrect/254292