### PR TITLE
refactor(sdk): Rename component-level MetabaseProvider to ComponentProvider

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx
@@ -65,7 +65,7 @@ const setup = (options: Options) => {
   setupPropertiesEndpoints(settingValues);
 
   return renderWithSDKProviders(<div>hello!</div>, {
-    sdkProviderProps: { authConfig: createMockSdkConfig() },
+    componentProviderProps: { authConfig: createMockSdkConfig() },
     storeInitialState: state,
   });
 };

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
@@ -60,7 +60,7 @@ const setup = (options: Options) => {
   setupPropertiesEndpoints(settingValues);
 
   return renderWithSDKProviders(<div>hello!</div>, {
-    sdkProviderProps: { authConfig: options.authConfig },
+    componentProviderProps: { authConfig: options.authConfig },
     storeInitialState: state,
   });
 };

--- a/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CollectionBrowser/CollectionBrowser.unit.spec.tsx
@@ -51,7 +51,7 @@ describe("CollectionBrowser", () => {
     const state = setupSdkState();
 
     renderWithSDKProviders(<CollectionBrowser collectionId="root" />, {
-      sdkProviderProps: {
+      componentProviderProps: {
         authConfig: createMockSdkConfig(),
       },
       storeInitialState: state,
@@ -120,7 +120,7 @@ async function setup({
   renderWithSDKProviders(
     <CollectionBrowserInner collectionId="root" {...props} />,
     {
-      sdkProviderProps: {
+      componentProviderProps: {
         authConfig: createMockSdkConfig(),
       },
       storeInitialState: state,

--- a/enterprise/frontend/src/embedding-sdk/components/public/ComponentProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/ComponentProvider.tsx
@@ -26,11 +26,11 @@ import { SdkFontsGlobalStyles } from "../private/SdkGlobalFontsStyles";
 import { PortalContainer } from "../private/SdkPortalContainer";
 import { SdkUsageProblemDisplay } from "../private/SdkUsageProblem";
 
-export interface InternalMetabaseProviderProps extends MetabaseProviderProps {
+type ComponentProviderInternalProps = ComponentProviderProps & {
   reduxStore: SdkStore;
-}
+};
 
-export const MetabaseProviderInternal = ({
+export const ComponentProviderInternal = ({
   children,
   authConfig,
   pluginsConfig,
@@ -41,12 +41,12 @@ export const MetabaseProviderInternal = ({
   errorComponent,
   loaderComponent,
   allowConsoleLog,
-}: InternalMetabaseProviderProps): JSX.Element => {
+}: ComponentProviderInternalProps): JSX.Element => {
   const { fontFamily } = theme ?? {};
 
-  // The main call of useInitData happens in the root MetabaseProvider
-  // This call in the component-level MetabaseProvider is still needed for:
-  // - Storybook stories, where we don't have the root MetabaseProvider
+  // The main call of useInitData happens in the MetabaseProvider
+  // This call in the ComponentProvider is still needed for:
+  // - Storybook stories, where we don't have the MetabaseProvider
   // - Unit tests
   useInitData({ reduxStore, authConfig, allowConsoleLog });
 
@@ -80,7 +80,7 @@ export const MetabaseProviderInternal = ({
     <EmotionCacheProvider>
       <SdkThemeProvider theme={theme}>
         <EnsureSingleInstance
-          groupId="component-level-providers"
+          groupId="component-providers"
           instanceId={ensureSingleInstanceId}
         >
           {({ isInstanceToRender }) => (
@@ -115,11 +115,14 @@ export const MetabaseProviderInternal = ({
   );
 };
 
-export const MetabaseProvider = memo(function MetabaseProvider({
+export type ComponentProviderProps = MetabaseProviderProps & {
+  reduxStore?: SdkStore;
+};
+
+export const ComponentProvider = memo(function ComponentProvider({
   children,
   ...props
-}: Omit<InternalMetabaseProviderProps, "reduxStore"> &
-  Partial<Pick<InternalMetabaseProviderProps, "reduxStore">>) {
+}: ComponentProviderProps) {
   const reduxStoreRef = useRef<SdkStore | null>(null);
 
   if (!reduxStoreRef.current) {
@@ -129,12 +132,12 @@ export const MetabaseProvider = memo(function MetabaseProvider({
   return (
     <MetabaseReduxProvider store={reduxStoreRef.current!}>
       <MetabotProvider>
-        <MetabaseProviderInternal
+        <ComponentProviderInternal
           {...props}
           reduxStore={reduxStoreRef.current!}
         >
           {children}
-        </MetabaseProviderInternal>
+        </ComponentProviderInternal>
       </MetabotProvider>
     </MetabaseReduxProvider>
   );

--- a/enterprise/frontend/src/embedding-sdk/components/public/ComponentProvider/ComponentProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/ComponentProvider/ComponentProvider.tsx
@@ -21,10 +21,10 @@ import { setOptions } from "metabase/redux/embed";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
 import { MetabotProvider } from "metabase-enterprise/metabot/context";
 
-import { SCOPED_CSS_RESET } from "../private/PublicComponentStylesWrapper";
-import { SdkFontsGlobalStyles } from "../private/SdkGlobalFontsStyles";
-import { PortalContainer } from "../private/SdkPortalContainer";
-import { SdkUsageProblemDisplay } from "../private/SdkUsageProblem";
+import { SCOPED_CSS_RESET } from "../../private/PublicComponentStylesWrapper";
+import { SdkFontsGlobalStyles } from "../../private/SdkGlobalFontsStyles";
+import { PortalContainer } from "../../private/SdkPortalContainer";
+import { SdkUsageProblemDisplay } from "../../private/SdkUsageProblem";
 
 type ComponentProviderInternalProps = ComponentProviderProps & {
   reduxStore: SdkStore;

--- a/enterprise/frontend/src/embedding-sdk/components/public/ComponentProvider/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/ComponentProvider/index.ts
@@ -1,0 +1,1 @@
+export * from "./ComponentProvider";

--- a/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/CreateDashboardModal/CreateDashboardModal.unit.spec.tsx
@@ -150,7 +150,7 @@ function setup(
   return renderWithSDKProviders(
     <CreateDashboardModal onCreate={jest.fn()} {...props} />,
     {
-      sdkProviderProps: {
+      componentProviderProps: {
         authConfig: createMockSdkConfig(),
       },
       storeInitialState: {

--- a/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion-multiple-questions.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion-multiple-questions.unit.spec.tsx
@@ -85,7 +85,7 @@ const setup = ({
   );
 
   return renderWithSDKProviders(children, {
-    sdkProviderProps: {
+    componentProviderProps: {
       authConfig: createMockSdkConfig(),
     },
     storeInitialState: state,

--- a/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion-themed.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion-themed.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from "metabase/embedding-sdk/theme";
 import { Box } from "metabase/ui";
 
-import { MetabaseProvider } from "../MetabaseProvider";
+import { ComponentProvider } from "../ComponentProvider";
 
 import { SdkQuestion } from "./SdkQuestion";
 
@@ -32,11 +32,11 @@ const Wrapper = ({
   children: ReactNode;
   theme: MetabaseTheme;
 }) => (
-  <MetabaseProvider theme={theme} authConfig={storybookSdkAuthDefaultConfig}>
+  <ComponentProvider theme={theme} authConfig={storybookSdkAuthDefaultConfig}>
     <Box p="xl" bg={theme.colors?.background}>
       {children}
     </Box>
-  </MetabaseProvider>
+  </ComponentProvider>
 );
 
 const DefaultTemplate = (theme: MetabaseTheme) => (

--- a/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion.EditorButton.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion.EditorButton.unit.spec.tsx
@@ -83,7 +83,7 @@ const setup = ({
       <SdkQuestion.EditorButton onClick={clickSpy} isOpen={isOpen} />
     </SdkQuestion>,
     {
-      sdkProviderProps: {
+      componentProviderProps: {
         authConfig: createMockSdkConfig(),
       },
       storeInitialState: state,

--- a/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion.tsx
@@ -41,7 +41,7 @@ import type { SdkQuestionIdProps } from "./types";
  */
 export type BaseSdkQuestionProps = SdkQuestionIdProps & {
   /**
-   * The children of the MetabaseProvider component.s
+   * The children of the component
    */
   children?: ReactNode;
   plugins?: SdkQuestionProviderProps["componentPlugins"];

--- a/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/SdkQuestion/SdkQuestion.unit.spec.tsx
@@ -142,7 +142,7 @@ const setup = ({
       {withCustomLayout ? <InteractiveQuestionCustomLayout /> : undefined}
     </SdkQuestion>,
     {
-      sdkProviderProps: {
+      componentProviderProps: {
         authConfig: createMockSdkConfig(),
       },
       storeInitialState: state,

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/SdkDashboard.stories.tsx
@@ -16,7 +16,7 @@ import {
   Title,
 } from "metabase/ui";
 
-import { MetabaseProvider } from "../MetabaseProvider";
+import { ComponentProvider } from "../ComponentProvider";
 import { SdkQuestion } from "../SdkQuestion";
 
 import { SdkDashboard, type SdkDashboardProps } from "./SdkDashboard";
@@ -151,9 +151,9 @@ export default {
 export const Default = {
   render(args: SdkDashboardProps) {
     return (
-      <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig}>
+      <ComponentProvider authConfig={storybookSdkAuthDefaultConfig}>
         <SdkDashboard {...args} />
-      </MetabaseProvider>
+      </ComponentProvider>
     );
   },
 
@@ -170,9 +170,9 @@ export const Default = {
 export const WithCustomQuestionLayout = {
   render(args: SdkDashboardProps) {
     return (
-      <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig}>
+      <ComponentProvider authConfig={storybookSdkAuthDefaultConfig}>
         <SdkDashboard {...args} />
-      </MetabaseProvider>
+      </ComponentProvider>
     );
   },
 
@@ -195,12 +195,12 @@ export const WithCustomGridColor = {
     });
 
     return (
-      <MetabaseProvider
+      <ComponentProvider
         authConfig={storybookSdkAuthDefaultConfig}
         theme={theme}
       >
         <SdkDashboard {...args} />
-      </MetabaseProvider>
+      </ComponentProvider>
     );
   },
 
@@ -215,12 +215,12 @@ export const WithCustomGridColor = {
 export const WithDarkTheme = {
   render(args: SdkDashboardProps) {
     return (
-      <MetabaseProvider
+      <ComponentProvider
         authConfig={storybookSdkAuthDefaultConfig}
         theme={darkTheme}
       >
         <SdkDashboard {...args} />
-      </MetabaseProvider>
+      </ComponentProvider>
     );
   },
 
@@ -235,9 +235,9 @@ export const WithDarkTheme = {
 export const MinimalConfiguration = {
   render(args: SdkDashboardProps) {
     return (
-      <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig}>
+      <ComponentProvider authConfig={storybookSdkAuthDefaultConfig}>
         <SdkDashboard {...args} />
-      </MetabaseProvider>
+      </ComponentProvider>
     );
   },
 
@@ -254,9 +254,9 @@ export const MinimalConfiguration = {
 export const WithDownloadsEnabled = {
   render(args: SdkDashboardProps) {
     return (
-      <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig}>
+      <ComponentProvider authConfig={storybookSdkAuthDefaultConfig}>
         <SdkDashboard {...args} />
-      </MetabaseProvider>
+      </ComponentProvider>
     );
   },
 
@@ -271,9 +271,9 @@ export const WithDownloadsEnabled = {
 export const WithCustomStyling = {
   render(args: SdkDashboardProps) {
     return (
-      <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig}>
+      <ComponentProvider authConfig={storybookSdkAuthDefaultConfig}>
         <SdkDashboard {...args} />
-      </MetabaseProvider>
+      </ComponentProvider>
     );
   },
 
@@ -296,9 +296,9 @@ export const WithCustomStyling = {
 export const WithInitialParameters = {
   render(args: SdkDashboardProps) {
     return (
-      <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig}>
+      <ComponentProvider authConfig={storybookSdkAuthDefaultConfig}>
         <SdkDashboard {...args} />
-      </MetabaseProvider>
+      </ComponentProvider>
     );
   },
 
@@ -319,7 +319,7 @@ export const WithInitialParameters = {
 export const ExperimentalLayout = {
   render(args: SdkDashboardProps) {
     return (
-      <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig}>
+      <ComponentProvider authConfig={storybookSdkAuthDefaultConfig}>
         <Paper
           display="flex"
           p="xl"
@@ -359,7 +359,7 @@ export const ExperimentalLayout = {
             </Flex>
           </SdkDashboard>
         </Paper>
-      </MetabaseProvider>
+      </ComponentProvider>
     );
   },
 

--- a/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/setup.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/public/dashboard/tests/setup.tsx
@@ -203,7 +203,7 @@ export const setupSdkDashboard = async ({
       />
     </Box>,
     {
-      sdkProviderProps: {
+      componentProviderProps: {
         ...providerProps,
         authConfig: createMockSdkConfig(),
       },

--- a/enterprise/frontend/src/embedding-sdk/components/public/index.ts
+++ b/enterprise/frontend/src/embedding-sdk/components/public/index.ts
@@ -7,7 +7,7 @@ export {
   EditableDashboard,
 } from "./dashboard";
 export { InteractiveQuestion } from "./InteractiveQuestion";
-export { MetabaseProvider } from "./MetabaseProvider";
+export { ComponentProvider } from "./ComponentProvider";
 export { StaticQuestion } from "./StaticQuestion";
 
 /**

--- a/enterprise/frontend/src/embedding-sdk/sdk-package/components/private/ComponentWrapper/ComponentWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/sdk-package/components/private/ComponentWrapper/ComponentWrapper.tsx
@@ -73,24 +73,24 @@ const ComponentWrapperInner = <TComponentProps,>({
     return <Loader />;
   }
 
-  const MetabaseProvider = isLoading
+  const ComponentProvider = isLoading
     ? null
-    : getWindow()?.MetabaseEmbeddingSDK?.MetabaseProvider;
+    : getWindow()?.MetabaseEmbeddingSDK?.ComponentProvider;
   const Component = getComponent();
 
-  if (!MetabaseProvider || !Component || !metabaseProviderProps.reduxStore) {
+  if (!ComponentProvider || !Component || !metabaseProviderProps.reduxStore) {
     return <Error message={SDK_NOT_LOADED_YET_MESSAGE} />;
   }
 
   return (
-    <MetabaseProvider
+    <ComponentProvider
       {...metabaseProviderProps}
       reduxStore={metabaseProviderProps.reduxStore}
     >
       <Component
         {...(componentProps as JSX.IntrinsicAttributes & TComponentProps)}
       />
-    </MetabaseProvider>
+    </ComponentProvider>
   );
 };
 

--- a/enterprise/frontend/src/embedding-sdk/sdk-package/hooks/private/use-load-sdk-bundle.ts
+++ b/enterprise/frontend/src/embedding-sdk/sdk-package/hooks/private/use-load-sdk-bundle.ts
@@ -55,7 +55,7 @@ export function useLoadSdkBundle(metabaseInstanceUrl: string) {
     // The SDK bundle script was loaded before
     if (window.MetabaseEmbeddingSDK) {
       // After the SDK bundle script was loaded, the MetabaseProviderProps store may be cleaned up.
-      // It happens when the root MetabaseProvider component is unmounted and remounted later.
+      // It happens when the MetabaseProvider component is unmounted and remounted later.
       // In this case we don't need to load the SDK bundle again, but we have to set the proper `Loaded` state.
       if (loadingState === SdkLoadingState.Initial) {
         metabaseProviderPropsStore.updateInternalProps({

--- a/enterprise/frontend/src/embedding-sdk/sdk-package/hooks/public/use-create-dashboard-api/use-create-dashboard-api.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/sdk-package/hooks/public/use-create-dashboard-api/use-create-dashboard-api.unit.spec.tsx
@@ -129,7 +129,7 @@ function setup(overrides: SetupProps = {}) {
         getCollectionNumericIdFromReference,
       },
       storeInitialState: state,
-      sdkProviderProps: {
+      componentProviderProps: {
         authConfig: createMockSdkConfig(),
       },
     },

--- a/enterprise/frontend/src/embedding-sdk/sdk-shared/lib/ensure-metabase-provider-props-store.ts
+++ b/enterprise/frontend/src/embedding-sdk/sdk-shared/lib/ensure-metabase-provider-props-store.ts
@@ -1,4 +1,4 @@
-import type { InternalMetabaseProviderProps } from "embedding-sdk/components/public/MetabaseProvider";
+import type { ComponentProviderProps } from "embedding-sdk/components/public/ComponentProvider";
 import {
   type SdkLoadingError,
   SdkLoadingState,
@@ -10,7 +10,7 @@ type MetabaseProviderPropsToStore = MetabaseProviderPropsStoreExternalProps &
   MetabaseProviderPropsStoreInternalProps;
 
 export type MetabaseProviderPropsStoreExternalProps = Omit<
-  InternalMetabaseProviderProps,
+  ComponentProviderProps,
   "children" | keyof MetabaseProviderPropsStoreInternalProps
 >;
 
@@ -18,7 +18,7 @@ export type MetabaseProviderPropsStoreInternalProps = {
   loadingPromise?: Promise<void> | null;
   loadingState?: SdkLoadingState;
   loadingError?: SdkLoadingError | null;
-  reduxStore?: InternalMetabaseProviderProps["reduxStore"] | null;
+  reduxStore?: ComponentProviderProps["reduxStore"] | null;
   singleInstanceIdsMap?: Record<string, string[]>;
 };
 

--- a/enterprise/frontend/src/embedding-sdk/test/CommonSdkCorsStoryWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/CommonSdkCorsStoryWrapper.tsx
@@ -1,6 +1,6 @@
 import type { StoryFn } from "@storybook/react";
 
-import { MetabaseProvider } from "embedding-sdk/components/public";
+import { ComponentProvider } from "embedding-sdk/components/public";
 import type { MetabaseAuthConfig } from "embedding-sdk/types";
 
 const METABASE_INSTANCE_URL =
@@ -11,7 +11,7 @@ const DEFAULT_AUTH_CONFIG: MetabaseAuthConfig = {
 };
 
 export const CommonSdkStoryCorsWrapper = (Story: StoryFn) => (
-  <MetabaseProvider authConfig={DEFAULT_AUTH_CONFIG}>
+  <ComponentProvider authConfig={DEFAULT_AUTH_CONFIG}>
     <Story />
-  </MetabaseProvider>
+  </ComponentProvider>
 );

--- a/enterprise/frontend/src/embedding-sdk/test/CommonSdkStoryWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/CommonSdkStoryWrapper.tsx
@@ -4,7 +4,7 @@ import type { StoryFn } from "@storybook/react";
 import { SignJWT } from "jose";
 import { useMemo } from "react";
 
-import { MetabaseProvider } from "embedding-sdk/components/public";
+import { ComponentProvider } from "embedding-sdk/components/public";
 import type { MetabaseAuthConfig } from "embedding-sdk/types/auth-config";
 
 import { USERS } from "../../../../../e2e/support/cypress_data";
@@ -59,14 +59,14 @@ export const CommonSdkStoryWrapper = (Story: StoryFn, context: any) => {
 
   return (
     <MantineProvider>
-      <MetabaseProvider
+      <ComponentProvider
         authConfig={authConfig}
         theme={theme}
         key={key}
         locale={locale}
       >
         <Story />
-      </MetabaseProvider>
+      </ComponentProvider>
     </MantineProvider>
   );
 };

--- a/enterprise/frontend/src/embedding-sdk/test/__support__/ui.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/__support__/ui.tsx
@@ -3,7 +3,7 @@ import type * as React from "react";
 import _ from "underscore";
 
 import { getStore } from "__support__/entities-store";
-import { MetabaseProviderInternal } from "embedding-sdk/components/public/MetabaseProvider";
+import { ComponentProviderInternal } from "embedding-sdk/components/public/ComponentProvider";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk/sdk-shared/lib/ensure-metabase-provider-props-store";
 import { sdkReducers } from "embedding-sdk/store";
 import type { SdkStore, SdkStoreState } from "embedding-sdk/store/types";
@@ -18,7 +18,7 @@ import { createMockState } from "metabase-types/store/mocks";
 
 export interface RenderWithSDKProvidersOptions {
   storeInitialState?: Partial<State>;
-  sdkProviderProps?: Partial<MetabaseProviderProps> | null;
+  componentProviderProps?: Partial<MetabaseProviderProps> | null;
   theme?: MantineThemeOverride;
   sdkBundleExports?: Partial<typeof window.MetabaseEmbeddingSDK>;
 }
@@ -27,7 +27,7 @@ export function renderWithSDKProviders(
   ui: React.ReactElement,
   {
     storeInitialState = {},
-    sdkProviderProps = null,
+    componentProviderProps = null,
     theme,
     sdkBundleExports,
     ...options
@@ -58,8 +58,8 @@ export function renderWithSDKProviders(
   ) as unknown as SdkStore;
 
   // Prevent spamming the console during tests
-  if (sdkProviderProps) {
-    sdkProviderProps.allowConsoleLog = false;
+  if (componentProviderProps) {
+    componentProviderProps.allowConsoleLog = false;
   }
 
   if (sdkBundleExports) {
@@ -76,9 +76,9 @@ export function renderWithSDKProviders(
       <MetabaseReduxProvider store={store}>
         {/* If we try to inject CSS variables to `.mb-wrapper`, it will slow the Jest tests down like crazy. */}
         <ThemeProviderContext.Provider value={{ withCssVariables: false }}>
-          <MetabaseProviderInternal
+          <ComponentProviderInternal
             {...props}
-            {...sdkProviderProps}
+            {...componentProviderProps}
             reduxStore={store}
           />
         </ThemeProviderContext.Provider>

--- a/enterprise/frontend/src/embedding-sdk/test/auth-flow/jwt.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/auth-flow/jwt.unit.spec.tsx
@@ -4,7 +4,7 @@ import fetchMock from "fetch-mock";
 import { renderWithProviders, waitForLoaderToBeRemoved } from "__support__/ui";
 import { waitForRequest } from "__support__/utils";
 import {
-  MetabaseProvider,
+  ComponentProvider,
   StaticQuestion,
 } from "embedding-sdk/components/public";
 import { defineMetabaseAuthConfig } from "embedding-sdk/sdk-package/lib/public/define-metabase-auth-config";
@@ -46,9 +46,9 @@ describe("Auth Flow - JWT", () => {
     ).toHaveLength(1);
 
     rerender(
-      <MetabaseProvider authConfig={authConfig}>
+      <ComponentProvider authConfig={authConfig}>
         <StaticQuestion questionId={1} />
-      </MetabaseProvider>,
+      </ComponentProvider>,
     );
 
     await waitForLoaderToBeRemoved();
@@ -159,9 +159,9 @@ describe("Auth Flow - JWT", () => {
     });
 
     renderWithProviders(
-      <MetabaseProvider authConfig={authConfig}>
+      <ComponentProvider authConfig={authConfig}>
         <StaticQuestion questionId={1} />
-      </MetabaseProvider>,
+      </ComponentProvider>,
     );
 
     await waitForLoaderToBeRemoved();

--- a/enterprise/frontend/src/embedding-sdk/test/auth-flow/saml.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/auth-flow/saml.unit.spec.tsx
@@ -4,7 +4,7 @@ import fetchMock from "fetch-mock";
 import { waitForLoaderToBeRemoved } from "__support__/ui";
 import { waitForRequest } from "__support__/utils";
 import {
-  MetabaseProvider,
+  ComponentProvider,
   StaticQuestion,
 } from "embedding-sdk/components/public";
 import { defineMetabaseAuthConfig } from "embedding-sdk/sdk-package/lib/public/define-metabase-auth-config";
@@ -46,9 +46,9 @@ describe("Auth Flow - SAML", () => {
     expect(popup.close).toHaveBeenCalled();
 
     rerender(
-      <MetabaseProvider authConfig={authConfig}>
+      <ComponentProvider authConfig={authConfig}>
         <StaticQuestion questionId={1} />
-      </MetabaseProvider>,
+      </ComponentProvider>,
     );
 
     await waitForLoaderToBeRemoved();

--- a/enterprise/frontend/src/embedding-sdk/test/auth-flow/setup.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/auth-flow/setup.tsx
@@ -7,7 +7,7 @@ import {
 } from "__support__/server-mocks";
 import { renderWithProviders } from "__support__/ui";
 import {
-  MetabaseProvider,
+  ComponentProvider,
   StaticQuestion,
 } from "embedding-sdk/components/public";
 import type { MetabaseProviderProps } from "embedding-sdk/types/metabase-provider";
@@ -60,9 +60,9 @@ export const setup = ({
 
   return {
     ...renderWithProviders(
-      <MetabaseProvider authConfig={authConfig} locale={locale}>
+      <ComponentProvider authConfig={authConfig} locale={locale}>
         <StaticQuestion questionId={1} />
-      </MetabaseProvider>,
+      </ComponentProvider>,
       {
         storeInitialState: state,
       },

--- a/enterprise/frontend/src/embedding-sdk/test/sdk-compatibility-warning.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/sdk-compatibility-warning.unit.spec.tsx
@@ -5,7 +5,7 @@ import {
   setupPropertiesEndpoints,
 } from "__support__/server-mocks";
 import { waitForLoaderToBeRemoved } from "__support__/ui";
-import { MetabaseProvider } from "embedding-sdk/components/public";
+import { ComponentProvider } from "embedding-sdk/components/public";
 import {
   createMockSettings,
   createMockTokenFeatures,
@@ -45,9 +45,9 @@ const setup = async ({
   setupCurrentUserEndpoint(createMockUser({ id: 1 }));
 
   render(
-    <MetabaseProvider authConfig={defaultAuthConfig}>
+    <ComponentProvider authConfig={defaultAuthConfig}>
       <div>Hello</div>
-    </MetabaseProvider>,
+    </ComponentProvider>,
   );
   await waitForLoaderToBeRemoved();
 };

--- a/enterprise/frontend/src/embedding-sdk/test/sdk-config-errors/sdk-config-errors.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk/test/sdk-config-errors/sdk-config-errors.unit.spec.tsx
@@ -7,7 +7,7 @@ import {
 import { waitForLoaderToBeRemoved } from "__support__/ui";
 import { waitForRequest } from "__support__/utils";
 import {
-  MetabaseProvider,
+  ComponentProvider,
   StaticQuestion,
 } from "embedding-sdk/components/public";
 import { defineMetabaseAuthConfig } from "embedding-sdk/sdk-package/lib/public/define-metabase-auth-config";
@@ -47,9 +47,9 @@ const setup = async (
     .mockImplementation(() => {});
 
   render(
-    <MetabaseProvider authConfig={config}>
+    <ComponentProvider authConfig={config}>
       <StaticQuestion questionId={1} />
-    </MetabaseProvider>,
+    </ComponentProvider>,
   );
 
   await waitForLoaderToBeRemoved();

--- a/enterprise/frontend/src/embedding-sdk/tests/sdk-locale-support.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/tests/sdk-locale-support.stories.tsx
@@ -1,5 +1,5 @@
 import {
-  MetabaseProvider,
+  ComponentProvider,
   StaticDashboard,
 } from "embedding-sdk/components/public";
 import { storybookSdkAuthDefaultConfig } from "embedding-sdk/test/CommonSdkStoryWrapper";
@@ -9,10 +9,10 @@ export default {
 };
 
 export const DeLocale = () => (
-  <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig} locale="de">
+  <ComponentProvider authConfig={storybookSdkAuthDefaultConfig} locale="de">
     <StaticDashboard
       dashboardId={(window as any).DASHBOARD_ID || 1}
       withDownloads
     />
-  </MetabaseProvider>
+  </ComponentProvider>
 );

--- a/enterprise/frontend/src/embedding-sdk/tests/styling-sdk-tests.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk/tests/styling-sdk-tests.stories.tsx
@@ -1,5 +1,5 @@
 import {
-  MetabaseProvider,
+  ComponentProvider,
   StaticQuestion,
 } from "embedding-sdk/components/public";
 import { storybookSdkAuthDefaultConfig } from "embedding-sdk/test/CommonSdkStoryWrapper";
@@ -25,13 +25,13 @@ export const NoStylesError = () => (
       <h1>This is outside of the provider</h1>
     </div>
 
-    <MetabaseProvider authConfig={configThatWillError}>
+    <ComponentProvider authConfig={configThatWillError}>
       <div style={{ border: "1px solid black" }}>
         <h1>This is inside of the provider</h1>
       </div>
 
       <StaticQuestion questionId={(window as any).QUESTION_ID || 1} />
-    </MetabaseProvider>
+    </ComponentProvider>
   </div>
 );
 
@@ -42,24 +42,24 @@ export const NoStylesSuccess = () => (
       <h1>This is outside of the provider</h1>
     </div>
 
-    <MetabaseProvider authConfig={storybookSdkAuthDefaultConfig}>
+    <ComponentProvider authConfig={storybookSdkAuthDefaultConfig}>
       <div style={{ border: "1px solid black" }}>
         <h1>This is inside of the provider</h1>
       </div>
 
       <StaticQuestion questionId={(window as any).QUESTION_ID || 1} />
-    </MetabaseProvider>
+    </ComponentProvider>
   </div>
 );
 
 export const FontFromConfig = () => (
   <div>
-    <MetabaseProvider
+    <ComponentProvider
       authConfig={storybookSdkAuthDefaultConfig}
       theme={{ fontFamily: "Impact" }}
     >
       <StaticQuestion questionId={(window as any).QUESTION_ID || 1} />
-    </MetabaseProvider>
+    </ComponentProvider>
   </div>
 );
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from "react";
 import { P, match } from "ts-pattern";
 
 import {
+  ComponentProvider,
   InteractiveDashboard,
-  MetabaseProvider,
   StaticDashboard,
   StaticQuestion,
 } from "embedding-sdk/bundle";
@@ -66,11 +66,11 @@ export const SdkIframeEmbedRoute = () => {
   });
 
   return (
-    <MetabaseProvider authConfig={authConfig} theme={theme} locale={locale}>
+    <ComponentProvider authConfig={authConfig} theme={theme} locale={locale}>
       <Box h="100vh" bg={theme?.colors?.background}>
         <SdkIframeEmbedView settings={embedSettings} />
       </Box>
-    </MetabaseProvider>
+    </ComponentProvider>
   );
 };
 


### PR DESCRIPTION
Rename component-level MetabaseProvider to ComponentProvider
We still have the root MetabaseProvider

How to verify:
- CI is green