### PR TITLE
Make Lib schemas better about catching MBQL-only keys in native stages or joins

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1320,7 +1320,9 @@
     ;; collection (table) this query should run against. Needed for MongoDB
     [:collection    {:optional true} [:maybe ::lib.schema.common/non-blank-string]]]
    (lib.schema.common/disallowed-keys
-    {:type "An inner query must not include :type, this will cause us to mix it up with an outer query"})])
+    {:type         "An inner query must not include :type, this will cause us to mix it up with an outer query"
+     :source-table ":source-table is only allowed in MBQL inner queries."
+     :fields       ":fields is only allowed in MBQL inner queries."})])
 
 (def NativeQuery
   "Schema for a valid, normalized native [inner] query."

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -76,9 +76,18 @@
     ;; TODO -- parameters??
     ]
    (common/disallowed-keys
-    {:source-table ":source-table is not allowed in a native query stage."
-     :source-card  ":source-card is not allowed in a native query stage."
-     :query        ":query is not allowed in a native query stage, you probably meant to use :native instead."})])
+    {:query        ":query is not allowed in a native query stage, you probably meant to use :native instead."
+     :source-table "MBQL stage keys like :source-table are not allowed in a native query stage."
+     :source-card  "MBQL stage keys like :source-card are not allowed in a native query stage."
+     :fields       "MBQL stage keys like :fields are not allowed in a native query stage."
+     :filter       "MBQL stage keys like :filter are not allowed in a native query stage."
+     :filters      "MBQL stage keys like :filters are not allowed in a native query stage."
+     :breakout     "MBQL stage keys like :breakout are not allowed in a native query stage."
+     :aggregation  "MBQL stage keys like :aggregation are not allowed in a native query stage."
+     :limit        "MBQL stage keys like :limit are not allowed in a native query stage."
+     :order-by     "MBQL stage keys like :order-by are not allowed in a native query stage."
+     :offset       "MBQL stage keys like :offset are not allowed in a native query stage."
+     :page         "MBQL stage keys like :page are not allowed in a native query stage."})])
 
 (mr/def ::breakout
   [:ref ::ref/ref])

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -3,38 +3,36 @@
   (:require
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
+   [metabase.lib.schema.util :as lib.schema.util]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli.registry :as mr]))
 
-;;; The Fields to include in the results *if* a top-level `:fields` clause *is not* specified. This can be either
-;;; `:none`, `:all`, or a sequence of Field clauses.
-;;;
-;;; *  `:none`: no Fields from the joined table or nested query are included (unless indirectly included by
-;;;    breakouts or other clauses). This is the default, and what is used for automatically-generated joins.
-;;;
-;;; *  `:all`: will include all of the Fields from the joined table or query
-;;;
-;;; * a sequence of Field clauses: include only the Fields specified. Only `:field` clauses are allowed here!
-;;;    References to expressions or aggregations in the thing we're joining should use column literal (string column
-;;;    name) `:field` references. This should be non-empty and all elements should be distinct. The normalizer will
-;;;    automatically remove duplicate fields for you, and replace empty clauses with `:none`.
-;;;
-;;; Driver implementations: you can ignore this clause. Relevant fields will be added to top-level `:fields` clause
-;;; with appropriate aliases.
 (mr/def ::fields
+  "The Fields to include in the results *if* a top-level `:fields` clause *is not* specified. This can be either
+  `:none`, `:all`, or a sequence of Field clauses.
+
+  * `:none`: no Fields from the joined table or nested query are included (unless indirectly included by breakouts or
+     other clauses). This is the default, and what is used for automatically-generated joins.
+
+  * `:all`: will include all of the Fields from the joined table or query
+
+  * a sequence of Field clauses: include only the Fields specified. Only `:field` clauses are allowed here! References
+    to expressions or aggregations in the thing we're joining should use column literal (string column name) `:field`
+    references. This should be non-empty and all elements should be distinct (ignoring `:lib/uuid`)."
   [:multi
    {:dispatch (some-fn keyword? string?)}
    [true  [:enum {:decode/normalize common/normalize-keyword} :all :none]]
    ;; TODO -- `:fields` is supposed to be distinct (ignoring UUID), e.g. you can't have `[:field {} 1]` in there
    ;; twice. (#32489)
-   [false [:sequential {:min 1} [:ref :mbql.clause/field]]]])
+   [false
+    [:and
+     [:sequential {:min 1} [:ref :mbql.clause/field]]
+     [:ref ::lib.schema.util/distinct-mbql-clauses]]]])
 
