### PR TITLE
Only test normal drivers in `nested-array-query-test`

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -48,7 +48,7 @@ jobs:
 
             # Initialize an empty array to store folders with changes
             CHANGED_FOLDERS=()
-            for folder in "src/metabase/lib" "src/metabase/query_processor" "modules/drivers"; do
+            for folder in "src/metabase/lib" "src/metabase/query_processor" "modules/drivers" "src/metabase/driver"; do
               if echo "$CHANGED_FILES" | grep -q "$folder"; then
                 CHANGED_FOLDERS+=("$folder")
               fi

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -1417,7 +1417,7 @@
 
 (deftest ^:parallel nested-array-query-test
   (testing "A nested array query should be returned in a readable format"
-    (mt/test-drivers (mt/driver-select {:+features [:test/nested-arrays]})
+    (mt/test-drivers (mt/normal-driver-select {:+features [:test/nested-arrays]})
       (mt/dataset test-data
         (is (= [[(native-nested-array-results driver/*driver*)]]
                (->> (mt/native-query {:query (native-nested-array-query driver/*driver*)})


### PR DESCRIPTION
### Description

Accidentally used `mt/driver-select` instead of `mt/normal-driver-select` in https://github.com/metabase/metabase/pull/61977.

Also look for changes in `src/metabase/driver` to run tier 3 driver tests. 

### How to verify

All tests should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
