### PR TITLE
Improved fallback logic & prometheus metrics for semantic search

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -8,7 +8,6 @@
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase.analytics.core :as analytics]
-   [metabase.analytics.prometheus :as prometheus]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.search.engine :as search.engine]
    [metabase.util.log :as log]
@@ -38,10 +37,10 @@
   :feature :semantic-search
   [search-ctx]
   (try
-    (let [{:keys [results filtered-count]} (semantic.pgvector-api/query
-                                            (semantic.env/get-pgvector-datasource!)
-                                            (semantic.env/get-index-metadata)
-                                            search-ctx)
+    (let [{:keys [results filtered-count]}
+          (semantic.pgvector-api/query (semantic.env/get-pgvector-datasource!)
+                                       (semantic.env/get-index-metadata)
+                                       search-ctx)
           final-count (count results)
           threshold (semantic.settings/semantic-search-min-results-threshold)]
       (if (or (>= final-count threshold)
@@ -60,7 +59,7 @@
             (take (semantic.settings/semantic-search-results-limit) deduped-results)))))
     (catch Exception e
       (log/error e "Error executing semantic search")
-      [])))
+      (throw (ex-info "Error executing semantic search" {:type :semantic-search-error} e)))))
 
 (defenterprise update-index!
   "Enterprise implementation of semantic index updating."

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.settings :as semantic.settings]
+   [metabase.analytics.core :as analytics]
    [metabase.analytics.prometheus :as prometheus]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.search.engine :as search.engine]
