### PR TITLE
Log propagation for notifications

### DIFF
--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -369,7 +369,8 @@
                                                              (pos? (queue-size queue))))
                                                (try
                                                  (when-let [notification (take-notification-with-timeout! queue 1000)]
-                                                   (send-notification-sync! notification))
+                                                   (log/with-restored-context-from-meta notification
+                                                     (send-notification-sync! notification)))
                                                  (catch InterruptedException _
                                                    (log/warn "Notification worker interrupted, shutting down")
                                                    (throw (InterruptedException.)))
@@ -385,7 +386,7 @@
                       (if-not (.get shutdown-flag)
                         (do
                           (ensure-enough-workers!)
-                          (put-notification! queue notification)
+                          (put-notification! queue (log/with-context-meta notification))
                           ::ok)
                         (do
                           (log/infof "Rejecting notification with id %d as the workers are being shutdown" (:id notification))


### PR DESCRIPTION
Adds a simple function and a macro to `metabase.util.log` to allow propagation of ThreadContext across thread boundaries.

`(with-context-meta some-map)` adds the `mb-` prefixed items in the `ThreadContext` to the metadata of that map.

`(with-restored-context-from-meta some-map)` takes a map presumably resulting from calling `with-context-meta`, and sets the current `ThreadContext` accordingly.

I changed the dispatch-fn and the worker consumption functions in `metabase.notification.send` to use these to propagate the ThreadContext to the worker thread.

Sending a notification like

```
(log/with-context {:aoooooook "hey"} (dispatch! {:flippity "ofosidjffoo"}))
```

now results in:

```
2025-08-18 14:42:45,716 ERROR notification.send :: Error in notification worker {mb-aoooooook=hey}
clojure.lang.ExceptionInfo: Invalid input: {:payload_type ["invalid dispatch value, got: {:flippity \"ofosidjffoo\"}"]}
```
