### PR TITLE
Prevent configuration of disabled  database-local settings

### DIFF
--- a/src/metabase/actions/settings.clj
+++ b/src/metabase/actions/settings.clj
@@ -5,18 +5,18 @@
 
 (setting/defsetting database-enable-actions
   (i18n/deferred-tru "Whether to enable Actions for a specific Database.")
-  :default          false
-  :database-feature :actions
-  :type             :boolean
-  :visibility       :public
-  :database-local   :only)
+  :default        false
+  :driver-feature :actions
+  :type           :boolean
+  :visibility     :public
+  :database-local :only)
 
 (setting/defsetting database-enable-table-editing
   (i18n/deferred-tru "Whether to enable table data editing for a specific Database.")
-  :default          false
-  :feature          :table-data-editing
-  :database-feature :actions/data-editing
-  :type             :boolean
-  :visibility       :public
-  :database-local   :only
-  :export?          true)
+  :default        false
+  :feature        :table-data-editing
+  :driver-feature :actions/data-editing
+  :type           :boolean
+  :visibility     :public
+  :database-local :only
+  :export?        true)

--- a/src/metabase/actions/settings.clj
+++ b/src/metabase/actions/settings.clj
@@ -5,17 +5,18 @@
 
 (setting/defsetting database-enable-actions
   (i18n/deferred-tru "Whether to enable Actions for a specific Database.")
-  :default false
-  :type :boolean
-  :visibility :public
-  :database-local :only)
+  :default          false
+  :database-feature :actions
+  :type             :boolean
+  :visibility       :public
+  :database-local   :only)
 
 (setting/defsetting database-enable-table-editing
   (i18n/deferred-tru "Whether to enable table data editing for a specific Database.")
-  :default false
-  ;; TODO should only allow being enabled? if the driver supports actions/data-editing
-  :feature :table-data-editing
-  :type :boolean
-  :visibility :public
-  :database-local :only
-  :export? true)
+  :default          false
+  :feature          :table-data-editing
+  :database-feature :actions/data-editing
+  :type             :boolean
+  :visibility       :public
+  :database-local   :only
+  :export?          true)

--- a/src/metabase/settings/core.clj
+++ b/src/metabase/settings/core.clj
@@ -111,6 +111,7 @@
   user-readable-values-map
   uuid-nonce-base
   validate-settings-formatting!
+  validate-settable-for-db!
   writable-settings]
  [metabase.settings.models.setting.cache
   cache-update-check-interval-ms

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -230,7 +230,7 @@
 
    ;; If non-nil, determines the database driver feature required for this setting. This is only valid for database-local
    ;; settings. If the database driver doesn't support the required feature, setting this will throw an exception.
-   [:database-feature [:maybe :keyword]]])
+   [:driver-feature [:maybe :keyword]]])
 
 (defonce ^{:doc "Map of loaded defsettings"}
   registered-settings
@@ -881,13 +881,13 @@
 (defn validate-settable-for-db!
   "Check whether the given setting can be set for the given database."
   [setting-definition-or-name database driver-supports?]
-  (let [{:keys [database-feature] :as setting} (resolve-setting setting-definition-or-name)
+  (let [{:keys [driver-feature] :as setting} (resolve-setting setting-definition-or-name)
         s-name (setting-name setting)]
     (validate-settable! setting)
-    (when (and database-feature (not (driver-supports? database database-feature)))
-      (throw (ex-info (tru "Setting {0} requires driver feature {1}, but the database does not support it" s-name database-feature)
+    (when (and driver-feature (not (driver-supports? database driver-feature)))
+      (throw (ex-info (tru "Setting {0} requires driver feature {1}, but the database does not support it" s-name driver-feature)
                       {:setting s-name
-                       :required-feature database-feature
+                       :required-feature driver-feature
                        :database-id (:id database)})))))
 
 (defn set!
@@ -974,7 +974,7 @@
                  :feature            nil
                  :database-local     :never
                  :user-local         :never
-                 :database-feature   nil
+                 :driver-feature   nil
                  :deprecated         nil
                  :enabled?           nil
                  :can-read-from-env? true
@@ -1017,8 +1017,8 @@
         (throw (ex-info (tru "Setting {0} uses both :enabled? and :feature options, which are mutually exclusive"
                              setting-name)
                         {:setting setting})))
-      (when (and (:database-feature setting) (not (allows-database-local-values? setting)))
-        (throw (ex-info (tru "Setting {0} has a :database-feature but does not allow database-local values"
+      (when (and (:driver-feature setting) (not (allows-database-local-values? setting)))
+        (throw (ex-info (tru "Setting {0} has a :driver-feature but does not allow database-local values"
                              setting-name)
                         {:setting setting})))
       (swap! registered-settings assoc setting-name <>))))
@@ -1202,7 +1202,7 @@
   The ability of this Setting to be /Database-local/. Valid values are `:only`, `:allowed`, and `:never`. Default:
   `:never`. See docstring for [[metabase.settings.models.setting]] for more information.
 
-  ###### `:database-feature`
+  ###### `:driver-feature`
 
   If non-nil, determines the database driver feature required for this setting. This is only valid for database-local
   settings (those with `:database-local` set to `:only` or `:allowed`). When setting a database-local setting, the

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -876,7 +876,7 @@
        (throw (ex-info (tru "You do not have access to the setting {0}" s-name) setting)))
      (when-not bypass-read-only?
        (when (= setter :none)
-         (throw (UnsupportedOperationException. ^String (tru "You cannot set {0}; it is a read-only setting." s-name))))))))
+         (throw (UnsupportedOperationException. (tru "You cannot set {0}; it is a read-only setting." s-name))))))))
 
 (defn validate-settable-for-db!
   "Check whether the given setting can be set for the given database."

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -1017,8 +1017,8 @@
         (throw (ex-info (tru "Setting {0} uses both :enabled? and :feature options, which are mutually exclusive"
                              setting-name)
                         {:setting setting})))
