### PR TITLE
Semantic search indexing status endpoint

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1800,8 +1800,8 @@
            api
            connection-pool
            models
-           premium-features
            permissions
+           premium-features
            search
            settings
            task

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1793,12 +1793,15 @@
 
   enterprise/semantic-search
   {:team "Metabot"
-   :api  #{metabase-enterprise.semantic-search.core
+   :api  #{metabase-enterprise.semantic-search.api
+           metabase-enterprise.semantic-search.core
            metabase-enterprise.semantic-search.init}
    :uses #{analytics
+           api
            connection-pool
            models
            premium-features
+           permissions
            search
            settings
            task

--- a/enterprise/backend/src/metabase_enterprise/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api/routes.clj
@@ -26,6 +26,7 @@
    [metabase-enterprise.permission-debug.api]
    [metabase-enterprise.sandbox.api.routes]
    [metabase-enterprise.scim.routes]
+   [metabase-enterprise.semantic-search.api]
    [metabase-enterprise.serialization.api]
    [metabase-enterprise.stale.api]
    [metabase-enterprise.upload-management.api]
@@ -50,6 +51,7 @@
    :llm-autodescription        (deferred-tru "LLM Auto-description")
    :metabot-v3                 (deferred-tru "MetaBot")
    :scim                       (deferred-tru "SCIM configuration")
+   :semantic-search            (deferred-tru "Semantic Search")
    :serialization              (deferred-tru "Serialization")
    :table-data-editing         (deferred-tru "Table Data Editing")
    :upload-management          (deferred-tru "Upload Management")
@@ -99,6 +101,7 @@
    "/metabot-v3"                   (premium-handler metabase-enterprise.metabot-v3.api/routes :metabot-v3)
    "/permission_debug"             (premium-handler metabase-enterprise.permission-debug.api/routes :advanced-permissions)
    "/scim"                         (premium-handler metabase-enterprise.scim.routes/routes :scim)
+   "/semantic-search"              (premium-handler metabase-enterprise.semantic-search.api/routes :semantic-search)
    "/serialization"                (premium-handler metabase-enterprise.serialization.api/routes :serialization)
    "/stale"                        (premium-handler metabase-enterprise.stale.api/routes :collection-cleanup)
    "/upload-management"            (premium-handler metabase-enterprise.upload-management.api/routes :upload-management)})

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/api.clj
@@ -1,0 +1,44 @@
+(ns metabase-enterprise.semantic-search.api
+  "/api/ee/semantic-search endpoints"
+  (:require
+   [clojure.core.memoize :as memoize]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
+   [metabase-enterprise.semantic-search.index :as semantic.index]
+   [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.permissions.core :as perms]
+   [metabase.search.ingestion :as search.ingestion]))
+
+(def ^:private indexible-items-count
+  (memoize/ttl search.ingestion/search-items-count
+               :ttl/threshold (* 5 60 1000))) ; 5 minutes
+
+(defn- active-index-document-count
+  [pgvector index-metadata]
+  (when-let [table-name (-> index-metadata :index :table-name)]
+    (semantic.index/index-size pgvector table-name)))
+
+(api.macros/defendpoint :get "/status"
+  "Fetch the indexing status of the currently active semantic search index table.
+
+  Returns a map with keys:
+   :indexed_count <number of indexed items>
+   :total_est     <estimated total number of items to index>
+
+  If no index is active, returns an empty map.
+   "
+  []
+  (perms/check-has-application-permission :setting)
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
+        index-metadata (semantic.env/get-index-metadata)
+        active-index   (when (and pgvector index-metadata)
+                         (semantic.index-metadata/get-active-index-state pgvector index-metadata))]
+    (if active-index
+      {:indexed_count (active-index-document-count pgvector active-index)
+       :total_est     (indexible-items-count)}
+      {})))
+
+(def ^{:arglists '([request respond raise])} routes
+  "`/api/ee/semantic-search` routes."
+  (api.macros/ns-handler *ns* +auth))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/api.clj
@@ -26,18 +26,20 @@
    :indexed_count <number of indexed items>
    :total_est     <estimated total number of items to index>
 
-  If no index is active, returns an empty map.
-   "
+  If no index is active, returns an empty map."
   []
   (perms/check-has-application-permission :setting)
   (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.env/get-index-metadata)
         active-index   (when (and pgvector index-metadata)
                          (semantic.index-metadata/get-active-index-state pgvector index-metadata))]
