### PR TITLE
Support API Keys tied to a single Collection

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -143,7 +143,8 @@
   api-keys
   {:team "UX West"
    :api  #{metabase.api-keys.api
-           metabase.api-keys.core}
+           metabase.api-keys.core
+           metabase.api-keys.schema}
    :uses #{api
            app-db
            events
@@ -992,7 +993,8 @@
   request
   {:team "UX West"
    :api  #{metabase.request.core
-           metabase.request.init}
+           metabase.request.init
+           metabase.request.schema}
    :uses #{api
            config
            permissions                  ; FIXME

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -59,16 +59,16 @@
       (do
         (log/info (u/format-color :blue "API key with name %s already exists, skipping" (pr-str name)))
         existing-api-key)
-      (let [group-id (case group
-                       "admin" (u/the-id (perms/admin-group))
-                       "all-users" (u/the-id (perms/all-users-group)))
+      (let [group-id     (case group
+                           "admin"     (u/the-id (perms/admin-group))
+                           "all-users" (u/the-id (perms/all-users-group)))
             unhashed-key (u.secret/secret key)
-            _ (when-not (and (<= 11 (count key) 254)
-                             (re-matches #"mb_[A-Za-z0-9+/=]+" key))
-                (throw (ex-info (format "Invalid API key format. Key must be between 11-254 characters and start with 'mb_'.")
-                                {:name name})))
-            prefix (api-key/prefix (u.secret/expose unhashed-key))
-            creator (get-admin-user-by-email creator)]
+            _            (when-not (and (<= 11 (count key) 254)
+                                        (re-matches #"mb_[A-Za-z0-9+/=]+" key))
+                           (throw (ex-info (format "Invalid API key format. Key must be between 11-254 characters and start with 'mb_'.")
+                                           {:name name})))
+            prefix       (api-key/prefix (u.secret/expose unhashed-key))
+            creator      (get-admin-user-by-email creator)]
 
         ;; Check if there's an existing API key with the same prefix
         (when (t2/exists? :model/ApiKey :key_prefix prefix)
@@ -78,22 +78,22 @@
         (log/info (u/format-color :green "Creating new API key %s" (pr-str name)))
         ;; Create a user for the API key
         (let [email (format "api-key-user-%s@api-key.invalid" (random-uuid))
-              user (first
-                    (t2/insert-returning-instances! :model/User
-                                                    {:email      email
-                                                     :first_name name
-                                                     :last_name  ""
-                                                     :type       :api-key
-                                                     :password   (str (random-uuid))}))]
+              user  (first
+                     (t2/insert-returning-instances! :model/User
+                                                     {:email      email
+                                                      :first_name name
+                                                      :last_name  ""
+                                                      :type       :api-key
+                                                      :password   (str (random-uuid))}))]
           ;; Set permissions groups for the user
           (user/set-permissions-groups! user [(perms/all-users-group) {:id group-id}])
           ;; Create the API key
           (t2/insert-returning-instance! :model/ApiKey
-                                         {:user_id      (u/the-id user)
-                                          :name         name
-                                          :unhashed_key unhashed-key
-                                          :creator_id   (u/the-id creator)
-                                          :updated_by_id (u/the-id creator)}))))))
+                                         {:user_id               (u/the-id user)
+                                          :name                  name
+                                          ::api-key/unhashed-key unhashed-key
+                                          :creator_id            (u/the-id creator)
+                                          :updated_by_id         (u/the-id creator)}))))))
 
 (defmethod advanced-config.file.i/initialize-section! :api-keys
   [_section-name api-keys]

--- a/enterprise/backend/src/metabase_enterprise/scim/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/scim/api.clj
@@ -29,12 +29,12 @@
     (t2/delete! :model/ApiKey :scope :scim)
     (let [unhashed-key (api-key/generate-key)]
       (->
-       (t2/insert-returning-instance! :model/ApiKey {:user_id       nil
-                                                     :scope         :scim
-                                                     :name          (scim-api-key-name)
-                                                     :unhashed_key  unhashed-key
-                                                     :creator_id    user-id
-                                                     :updated_by_id user-id})
+       (t2/insert-returning-instance! :model/ApiKey {:user_id               nil
+                                                     :scope                 :scim
+                                                     :name                  (scim-api-key-name)
+                                                     ::api-key/unhashed-key unhashed-key
+                                                     :creator_id            user-id
+                                                     :updated_by_id         user-id})
        (assoc :unmasked_key (u.secret/expose unhashed-key))))))
 
 (api.macros/defendpoint :get "/api_key"

--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -6,7 +6,7 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 
-(deftest ^:parallel properties-token-features-test
+(deftest properties-token-features-test
   (mt/with-premium-features #{:advanced-permissions
                               :attached-dwh
                               :audit-app

--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -6,7 +6,7 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 
-(deftest properties-token-features-test
+(deftest ^:parallel properties-token-features-test
   (mt/with-premium-features #{:advanced-permissions
                               :attached-dwh
                               :audit-app

--- a/enterprise/backend/test/metabase_enterprise/scim/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/scim/api_test.clj
@@ -51,18 +51,19 @@
       (testing "Can create a new SCIM API key"
         (let [key1 (mt/user-http-request :crowberto :post 200 "ee/scim/api_key")]
           (is (=? (scim-api-key-shape :crowberto) key1))
-
           (testing "Can refresh an API key"
             (let [key2 (mt/user-http-request :crowberto :post 200 "ee/scim/api_key")]
               (is (=? (scim-api-key-shape :crowberto) key2))
-              (is (not= key1 key2))))))
+              (is (not= key1 key2)))))))))
 
+(deftest ^:parallel post-api-key-test-2
+  (testing "POST /api/ee/scim/api_key"
+    (mt/with-premium-features #{:scim}
       (testing "A non-admin cannot create a SCIM API key"
-        (mt/user-http-request :rasta :post 403 "ee/scim/api_key"))
+        (mt/user-http-request :rasta :post 403 "ee/scim/api_key")))))
 
-      (testing "Users and Groups have entity IDs backfilled when a new SCIM key is generated"
-        (mt/with-temp [:model/User             user {:entity_id nil}
-                       :model/PermissionsGroup group {:entity_id nil}]
-          (mt/user-http-request :crowberto :post 200 "ee/scim/api_key")
-          (is (not (nil? (t2/select-one-fn :entity_id :model/User :id (:id user)))))
-          (is (not (nil? (t2/select-one-fn :entity_id :model/PermissionsGroup :id (:id group))))))))))
+(deftest ^:parallel post-api-key-test-3
+  (testing "POST /api/ee/scim/api_key"
+    (mt/with-premium-features #{:scim}
+      (testing "A non-admin cannot create a SCIM API key"
+        (mt/user-http-request :rasta :post 403 "ee/scim/api_key")))))

--- a/resources/migrations/057_update_migrations.yaml
+++ b/resources/migrations/057_update_migrations.yaml
@@ -134,11 +134,21 @@ databaseChangeLog:
                   type: int
                   constraints:
                     nullable: true
-                    referencedTableName: collection
-                    referencedColumnNames: id
-                    foreignKeyName: fk_api_key_collection_id
-                    deleteCascade: true
 
