### PR TITLE
fix: update grid design #1

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataContainer.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataContainer.module.css
@@ -7,6 +7,7 @@
 .gridWrapper {
   overflow: hidden;
   flex-grow: 1;
+  background-color: var(--mb-color-background);
 }
 
 .gridFooter {
@@ -18,4 +19,9 @@
   height: 2.5rem;
   justify-content: space-between;
   align-items: center;
+}
+
+.filtersSection {
+  background-color: var(--mb-color-background);
+  border-top: 1px solid var(--mb-color-border);
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataHeader.tsx
@@ -4,11 +4,12 @@ import { t } from "ttag";
 
 import { QuestionFiltersHeader } from "metabase/query_builder/components/view/ViewHeader/components";
 import { getFilterItems } from "metabase/querying/filters/components/FilterPanel/utils";
-import { Button, Icon, Stack } from "metabase/ui";
+import { Box, Button, Icon, Stack } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 
 import { TableHeader } from "../common/TableHeader";
 
+import S from "./EditTableDataContainer.module.css";
 import { EditTableDataFilterButton } from "./EditTableDataFilterButton";
 
 interface EditTableDataHeaderProps {
@@ -71,11 +72,13 @@ export const EditTableDataHeader = ({
         >{t`Delete`}</Button>
       </TableHeader>
       {question && (
-        <QuestionFiltersHeader
-          expanded={areFiltersExpanded}
-          question={question}
-          updateQuestion={onQuestionChange}
-        />
+        <Box className={S.filtersSection}>
+          <QuestionFiltersHeader
+            expanded={areFiltersExpanded}
+            question={question}
+            updateQuestion={onQuestionChange}
+          />
+        </Box>
       )}
     </Stack>
   );

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataOverlay.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataOverlay.module.css
@@ -23,8 +23,7 @@
 }
 
 .message {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: 700;
   color: var(--mb-color-brand);
-  text-transform: uppercase;
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataOverlay.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataOverlay.tsx
@@ -1,4 +1,5 @@
-import { Flex, Loader, Text } from "metabase/ui";
+import LoadingSpinner from "metabase/common/components/LoadingSpinner";
+import { Flex, Text } from "metabase/ui";
 
 import S from "./EditTableDataOverlay.module.css";
 
@@ -17,7 +18,7 @@ export function EditTableDataOverlay({
 
   return (
     <Flex className={S.overlay}>
-      <Loader size="lg" color="currentColor" />
+      <LoadingSpinner />
       {message && <Text className={S.message}>{message}</Text>}
     </Flex>
   );

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/EditTableDataGrid.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/EditTableDataGrid.module.css
@@ -1,12 +1,8 @@
 /** DataGrid overrides */
 
-.tableRoot {
-  border-top: 1px solid var(--mb-color-border);
-}
-
 .tableRow {
   &:hover .tableBodyCell {
-    background-color: var(--mb-base-color-blue-10);
+    background-color: var(--mb-base-color-blue-5);
   }
 
   &:hover .tableHeaderCell {
@@ -15,7 +11,7 @@
   }
 
   &[data-row-selected="true"] .tableBodyCell {
-    background-color: var(--mb-base-color-blue-10);
+    background-color: var(--mb-base-color-blue-5);
   }
 }
 
@@ -32,6 +28,11 @@
 
 .tableHeaderCell {
   border-right: 1px solid var(--mb-color-border);
+  font-weight: 700;
+
+  &:hover {
+    color: var(--mb-color-brand);
+  }
 
   &[data-column-id="__MB_ROW_SELECT"] {
     border-right: none;

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/EditTableDataGrid.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/EditTableDataGrid.tsx
@@ -140,7 +140,6 @@ export const EditTableDataGrid = ({
         bodyContainer: S.tableBodyContainer,
         bodyCell: S.tableBodyCell,
         row: S.tableRow,
-        root: S.tableRoot,
       },
 
       // Overrides theme constants and default bg

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/use-table-column-row-select.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/use-table-column-row-select.tsx
@@ -2,7 +2,7 @@ import type { Row, Table } from "@tanstack/react-table";
 import { useMemo } from "react";
 
 import type { ColumnOptions } from "metabase/data-grid";
-import { Checkbox, Flex } from "metabase/ui";
+import { Checkbox, Flex, rem } from "metabase/ui";
 import type { RowValue, RowValues } from "metabase-types/api";
 
 export const ROW_SELECT_COLUMN_ID = "__MB_ROW_SELECT";
@@ -20,24 +20,41 @@ export function getRowSelectColumn() {
     name: "",
     accessorFn: () => null,
     header: ({ table }: { table: Table<RowValues> }) => (
-      <Flex px=".5rem" h="100%" align="center" bg="var(--cell-bg-color)">
+      <Flex
+        p=".5rem"
+        h="100%"
+        align="center"
+        justify="center"
+        bg="var(--cell-bg-color)"
+      >
         <Checkbox
+          size={rem(16)}
           checked={table.getIsAllRowsSelected()}
           indeterminate={table.getIsSomeRowsSelected()}
           onChange={table.getToggleAllRowsSelectedHandler()}
-          variant="stacked"
           data-testid="row-select-all-checkbox"
+          styles={{
+            input: {
+              borderColor: "var(--mb-color-border)",
+            },
+          }}
         />
       </Flex>
     ),
     cell: ({ row }: { row: Row<RowValues> }) => (
-      <Flex p=".5rem" h="100%" align="start">
+      <Flex p=".5rem" h="100%" align="center" justify="center">
         <Checkbox
+          size={rem(16)}
           checked={row.getIsSelected()}
           disabled={!row.getCanSelect()}
           indeterminate={row.getIsSomeSelected()}
           onChange={row.getToggleSelectedHandler()}
           data-testid="row-select-checkbox"
+          styles={{
+            input: {
+              borderColor: "var(--mb-color-border)",
+            },
+          }}
         />
       </Flex>
     ),


### PR DESCRIPTION
Related to [WRK-626](https://linear.app/metabase/issue/WRK-626/update-grid-design)

* Add blue text hover state to column headers (keep gray background).
* Remove gray background behind filter tokens.
* Lighter border color for checkboxes to diminish visual impact
* Smaller checkbox size 16x16
* Normal checkbox button for 'select all' action instead of a double one
* Bold column headings
* Replace blocky “Loading data” with standard Metabase spinner.