### PR TITLE
Fix  Uberjar artifact reuse

### DIFF
--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -33,7 +33,7 @@ runs:
           });
 
           if (!artifacts.data?.artifacts?.[0]?.id) {
-            throw new Error(`No artifacts found for ${{ inputs.commit }}`);
+            throw new Error(`No artifacts found for ${{ inputs.name }}`);
           }
 
           const artifact_id = artifacts.data.artifacts[0].id;
@@ -52,11 +52,11 @@ runs:
       run: | # bash
         OUTPUT_NAME="${{ inputs.output-name }}"
         EXTRACT_PATH="${{ inputs.extract-path }}"
-        
+
         # Create target directory and extract
         mkdir -p "$EXTRACT_PATH"
         unzip mb.zip -d "$EXTRACT_PATH"
-        
+
         # Find and rename the jar
         if [ "$EXTRACT_PATH" == "." ]; then
           # Default case - extract to current directory
@@ -79,7 +79,7 @@ runs:
             exit 1
           fi
         fi
-        
+
         # Set the JAR_PATH environment variable
         if [ "$EXTRACT_PATH" == "." ]; then
           echo "JAR_PATH=$OUTPUT_NAME" >> $GITHUB_ENV

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -33,7 +33,7 @@ runs:
           });
 
           if (!artifacts.data?.artifacts?.[0]?.id) {
-            throw new Error(`No artifacts found for: ${{ inputs.name }}`);
+            throw new Error(`No artifacts found for ${{ inputs.commit }}`);
           }
 
           const artifact_id = artifacts.data.artifacts[0].id;
