### PR TITLE
docs: DB routing new DBs

### DIFF
--- a/docs/databases/connections/athena.md
+++ b/docs/databases/connections/athena.md
@@ -209,6 +209,14 @@ If Metabase also needs to create tables, you'll need additional AWS Glue permiss
 
 There aren't (yet) any model features available for Athena.
 
+## Database routing
+
+With database routing, an admin can build a question once using one data connection, and the question will run its query against a different data connection same schema depending on who is viewing the question.
+
+Note that the name "database routing" is misleading for Athena, because the term "database" in Athena is closer to "schema" in other databases. You can't use database routing to route queries between different _databases_ in Athena, but you can route between different data connections, e.g. different regions or buckets, or different IAM users, or different data sources/catalogs.
+
+See [Database routing](../../permissions/database-routing.md).
+
 ## Danger zone
 
 See [Danger Zone](../danger-zone.md).

--- a/docs/databases/connections/athena.md
+++ b/docs/databases/connections/athena.md
@@ -211,9 +211,9 @@ There aren't (yet) any model features available for Athena.
 
 ## Database routing
 
-With database routing, an admin can build a question once using one data connection, and the question will run its query against a different data connection same schema depending on who is viewing the question.
+With database routing, an admin can build a question once using a single data connection, and the question will run its query against a different data connection with the same schema depending on who is viewing the question.
 
-Note that the name "database routing" is misleading for Athena, because the term "database" in Athena is closer to "schema" in other databases. You can't use database routing to route queries between different _databases_ in Athena, but you can route between different data connections, e.g. different regions or buckets, or different IAM users, or different data sources/catalogs.
+Admittedly, the name "database routing" is misleading for Athena, because the term "database" in Athena is closer to "schema" in other databases. You _can't_ use database routing to route queries between different _databases_ in Athena, but you _can_ route between different data _connections_, e.g., different regions or buckets, or different IAM users, or different data sources/catalogs.
 
 See [Database routing](../../permissions/database-routing.md).
 

--- a/docs/databases/connections/bigquery.md
+++ b/docs/databases/connections/bigquery.md
@@ -163,6 +163,8 @@ There aren't (yet) any model features available for BigQuery.
 
 ## Database routing
 
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
 Database routing for BigQuery works between BigQuery **projects** with identical schemas.
 
 See [Database routing](../../permissions/database-routing.md).

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -101,6 +101,14 @@ A fingerprinting query examines the first 10,000 rows from each column and uses 
 
 There aren't (yet) any model features available for Databricks.
 
+## Database routing
+
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
+When **multi-catalog is not enabled**, you can route between catalogs on the same host. If multi-catalog is enabled, then you can only route between databases on separate hosts.
+
+See [Database routing](../../permissions/database-routing.md).
+
 ## Danger zone
 
 See [Danger zone](../danger-zone.md).

--- a/docs/databases/connections/druid.md
+++ b/docs/databases/connections/druid.md
@@ -66,6 +66,8 @@ There aren't (yet) any model features available for Druid.
 
 ## Database routing
 
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
 See [Database routing](../../permissions/database-routing.md).
 
 ## Danger zone

--- a/docs/databases/connections/mariadb.md
+++ b/docs/databases/connections/mariadb.md
@@ -95,6 +95,8 @@ JSON schema inference doesn't work with MariaDB, due to implementation differenc
 
 ## Database routing
 
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
 See [Database routing](../../permissions/database-routing.md).
 
 ## Danger zone

--- a/docs/databases/connections/mongodb.md
+++ b/docs/databases/connections/mongodb.md
@@ -132,6 +132,8 @@ If you're not seeing all of the fields show up for a collection in Metabase, one
 
 ## Database routing
 
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
 See [Database routing](../../permissions/database-routing.md).
 
 ## Danger zone

--- a/docs/databases/connections/mysql.md
+++ b/docs/databases/connections/mysql.md
@@ -183,6 +183,8 @@ We'll create tables with model data and refresh them on a schedule you define. T
 
 ## Database routing
 
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
 See [Database routing](../../permissions/database-routing.md).
 
 ## Danger zone

--- a/docs/databases/connections/postgresql.md
+++ b/docs/databases/connections/postgresql.md
@@ -192,6 +192,8 @@ We'll create tables with model data and refresh them on a schedule you define. T
 
 ## Database routing
 
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
 See [Database routing](../../permissions/database-routing.md).
 
 ## Danger zone

