### PR TITLE
fix: update editing grid cell styles

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/EditTableDataGrid.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/EditTableDataGrid.module.css
@@ -41,7 +41,7 @@
 
 .tableBodyCell {
   background-color: var(--mb-color-bg-white);
-  border-right: 1px solid var(--mb-color-border-alpha-30);
+  border-right: 1px solid var(--mb-color-border);
 }
 
 .headerCellContainer {

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/TableEditingCell.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/TableEditingCell.module.css
@@ -4,7 +4,6 @@
   outline-offset: -2px;
   border-color: transparent;
   box-sizing: border-box;
-  font-weight: 700;
   background-color: var(--mb-base-color-white);
   border-radius: 0;
   text-overflow: ellipsis;
@@ -28,9 +27,16 @@
   font-size: 12.5px;
 }
 
+.cell {
+  font-weight: normal;
+  border-bottom-color: var(--mb-color-border);
+}
+
 .readonlyCell {
+  font-weight: normal;
   color: var(--mb-color-text-disabled);
   cursor: not-allowed;
+  border-bottom-color: var(--mb-color-border);
 }
 
 .errorCell {

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/use-edit-datagrid-column-options.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/use-edit-datagrid-column-options.tsx
@@ -50,7 +50,7 @@ export function useEditDataDridColumnOptions({
   const getCellClassName = useCallback(
     (_value: RowValue, rowIndex: number, columnId: string) => {
       const cellState = getCellState(columnId, rowIndex);
-      return cx({
+      return cx(S.cell, {
         [S.updatingCell]: cellState === EditDataGridCellState.Updating,
         [S.errorCell]: cellState === EditDataGridCellState.Error,
       });

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/use-table-column-row-select.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/use-table-column-row-select.tsx
@@ -6,6 +6,7 @@ import { Checkbox, Flex, Group, Icon, Tooltip, rem } from "metabase/ui";
 import type { RowValue, RowValues } from "metabase-types/api";
 
 import S from "./EditTableDataGrid.module.css";
+import CellS from "./TableEditingCell.module.css";
 
 export const ROW_SELECT_COLUMN_ID = "__MB_ROW_SELECT";
 
@@ -52,7 +53,7 @@ export function getRowSelectColumn({
       </Flex>
     ),
     cell: ({ row }: { row: Row<RowValues> }) => (
-      <BaseCell>
+      <BaseCell className={CellS.cell}>
         <Group align="center" justify="flex-start" h="100%">
           <Checkbox
             size={rem(16)}


### PR DESCRIPTION
Related to [WRK-626](https://linear.app/metabase/issue/WRK-626/update-grid-design)

* Darker border color for grid lines
* Regular font weight for values in the table

<img width="1245" height="664" alt="image" src="https://github.com/user-attachments/assets/49db6ed5-8c56-4e0a-8fe8-123432f7ce5f" />
