### PR TITLE
feat(mage): add port option to mage nrepl

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -109,11 +109,15 @@
   {:doc      "Starts the babashka nrepl: helpful for mage development"
    :requires [[babashka.nrepl.server :as nrepl.server]
               [mage.color :as c]]
-   :examples [["./bin/mage nrepl" "Starts the nrepl server"]]
+   :examples [["./bin/mage nrepl" "Starts the nrepl server"]
+              ["./bin/mage nrepl --port 50506" "Starts the nrepl server"]
+              ["./bin/mage nrepl -p 50506" "Starts the nrepl server"]]
+   :options  [["-p" "--port PORT" "optionally provide a port to run the nrepl server on" :default 1667 :parse-fn Integer/parseInt]]
    :task     (task!
-               (spit ".nrepl-port" 1667)
-               (nrepl.server/start-server!)
-               (deref (promise)))}
+              (let [{:keys [port]} (:options parsed)]
+                (spit ".nrepl-port" port)
+                (nrepl.server/start-server! {:port port})
+                (deref (promise))))}
 
   lint-migrations
   {:doc        "Lint migrations files"


### PR DESCRIPTION
### Description

Adds an option to the mage nrepl command to customize the port mage's nrepl starts on. This is mostly so I don't need to modify my clojure-mcp configuration to point to a different port when working on mage stuff.

### Checklist

- [N/A] Tests have been added/updated to cover changes in this PR