@@ -47,52 +47,45 @@ runs:
 
           fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/mb.zip`, Buffer.from(download.data));
 
-    - name: unzip uberjar artifact
-      shell: bash
-      run: unzip mb.zip
-    - name: Process the Uberjar
+    - name: Extract and rename JAR
       shell: bash
       run: | # bash
         OUTPUT_NAME="${{ inputs.output-name }}"
         EXTRACT_PATH="${{ inputs.extract-path }}"
-
-        # Function to determine the final JAR path
-        get_jar_path() {
-          if [ "$EXTRACT_PATH" == "." ]; then
-            echo "$OUTPUT_NAME"
+        
+        # Create target directory and extract
+        mkdir -p "$EXTRACT_PATH"
+        unzip mb.zip -d "$EXTRACT_PATH"
+        
+        # Find and rename the jar
+        if [ "$EXTRACT_PATH" == "." ]; then
+          # Default case - extract to current directory
+          if [ -e "metabase.jar" ]; then
+            mv "metabase.jar" "$OUTPUT_NAME"
+          elif [ -e "target/uberjar/metabase.jar" ]; then
+            mv "target/uberjar/metabase.jar" "$OUTPUT_NAME"
           else
-            echo "$EXTRACT_PATH/$OUTPUT_NAME"
+            echo "Could not find metabase.jar"
+            exit 1
           fi
-        }
-
-        # Create target directory if it doesn't exist
-        if [ "$EXTRACT_PATH" != "." ]; then
-          mkdir -p "$EXTRACT_PATH"
-        fi
-
-        # Find the source jar file
-        if [ -e "metabase.jar" ]; then
-          SOURCE_JAR="metabase.jar"
-        elif [ -e "target/uberjar/metabase.jar" ]; then
-          SOURCE_JAR="target/uberjar/metabase.jar"
         else
-          echo "Could not find the metabase.jar file"
-          exit 1
+          # Custom extract path
+          if [ -e "$EXTRACT_PATH/metabase.jar" ]; then
+            mv "$EXTRACT_PATH/metabase.jar" "$EXTRACT_PATH/$OUTPUT_NAME"
+          elif [ -e "$EXTRACT_PATH/target/uberjar/metabase.jar" ]; then
+            mv "$EXTRACT_PATH/target/uberjar/metabase.jar" "$EXTRACT_PATH/$OUTPUT_NAME"
+          else
+            echo "Could not find metabase.jar in $EXTRACT_PATH"
+            exit 1
+          fi
         fi
-
-        # Get the target path
-        TARGET_PATH=$(get_jar_path)
-
-        # Move the jar if source and target differ
-        if [ "$SOURCE_JAR" == "$TARGET_PATH" ]; then
-          echo "Jar is already at the correct location: $TARGET_PATH"
+        
+        # Set the JAR_PATH environment variable
+        if [ "$EXTRACT_PATH" == "." ]; then
+          echo "JAR_PATH=$OUTPUT_NAME" >> $GITHUB_ENV
         else
-          echo "Moving $SOURCE_JAR to $TARGET_PATH"
-          mv "$SOURCE_JAR" "$TARGET_PATH"
+          echo "JAR_PATH=$EXTRACT_PATH/$OUTPUT_NAME" >> $GITHUB_ENV
         fi
-
-        # Export the path for subsequent steps
-        echo "JAR_PATH=$TARGET_PATH" >> $GITHUB_ENV
 
     - name: Verify that this is a valid JAR file
       shell: bash

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -53,32 +53,27 @@ runs:
         OUTPUT_NAME="${{ inputs.output-name }}"
         EXTRACT_PATH="${{ inputs.extract-path }}"
 
-        # Create target directory and extract
-        mkdir -p "$EXTRACT_PATH"
-        unzip mb.zip -d "$EXTRACT_PATH"
+        # Create a temporary directory for extraction to avoid conflicts
+        TEMP_DIR=$(mktemp -d)
+        
+        # Extract to temporary directory
+        unzip mb.zip -d "$TEMP_DIR"
 
-        # Find and rename the jar
-        if [ "$EXTRACT_PATH" == "." ]; then
-          # Default case - extract to current directory
-          if [ -e "metabase.jar" ]; then
-            mv "metabase.jar" "$OUTPUT_NAME"
-          elif [ -e "target/uberjar/metabase.jar" ]; then
-            mv "target/uberjar/metabase.jar" "$OUTPUT_NAME"
-          else
-            echo "Could not find metabase.jar"
-            exit 1
-          fi
+        # Create target directory
+        mkdir -p "$EXTRACT_PATH"
+
+        # Find and move the jar to final location
+        if [ -e "$TEMP_DIR/metabase.jar" ]; then
+          mv "$TEMP_DIR/metabase.jar" "$EXTRACT_PATH/$OUTPUT_NAME"
+        elif [ -e "$TEMP_DIR/target/uberjar/metabase.jar" ]; then
+          mv "$TEMP_DIR/target/uberjar/metabase.jar" "$EXTRACT_PATH/$OUTPUT_NAME"
         else
-          # Custom extract path
-          if [ -e "$EXTRACT_PATH/metabase.jar" ]; then
-            mv "$EXTRACT_PATH/metabase.jar" "$EXTRACT_PATH/$OUTPUT_NAME"
-          elif [ -e "$EXTRACT_PATH/target/uberjar/metabase.jar" ]; then
-            mv "$EXTRACT_PATH/target/uberjar/metabase.jar" "$EXTRACT_PATH/$OUTPUT_NAME"
-          else
-            echo "Could not find metabase.jar in $EXTRACT_PATH"
-            exit 1
-          fi
+          echo "Could not find metabase.jar in extracted files"
+          exit 1
         fi
+
+        # Clean up temporary directory
+        rm -rf "$TEMP_DIR"
 
         # Set the JAR_PATH environment variable
         if [ "$EXTRACT_PATH" == "." ]; then

--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -55,7 +55,7 @@ runs:
 
         # Create a temporary directory for extraction to avoid conflicts
         TEMP_DIR=$(mktemp -d)
-        
+
         # Extract to temporary directory
         unzip mb.zip -d "$TEMP_DIR"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,8 +72,6 @@ jobs:
     if: ${{ !cancelled() && !(needs.files-changed.outputs.documentation == 'true' && needs.files-changed.outputs.backend_all == 'false' && needs.files-changed.outputs.frontend_all == 'false' && needs.files-changed.outputs.e2e_all == 'false') }}
     uses: ./.github/workflows/uberjar.yml
     secrets: inherit
-    with:
-      source_changed: ${{ needs.files-changed.outputs.backend_all == 'true' || needs.files-changed.outputs.frontend_all == 'true' || needs.static-viz-files-changed.outputs.static_viz == 'true' }}
 
   backend-tests:
     if: ${{ !cancelled() }}

--- a/.github/workflows/uberjar-containerize-labeled.yml
+++ b/.github/workflows/uberjar-containerize-labeled.yml
@@ -13,8 +13,6 @@ jobs:
     if: ${{ github.event.label.name == 'build-docker-uberjar' }}
     uses: ./.github/workflows/uberjar.yml
     secrets: inherit
-    with:
-      source_changed: false
 
   containerize:
     needs: [uberjar]

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           name: metabase-ee-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
           output-name: metabase-ee.jar
+          extract-path: "ee-artifact"
 
       - name: Try to fetch existing OSS artifact
         id: check-oss
@@ -60,6 +61,7 @@ jobs:
         with:
           name: metabase-oss-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
           output-name: metabase-oss.jar
+          extract-path: "oss-artifact"
 
       - name: Decide if build is needed
         id: decide

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,7 +4,7 @@ name: Build Uberjar
 # or automatically for the listed branches
 
 concurrency:
-  group: uberjar-${{ github.ref }}
+  group: uberjar-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -52,7 +52,6 @@ jobs:
         with:
           name: metabase-ee-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
           output-name: metabase-ee.jar
-          extract-path: "ee-artifact"
 
       - name: Try to fetch existing OSS artifact
         id: check-oss
@@ -61,7 +60,6 @@ jobs:
         with:
           name: metabase-oss-${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}-uberjar
           output-name: metabase-oss.jar
-          extract-path: "oss-artifact"
 
       - name: Decide if build is needed
         id: decide

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -28,11 +28,6 @@ on:
       commit:
         description: "Optional full-length commit SHA-1 hash"
   workflow_call:
-    inputs:
-      source_changed:
-        description: "Whether source code has changed"
-        type: boolean
-        default: true
 
 jobs:
   check-existing-artifacts:
@@ -64,21 +59,20 @@ jobs:
       - name: Decide if build is needed
         id: decide
         run: |
-          SOURCE_CHANGED="${{ inputs.source_changed == true }}"
           EE_EXISTS="${{ steps.check-ee.outcome == 'success' }}"
           OSS_EXISTS="${{ steps.check-oss.outcome == 'success' }}"
 
-          echo "Source changed: $SOURCE_CHANGED"
           echo "EE exists: $EE_EXISTS"
           echo "OSS exists: $OSS_EXISTS"
 
-          # Build if source changed OR artifacts don't exist
-          if [[ "$SOURCE_CHANGED" == "true" ]] || [[ "$EE_EXISTS" == "false" ]] || [[ "$OSS_EXISTS" == "false" ]]; then
+          # Build only if artifacts don't exist for this commit hash
+          # Since we build by hash, if artifacts exist for this hash, we don't need to rebuild
+          if [[ "$EE_EXISTS" == "false" ]] || [[ "$OSS_EXISTS" == "false" ]]; then
             SHOULD_BUILD="true"
-            echo "Will build: source_changed=$SOURCE_CHANGED, ee_exists=$EE_EXISTS, oss_exists=$OSS_EXISTS"
+            echo "Will build: ee_exists=$EE_EXISTS, oss_exists=$OSS_EXISTS"
           else
             SHOULD_BUILD="false"
-            echo "Skipping build: artifacts exist and no source changes"
+            echo "Skipping build: artifacts exist for this commit hash"
           fi
 
           echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Problem: When fetching both OSS and EE artifacts in check-existing-artifacts job,
unzip was prompting for confirmation to replace COMMIT-ID file, causing the
workflow to fail with 'EOF or read error, treating as [N]one' error.

Solution: Use different extract paths for OSS and EE artifacts to avoid conflicts:
- EE artifact extracts to 'ee-artifact/' directory
- OSS artifact extracts to 'oss-artifact/' directory

This allows both artifacts to coexist without file conflicts, fixing the artifact recycling issue for both OSS and EE versions.

* Updated concurrency group in `.github/workflows/uberjar.yml` to use a unique identifier based on commit SHA or pull request head SHA, which helps prevent waiting for an uberjar build from a previous commit 