--- a/docs/databases/connections/presto.md
+++ b/docs/databases/connections/presto.md
@@ -90,6 +90,12 @@ Turn this option **ON** to scan a sample of values every time Metabase runs a [s
 
 A fingerprinting query examines the first 10,000 rows from each column and uses that data to guesstimate how many unique values each column has, what the minimum and maximum values are for numeric and timestamp columns, and so on. If you leave this option **OFF**, Metabase will only fingerprint your columns once during setup.
 
+## Database routing
+
+With database routing, an admin can build a question once using one database (data catalog), and the question will run its query against a different data catalog with the same schema depending on who is viewing the question.
+
+See [Database routing](../../permissions/database-routing.md).
+
 ## Danger zone
 
 See [Danger zone](../danger-zone.md).

--- a/docs/databases/connections/redshift.md
+++ b/docs/databases/connections/redshift.md
@@ -104,6 +104,12 @@ You can enable model persistence to allow Metabase to create tables with model d
 
 Check out [Model persistence](../../data-modeling/model-persistence.md).
 
+## Database routing
+
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
+See [Database routing](../../permissions/database-routing.md).
+
 ## Danger zone
 
 See [Danger zone](../danger-zone.md).

--- a/docs/databases/connections/snowflake.md
+++ b/docs/databases/connections/snowflake.md
@@ -133,6 +133,12 @@ A fingerprinting query examines the first 10,000 rows from each column and uses 
 
 There aren't (yet) any model features available for Snowflake.
 
+## Database routing
+
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
+See [Database routing](../../permissions/database-routing.md).
+
 ## Danger zone
 
 See [Danger zone](../danger-zone.md).

--- a/docs/databases/connections/sql-server.md
+++ b/docs/databases/connections/sql-server.md
@@ -95,6 +95,8 @@ To connect to Azure SQL, you'll need to set the port to 1433.
 
 ## Database routing
 
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
 See [Database routing](../../permissions/database-routing.md).
 
 ## Danger zone

--- a/docs/databases/connections/sqlite.md
+++ b/docs/databases/connections/sqlite.md
@@ -59,6 +59,8 @@ A fingerprinting query examines the first 10,000 rows from each column and uses 
 
 ## Database routing
 
+With database routing, an admin can build a question once using one database, and the question will run its query against a different database with the same schema depending on who is viewing the question.
+
 See [Database routing](../../permissions/database-routing.md).
 
 ## Danger zone

--- a/docs/databases/connections/starburst.md
+++ b/docs/databases/connections/starburst.md
@@ -91,6 +91,12 @@ A fingerprinting query examines the first 10,000 rows from each column and uses 
 
 There aren't (yet) any model features for Starburst.
 
+## Database routing
+
+With database routing, an admin can build a question once using one database (data catalog), and the question will run its query against a different data catalog with the same schema depending on who is viewing the question.
+
+See [Database routing](../../permissions/database-routing.md).
+
 ## Danger zone
 
 See [Danger zone](../danger-zone.md).

--- a/docs/permissions/database-routing.md
+++ b/docs/permissions/database-routing.md
@@ -16,16 +16,15 @@ Database routing is useful for:
 - Changing the target data warehouse for certain teams.
 - Managing separate connections to the same data warehouse, with each connection having separate privileges. This connection management is akin to [connection impersonation](./impersonation.md) for databases that prevent the same connection from changing roles.
 
-## Databases that support database routing
+## Database routing limitations
 
-- [BigQuery](../databases/connections/bigquery.md)
-- [Druid](../databases/connections/druid.md)
-- [MongoDB](../databases/connections/mongodb.md)
-- [MariaDB](../databases/connections/mariadb.md)
-- [MySQL](../databases/connections/mysql.md)
-- [PostgreSQL](../databases/connections/postgresql.md)
-- [SQL Server](../databases/connections/sql-server.md)
-- [SQLite](../databases/connections/sqlite.md)
+> Database routing is **not supported** on ClickHouse, Oracle, Spark SQL, and Vertica.
+
+There are limitations on the data sources available for database routing:
+
+- [Athena](../databases/connections/athena.md): Only routing between different connections, e.g. different buckets, roles, or catalogs is supported
+- [BigQuery](../databases/connections/bigquery.md): Only routing between databases in different projects is supported
+- [Databricks](../databases/connections/databricks.md): When multi-catalog is not enabled, you can route between catalogs on the same host. If multi-catalog is enabled, then you can only route between databases on separate hosts.
 
 ## How database routing works
 

--- a/docs/permissions/database-routing.md
+++ b/docs/permissions/database-routing.md
@@ -20,10 +20,10 @@ Database routing is useful for:
 
 > Database routing is **not supported** on ClickHouse, Oracle, Spark SQL, and Vertica.
 
-There are limitations on the data sources available for database routing:
+Different database have different setups, so _what_ you can route between (database, schema, data catalog, etc.) will differ slightly depending on which data warehouse you're using.
 
-- [Athena](../databases/connections/athena.md): Only routing between different connections, e.g. different buckets, roles, or catalogs is supported
-- [BigQuery](../databases/connections/bigquery.md): Only routing between databases in different projects is supported
+- [Athena](../databases/connections/athena.md): Only routing between different connections is supported (e.g., different buckets, roles, or catalogs). 
+- [BigQuery](../databases/connections/bigquery.md): Only routing between databases in different projects is supported.
 - [Databricks](../databases/connections/databricks.md): When multi-catalog is not enabled, you can route between catalogs on the same host. If multi-catalog is enabled, then you can only route between databases on separate hosts.
 
 ## How database routing works


### PR DESCRIPTION
Add DB routing for Athena, Redshift, Snowflake, Databricks, Presto, and Trino.

We support db routing on too many DBs to list all of them so i list just the ones unsupported or supported with caveats.

Also i added a little blurb about db routing to the DB pages to get people some info on what it is so that they could decide if they want to click on the link that follows.