@@ -51,8 +52,8 @@
         (let [fallback (fallback-engine)]
           (log/debugf "Semantic search returned %d final results (< %d) from %d raw results, supplementing with %s search"
                       final-count threshold filtered-count fallback)
-          (prometheus/inc! :metabase-search/semantic-fallback-triggered)
-          (prometheus/observe! :metabase-search/semantic-fallback-results final-count)
+          (analytics/inc! :metabase-search/semantic-fallback-triggered)
+          (analytics/observe! :metabase-search/semantic-results-before-fallback final-count)
           (let [fallback-results (search.engine/results (assoc search-ctx :search-engine fallback))
                 combined-results (concat results fallback-results)
                 deduped-results  (m/distinct-by (juxt :model :id) combined-results)]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -38,9 +38,9 @@
   [search-ctx]
   (try
     (let [{:keys [results filtered-count]} (semantic.pgvector-api/query
-                                            (semantic.env/get-pgvector-datasource!
-                                             (semantic.env/get-index-metadata)
-                                             search-ctx))
+                                            (semantic.env/get-pgvector-datasource!)
+                                            (semantic.env/get-index-metadata)
+                                            search-ctx)
           final-count (count results)
           threshold (semantic.settings/semantic-search-min-results-threshold)]
       (if (or (>= final-count threshold)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -31,9 +31,8 @@
    (semantic.settings/semantic-search-enabled)))
 
 (defenterprise results
-  "Enterprise implementation of semantic search results with improved fallback logic.
-  Falls back to appdb search only when semantic search finds few raw results AND
-  there are some filtered results (indicating the search found relevant content)."
+  "Enterprise implementation of semantic search results with improved fallback logic. Falls back to appdb search only
+  when semantic search returns too few results and some results were filtered out (e.g. due to permission checks)."
   :feature :semantic-search
   [search-ctx]
   (try

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -36,9 +36,9 @@
   [search-ctx]
   (try
     (let [semantic-results (semantic.pgvector-api/query
-                            (semantic.env/get-pgvector-datasource!
-                             (semantic.env/get-index-metadata)
-                             search-ctx))
+                            (semantic.env/get-pgvector-datasource!)
+                            (semantic.env/get-index-metadata)
+                            search-ctx)
           result-count (count semantic-results)]
       (if (>= result-count (semantic.settings/semantic-search-min-results-threshold))
         semantic-results

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -673,12 +673,12 @@
 
 (defn query-index
   "Query the index for documents similar to the search string.
-  Returns a map with :results and :filtered-count."
+  Returns a map with :results and :raw-count."
   [db index search-context]
   (let [{:keys [embedding-model]} index
         search-string (:search-string search-context)]
     (if (str/blank? search-string)
-      {:results [] :filtered-count 0}
+      {:results [] :raw-count 0}
       (let [timer (u/start-timer)
 
             embedding (embedding/get-embedding embedding-model search-string)
@@ -723,7 +723,7 @@
           (jdbc/execute! db (sql-format-quoted query)))
 
         {:results filtered-results
-         :filtered-count (count raw-results)}))))
+         :raw-count (count raw-results)}))))
 
 (comment
   (def embedding-model (embedding/get-configured-model))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -672,11 +672,13 @@
         filtered-docs))))
 
 (defn query-index
-  "Query the index for documents similar to the search string."
+  "Query the index for documents similar to the search string.
+  Returns a map with :results and :filtered-count."
   [db index search-context]
   (let [{:keys [embedding-model]} index
         search-string (:search-string search-context)]
-    (when-not (str/blank? search-string)
+    (if (str/blank? search-string)
+      {:results [] :filtered-count 0}
       (let [timer (u/start-timer)
 
             embedding (embedding/get-embedding embedding-model search-string)
@@ -720,7 +722,8 @@
         (comment
           (jdbc/execute! db (sql-format-quoted query)))
 
-        filtered-results))))
+        {:results filtered-results
+         :filtered-count (count raw-results)}))))
 
 (comment
   (def embedding-model (embedding/get-configured-model))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/pgvector_api.clj
@@ -70,7 +70,7 @@
       (throw (ex-info "No active semantic search index found" {:index-metadata index-metadata}))))
 
 (defn query
-  "Executes a semantic search query against the active index.
+  "Executes a semantic search query against the active index. Returns results and metadata about filtering.
   Requires init-semantic-search! to have been called first to establish active index, otherwise an exception will be thrown."
   [pgvector index-metadata search-context]
   (let [{:keys [index]} (ensure-active-index-state pgvector index-metadata)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -35,7 +35,7 @@
                             (fn [& _]
                               (reset! semantic-called? true)
                               {:results [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0}]
-                               :filtered-count 0})
+                               :raw-count 0})
                             appdb/results
                             (fn [_]
                               (reset! appdb-called? true)
@@ -53,7 +53,7 @@
                             (fn [& _]
                               (reset! semantic-called? true)
                               {:results [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0.8}]
-                               :filtered-count 0})
+                               :raw-count 0})
                             appdb/results
                             (fn [_]
                               (reset! appdb-called? true)
@@ -73,9 +73,9 @@
   [semantic-results appdb-results thunk]
   (with-redefs [semantic.pgvector-api/query (fn [_pgvector _index-metadata _search-ctx]
                                               {:results semantic-results
-                                               ;; Set filtered-count to a non-zero value to ensure fallback logic is
+                                               ;; Set raw-count to a non-zero value to ensure fallback logic is
                                                ;; triggered
-                                               :filtered-count 1})
+                                               :raw-count 1})
                 search.engine/results (fn [ctx]
                                         (case (:search-engine ctx)
                                           :search.engine/appdb (if (fn? appdb-results)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -35,7 +35,7 @@
                             (fn [& _]
                               (reset! semantic-called? true)
                               {:results [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0}]
-                               :filtered-count 1})
+                               :filtered-count 0})
                             appdb/results
                             (fn [_]
                               (reset! appdb-called? true)
@@ -53,7 +53,7 @@
                             (fn [& _]
                               (reset! semantic-called? true)
                               {:results [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0.8}]
-                               :filtered-count 1})
+                               :filtered-count 0})
                             appdb/results
                             (fn [_]
                               (reset! appdb-called? true)
@@ -73,6 +73,8 @@
   [semantic-results appdb-fn thunk]
   (with-redefs [semantic.pgvector-api/query (fn [_pgvector _index-metadata _search-ctx]
                                               {:results semantic-results
+                                               ;; Set filtered-count to a non-zero value to ensure fallback logic is
+                                               ;; triggered
                                                :filtered-count 1})
                 search.engine/supported-engine? (constantly true)
                 search.engine/results (fn [ctx]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -35,7 +35,7 @@
                             (fn [& _]
                               (reset! semantic-called? true)
                               {:results [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0}]
-                               :filtered-count 0})
+                               :filtered-count 1})
                             appdb/results
                             (fn [_]
                               (reset! appdb-called? true)
@@ -53,7 +53,7 @@
                             (fn [& _]
                               (reset! semantic-called? true)
                               {:results [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0.8}]
-                               :filtered-count 0})
+                               :filtered-count 1})
                             appdb/results
                             (fn [_]
                               (reset! appdb-called? true)
@@ -73,7 +73,7 @@
   [semantic-results appdb-fn thunk]
   (with-redefs [semantic.pgvector-api/query (fn [_pgvector _index-metadata _search-ctx]
                                               {:results semantic-results
-                                               :filtered-count 0})
+                                               :filtered-count 1})
                 search.engine/supported-engine? (constantly true)
                 search.engine/results (fn [ctx]
                                         (case (:search-engine ctx)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -70,18 +70,17 @@
 (defn- with-search-engine-mocks!
   "Sets up search engine mocks for the semantic & appdb backends for testing fallback behavior.
    appdb-fn can be a collection of results or a function that takes a context."
-  [semantic-results appdb-fn thunk]
+  [semantic-results appdb-results thunk]
   (with-redefs [semantic.pgvector-api/query (fn [_pgvector _index-metadata _search-ctx]
                                               {:results semantic-results
                                                ;; Set filtered-count to a non-zero value to ensure fallback logic is
                                                ;; triggered
                                                :filtered-count 1})
-                search.engine/supported-engine? (constantly true)
                 search.engine/results (fn [ctx]
                                         (case (:search-engine ctx)
-                                          :search.engine/appdb (if (fn? appdb-fn)
-                                                                 (appdb-fn ctx)
-                                                                 appdb-fn)
+                                          :search.engine/appdb (if (fn? appdb-results)
+                                                                 (appdb-results ctx)
+                                                                 appdb-results)
                                           :search.engine/semantic (semantic.core/results ctx)))]
     (thunk)))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -34,7 +34,8 @@
               (with-redefs [semantic.pgvector-api/query
                             (fn [& _]
                               (reset! semantic-called? true)
-                              [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0}])
+                              {:results [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0}]
+                               :filtered-count 0})
                             appdb/results
                             (fn [_]
                               (reset! appdb-called? true)
@@ -51,7 +52,8 @@
               (with-redefs [semantic.pgvector-api/query
                             (fn [& _]
                               (reset! semantic-called? true)
-                              [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0.8}])
+                              {:results [{:id 1 :name "semantic-result" :model "card" :collection_id 1  :score 0.8}]
+                               :filtered-count 0})
                             appdb/results
                             (fn [_]
                               (reset! appdb-called? true)
@@ -69,7 +71,9 @@
   "Sets up search engine mocks for the semantic & appdb backends for testing fallback behavior.
    appdb-fn can be a collection of results or a function that takes a context."
   [semantic-results appdb-fn thunk]
-  (with-redefs [semantic.pgvector-api/query (fn [_pgvector _index-metadata _search-ctx] semantic-results)
+  (with-redefs [semantic.pgvector-api/query (fn [_pgvector _index-metadata _search-ctx]
+                                              {:results semantic-results
+                                               :filtered-count 0})
                 search.engine/supported-engine? (constantly true)
                 search.engine/results (fn [ctx]
                                         (case (:search-engine ctx)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -112,7 +112,7 @@
 (defmethod semantic.embedding/pull-model           "mock" [_])
 
 (defn query-index [search-context]
-  (semantic.index/query-index db mock-index search-context))
+  (:results (semantic.index/query-index db mock-index search-context)))
 
 (defn upsert-index! [documents]
   (semantic.index/upsert-index! db mock-index documents))

--- a/src/metabase/analytics/core.clj
+++ b/src/metabase/analytics/core.clj
@@ -24,6 +24,7 @@
   clear!
   connection-pool-info
   inc!
+  observe!
   set!
   setup!
   shutdown!]

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -309,7 +309,7 @@
    (prometheus/counter :metabase-search/semantic-fallback-triggered
                        {:description "Number of times semantic search triggered fallback to appdb search due to insufficient results"
                         :labels [:fallback-engine]})
-   (prometheus/histogram :metabase-search/semantic-fallback-results
+   (prometheus/histogram :metabase-search/semantic-results-before-fallback
                          {:description "Distribution of result counts from semantic search when fallback is triggered"
                           :buckets [0 1 5 10 20 50 100]})
 

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -306,6 +306,12 @@
    (prometheus/counter :metabase-search/semantic-db-query-ms
                        {:description "Total number of ms spent querying the search index"
                         :labels [:embedding-model]})
+   (prometheus/counter :metabase-search/semantic-fallback-triggered
+                       {:description "Number of times semantic search triggered fallback to appdb search due to insufficient results"
+                        :labels [:fallback-engine]})
+   (prometheus/histogram :metabase-search/semantic-fallback-results
+                         {:description "Distribution of result counts from semantic search when fallback is triggered"
+                          :buckets [0 1 5 10 20 50 100]})
 
 ;; notification metrics
    (prometheus/counter :metabase-notification/send-ok


### PR DESCRIPTION
Quick PR to add some prometheus metrics around the semantic search fallback logic, for cases where too many semantic search results are filtered out by permission checks.

I've also adjusted the fallback logic to only trigger _if_ some semantic results were returned but filtered out. This should slightly improve performance in cases where no relevant results were returned in the first place.