### PR TITLE
Fix honeysql create-index :raw forms

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -414,7 +414,7 @@
        connectable
        (-> (sql.helpers/create-index
             [(keyword (hnsw-index-name index)) :if-not-exists]
-            [(keyword table-name) :using-hnsw [:raw "embedding vector_cosine_ops"]])
+            [(keyword table-name) :using-hnsw [[:raw "embedding vector_cosine_ops"]]])
            sql-format-quoted))
       (jdbc/execute!
        connectable

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index_metadata.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index_metadata.clj
@@ -146,7 +146,7 @@
      (sql/format
       (sql.helpers/create-index
        [(keyword (str (:gate-table-name index-metadata) "_gated_at")) :if-not-exists]
-       [(keyword (:gate-table-name index-metadata)) [:raw "gated_at"] [:raw "id"]])
+       [(keyword (:gate-table-name index-metadata)) :gated_at :id])
       :quoted true))
     nil))
 


### PR DESCRIPTION
### Description

https://metaboat.slack.com/archives/C07SJT1P0ET/p1755084667726149

Something changed with honeysql 2.7.1340 and `:raw` forms in the tail of a `create-index` now get unwrapped and need to be nested in another vector.

For example, in earlier versions

```Clojure
    (sql/format
     (sql.helpers/create-index
      [:foo-idx :if-not-exists]
      [:foo-table :using-hnsw [:raw "embedding vector_cosine_ops"]]))
```

produced an sql string like

```sql
CREATE INDEX IF NOT EXISTS foo_idx ON foo_table USING HNSW (embedding vector_cosine_ops)
```

but on 2.7.1340 you get

```sql
CREATE INDEX IF NOT EXISTS foo_idx ON foo_table USING HNSW (raw EMBEDDING VECTOR_COSINE_OPS)
```

Unclear if this is a honeysql bug or we're doing something unsupported, but fix it with a workaround for now by
wrapping the `:raw` in an extra vector like `[[:raw "foo"]]`, in order to (hopefully) get CI green.

### How to verify

Tests should no longer fail with `org.postgresql.util.PSQLException: ERROR: syntax error at or near "VECTOR_COSINE_OPS"`

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
