### PR TITLE
Reduce coupling between semantic.index and semantic.scoring

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -546,33 +546,41 @@
       (update base-query :where #(into [:and] [% filters]))
       base-query)))
 
-(defn- hybrid-coalesce
+(defn- hybrid-select
   "For a given `col-name` return a :coalesce expression to reference it from the outer hybrid search query.
 
    (hybrid-coalesce :model_id) -> [:coalesce :v.model_id :t.model_id]"
-  ([col-name]
-   (hybrid-coalesce col-name "v." "t."))
-  ([col-name vector-prefix text-prefix]
+  ([col-name-and-alias]
+   (hybrid-select col-name-and-alias "v." "t."))
+  ([[col-name col-alias] vector-prefix text-prefix]
    (let [prefix #(keyword (str %1 (name %2)))]
-     [:coalesce (prefix vector-prefix col-name) (prefix text-prefix col-name)])))
+     [[:coalesce (prefix vector-prefix col-name) (prefix text-prefix col-name)] col-alias])))
 
 (defn- hybrid-search-query
   "Build a hybrid search query using vector + keyword based searches and reranking with RRF"
-  [index embedding search-context scorers]
+  [index embedding search-context]
   (let [semantic-results (semantic-search-query index embedding search-context)
         keyword-results (keyword-search-query index search-context)
         full-query {:with [[:vector_results semantic-results]
                            [:text_results keyword-results]]
-                    :select [[(hybrid-coalesce :id) :id]
-                             [(hybrid-coalesce :model_id) :model_id]
-                             [(hybrid-coalesce :model) :model]
-                             [(hybrid-coalesce :content) :content]
-                             [(hybrid-coalesce :verified) :verified]
-                             [(hybrid-coalesce :metadata) :metadata]
-                             [[:coalesce :v.semantic_rank -1] :semantic_rank]
-                             [[:coalesce :t.keyword_rank -1] :keyword_rank]]
+                    :select (into
+                             (mapv hybrid-select common-search-columns)
+                             [[:v.semantic_rank :semantic_rank]
+                              [:t.keyword_rank :keyword_rank]])
                     :from [[:vector_results :v]]
                     :full-join [[:text_results :t] [:= :v.id :t.id]]
+                    :limit (semantic-settings/semantic-search-results-limit)}]
+    full-query))
+
+(defn- scored-search-query
+  "Build a hybrid search query with additional `scorers`"
+  [index embedding search-context scorers]
+  ;; The purpose of this query is just to project the coalesced hybrid columns with standard names so the scorers know
+  ;; what to call them (e.g. :model rather than [:coalesced :v.model :t.model]).
+  (let [hybrid-query (hybrid-search-query index embedding search-context)
+        full-query {:with [[:hybrid_results hybrid-query]]
+                    :select [:id :model_id :model :content :verified :metadata :semantic_rank :keyword_rank]
+                    :from [:hybrid_results]
                     :limit (semantic-settings/semantic-search-results-limit)}]
     (scoring/with-scores search-context scorers full-query)))
 
@@ -752,8 +760,8 @@
 
             db-timer (u/start-timer)
             weights (search.config/weights (:context search-context))
-            scorers (scoring/semantic-scorers (:table-name index) hybrid-coalesce search-context)
-            query (hybrid-search-query index embedding search-context scorers)
+            scorers (scoring/semantic-scorers (:table-name index) search-context)
+            query (scored-search-query index embedding search-context scorers)
             xform (comp (map decode-metadata)
                         (map (partial legacy-input-with-score weights (keys scorers))))
             reducible (jdbc/plan db (sql-format-quoted query) {:builder-fn jdbc.rs/as-unqualified-lower-maps})
@@ -796,7 +804,7 @@
   (def index (default-index embedding-model))
   (def search-ctx {:search-string "pasta"})
   (def embed (embedding/get-embedding embedding-model (:search-string search-ctx)))
-  (def scorers (scoring/semantic-scorers db (:table-name index) hybrid-coalesce search-ctx))
+  (def scorers (scoring/semantic-scorers (:table-name index) search-ctx))
 
   (keyword-search-query index search-ctx)
   (sql-format-quoted (keyword-search-query index search-ctx))
@@ -806,9 +814,13 @@
   (sql/format (semantic-search-query index embed search-ctx))
   (jdbc/execute! db (sql-format-quoted (semantic-search-query index embed search-ctx)))
 
