### PR TITLE
Replace Asia/Saigon with Asia/Ho_Chi_Minh

### DIFF
--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1177,8 +1177,8 @@
                                      :type     :native
                                      :native   {:query "SELECT current_setting('TIMEZONE') AS timezone;"}})))))]
       (testing "check that if we set report-timezone to US/Pacific that the session timezone is in fact US/Pacific"
-        (is  (= "US/Pacific"
-                (get-timezone-with-report-timezone "US/Pacific"))))
+        (is  (= "America/Los_Angeles"
+                (get-timezone-with-report-timezone "America/Los_Angeles"))))
       (testing "check that we can set it to something else: America/Chicago"
         (is (= "America/Chicago"
                (get-timezone-with-report-timezone "America/Chicago"))))

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -704,7 +704,7 @@
         (mt/with-report-timezone-id! "UTC"
           (is (= "2022-10-03T14:10:20+07:00"
                  (->> (mt/run-mbql-query times
-                        {:expressions {"expr" [:convert-timezone "2022-10-03T07:10:20" "Asia/Saigon" "UTC"]}
+                        {:expressions {"expr" [:convert-timezone "2022-10-03T07:10:20" "Asia/Bangkok" "UTC"]}
                          :fields      [[:expression "expr"]]})
                       mt/rows
                       ffirst))))))))
@@ -780,9 +780,9 @@
                   "2004-03-19T18:19:09+09:00"] ;; at +09
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Saigon" "UTC"]
+                        {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Bangkok" "UTC"]
                                        "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul"
-                                                      "Asia/Saigon"]}
+                                                      "Asia/Bangkok"]}
                          :filter      [:= $times.index 1]
                          :fields      [$times.dt
                                        [:expression "to-07"]
@@ -842,8 +842,8 @@
                                             (mt/application-database-metadata-provider (mt/id))
                                             [(mt/mbql-query
                                                times
-                                               {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Saigon" "UTC"]
-                                                              "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul" "Asia/Saigon"]}
+                                               {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Bangkok" "UTC"]
+                                                              "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul" "Asia/Bangkok"]}
                                                 :filter      [:= $times.index 1]
                                                 :fields      [$times.dt
                                                               [:expression "to-07"]
@@ -854,19 +854,19 @@
                            (lib.metadata/card (qp.store/metadata-provider) 1))]
                 (testing `lib.metadata.result-metadata/returned-columns
                   (is (=? [{:name "dt"}
-                           {:name "to-07", :converted-timezone "Asia/Saigon"}
+                           {:name "to-07", :converted-timezone "Asia/Bangkok"}
                            {:name "to-07-to-09", :converted-timezone "Asia/Seoul"}]
                           (map #(select-keys % [:name :converted-timezone])
                                (lib.metadata.result-metadata/returned-columns query)))))
                 (testing `annotate/expected-cols
                   (is (=? [{:name "dt"}
-                           {:name "to-07", :converted_timezone "Asia/Saigon"}
+                           {:name "to-07", :converted_timezone "Asia/Bangkok"}
                            {:name "to-07-to-09", :converted_timezone "Asia/Seoul"}]
                           (map #(select-keys % [:name :converted_timezone])
                                (annotate/expected-cols query)))))
                 (testing `qp.preprocess/query->expected-cols
                   (is (=? [{:name "dt"}
-                           {:name "to-07", :converted_timezone "Asia/Saigon"}
+                           {:name "to-07", :converted_timezone "Asia/Bangkok"}
                            {:name "to-07-to-09", :converted_timezone "Asia/Seoul"}]
                           (map #(select-keys % [:name :converted_timezone])
                                (qp.preprocess/query->expected-cols query)))))))

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -704,7 +704,7 @@
         (mt/with-report-timezone-id! "UTC"
           (is (= "2022-10-03T14:10:20+07:00"
                  (->> (mt/run-mbql-query times
-                        {:expressions {"expr" [:convert-timezone "2022-10-03T07:10:20" "Asia/Bangkok" "UTC"]}
+                        {:expressions {"expr" [:convert-timezone "2022-10-03T07:10:20" "Asia/Ho_Chi_Minh" "UTC"]}
                          :fields      [[:expression "expr"]]})
                       mt/rows
                       ffirst))))))))
@@ -780,9 +780,9 @@
                   "2004-03-19T18:19:09+09:00"] ;; at +09
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Bangkok" "UTC"]
+                        {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Ho_Chi_Minh" "UTC"]
                                        "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul"
-                                                      "Asia/Bangkok"]}
+                                                      "Asia/Ho_Chi_Minh"]}
                          :filter      [:= $times.index 1]
                          :fields      [$times.dt
                                        [:expression "to-07"]
@@ -842,8 +842,8 @@
                                             (mt/application-database-metadata-provider (mt/id))
                                             [(mt/mbql-query
                                                times
-                                               {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Bangkok" "UTC"]
-                                                              "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul" "Asia/Bangkok"]}
+                                               {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Ho_Chi_Minh" "UTC"]
+                                                              "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul" "Asia/Ho_Chi_Minh"]}
                                                 :filter      [:= $times.index 1]
                                                 :fields      [$times.dt
                                                               [:expression "to-07"]
@@ -854,19 +854,19 @@
                            (lib.metadata/card (qp.store/metadata-provider) 1))]
                 (testing `lib.metadata.result-metadata/returned-columns
                   (is (=? [{:name "dt"}
-                           {:name "to-07", :converted-timezone "Asia/Bangkok"}
+                           {:name "to-07", :converted-timezone "Asia/Ho_Chi_Minh"}
                            {:name "to-07-to-09", :converted-timezone "Asia/Seoul"}]
                           (map #(select-keys % [:name :converted-timezone])
                                (lib.metadata.result-metadata/returned-columns query)))))
                 (testing `annotate/expected-cols
                   (is (=? [{:name "dt"}
-                           {:name "to-07", :converted_timezone "Asia/Bangkok"}
+                           {:name "to-07", :converted_timezone "Asia/Ho_Chi_Minh"}
                            {:name "to-07-to-09", :converted_timezone "Asia/Seoul"}]
                           (map #(select-keys % [:name :converted_timezone])
                                (annotate/expected-cols query)))))
                 (testing `qp.preprocess/query->expected-cols
                   (is (=? [{:name "dt"}
-                           {:name "to-07", :converted_timezone "Asia/Bangkok"}
+                           {:name "to-07", :converted_timezone "Asia/Ho_Chi_Minh"}
                            {:name "to-07-to-09", :converted_timezone "Asia/Seoul"}]
                           (map #(select-keys % [:name :converted_timezone])
                                (qp.preprocess/query->expected-cols query)))))))

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -704,7 +704,7 @@
         (mt/with-report-timezone-id! "UTC"
           (is (= "2022-10-03T14:10:20+07:00"
                  (->> (mt/run-mbql-query times
-                        {:expressions {"expr" [:convert-timezone "2022-10-03T07:10:20" "Asia/Ho_Chi_Minh" "UTC"]}
+                        {:expressions {"expr" [:convert-timezone "2022-10-03T07:10:20" "Asia/Bangkok" "UTC"]}
                          :fields      [[:expression "expr"]]})
                       mt/rows
                       ffirst))))))))
