### PR TITLE
auto-fix generated sql

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1748,8 +1748,8 @@
            system
            users
            util
+           warehouses
            warehouse-schema
-
            enterprise/documents}}
 
   enterprise/permission-debug

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1748,8 +1748,8 @@
            system
            users
            util
-           warehouses
            warehouse-schema
+           warehouses
            enterprise/documents}}
 
   enterprise/permission-debug

--- a/enterprise/backend/src/metabase_enterprise/ai_sql_fixer/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/ai_sql_fixer/api.clj
@@ -6,74 +6,9 @@
    [metabase.api.routes.common :refer [+auth]]
    [metabase.driver.util :as driver.u]
    [metabase.query-processor.middleware.permissions :as qp.perms]
-   [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2])
-  (:import
-   (java.io StringWriter Writer)))
+   [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
-
-;; some arbitrary limits
-(def ^:private max-schema-sample-tables
-  "If the number of tables in the database doesn't exceed this number, we send them all to the agent."
-  10)
-
-(defn- format-escaped
-  [^String identifier ^Writer writer]
-  (if (re-matches #"[\p{Alpha}_][\p{Alnum}_]*" identifier)
-    (.append writer identifier)
-    (do
-      (.append writer \")
-      (doseq [^Character c identifier]
-        (when (= c \")
-          (.append writer c))
-        (.append writer c))
-      (.append writer \"))))
-
-(defn- format-field-ddl
-  [{:keys [^String database_type], fname :name} ^Writer writer]
-  (format-escaped fname writer)
-  (.append writer " ")
-  (.append writer database_type))
-
-(defn- format-table-ddl
-  [{:keys [schema fields], tname :name} ^Writer writer]
-  (.append writer "CREATE TABLE ")
-  (when (seq schema)
-    (format-escaped schema writer)
-    (.append writer \.))
-  (format-escaped tname writer)
-  (.append writer " (")
-  (when (seq fields)
-    (.append writer "\n  ")
-    (format-field-ddl (first fields) writer)
-    (doseq [field (rest fields)]
-      (.append writer ",\n  ")
-      (format-field-ddl field writer)))
-  (.append writer "\n);"))
-
-(defn- format-schema-ddl
-  [tables]
-  (let [sw (StringWriter.)]
-    (doseq [table tables]
-      (format-table-ddl table sw)
-      (.append sw \newline))
-    (str sw)))
-
-(defn- schema-sample
-  ([query]
-   (schema-sample query nil))
-  ([{:keys [database] :as query} {:keys [all-tables-limit] :or {all-tables-limit max-schema-sample-tables}}]
-   (let [tables (t2/select [:model/Table :id :name :schema]
-                           :db_id database
-                           :active true
-                           :visibility_type nil
-                           {:limit (inc all-tables-limit)})
-         tables (if (> (count tables) all-tables-limit)
-                  (metabot-v3/used-tables query)
-                  tables)
-         tables (t2/hydrate tables :fields)]
-     (format-schema-ddl tables))))
 
 (api.macros/defendpoint :post "/fix"
   "Suggest fixes for a SQL query."
@@ -88,7 +23,7 @@
     (-> (metabot-v3/fix-sql {:sql (-> query :native :query)
                              :dialect driver
                              :error_message error_message
-                             :schema_ddl (schema-sample query)})
+                             :schema_ddl (metabot-v3/schema-sample query)})
         (select-keys [:fixes]))))
 
 (def ^{:arglists '([request respond raise])} routes

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/document.clj
@@ -30,7 +30,7 @@
     (qp/process-query query)
     nil
     (catch Exception e
-      (.getMessage e))))
+      (ex-message e))))
 
 (api.macros/defendpoint :post "/generate-content"
   "Create a new piece of content to insert into the document."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/core.clj
@@ -16,4 +16,5 @@
   generate-sql]
  [metabase-enterprise.metabot-v3.table-utils
   database-tables
-  used-tables])
+  used-tables
+  schema-sample])

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/table_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/table_utils.clj
@@ -9,6 +9,7 @@
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize])
   (:import
+   (java.io StringWriter Writer)
    (org.apache.commons.text.similarity LevenshteinDistance)))
 
 (set! *warn-on-reflection* true)
@@ -17,6 +18,10 @@
 (def ^:private max-database-tables
   "If the number of tables in the database doesn't exceed this number, we send them all to the agent."
   100)
+
+(def ^:private max-schema-sample-tables
+  "If the number of tables in the database doesn't exceed this number, we send them all to the agent."
+  10)
 
 (defn database-tables
   "Get database tables formatted for AI context, with proper permissions filtering.
@@ -153,3 +158,61 @@
         {recognized-tables true, unrecognized-tables false} (group-by t2/instance? queried-tables)]
     (concat recognized-tables
             (find-matching-tables database unrecognized-tables (map :id recognized-tables)))))
