### PR TITLE
Default is-save-enabled to false on Embed JS and embed flow

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -309,7 +309,10 @@ H.describeWithSnowplow(suiteTitle, () => {
       event_detail: "isSaveEnabled",
     });
 
-    H.getSimpleEmbedIframeContent().findByText("Save").should("be.visible");
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByText("Orders").click();
+      cy.findByText("Save").should("be.visible");
+    });
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -293,27 +293,27 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     getEmbedSidebar()
       .findByLabelText("Allow users to save new questions")
-      .should("be.checked");
+      .should("not.be.checked");
 
-    cy.log("save button should be visible by default");
-    H.getSimpleEmbedIframeContent().findByText("Save").should("be.visible");
+    cy.log("save button should be hidden by default");
+    H.getSimpleEmbedIframeContent().findByText("Save").should("not.exist");
 
-    cy.log("turn off save option");
+    cy.log("turn on save option");
     getEmbedSidebar()
       .findByLabelText("Allow users to save new questions")
       .click()
-      .should("not.be.checked");
+      .should("be.checked");
 
     H.expectUnstructuredSnowplowEvent({
       event: "embed_wizard_option_changed",
       event_detail: "isSaveEnabled",
     });
 
-    H.getSimpleEmbedIframeContent().findByText("Save").should("not.exist");
+    H.getSimpleEmbedIframeContent().findByText("Save").should("be.visible");
 
     cy.log("snippet should be updated");
     getEmbedSidebar().findByText("Get Code").click();
-    codeBlock().should("contain", 'is-save-enabled="false"');
+    codeBlock().should("contain", 'is-save-enabled="true"');
   });
 
   it("can change brand color and reset colors", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/user-settings-persistence.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/user-settings-persistence.cy.spec.ts
@@ -108,12 +108,15 @@ describe("scenarios > embedding > sdk iframe embed setup > user settings persist
     cy.log("1. set exploration settings to non-default values");
     getEmbedSidebar().within(() => {
       cy.findByLabelText("Allow users to save new questions")
-        .should("be.checked")
+        .should("not.be.checked")
         .click()
-        .should("not.be.checked");
+        .should("be.checked");
     });
 
-    H.getSimpleEmbedIframeContent().findByText("Save").should("not.exist");
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByText("Orders").click();
+      cy.findByText("Save").should("exist");
+    });
 
     cy.log("2. reload the page");
     waitAndReload();
@@ -125,7 +128,7 @@ describe("scenarios > embedding > sdk iframe embed setup > user settings persist
     getEmbedSidebar().within(() => {
       cy.log("3. persisted settings should be restored");
       cy.findByLabelText("Allow users to save new questions").should(
-        "not.be.checked",
+        "be.checked",
       );
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
@@ -111,6 +111,9 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
       cy.log("4. clicking on the filter should drill down");
       cy.get('[type="filter"] button').first().click();
       cy.findAllByText("29.8").first().should("be.visible");
+
+      cy.log("5. should not show a save button");
+      cy.findByText("Save").should("not.exist");
     });
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -64,9 +64,6 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
 
     frame.within(() => {
       H.assertSdkInteractiveQuestionOrdersUsable();
-
-      cy.log("should not show a save button by default");
-      cy.findByText("Save").should("not.exist");
     });
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -64,6 +64,9 @@ describe("scenarios > embedding > sdk iframe embedding", () => {
 
     frame.within(() => {
       H.assertSdkInteractiveQuestionOrdersUsable();
+
+      cy.log("should not show a save button by default");
+      cy.findByText("Save").should("not.exist");
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -153,7 +153,7 @@ const SdkIframeEmbedView = ({
         return (
           <SdkQuestion
             {...commonProps}
-            isSaveEnabled={settings.isSaveEnabled}
+            isSaveEnabled={settings.isSaveEnabled ?? false}
             key={rerenderKey}
             targetCollection={settings.targetCollection}
             entityTypes={settings.entityTypes}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/constants.ts
@@ -33,6 +33,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
   ] satisfies (keyof DashboardEmbedOptions)[],
   chart: [
     "questionId",
+    "isSaveEnabled",
     "withTitle",
     "withDownloads",
     "initialSqlParameters",

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
@@ -32,13 +32,14 @@ export const getDefaultSdkIframeEmbedSettings = (
         drills: true,
         withDownloads: false,
         withTitle: true,
+        isSaveEnabled: false,
       }),
     )
     .with(
       "exploration",
       (): ExplorationEmbedOptions => ({
         template: "exploration",
-        isSaveEnabled: true,
+        isSaveEnabled: false,
       }),
     )
     .exhaustive();


### PR DESCRIPTION
Closes EMB-713

### Description

Updates the default behavior for the `isSaveEnabled` option in the embed flow to default to `false` instead of `true`.
### How to verify

1. Navigate to the embed flow for exploration
2. Verify that "Allow users to save new questions" is unchecked by default
3. Verify that the Save button is not visible in the embedded content by default
4. Enable the save option and verify the Save button becomes visible
5. Check that the generated code snippet includes `is-save-enabled="true"` when enabled

### Checklist

- [x] Tests have been added/updated to cover changes in this PR