### PR TITLE
[Transforms] Address two potentially flaky transform-execution tests

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -45,12 +45,12 @@
    Returns a legacy MBQL query structure for API compatibility."
   [category]
   (mt/dataset transforms-dataset/transforms-test
-    (let [query (query-test-util/make-filter-query
-                 {:table-suffix           "products"
-                  :column-name            "category"
-                  :filter-value           category
-                  :clickhouse-expression? true})]
-      ;; Convert to legacy MBQL which the transform API expects?
+    (let [query (query-test-util/make-query
+                 {:source-table  "products"
+                  :source-column "category"
+                  :filter-fn     lib/=
+                  :filter-values [category]})]
+      ;; Convert to legacy MBQL which the transform API expects
       (lib.convert/->legacy-MBQL query))))
 
 (defn- get-test-schema

--- a/enterprise/backend/test/metabase_enterprise/transforms/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/execute_test.clj
@@ -30,7 +30,7 @@
 
 (defn- wait-for-table
   [table-name timeout-ms]
-  (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+  (let [mp    (lib.metadata.jvm/application-database-metadata-provider (mt/id))
         limit (+ (System/currentTimeMillis) timeout-ms)]
     (loop []
       (Thread/sleep 200)
@@ -43,27 +43,27 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
     (mt/dataset transforms-dataset/transforms-test
       (let [target-type "table"
-            schema (t2/select-one-fn :schema :model/Table (mt/id :products))]
-        (with-transform-cleanup! [{table1-name :name :as target1} {:type target-type
+            schema      (t2/select-one-fn :schema :model/Table (mt/id :products))]
+        (with-transform-cleanup! [{table1-name :name :as target1} {:type   target-type
                                                                    :schema schema
-                                                                   :name "g_products"}
-                                  {table2-name :name :as target2} {:type target-type
+                                                                   :name   "g_products"}
+                                  {table2-name :name :as target2} {:type   target-type
                                                                    :schema schema
-                                                                   :name "gizmo_products"}]
+                                                                   :name   "gizmo_products"}]
           (let [t1-query (make-query "products" "category" lib/starts-with "G")]
-            (mt/with-temp [:model/Transform t1 {:name "transform1"
-                                                :source {:type :query
+            (mt/with-temp [:model/Transform t1 {:name   "transform1"
+                                                :source {:type  :query
                                                          :query (lib.convert/->legacy-MBQL t1-query)}
                                                 :target target1}]
               (transforms.execute/run-mbql-transform! t1 {:run-method :manual})
-              (let [table1 (wait-for-table table1-name 10000)
+              (let [table1   (wait-for-table table1-name 10000)
                     t2-query (make-query table1 "category" lib/= "Gizmo")]
-                (mt/with-temp [:model/Transform t2 {:name "transform2"
-                                                    :source {:type :query
+                (mt/with-temp [:model/Transform t2 {:name   "transform2"
+                                                    :source {:type  :query
                                                              :query (lib.convert/->legacy-MBQL t2-query)}
                                                     :target target2}]
                   (transforms.execute/run-mbql-transform! t2 {:run-method :cron})
-                  (let [table2 (wait-for-table table2-name 10000)
+                  (let [table2      (wait-for-table table2-name 10000)
                         check-query (lib/aggregate (make-query table2) (lib/count))]
                     ;; The transforms-test dataset has exactly 4 Gizmo products (IDs 6, 8, 12, 14)
                     ;; First transform filters for categories starting with "G" (Gadget and Gizmo)

--- a/enterprise/backend/test/metabase_enterprise/transforms/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/execute_test.clj
@@ -20,9 +20,13 @@
   "Create a query using the shared test utility.
    Maintains the same signature for compatibility with existing tests."
   ([source-table]
-   (query-test-util/make-query source-table))
+   (query-test-util/make-query {:source-table source-table}))
   ([source-table source-column constraint-fn & constraint-params]
-   (apply query-test-util/make-query source-table source-column constraint-fn constraint-params)))
+   (query-test-util/make-query
+    {:source-table  source-table
+     :source-column source-column
+     :filter-fn     constraint-fn
+     :filter-values constraint-params})))
 
 (defn- wait-for-table
   [table-name timeout-ms]

--- a/enterprise/backend/test/metabase_enterprise/transforms/query_test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/query_test_util.clj
@@ -30,12 +30,12 @@
 
    Returns an MLv2 query object."
   [& {:keys [source-table source-column filter-fn filter-values]}]
-   (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
-         table (if (string? source-table)
+  (let [mp     (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+        table  (if (string? source-table)
                  (table-from-metadata mp source-table)
                  source-table)
-         query (lib/query mp table)
-         column (some->> source-column (filter-on-column query))]
-     (cond-> query
+        query  (lib/query mp table)
+        column (some->> source-column (filter-on-column query))]
+    (cond-> query
       (and column filter-fn)
       (lib/filter (apply filter-fn column filter-values)))))


### PR DESCRIPTION
### Description

Problem 1: Transform execution tests were cleaning up tables after themselves, but not the metadata about those tables.
Problem 2: Transform tests were unnecessarily using fuzzy comparison to query tables (holdover from hackathon days likely)

Outcome: the possibility (realized locally on my machine) of strangely flaky tests
