### PR TITLE
Fix field resolution when using a field name ref in the first stage

### DIFF
--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -542,7 +542,7 @@
   (mr/validator ::lib.schema.aggregation/aggregation))
 
 (def ^:private filter-validator
-  (mr/validator ::lib.schema/filterable))
+  (mr/validator ::lib.schema.expression/boolean))
 
 (defn- expression->name
   [expr]

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -425,7 +425,7 @@
 
 (defn- fallback-metadata [id-or-name]
   (log/warn (u/format-color :red
-                            (str "We tried every trick we could think of and still failed to resolve field a"
+                            (str "We tried every trick we could think of and still failed to resolve a field"
                                  " ref. If the query doesn't work, this is why. Returning fallback metadata for %s")
                             (pr-str id-or-name)))
   (merge

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -211,6 +211,7 @@
         query (-> query
                   (assoc :lib/metadata metadata-provider)
                   (dissoc :lib.convert/converted?)
+
                   lib.normalize/normalize)
         stages (:stages query)]
     (cond-> query

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -93,11 +93,8 @@
    [:sequential {:min 1} [:ref ::ref/ref]]
    [:ref ::lib.schema.util/distinct-mbql-clauses]])
 
-(mr/def ::filterable
-  [:ref ::expression/boolean])
-
 (mr/def ::filters
-  [:sequential {:min 1} ::filterable])
+  [:sequential {:min 1} [:ref ::expression/boolean]])
 
 (defn- bad-ref-clause? [ref-type valid-ids x]
   (and (vector? x)

--- a/src/metabase/lib/schema/common.cljc
+++ b/src/metabase/lib/schema/common.cljc
@@ -162,7 +162,9 @@
                       (str "Not a valid base type: " (pr-str value)))}
     base-type?]])
 
