### PR TITLE
docs: remove examples for R/CLS docs

### DIFF
--- a/docs/permissions/row-and-column-security.md
+++ b/docs/permissions/row-and-column-security.md
@@ -61,7 +61,6 @@ You can use a question to filter tables to:
 
 - [Display an edited column instead of hiding the column](#displaying-edited-columns).
 - [Pass a user attribute to a SQL parameter](#restricting-rows-with-user-attributes-using-a-sql-variable).
-- [Pass a user attribute to a Markdown parameter](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/dashboards/markdown#custom-url-with-a-sandboxing-attribute).
 
 ## Prerequisites for row security
 
@@ -87,7 +86,6 @@ Examples of user attributes in play:
 
 - [Row security](./row-and-column-security-examples.md#filtering-rows-based-on-user-attributes)
 - [Restricting rows and columns](./row-and-column-security-examples.md#custom-example-2-filtering-rows-and-columns)
-- [Displaying custom text in Markdown dashboard cards](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/dashboards/markdown#custom-url-with-a-sandboxing-attribute)
 
 ## Adding row-level security
 


### PR DESCRIPTION
The examples linked don't make sense and I'll remove them from Learn. Ahead of this, we should remove them from docs