-    (if active-index
-      {:indexed_count (active-index-document-count pgvector active-index)
-       :total_est     (indexible-items-count)}
-      {})))
+    (try
+      (if active-index
+        {:indexed_count (active-index-document-count pgvector active-index)
+         :total_est     (indexible-items-count)}
+        {})
+      (catch Exception e
+        (throw (ex-info "Error fetching semantic search index status" {:cause e}))))))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/semantic-search` routes."

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -143,16 +143,21 @@
    :legacy_input        [:cast (json/encode legacy_input) :jsonb]
    :metadata            [:cast (json/encode doc) :jsonb]})
 
+(defn index-size
+  "Fetches the number of documents in the index table."
+  [connectable table-name]
+  (->> (jdbc/execute-one! connectable
+                          (-> (sql.helpers/select [:%count.* :count])
+                              (sql.helpers/from (keyword table-name))
+                              (sql.helpers/limit 1)
+                              sql-format-quoted))
+       :count))
+
 (defn- analytics-set-index-size!
   "Set the semantic-index-size metric to the number of rows in the index table."
   [connectable table-name]
   (try
-    (->> (jdbc/execute-one! connectable
-                            (-> (sql.helpers/select [:%count.* :count])
-                                (sql.helpers/from (keyword table-name))
-                                (sql.helpers/limit 1)
-                                sql-format-quoted))
-         :count
+    (->> (index-size connectable table-name)
          (analytics/set! :metabase-search/semantic-index-size))
     (catch Exception e
       (log/warn e "Failed to set :metabase-search/semantic-index-size metric"))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
@@ -1,10 +1,12 @@
 (ns metabase-enterprise.semantic-search.api-test
   (:require
+   [clojure.core.memoize :as memoize]
    [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.api :as semantic.api]
+   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
-   [metabase.search.core :as search.core]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
@@ -13,23 +15,33 @@
                      (fixtures/initialize :db)
                      #'semantic.tu/once-fixture))
 
+(defmacro with-mock-index-metadata!
+  [& body]
+  `(with-redefs [semantic.env/get-pgvector-datasource! (constantly semantic.tu/db)
+                 semantic.embedding/get-configured-model (constantly semantic.tu/mock-embedding-model)
+                 semantic.env/get-index-metadata (constantly semantic.tu/mock-index-metadata)]
+     ~@body))
+
 (deftest status-endpoint-test
   (testing "GET /api/ee/semantic-search/status"
     (mt/with-premium-features #{:semantic-search}
-      (testing "correctly returns 0 indexed documents for a fresh index"
-        (with-redefs [semantic.index-metadata/default-index-metadata semantic.tu/mock-index-metadata]
-          (with-open [_ (semantic.tu/open-temp-index!)]
-            (let [{:keys [indexed_count total_est]} (mt/user-http-request :crowberto :get 200 "ee/semantic-search/status")]
-              (is (= 0 indexed_count))
-              (is (< 0 total_est)))))
+      (with-mock-index-metadata!
+        (with-open [index-ref (semantic.tu/open-temp-index!)]
+          (with-redefs [semantic.index-metadata/get-active-index-state (fn [_ _]
+                                                                         {:index @index-ref
+                                                                          :status :active})]
+            (let [expected-search-items-count (search.ingestion/search-items-count)]
+              (memoize/memo-clear! @#'semantic.api/indexible-items-count)
+              (testing "Correctly reports empty index status"
+                (let [{:keys [indexed_count total_est]} (mt/user-http-request :crowberto :get 200 "ee/semantic-search/status")]
+                  (is (= 0 indexed_count))
+                  (is (= expected-search-items-count total_est))))
 
-        (testing "indexed count matches total count once indexing is complete"
-          (binding [search.ingestion/*force-sync* true]
-            (search.core/reindex! :search.engine/semantic {:force-reset true})
-            (let [{:keys [indexed_count total_est]} (mt/user-http-request :crowberto :get 200 "ee/semantic-search/status")]
-              (is (< 0 indexed_count))
-              (is (< 0 total_est))
-              (is (= indexed_count total_est)))))))
+              (testing "Correctly reports size of index after inserting documents"
+                (semantic.tu/upsert-index! (semantic.tu/mock-documents))
+                (let [{:keys [indexed_count total_est]} (mt/user-http-request :crowberto :get 200 "ee/semantic-search/status")]
+                  (is (= 2 indexed_count))
+                  (is (= expected-search-items-count total_est)))))))))
 
     (testing "with semantic search disabled"
       (mt/with-premium-features #{}
@@ -48,11 +60,8 @@
 (deftest status-endpoint-permissions-test
   (testing "GET /api/ee/semantic-search/status permissions"
     (mt/with-premium-features #{:semantic-search}
-      (with-open [_ (semantic.tu/open-temp-index!)]
-        (semantic.tu/cleanup-index-metadata! semantic.tu/db semantic.tu/mock-index-metadata)
-        (semantic.tu/with-index!
-          (testing "admin users can access status endpoint"
-            (mt/user-http-request :crowberto :get 200 "ee/semantic-search/status"))
+      (testing "admin users can access status endpoint"
+        (mt/user-http-request :crowberto :get 200 "ee/semantic-search/status"))
 
-          (testing "regular users cannot access status endpoint"
-            (mt/user-http-request :rasta :get 403 "ee/semantic-search/status")))))))
+      (testing "regular users cannot access status endpoint"
+        (mt/user-http-request :rasta :get 403 "ee/semantic-search/status")))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
@@ -1,0 +1,58 @@
+(ns metabase-enterprise.semantic-search.api-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
+   [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.search.core :as search.core]
+   [metabase.search.ingestion :as search.ingestion]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (compose-fixtures
+                     (fixtures/initialize :db)
+                     #'semantic.tu/once-fixture))
+
+(deftest status-endpoint-test
+  (testing "GET /api/ee/semantic-search/status"
+    (mt/with-premium-features #{:semantic-search}
+      (testing "correctly returns 0 indexed documents for a fresh index"
+        (with-redefs [semantic.index-metadata/default-index-metadata semantic.tu/mock-index-metadata]
+          (with-open [_ (semantic.tu/open-temp-index!)]
+            (let [{:keys [indexed_count total_est]} (mt/user-http-request :crowberto :get 200 "ee/semantic-search/status")]
+              (is (= 0 indexed_count))
+              (is (< 0 total_est)))))
+
+        (testing "indexed count matches total count once indexing is complete"
+          (binding [search.ingestion/*force-sync* true]
+            (search.core/reindex! :search.engine/semantic {:force-reset true})
+            (let [{:keys [indexed_count total_est]} (mt/user-http-request :crowberto :get 200 "ee/semantic-search/status")]
+              (is (< 0 indexed_count))
+              (is (< 0 total_est))
+              (is (= indexed_count total_est)))))))
+
+    (testing "with semantic search disabled"
+      (mt/with-premium-features #{}
+        (let [response (mt/user-http-request :crowberto :get 402 "ee/semantic-search/status")]
+          (testing "returns 402 when semantic search feature is not available"
+            (is (= 402 (get-in response [:data :status-code])))))))
+
+    (testing "with no active index"
+      (mt/with-premium-features #{:semantic-search}
+        (with-redefs [semantic.env/get-pgvector-datasource! (constantly nil)
+                      semantic.env/get-index-metadata (constantly nil)]
+          (let [response (mt/user-http-request :crowberto :get 200 "ee/semantic-search/status")]
+            (testing "returns empty map when no index is active"
+              (is (= {} response)))))))))
+
+(deftest status-endpoint-permissions-test
+  (testing "GET /api/ee/semantic-search/status permissions"
+    (mt/with-premium-features #{:semantic-search}
+      (with-open [_ (semantic.tu/open-temp-index!)]
+        (semantic.tu/cleanup-index-metadata! semantic.tu/db semantic.tu/mock-index-metadata)
+        (semantic.tu/with-index!
+          (testing "admin users can access status endpoint"
+            (mt/user-http-request :crowberto :get 200 "ee/semantic-search/status"))
+
+          (testing "regular users cannot access status endpoint"
+            (mt/user-http-request :rasta :get 403 "ee/semantic-search/status")))))))

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -167,6 +167,18 @@
   []
   (query->documents (search-items-reducible)))
 
+(defn search-items-count
+  "Returns a count of all searchable items in the database."
+  []
+  (reduce
+   +
+   (for [model search.spec/search-models]
+     (-> (spec-index-query-where model nil)
+         (assoc :select [:%count.*])
+         t2/query
+         first
+         :count))))
+
 (def ^:dynamic *force-sync*
   "Force ingestion to happen immediately, on the same thread."
   false)

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -170,14 +170,14 @@
 (defn search-items-count
   "Returns a count of all searchable items in the database."
   []
-  (reduce
-   +
-   (for [model search.spec/search-models]
-     (-> (spec-index-query-where model nil)
-         (assoc :select [:%count.*])
-         t2/query
-         first
-         :count))))
+  (->> (for [model search.spec/search-models]
+         (-> (spec-index-query-where model nil)
+             (assoc :select [[:%count.* :count]])
+             t2/query
+             first
+             :count))
+       (filter some?)
+       (reduce + 0)))
 
 (def ^:dynamic *force-sync*
   "Force ingestion to happen immediately, on the same thread."


### PR DESCRIPTION
Adds a basic index status endpoint that returns stats about the currently-active index. This starts with just:
* `indexed_count` - the size of the index table
* `total_est` - an estimate of the expected index size. Obtained by querying the counts of the tables used for generating `searchable-documents`, with a 5-minute in memory cache so that we're not hammering the DB. 

This should be enough to show a basic progress bar/indexing percentage on the admin page. I think we can infer the indexing process as "done" when `indexed_count >= total_est*.95` or something along those lines, to account for fluctuations in the set of searchable documents. The next milestone will be to track the status of an index's initial indexing job and report explicit success/error states, sort of like what we do in the DB sync process.

Had a fair bit of difficulty figuring out the right things to mock in the tests to ensure `get-active-index-state` would return the correct test index, especially since I was seeing failures in CI that didn't repro locally... eventually fell back to mocking almost everything. I'm sure the tests can be simplified but hopefully this is good enough for now.