-      (when (and (:driver-feature setting) (not (allows-database-local-values? setting)))
-        (throw (ex-info (tru "Setting {0} has a :driver-feature but does not allow database-local values"
+      (when (and (:driver-feature setting) (not (database-local-only? setting)))
+        (throw (ex-info (tru "Setting {0} requires a :driver-feature but is not limited to only database-local values."
                              setting-name)
                         {:setting setting})))
       (swap! registered-settings assoc setting-name <>))))
@@ -1204,9 +1204,9 @@
 
   ###### `:driver-feature`
 
-  If non-nil, determines the database driver feature required for this setting. This is only valid for database-local
-  settings (those with `:database-local` set to `:only` or `:allowed`). When setting a database-local setting, the
-  system will check if the database driver supports the specified feature. If not, an exception will be thrown.
+  If non-nil, determines the database driver feature required to use this setting. This is only valid for database-local
+  settings (those with `:database-local` set to `:only`). When setting a database-local setting, the system will check
+  if the database driver supports the specified feature. If not, an exception will be thrown.
 
   ###### `:user-local`
 

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -1018,7 +1018,7 @@
                              setting-name)
                         {:setting setting})))
       (when (and (:driver-feature setting) (not (database-local-only? setting)))
-        (throw (ex-info (tru "Setting {0} requires a :driver-feature but is not limited to only database-local values."
+        (throw (ex-info (tru "Setting {0} requires a :driver-feature, but is not limited to only database-local values."
                              setting-name)
                         {:setting setting})))
       (swap! registered-settings assoc setting-name <>))))

--- a/src/metabase/warehouses/api.clj
+++ b/src/metabase/warehouses/api.clj
@@ -25,7 +25,7 @@
    [metabase.request.core :as request]
    [metabase.sample-data.core :as sample-data]
    [metabase.secrets.core :as secret]