+
+(defn- format-escaped
+  [^String identifier ^Writer writer]
+  (if (re-matches #"[\p{Alpha}_][\p{Alnum}_]*" identifier)
+    (.append writer identifier)
+    (do
+      (.append writer \")
+      (doseq [^Character c identifier]
+        (when (= c \")
+          (.append writer c))
+        (.append writer c))
+      (.append writer \"))))
+
+(defn- format-field-ddl
+  [{:keys [^String database_type], fname :name} ^Writer writer]
+  (format-escaped fname writer)
+  (.append writer " ")
+  (.append writer database_type))
+
+(defn- format-table-ddl
+  [{:keys [schema fields], tname :name} ^Writer writer]
+  (.append writer "CREATE TABLE ")
+  (when (seq schema)
+    (format-escaped schema writer)
+    (.append writer \.))
+  (format-escaped tname writer)
+  (.append writer " (")
+  (when (seq fields)
+    (.append writer "\n  ")
+    (format-field-ddl (first fields) writer)
+    (doseq [field (rest fields)]
+      (.append writer ",\n  ")
+      (format-field-ddl field writer)))
+  (.append writer "\n);"))
+
+(defn- format-schema-ddl
+  [tables]
+  (let [sw (StringWriter.)]
+    (doseq [table tables]
+      (format-table-ddl table sw)
+      (.append sw \newline))
+    (str sw)))
+
+(defn schema-sample
+  "Returns the DDL for the tables available in the given schema"
+  ([query]
+   (schema-sample query nil))
+  ([{:keys [database] :as query} {:keys [all-tables-limit] :or {all-tables-limit max-schema-sample-tables}}]
+   (let [tables (t2/select [:model/Table :id :name :schema]
+                           :db_id database
+                           :active true
+                           :visibility_type nil
+                           {:limit (inc all-tables-limit)})
+         tables (if (> (count tables) all-tables-limit)
+                  (used-tables query)
+                  tables)
+         tables (t2/hydrate tables :fields)]
+     (format-schema-ddl tables))))

--- a/enterprise/backend/test/metabase_enterprise/ai_sql_fixer/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/ai_sql_fixer/api_test.clj
@@ -5,13 +5,6 @@
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
    [metabase.test :as mt]))
 
-(deftest ^:parallel format-escpaed-test
-  (are [in out] (= out
-                   (with-out-str (table-utils/format-escaped in *out*)))
-    "almallama"      "almallama"
-    "alma llama"     "\"alma llama\""
-    "\"alma\" llama" "\"\"\"alma\"\" llama\""))
-
 (deftest ^:parallel schema-sample-test
   (mt/test-driver :h2
     (let [query {:database (mt/id)

--- a/enterprise/backend/test/metabase_enterprise/ai_sql_fixer/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/ai_sql_fixer/api_test.clj
@@ -2,12 +2,12 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase-enterprise.ai-sql-fixer.api :as ai-sql-fixer.api]
+   [metabase-enterprise.metabot-v3.table-utils :as table-utils]
    [metabase.test :as mt]))
 
 (deftest ^:parallel format-escpaed-test
   (are [in out] (= out
-                   (with-out-str (#'ai-sql-fixer.api/format-escaped in *out*)))
+                   (with-out-str (table-utils/format-escaped in *out*)))
     "almallama"      "almallama"
     "alma llama"     "\"alma llama\""
     "\"alma\" llama" "\"\"\"alma\"\" llama\""))
@@ -48,7 +48,7 @@
                       ");\n")
                  normalize)
              (-> (mt/with-current-user (mt/user->id :crowberto)
-                   (#'ai-sql-fixer.api/schema-sample query {:all-tables-limit 5}))
+                   (table-utils/schema-sample query {:all-tables-limit 5}))
                  normalize))))))
 
 (deftest ^:parallel no-used-table-test
@@ -75,5 +75,5 @@
                       ");\n")
                  normalize)
              (-> (mt/with-current-user (mt/user->id :crowberto)
-                   (#'ai-sql-fixer.api/schema-sample query {:all-tables-limit 5}))
+                   (table-utils/schema-sample query {:all-tables-limit 5}))
                  normalize))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/table_utils_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/table_utils_test.clj
@@ -262,3 +262,10 @@
         (let [tables (table-utils/database-tables db-id)]
           (is (every? #(not= "hidden_table" (:name %)) tables))
           (is (some #(= "visible_table" (:name %)) tables)))))))
+
+(deftest ^:parallel format-escaped-test
+  (are [in out] (= out
+                   (with-out-str (#'table-utils/format-escaped in *out*)))
+    "almallama"      "almallama"
+    "alma llama"     "\"alma llama\""
+    "\"alma\" llama" "\"\"\"alma\"\" llama\""))


### PR DESCRIPTION
### Description

Auto-executes SQL up to 5 times and attempts to fix any failures before returning it from the `generate-content` API


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
