### PR TITLE
Allow offset as filter variable value

### DIFF
--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -250,9 +250,9 @@
 
 (defmethod normalize-mbql-clause-tokens :offset
   [[_tag opts expr n, :as clause]]
-  {:pre [(= (count clause) 4)]}
-  (let [opts (lib.normalize/normalize :metabase.lib.schema.common/options (or opts {}))]
-    [:offset opts (normalize-tokens expr nil) n]))
+  (when (= (count clause) 4)
+    (let [opts (lib.normalize/normalize :metabase.lib.schema.common/options (or opts {}))]
+      [:offset opts (normalize-tokens expr nil) n])))
 
 (defmethod normalize-mbql-clause-tokens :default
   ;; MBQL clauses by default are recursively normalized.

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -1254,3 +1254,18 @@
                 {:card-id 1
                  :query   "SELECT * FROM table WHERE x LIKE ?"
                  :params  ["G%"]})}))))))
+
+(deftest ^:parallel offset-as-filter-variable-value-test
+  (let [query "select 1 where {{variable}} is not null"]
+    (is (= [[1]]
+           (mt/rows
+            (qp/process-query
+             {:database (mt/id)
+              :type :native
+              :native {:query query
+                       :template-tags {"variable" {:name         "variable"
+                                                   :display_name "Variable"
+                                                   :type         "text"}}}
+              :parameters [{:type   :string/=
+                            :value  ["offset"]
+                            :target [:variable [:template-tag "variable"]]}]}))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61787

### Description

Using offset as a filter variable value doesn't work. It's because when we're normalizing mbql clause tokens we are asserting that the offset value is from the `Offset` expression function (clause length 4) rather than a filter variable (length 1)

### How to verify

1. Run this query on a postgres DB from the native editor:
`SELECT 1 WHERE {{variable}} IS NOT NULL;`
2. Set the variable value as offset
3. You should get 1 as a result instead of an error

### Demo

https://github.com/user-attachments/assets/4cee919d-b7f9-4364-a4de-042ae41785c3

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