-;;; The name used to alias the joined table or query. This is usually generated automatically and generally looks
-;;; like `table__via__field`. You can specify this yourself if you need to reference a joined field with a
-;;; `:join-alias` in the options.
-;;;
-;;; Driver implementations: This is guaranteed to be present after pre-processing.
 (mr/def ::alias
+  "The name used to alias the joined table or query. This is usually generated automatically and generally looks like
+  `table__via__field`. You can specify this yourself if you need to reference a joined field with a `:join-alias` in
+  the options."
   [:schema
    {:gen/fmap #(str % "-" (random-uuid))}
    ::common/non-blank-string])
@@ -57,14 +55,14 @@
   "Operators that should be listed as options in join conditions."
   (into [:enum] condition-operators))
 
-;;; valid values for the optional `:strategy` key in a join. Note that these are only valid if the current Database
-;;; supports that specific join type; these match 1:1 with the Database `:features`, e.g. a Database that supports
-;;; left joins will support the `:left-join` feature.
-;;;
-;;; When `:strategy` is not specified, `:left-join` is the default strategy.
 (mr/def ::strategy
+  "Valid values for the optional `:strategy` key in a join. Note that these are only valid if the current Database
+  supports that specific join type; these match 1:1 with the Database `:features`, e.g. a Database that supports left
+  joins will support the `:left-join` feature.
+
+  When `:strategy` is not specified, `:left-join` is the default strategy."
   [:enum
-   {:decode/normalize common/normalize-keyword}
+   {:decode/normalize common/normalize-keyword, :default :left-join}
    :left-join
    :right-join
    :inner-join
@@ -89,6 +87,27 @@
         (-> (dissoc :condition)
             (assoc :conditions [(:condition join)]))))))
 
+(mr/def ::validate-field-aliases-match-join-alias
+  [:fn
+   {:error/message    "All join :fields should have a :join-alias that matches the join's :alias"
+    :decode/normalize (fn [join]
+                        (cond-> join
+                          (and (:alias join)
+                               (sequential? (:fields join)))
+                          (update :fields (fn [fields]
+                                            (mapv (fn [[tag opts id-or-name :as _field-ref]]
+                                                    [tag (assoc opts :join-alias (:alias join)) id-or-name])
+                                                  fields)))))}
+   (fn [{join-alias :alias, fields :fields, :as _join}]
+     (or
+      (not (sequential? fields))
+      ;; a [[metabase.lib.join.util/PartialJoin]] (a join being built) might not have an alias yet; do not validate
+      ;; in that case.
+      (not join-alias)
+      (every? (fn [[_tag opts _id-or-name :as _field-ref]]
+                (= (:join-alias opts) join-alias))
+              fields)))])
+
 (mr/def ::join
   [:and
    [:map
@@ -108,7 +127,10 @@
      :condition          ":condition is not allowed for MBQL 5 joins, use :conditions instead"
      :source-card        "join should not have :source-card; use :stages instead"
      :source-table       "join should not have :source-table; use :stages instead"
-     :source-query       "join should not have :source-query; use :stages instead"})])
+     :source-query       "join should not have :source-query; use :stages instead"
+     :filter             "join should not have top-level :filters; these should belong to one of the join :stages"
+     :filters            "join should not have top-level :filters; these should belong to one of the join :stages"})
+   [:ref ::validate-field-aliases-match-join-alias]])
 
 (mr/def ::joins
   [:and

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -653,6 +653,7 @@
   [:map
    [:lib/type [:= :metadata/native-query-snippet]]
    [:id       ::lib.schema.id/native-query-snippet]])
+;;; TODO (Cam 8/8/25) -- description, content, archived, collection-id
 
 (mr/def ::table
   "Schema for metadata about a specific [[metabase.warehouse-schema.models.table]]. More or less the same but with


### PR DESCRIPTION
Minor Lib schema improvements I pulled out of some of my dusty PRs so they still have a chance of landing.

- Require join `:fields` to have the correct `:alias` -- this is a no-brainer and nothing will work correctly if you violate this rule. Normalization will fix it for you automatically
- Catch bugs where someone tries to add `:filter`/`:filters` or other MBQL keys to a NATIVE query stage (these are ignored so if you're doing it you're doing something wrong). Same with joins
- Fix a bug with replacing a field in join `:fields` -- makes sure the replaced field has the correct `:join-alias`