### PR TITLE
Fix: Don't containerize on doc-only change  and explicit artifact name 

### DIFF
--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -33,7 +33,7 @@ runs:
           });
 
           if (!artifacts.data?.artifacts?.[0]?.id) {
-            throw new Error(`No artifacts found for ${{ inputs.commit }}`);
+            throw new Error(`No artifacts found for: ${{ inputs.name }}`);
           }
 
           const artifact_id = artifacts.data.artifacts[0].id;

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           name: metabase-${{ inputs.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
           extract-path: "target/uberjar"
+          output-name: "metabase.jar"
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
           extract-path: "target/uberjar"
+          output-name: "metabase.jar"
       - name: Move uberjar to bin/docker
         run: |
           jar xf target/uberjar/metabase.jar

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
           extract-path: "target/uberjar"
+          output-name: "metabase.jar"
       - name: Move uberjar to bin/docker
         run: |
           jar xf target/uberjar/metabase.jar

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -135,6 +135,7 @@ jobs:
     needs: [uberjar]
     if: |
       !cancelled() &&
+      needs.uberjar.result == 'success' &&
       (
         (github.event_name == 'push' && contains(fromJson('["master", "metabot-v3-main", "internal-tools"]'), github.ref_name)) ||
         (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-docker-uberjar'))


### PR DESCRIPTION
The containerize job was running even when uberjar was skipped (e.g., documentation-only changes).

This adds a check for `needs.uberjar.result == 'success'` to ensure containerization only runs when the uberjar job actually succeeds.

E2E tests were failing due to a wrong artifact path, fixed.