-(defn- normalize-options-map [m]
+(defn normalize-options-map
+  "Basic normalization behavior for an MBQL clause options map."
+  [m]
   (let [m (normalize-map m)]
     (-> m
         ;; add `:lib/uuid` if it's missing

--- a/src/metabase/lib/schema/literal.cljc
+++ b/src/metabase/lib/schema/literal.cljc
@@ -142,6 +142,13 @@
   [:merge
    [:ref ::common/options]
    [:map
+    {:decode/normalize (fn [m]
+                         (when (map? m)
+                           (-> m
+                               common/normalize-options-map
+                               (cond-> (and (:base-type m)
+                                            (not (:effective-type m)))
+                                 (assoc :effective-type (:base-type m))))))}
     [:effective-type ::common/base-type]
     [:unit {:optional true} [:maybe ::temporal-bucketing/unit]]]])
 

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -1441,3 +1441,32 @@
                          "  20"]}
                (-> (qp.compile/compile query)
                    (update :query #(str/split-lines (driver/prettify-native-form :h2 %))))))))))
+
+(deftest ^:parallel field-name-ref-in-parameters-test
+  (testing "Should generate correct SQL if we use a field name ref in parameters"
+    (let [query {:type       :query
+                 :database   (meta/id)
+                 :query      {:source-table (meta/id :products)}
+                 :parameters [{:type   :id
+                               :value  [144]
+                               :id     "92eb69ea"
+                               :target [:dimension [:field "ID" {:base-type :type/BigInteger}]]}]}]
+      (qp.store/with-metadata-provider meta/metadata-provider
+        (is (= {:query  ["SELECT"
+                         "  \"PUBLIC\".\"PRODUCTS\".\"ID\" AS \"ID\","
+                         "  \"PUBLIC\".\"PRODUCTS\".\"EAN\" AS \"EAN\","
+                         "  \"PUBLIC\".\"PRODUCTS\".\"TITLE\" AS \"TITLE\","
+                         "  \"PUBLIC\".\"PRODUCTS\".\"CATEGORY\" AS \"CATEGORY\","
+                         "  \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\","
+                         "  \"PUBLIC\".\"PRODUCTS\".\"PRICE\" AS \"PRICE\","
+                         "  \"PUBLIC\".\"PRODUCTS\".\"RATING\" AS \"RATING\","
+                         "  \"PUBLIC\".\"PRODUCTS\".\"CREATED_AT\" AS \"CREATED_AT\""
+                         "FROM"
+                         "  \"PUBLIC\".\"PRODUCTS\""
+                         "WHERE"
+                         "  \"PUBLIC\".\"PRODUCTS\".\"ID\" = 144"
+                         "LIMIT"
+                         "  1048575"]
+                :params nil}
+               (-> (qp.compile/compile query)
+                   (update :query #(str/split-lines (driver/prettify-native-form :h2 %))))))))))

--- a/test/metabase/lib/field/resolution_test.cljc
+++ b/test/metabase/lib/field/resolution_test.cljc
@@ -1285,3 +1285,27 @@
               (lib.field.resolution/resolve-field-ref
                query -1
                [:field {:base-type :type/Integer, :lib/uuid "00000000-0000-0000-0000-000000000000"} "my_numberLiteral"]))))))
+
+(deftest ^:parallel field-name-ref-in-first-stage-test
+  (testing "Should be able to resolve a field name ref in the first stage of a query"
+    (let [query (lib/query
+                 meta/metadata-provider
+                 {:lib/type :mbql/query
+                  :database (meta/id)
+                  :stages   [{:lib/type     :mbql.stage/mbql
+                              :source-table (meta/id :products)
+                              :fields       [[:field {} (meta/id :products :id)]
+                                             [:field {} (meta/id :products :title)]]
+                              :filters      [[:=
+                                              {}
+                                              [:field {:base-type :type/BigInteger} "ID"]
+                                              [:value {:base-type :type/BigInteger} 144]]]}]})]
+      (is (=? (-> (lib.field.resolution/resolve-field-ref
+                   query
+                   -1
+                   [:field {:base-type :type/BigInteger, :lib/uuid "00000000-0000-0000-0000-000000000000"} (meta/id :products :id)])
+                  (dissoc :lib/original-ref :lib/original-display-name))
+              (lib.field.resolution/resolve-field-ref
+               query
+               -1
+               [:field {:base-type :type/BigInteger, :lib/uuid "00000000-0000-0000-0000-000000000000"} "ID"]))))))

--- a/test/metabase/lib/schema/filter_test.cljc
+++ b/test/metabase/lib/schema/filter_test.cljc
@@ -125,3 +125,15 @@
            [:=
             [:field {} 2]
             [:field {:join-alias "Parent"} 1]]))))
+
+(deftest ^:parallel normalize-clause-add-uuids-test
+  (is (=? [:=
+           {:lib/uuid string?}
+           [:field {:lib/uuid string?, :base-type :type/BigInteger} "ID"]
+           [:value {:lib/uuid string?, :base-type :type/BigInteger, :effective-type :type/BigInteger} 144]]
+          (lib/normalize
+           :mbql.clause/=
+           [:=
+            {}
+            [:field {:base-type :type/BigInteger} "ID"]
+            [:value {:base-type :type/BigInteger} 144]]))))

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -1294,3 +1294,27 @@
                   first
                   :filters
                   first))))))
+
+(deftest ^:parallel field-name-ref-in-first-stage-test
+  (testing "Should add correct alias info if we use a field name ref in the first stage of a query"
+    (let [query (lib/query
+                 meta/metadata-provider
+                 {:type       :query
+                  :database   (meta/id)
+                  :query      {:source-table (meta/id :products)}
+                  :parameters [{:type   :id
+                                :value  [144]
+                                :id     "92eb69ea"
+                                :target [:dimension [:field "ID" {:base-type :type/BigInteger}]]}]})]
+      (is (=? [:=
+               {}
+               [:field
+                {::add/source-alias "ID"
+                 ::add/source-table (meta/id :products)}
+                "ID"]
+               [:value {} 144]]
+              (-> (add-alias-info query)
+                  :stages
+                  first
+                  :filters
+                  first))))))


### PR DESCRIPTION
If you do something like

```clj
{:stages [{:source-table 1, :fields [[:field {} "ID"]]}]}
```

Resolution currently trips out because `"ID"` normally means it came from a previous stage or a join.

You probably shouldn't be doing this, but we can figure out what you mean