### PR TITLE
Improve input_type assignments in /actions-v2/execute-form

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -45,19 +45,6 @@
     [:action-kw :keyword]
     [:mapping [:maybe :map]]]])
 
-(mr/def ::execute-form
-  "A description of the form to render for executing an action"
-  [:map
-   [:title :string]
-   ;; TODO fully define the shape of a parameter
-   [:parameters [:sequential [:map {:closed false}
-                              [:id :string]
-                              [:display_name :string]
-                              [:input_type ::data-editing.execute-form/input-type]
-                              [:optional :boolean]
-                              [:readonly :boolean]
-                              [:value {:optional true} :any]]]]])
-
 (mu/defn- fetch-unified-action :- ::action-expression
   "Resolve various flavors of action-id into plain data, making it easier to dispatch on. Fetch config etc."
   [scope :- ::types/scope.hydrated
@@ -200,7 +187,8 @@
   [{}
    {}
    ;; TODO support for bulk actions
-   {:keys [action scope input]}] :- ::execute-form
+   {:keys [action scope input]}]
+  :- :metabase-enterprise.action-v2.execute-form/action-description
   ;; This check should be redundant in practice with the permission checks within perform-action!
   ;; Since test coverage is light and the logic is so simple, we've decided to be extra cautious for now.
   (api/check-superuser)

--- a/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/api.clj
@@ -53,7 +53,7 @@
    [:parameters [:sequential [:map {:closed false}
                               [:id :string]
                               [:display_name :string]
-                              [:input_type :string]
+                              [:input_type ::data-editing.execute-form/input-type]
                               [:optional :boolean]
                               [:readonly :boolean]
                               [:value {:optional true} :any]]]]])

