### PR TITLE
Use dimensions param in OpenAI api calls

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -208,7 +208,7 @@
   [{:keys [model-name] :as _embedding-model}]
   (boolean
    (when (string? model-name)
-     (re-find #"^text-embedding-3" model-name))))
+     (str/starts-with? model-name "text-embedding-3"))))
 
 (defn- openai-get-embeddings-batch
   [{:keys [model-name vector-dimensions] :as embedding-model} texts]


### PR DESCRIPTION
After recent change for openani models to work the MB_EE_EMBEDDING_MODEL_DIMENSIONS has to match defaults of model used in a request.

This PR adds dimensions param to that request so returned embeddings sizes correspond to that number.

The dimensions parameter [is supported](https://platform.openai.com/docs/api-reference/embeddings/create) on `text-embedding-3` and newer. Change was tested manually. I see no place in the code that summarizes supported models. If we decide for that in the future we should add tests and maybe extend `supported-dimensions?` accordingly.