+  # Need to create the FK separately because deleteCascade doesn't work in addColumn: see https://liquibase.jira.com/browse/CORE-3058
+  - changeSet:
+      id: v57.2025-08-12T13:00:01
+      author: camsaul
+      comment: Add single_collection_id FK to api_key to support API keys tied to one specific Collection
+      preConditions:
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: api_key
+            baseColumnNames: single_collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_api_key_single_collection_id
+            onDelete: CASCADE
 
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/057_update_migrations.yaml
+++ b/resources/migrations/057_update_migrations.yaml
@@ -120,6 +120,27 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  - changeSet:
+      id: v57.2025-08-12T13:00:00
+      author: camsaul
+      comment: Add single_collection_id FK to api_key to support API keys tied to one specific Collection
+      changes:
+        - addColumn:
+            tableName: api_key
+            columns:
+              - column:
+                  name: single_collection_id
+                  remarks: If this API Key is tied to a single Collection, this is the ID of that Collection
+                  type: int
+                  constraints:
+                    nullable: true
+                    referencedTableName: collection
+                    referencedColumnNames: id
+                    foreignKeyName: fk_api_key_collection_id
+                    deleteCascade: true
+
+
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api_keys/api.clj
+++ b/src/metabase/api_keys/api.clj
@@ -1,13 +1,12 @@
 (ns metabase.api-keys.api
   "/api/api-key endpoints for CRUD management of API Keys"
   (:require
+   [medley.core :as m]
+   [metabase.api-keys.core :as-alias api-keys]
    [metabase.api-keys.models.api-key :as api-key]
+   [metabase.api-keys.schema :as api-keys.schema]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.events.core :as events]
-   [metabase.permissions.core :as perms]
-   [metabase.users.models.user :as user]
-   [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
    [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
@@ -33,44 +32,16 @@
       (maybe-expose-key)
       (update :updated_by #(select-keys % [:common_name :id]))))
 
-(defn- with-updated-by [api-key]
-  (assoc api-key :updated_by_id api/*current-user-id*))
-
-(defn- with-creator [api-key]
-  (assoc api-key :creator_id api/*current-user-id*))
-
 (api.macros/defendpoint :post "/"
   "Create a new API key (and an associated `User`) with the provided name and group ID."
   [_route-params
    _query-params
-   {:keys [group_id name] :as _body} :- [:map
-                                         [:group_id ms/PositiveInt]
-                                         [:name     ms/NonBlankString]]]
+   {group-id :group_id, key-name :name, :as _body} :- [:map
+                                                       [:group_id ::api-keys.schema/id]
+                                                       [:name     ms/NonBlankString]]]
   (api/check-superuser)
-  (api/checkp (not (t2/exists? :model/ApiKey :name name))
-              "name" "An API key with this name already exists.")
-  (let [unhashed-key (api-key/key-with-unique-prefix)
-        email        (format "api-key-user-%s@api-key.invalid" (random-uuid))]
-    (t2/with-transaction [_conn]
-      (let [user (first
-                  (t2/insert-returning-instances! :model/User
-                                                  {:email      email
-                                                   :first_name name
-                                                   :last_name  ""
-                                                   :type       :api-key
-                                                   :password (str (random-uuid))}))]
-        (user/set-permissions-groups! user [(perms/all-users-group) group_id])
-        (let [api-key (-> (t2/insert-returning-instance! :model/ApiKey
-                                                         (-> {:user_id       (u/the-id user)
-                                                              :name          name
-                                                              :unhashed_key  unhashed-key}
-                                                             with-creator
-                                                             with-updated-by))
-                          (t2/hydrate :group :updated_by))]
-          (events/publish-event! :event/api-key-create
-                                 {:object  api-key
-                                  :user-id api/*current-user-id*})
-          (present-api-key (assoc api-key :unmasked_key unhashed-key)))))))
+  (-> (api-key/create-api-key-with-new-user! {:key-name key-name, :group-id group-id})
+      present-api-key))
 
 (api.macros/defendpoint :get "/count"
   "Get the count of API keys in the DB with the default scope."
@@ -83,51 +54,31 @@
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]
    _query-params
-   {:keys [group_id name] :as _body} :- [:map
-                                         [:group_id {:optional true} [:maybe ms/PositiveInt]]
-                                         [:name     {:optional true} [:maybe ms/NonBlankString]]]]
+   {group-id :group_id, key-name :name} :- [:map
+                                            [:group_id {:optional true} [:maybe ms/PositiveInt]]
+                                            [:name     {:optional true} [:maybe ::api-keys.schema/name]]]]
   (api/check-superuser)
-  (let [api-key-before (-> (t2/select-one :model/ApiKey :id id)
-                           ;; hydrate the group_name for audit logging
-                           (t2/hydrate :group)
-                           (api/check-404))]
-    (t2/with-transaction [_conn]
-      (when group_id
-        (let [user (-> api-key-before (t2/hydrate :user) :user)]
-          (user/set-permissions-groups! user [(perms/all-users-group) {:id group_id}])))
-      (when name
-        ;; A bit of a pain to keep these in sync, but oh well.
-        (t2/update! :model/User (:user_id api-key-before) {:first_name name
-                                                           :last_name ""})
-        (t2/update! :model/ApiKey id (with-updated-by {:name name}))))
-    (let [updated-api-key (-> (t2/select-one :model/ApiKey :id id)
-                              (t2/hydrate :group :updated_by))]
-      (events/publish-event! :event/api-key-update {:object          updated-api-key
-                                                    :previous-object api-key-before
-                                                    :user-id         api/*current-user-id*})
-      (present-api-key updated-api-key))))
+  (api/let-404 [api-key-before (t2/select-one :model/ApiKey id)]
+    (-> api-key-before
+        (m/assoc-some ::api-keys/group-id group-id, :name key-name)
+        t2/save!
+        present-api-key)))
 
-(api.macros/defendpoint :put "/:id/regenerate"
+(api.macros/defendpoint :put "/:id/regenerate" :- [:map
+                                                   [:id           ::api-keys.schema/id]
+                                                   [:unmasked_key ::api-keys.schema/key.raw]
+                                                   [:masked_key   ::api-keys.schema/key.masked]
+                                                   [:prefix       ::api-keys.schema/prefix]]
   "Regenerate an API Key"
   [{:keys [id]} :- [:map
-                    [:id ms/PositiveInt]]]
+                    [:id ::api-keys.schema/id]]]
   (api/check-superuser)
-  (let [api-key-before (-> (t2/select-one :model/ApiKey id)
-                           (t2/hydrate :group)
-                           (api/check-404))
-        unhashed-key (api-key/key-with-unique-prefix)
-        api-key-after (assoc api-key-before
-                             :unhashed_key unhashed-key
-                             :key_prefix (api-key/prefix unhashed-key))]
-    (t2/update! :model/ApiKey :id id (with-updated-by
-                                       (select-keys api-key-after [:unhashed_key])))
-    (events/publish-event! :event/api-key-regenerate
-                           {:object api-key-after
-                            :previous-object api-key-before
-                            :user-id api/*current-user-id*})
-    (present-api-key (assoc api-key-after
-                            :unmasked_key unhashed-key
-                            :masked_key (api-key/mask unhashed-key)))))
+  (api/check-404 (t2/exists? :model/ApiKey id))
+  (let [regenerated (api-key/regenerate! id)]
+    {:id           id
+     :unmasked_key (u.secret/expose (:unmasked-key regenerated))
+     :masked_key   (:masked-key regenerated)
+     :prefix       (:prefix regenerated)}))
 
 (api.macros/defendpoint :get "/"
   "Get a list of API keys with the default scope. Non-paginated."
@@ -139,15 +90,13 @@
 (api.macros/defendpoint :delete "/:id"
   "Delete an ApiKey"
   [{:keys [id]} :- [:map
-                    [:id ms/PositiveInt]]]
+                    [:id ::api-keys.schema/id]]]
   (api/check-superuser)
-  (let [api-key (-> (t2/select-one :model/ApiKey id)
-                    (t2/hydrate :group)
-                    (api/check-404))]
-    (t2/with-transaction [_tx]
-      (t2/delete! :model/ApiKey id)
-      (t2/update! :model/User (:user_id api-key) {:is_active false}))
-    (events/publish-event! :event/api-key-delete
-                           {:object api-key
-                            :user-id api/*current-user-id*})
-    api/generic-204-no-content))
+  (api/check-404 (t2/exists? :model/ApiKey id))
+  (t2/delete! :model/ApiKey id)
+  api/generic-204-no-content)
+
+#_:clj-kondo/ignore
+(comment
+  ;; check the generated docs
+  (metabase.api.open-api/open-api-spec (metabase.api.macros/ns-handler) "/api/api-key"))

--- a/src/metabase/api_keys/api.clj
+++ b/src/metabase/api_keys/api.clj
@@ -8,7 +8,6 @@
    [metabase.permissions.core :as perms]
    [metabase.users.models.user :as user]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]
    [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
@@ -34,16 +33,6 @@
       (maybe-expose-key)
       (update :updated_by #(select-keys % [:common_name :id]))))
 
-(defn- key-with-unique-prefix []
-  (u/auto-retry 5
-    (let [api-key (api-key/generate-key)
-          prefix (api-key/prefix (u.secret/expose api-key))]
-     ;; we could make this more efficient by generating 5 API keys up front and doing one select to remove any
-     ;; duplicates. But a duplicate should be rare enough to just do multiple queries for now.
-      (if-not (t2/exists? :model/ApiKey :key_prefix prefix)
-        api-key
-        (throw (ex-info (tru "could not generate key with unique prefix") {}))))))
-
 (defn- with-updated-by [api-key]
   (assoc api-key :updated_by_id api/*current-user-id*))
 
@@ -60,7 +49,7 @@
   (api/check-superuser)
   (api/checkp (not (t2/exists? :model/ApiKey :name name))
               "name" "An API key with this name already exists.")
-  (let [unhashed-key (key-with-unique-prefix)
+  (let [unhashed-key (api-key/key-with-unique-prefix)
         email        (format "api-key-user-%s@api-key.invalid" (random-uuid))]
     (t2/with-transaction [_conn]
       (let [user (first
@@ -126,10 +115,10 @@
   (let [api-key-before (-> (t2/select-one :model/ApiKey id)
                            (t2/hydrate :group)
                            (api/check-404))
-        unhashed-key (key-with-unique-prefix)
+        unhashed-key (api-key/key-with-unique-prefix)
         api-key-after (assoc api-key-before
                              :unhashed_key unhashed-key
-                             :key_prefix (api-key/prefix (u.secret/expose unhashed-key)))]
+                             :key_prefix (api-key/prefix unhashed-key))]
     (t2/update! :model/ApiKey :id id (with-updated-by
                                        (select-keys api-key-after [:unhashed_key])))
     (events/publish-event! :event/api-key-regenerate

--- a/src/metabase/api_keys/core.clj
+++ b/src/metabase/api_keys/core.clj
@@ -9,4 +9,5 @@
  [metabase.api-keys.models.api-key
   generate-key
   is-api-key-user?
-  prefix])
+  prefix
+  create-single-collection-api-key!])

--- a/src/metabase/api_keys/models/api_key.clj
+++ b/src/metabase/api_keys/models/api_key.clj
@@ -2,28 +2,28 @@
   (:require
    [clojure.core.memoize :as memoize]
    [crypto.random :as crypto-random]
+   [malli.error :as me]
+   [metabase.api-keys.schema :as api-keys.schema]
    [metabase.app-db.core :as mdb]
    [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
    [metabase.util.password :as u.password]
    [metabase.util.secret :as u.secret]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
-;; the prefix length, the length of `mb_1234`
-(def ^:private prefix-length 7)
-
-;; the total number of bytes of randomness we generate for API keys
-(def ^:private bytes-key-length 32)
+(set! *warn-on-reflection* true)
 
 (methodical/defmethod t2/table-name :model/ApiKey [_model] :api_key)
 
-(mi/define-batched-hydration-method add-group
-  :group
-  "Add to each ApiKey a single group. Assume that each ApiKey is a member of either zero or one groups other than
-  the 'All Users' group."
-  [api-keys]
+(methodical/defmethod toucan2.tools.hydrate/batched-hydrate [:model/ApiKey :group]
+  "Add to each ApiKey a single group. Assume that each ApiKey is a member of either zero or one groups other than the
+  'All Users' group."
+  [_model _k api-keys]
   (when (seq api-keys)
     (let [api-key-id->permissions-groups
           (group-by :api-key-id
@@ -51,51 +51,76 @@
 (t2/deftransforms :model/ApiKey
   {:scope mi/transform-keyword})
 
-(defn prefix
-  "Given an API key, returns the standardized prefix for that API key."
-  [key]
-  (apply str (take prefix-length key)))
+(mu/defn- expose :- :string
+  ^String [s :- [:or ::u.secret/secret :string]]
+  (cond-> s
+    (u.secret/secret? s) u.secret/expose))
 
-(defn- add-prefix [{:keys [unhashed_key] :as api-key}]
+(mu/defn prefix :- ::api-keys.schema/prefix
+  "Given an API key, returns the standardized prefix for that API key."
+  ^String [k :- [:or
+                 ::api-keys.schema/key.unhashed-or-secret
+                 ::api-keys.schema/prefix]]
+  (subs (expose k) 0 api-keys.schema/prefix-length))
+
+(mu/defn- add-prefix :- [:map
+                         [:key_prefix ::api-keys.schema/prefix]]
+  [{:keys [unhashed_key] :as api-key} :- [:map
+                                          [:unhashed_key {:optional true} ::api-keys.schema/key.unhashed]]]
   (cond-> api-key
     (contains? api-key :unhashed_key)
     (assoc :key_prefix (some-> unhashed_key u.secret/expose prefix))))
 
-(defn generate-key
+(mu/defn generate-key :- ::api-keys.schema/key.secret
   "Generates a new API key - a random base64 string prefixed with `mb_`"
   []
   (u.secret/secret
-   (str "mb_" (crypto-random/base64 bytes-key-length))))
+   (str "mb_" (crypto-random/base64 api-keys.schema/bytes-key-length))))
 
-(def ^:private string-key-length (delay (count (u.secret/expose (generate-key)))))
-
-(defn mask
+(mu/defn mask :- ::api-keys.schema/key.unhashed
   "Given an API key, returns a string of the same length with all but the prefix masked with `*`s"
-  [key]
-  (->> (concat (prefix key) (repeat "*"))
-       (take @string-key-length)
-       (apply str)))
+  ^String [k :- [:or
+                 ::api-keys.schema/key.unhashed-or-secret
+                 ::api-keys.schema/prefix]]
+  (let [sb (StringBuilder.)]
+    (.append sb (prefix k))
+    (dotimes [_ (- api-keys.schema/string-key-length api-keys.schema/prefix-length)]
+      (.append sb \*))
+    (str sb)))
 
-(defn- add-key
+(mu/defn- hash-bcrypt :- ::api-keys.schema/key.hashed
+  [k :- ::api-keys.schema/key.unhashed-or-secret]
+  (-> k u.secret/expose u.password/hash-bcrypt))
+
+(mu/defn- add-key
   "Adds the `key` based on the `unhashed_key` passed in."
-  [{:keys [unhashed_key] :as api-key}]
-  (cond-> api-key
-    (contains? api-key :unhashed_key)
-    (assoc :key (some-> unhashed_key u.secret/expose u.password/hash-bcrypt))
+  [{unhashed-key :unhashed_key, :as api-key} :- [:map
+                                                 [:unhashed-key {:optional true} ::api-keys.schema/key.unhashed]]]
+  (-> api-key
+      (cond-> (contains? api-key :unhashed_key) (assoc :key (some-> unhashed-key hash-bcrypt)))
+      (dissoc :unhashed_key)))
 
-    true (dissoc :unhashed_key)))
+(defn- validate-with-schema [api-key schema]
+  (when-let [error (mr/explain schema api-key)]
+    (let [humanized (me/humanize error)]
+      (throw (ex-info (format "Invalid API Key: %s" (pr-str humanized))
+                      {:error    humanized
+                       :original error}))))
+  api-key)
 
 (t2/define-before-insert :model/ApiKey
   [api-key]
   (-> api-key
       add-prefix
-      add-key))
+      add-key
+      (validate-with-schema ::api-keys.schema/api-key.insert)))
 
 (t2/define-before-update :model/ApiKey
   [api-key]
   (-> api-key
       add-prefix
-      add-key))
+      add-key
+      (validate-with-schema ::api-keys.schema/api-key.update)))
 
 (defn- add-masked-key [api-key]
   (if-let [prefix (:key_prefix api-key)]
@@ -119,3 +144,34 @@
    ;; cache the results for 60 minutes; TTL is here only to eventually clear out old entries/keep it from growing too
    ;; large
    :ttl/threshold (* 60 60 1000)))
+
+(mu/defn key-with-unique-prefix :- ::api-keys.schema/key.secret
+  "Generate an unique API key with a unique prefix."
+  []
+  (u/auto-retry 5
+    (let [api-key (generate-key)
+          prefix (prefix (u.secret/expose api-key))]
+     ;; we could make this more efficient by generating 5 API keys up front and doing one select to remove any
+     ;; duplicates. But a duplicate should be rare enough to just do multiple queries for now.
+      (if-not (t2/exists? :model/ApiKey :key_prefix prefix)
+        api-key
+        (throw (ex-info (tru "could not generate key with unique prefix") {}))))))
+
+(mu/defn create-single-collection-api-key! :- ::api-keys.schema/key.secret
+  "Create a new API key to give `user-id` permissions to read/write a single collection with `collection-id`. Make sure
+  the user has perms to do this before creating the token!"
+  [user-id       :- pos-int?
+   collection-id :- pos-int?]
+  (let [api-key  (generate-key)
+        prefix   (prefix api-key)
+        key-name (format "Single Collection API Key for User %d and Collection %d starting with %s"
+                         user-id collection-id prefix)]
+    (t2/insert! :model/ApiKey {:user_id              user-id
+                               :creator_id           user-id
+                               :updated_by_id        user-id
+                               :name                 key-name
+                               :key                  (hash-bcrypt api-key)
+                               :key_prefix           prefix
+                               :scope                :api-key.scope/single-collection
+                               :single_collection_id collection-id})
+    api-key))

--- a/src/metabase/api_keys/models/api_key.clj
+++ b/src/metabase/api_keys/models/api_key.clj
@@ -82,7 +82,7 @@
   "Generates a new API key - a random base64 string prefixed with `mb_`"
   []
   (u.secret/secret
-   (str "mb_" (crypto-random/base64 api-keys.schema/bytes-key-length))))
+   (str "mb_" (crypto-random/base64 api-keys.schema/generated-bytes-key-length))))
 
 (mu/defn mask :- ::api-keys.schema/key.masked
   "Given an API key, returns a string of the same length with all but the prefix masked with `*`s"
@@ -91,7 +91,7 @@
                  ::api-keys.schema/prefix]]
   (let [sb (StringBuilder.)]
     (.append sb (prefix k))
-    (dotimes [_ (- api-keys.schema/string-key-length api-keys.schema/prefix-length)]
+    (dotimes [_ (- api-keys.schema/generated-string-key-length api-keys.schema/prefix-length)]
       (.append sb \*))
     (str sb)))
 

--- a/src/metabase/api_keys/schema.clj
+++ b/src/metabase/api_keys/schema.clj
@@ -1,0 +1,114 @@
+(ns metabase.api-keys.schema
+  (:require
+   [clojure.math :as math]
+   [clojure.string :as str]
+   [malli.core :as mc]
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms]
+   [metabase.util.secret]))
+
+(def prefix-length
+  "The prefix length, the length of `mb_1234`"
+  7)
+
+(def bytes-key-length
+  "The total number of bytes of randomness we generate for API keys."
+  32)
+
+(def string-key-length
+  "Total length of an unhashed API key `key` string, including the `mb_` prefix."
+  (let [num-bits   (* bytes-key-length 8)
+        num-unpadded-chars  (/ num-bits 6)              ; base-64 uses one character for every 6 bits
+        num-blocks (math/ceil (/ num-unpadded-chars 4)) ; base-64 adds padding so the number of chars is divisible by 4
+        num-chars  (* num-blocks 4)]
+    (long (+ num-chars 3))))                            ; add 3 characters for the `mb_` prefix
+
+(mr/def ::key.unhashed
+  [:and
+   [:string {:min string-key-length, :max string-key-length}]
+   [:fn
+    {:error/message "An API token key must start with 'mb_'"}
+    (fn [s]
+      (and (string? s)
+           (str/starts-with? s "mb_")))]])
+
+(mr/def ::key.secret
+  [:ref :metabase.util.secret/secret])
+
+(mr/def ::key.unhashed-or-secret
+  [:or
+   [:ref ::key.unhashed]
+   [:ref ::key.secret]])
+
+(mr/def ::key.hashed
+  [:and
+   [:string {:min 60, :max 60}] ; bcrypt hashes are 60 characters, at least ours always are.
+   [:fn
+    {:error/message "A hashed API token key should NOT start with `mb_` (this means it is unhashed)."}
+    (fn [s]
+      (and (string? s)
+           (not (str/starts-with? s "mb_"))))]])
+
+(mr/def ::id
+  pos-int?)
+
+(mr/def ::prefix
+  [:string {:min prefix-length, :max prefix-length}])
+
+(mr/def ::name
+  [:string {:min 1, :max 254}]) ; min/max are from the app DB being varchar(254)
+
+(mr/def ::scope
+  [:enum
+   ;; TODO (Cam 8/12/25) -- we should namespace this key as well, I guess we can probably just have the T2 transform
+   ;; take care of it.
+   :scim
+   :api-key.scope/single-collection])
+
+(mr/def ::timestamp
+  [:or
+   (ms/InstanceOfClass java.time.OffsetDateTime)
+   (ms/InstanceOfClass java.time.ZonedDateTime)])
+
+(mr/def ::api-key
+  "Schema for a `:model/ApiKey`; this is based on the `api_key` table as defined in the application database.
+
+  This schema corresponds to a row as you would get with `SELECT`."
+  [:map
+   {:closed true}
+   [:id                   {::insert.optional true} ::id]
+   [:user_id              {:optional true} [:maybe pos-int?]]
+   [:key                  [:ref ::key.hashed]]
+   [:key_prefix           [:ref ::prefix]]
+   [:creator_id           pos-int?]
+   [:created_at           {::insert.optional true} [:ref ::timestamp]]
+   [:updated_at           {::insert.optional true} [:ref ::timestamp]]
+   [:name                 [:ref ::name]]
+   [:updated_by_id        pos-int?]
+   [:scope                {:optional true} [:maybe [:ref ::scope]]]
+   [:single_collection_id {:optional true} [:maybe pos-int?]]])
+
+(defn- insert-schema [map-schema]
+  (into [:map]
+        (map (fn [[k properties schema]]
+               (if properties
+                 [k
+                  (cond-> properties
+                    (::insert.optional properties) (assoc :optional true))
+                  schema]
+                 [k schema])))
+        (mc/children (mr/resolve-schema map-schema))))
+
+(mr/def ::api-key.insert
+  (insert-schema ::api-key))
+
+(defn- update-schema [map-schema]
+  (into [:map]
+        (map (fn [[k properties schema]]
+               [k
+                (assoc properties :optional true)
+                schema]))
+        (mc/children (mr/resolve-schema map-schema))))
+
+(mr/def ::api-key.update
+  (update-schema ::api-key))

--- a/src/metabase/lib/schema/id.cljc
+++ b/src/metabase/lib/schema/id.cljc
@@ -66,3 +66,6 @@
 
 (mr/def ::native-query-snippet
   [:schema {:doc/title "Valid Native Query Snippet ID"} pos-int?])
+
+(mr/def ::collection
+  [:schema {:doc/title "Valid Collection ID"} pos-int?])

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -89,7 +89,8 @@
  [metabase.permissions.path
   application-perms-path
   collection-read-path
-  collection-readwrite-path]
+  collection-readwrite-path
+  collection-path?]
  [metabase.permissions.user
   user-permissions-set]
  [metabase.permissions.util

--- a/src/metabase/permissions/models/permissions.clj
+++ b/src/metabase/permissions/models/permissions.clj
@@ -141,7 +141,7 @@
 
   ### Known Permissions Paths
 
-  See [[path-regex-v1]] for an always-up-to-date list of permissions paths.
+  See [[metabase.permissions.util/path-regex-v1]] for an always-up-to-date list of permissions paths.
 
     /collection/:id/                                ; read-write perms for a Coll and its non-Coll children
     /collection/:id/read/                           ; read-only  perms for a Coll and its non-Coll children

--- a/src/metabase/permissions/path.clj
+++ b/src/metabase/permissions/path.clj
@@ -1,5 +1,6 @@
 (ns metabase.permissions.path
   (:require
+   [clojure.string :as str]
    [metabase.permissions.util :as perms.u]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
@@ -17,6 +18,16 @@
     (if-let [collection-namespace (:namespace collection-or-id)]
       (format "/collection/namespace/%s/root/" (perms.u/escape-path-component (u/qualified-name collection-namespace)))
       "/collection/root/")))
+
+(mu/defn collection-path?
+  "Whether permissions `path` is any type of path for any Collection (1-arity) or for the Collection with
+  `collection-id` (2-arity)."
+  ([path :- [:maybe perms.u/PathSchema]]
+   (str/starts-with? path "/collection/"))
+
+  ([path          :- [:maybe perms.u/PathSchema]
+    collection-id :- pos-int?]
+   (str/starts-with? path (format "/collection/%d/" collection-id))))
 
 (mu/defn collection-read-path :- perms.u/PathSchema
   "Return the permissions path for *read* access for a `collection-or-id`."

--- a/src/metabase/request/schema.clj
+++ b/src/metabase/request/schema.clj
@@ -1,0 +1,16 @@
+(ns metabase.request.schema
+  (:require
+   [metabase.util.malli.registry :as mr]))
+
+(mr/def ::current-user-info
+  [:map
+   [:metabase-user-id  pos-int?]
+   [:is-superuser?     {:optional true} :boolean]
+   [:user-locale       {:optional true} [:maybe string?]]
+   [:is-group-manager? {:optional true} :boolean]
+   [:permissions-set   {:optional true} [:set :string]]
+   ;; if this is specified, restrict permissions to only this Collections. Added
+   ;; by [[metabase.server.middleware.session/current-user-info-for-api-key]] for API keys created
+   ;; with [[metabase.api-keys.models.api-key/create-single-collection-api-key!]].
+   ;; [[metabase.request.session/current-user-info->permissions-set]] handles restricting the permissions set.
+   [:api-key/allowed-collection-id {:optional true} [:maybe pos-int?]]])

--- a/src/metabase/request/schema.clj
+++ b/src/metabase/request/schema.clj
@@ -4,7 +4,7 @@
 
 (mr/def ::current-user-info
   [:map
-   [:metabase-user-id  pos-int?]
+   [:metabase-user-id  {:optional true} pos-int?]
    [:is-superuser?     {:optional true} :boolean]
    [:user-locale       {:optional true} [:maybe string?]]
    [:is-group-manager? {:optional true} :boolean]

--- a/src/metabase/request/session.clj
+++ b/src/metabase/request/session.clj
@@ -46,7 +46,7 @@
 
 (mu/defn do-with-current-user
   "Impl for [[with-current-user]]."
-  [{:keys [metabase-user-id is-superuser? user-locale settings is-group-manager?], :as current-user-info} :- ::request.schema/current-user-info
+  [{:keys [metabase-user-id is-superuser? user-locale settings is-group-manager?], :as current-user-info} :- [:maybe ::request.schema/current-user-info]
    thunk]
   (binding [*current-user-id*              metabase-user-id
             i18n/*user-locale*             user-locale

--- a/src/metabase/request/session.clj
+++ b/src/metabase/request/session.clj
@@ -1,6 +1,5 @@
 (ns metabase.request.session
   (:require
-   [clojure.string :as str]
    [flatland.ordered.set :as ordered-set]
    [metabase.api.common
     :as api

--- a/src/metabase/request/session.clj
+++ b/src/metabase/request/session.clj
@@ -1,6 +1,5 @@
 (ns metabase.request.session
   (:require
-   [flatland.ordered.set :as ordered-set]
    [metabase.api.common
     :as api
     :refer [*current-user* *current-user-id* *current-user-permissions-set* *is-group-manager?* *is-superuser?*]]
@@ -37,7 +36,7 @@
   (when-let [perms-set (or permissions-set
                            (some-> metabase-user-id perms/user-permissions-set))]
     (if allowed-collection-id
-      (into (ordered-set/ordered-set)   ; for REPL-friendliness
+      (into (sorted-set) ; for REPL-friendliness
             (remove (fn [path]
                       (and (perms/collection-path? path)
                            (not (perms/collection-path? path allowed-collection-id)))))

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -31,6 +31,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
    [metabase.util.password :as u.password]
    [metabase.util.string :as string]
    [toucan2.core :as t2]
@@ -200,8 +201,10 @@
 
 (mu/defn- current-user-info-for-api-key :- [:maybe ::request.schema/current-user-info]
   "Return User ID and superuser status for an API Key with `api-key-id"
-  [api-key :- ::api-keys.schema/key.unhashed]
-  (when (and api-key (init-status/complete?))
+  [api-key :- [:maybe :string]]
+  (when (and api-key
+             (mr/validate ::api-keys.schema/key.raw api-key)
+             (init-status/complete?))
     (let [user-info (-> (t2/query-one (cons (user-data-for-api-key-prefix-query
                                              (premium-features/enable-advanced-permissions?))
                                             [(api-key/prefix api-key)]))

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -203,6 +203,7 @@
   "Return User ID and superuser status for an API Key with `api-key-id"
   [api-key :- [:maybe :string]]
   (when (and api-key
+             (mr/validate ::api-keys.schema/key.raw api-key)
              (init-status/complete?))
     (let [user-info (-> (t2/query-one (cons (user-data-for-api-key-prefix-query
                                              (premium-features/enable-advanced-permissions?))

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -203,7 +203,6 @@
   "Return User ID and superuser status for an API Key with `api-key-id"
   [api-key :- [:maybe :string]]
   (when (and api-key
-             (mr/validate ::api-keys.schema/key.raw api-key)
              (init-status/complete?))
     (let [user-info (-> (t2/query-one (cons (user-data-for-api-key-prefix-query
                                              (premium-features/enable-advanced-permissions?))

--- a/src/metabase/util/malli/describe.cljc
+++ b/src/metabase/util/malli/describe.cljc
@@ -1,5 +1,6 @@
 (ns metabase.util.malli.describe
-  "This is exactly the same as [[malli.experimental.describe]], but handles our deferred i18n forms."
+  "This is exactly the same as [[malli.experimental.describe]], but handles our deferred i18n forms, and uses our
+  registry."
   (:require
    [clojure.string :as str]
    [malli.core :as mc]

--- a/src/metabase/util/secret.clj
+++ b/src/metabase/util/secret.clj
@@ -7,8 +7,12 @@
 
 (set! *warn-on-reflection* true)
 
-;; Define a protocol for secrets to make things harder to accidentally expose.
-(p/defprotocol+ ISecret
+;; Define an interface for secrets to make things harder to accidentally expose.
+;;
+;; This uses `definterface` rather than `defprotocol` because [[secret?]] below only works correctly for classes that
+;; implement it at definition time; making it an interface discourages people from thinking an object that you
+;; `extend-protocol`-ed would work
+(p/definterface+ ISecret
   (expose [this] "Expose the secret"))
 
 (p/deftype+ Secret [value-fn]
@@ -33,6 +37,7 @@
   (instance? metabase.util.secret.ISecret x))
 
 (mr/def ::secret
+  "An instance of a metabase.util.secret.ISecret."
   [:fn
-   {:error/message "An instance of a Secret"}
+   {:error/message "An instance of a metabase.util.secret.ISecret."}
    #'secret?])

--- a/src/metabase/util/secret.clj
+++ b/src/metabase/util/secret.clj
@@ -1,29 +1,38 @@
 (ns metabase.util.secret
   (:require
-   [metabase.util.i18n :refer [trs]])
-  (:import (java.io Writer)))
+   [metabase.util.i18n :refer [trs]]
+   [metabase.util.malli.registry :as mr]
+   [potemkin :as p]
+   [pretty.core :as pretty]))
 
 (set! *warn-on-reflection* true)
 
 ;; Define a protocol for secrets to make things harder to accidentally expose.
-(defprotocol ISecret
+(p/defprotocol+ ISecret
   (expose [this] "Expose the secret"))
 
-(defrecord Secret [value-fn]
+(p/deftype+ Secret [value-fn]
   ISecret
   (expose [_this] (value-fn))
+
   Object
-  (toString [_this] (trs "<< REDACTED SECRET >>")))
+  (toString [_this] (trs "<< REDACTED SECRET >>"))
 
-(defmethod print-method Secret
-  [^Secret secret ^Writer writer]
-  (.write writer (.toString secret)))
-
-(defmethod print-dup Secret
-  [^Secret secret ^Writer w]
-  (.write w (.toString secret)))
+  pretty/PrettyPrintable
+  (pretty [this]
+    (.toString this)))
 
 (defn secret
   "Create a `Secret` that can't be accidentally read without calling the `expose` method on it."
   [value]
   (->Secret (constantly value)))
+
+(defn secret?
+  "Whether `x` is an instance of a `Secret`."
+  [x]
+  (instance? metabase.util.secret.ISecret x))
+
+(mr/def ::secret
+  [:fn
+   {:error/message "An instance of a Secret"}
+   #'secret?])

--- a/test/metabase/api_keys/api_test.clj
+++ b/test/metabase/api_keys/api_test.clj
@@ -1,14 +1,17 @@
 (ns metabase.api-keys.api-test
   "Tests for /api/api-key endpoints"
   (:require
-   [clojure.test :refer [deftest testing is]]
+   [clojure.test :refer :all]
    [metabase.api-keys.models.api-key :as api-key]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
    [toucan2.core :as t2]))
 
-(deftest api-key-creation-test
+(use-fixtures :once (fixtures/initialize :test-users :web-server))
+
+(deftest ^:parallel api-key-creation-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Cool Friends"}]
     (testing "POST /api/api-key works"
       (let [name (str (random-uuid))
@@ -20,7 +23,10 @@
         (is (= (select-keys (mt/fetch-user :crowberto) [:id :common_name])
                (:updated_by resp)))
         (is (= {:name "Cool Friends" :id group-id} (:group resp)))
-        (is (= name (:name resp)))))
+        (is (= name (:name resp)))))))
+
+(deftest ^:parallel api-key-creation-test-2
+  (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Cool Friends"}]
     (testing "Trying to create another API key with the same name fails"
       (let [key-name (str (random-uuid))]
         ;; works once...
@@ -31,7 +37,10 @@
         (is (= {:errors {:name "An API key with this name already exists."}}
                (mt/user-http-request :crowberto :post 400 "api-key"
                                      {:group_id group-id
-                                      :name     key-name})))))
+                                      :name     key-name})))))))
+
+(deftest api-key-creation-test-3
+  (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Cool Friends"}]
     (testing "API key generation is retried if a prefix collision occurs"
       ;; mock out the `api-key/generate-key` function to generate the same key (with the same prefix) repeatedly
       (let [generated-key  (api-key/generate-key)
@@ -44,35 +53,44 @@
                                                     (swap! generated-keys next)
                                                     next-val))]
           ;; put an API Key in the database with that key.
-          (mt/with-temp [:model/ApiKey _ {:unhashed_key  generated-key
-                                          :name          "my cool name"
-                                          :user_id       (mt/user->id :crowberto)
-                                          :creator_id (mt/user->id :crowberto)
-                                          :updated_by_id (mt/user->id :crowberto)}]
+          (mt/with-temp [:model/ApiKey _ {:metabase.api-keys.core/unhashed-key generated-key
+                                          :name                                "my cool name"
+                                          :user_id                             (mt/user->id :crowberto)
+                                          :creator_id                          (mt/user->id :crowberto)
+                                          :updated_by_id                       (mt/user->id :crowberto)}]
             ;; this will try to generate a new API key
             (mt/user-http-request :crowberto :post 200 "api-key"
                                   {:group_id group-id
                                    :name     (str (random-uuid))})
             ;; we've exhausted the `generated-keys` we mocked
-            (is (empty? @generated-keys))))))
+            (is (empty? @generated-keys))))))))
+
+(deftest api-key-creation-test-4
+  (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Cool Friends"}]
     (testing "We don't retry forever if prefix collision keeps happening"
       (let [generated-key (api-key/generate-key)]
         (with-redefs [api-key/generate-key (constantly generated-key)]
-          (mt/with-temp [:model/ApiKey _ {:unhashed_key  generated-key
-                                          :name          "my cool name"
-                                          :user_id       (mt/user->id :crowberto)
-                                          :creator_id (mt/user->id :crowberto)
-                                          :updated_by_id (mt/user->id :crowberto)}]
+          (mt/with-temp [:model/ApiKey _ {:metabase.api-keys.core/unhashed-key generated-key
+                                          :name                                "my cool name"
+                                          :user_id                             (mt/user->id :crowberto)
+                                          :creator_id                          (mt/user->id :crowberto)
+                                          :updated_by_id                       (mt/user->id :crowberto)}]
             (is (= "could not generate key with unique prefix"
                    (:message (mt/user-http-request :crowberto :post 500 "api-key"
                                                    {:group_id group-id
-                                                    :name     (str (random-uuid))}))))))))
+                                                    :name     (str (random-uuid))}))))))))))
+
+(deftest ^:parallel api-key-creation-test-5
+  (testing "POST /api/api-key"
     (testing "A group is required"
       (is (= {:errors          {:group_id "value must be an integer greater than zero."}
               :specific-errors {:group_id ["value must be an integer greater than zero., received: nil"]}}
              (mt/user-http-request :crowberto :post 400 "api-key"
                                    {:group_id nil
-                                    :name     (str (random-uuid))}))))
+                                    :name     (str (random-uuid))}))))))
+
+(deftest ^:parallel api-key-creation-test-6
+  (testing "POST /api/api-key"
     (testing "The group can be 'All Users'"
       (is (mt/user-http-request :crowberto :post 200 "api-key"
                                 {:group_id (:id (perms-group/all-users))
@@ -81,13 +99,19 @@
              (get-in (mt/user-http-request :crowberto :post 200 "api-key"
                                            {:group_id (:id (perms-group/all-users))
                                             :name (str (random-uuid))})
-                     [:group :name]))))
+                     [:group :name]))))))
+
+(deftest ^:parallel api-key-creation-test-7
+  (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Cool Friends"}]
     (testing "A non-empty name is required"
       (is (= {:errors          {:name "value must be a non-blank string."}
               :specific-errors {:name ["should be at least 1 character, received: \"\"" "non-blank string, received: \"\""]}}
              (mt/user-http-request :crowberto :post 400 "api-key"
                                    {:group_id group-id
-                                    :name     ""}))))
+                                    :name     ""}))))))
+
+(deftest ^:parallel api-key-creation-test-8
+  (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Cool Friends"}]
     (testing "A non-blank name is required"
       (is (= {:errors          {:name "value must be a non-blank string."}
               :specific-errors {:name ["non-blank string, received: \"   \""]}}
@@ -98,26 +122,25 @@
 (deftest api-count-works
   (mt/with-empty-h2-app-db!
     (is (zero? (mt/user-http-request :crowberto :get 200 "api-key/count")))
-    (mt/with-temp [:model/ApiKey _ {:unhashed_key  (api-key/generate-key)
-                                    :name          "my cool name"
-                                    :user_id       (mt/user->id :crowberto)
-                                    :creator_id    (mt/user->id :crowberto)
-                                    :updated_by_id (mt/user->id :crowberto)}]
+    (mt/with-temp [:model/ApiKey _ {:metabase.api-keys.core/unhashed-key (api-key/generate-key)
+                                    :name                                "my cool name"
+                                    :user_id                             (mt/user->id :crowberto)
+                                    :creator_id                          (mt/user->id :crowberto)
+                                    :updated_by_id                       (mt/user->id :crowberto)}]
       (is (= 1 (mt/user-http-request :crowberto :get 200 "api-key/count")))
-      (mt/with-temp [:model/ApiKey _ {:unhashed_key  (api-key/generate-key)
-                                      :name          "my cool OTHER name"
-                                      :user_id       (mt/user->id :crowberto)
-                                      :creator_id    (mt/user->id :crowberto)
-                                      :updated_by_id (mt/user->id :crowberto)}]
+      (mt/with-temp [:model/ApiKey _ {:metabase.api-keys.core/unhashed-key (api-key/generate-key)
+                                      :name                                "my cool OTHER name"
+                                      :user_id                             (mt/user->id :crowberto)
+                                      :creator_id                          (mt/user->id :crowberto)
+                                      :updated_by_id                       (mt/user->id :crowberto)}]
         (is (= 2 (mt/user-http-request :crowberto :get 200 "api-key/count"))))
-
       (testing "API keys with non-default scopes, like SCIM, are excluded"
-        (mt/with-temp [:model/ApiKey _ {:unhashed_key  (api-key/generate-key)
-                                        :name          "my cool OTHER name"
-                                        :user_id       (mt/user->id :crowberto)
-                                        :creator_id    (mt/user->id :crowberto)
-                                        :updated_by_id (mt/user->id :crowberto)
-                                        :scope         "scim"}]
+        (mt/with-temp [:model/ApiKey _ {:metabase.api-keys.core/unhashed-key (api-key/generate-key)
+                                        :name                                "my cool OTHER name"
+                                        :user_id                             (mt/user->id :crowberto)
+                                        :creator_id                          (mt/user->id :crowberto)
+                                        :updated_by_id                       (mt/user->id :crowberto)
+                                        :scope                               :scim}]
           (is (= 1 (mt/user-http-request :crowberto :get 200 "api-key/count"))))))))
 
 (deftest api-keys-work-e2e
@@ -137,7 +160,7 @@
         (is (= "Unauthenticated"
                (client/client :get 401 "user/current" {:request-options {:headers {"x-api-key" api-key}}})))))))
 
-(deftest api-keys-can-be-updated
+(deftest ^:parallel api-keys-can-be-updated
   (mt/with-temp [:model/PermissionsGroup {group-id-1 :id} {:name "Cool Friends"}
                  :model/PermissionsGroup {group-id-2 :id} {:name "Uncool Friends"}]
     ;; create the API Key
@@ -146,8 +169,9 @@
                                 :post 200 "api-key"
                                 {:group_id group-id-1
                                  :name     (str (random-uuid))})
+          _                (assert (t2/exists? :model/ApiKey id))
           _                (is (= "Cool Friends" (-> create-resp :group :name)))
-          api-user-id      (:id (:user (t2/hydrate (t2/select-one :model/ApiKey :id id) :user)))
+          api-user-id      (t2/select-one-fn :user_id :model/ApiKey :id id)
           member-of-group? (fn [group-id]
                              (t2/exists? :model/PermissionsGroupMembership
                                          :user_id api-user-id
@@ -155,12 +179,15 @@
       (is (member-of-group? group-id-1))
       (is (not (member-of-group? group-id-2)))
       (testing "You can change the group of an API key"
+        (is (=? {:group {:id group-id-2, :name "Uncool Friends"}}
+                (mt/user-http-request :crowberto :put 200 (format "api-key/%s" id) {:group_id group-id-2})))
         (is (= "Uncool Friends"
-               (-> (mt/user-http-request :crowberto :put 200 (format "api-key/%s" id) {:group_id group-id-2})
-                   :group
-                   :name)))
+               (t2/select-one-fn :name :model/PermissionsGroup group-id-2)))
         (is (not (member-of-group? group-id-1)))
-        (is (member-of-group? group-id-2))))
+        (is (member-of-group? group-id-2))))))
+
+(deftest ^:parallel api-keys-can-be-updated-2
+  (mt/with-temp [:model/PermissionsGroup {group-id-1 :id} {:name "Cool Friends"}]
     (testing "You can change the name of an API key"
       (let [name-1      (str "My First Name" (random-uuid))
             name-2      (str "My Second Name" (random-uuid))
@@ -169,7 +196,6 @@
                                               {:group_id group-id-1
                                                :name     name-1})
             api-user-id (-> (t2/select-one :model/ApiKey :id id) (t2/hydrate :user) :user :id)]
-
         (testing "before the change..."
           (is (= name-1 (:common_name (t2/select-one :model/User api-user-id)))))
         (testing "after the change..."
@@ -179,27 +205,37 @@
         (testing "the shape of the response is correct"
           (is (= #{:created_at :updated_at :updated_by :id :group :name :masked_key}
                  (set (keys (mt/user-http-request :crowberto :put 200 (str "api-key/" id)
-                                                  {:name name-1}))))))))
-    (testing "A nonexistent API Key can't be updated"
-      (mt/user-http-request :crowberto
-                            :put 404 (format "api-key/%s/regenerate" (+ 13371337 (rand-int 100)))))))
+                                                  {:name name-1}))))))))))
 
-(deftest api-keys-can-be-regenerated
+(deftest ^:parallel api-keys-can-be-updated-3
+  (testing "A nonexistent API Key can't be updated"
+    (mt/user-http-request :crowberto :put 404 (format "api-key/%s/regenerate" (+ 13371337 (rand-int 100))))))
+
+(deftest ^:parallel api-keys-can-be-regenerated
   (testing "You can regenerate an API key"
     (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Cool Friends"}]
-      (let [{id :id old-key :unmasked_key}
+      (let [{id :id old-key :unmasked_key, :as response}
             (mt/user-http-request :crowberto
                                   :post 200 "api-key"
                                   {:group_id group-id
                                    :name (str (random-uuid))})
+
+            _ (is (=? {:id pos-int?}
+                      response))
             _ (is (client/client :get 200 "user/current" {:request-options {:headers {"x-api-key" old-key}}}))
-            {:as resp new-key :unmasked_key}
+
+            {new-key :unmasked_key, :as response}
             (mt/user-http-request :crowberto
                                   :put 200 (format "api-key/%s/regenerate" id))]
-        (is (= #{:created_at :updated_at :id :name :unmasked_key :masked_key :group :updated_by}
-               (set (keys resp))))
-        (is (client/client :get 401 "user/current" {:request-options {:headers {"x-api-key" old-key}}}))
-        (is (client/client :get 200 "user/current" {:request-options {:headers {"x-api-key" new-key}}})))))
+        (is (= #{:id :unmasked_key :masked_key :prefix}
+               (cond-> response
+                 (map? response) (-> keys set))))
+        (is (= "Unauthenticated"
+               (client/client :get 401 "user/current" {:request-options {:headers {"x-api-key" old-key}}})))
+        (is (=? {}
+                (client/client :get 200 "user/current" {:request-options {:headers {"x-api-key" new-key}}})))))))
+
+(deftest ^:parallel api-keys-can-be-regenerated-2
   (testing "A nonexistent API Key can't be regenerated"
     (mt/user-http-request :crowberto
                           :put 404 (format "api-key/%s/regenerate" (+ 13371337 (rand-int 100))))))
@@ -208,39 +244,35 @@
   (mt/with-empty-h2-app-db!
     (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Cool Friends"}]
       (is (= [] (mt/user-http-request :crowberto :get 200 "api-key")))
-
       (mt/user-http-request :crowberto
                             :post 200 "api-key"
                             {:group_id group-id
                              :name     "My First API Key"})
       (is (= [{:name       "My First API Key"
-               :group {:name "Cool Friends"
-                       :id group-id}
+               :group      {:name "Cool Friends"
+                            :id   group-id}
                :updated_by (select-keys (mt/fetch-user :crowberto) [:common_name :id])}]
              (map #(select-keys % [:name :group :updated_by])
                   (mt/user-http-request :crowberto :get 200 "api-key"))))
-
       (mt/user-http-request :crowberto
                             :post 200 "api-key"
                             {:group_id (:id (perms-group/all-users))
-                             :name "My Second API Key"})
-
-      (is (= [{:name "My First API Key"
+                             :name     "My Second API Key"})
+      (is (= [{:name  "My First API Key"
                :group {:name "Cool Friends"
-                       :id group-id}}
-              {:name "My Second API Key"
+                       :id   group-id}}
+              {:name  "My Second API Key"
                :group {:name "All Users"
-                       :id (:id (perms-group/all-users))}}]
+                       :id   (:id (perms-group/all-users))}}]
              (map #(select-keys % [:name :group])
                   (mt/user-http-request :crowberto :get 200 "api-key"))))
-
       (testing "API keys with non-default scopes, like SCIM, are excluded"
-        (mt/with-temp [:model/ApiKey _ {:unhashed_key  (api-key/generate-key)
-                                        :name          "SCIM API key"
-                                        :user_id       (mt/user->id :crowberto)
-                                        :creator_id    (mt/user->id :crowberto)
-                                        :updated_by_id (mt/user->id :crowberto)
-                                        :scope         "scim"}]
+        (mt/with-temp [:model/ApiKey _ {:metabase.api-keys.core/unhashed-key (api-key/generate-key)
+                                        :name                                "SCIM API key"
+                                        :user_id                             (mt/user->id :crowberto)
+                                        :creator_id                          (mt/user->id :crowberto)
+                                        :updated_by_id                       (mt/user->id :crowberto)
+                                        :scope                               :scim}]
           (is (= 2 (count (mt/user-http-request :crowberto :get 200 "api-key")))))))))
 
 (deftest api-keys-can-be-deleted
@@ -251,6 +283,7 @@
                                          :post 200 "api-key"
                                          {:group_id (:id (perms-group/all-users))
                                           :name     "My First API Key"})]
+      (assert (pos-int? id))
       (is (= 1 (count (mt/user-http-request :crowberto :get 200 "api-key"))))
       (is (= 1 (mt/user-http-request :crowberto :get 200 "api-key/count")))
       (mt/user-http-request :crowberto :delete 204 (format "api-key/%s" id))
@@ -262,8 +295,53 @@
 (deftest api-key-operations-are-audit-logged
   (mt/with-premium-features #{:audit-app}
     (mt/with-empty-h2-app-db!
+      (mt/with-temp [:model/PermissionsGroup {group-id-1 :id} {:name "Cool Friends"}]
+        ;; create the API key
+        (let [{id :id} (mt/user-http-request :crowberto
+                                             :post 200 "api-key"
+                                             {:group_id group-id-1
+                                              :name     "My API Key"})]
+          (testing "Creation was audit logged"
+            (is (=? {:details  {:name    "My API Key"
+                                :group   {:name "Cool Friends"}
+                                :user_id (t2/select-one-fn :user_id :model/ApiKey id)}
+                     :model    "ApiKey"
+                     :model_id id
+                     :user_id  (mt/user->id :crowberto)}
+                    (mt/latest-audit-log-entry :api-key-create id)))
+            (is (= #{:name :group :key_prefix :user_id}
+                   (-> (mt/latest-audit-log-entry :api-key-create id) :details keys set)))))))))
+
+(deftest api-key-operations-are-audit-logged-2
+  (mt/with-premium-features #{:audit-app}
+    (mt/with-empty-h2-app-db!
       (mt/with-temp [:model/PermissionsGroup {group-id-1 :id} {:name "Cool Friends"}
                      :model/PermissionsGroup {group-id-2 :id} {:name "Less Cool Friends"}]
+        ;; create the API key
+        (let [{id :id} (mt/user-http-request :crowberto
+                                             :post 200 "api-key"
+                                             {:group_id group-id-1
+                                              :name     "My API Key"})
+              url      (fn [url] (format url id))]
+          (testing "Update is audit logged"
+            (is (=? {:id pos-int?}
+                    (mt/user-http-request :crowberto
+                                          :put 200 (url "api-key/%s")
+                                          {:group_id group-id-2
+                                           :name     "A New Name"})))
+            (is (=? {:details  {:previous {:name  "My API Key"
+                                           :group {:name "Cool Friends"}}
+                                :new      {:name  "A New Name"
+                                           :group {:name "Less Cool Friends"}}}
+                     :model    "ApiKey"
+                     :model_id id
+                     :user_id  (mt/user->id :crowberto)}
+                    (mt/latest-audit-log-entry :api-key-update id)))))))))
+
+(deftest api-key-operations-are-audit-logged-3
+  (mt/with-premium-features #{:audit-app}
+    (mt/with-empty-h2-app-db!
+      (mt/with-temp [:model/PermissionsGroup {group-id-1 :id} {:name "Cool Friends"}]
         ;; create the API key
         (let [{id           :id
                unmasked-key :unmasked_key} (mt/user-http-request :crowberto
@@ -272,46 +350,39 @@
                                                                   :name     "My API Key"})
               old-prefix                   (api-key/prefix unmasked-key)
               url                          (fn [url] (format url id))]
-          (testing "Creation was audit logged"
-            (is (=? {:details  {:name       "My API Key"
-                                :group      {:name  "Cool Friends"}
-                                :user_id    (t2/select-one-fn :user_id :model/ApiKey id)}
-                     :model    "ApiKey"
-                     :model_id id
-                     :user_id  (mt/user->id :crowberto)}
-                    (mt/latest-audit-log-entry :api-key-create id)))
-            (is (= #{:name :group :key_prefix :user_id}
-                   (-> (mt/latest-audit-log-entry :api-key-create id) :details keys set))))
-          (testing "Update is audit logged"
-            (mt/user-http-request :crowberto
-                                  :put 200 (url "api-key/%s")
-                                  {:group_id group-id-2
-                                   :name     "A New Name"})
-            (is (=? {:details  {:previous {:name       "My API Key"
-                                           :group {:name "Cool Friends"}}
-                                :new      {:name       "A New Name"
-                                           :group {:name "Less Cool Friends"}}}
-                     :model    "ApiKey"
-                     :model_id id
-                     :user_id  (mt/user->id :crowberto)}
-                    (mt/latest-audit-log-entry :api-key-update id))))
           (testing "Regeneration is audit logged"
-            (let [{:keys [unmasked_key]}
-                  (mt/user-http-request :crowberto
-                                        :put 200 (url "api-key/%s/regenerate"))
-                  new-prefix (api-key/prefix unmasked_key)]
+            (let [{unmasked-key :unmasked_key} (mt/user-http-request :crowberto :put 200 (url "api-key/%s/regenerate"))
+                  _                            (assert (string? unmasked-key))
+                  new-prefix                   (api-key/prefix unmasked-key)]
               (is (=? {:details  {:previous {:key_prefix old-prefix}
                                   :new      {:key_prefix new-prefix}}
                        :model    "ApiKey"
                        :model_id id
                        :user_id  (mt/user->id :crowberto)}
-                      (mt/latest-audit-log-entry :api-key-regenerate id)))))
+                      (mt/latest-audit-log-entry :api-key-regenerate id))))))))))
+
+(deftest api-key-operations-are-audit-logged-4
+  (mt/with-premium-features #{:audit-app}
+    (mt/with-empty-h2-app-db!
+      (mt/with-temp [:model/PermissionsGroup {group-id-1 :id} {:name "Cool Friends"}]
+        ;; create the API key
+        (let [{id :id} (mt/user-http-request :crowberto
+                                             :post 200 "api-key"
+                                             {:group_id group-id-1
+                                              :name     "My API Key"})
+              url      (fn [url] (format url id))]
           (testing "Deletion is audit logged"
-            (mt/user-http-request :crowberto
-                                  :delete 204 (url "api-key/%s"))
-            (is (=? {:details  {:name       "A New Name"
-                                :group {:name "Less Cool Friends"}}
+            (is (nil? (mt/user-http-request :crowberto
+                                            :delete 204 (url "api-key/%s"))))
+            (is (=? {:details  {:name  "My API Key"
+                                :group {:name "Cool Friends"}}
                      :model    "ApiKey"
                      :model_id id
                      :user_id  (mt/user->id :crowberto)}
                     (mt/latest-audit-log-entry :api-key-delete id)))))))))
+
+(deftest do-not-mark-user-inactive-when-deleting-api-key-for-normal-user
+  (mt/with-temp [:model/Collection {collection-id :id} {}]
+    (let [{api-key-id :id} (api-key/create-single-collection-api-key! (mt/user->id :crowberto) collection-id)]
+      (is (nil? (mt/user-http-request :crowberto :delete 204 (format "api-key/%d" api-key-id))))
+      (is (true? (t2/select-one-fn :is_active :model/User :id (mt/user->id :crowberto)))))))

--- a/test/metabase/api_keys/models/api_key_test.clj
+++ b/test/metabase/api_keys/models/api_key_test.clj
@@ -1,0 +1,39 @@
+(ns metabase.api-keys.models.api-key-test
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer :all]
+   [metabase.api-keys.core :as api-key]
+   [metabase.api.common :as api]
+   [metabase.permissions.core :as perms]
+   [metabase.request.core :as request]
+   [metabase.server.middleware.session :as mw.session]
+   [metabase.test :as mt]
+   [metabase.util.secret :as u.secret]))
+
+(deftest ^:synchronized single-collection-api-key-e2e-test
+  (mt/with-temp [:model/Collection {collection-1-id :id} {}
+                 :model/Collection {collection-2-id :id} {}]
+    (let [perms-set             (fn [current-user-info]
+                                  (request/do-with-current-user
+                                   current-user-info
+                                   (fn [] @api/*current-user-permissions-set*)))
+          has-collection-perms? (fn [perms-set collection-number]
+                                  (let [collection-id (case collection-number
+                                                        1 collection-1-id
+                                                        2 collection-2-id)]
+                                    (contains? perms-set (perms/collection-readwrite-path collection-id))))
+          original-perms-set    (perms-set {:metabase-user-id (mt/user->id :rasta)})]
+      (testing "Sanity check: original perms should have perms for both collections"
+        (is (has-collection-perms? original-perms-set 1))
+        (is (has-collection-perms? original-perms-set 2)))
+      (testing "with API key"
+        (mt/with-model-cleanup [:model/ApiKey]
+          (let [api-key                   (-> (api-key/create-single-collection-api-key! (mt/user->id :rasta) collection-1-id)
+                                              u.secret/expose)
+                api-key-current-user-info (#'mw.session/merge-current-user-info {:headers {"x-api-key" api-key}})]
+            (is (=? {:api-key/allowed-collection-id collection-1-id}
+                    api-key-current-user-info))
+            (let [api-key-perms-set (perms-set api-key-current-user-info)]
+              (is (set/subset? api-key-perms-set original-perms-set))
+              (is (has-collection-perms? api-key-perms-set 1))
+              (is (not (has-collection-perms? api-key-perms-set 2))))))))))

--- a/test/metabase/api_keys/models/api_key_test.clj
+++ b/test/metabase/api_keys/models/api_key_test.clj
@@ -8,32 +8,42 @@
    [metabase.request.core :as request]
    [metabase.server.middleware.session :as mw.session]
    [metabase.test :as mt]
-   [metabase.util.secret :as u.secret]))
+   [metabase.util.secret :as u.secret]
+   [toucan2.core :as t2]))
 
-(deftest ^:synchronized single-collection-api-key-e2e-test
-  (mt/with-temp [:model/Collection {collection-1-id :id} {}
-                 :model/Collection {collection-2-id :id} {}]
-    (let [perms-set             (fn [current-user-info]
-                                  (request/do-with-current-user
-                                   current-user-info
-                                   (fn [] @api/*current-user-permissions-set*)))
-          has-collection-perms? (fn [perms-set collection-number]
-                                  (let [collection-id (case collection-number
-                                                        1 collection-1-id
-                                                        2 collection-2-id)]
-                                    (contains? perms-set (perms/collection-readwrite-path collection-id))))
-          original-perms-set    (perms-set {:metabase-user-id (mt/user->id :rasta)})]
-      (testing "Sanity check: original perms should have perms for both collections"
-        (is (has-collection-perms? original-perms-set 1))
-        (is (has-collection-perms? original-perms-set 2)))
-      (testing "with API key"
-        (mt/with-model-cleanup [:model/ApiKey]
+(deftest single-collection-api-key-e2e-test
+  (let [api-key-prefix (promise)
+        api-key-exists? (fn []
+                          (when (realized? api-key-prefix)
+                            (let [prefix @api-key-prefix]
+                              (t2/exists? :model/ApiKey :key_prefix prefix))))]
+    (mt/with-temp [:model/Collection {collection-1-id :id} {}
+                   :model/Collection {collection-2-id :id} {}]
+      (let [perms-set             (fn [current-user-info]
+                                    (request/do-with-current-user
+                                     current-user-info
+                                     (fn [] @api/*current-user-permissions-set*)))
+            has-collection-perms? (fn [perms-set collection-number]
+                                    (let [collection-id (case collection-number
+                                                          1 collection-1-id
+                                                          2 collection-2-id)]
+                                      (contains? perms-set (perms/collection-readwrite-path collection-id))))
+            original-perms-set    (perms-set {:metabase-user-id (mt/user->id :rasta)})]
+        (testing "Sanity check: original perms should have perms for both collections"
+          (is (has-collection-perms? original-perms-set 1))
+          (is (has-collection-perms? original-perms-set 2)))
+        (testing "with API key"
           (let [api-key                   (-> (api-key/create-single-collection-api-key! (mt/user->id :rasta) collection-1-id)
+                                              :key
                                               u.secret/expose)
                 api-key-current-user-info (#'mw.session/merge-current-user-info {:headers {"x-api-key" api-key}})]
             (is (=? {:api-key/allowed-collection-id collection-1-id}
                     api-key-current-user-info))
+            (deliver api-key-prefix (api-key/prefix api-key))
+            (is (api-key-exists?))
             (let [api-key-perms-set (perms-set api-key-current-user-info)]
               (is (set/subset? api-key-perms-set original-perms-set))
               (is (has-collection-perms? api-key-perms-set 1))
-              (is (not (has-collection-perms? api-key-perms-set 2))))))))))
+              (is (not (has-collection-perms? api-key-perms-set 2))))))))
+    (testing "API key should get deleted automatically when Collection is deleted"
+      (is (not (api-key-exists?))))))

--- a/test/metabase/channel/email/messages_test.clj
+++ b/test/metabase/channel/email/messages_test.clj
@@ -121,11 +121,11 @@
           (is (= 1 (count @mt/inbox))))))))
 
 (deftest all-admin-recipients
-  (mt/with-temp [:model/ApiKey _ {:unhashed_key  (api-key/generate-key)
-                                  :name          "Test API key"
-                                  :user_id       (mt/user->id :crowberto)
-                                  :creator_id    (mt/user->id :crowberto)
-                                  :updated_by_id (mt/user->id :crowberto)}]
+  (mt/with-temp [:model/ApiKey _ {::api-key/unhashed-key (api-key/generate-key)
+                                  :name                  "Test API key"
+                                  :user_id               (mt/user->id :crowberto)
+                                  :creator_id            (mt/user->id :crowberto)
+                                  :updated_by_id         (mt/user->id :crowberto)}]
     (testing "all-admin-recipients returns all admin emails"
       (let [emails (#'messages/all-admin-recipients)]
         (is (some #(= % "crowberto@metabase.com") emails))

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -128,15 +128,14 @@
         {:headers {}}))))
 
 (deftest ^:parallel current-user-info-for-api-key-test-2
-  (let [k (api-key/generate-key)]
-    (mt/with-temp [:model/ApiKey _ {:name                  "An API Key without an internal user"
-                                    :user_id               nil
-                                    :creator_id            (mt/user->id :lucky)
-                                    :updated_by_id         (mt/user->id :lucky)
-                                    ::api-key/unhashed-key k}]
-      (testing "An API key without an internal user (e.g. a SCIM key) should not modify the request"
-        (let [req {:headers {"x-api-key" (u.secret/expose k)}}]
-          (is (= req (#'mw.session/merge-current-user-info req))))))))
+  (mt/with-temp [:model/ApiKey _ {:name                  "An API Key without an internal user"
+                                  :user_id               nil
+                                  :creator_id            (mt/user->id :lucky)
+                                  :updated_by_id         (mt/user->id :lucky)
+                                  ::api-key/unhashed-key (u.secret/secret "mb_foobar")}]
+    (testing "An API key without an internal user (e.g. a SCIM key) should not modify the request"
+      (let [req {:headers {"x-api-key" "mb_foobar"}}]
+        (is (= req (#'mw.session/merge-current-user-info req)))))))
 
 (defn- simple-auth-handler
   "A handler that just does authentication and returns a map from the dynamic variables that are bound as a result."
@@ -154,33 +153,31 @@
      identity
      (fn [e] (throw e)))))
 
-(deftest ^:parallel user-data-is-correctly-bound-for-api-keys
-  (let [k1 (api-key/generate-key)
-        k2 (api-key/generate-key)]
-    (mt/with-temp [:model/ApiKey _ {:name                  "An API Key"
-                                    :user_id               (mt/user->id :lucky)
-                                    :creator_id            (mt/user->id :lucky)
-                                    :updated_by_id         (mt/user->id :lucky)
-                                    ::api-key/unhashed-key k1}
-                   :model/ApiKey _ {:name                  "A superuser API Key"
-                                    :user_id               (mt/user->id :crowberto)
-                                    :creator_id            (mt/user->id :lucky)
-                                    :updated_by_id         (mt/user->id :lucky)
-                                    ::api-key/unhashed-key k2}]
-      (testing "A valid API key works, and user info is added to the request"
-        (is (= {:is-superuser?     false
-                :is-group-manager? false
-                :user-id           (mt/user->id :lucky)
-                :user              {:id    (mt/user->id :lucky)
-                                    :email (:email (mt/fetch-user :lucky))}}
-               (simple-auth-handler {:headers {"x-api-key" (u.secret/expose k1)}}))))
-      (testing "A superuser API key has `*is-superuser?*` bound correctly"
-        (is (= {:is-superuser?     true
-                :is-group-manager? false
-                :user-id           (mt/user->id :crowberto)
-                :user              {:id    (mt/user->id :crowberto)
-                                    :email (:email (mt/fetch-user :crowberto))}}
-               (simple-auth-handler {:headers {"x-api-key" (u.secret/expose k2)}})))))))
+(deftest user-data-is-correctly-bound-for-api-keys
+  (mt/with-temp [:model/ApiKey _ {:name                  "An API Key"
+                                  :user_id               (mt/user->id :lucky)
+                                  :creator_id            (mt/user->id :lucky)
+                                  :updated_by_id         (mt/user->id :lucky)
+                                  ::api-key/unhashed-key (u.secret/secret "mb_foobar")}
+                 :model/ApiKey _ {:name                  "A superuser API Key"
+                                  :user_id               (mt/user->id :crowberto)
+                                  :creator_id            (mt/user->id :lucky)
+                                  :updated_by_id         (mt/user->id :lucky)
+                                  ::api-key/unhashed-key (u.secret/secret "mb_superuser")}]
+    (testing "A valid API key works, and user info is added to the request"
+      (is (= {:is-superuser?     false
+              :is-group-manager? false
+              :user-id           (mt/user->id :lucky)
+              :user              {:id    (mt/user->id :lucky)
+                                  :email (:email (mt/fetch-user :lucky))}}
+             (simple-auth-handler {:headers {"x-api-key" "mb_foobar"}}))))
+    (testing "A superuser API key has `*is-superuser?*` bound correctly"
+      (is (= {:is-superuser?     true
+              :is-group-manager? false
+              :user-id           (mt/user->id :crowberto)
+              :user              {:id    (mt/user->id :crowberto)
+                                  :email (:email (mt/fetch-user :crowberto))}}
+             (simple-auth-handler {:headers {"x-api-key" "mb_superuser"}}))))))
 
 (deftest cannot-use-session-id-for-auth
   (testing "The session id is checked on requests, but only for uuid-formatted keys. Allowing users to auth with core_session.id values would be a security risk."
@@ -331,14 +328,13 @@
             :user    {:id    (mt/user->id :rasta)
                       :email (:email (mt/fetch-user :rasta))}}
            (user-bound-handler
-            (request-with-user-id (mt/user->id :rasta)))))))
+            (request-with-user-id (mt/user->id :rasta))))))
 
-(deftest ^:parallel add-user-id-key-test-2
   (testing "with invalid user-id (not sure how this could ever happen, but lets test it anyways)"
-    (is (= {:user-id Integer/MAX_VALUE
+    (is (= {:user-id 0
             :user    {}}
            (user-bound-handler
-            (request-with-user-id Integer/MAX_VALUE))))))
+            (request-with-user-id 0))))))
 
 ;;; ----------------------------------------------   with-current-user -------------------------------------------------
 

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -108,33 +108,55 @@
                                   :user_id               (mt/user->id :lucky)
                                   :creator_id            (mt/user->id :lucky)
                                   :updated_by_id         (mt/user->id :lucky)
-                                  ::api-key/unhashed-key (u.secret/secret "mb_foobar")}]
+                                  ::api-key/unhashed-key (u.secret/secret "mb_foobar123")}]
     (testing "A valid API key works, and user info is added to the request"
-      (let [req {:headers {"x-api-key" "mb_foobar"}}]
+      (let [req {:headers {"x-api-key" "mb_foobar123"}}]
         (is (= (merge req {:metabase-user-id  (mt/user->id :lucky)
                            :is-superuser?     false
                            :is-group-manager? false
                            :user-locale       nil})
-               (#'mw.session/merge-current-user-info req)))))
-    (testing "Various invalid API keys do not modify the request"
-      (are [req] (= req (#'mw.session/merge-current-user-info req))
-        ;; a matching prefix, invalid key
-        {:headers {"x-api-key" "mb_fooby"}}
+               (#'mw.session/merge-current-user-info req)))))))
 
-        ;; no matching prefix, invalid key
-        {:headers {"x-api-key" "abcde"}}
+(deftest ^:parallel current-user-info-for-api-key-test-1b
+  (testing "Various invalid API keys do not modify the request"
+    (are [req] (= req (#'mw.session/merge-current-user-info req))
+      ;; a matching prefix, invalid key
+      {:headers {"x-api-key" "mb_fooby"}}
 
-        ;; no key at all
-        {:headers {}}))))
+      ;; no matching prefix, invalid key
+      {:headers {"x-api-key" "abcde"}}
+
+      ;; no key at all
+      {:headers {}})))
+
+(deftest ^:parallel current-user-info-for-api-key-log-errors-test
+  (testing "Log an error about invalid API keys"
+    (mt/with-log-messages-for-level [messages [metabase.server.middleware.session :error]]
+      (#'mw.session/merge-current-user-info {:headers {"x-api-key" "mb_fooby"}})
+      (is (= {:namespace 'metabase.server.middleware.session
+              :level     :error
+              :e         nil
+              :message   "Ignoring invalid API Key: [\"should be at least 12 characters\"]"}
+             (messages))))))
+
+(deftest ^:parallel current-user-info-for-api-key-log-errors-test-2
+  (testing "Do not include the key itself in the error message -- fall back to a generic error message"
+    (mt/with-log-messages-for-level [messages [metabase.server.middleware.session :error]]
+      (#'mw.session/merge-current-user-info {:headers {"x-api-key" "characters"}})
+      (is (= {:namespace 'metabase.server.middleware.session
+              :level     :error
+              :e         nil
+              :message   "Ignoring invalid API Key"}
+             (messages))))))
 
 (deftest ^:parallel current-user-info-for-api-key-test-2
   (mt/with-temp [:model/ApiKey _ {:name                  "An API Key without an internal user"
                                   :user_id               nil
                                   :creator_id            (mt/user->id :lucky)
                                   :updated_by_id         (mt/user->id :lucky)
-                                  ::api-key/unhashed-key (u.secret/secret "mb_foobar")}]
+                                  ::api-key/unhashed-key (u.secret/secret "mb_foobar123")}]
     (testing "An API key without an internal user (e.g. a SCIM key) should not modify the request"
-      (let [req {:headers {"x-api-key" "mb_foobar"}}]
+      (let [req {:headers {"x-api-key" "mb_foobar123"}}]
         (is (= req (#'mw.session/merge-current-user-info req)))))))
 
 (defn- simple-auth-handler
@@ -153,12 +175,12 @@
      identity
      (fn [e] (throw e)))))
 
-(deftest user-data-is-correctly-bound-for-api-keys
+(deftest ^:parallel user-data-is-correctly-bound-for-api-keys
   (mt/with-temp [:model/ApiKey _ {:name                  "An API Key"
                                   :user_id               (mt/user->id :lucky)
                                   :creator_id            (mt/user->id :lucky)
                                   :updated_by_id         (mt/user->id :lucky)
-                                  ::api-key/unhashed-key (u.secret/secret "mb_foobar")}
+                                  ::api-key/unhashed-key (u.secret/secret "mb_foobar123")}
                  :model/ApiKey _ {:name                  "A superuser API Key"
                                   :user_id               (mt/user->id :crowberto)
                                   :creator_id            (mt/user->id :lucky)
@@ -170,7 +192,7 @@
               :user-id           (mt/user->id :lucky)
               :user              {:id    (mt/user->id :lucky)
                                   :email (:email (mt/fetch-user :lucky))}}
-             (simple-auth-handler {:headers {"x-api-key" "mb_foobar"}}))))
+             (simple-auth-handler {:headers {"x-api-key" "mb_foobar123"}}))))
     (testing "A superuser API key has `*is-superuser?*` bound correctly"
       (is (= {:is-superuser?     true
               :is-group-manager? false
@@ -328,13 +350,14 @@
             :user    {:id    (mt/user->id :rasta)
                       :email (:email (mt/fetch-user :rasta))}}
            (user-bound-handler
-            (request-with-user-id (mt/user->id :rasta))))))
+            (request-with-user-id (mt/user->id :rasta)))))))
 
+(deftest ^:parallel add-user-id-key-test-2
   (testing "with invalid user-id (not sure how this could ever happen, but lets test it anyways)"
-    (is (= {:user-id 0
+    (is (= {:user-id Integer/MAX_VALUE
             :user    {}}
            (user-bound-handler
-            (request-with-user-id 0))))))
+            (request-with-user-id Integer/MAX_VALUE))))))
 
 ;;; ----------------------------------------------   with-current-user -------------------------------------------------
 


### PR DESCRIPTION
These tokens only have Collection permissions for a single Collection. This is needed to support the upcoming Workspaces feature.