### PR TITLE
Add secondary role explanation for snowflake impersonation to docs

### DIFF
--- a/docs/permissions/impersonation.md
+++ b/docs/permissions/impersonation.md
@@ -73,7 +73,7 @@ ALTER TABLE people ENABLE ROW LEVEL SECURITY;
 
 ### Snowflake connections should disable secondary roles when using impersonation
 
-For impersonation to work correctly with **Snowflake** databases, the user account Metabase uses to [connect to your Snowflake database](../databases/connections/snowflake.md) must have [secondary roles](https://docs.snowflake.com/en/user-guide/security-access-control-overview#authorization-through-primary-role-and-secondary-roles) disabled. You can disable roles with:
+For impersonation to work correctly with **Snowflake** databases, the user account Metabase uses to [connect to your Snowflake database](../databases/connections/snowflake.md) must have [secondary roles](https://docs.snowflake.com/en/user-guide/security-access-control-overview#authorization-through-primary-role-and-secondary-roles) disabled. You can disable secondary roles with:
 
 ```sql
 ALTER USER metabase_user SET DEFAULT_SECONDARY_ROLES = ();

--- a/docs/permissions/impersonation.md
+++ b/docs/permissions/impersonation.md
@@ -71,6 +71,8 @@ SELECT TO vermont_sales_team USING (state = 'VT');
 ALTER TABLE people ENABLE ROW LEVEL SECURITY;
 ```
 
+> For **Snowflake** databases, the user account Metabase uses to [connect to your Snowflake database](../databases/connections/snowflake.md) must have [secondary roles](https://docs.snowflake.com/en/user-guide/security-access-control-overview#authorization-through-primary-role-and-secondary-roles) disabled with `ALTER USER metabase_user SET DEFAULT_SECONDARY_ROLES = ();` for impersonation to work correctly. Otherwise, each impersonated role will have the permissions of all of the user's granted roles combined.
+
 ### Set up a Metabase group
 
 Permissions in Metabase, including impersonation, are managed by groups, so you'll need to:

--- a/docs/permissions/impersonation.md
+++ b/docs/permissions/impersonation.md
@@ -71,7 +71,15 @@ SELECT TO vermont_sales_team USING (state = 'VT');
 ALTER TABLE people ENABLE ROW LEVEL SECURITY;
 ```
 
-> For **Snowflake** databases, the user account Metabase uses to [connect to your Snowflake database](../databases/connections/snowflake.md) must have [secondary roles](https://docs.snowflake.com/en/user-guide/security-access-control-overview#authorization-through-primary-role-and-secondary-roles) disabled with `ALTER USER metabase_user SET DEFAULT_SECONDARY_ROLES = ();` for impersonation to work correctly. Otherwise, each impersonated role will have the permissions of all of the user's granted roles combined.
+### Snowflake connections should disable secondary roles when using impersonation
+
+For impersonation to work correctly with **Snowflake** databases, the user account Metabase uses to [connect to your Snowflake database](../databases/connections/snowflake.md) must have [secondary roles](https://docs.snowflake.com/en/user-guide/security-access-control-overview#authorization-through-primary-role-and-secondary-roles) disabled. You can disable roles with:
+
+```sql
+ALTER USER metabase_user SET DEFAULT_SECONDARY_ROLES = ();
+```
+
+If you don't disable secondary roles, each impersonated role will also get permissions of all other roles you've granted to the Metabase user.
 
 ### Set up a Metabase group
 


### PR DESCRIPTION
Adding a message on Impersonation docs about the following (slightly confusing) default behavior of roles in snowflake:

Say I have a user with roles `READ_TABLE_A`, `READ_TABLE_B`.
If I log into this user, and `USE ROLE READ_TABLE_A`, then `SELECT * FROM TABLE_B` still works. This is what happens with Metabase SQL impersonation as well.
The reason is: to decide if you can execute SQL statements that are not `CREATE`, Snowflake decides based on your primary role (`READ_TABLE_A`) and your [current secondary roles](https://docs.snowflake.com/en/user-guide/security-access-control-overview#authorization-through-primary-role-and-secondary-roles), which by [default are `ALL`](https://community.snowflake.com/s/article/default-secondary-roles-all-overview-and-additional-explanations) your granted roles:  `READ_TABLE_A` and `READ_TABLE_B` , so it lets you get Table B anyway.
To guarantee that the only role at play is your primary role (so impersonation works as expected), you'll need to set the Metabase User's secondary roles to none by doing `ALTER USER METABASE_USER SET DEFAULT_SECONDARY_ROLES = ();`