### PR TITLE
Snowplow events for transforms

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -14,10 +14,11 @@ const TARGET_TABLE_2 = "transform_table_2";
 const TARGET_SCHEMA = "Schema A";
 const TARGET_SCHEMA_2 = "Schema B";
 
-describe("scenarios > admin > transforms", () => {
+H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
   beforeEach(() => {
     H.restore("postgres-writable");
     H.resetTestTable({ type: "postgres", table: "many_schemas" });
+    H.resetSnowplow();
     cy.signInAsAdmin();
     H.activateToken("bleeding-edge");
     H.resyncDatabase({ dbId: WRITABLE_DB_ID });
@@ -34,12 +35,23 @@ describe("scenarios > admin > transforms", () => {
     cy.intercept("DELETE", "/api/ee/transform-tag/*").as("deleteTag");
   });
 
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
+
   describe("creation", () => {
     it("should be able to create and run an mbql transform", () => {
       cy.log("create a new transform");
       visitTransformListPage();
       getTransformListPage().button("Create a transform").click();
       H.popover().findByText("Query builder").click();
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_create",
+        event_detail: "query",
+        triggered_from: "transform-page-create-menu",
+      });
+
       H.entityPickerModal().within(() => {
         cy.findByText(DB_NAME).click();
         cy.findByText(SOURCE_TABLE).click();
@@ -54,9 +66,17 @@ describe("scenarios > admin > transforms", () => {
 
       cy.log("run the transform and make sure its table can be queried");
       runTransformAndWaitForSuccess();
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_trigger_manual_run",
+        triggered_from: "transform-page",
+      });
+
       getTableLink().click();
       H.queryBuilderHeader().findByText("Transform Table").should("be.visible");
       H.assertQueryBuilderRowCount(3);
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_created",
+      });
     });
 
     it("should be able to create and run a SQL transform", () => {
@@ -64,6 +84,13 @@ describe("scenarios > admin > transforms", () => {
       visitTransformListPage();
       getTransformListPage().button("Create a transform").click();
       H.popover().findByText("SQL query").click();
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_create",
+        event_detail: "native",
+        triggered_from: "transform-page-create-menu",
+      });
+
       H.popover().findByText(DB_NAME).click();
       H.NativeEditor.type(`SELECT * FROM "${TARGET_SCHEMA}"."${SOURCE_TABLE}"`);
       getQueryEditor().button("Save").click();
@@ -74,8 +101,17 @@ describe("scenarios > admin > transforms", () => {
         cy.wait("@createTransform");
       });
 
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_created",
+      });
+
       cy.log("run the transform and make sure its table can be queried");
       runTransformAndWaitForSuccess();
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_trigger_manual_run",
+        triggered_from: "transform-page",
+      });
+
       getTableLink().click();
       H.queryBuilderHeader().findByText(DB_NAME).should("be.visible");
       H.assertQueryBuilderRowCount(3);
@@ -89,6 +125,8 @@ describe("scenarios > admin > transforms", () => {
         type: CardType;
         label: string;
       }) {
+        H.resetSnowplow();
+
         cy.log("create a query in the target database");
         H.getTableId({ name: SOURCE_TABLE, databaseId: WRITABLE_DB_ID }).then(
           (tableId) =>
@@ -106,6 +144,12 @@ describe("scenarios > admin > transforms", () => {
         visitTransformListPage();
         getTransformListPage().button("Create a transform").click();
         H.popover().findByText("A saved question").click();
+        H.expectUnstructuredSnowplowEvent({
+          event: "transform_create",
+          event_detail: "saved-question",
+          triggered_from: "transform-page-create-menu",
+        });
+
         H.entityPickerModal().within(() => {
           H.entityPickerModalTab(label);
           cy.findByText("Test").click();
@@ -118,8 +162,17 @@ describe("scenarios > admin > transforms", () => {
           cy.wait("@createTransform");
         });
 
+        H.expectUnstructuredSnowplowEvent({
+          event: "transform_created",
+        });
+
         cy.log("run the transform and make sure its table can be queried");
         runTransformAndWaitForSuccess();
+        H.expectUnstructuredSnowplowEvent({
+          event: "transform_trigger_manual_run",
+          triggered_from: "transform-page",
+        });
+
         getTableLink().click();
         H.queryBuilderHeader().findByText(DB_NAME).should("be.visible");
         H.assertQueryBuilderRowCount(3);
@@ -746,7 +799,11 @@ describe("scenarios > admin > transforms > jobs", () => {
     });
   });
 
-  describe("runs", () => {
+  H.describeWithSnowplowEE("runs", () => {
+    beforeEach(() => {
+      H.resetSnowplow();
+    });
+
     it("should be able to manually run a job", () => {
       H.createTransformTag({ name: "New tag" }).then(({ body: tag }) => {
         createMbqlTransform({
@@ -758,6 +815,10 @@ describe("scenarios > admin > transforms > jobs", () => {
         );
       });
       runJobAndWaitForSuccess();
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_trigger_manual_run",
+        triggered_from: "job-page",
+      });
       getNavSidebar().findByText("Runs").click();
       getContentTable().within(() => {
         cy.findByText("MBQL transform").should("be.visible");

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -816,7 +816,7 @@ describe("scenarios > admin > transforms > jobs", () => {
       });
       runJobAndWaitForSuccess();
       H.expectUnstructuredSnowplowEvent({
-        event: "transform_trigger_manual_run",
+        event: "transform_job_trigger_manual_run",
         triggered_from: "job-page",
       });
       getNavSidebar().findByText("Runs").click();

--- a/enterprise/frontend/src/metabase-enterprise/transforms/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/analytics.ts
@@ -1,0 +1,30 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+import type { TransformId, TransformJobId } from "metabase-types/api";
+
+export function trackTranformTriggerManualRun({
+  transformId,
+  triggeredFrom,
+}: {
+  transformId: TransformId;
+  triggeredFrom: "transform-page";
+}) {
+  trackSimpleEvent({
+    event: "transform_trigger_manual_run",
+    target_id: transformId,
+    triggered_from: triggeredFrom,
+  });
+}
+
+export function trackTranformJobTriggerManualRun({
+  jobId,
+  triggeredFrom,
+}: {
+  jobId: TransformJobId;
+  triggeredFrom: "job-page";
+}) {
+  trackSimpleEvent({
+    event: "transform_job_trigger_manual_run",
+    target_id: jobId,
+    triggered_from: triggeredFrom,
+  });
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/analytics.ts
@@ -28,3 +28,28 @@ export function trackTranformJobTriggerManualRun({
     triggered_from: triggeredFrom,
   });
 }
+
+export function trackTransformCreate({
+  triggeredFrom,
+  creationType,
+}: {
+  triggeredFrom: "transform-page-create-menu";
+  creationType: "query" | "native" | "saved-question";
+}) {
+  trackSimpleEvent({
+    event: "transform_create",
+    triggered_from: triggeredFrom,
+    event_detail: creationType,
+  });
+}
+
+export function trackTransformCreated({
+  transformId,
+}: {
+  transformId: TransformId;
+}) {
+  trackSimpleEvent({
+    event: "transform_created",
+    target_id: transformId,
+  });
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/ScheduleSection/ScheduleSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/ScheduleSection/ScheduleSection.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import { CronExpressionInput } from "metabase/common/components/CronExpressioInput";
+import { trackSimpleEvent } from "metabase/lib/analytics";
 import {
   formatCronExpressionForUI,
   getScheduleExplanation,
@@ -96,7 +97,15 @@ function RunButtonSection({ job }: RunButtonSectionProps) {
     if (job.id == null) {
       return;
     }
+
+    trackSimpleEvent({
+      event: "transform_trigger_manual_run",
+      target_id: job.id,
+      triggered_from: "job-page",
+    });
+
     const { error } = await runJob(job.id);
+
     if (error) {
       sendErrorToast(t`Failed to run job`);
     } else {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/ScheduleSection/ScheduleSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/ScheduleSection/ScheduleSection.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import { CronExpressionInput } from "metabase/common/components/CronExpressioInput";
-import { trackSimpleEvent } from "metabase/lib/analytics";
 import {
   formatCronExpressionForUI,
   getScheduleExplanation,
@@ -13,6 +12,7 @@ import {
   useLazyGetTransformJobQuery,
   useRunTransformJobMutation,
 } from "metabase-enterprise/api";
+import { trackTranformJobTriggerManualRun } from "metabase-enterprise/transforms/analytics";
 
 import { RunButton } from "../../../components/RunButton";
 import { SplitSection } from "../../../components/SplitSection";
@@ -98,10 +98,9 @@ function RunButtonSection({ job }: RunButtonSectionProps) {
       return;
     }
 
-    trackSimpleEvent({
-      event: "transform_trigger_manual_run",
-      target_id: job.id,
-      triggered_from: "job-page",
+    trackTranformJobTriggerManualRun({
+      jobId: job.id,
+      triggeredFrom: "job-page",
     });
 
     const { error } = await runJob(job.id);

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/CreateTransformModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/CreateTransformModal.tsx
@@ -12,6 +12,7 @@ import {
   FormSubmitButton,
   FormTextInput,
 } from "metabase/forms";
+import { trackSimpleEvent } from "metabase/lib/analytics";
 import * as Errors from "metabase/lib/errors";
 import { Box, Button, FocusTrap, Group, Modal, Stack } from "metabase/ui";
 import { useCreateTransformMutation } from "metabase-enterprise/api";
@@ -91,6 +92,12 @@ function CreateTransformForm({
   const handleSubmit = async (values: NewTransformValues) => {
     const request = getCreateRequest(query, values);
     const transform = await createTransform(request).unwrap();
+
+    trackSimpleEvent({
+      event: "transform_created",
+      target_id: transform.id,
+    });
+
     onCreate(transform);
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/CreateTransformModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/CreateTransformModal.tsx
@@ -12,10 +12,10 @@ import {
   FormSubmitButton,
   FormTextInput,
 } from "metabase/forms";
-import { trackSimpleEvent } from "metabase/lib/analytics";
 import * as Errors from "metabase/lib/errors";
 import { Box, Button, FocusTrap, Group, Modal, Stack } from "metabase/ui";
 import { useCreateTransformMutation } from "metabase-enterprise/api";
+import { trackTransformCreated } from "metabase-enterprise/transforms/analytics";
 import type {
   CreateTransformRequest,
   DatasetQuery,
@@ -93,10 +93,7 @@ function CreateTransformForm({
     const request = getCreateRequest(query, values);
     const transform = await createTransform(request).unwrap();
 
-    trackSimpleEvent({
-      event: "transform_created",
-      target_id: transform.id,
-    });
+    trackTransformCreated({ transformId: transform.id });
 
     onCreate(transform);
   };

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
@@ -7,9 +7,9 @@ import {
   QuestionPickerModal,
   type QuestionPickerValueItem,
 } from "metabase/common/components/Pickers/QuestionPicker";
-import { trackSimpleEvent } from "metabase/lib/analytics";
 import { useDispatch } from "metabase/lib/redux";
 import { Button, Icon, Menu } from "metabase/ui";
+import { trackTransformCreate } from "metabase-enterprise/transforms/analytics";
 
 import {
   getNewTransformFromCardUrl,
@@ -23,10 +23,9 @@ export function CreateTransformMenu() {
 
   const handleSavedQuestionClick = () => {
     openPicker();
-    trackSimpleEvent({
-      event: "transform_create",
-      triggered_from: "transform-page-create-menu",
-      event_detail: "saved-question",
+    trackTransformCreate({
+      triggeredFrom: "transform-page-create-menu",
+      creationType: "saved-question",
     });
   };
 
@@ -52,10 +51,9 @@ export function CreateTransformMenu() {
             to={getNewTransformFromTypeUrl("query")}
             leftSection={<Icon name="notebook" />}
             onClick={() => {
-              trackSimpleEvent({
-                event: "transform_create",
-                triggered_from: "transform-page-create-menu",
-                event_detail: "query",
+              trackTransformCreate({
+                triggeredFrom: "transform-page-create-menu",
+                creationType: "query",
               });
             }}
           >
@@ -66,10 +64,9 @@ export function CreateTransformMenu() {
             to={getNewTransformFromTypeUrl("native")}
             leftSection={<Icon name="sql" />}
             onClick={() => {
-              trackSimpleEvent({
-                event: "transform_create",
-                triggered_from: "transform-page-create-menu",
-                event_detail: "native",
+              trackTransformCreate({
+                triggeredFrom: "transform-page-create-menu",
+                creationType: "native",
               });
             }}
           >

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
@@ -7,6 +7,7 @@ import {
   QuestionPickerModal,
   type QuestionPickerValueItem,
 } from "metabase/common/components/Pickers/QuestionPicker";
+import { trackSimpleEvent } from "metabase/lib/analytics";
 import { useDispatch } from "metabase/lib/redux";
 import { Button, Icon, Menu } from "metabase/ui";
 
@@ -19,6 +20,15 @@ export function CreateTransformMenu() {
   const dispatch = useDispatch();
   const [isPickerOpened, { open: openPicker, close: closePicker }] =
     useDisclosure();
+
+  const handleSavedQuestionClick = () => {
+    openPicker();
+    trackSimpleEvent({
+      event: "transform_create",
+      triggered_from: "transform-page-create-menu",
+      event_detail: "saved-question",
+    });
+  };
 
   const handlePickerChange = (item: QuestionPickerValueItem) => {
     dispatch(push(getNewTransformFromCardUrl(item.id)));
@@ -41,6 +51,13 @@ export function CreateTransformMenu() {
             component={ForwardRefLink}
             to={getNewTransformFromTypeUrl("query")}
             leftSection={<Icon name="notebook" />}
+            onClick={() => {
+              trackSimpleEvent({
+                event: "transform_create",
+                triggered_from: "transform-page-create-menu",
+                event_detail: "query",
+              });
+            }}
           >
             {t`Query builder`}
           </Menu.Item>
@@ -48,10 +65,20 @@ export function CreateTransformMenu() {
             component={ForwardRefLink}
             to={getNewTransformFromTypeUrl("native")}
             leftSection={<Icon name="sql" />}
+            onClick={() => {
+              trackSimpleEvent({
+                event: "transform_create",
+                triggered_from: "transform-page-create-menu",
+                event_detail: "native",
+              });
+            }}
           >
             {t`SQL query`}
           </Menu.Item>
-          <Menu.Item leftSection={<Icon name="folder" />} onClick={openPicker}>
+          <Menu.Item
+            leftSection={<Icon name="folder" />}
+            onClick={handleSavedQuestionClick}
+          >
             {t`A saved question`}
           </Menu.Item>
         </Menu.Dropdown>

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/RunSection/RunSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/RunSection/RunSection.tsx
@@ -1,7 +1,6 @@
 import { Link } from "react-router";
 import { t } from "ttag";
 
-import { trackSimpleEvent } from "metabase/lib/analytics";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Anchor, Box, Divider, Group, Icon, Stack } from "metabase/ui";
 import {
@@ -9,6 +8,7 @@ import {
   useRunTransformMutation,
   useUpdateTransformMutation,
 } from "metabase-enterprise/api";
+import { trackTranformTriggerManualRun } from "metabase-enterprise/transforms/analytics";
 import type { Transform, TransformTagId } from "metabase-types/api";
 
 import { RunButton } from "../../../components/RunButton";
@@ -141,10 +141,9 @@ function RunButtonSection({ transform }: RunButtonSectionProps) {
   const { sendErrorToast } = useMetadataToasts();
 
   const handleRun = async () => {
-    trackSimpleEvent({
-      event: "transform_trigger_manual_run",
-      target_id: transform.id,
-      triggered_from: "transform-page",
+    trackTranformTriggerManualRun({
+      transformId: transform.id,
+      triggeredFrom: "transform-page",
     });
 
     const { error } = await runTransform(transform.id);

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/RunSection/RunSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/RunSection/RunSection.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 import { t } from "ttag";
 
+import { trackSimpleEvent } from "metabase/lib/analytics";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Anchor, Box, Divider, Group, Icon, Stack } from "metabase/ui";
 import {
@@ -140,6 +141,12 @@ function RunButtonSection({ transform }: RunButtonSectionProps) {
   const { sendErrorToast } = useMetadataToasts();
 
   const handleRun = async () => {
+    trackSimpleEvent({
+      event: "transform_trigger_manual_run",
+      target_id: transform.id,
+      triggered_from: "transform-page",
+    });
+
     const { error } = await runTransform(transform.id);
     if (error) {
       sendErrorToast(t`Failed to run transform`);

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -3,7 +3,11 @@ import type {
   ChecklistItemValue,
 } from "metabase/home/components/Onboarding/types";
 import type { KeyboardShortcutId } from "metabase/palette/shortcuts";
-import type { Engine, VisualizationDisplay } from "metabase-types/api";
+import type {
+  Engine,
+  TransformId,
+  VisualizationDisplay,
+} from "metabase-types/api";
 
 type SimpleEventSchema = {
   event: string;
@@ -254,8 +258,14 @@ export type ConnectionStringParsedFailedEvent = ValidateEvent<{
 
 export type TransformTriggerManualRunEvent = ValidateEvent<{
   event: "transform_trigger_manual_run";
-  triggered_from: "transform-page" | "job-page";
-  target_id: number;
+  triggered_from: "transform-page";
+  target_id: TransformId;
+}>;
+
+export type TransformJobTriggerManualRunEvent = ValidateEvent<{
+  event: "transform_job_trigger_manual_run";
+  triggered_from: "job-page";
+  target_id: TransformId;
 }>;
 
 export type TransformCreateEvent = ValidateEvent<{
@@ -309,5 +319,6 @@ export type SimpleEvent =
   | ConnectionStringParsedSuccessEvent
   | ConnectionStringParsedFailedEvent
   | TransformTriggerManualRunEvent
+  | TransformJobTriggerManualRunEvent
   | TransformCreatedEvent
   | TransformCreateEvent;

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -258,6 +258,12 @@ export type TransformTriggerManualRunEvent = ValidateEvent<{
   target_id: number;
 }>;
 
+export type TransformCreateEvent = ValidateEvent<{
+  event: "transform_create";
+  triggered_from: "transform-page-create-menu";
+  event_detail: "query" | "native" | "saved-question";
+}>;
+
 export type TransformCreatedEvent = ValidateEvent<{
   event: "transform_created";
   target_id: number;
@@ -303,4 +309,5 @@ export type SimpleEvent =
   | ConnectionStringParsedSuccessEvent
   | ConnectionStringParsedFailedEvent
   | TransformTriggerManualRunEvent
-  | TransformCreatedEvent;
+  | TransformCreatedEvent
+  | TransformCreateEvent;

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -258,6 +258,11 @@ export type TransformTriggerManualRunEvent = ValidateEvent<{
   target_id: number;
 }>;
 
+export type TransformCreatedEvent = ValidateEvent<{
+  event: "transform_created";
+  target_id: number;
+}>;
+
 export type EmbedWizardEvent =
   | EmbedWizardExperienceSelectedEvent
   | EmbedWizardResourceSelectedEvent
@@ -297,4 +302,5 @@ export type SimpleEvent =
   | EmbedWizardEvent
   | ConnectionStringParsedSuccessEvent
   | ConnectionStringParsedFailedEvent
-  | TransformTriggerManualRunEvent;
+  | TransformTriggerManualRunEvent
+  | TransformCreatedEvent;

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -254,7 +254,7 @@ export type ConnectionStringParsedFailedEvent = ValidateEvent<{
 
 export type TransformTriggerManualRunEvent = ValidateEvent<{
   event: "transform_trigger_manual_run";
-  triggered_from: "transform-page";
+  triggered_from: "transform-page" | "job-page";
   target_id: number;
 }>;
 

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -252,6 +252,12 @@ export type ConnectionStringParsedFailedEvent = ValidateEvent<{
   triggered_from: "admin" | "setup" | "embedding_setup";
 }>;
 
+export type TransformTriggerManualRunEvent = ValidateEvent<{
+  event: "transform_trigger_manual_run";
+  triggered_from: "transform-page";
+  target_id: number;
+}>;
+
 export type EmbedWizardEvent =
   | EmbedWizardExperienceSelectedEvent
   | EmbedWizardResourceSelectedEvent
@@ -290,4 +296,5 @@ export type SimpleEvent =
   | DashboardFilterMovedEvent
   | EmbedWizardEvent
   | ConnectionStringParsedSuccessEvent
-  | ConnectionStringParsedFailedEvent;
+  | ConnectionStringParsedFailedEvent
+  | TransformTriggerManualRunEvent;


### PR DESCRIPTION
Closes QUE-2132

Adds snowplow events for:
- Manually running a transform
- Manually running a job
- Creating a transform
- Saving a transform

Navigating to each of the transforms, jobs and runs page are covered by the default navigation events.