### PR TITLE
Fix non-batched get-embedding for openai and ai-service providers

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -171,9 +171,9 @@
       (log/error e "Failed to pull embedding model")
       (throw e))))
 
-(defmethod get-embedding        "ollama" [{:keys [model-name]} text] (ollama-get-embedding model-name text))
-(defmethod get-embeddings-batch "ollama" [{:keys [model-name]} text] (ollama-get-embeddings-batch model-name text))
-(defmethod pull-model           "ollama" [{:keys [model-name]}]      (ollama-pull-model model-name))
+(defmethod get-embedding        "ollama" [{:keys [model-name]} text]  (ollama-get-embedding model-name text))
+(defmethod get-embeddings-batch "ollama" [{:keys [model-name]} texts] (ollama-get-embeddings-batch model-name texts))
+(defmethod pull-model           "ollama" [{:keys [model-name]}]       (ollama-pull-model model-name))
 
 ;;;; AI Service impl
 
@@ -192,13 +192,13 @@
 (defn- ai-service-get-embedding [model-name text]
   (try
     (log/debug "Generating AI Service embedding for text of length:" (count text))
-    (first (ai-service-get-embeddings-batch model-name text))
+    (first (ai-service-get-embeddings-batch model-name [text]))
     (catch Exception e
       (log/error e "Failed to generate AI Service embedding for text of length:" (count text))
       (throw e))))
 
-(defmethod get-embedding        "ai-service" [{:keys [model-name]} text] (ai-service-get-embedding model-name text))
-(defmethod get-embeddings-batch "ai-service" [{:keys [model-name]} text] (ai-service-get-embeddings-batch model-name text))
+(defmethod get-embedding        "ai-service" [{:keys [model-name]} text]  (ai-service-get-embedding model-name text))
+(defmethod get-embeddings-batch "ai-service" [{:keys [model-name]} texts] (ai-service-get-embeddings-batch model-name texts))
 
 ;;;; OpenAI impl
 
@@ -239,13 +239,13 @@
 (defn- openai-get-embedding [embedding-model text]
   (try
     (log/debug "Generating OpenAI embedding for text of length:" (count text))
-    (first (openai-get-embeddings-batch embedding-model text))
+    (first (openai-get-embeddings-batch embedding-model [text]))
     (catch Exception e
       (log/error e "Failed to generate OpenAI embedding for text of length:" (count text))
       (throw e))))
 
-(defmethod get-embedding        "openai" [embedding-model text] (openai-get-embedding embedding-model text))
-(defmethod get-embeddings-batch "openai" [embedding-model text] (openai-get-embeddings-batch embedding-model text))
+(defmethod get-embedding        "openai" [embedding-model text]  (openai-get-embedding embedding-model text))
+(defmethod get-embeddings-batch "openai" [embedding-model texts] (openai-get-embeddings-batch embedding-model texts))
 (defmethod pull-model           "openai" [_] (log/debug "OpenAI provider does not require pulling a model"))
 
 ;;;; Global embedding model
@@ -290,7 +290,6 @@
 
             (transduce (map-indexed process-batch) (partial merge-with +) batches))
 
-          ;; No batching for other providers
           (let [embeddings (get-embeddings-batch embedding-model texts)
                 text-embedding-map (zipmap texts embeddings)]
             (process-fn text-embedding-map)))))))


### PR DESCRIPTION
Closes BOT-326

### Description

Fix non-batched `get-embedding` for openai and ai-service providers. We were passing a single text string rather than a seq of texts, resulting in an error when we tried to get the token
count.

    ERROR semantic-search.embedding :: Failed to generate OpenAI embedding for text of length: 8
    java.lang.ClassCastException: class java.lang.Character cannot be cast to class java.lang.String

~~I'm actually not sure how this is working on fiery-blue, which has me worried I might be missing something. It was failing reliably for me locally, but fiery-blue does seem to return results, even if I can find [instances of this error in the logs](https://grafana.monitoring.metabase.com/d/Zjw_nJX7k/metabase-logs?orgId=1&var-cluster=staging-1&var-filter=java.lang.Character+cannot+be+cast+to+class+java.lang.String&var-namespace=hosting-011969f910d14016&var-dns_host=fiery-blue.hosted.staging.metabase.com&refresh=5m&var-pod=All&var-log_level=All&from=1754883533847&to=1754969933847).~~

**edit:** It works on fiery-blue because the offending call to `count-tokens-batch` happens inside a `log/debug` call, and debug logging is not enabled on fiery-blue.

Please try it yourself locally and let me know if it's working for you (with or without this fix).

### How to verify

Start metabase with "openai" or "ai-service" for `MB_EE_EMBEDDING_PROVIDER`. Let it reindex, then run some search queries. Observe no `java.lang.ClassCastException` and search results are returned.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
