### PR TITLE
Search robustness

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -110,6 +110,17 @@
                   (is (= (rest appdb-results)
                          (rest results))))))))))))
 
+(deftest test-semantic-search-fallback-failure-resilient
+  (testing "semantic search is resilient to fallback engine failure"
+    (mt/with-premium-features #{:semantic-search}
+      (mt/with-temporary-setting-values [semantic-search-min-results-threshold 3]
+        (let [semantic-result (make-card-result 1 "semantic-card" :score 0.9)
+              search-ctx      search-context]
+          (with-search-engine-mocks! [semantic-result] (fn [_] (throw (ex-info "Fallback fail" {})))
+            (fn []
+              (let [results (into [] (semantic.core/results search-ctx))]
+                (is (= [semantic-result] results))))))))))
+
 (deftest test-semantic-search-above-threshold-no-fallback
   (testing "semantic search results above threshold are not supplemented"
     (mt/with-premium-features #{:semantic-search}

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -50,12 +50,14 @@
 (declare exists?)
 
 (defn- sync-tracking-atoms! []
-  (reset! *indexes* (into {}
-                          (for [[status table-name] (search-index-metadata/indexes :appdb *index-version-id*)]
-                            (if (exists? table-name)
-                              [status (keyword table-name)]
-                                ;; For debugging, make it clear why we are not tracking the given metadata.
-                              [(keyword (name status) "not-found") (keyword table-name)])))))
+  (let [indexes (into {}
+                      (for [[status table-name] (search-index-metadata/indexes :appdb *index-version-id*)]
+                        (if (exists? table-name)
+                          [status (keyword table-name)]
+                          ;; For debugging, make it clear why we are not tracking the given metadata.
+                          [(keyword (name status) "not-found") (keyword table-name)])))]
+    (log/debugf "Sync tracking atoms: %s" indexes)
+    (reset! *indexes* indexes)))
 
 ;; This exists only to be mocked.
 (defn- now [] (System/nanoTime))
@@ -119,14 +121,14 @@
   ;; Delete metadata around indexes that are no longer needed.
   (search-index-metadata/delete-obsolete! *index-version-id*)
   ;; Drop any indexes that are no longer referenced.
-  (let [dropped (volatile! 0)]
+  (let [dropped (volatile! [])]
     (doseq [table (orphan-indexes)]
       (try
         (t2/query (sql.helpers/drop-table table))
-        (vswap! dropped inc)
+        (vswap! dropped conj table)
         ;; Deletion could fail if it races with other instances
         (catch ExceptionInfo _)))
-    (log/infof "Dropped %d stale indexes" @dropped)))
+    (log/infof "Dropped %d stale indexes: %s" (count @dropped) @dropped)))
 
 (defn- ->db-type [t]
   (get {:pk :int, :timestamp :timestamp-with-time-zone} t t))
@@ -190,10 +192,13 @@
     (let [{:keys [pending]} (sync-tracking-atoms!)]
       (or pending
           (let [table-name (gen-table-name)]
+            (log/infof "Creating pending index %s" table-name)
             ;; We may fail to insert a new metadata row if we lose a race with another instance.
             (when (search-index-metadata/create-pending! :appdb *index-version-id* table-name)
               (create-table! table-name))
-            (:pending (sync-tracking-atoms!)))))))
+            (let [pending (:pending (sync-tracking-atoms!))]
+              (log/infof "New pending index %s" pending)
+              pending))))))
 
 (defn activate-table!
   "Make the pending index active if it exists. Returns true if it did so."
@@ -205,9 +210,11 @@
        (reset! *indexes* {:pending nil, :active pending})))
     ;; Ensure the metadata is updated and pruned.
     (let [{:keys [pending]} (sync-tracking-atoms!)]
+      (log/infof "Activating pending index %s" pending)
       (when pending
-        (reset! *indexes* {:pending nil
-                           :active  (keyword (search-index-metadata/active-pending! :appdb *index-version-id*))}))
+        (let [active (keyword (search-index-metadata/active-pending! :appdb *index-version-id*))]
+          (reset! *indexes* {:pending nil :active active})
+          (log/infof "Activated pending index %s" active)))
       ;; Clean up while we're here
       (delete-obsolete-tables!)
       ;; Did *we* do a rotation?
@@ -332,10 +339,14 @@
 (defn reset-index!
   "Ensure we have a blank slate; in case the table schema or stored data format has changed."
   []
+  (log/infof "Resetting appdb index for version %s, active table: %s" *index-version-id*
+             (pr-str (active-table)))
   ;; stop tracking any pending table
   (when-let [table-name (pending-table)]
     (when-not *mocking-tables*
-      (search-index-metadata/delete-index! :appdb *index-version-id* table-name))
+      (let [deleted (search-index-metadata/delete-index! :appdb *index-version-id* table-name)]
+        (when (pos? deleted)
+          (log/infof "Deleted %d pending indices" deleted))))
     (swap! *indexes* assoc :pending nil))
   (maybe-create-pending!)
   (activate-table!))

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -1,5 +1,7 @@
 ;; The interface encapsulating the various search engine backends.
-(ns metabase.search.engine)
+(ns metabase.search.engine
+  (:require
+   [metabase.search.settings :as settings]))
 
 (def fallback-engine-priority
   "Search engines in order of preference for fallback scenarios."
@@ -72,9 +74,11 @@
   (keys (dissoc (methods supported-engine?) :default)))
 
 (defn active-engines
-  "List the search engines that are supported. Does not mention the legacy in-place engine."
+  "List the search engines that are supported. Does not mention the legacy in-place engine.
+   Default engine comes first."
   []
-  (for [[k p] (dissoc (methods supported-engine?) :default :search.engine/in-place) :when (p k)] k))
+  (->> (for [[k p] (dissoc (methods supported-engine?) :default :search.engine/in-place) :when (p k)] k)
+       (sort-by #(if (= (name %) (name (settings/search-engine))) 0 1))))
 
 (defn known-engine?
   "Is the given engine recognized?"

--- a/src/metabase/search/models/search_index_metadata.clj
+++ b/src/metabase/search/models/search_index_metadata.clj
@@ -4,6 +4,7 @@
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
+   [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -56,6 +57,7 @@
                                                :lang_code (i18n/site-locale-string)
                                                :status     :pending
                                                :index_name (name index-name)})
+       (log/infof "Inserted new pending table %s" index-name)
        true
        (catch Exception _
          ;; We assume that failure corresponds to a unique index conflict (a pending entry already exists)


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-341/initialize-semantic-engine-first
Closes https://linear.app/metabase/issue/BOT-342/make-semantic-search-resilient-to-fallback-engine-errors

- make semantic search resilient to errors on fallback engine
- deterministically init default engine first 
- add more debug logging around appdb index creation