### PR TITLE
Fix flaky parameter test

### DIFF
--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -1,9 +1,7 @@
 const { H } = cy;
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type {
   NativeQuestionDetails,
-  QuestionDetails,
   StructuredQuestionDetails,
 } from "e2e/support/helpers";
 import type { IconName } from "metabase/ui";
@@ -390,46 +388,20 @@ describe("issues 52811, 52812", () => {
 });
 
 describe("issue 52806", () => {
-  const questionDetails: QuestionDetails = {
-    name: "SQL",
-    dataset_query: {
-      database: SAMPLE_DB_ID,
-      type: "native",
-      native: {
-        query: "SELECT * FROM ORDERS WHERE ID = {{id}}",
-        "template-tags": {
-          id: {
-            id: "b22a5ce2-fe1d-44e3-8df4-f8951f7921bc",
-            name: "id",
-            "display-name": "ID",
-            type: "number",
-            default: "1",
-          },
-        },
-      },
-    },
-    visualization_settings: {},
-  };
-
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();
   });
 
-  it(
-    "should remove parameter values from the URL when leaving the query builder and discarding changes (metabase#52806)",
-    { tags: "@flaky" },
-    () => {
-      cy.intercept("/api/automagic-dashboards/database/*/candidates").as(
-        "candidates",
-      );
-      H.visitQuestionAdhoc(questionDetails);
-      cy.findByTestId("main-logo-link").click();
-      H.modal().button("Discard changes").click();
-      cy.wait("@candidates");
-      cy.location().should((location) => expect(location.search).to.eq(""));
-    },
-  );
+  it("should remove parameter values from the URL when leaving the query builder and discarding changes (metabase#52806)", () => {
+    cy.visit("/");
+    H.newButton("SQL query").click();
+    H.NativeEditor.focus().type("select {{x}}");
+    cy.findByTestId("main-logo-link").click();
+    H.modal().button("Discard changes").click();
+    cy.findByTestId("home-page");
+    cy.location().should((location) => expect(location.search).to.eq(""));
+  });
 });
 
 describe("issue 55951", () => {


### PR DESCRIPTION
Original issue: https://github.com/metabase/metabase/issues/52806

Original fix + test: https://github.com/metabase/metabase/pull/54863

This PR simplifies the test to remove network calls that were flaking. The original test used the `H.visitQuestionAdhoc` helper which auto-runs native queries, and on a slow network the helper was flaking. The new test just performs the simplest possible actions from the users POV to perform the reproduction.

I verified by that the new test fails without the fix from https://github.com/metabase/metabase/pull/54863 and passes with the fix applied.