### PR TITLE
Add link to `MB_PLUGINS_DIR` reference

### DIFF
--- a/docs/developers-guide/community-drivers.md
+++ b/docs/developers-guide/community-drivers.md
@@ -15,7 +15,7 @@ In addition to our [Officially supported drivers](../databases/connecting.md#con
 
 To use a Community driver on a self-hosted Metabase:
 
-1. Download the latest jar file from the driver's repository (see the repo's Releases section for the JAR files).
+1. Download the latest JAR file from the driver's repository (see the repo's Releases section for the JAR files).
 2. Copy the JAR file into the plugins directory in your Metabase directory (the directory where you run the Metabase JAR).
 
 You can change the location of the plugins directory by setting the environment variable `MB_PLUGINS_DIR`.

--- a/docs/developers-guide/community-drivers.md
+++ b/docs/developers-guide/community-drivers.md
@@ -18,7 +18,7 @@ To use a Community driver on a self-hosted Metabase:
 1. Download the latest JAR file from the driver's repository (see the repo's Releases section for the JAR files).
 2. Copy the JAR file into the plugins directory in your Metabase directory (the directory where you run the Metabase JAR).
 
-You can change the location of the plugins directory by setting the environment variable `MB_PLUGINS_DIR`.
+You can change the location of the plugins directory by setting the environment variable [`MB_PLUGINS_DIR`](../configuring-metabase/environment-variables#mb_plugins_dir).
 
 ## Community drivers
 


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

### Description

Add link to `MB_PLUGINS_DIR` variable, to understand where plugins should go by default.

### How to verify

View docs.

### Demo

N/A

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
