### PR TITLE
fix visualizer cards don't have dashcard description setting

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -345,6 +345,28 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     });
   });
 
+  it("should allow adding description to a visualizer dashcard (metabase#61457)", () => {
+    createDashboardWithVisualizerDashcards();
+    H.editDashboard();
+
+    H.showDashcardVisualizerModal(0);
+    H.modal().within(() => {
+      cy.findByText("Settings").click();
+      cy.findByTestId("card.description").should("have.value", "");
+      cy.findByTestId("card.description").type("My description").blur();
+    });
+
+    H.saveDashcardVisualizerModal();
+    H.saveDashboard();
+
+    H.getDashboardCard(0)
+      .realHover()
+      .within(() => {
+        cy.icon("info").realHover();
+      });
+    H.tooltip().findByText("My description").should("exist");
+  });
+
   it("should start in a pristine state and update dirtyness accordingly", () => {
     createDashboardWithVisualizerDashcards();
     H.editDashboard();

--- a/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
+++ b/frontend/src/metabase/visualizer/components/VizSettingsSidebar/VizSettingsSidebar.tsx
@@ -14,7 +14,7 @@ import {
 import { updateSettings } from "metabase/visualizer/visualizer.slice";
 import type { VisualizationSettings } from "metabase-types/api";
 
-const HIDDEN_SETTING_WIDGETS = ["card.title", "card.description"];
+const HIDDEN_SETTING_WIDGETS = ["card.title"];
 
 export function VizSettingsSidebar({ className }: { className?: string }) {
   const series = useSelector(getVisualizerRawSeries);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61457

### Description

Fixes visualizer cards can't have a description as there is no such viz setting in the Visualizer modal.

### Demo

<img width="1601" height="581" alt="Screenshot 2025-08-11 at 12 16 27 AM" src="https://github.com/user-attachments/assets/7d3ed812-be8c-4824-aa18-02b1443d0590" />

<img width="619" height="385" alt="Screenshot 2025-08-11 at 12 16 33 AM" src="https://github.com/user-attachments/assets/15d401c8-59ac-44ee-ab41-30a0e3bc80ec" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
