### PR TITLE
Fix: Adjust perf tests workflow

### DIFF
--- a/.github/workflows/perf-test-labeled.yml
+++ b/.github/workflows/perf-test-labeled.yml
@@ -9,9 +9,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  uberjar:
+    if: ${{ github.event.label.name == 'Run-perf' }}
+    uses: ./.github/workflows/uberjar.yml
+    secrets: inherit
+
   run-perf-test:
+    needs: [uberjar]
     if: ${{ github.event.label.name == 'Run-perf' }}
     uses: ./.github/workflows/perf-test.yml
-    with:
-      wait_for_uberjar: true
     secrets: inherit

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -3,11 +3,6 @@ run-name: Run perf test for ${{ github.ref_name }} by @${{ github.actor }}
 
 on:
   workflow_call:
-    inputs:
-      wait_for_uberjar:
-        description: "Wait for uberjar build"
-        required: false
-        type: boolean
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -31,63 +26,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registries: "${{ secrets.PR_ENV_AWS_ACCOUNT_ID }}"
-      - name: Wait for uberjar
-        id: wait_for_uberjar
-        if: ${{ inputs.wait_for_uberjar == true }}
-        run: |
-          ## Get workflow run id for uberjar build
-          curl -Ls --output e2e-tests.json \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/${{ github.repository }}/actions/workflows/run-tests.yml/runs?head_sha=${{ github.event.pull_request.head.sha || github.sha }}
-          ID=$(jq -r '.workflow_runs[0].id' e2e-tests.json)
-          echo "Run ID: ${ID}"
-
-          ## Get workflow run id for uberjar build
-          while [ -z "$JOB_ID" ]; do
-            NEXT_URL="https://api.github.com/repos/${{ github.repository }}/actions/runs/${ID}/jobs?filter=latest"
-
-            # Search for build job
-            echo "Searching for build job..."
-            while [ -z "$JOB_ID" ] && [ -n "$NEXT_URL" ]; do
-              # Get one page of jobs
-              RESPONSE=$(curl -s -i \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "$NEXT_URL")
-
-              # Extract headers and body
-              HEADERS=$(echo "$RESPONSE" | sed -n '1,/^\r$/p')
-              BODY=$(echo "$RESPONSE" | sed '1,/^\r$/d')
-              LINK_HEADER=$(echo "$HEADERS" | grep -i '^link:' | sed 's/^link: //')
-
-              # Check for next page in Link header
-              if echo "$LINK_HEADER" | grep -q 'rel="next"'; then
-                NEXT_URL=$(echo "$LINK_HEADER" | sed -E 's/.*<([^>]+)>; rel="next".*/\1/')
-              else
-                NEXT_URL=""
-              fi
-
-              # Check for build job
-              JOB_ID=$(echo "$BODY" | jq -r '.jobs[] | select(.name | contains("build (ee)")) | .id')
-            done
-          done
-          echo "Job ID: ${JOB_ID}"
-
-          ## Wait for uberjar build to complete
-          while [ true ]; do
-            curl -Ls --output uberjar.json \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/actions/jobs/${JOB_ID}
-            jq -r '.steps[] | select(.name == "Prepare uberjar artifact") | .status' uberjar.json | grep -q "completed" && break
-            echo "Waiting for uberjar build..."
-            sleep 10
-          done
-          echo "run_id=$(jq -r '.workflow_runs[0].id' e2e-tests.json)" >> $GITHUB_OUTPUT
       - name: Retrieve uberjar artifact for ee
         uses: ./.github/actions/fetch-artifact
         with:


### PR DESCRIPTION
 Problem

  Perf tests failing - couldn't find uberjar artifact because wait_for_uberjar was looking for wrong job name ("build (ee)" vs actual "Build MB ee").

  Solution

  Follow pr-env-labeled.yml pattern: build uberjar first, then run perf test. Remove unnecessary wait mechanism.

  Changes

  - perf-test-labeled.yml: Add uberjar build job
  - perf-test.yml: Remove 56 lines of wait logic