### PR TITLE
fix: change editing modals to sidesheets

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/CreateRowActionFormModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/CreateRowActionFormModal.tsx
@@ -3,17 +3,8 @@ import { useFormik } from "formik";
 import { useCallback, useEffect } from "react";
 import { t } from "ttag";
 
-import {
-  ActionIcon,
-  Button,
-  Center,
-  Flex,
-  Group,
-  Icon,
-  Loader,
-  Modal,
-  rem,
-} from "metabase/ui";
+import Animation from "metabase/css/core/animation.module.css";
+import { Button, Center, Flex, Loader, Modal } from "metabase/ui";
 import type { RowValue } from "metabase-types/api";
 
 import type {
@@ -93,18 +84,15 @@ export function CreateRowActionFormModal({
   return (
     <Modal.Root opened={opened} onClose={onClose}>
       <Modal.Overlay />
-      <Modal.Content>
+      <Modal.Content
+        transitionProps={{ transition: "slide-left" }}
+        classNames={{
+          content: cx(S.modalContent, Animation.slideLeft),
+        }}
+      >
         <form onSubmit={handleSubmit}>
           <Modal.Header px="xl" pb="0" className={S.modalHeader}>
             <Modal.Title>{t`Create a new record`}</Modal.Title>
-            <Group
-              gap="xs"
-              mr={rem(-5) /* aligns cross with modal right padding */}
-            >
-              <ActionIcon variant="subtle" onClick={onClose}>
-                <Icon name="close" />
-              </ActionIcon>
-            </Group>
           </Modal.Header>
           <Modal.Body px="xl" py="lg" className={cx(S.modalBody)}>
             {!description ? (

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModal.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModal.module.css
@@ -1,3 +1,12 @@
+.modalContent {
+  position: fixed;
+  width: 45rem;
+  height: 100dvh;
+  max-height: 100dvh;
+  inset-inline-end: 0;
+  border-radius: 0;
+}
+
 .modalHeader {
   background-color: var(--mb-color-background);
   border-bottom: 1px solid var(--mb-color-border);
@@ -8,23 +17,16 @@
 }
 
 .modalBody {
-  background-color: var(--mb-base-color-orion-5);
   display: grid;
-  grid-template-columns: 45% auto;
+  grid-template-columns: 35% auto;
+  grid-template-rows: repeat(auto-fill, rem(40));
   row-gap: rem(24);
-  max-height: calc(
-    100vh - (var(--modal-y-offset) * 2) - rem(80) - rem(72)
-      /* header + footer */
-  );
+  height: calc(100dvh - rem(80) - rem(72) /* header + footer */);
   overflow-y: scroll;
 }
 
 .modalBodyLoader {
   grid-column: 1 / -1;
-}
-
-.modalBodyEditing {
-  max-height: calc(100vh - (var(--modal-y-offset) * 2) - rem(80) /* header */);
 }
 
 .modalBodyColumn {

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/UpdateRowActionFormModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/UpdateRowActionFormModal.tsx
@@ -1,19 +1,10 @@
 import cx from "classnames";
 import { useFormik } from "formik";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { t } from "ttag";
 
-import {
-  ActionIcon,
-  Button,
-  Center,
-  Flex,
-  Group,
-  Icon,
-  Loader,
-  Modal,
-  rem,
-} from "metabase/ui";
+import Animation from "metabase/css/core/animation.module.css";
+import { Button, Center, Flex, Loader, Modal } from "metabase/ui";
 import type { RowValue } from "metabase-types/api";
 
 import type {
@@ -22,7 +13,6 @@ import type {
   TableActionFormParameter,
 } from "../../api/types";
 
-import { DeleteRowConfirmationModal } from "./DeleteRowConfirmationModal";
 import { ModalParameterActionInput } from "./ModalParameterActionInput";
 import S from "./TableActionFormModal.module.css";
 import { TableActionFormModalParameter } from "./TableActionFormModalParameter";
@@ -38,46 +28,14 @@ interface UpdateRowActionFormModalProps {
   onDelete: () => Promise<boolean>;
 }
 
-enum ModalState {
-  Opened,
-  DeleteRequested,
-  Closed,
-}
-
 export function UpdateRowActionFormModal({
   opened,
   description,
   isLoading,
-  isDeleting,
   initialValues,
   onClose,
   onSubmit,
-  onDelete,
 }: UpdateRowActionFormModalProps) {
-  const [modalState, setModalState] = useState<ModalState>(ModalState.Closed);
-
-  useEffect(() => {
-    setModalState(opened ? ModalState.Opened : ModalState.Closed);
-  }, [opened]);
-
-  const requestDeletion = useCallback(
-    () => setModalState(ModalState.DeleteRequested),
-    [],
-  );
-
-  const closeDeletionModal = useCallback(
-    () => setModalState(ModalState.Opened),
-    [],
-  );
-
-  const handleDeleteConfirmation = useCallback(async () => {
-    const result = await onDelete();
-
-    if (result) {
-      onClose();
-    }
-  }, [onDelete, onClose]);
-
   const validateForm = useCallback(
     (values: RowCellsWithPkValue) => {
       const errors: Record<string, string> = {};
@@ -132,38 +90,18 @@ export function UpdateRowActionFormModal({
     }
   }, [opened, resetForm, revalidateForm]);
 
-  if (modalState === ModalState.DeleteRequested) {
-    return (
-      <DeleteRowConfirmationModal
-        isLoading={isDeleting}
-        onCancel={closeDeletionModal}
-        onConfirm={handleDeleteConfirmation}
-      />
-    );
-  }
-
   return (
     <Modal.Root opened={opened} onClose={onClose}>
       <Modal.Overlay />
-      <Modal.Content>
+      <Modal.Content
+        transitionProps={{ transition: "slide-left" }}
+        classNames={{
+          content: cx(S.modalContent, Animation.slideLeft),
+        }}
+      >
         <form onSubmit={handleSubmit}>
           <Modal.Header px="xl" pb="0" className={S.modalHeader}>
             <Modal.Title>{t`Edit record`}</Modal.Title>
-            <Group
-              gap="xs"
-              mr={rem(-5) /* aligns cross with modal right padding */}
-            >
-              <ActionIcon
-                variant="subtle"
-                onClick={requestDeletion}
-                data-testid="delete-row-icon"
-              >
-                <Icon name="trash" />
-              </ActionIcon>
-              <ActionIcon variant="subtle" onClick={onClose}>
-                <Icon name="close" />
-              </ActionIcon>
-            </Group>
           </Modal.Header>
           <Modal.Body px="xl" py="lg" className={cx(S.modalBody)}>
             {!description ? (
@@ -197,7 +135,7 @@ export function UpdateRowActionFormModal({
               type="submit"
               data-testid="update-row-save-button"
             >
-              {t`Save`}
+              {t`Save changes`}
             </Button>
           </Flex>
         </form>


### PR DESCRIPTION
Related to [WRK-626](https://linear.app/metabase/issue/WRK-626/update-grid-design)

* Remove trash icon from Record Details
* Change modal component for single record editing via a form from modal to the side sheet.
* 65% or so to be dedicated to inputs (inputs should have more width than the field names)

<img width="1454" height="823" alt="image" src="https://github.com/user-attachments/assets/41ef9205-4b15-4916-b7a8-5fb1435c0660" />
<img width="1454" height="823" alt="image" src="https://github.com/user-attachments/assets/051360b9-2368-4642-a14c-955870f86ea0" />
