### PR TITLE
docs: JSON unfolding

### DIFF
--- a/docs/data-modeling/json-unfolding.md
+++ b/docs/data-modeling/json-unfolding.md
@@ -68,10 +68,10 @@ For example, if you upload a CSV with JSON in it, you might need to update the d
 
 - [BigQuery](../databases/connections/postgresql.md): automatically enabled, applies to `STRUCT` types only.
   
-  If your data is stored in the [STRUCT data type](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type) type in BigQuery, you can query the table's nested fields. This is enabled by default. However, Metabase won't unfold JSON stored in BigQuery as the `JSON` type. This is because in BigQuery, nested fields are _part of the table definition itself_, so when Metabase syncs with your BigQuery database, it'll be able to get metadata about any of your tables, including tables with nested fields. Querying nested fields, however, doesn't extend to arrays (REPEATED (STRUCT)) in BigQuery.
+  If your data is stored in the [STRUCT data type](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type) in BigQuery, you can query the table's nested fields. This is enabled by default. However, Metabase won't unfold JSON stored in BigQuery as the `JSON` type. This is because in BigQuery, nested fields are _part of the table definition itself_, so when Metabase syncs with your BigQuery database, it'll be able to get metadata about any of your tables, including tables with nested fields. Querying nested fields, however, doesn't extend to arrays (REPEATED (STRUCT)) in BigQuery.
   
 - [Druid (JDBC)](../databases/connections/druid.md)
-- [MongoDB](../databases/connections/mysql.md): automatically enabled.
+- [MongoDB](../databases/connections/mysql.md): automatically enabled for all nested fields.
 - [MySQL](../databases/connections/mysql.md)
 - [PostgreSQL](../databases/connections/postgresql.md)
 

--- a/docs/data-modeling/json-unfolding.md
+++ b/docs/data-modeling/json-unfolding.md
@@ -66,8 +66,12 @@ For example, if you upload a CSV with JSON in it, you might need to update the d
 
 ## Databases that support JSON unfolding
 
-- [PostgreSQL](../databases/connections/postgresql.md)
-- [MySQL](../databases/connections/mysql.md)
+- [BigQuery](../databases/connections/postgresql.md): automatically enabled, applies to `STRUCT` types only.
+  
+  If your data is stored in the [STRUCT data type](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type) type in BigQuery, you can query the table's nested fields. This is enabled by default. However, Metabase won't unfold JSON stored in BigQuery as the `JSON` type. This is because in BigQuery, nested fields are _part of the table definition itself_, so when Metabase syncs with your BigQuery database, it'll be able to get metadata about any of your tables, including tables with nested fields. Querying nested fields, however, doesn't extend to arrays (REPEATED (STRUCT)) in BigQuery.
+  
 - [Druid (JDBC)](../databases/connections/druid.md)
+- [MongoDB](../databases/connections/mysql.md): automatically enabled.
+- [MySQL](../databases/connections/mysql.md)
+- [PostgreSQL](../databases/connections/postgresql.md)
 
-A note on [BigQuery](../databases/connections/bigquery.md): Metabase supports the [STRUCT data type](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type) in BigQuery, but it won't unfold JSON stored in BigQuery as the `JSON` type. If your data is stored in the `STRUCT` type in BigQuery, you can query the table's nested fields. Some background here: BigQuery differs from other databases in that nested fields are _part of the table definition itself_. So when Metabase syncs with your BigQuery database, it'll be able to get metadata about any of your tables, including tables with nested fields. Querying nested fields, however, doesn't extend to arrays (REPEATED (STRUCT)) in BigQuery.


### PR DESCRIPTION
Rephrase the bigquery part a bit, alphabetize, and add MongoDB. Yes, technically unfolding mongodb fields is not json unfolding but I don't thin users understand this technicality, just just wanna know if we unfold their stuff :) (come to think of it, maybe we should rename this doc "working with nested fields" to incorporate mongodb and BQ STRUCT stuff)