### PR TITLE
Exempt admins from sandboxing on `query_metadata`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -70,8 +70,9 @@
   "Given collection of table-ids, return the sandboxes that should be enforced for the current user on any of the tables. A
   sandbox is not enforced if the user is in a different permissions group that grants full access to the table."
   [table-ids]
-  (let [enforced-sandboxes-for-user (perms/sandboxes-for-user)]
-    (filter #((set table-ids) (:table_id %)) enforced-sandboxes-for-user)))
+  (when-not *is-superuser?*
+    (let [enforced-sandboxes-for-user (perms/sandboxes-for-user)]
+      (filter #((set table-ids) (:table_id %)) enforced-sandboxes-for-user))))
 
 (defn sandboxed-user-for-db?
   "Returns true if the currently logged in user has any enforced sandboxes for the provided database. Throws an

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
@@ -35,6 +35,20 @@
         (is (= all-columns
                (field-names :crowberto)))))))
 
+(deftest query-metadata-not-sandboxed-for-admins-test
+  (testing "GET /api/table/:id/query_metadata"
+    ;; checks that admins are exempt from normal perms checking.
+    ;; the above test did not trigger this case because the admin is not *in* "All Users".
+    (met/with-gtaps-for-all-users!
+      {:gtaps      {:venues
+                    {:remappings {}
+                     :query      (mt.tu/restricted-column-query (mt/id))}}
+       :attributes {:cat 50}}
+      (is (= #{"ID" "CATEGORY_ID" "NAME"}
+             (field-names :rasta)))
+      (is (= all-columns
+             (field-names :crowberto))))))
+
 (deftest native-query-metadata-test
   (testing "GET /api/table/:id/query_metadata"
     (met/with-gtaps! {:gtaps      {:venues

--- a/enterprise/backend/test/metabase_enterprise/test.clj
+++ b/enterprise/backend/test/metabase_enterprise/test.clj
@@ -10,4 +10,5 @@
  [sandbox.tu
   with-gtaps!
   with-gtaps-for-user!
+  with-gtaps-for-all-users!
   with-user-attributes!])


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62038

In `enforced-sandboxes-for-tables` we were only checking the
permission in the `data_permissions` table, without special-casing
administrators like we do elsewhere.

So when checking to see if an administrator in `All Users` (sandboxed)
and `Administrators` had an enforced sandbox for a table, we were
checking to see whether there were rows in `data_permissions` providing
`Administrators` with `:unrestricted` data access to the table - which
will never be the case, because Administrators is special and never gets
any rows there.

Instead, special-case the super user case like we do elsewhere. Don't
bother getting the groups they're a part of - we know the set of tables
they're sandboxed on is empty.
