### PR TITLE
Add view_count scorer to semantic search backend

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1802,6 +1802,7 @@
            metabase-enterprise.semantic-search.init}
    :uses #{analytics
            api
+           config
            connection-pool
            models
            permissions

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -742,7 +742,7 @@
 
             db-timer (u/start-timer)
             weights (search.config/weights (:context search-context))
-            scorers (scoring/semantic-scorers search-context)
+            scorers (scoring/semantic-scorers db (:table-name index) search-context)
             query (->> (hybrid-search-query index embedding search-context)
                        (scoring/with-scores search-context scorers))
             xform (comp (map decode-metadata)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -742,7 +742,7 @@
 
             db-timer (u/start-timer)
             weights (search.config/weights (:context search-context))
-            scorers (scoring/semantic-scorers db (:table-name index) search-context)
+            scorers (scoring/semantic-scorers (:table-name index) search-context)
             query (->> (hybrid-search-query index embedding search-context)
                        (scoring/with-scores search-context scorers))
             xform (comp (map decode-metadata)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -1,10 +1,15 @@
 (ns metabase-enterprise.semantic-search.scoring
   (:require
+   [clojure.core.memoize :as memoize]
+   [honey.sql :as sql]
    [honey.sql.helpers :as sql.helpers]
+   [metabase.config.core :as config]
    [metabase.premium-features.core :as premium-features]
    [metabase.search.config :as search.config]
    [metabase.search.scoring :as search.scoring]
-   [toucan2.util :as u]))
+   [metabase.util :as u]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as jdbc.rs]))
 
 (defn- ->col-expr
   "For a given `col-name` return a :coalesce expression to reference it from the outer hybrid search query.
@@ -13,6 +18,41 @@
   [col-name]
   (let [prefix #(keyword (str %1 (name %2)))]
     [:coalesce (prefix "v." col-name) (prefix "t." col-name)]))
+
+(defn- view-count-percentile-query
+  [index-table p-value]
+  (let [expr [:raw "percentile_cont(" [:lift p-value] ") WITHIN GROUP (ORDER BY view_count)"]]
+    {:select   [:search_index.model [expr :vcp]]
+     :from     [[(keyword index-table) :search_index]]
+     :group-by [:search_index.model]
+     :having   [:is-not expr nil]}))
+
+(defn- view-count-percentiles*
+  [db index-table p-value]
+  (into {} (for [{:keys [model vcp]}
+                 (jdbc/execute! db
+                                (-> (view-count-percentile-query
+                                     index-table
+                                     p-value)
+                                    (sql/format {:quoted true}))
+                                {:builder-fn jdbc.rs/as-unqualified-lower-maps})]
+             [(keyword model) vcp])))
+
+(def ^{:private true
+       :arglists '([db index-table p-value])}
+  view-count-percentiles
+  (if config/is-prod?
+    (memoize/ttl view-count-percentiles*
+                 :ttl/threshold (u/hours->ms 1))
+    view-count-percentiles*))
+
+(defn- view-count-expr [db index-table percentile]
+  (let [views (view-count-percentiles db index-table percentile)
+        cases (for [[sm v] views]
+                [[:= (->col-expr :model) [:inline (name sm)]] (max (or v 0) 1)])]
+    (search.scoring/size (->col-expr :view_count) (if (seq cases)
+                                                    (into [:case] cat cases)
+                                                    1))))
 
 (defn- model-rank-exp [{:keys [context]}]
   (let [search-order search.config/models-search-order
@@ -38,29 +78,30 @@
 
 (defn base-scorers
   "The default constituents of the search ranking scores."
-  [{:keys [search-string limit-int] :as search-ctx}]
+  [db index-table {:keys [search-string limit-int] :as search-ctx}]
   (if (and limit-int (zero? limit-int))
     {:model [:inline 1]}
     ;; NOTE: we calculate scores even if the weight is zero, so that it's easy to consider how we could affect any
     ;; given set of results. At some point, we should optimize away the irrelevant scores for any given context.
     {:rrf       rrf-rank-exp
-     :pinned    (search.scoring/truthy (->col-expr :pinned))
-     :recency   (search.scoring/inverse-duration [:coalesce
-                                                  (->col-expr :last_viewed_at)
-                                                  (->col-expr :model_updated_at)]
-                                                 [:now]
-                                                 search.config/stale-time-in-days)
-     :dashboard (search.scoring/size (->col-expr :dashboardcard_count) search.config/dashboard-count-ceiling)
-     :model     (model-rank-exp search-ctx)
-     :mine      (search.scoring/equal (->col-expr :creator_id) (:current-user-id search-ctx))
-     :exact     (if search-string
-                  ;; perform the lower casing within the database, in case it behaves differently to our helper
-                  (search.scoring/equal [:lower (->col-expr :name)] [:lower search-string])
-                  [:inline 0])
-     :prefix    (if search-string
-                  ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
-                  (search.scoring/prefix [:lower (->col-expr :name)] (u/lower-case-en search-string))
-                  [:inline 0])}))
+     :view-count (view-count-expr db index-table search.config/view-count-scaling-percentile)
+     :pinned     (search.scoring/truthy (->col-expr :pinned))
+     :recency    (search.scoring/inverse-duration [:coalesce
+                                                   (->col-expr :last_viewed_at)
+                                                   (->col-expr :model_updated_at)]
+                                                  [:now]
+                                                  search.config/stale-time-in-days)
+     :dashboard  (search.scoring/size (->col-expr :dashboardcard_count) search.config/dashboard-count-ceiling)
+     :model      (model-rank-exp search-ctx)
+     :mine       (search.scoring/equal (->col-expr :creator_id) (:current-user-id search-ctx))
+     :exact      (if search-string
+                   ;; perform the lower casing within the database, in case it behaves differently to our helper
+                   (search.scoring/equal [:lower (->col-expr :name)] [:lower search-string])
+                   [:inline 0])
+     :prefix     (if search-string
+                   ;; in this case, we need to transform the string into a pattern in code, so forced to use helper
+                   (search.scoring/prefix [:lower (->col-expr :name)] (u/lower-case-en search-string))
+                   [:inline 0])}))
 
 (def ^:private enterprise-scorers
   {:official-collection {:expr (search.scoring/truthy (->col-expr :official_collection))
@@ -79,8 +120,8 @@
 
 (defn semantic-scorers
   "Return the select-item expressions used to calculate the score for semantic search results."
-  [search-ctx]
-  (merge (base-scorers search-ctx)
+  [db index-table search-ctx]
+  (merge (base-scorers db index-table search-ctx)
          (additional-scorers)))
 
 (defn with-scores
@@ -93,3 +134,9 @@
   "Score stats for each scorer"
   [weights scorers index-row]
   (search.scoring/all-scores weights scorers index-row))
+
+(comment
+  (def db @@(requiring-resolve 'metabase-enterprise.semantic-search.db/data-source))
+  (def embedding-model ((requiring-resolve 'metabase-enterprise.semantic-search.embedding/get-configured-model)))
+  (def index ((requiring-resolve 'metabase-enterprise.semantic-search.index/default-index) embedding-model))
+  (def index-table (:table-name index)))


### PR DESCRIPTION
Closes BOT-311

### Description

Add the `view_count` metadata scorer to the semantic search backend. The implementation largely follows the one for the appdb backend, but updated to query the semantic index rather than the appdb to get the `view-count-percentiles`.

### How to verify

Search for some items that have been viewed, and verify they get a non-zero `view-count` component in their score. Note the item has to be reindexed after viewing it in order for the `view_count` to be recorded in the index.

```
{
    "score": 1.0,
    "name": "view-count",
    "weight": 2,
    "contribution": 2.0
}
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
