### PR TITLE
[Search] Increase search reporting

### DIFF
--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -56,7 +56,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
               position: 3,
               search_engine: P.string,
               request_id: P.string,
-              entity_model: "dataset",
+              entity_model: P.string,
               search_term_hash: ORDERS_SEARCH_TERM_HASH,
               search_term: null,
             },
@@ -93,7 +93,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
         {
           event: SEARCH_CLICK,
           context: "command-palette",
-          position: 0,
+          position: 2,
         },
         1,
       );

--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -7,9 +7,6 @@ import { commandPaletteInput } from "../../../support/helpers/e2e-command-palett
 H.describeWithSnowplow("scenarios > search > snowplow", () => {
   const NEW_SEARCH_QUERY_EVENT_NAME = "search_query";
   const SEARCH_CLICK = "search_click";
-  const ORDERS_SEARCH_TERM = "Orders";
-  const ORDERS_SEARCH_TERM_HASH =
-    "6f87db3f4884dbd2026b952f0ddf8a56f383b1cb36fe650164762ceed27acaf4";
 
   beforeEach(() => {
     H.restore();
@@ -26,7 +23,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
   describe("command palette", () => {
     it("should send snowplow events search queries on a click", () => {
       cy.visit("/");
-      H.commandPaletteSearch(ORDERS_SEARCH_TERM, false);
+      H.commandPaletteSearch("Orders", false);
 
       //Passing a function to ensure that runtime_milliseconds is populated as a number
       H.expectUnstructuredSnowplowEvent((event) =>
@@ -38,7 +35,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
             search_engine: P.string,
             request_id: P.string,
             offset: null,
-            search_term_hash: ORDERS_SEARCH_TERM_HASH,
+            search_term_hash: P.string,
             search_term: null,
           },
           event,
@@ -57,7 +54,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
               search_engine: P.string,
               request_id: P.string,
               entity_model: P.string,
-              search_term_hash: ORDERS_SEARCH_TERM_HASH,
+              search_term_hash: P.string,
               search_term: null,
             },
             event,
@@ -68,7 +65,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
 
     it("should send snowplow events search queries on keyboard navigation", () => {
       cy.visit("/");
-      H.commandPaletteSearch(ORDERS_SEARCH_TERM, false);
+      H.commandPaletteSearch("Orders", false);
 
       //Passing a function to ensure that runtime_milliseconds is populated as a number
       H.expectUnstructuredSnowplowEvent((event) =>

--- a/frontend/src/metabase-types/analytics/search.ts
+++ b/frontend/src/metabase-types/analytics/search.ts
@@ -17,6 +17,7 @@ type SearchEventSchema = {
   search_engine?: string | null;
   request_id?: string | null;
   offset?: number | null;
+  entity_model?: string | null;
 };
 
 type ValidateEvent<
@@ -69,6 +70,7 @@ export type SearchClickEvent = ValidateEvent<{
   context: SearchContext | null;
   search_engine: string | null;
   request_id: string | null;
+  entity_model: string | null;
 }>;
 
 export type SearchEvent = SearchQueryEvent | SearchClickEvent;

--- a/frontend/src/metabase-types/analytics/search.ts
+++ b/frontend/src/metabase-types/analytics/search.ts
@@ -16,6 +16,7 @@ type SearchEventSchema = {
   search_archived?: boolean | null;
   search_engine?: string | null;
   request_id?: string | null;
+  offset?: number | null;
 };
 
 type ValidateEvent<
@@ -56,8 +57,9 @@ export type SearchQueryEvent = ValidateEvent<{
   verified_items: boolean;
   search_native_queries: boolean;
   search_archived: boolean;
-  search_engine: string;
+  search_engine: string | null;
   request_id: string | null;
+  offset: number | null;
 }>;
 
 export type SearchClickEvent = ValidateEvent<{

--- a/frontend/src/metabase-types/analytics/search.ts
+++ b/frontend/src/metabase-types/analytics/search.ts
@@ -14,6 +14,7 @@ type SearchEventSchema = {
   verified_items?: boolean | null;
   search_native_queries?: boolean | null;
   search_archived?: boolean | null;
+  search_engine?: string | null;
 };
 
 type ValidateEvent<
@@ -54,13 +55,15 @@ export type SearchQueryEvent = ValidateEvent<{
   verified_items: boolean;
   search_native_queries: boolean;
   search_archived: boolean;
+  search_engine: string;
 }>;
 
 export type SearchClickEvent = ValidateEvent<{
   event: "search_click";
   position: number;
-  target_type: "item" | "view_more";
+  target_type: "item";
   context: SearchContext | null;
+  search_engine: string;
 }>;
 
 export type SearchEvent = SearchQueryEvent | SearchClickEvent;

--- a/frontend/src/metabase-types/analytics/search.ts
+++ b/frontend/src/metabase-types/analytics/search.ts
@@ -18,6 +18,7 @@ type SearchEventSchema = {
   request_id?: string | null;
   offset?: number | null;
   entity_model?: string | null;
+  search_term_hash?: string | null;
 };
 
 type ValidateEvent<
@@ -46,6 +47,7 @@ type SearchContext =
 
 export type SearchQueryEvent = ValidateEvent<{
   event: "search_query";
+  search_term_hash: string | null;
   runtime_milliseconds: number;
   context: SearchContext | null;
   total_results: number;
@@ -71,6 +73,7 @@ export type SearchClickEvent = ValidateEvent<{
   search_engine: string | null;
   request_id: string | null;
   entity_model: string | null;
+  search_term_hash: string | null;
 }>;
 
 export type SearchEvent = SearchQueryEvent | SearchClickEvent;

--- a/frontend/src/metabase-types/analytics/search.ts
+++ b/frontend/src/metabase-types/analytics/search.ts
@@ -65,7 +65,7 @@ export type SearchClickEvent = ValidateEvent<{
   position: number;
   target_type: "item";
   context: SearchContext | null;
-  search_engine: string;
+  search_engine: string | null;
   request_id: string | null;
 }>;
 

--- a/frontend/src/metabase-types/analytics/search.ts
+++ b/frontend/src/metabase-types/analytics/search.ts
@@ -66,7 +66,7 @@ export type SearchQueryEvent = ValidateEvent<{
 export type SearchClickEvent = ValidateEvent<{
   event: "search_click";
   position: number;
-  target_type: "item";
+  target_type: "item" | "view_more";
   context: SearchContext | null;
   search_engine: string | null;
   request_id: string | null;

--- a/frontend/src/metabase-types/analytics/search.ts
+++ b/frontend/src/metabase-types/analytics/search.ts
@@ -15,6 +15,7 @@ type SearchEventSchema = {
   search_native_queries?: boolean | null;
   search_archived?: boolean | null;
   search_engine?: string | null;
+  request_id?: string | null;
 };
 
 type ValidateEvent<
@@ -56,6 +57,7 @@ export type SearchQueryEvent = ValidateEvent<{
   search_native_queries: boolean;
   search_archived: boolean;
   search_engine: string;
+  request_id: string | null;
 }>;
 
 export type SearchClickEvent = ValidateEvent<{
@@ -64,6 +66,7 @@ export type SearchClickEvent = ValidateEvent<{
   target_type: "item";
   context: SearchContext | null;
   search_engine: string;
+  request_id: string | null;
 }>;
 
 export type SearchEvent = SearchQueryEvent | SearchClickEvent;

--- a/frontend/src/metabase-types/analytics/search.ts
+++ b/frontend/src/metabase-types/analytics/search.ts
@@ -19,6 +19,7 @@ type SearchEventSchema = {
   offset?: number | null;
   entity_model?: string | null;
   search_term_hash?: string | null;
+  search_term?: string | null;
 };
 
 type ValidateEvent<
@@ -48,6 +49,7 @@ type SearchContext =
 export type SearchQueryEvent = ValidateEvent<{
   event: "search_query";
   search_term_hash: string | null;
+  search_term: string | null;
   runtime_milliseconds: number;
   context: SearchContext | null;
   total_results: number;
@@ -74,6 +76,7 @@ export type SearchClickEvent = ValidateEvent<{
   request_id: string | null;
   entity_model: string | null;
   search_term_hash: string | null;
+  search_term: string | null;
 }>;
 
 export type SearchEvent = SearchQueryEvent | SearchClickEvent;

--- a/frontend/src/metabase-types/api/mocks/search.ts
+++ b/frontend/src/metabase-types/api/mocks/search.ts
@@ -64,6 +64,7 @@ export const createMockSearchResults = ({
     offset: 0,
     table_db_id: null,
     total: items.length,
+    engine: "search.engine/appdb",
     ...options,
   };
 };

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -154,6 +154,7 @@ export const createMockSettingDefinition = <
 export const createMockSettings = (
   opts?: Partial<Settings | EnterpriseSettings>,
 ): EnterpriseSettings => ({
+  "analytics-uuid": "eefb3320-1d3f-4686-a22a-1d30ae729525",
   "admin-email": "admin@metabase.test",
   "airgap-enabled": false,
   "allowed-iframe-hosts": "*",

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -48,6 +48,7 @@ export type SearchResponse<
   models: Model[] | null;
   available_models: SearchModel[];
   table_db_id: DatabaseId | null;
+  engine: string;
 } & PaginationResponse;
 
 export type CollectionEssentials = Pick<

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -438,6 +438,7 @@ type PrivilegedSettings = AdminSettings & SettingsManagerSettings;
 
 interface PublicSettings {
   "allowed-iframe-hosts": string;
+  "analytics-uuid": string;
   "anon-tracking-enabled": boolean;
   "application-font": string;
   "application-font-files": FontFile[] | null;

--- a/frontend/src/metabase/api/search.ts
+++ b/frontend/src/metabase/api/search.ts
@@ -14,12 +14,12 @@ export const searchApi = Api.injectEndpoints({
       }),
       providesTags: (response, error, { models }) =>
         provideSearchItemListTags(response?.data ?? [], models),
-      onQueryStarted: (args, { queryFulfilled }) => {
+      onQueryStarted: (args, { queryFulfilled, requestId }) => {
         if (args.context) {
           const start = Date.now();
           queryFulfilled.then(({ data }) => {
             const duration = Date.now() - start;
-            trackSearchRequest(args, data, duration);
+            trackSearchRequest(args, data, duration, requestId);
           });
         }
       },

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -265,6 +265,7 @@ export function EntityPickerModal<
             searchResults={finalSearchResults ?? []}
             searchEngine={data?.engine}
             searchRequestId={requestId}
+            searchTerm={searchQuery}
             selectedItem={selectedItem}
             onItemSelect={onItemSelect}
             onSearchScopeChange={setSearchScope}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -182,7 +182,7 @@ export function EntityPickerModal<
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery);
   useDebounce(() => setDebouncedSearchQuery(searchQuery), 200, [searchQuery]);
 
-  const { data, isFetching } = useSearchQuery(
+  const { data, isFetching, requestId } = useSearchQuery(
     {
       q: debouncedSearchQuery,
       models: searchModels,
@@ -264,6 +264,7 @@ export function EntityPickerModal<
             searchScope={searchScope}
             searchResults={finalSearchResults ?? []}
             searchEngine={data?.engine}
+            searchRequestId={requestId}
             selectedItem={selectedItem}
             onItemSelect={onItemSelect}
             onSearchScopeChange={setSearchScope}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -263,6 +263,7 @@ export function EntityPickerModal<
             isLoading={isFetching}
             searchScope={searchScope}
             searchResults={finalSearchResults ?? []}
+            searchEngine={data?.engine}
             selectedItem={selectedItem}
             onItemSelect={onItemSelect}
             onSearchScopeChange={setSearchScope}

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
@@ -18,6 +18,7 @@ interface Props<
   folder: Item | undefined;
   searchResults: SearchItem[];
   searchEngine?: string;
+  searchRequestId?: string;
   selectedItem: Item | null;
   onItemSelect: (item: Item) => void;
 }
@@ -30,6 +31,7 @@ export const SearchResults = <
   folder,
   searchResults,
   searchEngine,
+  searchRequestId,
   selectedItem,
   onItemSelect,
 }: Props<Id, Model, Item>) => {
@@ -55,6 +57,7 @@ export const SearchResults = <
                     index,
                     "entity-picker",
                     searchEngine || "unknown",
+                    searchRequestId,
                   );
                   onItemSelect(item as unknown as Item);
                 }}

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
@@ -54,15 +54,15 @@ export const SearchResults = <
                 key={item.model + item.id}
                 item={item}
                 onClick={() => {
-                  trackSearchClick(
-                    "item",
-                    index,
-                    "entity-picker",
-                    searchEngine || "unknown",
-                    searchRequestId,
-                    item.model,
+                  trackSearchClick({
+                    itemType: "item",
+                    position: index,
+                    context: "entity-picker",
+                    searchEngine: searchEngine || "unknown",
+                    requestId: searchRequestId,
+                    entityModel: item.model,
                     searchTerm,
-                  );
+                  });
                   onItemSelect(item as unknown as Item);
                 }}
                 isSelected={

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
@@ -19,6 +19,7 @@ interface Props<
   searchResults: SearchItem[];
   searchEngine?: string;
   searchRequestId?: string;
+  searchTerm?: string;
   selectedItem: Item | null;
   onItemSelect: (item: Item) => void;
 }
@@ -32,6 +33,7 @@ export const SearchResults = <
   searchResults,
   searchEngine,
   searchRequestId,
+  searchTerm,
   selectedItem,
   onItemSelect,
 }: Props<Id, Model, Item>) => {
@@ -59,6 +61,7 @@ export const SearchResults = <
                     searchEngine || "unknown",
                     searchRequestId,
                     item.model,
+                    searchTerm,
                   );
                   onItemSelect(item as unknown as Item);
                 }}

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
@@ -58,6 +58,7 @@ export const SearchResults = <
                     "entity-picker",
                     searchEngine || "unknown",
                     searchRequestId,
+                    item.model,
                   );
                   onItemSelect(item as unknown as Item);
                 }}

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
@@ -17,6 +17,7 @@ interface Props<
 > {
   folder: Item | undefined;
   searchResults: SearchItem[];
+  searchEngine?: string;
   selectedItem: Item | null;
   onItemSelect: (item: Item) => void;
 }
@@ -28,6 +29,7 @@ export const SearchResults = <
 >({
   folder,
   searchResults,
+  searchEngine,
   selectedItem,
   onItemSelect,
 }: Props<Id, Model, Item>) => {
@@ -48,7 +50,12 @@ export const SearchResults = <
                 key={item.model + item.id}
                 item={item}
                 onClick={() => {
-                  trackSearchClick("item", index, "entity-picker");
+                  trackSearchClick(
+                    "item",
+                    index,
+                    "entity-picker",
+                    searchEngine || "unknown",
+                  );
                   onItemSelect(item as unknown as Item);
                 }}
                 isSelected={

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchTab.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchTab.tsx
@@ -22,6 +22,7 @@ interface Props<
   isLoading: boolean;
   searchScope: EntityPickerSearchScope;
   searchResults: SearchItem[];
+  searchEngine?: string;
   selectedItem: Item | null;
   onItemSelect: (item: Item) => void;
   onSearchScopeChange: (scope: EntityPickerSearchScope) => void;
@@ -36,6 +37,7 @@ export const SearchTab = <
   isLoading,
   searchScope,
   searchResults,
+  searchEngine,
   selectedItem,
   onItemSelect,
   onSearchScopeChange,
@@ -83,6 +85,7 @@ export const SearchTab = <
           <SearchResults
             folder={folder}
             searchResults={searchResults}
+            searchEngine={searchEngine}
             selectedItem={selectedItem}
             onItemSelect={onItemSelect}
           />

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchTab.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchTab.tsx
@@ -23,6 +23,7 @@ interface Props<
   searchScope: EntityPickerSearchScope;
   searchResults: SearchItem[];
   searchEngine?: string;
+  searchRequestId?: string;
   selectedItem: Item | null;
   onItemSelect: (item: Item) => void;
   onSearchScopeChange: (scope: EntityPickerSearchScope) => void;
@@ -38,6 +39,7 @@ export const SearchTab = <
   searchScope,
   searchResults,
   searchEngine,
+  searchRequestId,
   selectedItem,
   onItemSelect,
   onSearchScopeChange,
@@ -86,6 +88,7 @@ export const SearchTab = <
             folder={folder}
             searchResults={searchResults}
             searchEngine={searchEngine}
+            searchRequestId={searchRequestId}
             selectedItem={selectedItem}
             onItemSelect={onItemSelect}
           />

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchTab.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchTab.tsx
@@ -24,6 +24,7 @@ interface Props<
   searchResults: SearchItem[];
   searchEngine?: string;
   searchRequestId?: string;
+  searchTerm?: string;
   selectedItem: Item | null;
   onItemSelect: (item: Item) => void;
   onSearchScopeChange: (scope: EntityPickerSearchScope) => void;
@@ -40,6 +41,7 @@ export const SearchTab = <
   searchResults,
   searchEngine,
   searchRequestId,
+  searchTerm,
   selectedItem,
   onItemSelect,
   onSearchScopeChange,
@@ -89,6 +91,7 @@ export const SearchTab = <
             searchResults={searchResults}
             searchEngine={searchEngine}
             searchRequestId={searchRequestId}
+            searchTerm={searchTerm}
             selectedItem={selectedItem}
             onItemSelect={onItemSelect}
           />

--- a/frontend/src/metabase/lib/analytics.ts
+++ b/frontend/src/metabase/lib/analytics.ts
@@ -28,7 +28,7 @@ const VERSIONS: Record<SchemaType, SchemaVersion> = {
   invite: "1-0-1",
   model: "1-0-0",
   question: "1-0-6",
-  search: "1-1-0",
+  search: "1-2-0",
   serialization: "1-0-1",
   settings: "1-0-2",
   setup: "1-0-3",

--- a/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
@@ -168,6 +168,7 @@ export const SearchResults = ({
                 onClick={onClick}
                 index={index}
                 context="search-bar"
+                searchTerm={searchText}
               />
             </li>
           );

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -198,6 +198,7 @@ export const useCommandPalette = ({
                   "command-palette",
                   searchResults?.engine || "unknown",
                   searchRequestId,
+                  result.model,
                 );
               },
               extra: {

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -175,15 +175,15 @@ export const useCommandPalette = ({
             keywords: debouncedSearchText,
             icon: "link" as IconName,
             perform: () => {
-              trackSearchClick(
-                "view_more",
-                0,
-                "command-palette",
-                searchResults?.engine || "unknown",
-                searchRequestId,
-                null,
-                debouncedSearchText,
-              );
+              trackSearchClick({
+                itemType: "view_more",
+                position: 0,
+                context: "command-palette",
+                searchEngine: searchResults?.engine || "unknown",
+                requestId: searchRequestId,
+                entityModel: null,
+                searchTerm: debouncedSearchText,
+              });
             },
             priority: Priority.HIGH,
             extra: {
@@ -203,15 +203,15 @@ export const useCommandPalette = ({
               keywords: debouncedSearchText,
               priority: Priority.NORMAL - index,
               perform: () => {
-                trackSearchClick(
-                  "item",
-                  index,
-                  "command-palette",
-                  searchResults?.engine || "unknown",
-                  searchRequestId,
-                  result.model,
-                  debouncedSearchText,
-                );
+                trackSearchClick({
+                  itemType: "item",
+                  position: index,
+                  context: "command-palette",
+                  searchEngine: searchResults?.engine || "unknown",
+                  requestId: searchRequestId,
+                  entityModel: result.model,
+                  searchTerm: debouncedSearchText,
+                });
               },
               extra: {
                 moderatedStatus: result.moderated_status,

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -72,6 +72,7 @@ export const useCommandPalette = ({
     currentData: searchResults,
     isFetching: isSearchLoading,
     error: searchError,
+    requestId: searchRequestId,
   } = useSearchQuery(
     {
       q: debouncedSearchText,
@@ -196,6 +197,7 @@ export const useCommandPalette = ({
                   index,
                   "command-palette",
                   searchResults?.engine || "unknown",
+                  searchRequestId,
                 );
               },
               extra: {
@@ -229,6 +231,7 @@ export const useCommandPalette = ({
     searchResults,
     locationQuery,
     isSearchTypeaheadEnabled,
+    searchRequestId,
   ]);
 
   useRegisterActions(searchResultActions, [searchResultActions]);

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -182,6 +182,7 @@ export const useCommandPalette = ({
                 searchResults?.engine || "unknown",
                 searchRequestId,
                 null,
+                debouncedSearchText,
               );
             },
             priority: Priority.HIGH,
@@ -209,6 +210,7 @@ export const useCommandPalette = ({
                   searchResults?.engine || "unknown",
                   searchRequestId,
                   result.model,
+                  debouncedSearchText,
                 );
               },
               extra: {

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -174,6 +174,16 @@ export const useCommandPalette = ({
             section: "search",
             keywords: debouncedSearchText,
             icon: "link" as IconName,
+            perform: () => {
+              trackSearchClick(
+                "view_more",
+                0,
+                "command-palette",
+                searchResults?.engine || "unknown",
+                searchRequestId,
+                null,
+              );
+            },
             priority: Priority.HIGH,
             extra: {
               href: searchLocation,

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -173,9 +173,6 @@ export const useCommandPalette = ({
             section: "search",
             keywords: debouncedSearchText,
             icon: "link" as IconName,
-            perform: () => {
-              trackSearchClick("view_more", 0, "command-palette");
-            },
             priority: Priority.HIGH,
             extra: {
               href: searchLocation,
@@ -194,7 +191,12 @@ export const useCommandPalette = ({
               keywords: debouncedSearchText,
               priority: Priority.NORMAL - index,
               perform: () => {
-                trackSearchClick("item", index, "command-palette");
+                trackSearchClick(
+                  "item",
+                  index,
+                  "command-palette",
+                  searchResults?.engine || "unknown",
+                );
               },
               extra: {
                 moderatedStatus: result.moderated_status,

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -2,6 +2,9 @@ import { trackSchemaEvent } from "metabase/lib/analytics";
 import Settings from "metabase/lib/settings";
 import type { SearchRequest, SearchResponse } from "metabase-types/api";
 
+const shouldReportSearchTerm = () =>
+  Settings.get("analytics-uuid") === "d97541bd-59b0-4656-b437-d659ac48eae1";
+
 type SearchRequestFilter = Pick<
   SearchRequest,
   | "q"
@@ -46,6 +49,8 @@ export const trackSearchRequest = (
       search_term_hash: searchRequest.q
         ? await hashSearchTerm(searchRequest.q)
         : null,
+      search_term:
+        shouldReportSearchTerm() && searchRequest.q ? searchRequest.q : null,
       content_type: searchRequest.models ?? null,
       creator: !!searchRequest.created_by,
       creation_date: !!searchRequest.created_at,
@@ -95,6 +100,7 @@ export const trackSearchClick = ({
       request_id: requestId,
       entity_model: entityModel,
       search_term_hash: searchTerm ? await hashSearchTerm(searchTerm) : null,
+      search_term: shouldReportSearchTerm() && searchTerm ? searchTerm : null,
     });
   };
 

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -13,6 +13,7 @@ type SearchRequestFilter = Pick<
   | "models"
   | "archived"
   | "q"
+  | "offset"
 >;
 
 export const trackSearchRequest = (
@@ -37,6 +38,7 @@ export const trackSearchRequest = (
     page_results: searchResponse.limit,
     search_engine: searchResponse.engine,
     request_id: requestId,
+    offset: searchRequest.offset ?? null,
   });
 };
 

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -34,18 +34,21 @@ export const trackSearchRequest = (
     runtime_milliseconds: duration,
     total_results: searchResponse.total,
     page_results: searchResponse.limit,
+    search_engine: searchResponse.engine,
   });
 };
 
 export const trackSearchClick = (
-  itemType: "item" | "view_more",
+  itemType: "item",
   position: number,
   context: SearchRequest["context"],
+  searchEngine: string,
 ) => {
   trackSchemaEvent("search", {
     event: "search_click",
     position,
     target_type: itemType,
     context: context ?? null,
+    search_engine: searchEngine,
   });
 };

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -48,6 +48,7 @@ export const trackSearchClick = (
   context: SearchRequest["context"],
   searchEngine: string,
   requestId: string | null = null,
+  entityModel: string | null = null,
 ) => {
   trackSchemaEvent("search", {
     event: "search_click",
@@ -56,5 +57,6 @@ export const trackSearchClick = (
     context: context ?? null,
     search_engine: searchEngine,
     request_id: requestId,
+    entity_model: entityModel,
   });
 };

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -66,15 +66,25 @@ export const trackSearchRequest = (
   dispatchTrackSearchQuery();
 };
 
-export const trackSearchClick = (
-  itemType: "item" | "view_more",
-  position: number,
-  context: SearchRequest["context"],
-  searchEngine: string,
-  requestId: string | null = null,
-  entityModel: string | null = null,
-  searchTerm: string | null = null,
-) => {
+type TrackSearchClickParams = {
+  itemType: "item" | "view_more";
+  position: number;
+  context: SearchRequest["context"];
+  searchEngine: string;
+  requestId?: string | null;
+  entityModel?: string | null;
+  searchTerm?: string | null;
+};
+
+export const trackSearchClick = ({
+  itemType,
+  position,
+  context,
+  searchEngine,
+  requestId = null,
+  entityModel = null,
+  searchTerm = null,
+}: TrackSearchClickParams) => {
   const dispatchTrackSearchClick = async () => {
     trackSchemaEvent("search", {
       event: "search_click",

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -1,8 +1,10 @@
 import { trackSchemaEvent } from "metabase/lib/analytics";
+import Settings from "metabase/lib/settings";
 import type { SearchRequest, SearchResponse } from "metabase-types/api";
 
 type SearchRequestFilter = Pick<
   SearchRequest,
+  | "q"
   | "created_by"
   | "created_at"
   | "last_edited_at"
@@ -16,30 +18,52 @@ type SearchRequestFilter = Pick<
   | "offset"
 >;
 
+async function hashSearchTerm(searchTerm: string) {
+  try {
+    const analyticsUuid = Settings.get("analytics-uuid");
+    const saltedSearchTerm = searchTerm + "-salt-" + analyticsUuid;
+
+    const dataBuffer = new TextEncoder().encode(saltedSearchTerm);
+    const hashBuffer = await crypto.subtle.digest("SHA-256", dataBuffer);
+
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+  } catch (err) {
+    console.warn("Failed to hash search term", err);
+    return null;
+  }
+}
+
 export const trackSearchRequest = (
   searchRequest: SearchRequestFilter,
   searchResponse: SearchResponse,
   duration: number,
   requestId: string | null = null,
 ) => {
-  trackSchemaEvent("search", {
-    event: "search_query",
-    content_type: searchRequest.models ?? null,
-    creator: !!searchRequest.created_by,
-    creation_date: !!searchRequest.created_at,
-    last_edit_date: !!searchRequest.last_edited_at,
-    last_editor: !!searchRequest.last_edited_by,
-    verified_items: !!searchRequest.verified,
-    search_native_queries: !!searchRequest.search_native_query,
-    search_archived: !!searchRequest.archived,
-    context: searchRequest.context ?? null,
-    runtime_milliseconds: duration,
-    total_results: searchResponse.total,
-    page_results: searchResponse.limit,
-    search_engine: searchResponse.engine,
-    request_id: requestId,
-    offset: searchRequest.offset ?? null,
-  });
+  const dispatchTrackSearchQuery = async () => {
+    trackSchemaEvent("search", {
+      event: "search_query",
+      search_term_hash: searchRequest.q
+        ? await hashSearchTerm(searchRequest.q)
+        : null,
+      content_type: searchRequest.models ?? null,
+      creator: !!searchRequest.created_by,
+      creation_date: !!searchRequest.created_at,
+      last_edit_date: !!searchRequest.last_edited_at,
+      last_editor: !!searchRequest.last_edited_by,
+      verified_items: !!searchRequest.verified,
+      search_native_queries: !!searchRequest.search_native_query,
+      search_archived: !!searchRequest.archived,
+      context: searchRequest.context ?? null,
+      runtime_milliseconds: duration,
+      total_results: searchResponse.total,
+      page_results: searchResponse.limit,
+      search_engine: searchResponse.engine,
+      request_id: requestId,
+      offset: searchRequest.offset ?? null,
+    });
+  };
+  dispatchTrackSearchQuery();
 };
 
 export const trackSearchClick = (
@@ -49,14 +73,20 @@ export const trackSearchClick = (
   searchEngine: string,
   requestId: string | null = null,
   entityModel: string | null = null,
+  searchTerm: string | null = null,
 ) => {
-  trackSchemaEvent("search", {
-    event: "search_click",
-    position,
-    target_type: itemType,
-    context: context ?? null,
-    search_engine: searchEngine,
-    request_id: requestId,
-    entity_model: entityModel,
-  });
+  const dispatchTrackSearchClick = async () => {
+    trackSchemaEvent("search", {
+      event: "search_click",
+      position,
+      target_type: itemType,
+      context: context ?? null,
+      search_engine: searchEngine,
+      request_id: requestId,
+      entity_model: entityModel,
+      search_term_hash: searchTerm ? await hashSearchTerm(searchTerm) : null,
+    });
+  };
+
+  dispatchTrackSearchClick();
 };

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -2,12 +2,13 @@ import { trackSchemaEvent } from "metabase/lib/analytics";
 import Settings from "metabase/lib/settings";
 import type { SearchRequest, SearchResponse } from "metabase-types/api";
 
+const MB_STATS_ANALYTICS_UUID = "d97541bd-59b0-4656-b437-d659ac48eae1";
+
 const shouldReportSearchTerm = () =>
-  Settings.get("analytics-uuid") === "d97541bd-59b0-4656-b437-d659ac48eae1";
+  Settings.get("analytics-uuid") === MB_STATS_ANALYTICS_UUID;
 
 type SearchRequestFilter = Pick<
   SearchRequest,
-  | "q"
   | "created_by"
   | "created_at"
   | "last_edited_at"

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -43,6 +43,7 @@ export const trackSearchClick = (
   position: number,
   context: SearchRequest["context"],
   searchEngine: string,
+  requestId: string | null = null,
 ) => {
   trackSchemaEvent("search", {
     event: "search_click",
@@ -50,5 +51,6 @@ export const trackSearchClick = (
     target_type: itemType,
     context: context ?? null,
     search_engine: searchEngine,
+    request_id: requestId,
   });
 };

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -43,7 +43,7 @@ export const trackSearchRequest = (
 };
 
 export const trackSearchClick = (
-  itemType: "item",
+  itemType: "item" | "view_more",
   position: number,
   context: SearchRequest["context"],
   searchEngine: string,

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -19,6 +19,7 @@ export const trackSearchRequest = (
   searchRequest: SearchRequestFilter,
   searchResponse: SearchResponse,
   duration: number,
+  requestId: string | null = null,
 ) => {
   trackSchemaEvent("search", {
     event: "search_query",
@@ -35,6 +36,7 @@ export const trackSearchRequest = (
     total_results: searchResponse.total,
     page_results: searchResponse.limit,
     search_engine: searchResponse.engine,
+    request_id: requestId,
   });
 };
 

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
@@ -37,6 +37,7 @@ export function SearchResult({
   context = "search-app",
   searchEngine,
   searchRequestId,
+  searchTerm,
 }: {
   result: WrappedResult;
   compact?: boolean;
@@ -48,6 +49,7 @@ export function SearchResult({
   context?: SearchContext;
   searchEngine?: string;
   searchRequestId?: string;
+  searchTerm?: string;
 }) {
   const { name, model, description, moderated_status }: WrappedResult = result;
 
@@ -95,6 +97,7 @@ export function SearchResult({
       searchEngine || "unknown",
       searchRequestId,
       result.model,
+      searchTerm,
     );
     onChangeLocation(result.getUrl());
   };

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
@@ -90,15 +90,15 @@ export function SearchResult({
       onClick(result);
       return;
     }
-    trackSearchClick(
-      "item",
-      index,
+    trackSearchClick({
+      itemType: "item",
+      position: index,
       context,
-      searchEngine || "unknown",
-      searchRequestId,
-      result.model,
+      searchEngine: searchEngine || "unknown",
+      requestId: searchRequestId,
+      entityModel: result.model,
       searchTerm,
-    );
+    });
     onChangeLocation(result.getUrl());
   };
 

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
@@ -36,6 +36,7 @@ export function SearchResult({
   index,
   context = "search-app",
   searchEngine,
+  searchRequestId,
 }: {
   result: WrappedResult;
   compact?: boolean;
@@ -46,6 +47,7 @@ export function SearchResult({
   index: number;
   context?: SearchContext;
   searchEngine?: string;
+  searchRequestId?: string;
 }) {
   const { name, model, description, moderated_status }: WrappedResult = result;
 
@@ -86,7 +88,13 @@ export function SearchResult({
       onClick(result);
       return;
     }
-    trackSearchClick("item", index, context, searchEngine || "unknown");
+    trackSearchClick(
+      "item",
+      index,
+      context,
+      searchEngine || "unknown",
+      searchRequestId,
+    );
     onChangeLocation(result.getUrl());
   };
 

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
@@ -94,6 +94,7 @@ export function SearchResult({
       context,
       searchEngine || "unknown",
       searchRequestId,
+      result.model,
     );
     onChangeLocation(result.getUrl());
   };

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
@@ -35,6 +35,7 @@ export function SearchResult({
   className,
   index,
   context = "search-app",
+  searchEngine,
 }: {
   result: WrappedResult;
   compact?: boolean;
@@ -44,6 +45,7 @@ export function SearchResult({
   className?: string;
   index: number;
   context?: SearchContext;
+  searchEngine?: string;
 }) {
   const { name, model, description, moderated_status }: WrappedResult = result;
 
@@ -84,7 +86,7 @@ export function SearchResult({
       onClick(result);
       return;
     }
-    trackSearchClick("item", index, context);
+    trackSearchClick("item", index, context, searchEngine || "unknown");
     onChangeLocation(result.getUrl());
   };
 

--- a/frontend/src/metabase/search/containers/SearchApp.jsx
+++ b/frontend/src/metabase/search/containers/SearchApp.jsx
@@ -72,7 +72,7 @@ function SearchApp({ location }) {
     [onChangeLocation, searchText],
   );
 
-  const { data, error, isFetching } = useSearchQuery(query);
+  const { data, error, isFetching, requestId } = useSearchQuery(query);
   const list = useMemo(() => {
     return data?.data?.map((item) => Search.wrapEntity(item, dispatch)) ?? [];
   }, [data, dispatch]);
@@ -107,6 +107,7 @@ function SearchApp({ location }) {
                 totalResults={data.total}
                 results={list}
                 searchEngine={data.engine}
+                searchRequestId={requestId}
               />
               <Group justify="flex-end" align="center" my="1rem">
                 <PaginationControls

--- a/frontend/src/metabase/search/containers/SearchApp.jsx
+++ b/frontend/src/metabase/search/containers/SearchApp.jsx
@@ -108,6 +108,8 @@ function SearchApp({ location }) {
                 results={list}
                 searchEngine={data.engine}
                 searchRequestId={requestId}
+                page={page}
+                pageSize={PAGE_SIZE}
               />
               <Group justify="flex-end" align="center" my="1rem">
                 <PaginationControls

--- a/frontend/src/metabase/search/containers/SearchApp.jsx
+++ b/frontend/src/metabase/search/containers/SearchApp.jsx
@@ -108,6 +108,7 @@ function SearchApp({ location }) {
                 results={list}
                 searchEngine={data.engine}
                 searchRequestId={requestId}
+                searchTerm={searchText}
                 page={page}
                 pageSize={PAGE_SIZE}
               />

--- a/frontend/src/metabase/search/containers/SearchApp.jsx
+++ b/frontend/src/metabase/search/containers/SearchApp.jsx
@@ -103,7 +103,11 @@ function SearchApp({ location }) {
 
           {!error && !isFetching && list.length > 0 && (
             <Box>
-              <SearchResultSection totalResults={data.total} results={list} />
+              <SearchResultSection
+                totalResults={data.total}
+                results={list}
+                searchEngine={data.engine}
+              />
               <Group justify="flex-end" align="center" my="1rem">
                 <PaginationControls
                   showTotal

--- a/frontend/src/metabase/search/containers/SearchResultSection.tsx
+++ b/frontend/src/metabase/search/containers/SearchResultSection.tsx
@@ -9,11 +9,15 @@ export const SearchResultSection = ({
   totalResults,
   searchEngine,
   searchRequestId,
+  page,
+  pageSize,
 }: {
   results: WrappedResult[];
   totalResults: number;
   searchEngine?: string;
   searchRequestId?: string;
+  page?: number;
+  pageSize?: number;
 }) => {
   const resultsLabel = ngettext(
     msgid`${totalResults} result`,
@@ -28,11 +32,12 @@ export const SearchResultSection = ({
           {resultsLabel}
         </Text>
         {results.map((item, index) => {
+          const absolutePosition = (page ?? 0) * (pageSize ?? 1) + index;
           return (
             <SearchResult
               key={`${item.id}__${item.model}`}
               result={item}
-              index={index}
+              index={absolutePosition}
               searchEngine={searchEngine}
               searchRequestId={searchRequestId}
             />

--- a/frontend/src/metabase/search/containers/SearchResultSection.tsx
+++ b/frontend/src/metabase/search/containers/SearchResultSection.tsx
@@ -9,6 +9,7 @@ export const SearchResultSection = ({
   totalResults,
   searchEngine,
   searchRequestId,
+  searchTerm,
   page,
   pageSize,
 }: {
@@ -16,6 +17,7 @@ export const SearchResultSection = ({
   totalResults: number;
   searchEngine?: string;
   searchRequestId?: string;
+  searchTerm?: string;
   page?: number;
   pageSize?: number;
 }) => {
@@ -40,6 +42,7 @@ export const SearchResultSection = ({
               index={absolutePosition}
               searchEngine={searchEngine}
               searchRequestId={searchRequestId}
+              searchTerm={searchTerm}
             />
           );
         })}

--- a/frontend/src/metabase/search/containers/SearchResultSection.tsx
+++ b/frontend/src/metabase/search/containers/SearchResultSection.tsx
@@ -7,9 +7,11 @@ import { Paper, Stack, Text } from "metabase/ui";
 export const SearchResultSection = ({
   results,
   totalResults,
+  searchEngine,
 }: {
   results: WrappedResult[];
   totalResults: number;
+  searchEngine?: string;
 }) => {
   const resultsLabel = ngettext(
     msgid`${totalResults} result`,
@@ -29,6 +31,7 @@ export const SearchResultSection = ({
               key={`${item.id}__${item.model}`}
               result={item}
               index={index}
+              searchEngine={searchEngine}
             />
           );
         })}

--- a/frontend/src/metabase/search/containers/SearchResultSection.tsx
+++ b/frontend/src/metabase/search/containers/SearchResultSection.tsx
@@ -8,10 +8,12 @@ export const SearchResultSection = ({
   results,
   totalResults,
   searchEngine,
+  searchRequestId,
 }: {
   results: WrappedResult[];
   totalResults: number;
   searchEngine?: string;
+  searchRequestId?: string;
 }) => {
   const resultsLabel = ngettext(
     msgid`${totalResults} result`,
@@ -32,6 +34,7 @@ export const SearchResultSection = ({
               result={item}
               index={index}
               searchEngine={searchEngine}
+              searchRequestId={searchRequestId}
             />
           );
         })}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-0
@@ -175,6 +175,14 @@
       ],
       "minimum": 0,
       "maximum": 2147483647
+    },
+    "entity_model": {
+      "description": "The model type of the clicked entity",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
     }
   },
   "required": [

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-0
@@ -158,6 +158,14 @@
         "null"
       ],
       "maxLength": 1024
+    },
+    "request_id": {
+      "description": "The unique request ID for the search request",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
     }
   },
   "required": [

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-0
@@ -166,6 +166,15 @@
         "null"
       ],
       "maxLength": 1024
+    },
+    "offset": {
+      "description": "The offset of the search results (for pagination)",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
     }
   },
   "required": [

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-0
@@ -150,6 +150,14 @@
         "boolean",
         "null"
       ]
+    },
+    "search_engine": {
+      "description": "The search engine used to perform the search",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
     }
   },
   "required": [

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-2-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-2-0
@@ -191,6 +191,14 @@
         "null"
       ],
       "maxLength": 1024
+    },
+    "search_term": {
+      "description": "The search term as a string (only reported for specific analytics UUIDs)",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
     }
   },
   "required": [

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-2-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-2-0
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "search",
     "format": "jsonschema",
-    "version": "1-1-0"
+    "version": "1-2-0"
   },
   "type": "object",
   "properties": {
@@ -150,6 +150,39 @@
         "boolean",
         "null"
       ]
+    },
+    "search_engine": {
+      "description": "The search engine used to perform the search",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "request_id": {
+      "description": "The unique request ID for the search request",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "offset": {
+      "description": "The offset of the search results (for pagination)",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "entity_model": {
+      "description": "The model type of the clicked entity",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
     }
   },
   "required": [

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-2-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-2-0
@@ -183,6 +183,14 @@
         "null"
       ],
       "maxLength": 1024
+    },
+    "search_term_hash": {
+      "description": "A hash of the search term and instance id",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
     }
   },
   "required": [


### PR DESCRIPTION
Closes [BOT-302](https://linear.app/metabase/issue/BOT-302/add-snowplow-search-event-tracking-for-stats)

### Description

Add more data to what we report for `search_query` and `search_click` events:
- `search_engine` - for both events, so we can distinguish result quality by the engine that backs it.
- `request_id` - for both events, so we can connect search clicks to the events that power them. 
- `offset` - for `search_query` only, events reported today can't be distinguished as being the second page of results
-  `entity_model` - for `search_click` only
- `search_term_hash` - for `search_click` only, a salted has of the user's search term (salted to ensure privacy and avoid rainbow look ups)

### How to verify

- Search something and inspect the reported events
- Click a search result, and inspect the reported event

### Checklist

- [x] Tests have been added/updated to cover changes in this PR