### PR TITLE
fix: handle special cased migration

### DIFF
--- a/src/metabase/app_db/liquibase.clj
+++ b/src/metabase/app_db/liquibase.clj
@@ -478,10 +478,22 @@
             "v45.00-001" legacy-migrations-file
             "v56.0000-00-00T00:00:00" update001-migrations-file]))))))
 
+(def ^:private special-case-migrations #{"v56.2025-06-05T16:48:48" "v56.2025-05-19T16:48:48"})
+
+(defn- handle-special-case-migrations
+  "This handles v56 migrations that were checked into the v55 branch to resolve an issue with
+  inadventently backported migrations in 55. We check if this or the bad backports are the most recent
+  available migration and explicitly return 55 as the available major version if so."
+  [s]
+  (when (contains? special-case-migrations s)
+    55))
+
 (defn- extract-numbers
   "Returns contiguous integers parsed from string s"
   [s]
-  (map #(Integer/parseInt %) (re-seq #"\d+" s)))
+  (if-let [special-cased (handle-special-case-migrations s)]
+    [special-cased]
+    (map #(Integer/parseInt %) (re-seq #"\d+" s))))
 
 (defn latest-available-major-version
   "Get the latest version that Liquibase would apply if we ran migrations right now."

--- a/test/metabase/app_db/liquibase_test.clj
+++ b/test/metabase/app_db/liquibase_test.clj
@@ -153,6 +153,11 @@
         (.update liquibase "")
         (is (< 52 (liquibase/latest-applied-major-version conn (.getDatabase liquibase))))))))
 
+(deftest extract-numbers-special-case-test
+  (testing "when specific migration verison is passed reports different major version"
+    (is (= 55 (first (#'liquibase/extract-numbers "v56.2025-06-05T16:48:48"))))
+    (is (= 55 (first (#'liquibase/extract-numbers "v56.2025-05-19T16:48:48"))))))
+
 (deftest rollback-major-version
   (mt/test-drivers #{:h2 :mysql :rollback}
     (mt/with-temp-empty-app-db [conn driver/*driver*]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62104
### Description

Handles a 56 [migration](https://github.com/metabase/metabase/pull/59066/files) we added into the v55 branch to handle an inadvertently backported [migration](https://github.com/metabase/metabase/pull/58168) to the v55 [branch](https://github.com/metabase/metabase/pull/58728). Since those migrations were released some users would have had 'latest available version' report 56 on a 55 release, so adding the dummy migration prevented the downgrade message from being unnecessarily shown. 

However this dummy migration prevents actual downgrades from 56 -> 55 from showing the downgrade message, so instead we want to special case that migration or the migrations on 55.1 and have it return version 55 if it is the the most recent migration available in a 55 release.  

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a new 56 instance
2. Downgrade to 55
3. See that downgrade message is shown.

Also 

1. create a new 55.1 (where the bad 56 changesets were)
2. upgrade to 55.11
3. See that no downgrade message is shown.

Also
1. create a new 55.1
2. upgrade to 56.2
3. See that the upgrade was successful

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
