### PR TITLE
Give additional option timezone precedence of report timezone

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -14,6 +14,7 @@
    [metabase.driver :as driver]
    [metabase.driver-api.core :as driver-api]
    [metabase.driver.settings :as driver.settings]
+   [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute.diagnostic :as sql-jdbc.execute.diagnostic]
    [metabase.driver.sql-jdbc.execute.old-impl :as sql-jdbc.execute.old]
@@ -376,7 +377,11 @@
   (when-not (recursive-connection?)
     (log/tracef "Setting default connection options with options %s" (pr-str options))
     (set-best-transaction-level! driver conn)
-    (set-time-zone-if-supported! driver conn session-timezone)
+    (let [additional-options (-> db-or-id-or-spec :details :additional-options)
+          opts-map (sql-jdbc.common/additional-options->map additional-options :url)
+          options-timezone (get opts-map "timezone")
+          session-timezone (or options-timezone session-timezone)]
+      (set-time-zone-if-supported! driver conn session-timezone))
     (let [read-only? (not write?)]
       (try
         ;; Setting the connection to read-only does not prevent writes on some databases, and is meant


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62076

### Description

The timezone parameter in the additional options is ignored in favour of the report timezone. This changes it so that if a user specifies a TimeZone option then it will be used over the report timezone. Note this change relies on the option looking like `TimeZone=Europe/Paris&ApplicationName=TestAppName` rather than `options=-c%20TimeZone=Europe/Paris&ApplicationName=TestAppName`, so we'll either need to change how the parsing is done or update these documents: https://www.metabase.com/docs/v0.55/databases/connections/postgresql#additional-jdbc-connection-string-options

### How to verify

See steps in reported issue. It should return Europe/Paris.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