@@ -780,9 +780,9 @@
                   "2004-03-19T18:19:09+09:00"] ;; at +09
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Ho_Chi_Minh" "UTC"]
+                        {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Bangkok" "UTC"]
                                        "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul"
-                                                      "Asia/Ho_Chi_Minh"]}
+                                                      "Asia/Bangkok"]}
                          :filter      [:= $times.index 1]
                          :fields      [$times.dt
                                        [:expression "to-07"]
@@ -842,8 +842,8 @@
                                             (mt/application-database-metadata-provider (mt/id))
                                             [(mt/mbql-query
                                                times
-                                               {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Ho_Chi_Minh" "UTC"]
-                                                              "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul" "Asia/Ho_Chi_Minh"]}
+                                               {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Bangkok" "UTC"]
+                                                              "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul" "Asia/Bangkok"]}
                                                 :filter      [:= $times.index 1]
                                                 :fields      [$times.dt
                                                               [:expression "to-07"]
@@ -854,19 +854,19 @@
                            (lib.metadata/card (qp.store/metadata-provider) 1))]
                 (testing `lib.metadata.result-metadata/returned-columns
                   (is (=? [{:name "dt"}
-                           {:name "to-07", :converted-timezone "Asia/Ho_Chi_Minh"}
+                           {:name "to-07", :converted-timezone "Asia/Bangkok"}
                            {:name "to-07-to-09", :converted-timezone "Asia/Seoul"}]
                           (map #(select-keys % [:name :converted-timezone])
                                (lib.metadata.result-metadata/returned-columns query)))))
                 (testing `annotate/expected-cols
                   (is (=? [{:name "dt"}
-                           {:name "to-07", :converted_timezone "Asia/Ho_Chi_Minh"}
+                           {:name "to-07", :converted_timezone "Asia/Bangkok"}
                            {:name "to-07-to-09", :converted_timezone "Asia/Seoul"}]
                           (map #(select-keys % [:name :converted_timezone])
                                (annotate/expected-cols query)))))
                 (testing `qp.preprocess/query->expected-cols
                   (is (=? [{:name "dt"}
-                           {:name "to-07", :converted_timezone "Asia/Ho_Chi_Minh"}
+                           {:name "to-07", :converted_timezone "Asia/Bangkok"}
                            {:name "to-07-to-09", :converted_timezone "Asia/Seoul"}]
                           (map #(select-keys % [:name :converted_timezone])
                                (qp.preprocess/query->expected-cols query)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Newest version of `postgres:latest` docker image has removed many deprecated timezones such as `Asia/Saigon` which is causing CI failures. We can replace `Asia/Saigon` with another UTC+7 timezone such as `Asia/Bangkok`. Similarly needed to replace `US/Pacific` with `America/Los_Angeles`.

### How to verify

All tests should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