-   [metabase.settings.models.setting :as setting]
+   [metabase.settings.core :as setting]
    [metabase.sync.core :as sync]
    [metabase.sync.schedules :as sync.schedules]
    [metabase.sync.util :as sync-util]

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -1039,31 +1039,32 @@
 
 (defsetting ^:private test-driver-feature-only-setting
   (deferred-tru "test Setting")
-  :database-local   :only
+  :database-local :only
   :driver-feature :actions
-  :encryption       :when-encryption-key-set)
-
-(defsetting ^:private test-driver-feature-allowed-setting
-  (deferred-tru "test Setting")
-  :database-local   :allowed
-  :driver-feature :actions/data-editing
-  :encryption       :when-encryption-key-set)
+  :encryption     :when-encryption-key-set)
 
 (deftest driver-feature-validation-test
   (testing "A setting with :driver-feature must be database-local"
     (is (thrown-with-msg?
          Throwable
-         #"Setting :test-driver-feature-non-local-setting has a :driver-feature but does not allow database-local values"
+         #"Setting :test-driver-feature-non-local-setting requires a :driver-feature but is not limited to only database-local values."
          (defsetting test-driver-feature-non-local-setting
            (deferred-tru "test Setting")
            :driver-feature :actions
-           :encryption :when-encryption-key-set))))
-
-  (testing "A setting with :driver-feature and :database-local :only should be valid"
-    (is (some? test-driver-feature-only-setting)))
+           :encryption     :when-encryption-key-set))))
 
   (testing "A setting with :driver-feature and :database-local :allowed should be valid"
-    (is (some? test-driver-feature-allowed-setting))))
+    (is (thrown-with-msg?
+         Throwable
+         #"Setting :test-driver-feature-allowed-setting requires a :driver-feature but is not limited to only database-local values."
+         (defsetting test-driver-feature-allowed-setting
+           (deferred-tru "test Setting")
+           :database-local :allowed
+           :driver-feature :actions/data-editing
+           :encryption     :when-encryption-key-set))))
+
+  (testing "A setting with :driver-feature and :database-local :only should be valid"
+    (is (some? test-driver-feature-only-setting))))
 
 (deftest validate-settable-for-db-test
   (testing "validate-settable-for-db! validates database feature requirements"

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -1037,38 +1037,38 @@
 
 ;;; ------------------------------------------------ Database-feature Settings ----------------------------------------
 
-(defsetting ^:private test-database-feature-only-setting
+(defsetting ^:private test-driver-feature-only-setting
   (deferred-tru "test Setting")
   :database-local   :only
-  :database-feature :actions
+  :driver-feature :actions
   :encryption       :when-encryption-key-set)
 
-(defsetting ^:private test-database-feature-allowed-setting
+(defsetting ^:private test-driver-feature-allowed-setting
   (deferred-tru "test Setting")
   :database-local   :allowed
-  :database-feature :actions/data-editing
+  :driver-feature :actions/data-editing
   :encryption       :when-encryption-key-set)
 
-(deftest database-feature-validation-test
-  (testing "A setting with :database-feature must be database-local"
+(deftest driver-feature-validation-test
+  (testing "A setting with :driver-feature must be database-local"
     (is (thrown-with-msg?
          Throwable
-         #"Setting :test-database-feature-non-local-setting has a :database-feature but does not allow database-local values"
-         (defsetting test-database-feature-non-local-setting
+         #"Setting :test-driver-feature-non-local-setting has a :driver-feature but does not allow database-local values"
+         (defsetting test-driver-feature-non-local-setting
            (deferred-tru "test Setting")
-           :database-feature :actions
+           :driver-feature :actions
            :encryption :when-encryption-key-set))))
 
-  (testing "A setting with :database-feature and :database-local :only should be valid"
-    (is (some? test-database-feature-only-setting)))
+  (testing "A setting with :driver-feature and :database-local :only should be valid"
+    (is (some? test-driver-feature-only-setting)))
 
-  (testing "A setting with :database-feature and :database-local :allowed should be valid"
-    (is (some? test-database-feature-allowed-setting))))
+  (testing "A setting with :driver-feature and :database-local :allowed should be valid"
+    (is (some? test-driver-feature-allowed-setting))))
 
 (deftest validate-settable-for-db-test
   (testing "validate-settable-for-db! validates database feature requirements"
     (let [database                       {:id 1, :engine :h2}
-          setting-with-driver-feature    :test-database-feature-only-setting
+          setting-with-driver-feature    :test-driver-feature-only-setting
           setting-without-driver-feature :test-database-local-allowed-setting
           driver-supports-everything?    (constantly true)
           driver-supports-nothing?       (constantly false)]
@@ -1079,10 +1079,10 @@
       (testing "should throw when driver does not support required feature"
         (is (thrown-with-msg?
              ExceptionInfo
-             #"Setting test-database-feature-only-setting requires driver feature :actions, but the database does not support it"
+             #"Setting test-driver-feature-only-setting requires driver feature :actions, but the database does not support it"
              (setting/validate-settable-for-db! setting-with-driver-feature database driver-supports-nothing?))))
 
-      (testing "should succeed for settings without database-feature requirement"
+      (testing "should succeed for settings without driver-feature requirement"
         (is (nil? (setting/validate-settable-for-db! setting-without-driver-feature database driver-supports-nothing?)))))))
 
 (deftest identity-hash-test

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -1044,26 +1044,26 @@
   :encryption     :when-encryption-key-set)
 
 (deftest driver-feature-validation-test
-  (testing "A setting with :driver-feature must be database-local"
+  (testing "A setting with :driver-feature must be :database-local"
     (is (thrown-with-msg?
          Throwable
-         #"Setting :test-driver-feature-non-local-setting requires a :driver-feature but is not limited to only database-local values."
+         #"Setting :test-driver-feature-non-local-setting requires a :driver-feature, but is not limited to only database-local values."
          (defsetting test-driver-feature-non-local-setting
            (deferred-tru "test Setting")
            :driver-feature :actions
            :encryption     :when-encryption-key-set))))
 
-  (testing "A setting with :driver-feature and :database-local :allowed should be valid"
+  (testing "Having :database-local :allowed is not enough"
     (is (thrown-with-msg?
          Throwable
-         #"Setting :test-driver-feature-allowed-setting requires a :driver-feature but is not limited to only database-local values."
+         #"Setting :test-driver-feature-allowed-setting requires a :driver-feature, but is not limited to only database-local values."
          (defsetting test-driver-feature-allowed-setting
-           (deferred-tru "test Setting")
+           (deferred-tru "test Setting 2")
            :database-local :allowed
            :driver-feature :actions/data-editing
            :encryption     :when-encryption-key-set))))
 
-  (testing "A setting with :driver-feature and :database-local :only should be valid"
+  (testing "Having :database-local :only is OK"
     (is (some? test-driver-feature-only-setting))))
 
 (deftest validate-settable-for-db-test

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -19,7 +19,9 @@
    [metabase.util.encryption-test :as encryption-test]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (clojure.lang ExceptionInfo)))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -1032,6 +1034,56 @@
            :user-local     :allowed
            :database-local :allowed
            :encryption     :when-encryption-key-set)))))
+
+;;; ------------------------------------------------ Database-feature Settings ----------------------------------------
+
+(defsetting ^:private test-database-feature-only-setting
+  (deferred-tru "test Setting")
+  :database-local   :only
+  :database-feature :actions
+  :encryption       :when-encryption-key-set)
+
+(defsetting ^:private test-database-feature-allowed-setting
+  (deferred-tru "test Setting")
+  :database-local   :allowed
+  :database-feature :actions/data-editing
+  :encryption       :when-encryption-key-set)
+
+(deftest database-feature-validation-test
+  (testing "A setting with :database-feature must be database-local"
+    (is (thrown-with-msg?
+         Throwable
+         #"Setting :test-database-feature-non-local-setting has a :database-feature but does not allow database-local values"
+         (defsetting test-database-feature-non-local-setting
+           (deferred-tru "test Setting")
+           :database-feature :actions
+           :encryption :when-encryption-key-set))))
+
+  (testing "A setting with :database-feature and :database-local :only should be valid"
+    (is (some? test-database-feature-only-setting)))
+
+  (testing "A setting with :database-feature and :database-local :allowed should be valid"
+    (is (some? test-database-feature-allowed-setting))))
+
+(deftest validate-settable-for-db-test
+  (testing "validate-settable-for-db! validates database feature requirements"
+    (let [database                       {:id 1, :engine :h2}
+          setting-with-driver-feature    :test-database-feature-only-setting
+          setting-without-driver-feature :test-database-local-allowed-setting
+          driver-supports-everything?    (constantly true)
+          driver-supports-nothing?       (constantly false)]
+
+      (testing "should succeed when driver supports required feature"
+        (is (nil? (setting/validate-settable-for-db! setting-with-driver-feature database driver-supports-everything?))))
+
+      (testing "should throw when driver does not support required feature"
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"Setting test-database-feature-only-setting requires driver feature :actions, but the database does not support it"
+             (setting/validate-settable-for-db! setting-with-driver-feature database driver-supports-nothing?))))
+
+      (testing "should succeed for settings without database-feature requirement"
+        (is (nil? (setting/validate-settable-for-db! setting-without-driver-feature database driver-supports-nothing?)))))))
 
 (deftest identity-hash-test
   (testing "Settings are hashed based on the key"


### PR DESCRIPTION
This adds write-protection for the action-related database settings.

This also lays the ground work for removing the duplicate logic from the FE.