### PR TITLE
Ensure we cleanup the mock index metadata tables as well as the index table in test utils with-index!

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -42,8 +42,7 @@
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
         (semantic.tu/with-index!
-          (let [not-top-10? #(or (nil? %) (< 10 %))
-                top-three? #(< % 3)]
+          (let [not-top-10? #(or (nil? %) (< 10 %))]
             (doseq [{:keys [name desc search-string search-native-query? expected-index?]}
                     [{:name "Dog Training Guide"
                       :desc "contains"
@@ -54,7 +53,7 @@
                       :desc "contains"
                       :search-string "AVG(tricks)"
                       :search-native-query? true
-                      :expected-index? top-three?}
+                      :expected-index? zero?}
                      {:name "Dog Training Guide"
                       :desc "contains"
                       :search-string "GROUP BY breed"
@@ -64,7 +63,7 @@
                       :desc "contains"
                       :search-string "GROUP BY breed"
                       :search-native-query? true
-                      :expected-index? top-three?}
+                      :expected-index? zero?}
                      {:name "Dog Training Guide"
                       :desc "does not contain"
                       :search-string "SUM(tricks)"
@@ -84,22 +83,22 @@
                       :desc "semantic search"
                       :search-string "puppy"
                       :search-native-query? true
-                      :expected-index? top-three?}
+                      :expected-index? zero?}
                      {:name "Bird Watching Tips"
                       :desc "semantic search"
                       :search-string "avian"
                       :search-native-query? true
-                      :expected-index? top-three?}
+                      :expected-index? zero?}
                      {:name "Dog Training Guide"
                       :desc "non-native keyword query"
                       :search-string "Training"
                       :search-native-query? true
-                      :expected-index? top-three?}
+                      :expected-index? zero?}
                      {:name "Bird Watching Tips"
                       :desc "non-native keyword query"
                       :search-string "Watching"
                       :search-native-query? true
-                      :expected-index? top-three?}]]
+                      :expected-index? zero?}]]
               (testing (format "\n%s %s %s %s" name desc search-string search-native-query?)
                 (is (-> (semantic.tu/query-index {:search-string search-string
                                                   :search-native-query search-native-query?})


### PR DESCRIPTION
### Description

Ensure we cleanup the mock index metadata tables as well as the mock index table in the test utils `with-index!`

Otherwise, we wind up with many "duplicate" docs in the gate table which results in duplicates in the mock index. These are not true duplicates; they have fresh model ids from the with-temp'ed mock docs we create, but they have identical content, so they have identical embeddings and tsvectors. Those documents then wind up with identical text and semantic scores when querying the index, and since we ORDER BY the scores (with no tie breaker secondary ordering), this creates non-determinism in the semantic and keyword rankings, making test assertions wonky.

Tighten up test assertions in `native-query-test`

These were relaxed to `top-three?` in #62101, but since the query results are no longer non-deterministic, it should be safe to switch back to requiring the match to be the first result.

### How to verify

Run the same search query multiple times inside a `with-index!`. You should get stable rankings and rrf scores. Additionally, index metadata tables no longer persist in db after test run.