--- a/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
@@ -9,17 +9,18 @@
 
 (mr/def ::input-type
   [:enum
-   {:encode/string name
-    :decode/string #(keyword "input" %)}
-   :boolean
-   :date
-   :datetime
-   :dropdown
-   :float
-   :integer
-   :text
-   :textarea
-   :time])
+   {:encode/api name
+    :decode/api #(keyword "input" %)}
+
+   :input/boolean
+   :input/date
+   :input/datetime
+   :input/dropdown
+   :input/float
+   :input/integer
+   :input/text
+   :input/textarea
+   :input/time])
 
 (mr/def ::describe-param
   [:map #_{:closed true}
@@ -50,25 +51,25 @@
 (defn- field-input-type
   [field field-values]
   (condp #(isa? %2 %1) (:semantic_type field)
-    :type/Name        :text
-    :type/Title       :text
-    :type/Source      :text
-    :type/Description :textarea
-    :type/Category    :dropdown
-    :type/FK          :dropdown
-    :type/PK          :dropdown
+    :type/Name        :input/text
+    :type/Title       :input/text
+    :type/Source      :input/text
+    :type/Description :input/textarea
+    :type/Category    :input/dropdown
+    :type/FK          :input/dropdown
+    :type/PK          :input/dropdown
     (if (#{:list :auto-list :search} (:type field-values))
-      :dropdown
+      :input/dropdown
       (condp #(isa? %2 %1) (:base_type field)
-        :type/Boolean    :boolean
-        :type/Integer    :integer
-        :type/BigInteger :integer
-        :type/Float      :float
-        :type/Decimal    :float
-        :type/Date       :date
-        :type/DateTime   :datetime
-        :type/Time       :time
-        :text))))
+        :type/Boolean    :input/boolean
+        :type/Integer    :input/integer
+        :type/BigInteger :input/integer
+        :type/Float      :input/float
+        :type/Decimal    :input/float
+        :type/Date       :input/date
+        :type/DateTime   :input/datetime
+        :type/Time       :input/time
+        :input/text))))
 
 (defn- describe-table-action
   [{:keys [action-kw

--- a/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
@@ -9,15 +9,15 @@
 
 (mr/def ::input-type
   [:enum
-   :input/boolean
-   :input/date
-   :input/datetime
-   :input/dropdown
-   :input/float
-   :input/integer
-   :input/text
-   :input/textarea
-   :input/time])
+   :boolean
+   :date
+   :datetime
+   :dropdown
+   :float
+   :integer
+   :text
+   :textarea
+   :time])
 
 (mr/def ::describe-param
   [:map #_{:closed true}
@@ -48,25 +48,25 @@
 (defn- field-input-type
   [field field-values]
   (condp #(isa? %2 %1) (:semantic_type field)
-    :type/Name        :input/text
-    :type/Title       :input/text
-    :type/Source      :input/text
-    :type/Description :input/textarea
-    :type/Category    :input/dropdown
-    :type/FK          :input/dropdown
-    :type/PK          :input/dropdown
+    :type/Name        :text
+    :type/Title       :text
+    :type/Source      :text
+    :type/Description :textarea
+    :type/Category    :dropdown
+    :type/FK          :dropdown
+    :type/PK          :dropdown
     (if (#{:list :auto-list :search} (:type field-values))
-      :input/dropdown
+      :dropdown
       (condp #(isa? %2 %1) (:base_type field)
-        :type/Boolean    :input/boolean
-        :type/Integer    :input/integer
-        :type/BigInteger :input/integer
-        :type/Float      :input/float
-        :type/Decimal    :input/float
-        :type/Date       :input/date
-        :type/DateTime   :input/datetime
-        :type/Time       :input/time
-        :input/text))))
+        :type/Boolean    :boolean
+        :type/Integer    :integer
+        :type/BigInteger :integer
+        :type/Float      :float
+        :type/Decimal    :float
+        :type/Date       :date
+        :type/DateTime   :datetime
+        :type/Time       :time
+        :text))))
 
 (defn- describe-table-action
   [{:keys [action-kw
@@ -118,7 +118,7 @@
                          {:id                      (:name field)
                           :display_name            (:display_name field)
                           :semantic_type           (:semantic_type field)
-                          :input_type              (name (field-input-type field field-values))
+                          :input_type              (field-input-type field field-values)
                           :field_id                (:id field)
                           :human_readable_field_id (-> field :dimensions first :human_readable_field_id)
                           :optional                (not required)
@@ -145,8 +145,8 @@
     ;; TODO remove assumption that all primitives are table actions
     (:action-kw action-def)
     (describe-table-action
-     {:action-kw    (:action-kw action-def)
-      :table-id     (:table-id partial-input)
-      :param-map    (:param-map action-def)})
+     {:action-kw (:action-kw action-def)
+      :table-id  (:table-id partial-input)
+      :param-map (:param-map action-def)})
     :else
     (throw (ex-info "Not able to execute given action yet" {:status-code 500 :scope scope :action-def action-def}))))

--- a/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
@@ -8,19 +8,23 @@
    [toucan2.core :as t2]))
 
 (mr/def ::input-type
-  [:enum
-   {:encode/api name
-    :decode/api #(keyword "input" %)}
+  ;; TODO this is a clumsy workaround due to the api encoders not being run for some reason
+  (mapv
+   #(if (keyword? %) (keyword (name %)) %)
 
-   :input/boolean
-   :input/date
-   :input/datetime
-   :input/dropdown
-   :input/float
-   :input/integer
-   :input/text
-   :input/textarea
-   :input/time])
+   [:enum
+    {:encode/api name
+     :decode/api #(keyword "input" %)}
+
+    :input/boolean
+    :input/date
+    :input/datetime
+    :input/dropdown
+    :input/float
+    :input/integer
+    :input/text
+    :input/textarea
+    :input/time]))
 
 (mr/def ::describe-param
   [:map #_{:closed true}
@@ -121,7 +125,8 @@
                          {:id                      (:name field)
                           :display_name            (:display_name field)
                           :semantic_type           (:semantic_type field)
-                          :input_type              (field-input-type field field-values)
+                          ;; TODO we are manually removing the namespace due to an issue with encoder/api not running
+                          :input_type              (keyword (name (field-input-type field field-values)))
                           :field_id                (:id field)
                           :human_readable_field_id (-> field :dimensions first :human_readable_field_id)
                           :optional                (not required)

--- a/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
@@ -9,6 +9,8 @@
 
 (mr/def ::input-type
   [:enum
+   {:encode/string name
+    :decode/string #(keyword "input" %)}
    :boolean
    :date
    :datetime

--- a/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
@@ -7,10 +7,12 @@
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
 
+(def ^:private strip-namespace-hack (comp keyword name))
+
 (mr/def ::input-type
   ;; TODO this is a clumsy workaround due to the api encoders not being run for some reason
   (mapv
-   #(if (keyword? %) (keyword (name %)) %)
+   #(if (keyword? %) (strip-namespace-hack %) %)
 
    [:enum
     {:encode/api name
@@ -126,7 +128,7 @@
                           :display_name            (:display_name field)
                           :semantic_type           (:semantic_type field)
                           ;; TODO we are manually removing the namespace due to an issue with encoder/api not running
-                          :input_type              (keyword (name (field-input-type field field-values)))
+                          :input_type              (strip-namespace-hack (field-input-type field field-values))
                           :field_id                (:id field)
                           :human_readable_field_id (-> field :dimensions first :human_readable_field_id)
                           :optional                (not required)

--- a/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/execute_form.clj
@@ -64,17 +64,17 @@
     :type/Category    :input/dropdown
     :type/FK          :input/dropdown
     :type/PK          :input/dropdown
-    (if (#{:list :auto-list :search} (:type field-values))
-      :input/dropdown
-      (condp #(isa? %2 %1) (:base_type field)
-        :type/Boolean    :input/boolean
-        :type/Integer    :input/integer
-        :type/BigInteger :input/integer
-        :type/Float      :input/float
-        :type/Decimal    :input/float
-        :type/Date       :input/date
-        :type/DateTime   :input/datetime
-        :type/Time       :input/time
+    (condp #(isa? %2 %1) (:base_type field)
+      :type/Boolean    :input/boolean
+      :type/Integer    :input/integer
+      :type/BigInteger :input/integer
+      :type/Float      :input/float
+      :type/Decimal    :input/float
+      :type/Date       :input/date
+      :type/DateTime   :input/datetime
+      :type/Time       :input/time
+      (if (#{:list :auto-list :search} (:type field-values))
+        :input/dropdown
         :input/text))))
 
 (defn- describe-table-action

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -579,8 +579,11 @@
         (action-v2.tu/with-test-tables! [table-id [{:id        [:int]
                                                     :text      [:text]
                                                     :int       [:int]
+                                                    :bool      [:boolean]
+                                                    :float_val [:float]
                                                     :timestamp [:timestamp]
                                                     :date      [:date]
+                                                    :time_val  [:time]
                                                     :inactive  [:text]}
                                                    {:primary-key [:id]}]]
           ;; This inactive field should not show up
@@ -592,27 +595,33 @@
                   scope               {:table-id table-id}]
 
               (testing "create"
-                (is (=? {:parameters [{:id "id"        :display_name "ID"        :input_type "text"     :optional false :readonly false}
-                                      {:id "text"      :display_name "Text"      :input_type "text"     :optional true  :readonly false}
-                                      {:id "int"       :display_name "Int"       :input_type "text"     :optional true  :readonly false}
-                                      {:id "timestamp" :display_name "Timestamp" :input_type "datetime" :optional true  :readonly false}
-                                      {:id "date"      :display_name "Date"      :input_type "date"     :optional true  :readonly false}]}
+                (is (=? {:parameters [{:id "id"        :display_name "ID"         :input_type "dropdown" :optional false :readonly false}
+                                      {:id "text"      :display_name "Text"       :input_type "text"     :optional true  :readonly false}
+                                      {:id "int"       :display_name "Int"        :input_type "integer"  :optional true  :readonly false}
+                                      {:id "bool"      :display_name "Bool"       :input_type "boolean"  :optional true  :readonly false}
+                                      {:id "float_val" :display_name "Float Val"  :input_type "float"    :optional true  :readonly false}
+                                      {:id "timestamp" :display_name "Timestamp"  :input_type "datetime" :optional true  :readonly false}
+                                      {:id "date"      :display_name "Date"       :input_type "date"     :optional true  :readonly false}
+                                      {:id "time_val"  :display_name "Time Val"   :input_type "time"     :optional true  :readonly false}]}
                         (mt/user-http-request :crowberto :post 200 execute-form-url
                                               {:scope     scope
                                                :action create-id}))))
 
               (testing "update"
-                (is (=? {:parameters [{:id "id"        :display_name "ID"        :input_type "text"     :optional false :readonly true}
-                                      {:id "text"      :display_name "Text"      :input_type "text"     :optional true  :readonly false}
-                                      {:id "int"       :display_name "Int"       :input_type "text"     :optional true  :readonly false}
-                                      {:id "timestamp" :display_name "Timestamp" :input_type "datetime" :optional true  :readonly false}
-                                      {:id "date"      :display_name "Date"      :input_type "date"     :optional true  :readonly false}]}
+                (is (=? {:parameters [{:id "id"        :display_name "ID"         :input_type "dropdown" :optional false :readonly true}
+                                      {:id "text"      :display_name "Text"       :input_type "text"     :optional true  :readonly false}
+                                      {:id "int"       :display_name "Int"        :input_type "integer"  :optional true  :readonly false}
+                                      {:id "bool"      :display_name "Bool"       :input_type "boolean"  :optional true  :readonly false}
+                                      {:id "float_val" :display_name "Float Val"  :input_type "float"    :optional true  :readonly false}
+                                      {:id "timestamp" :display_name "Timestamp"  :input_type "datetime" :optional true  :readonly false}
+                                      {:id "date"      :display_name "Date"       :input_type "date"     :optional true  :readonly false}
+                                      {:id "time_val"  :display_name "Time Val"   :input_type "time"     :optional true  :readonly false}]}
                         (mt/user-http-request :crowberto :post 200 execute-form-url
                                               {:scope     scope
                                                :action update-id}))))
 
               (testing "delete"
-                (is (=? {:parameters [{:id "id" :display_name "ID" :input_type "text" :optional false :readonly true}]}
+                (is (=? {:parameters [{:id "id" :display_name "ID" :input_type "dropdown" :optional false :readonly true}]}
                         (mt/user-http-request :crowberto :post 200 execute-form-url
                                               {:scope     scope
                                                :action delete-id}))))))))
@@ -621,9 +630,12 @@
         (action-v2.tu/with-test-tables! [table-id [{:id 'auto-inc-type
                                                     :text      [:text]
                                                     :int       [:int]
+                                                    :bool      [:boolean]
+                                                    :float_val [:float]
                                                     :timestamp [:timestamp]
-                                                    :date [:date]
-                                                    :inactive [:text]}
+                                                    :date      [:date]
+                                                    :time_val  [:time]
+                                                    :inactive  [:text]}
                                                    {:primary-key [:id]}]]
           ;; This inactive field should not show up
           (t2/update! :model/Field {:table_id table-id, :name "inactive"} {:active false})
@@ -634,26 +646,32 @@
                   scope               {:table-id table-id}]
 
               (testing "create"
-                (is (=? {:parameters [{:id "text"      :display_name "Text"      :input_type "text",     :optional true, :readonly false}
-                                      {:id "int"       :display_name "Int"       :input_type "text",     :optional true, :readonly false}
-                                      {:id "timestamp" :display_name "Timestamp" :input_type "datetime", :optional true, :readonly false}
-                                      {:id "date"      :display_name "Date"      :input_type "date",     :optional true, :readonly false}]}
+                (is (=? {:parameters [{:id "text"      :display_name "Text"       :input_type "text",     :optional true, :readonly false}
+                                      {:id "int"       :display_name "Int"        :input_type "integer",  :optional true, :readonly false}
+                                      {:id "bool"      :display_name "Bool"       :input_type "boolean",  :optional true, :readonly false}
+                                      {:id "float_val" :display_name "Float Val"  :input_type "float",    :optional true, :readonly false}
+                                      {:id "timestamp" :display_name "Timestamp"  :input_type "datetime", :optional true, :readonly false}
+                                      {:id "date"      :display_name "Date"       :input_type "date",     :optional true, :readonly false}
+                                      {:id "time_val"  :display_name "Time Val"   :input_type "time",     :optional true, :readonly false}]}
                         (mt/user-http-request :crowberto :post 200 execute-form-url
                                               {:scope     scope
                                                :action create-id}))))
 
               (testing "update"
-                (is (=? {:parameters [{:id "id"        :display_name "ID"        :input_type "text",     :optional false, :readonly true}
-                                      {:id "text"      :display_name "Text"      :input_type "text",     :optional true, :readonly false}
-                                      {:id "int"       :display_name "Int"       :input_type "text",     :optional true, :readonly false}
-                                      {:id "timestamp" :display_name "Timestamp" :input_type "datetime", :optional true, :readonly false}
-                                      {:id "date"      :display_name "Date"      :input_type "date",     :optional true, :readonly false}]}
+                (is (=? {:parameters [{:id "id"        :display_name "ID"         :input_type "dropdown", :optional false, :readonly true}
+                                      {:id "text"      :display_name "Text"       :input_type "text",     :optional true, :readonly false}
+                                      {:id "int"       :display_name "Int"        :input_type "integer",  :optional true, :readonly false}
+                                      {:id "bool"      :display_name "Bool"       :input_type "boolean",  :optional true, :readonly false}
+                                      {:id "float_val" :display_name "Float Val"  :input_type "float",    :optional true, :readonly false}
+                                      {:id "timestamp" :display_name "Timestamp"  :input_type "datetime", :optional true, :readonly false}
+                                      {:id "date"      :display_name "Date"       :input_type "date",     :optional true, :readonly false}
+                                      {:id "time_val"  :display_name "Time Val"   :input_type "time",     :optional true, :readonly false}]}
                         (mt/user-http-request :crowberto :post 200 execute-form-url
                                               {:scope     scope
                                                :action update-id}))))
 
               (testing "delete"
-                (is (=? {:parameters [{:id "id" :display_name "ID" :input_type "text", :optional false, :readonly true}]}
+                (is (=? {:parameters [{:id "id" :display_name "ID" :input_type "dropdown", :optional false, :readonly true}]}
                         (mt/user-http-request :crowberto :post 200 execute-form-url
                                               {:scope     scope
                                                :action delete-id})))))))))))

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -4,6 +4,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.test :refer :all]
+   [flatland.ordered.map :refer [ordered-map]]
    [metabase-enterprise.action-v2.api]
    [metabase-enterprise.action-v2.coerce :as coerce]
    [metabase-enterprise.action-v2.data-editing :as data-editing]
@@ -576,7 +577,8 @@
                       [:message])))))))
 
       (testing "Non auto-incrementing pk"
-        (action-v2.tu/with-test-tables! [table-id [{:id        [:int]
+        (action-v2.tu/with-test-tables! [table-id [(ordered-map
+                                                    :id        [:int]
                                                     :text      [:text]
                                                     :int       [:int]
                                                     :bool      [:boolean]
@@ -584,7 +586,7 @@
                                                     :timestamp [:timestamp]
                                                     :date      [:date]
                                                     :time_val  [:time]
-                                                    :inactive  [:text]}
+                                                    :inactive  [:text])
                                                    {:primary-key [:id]}]]
           ;; This inactive field should not show up
           (t2/update! :model/Field {:table_id table-id, :name "inactive"} {:active false})
@@ -627,7 +629,8 @@
                                                :action delete-id}))))))))
 
       (testing "Auto incrementing pk"
-        (action-v2.tu/with-test-tables! [table-id [{:id 'auto-inc-type
+        (action-v2.tu/with-test-tables! [table-id [(ordered-map
+                                                    :id        'auto-inc-type
                                                     :text      [:text]
                                                     :int       [:int]
                                                     :bool      [:boolean]
@@ -635,7 +638,7 @@
                                                     :timestamp [:timestamp]
                                                     :date      [:date]
                                                     :time_val  [:time]
-                                                    :inactive  [:text]}
+                                                    :inactive  [:text])
                                                    {:primary-key [:id]}]]
           ;; This inactive field should not show up
           (t2/update! :model/Field {:table_id table-id, :name "inactive"} {:active false})


### PR DESCRIPTION
- Add more input types, to cover all the core database types.
- Give semantic and database types precedence over whether they're listable or searchable.
- Use namespaced keywords internally for clarity and searchability.
- Treat PKs like FKs.