-  (hybrid-search-query index embed search-ctx scorers)
-  (sql-format-quoted (hybrid-search-query index embed search-ctx scorers))
-  (jdbc/execute! db (sql-format-quoted (hybrid-search-query index embed search-ctx scorers)))
+  (hybrid-search-query index embed search-ctx)
+  (sql-format-quoted (hybrid-search-query index embed search-ctx))
+  (jdbc/execute! db (sql-format-quoted (hybrid-search-query index embed search-ctx)))
+
+  (scored-search-query index embed search-ctx scorers)
+  (sql-format-quoted (scored-search-query index embed search-ctx scorers))
+  (jdbc/execute! db (sql-format-quoted (scored-search-query index embed search-ctx scorers)))
 
   (query-index db index search-ctx))
 
@@ -876,17 +888,19 @@
   (def search-context {:search-string search-string})
 
   (def embedding (embedding/get-embedding (:embedding-model index) search-string))
-  (def scorers (scoring/semantic-scorers db (:table-name index) hybrid-coalesce search-context))
+  (def scorers (scoring/semantic-scorers (:table-name index) search-context))
 
   ;; Format queries for execution
   (def semantic-sql (sql-format-quoted (semantic-search-query index embedding search-context)))
   (def keyword-sql (sql-format-quoted (keyword-search-query index search-context)))
-  (def hybrid-sql (sql-format-quoted (hybrid-search-query index embedding search-context scorers)))
+  (def hybrid-sql (sql-format-quoted (hybrid-search-query index embedding search-context)))
+  (def scored-sql (sql-format-quoted (scored-search-query index embedding search-context scorers)))
 
   ;; do in repl ->
   #_(explain-analyze-query db semantic-sql)
   #_(explain-analyze-query db keyword-sql)
   #_(explain-analyze-query db hybrid-sql)
+  #_(explain-analyze-query db scored-sql)
 
   (def existing-sql (sql-format-quoted (existing-embedding-query index ["Some Text"])))
   #_(explain-analyze-query db existing-sql)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -211,18 +211,3 @@
         [{:model "card" :id 1 :name "card popular" :dashboardcard_count 200}
          {:model "card" :id 2 :name "card" :dashboardcard_count 201}]
         (is (indifferent? :dashboard "card"))))))
-
-(deftest semantic-scorers->col-expr-is-respected-test
-  (mt/with-premium-features #{:semantic-search}
-    (with-open [index (semantic.tu/open-temp-index!)]
-      (let [search-ctx {:search-string "a string"
-                        :search-engine "semantic"}]
-        (testing "->col-expr is identity"
-          (is (=? {:pinned [:coalesce [:cast :pinned :integer] [:inline 0]]}
-                  (semantic.scoring/semantic-scorers (:table-name @index) identity search-ctx))))
-        (testing "->col-expr adds namespace qualifier"
-          (is (=? {:pinned [:coalesce [:cast ::pinned :integer] [:inline 0]]}
-                  (semantic.scoring/semantic-scorers
-                   (:table-name @index)
-                   #(keyword (namespace ::foo) (name %))
-                   search-ctx))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -211,3 +211,18 @@
         [{:model "card" :id 1 :name "card popular" :dashboardcard_count 200}
          {:model "card" :id 2 :name "card" :dashboardcard_count 201}]
         (is (indifferent? :dashboard "card"))))))
+
+(deftest semantic-scorers->col-expr-is-respected-test
+  (mt/with-premium-features #{:semantic-search}
+    (with-open [index (semantic.tu/open-temp-index!)]
+      (let [search-ctx {:search-string "a string"
+                        :search-engine "semantic"}]
+        (testing "->col-expr is identity"
+          (is (=? {:pinned [:coalesce [:cast :pinned :integer] [:inline 0]]}
+                  (semantic.scoring/semantic-scorers (:table-name @index) identity search-ctx))))
+        (testing "->col-expr adds namespace qualifier"
+          (is (=? {:pinned [:coalesce [:cast ::pinned :integer] [:inline 0]]}
+                  (semantic.scoring/semantic-scorers
+                   (:table-name @index)
+                   #(keyword (namespace ::foo) (name %))
+                   search-ctx))))))))


### PR DESCRIPTION
### Description

Previously, `->col-expr` was defined in the scoring namespace and had to "know" about hybrid search query table aliases, which is gross.

~~Instead, define a `hybrid-coalesce` func in the `semantic.index` namespace and pass it into the `semantic-scorers` function. Also use it in `hybrid-search-query`, to ensure hybrid column references are constructed in the same way in both places.~~

Re-project the columns with well-known names, per [@wotbrew's comment](https://github.com/metabase/metabase/pull/62089#issuecomment-3182869133)

### How to verify

Should be no behavior change, just a refactoring.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
