### PR TITLE
hide metabot within documents when disabled

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
@@ -13,7 +13,6 @@ import { t } from "ttag";
 import { DND_IGNORE_CLASS_NAME } from "metabase/common/components/dnd";
 import CS from "metabase/css/core/index.css";
 import { useSelector, useStore } from "metabase/lib/redux";
-import { PLUGIN_METABOT } from "metabase/plugins";
 import { getSetting } from "metabase/selectors/settings";
 import { Box, Loader } from "metabase/ui";
 import { getMentionsCache } from "metabase-enterprise/documents/selectors";
@@ -130,20 +129,16 @@ export const Editor: React.FC<EditorProps> = ({
           render: createSuggestionRenderer(CommandSuggestion),
         },
       }),
-      ...(PLUGIN_METABOT.isEnabled()
-        ? [
-            MetabotNode.configure({
-              serializePrompt: getMetabotPromptSerializer(getState),
-            }),
-            DisableMetabotSidebar,
-            MetabotMentionExtension.configure({
-              suggestion: {
-                allow: ({ state }) => isMetabotBlock(state),
-                render: createSuggestionRenderer(MetabotMentionSuggestion),
-              },
-            }),
-          ]
-        : []),
+      MetabotNode.configure({
+        serializePrompt: getMetabotPromptSerializer(getState),
+      }),
+      DisableMetabotSidebar,
+      MetabotMentionExtension.configure({
+        suggestion: {
+          allow: ({ state }) => isMetabotBlock(state),
+          render: createSuggestionRenderer(MetabotMentionSuggestion),
+        },
+      }),
     ],
     [siteUrl, getState],
   );

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
@@ -13,13 +13,14 @@ import { t } from "ttag";
 import { DND_IGNORE_CLASS_NAME } from "metabase/common/components/dnd";
 import CS from "metabase/css/core/index.css";
 import { useSelector, useStore } from "metabase/lib/redux";
+import { PLUGIN_METABOT } from "metabase/plugins";
 import { getSetting } from "metabase/selectors/settings";
 import { Box, Loader } from "metabase/ui";
 import { getMentionsCache } from "metabase-enterprise/documents/selectors";
 import type { DocumentsStoreState } from "metabase-enterprise/documents/types";
 import { getMentionsCacheKey } from "metabase-enterprise/documents/utils/mentionsUtils";
 
-import styles from "./Editor.module.css";
+import S from "./Editor.module.css";
 import { EditorBubbleMenu } from "./EditorBubbleMenu";
 import { CardEmbed } from "./extensions/CardEmbed/CardEmbedNode";
 import { CommandExtension } from "./extensions/Command/CommandExtension";
@@ -99,7 +100,7 @@ export const Editor: React.FC<EditorProps> = ({
       Image.configure({
         inline: false,
         HTMLAttributes: {
-          class: styles.img,
+          class: S.img,
         },
       }),
       SmartLink.configure({
@@ -117,10 +118,6 @@ export const Editor: React.FC<EditorProps> = ({
         placeholder: t`Start writing, press "/" to open command palette, or "@" to insert a link...`,
       }),
       CardEmbed,
-      MetabotNode.configure({
-        serializePrompt: getMetabotPromptSerializer(getState),
-      }),
-      DisableMetabotSidebar,
       MentionExtension.configure({
         suggestion: {
           allow: ({ state }) => !isMetabotBlock(state),
@@ -133,12 +130,20 @@ export const Editor: React.FC<EditorProps> = ({
           render: createSuggestionRenderer(CommandSuggestion),
         },
       }),
-      MetabotMentionExtension.configure({
-        suggestion: {
-          allow: ({ state }) => isMetabotBlock(state),
-          render: createSuggestionRenderer(MetabotMentionSuggestion),
-        },
-      }),
+      ...(PLUGIN_METABOT.isEnabled()
+        ? [
+            MetabotNode.configure({
+              serializePrompt: getMetabotPromptSerializer(getState),
+            }),
+            DisableMetabotSidebar,
+            MetabotMentionExtension.configure({
+              suggestion: {
+                allow: ({ state }) => isMetabotBlock(state),
+                render: createSuggestionRenderer(MetabotMentionSuggestion),
+              },
+            }),
+          ]
+        : []),
     ],
     [siteUrl, getState],
   );
@@ -192,21 +197,21 @@ export const Editor: React.FC<EditorProps> = ({
 
   if (isLoading) {
     return (
-      <Box className={cx(styles.editor, DND_IGNORE_CLASS_NAME)}>
+      <Box className={cx(S.editor, DND_IGNORE_CLASS_NAME)}>
         <Loader />
       </Box>
     );
   }
 
   return (
-    <Box className={cx(styles.editor, DND_IGNORE_CLASS_NAME)}>
+    <Box className={cx(S.editor, DND_IGNORE_CLASS_NAME)}>
       <Box
-        className={styles.editorContent}
+        className={S.editorContent}
         onClick={(e) => {
           // Focus editor when clicking on empty space
           const target = e.target as HTMLElement;
           if (
-            target.classList.contains(styles.editorContent) ||
+            target.classList.contains(S.editorContent) ||
             target.classList.contains("ProseMirror")
           ) {
             const clickY = e.clientY;

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { t } from "ttag";
 
+import { PLUGIN_METABOT } from "metabase/plugins";
 import {
   Box,
   Divider,
@@ -138,11 +139,15 @@ const CommandSuggestionComponent = forwardRef<
     () => [
       {
         items: [
-          {
-            icon: "metabot",
-            label: t`Ask Metabot`,
-            command: "metabot",
-          },
+          ...(PLUGIN_METABOT.isEnabled()
+            ? ([
+                {
+                  icon: "metabot",
+                  label: t`Ask Metabot`,
+                  command: "metabot",
+                },
+              ] as const)
+            : []),
           {
             icon: "lineandbar",
             label: t`Chart`,

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.unit.spec.tsx
@@ -1,0 +1,82 @@
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { PLUGIN_METABOT } from "metabase/plugins";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { CommandSuggestion } from "./CommandSuggestion";
+
+describe("CommandSuggestion", () => {
+  const defaultProps = {
+    items: [],
+    command: jest.fn(),
+    editor: {} as any,
+    query: "",
+    range: { from: 0, to: 0 },
+  };
+
+  const expectStandardCommandsToBePresent = () => {
+    // Main commands
+    expect(screen.getByText("Chart")).toBeInTheDocument();
+    expect(screen.getByText("Link")).toBeInTheDocument();
+
+    // Formatting commands
+    expect(screen.getByText("Heading 1")).toBeInTheDocument();
+    expect(screen.getByText("Heading 2")).toBeInTheDocument();
+    expect(screen.getByText("Heading 3")).toBeInTheDocument();
+    expect(screen.getByText("Bullet list")).toBeInTheDocument();
+    expect(screen.getByText("Numbered list")).toBeInTheDocument();
+    expect(screen.getByText("Quote")).toBeInTheDocument();
+    expect(screen.getByText("Code block")).toBeInTheDocument();
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when metabot is disabled", () => {
+    beforeEach(() => {
+      PLUGIN_METABOT.isEnabled = jest.fn(() => false);
+    });
+
+    it("should show all available commands except Metabot", () => {
+      const settings = mockSettings({
+        "token-features": createMockTokenFeatures({
+          metabot_v3: false,
+        }),
+      });
+
+      renderWithProviders(<CommandSuggestion {...defaultProps} />, {
+        storeInitialState: createMockState({
+          settings,
+        }),
+      });
+
+      expect(screen.queryByText("Ask Metabot")).not.toBeInTheDocument();
+      expectStandardCommandsToBePresent();
+    });
+  });
+
+  describe("when metabot is enabled", () => {
+    beforeEach(() => {
+      PLUGIN_METABOT.isEnabled = jest.fn(() => true);
+    });
+
+    it("should show all available commands including Metabot", () => {
+      const settings = mockSettings({
+        "token-features": createMockTokenFeatures({
+          metabot_v3: true,
+        }),
+      });
+
+      renderWithProviders(<CommandSuggestion {...defaultProps} />, {
+        storeInitialState: createMockState({
+          settings,
+        }),
+      });
+
+      expect(screen.getByText("Ask Metabot")).toBeInTheDocument();
+      expectStandardCommandsToBePresent();
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.tsx
@@ -7,12 +7,13 @@ import {
   NodeViewWrapper,
   ReactNodeViewRenderer,
 } from "@tiptap/react";
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useLatest } from "react-use";
 import { t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
 import { useDispatch } from "metabase/lib/redux";
+import { PLUGIN_METABOT } from "metabase/plugins";
 import { Box, Button, Flex, Icon, Text, Tooltip } from "metabase/ui";
 import { useLazyMetabotGenerateContentQuery } from "metabase-enterprise/api/metabot";
 import {
@@ -148,6 +149,7 @@ export const MetabotComponent = memo(
     const [isLoading, setIsLoading] = useState(false);
     const [errorText, setErrorText] = useState("");
     const [queryMetabot] = useLazyMetabotGenerateContentQuery();
+    const isMetabotEnabled = PLUGIN_METABOT.isEnabled();
 
     const handleRunMetabot = async () => {
       const serializePrompt =
@@ -272,6 +274,13 @@ export const MetabotComponent = memo(
       };
     }, [editor, onRunMetabotRef]);
 
+    const tooltip = useMemo(() => {
+      if (!isMetabotEnabled) {
+        return t`Metabot is disabled`;
+      }
+      return isLoading ? t`Stop generating` : null;
+    }, [isMetabotEnabled, isLoading]);
+
     return (
       <NodeViewWrapper>
         <Flex
@@ -328,12 +337,13 @@ export const MetabotComponent = memo(
               ) : null}
             </Flex>
             <Tooltip
-              label={t`Stop generating`}
-              disabled={!isLoading}
+              label={tooltip}
+              disabled={tooltip == null}
               position="bottom"
             >
               <Button
                 size="sm"
+                disabled={!isMetabotEnabled}
                 onClick={() =>
                   isLoading ? handleStopMetabot() : handleRunMetabot()
                 }

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.unit.spec.tsx
@@ -1,0 +1,87 @@
+import userEvent from "@testing-library/user-event";
+
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { PLUGIN_METABOT } from "metabase/plugins";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { MetabotComponent } from "./MetabotEmbed";
+import {
+  createMockExtension,
+  createMockNodeViewProps,
+  createMockProseMirrorNode,
+} from "./__support__/node-view-mocks";
+
+describe("MetabotEmbed", () => {
+  const defaultProps = createMockNodeViewProps({
+    node: createMockProseMirrorNode({
+      textContent: "Test prompt",
+      content: { content: [] },
+    }),
+    extension: createMockExtension({
+      options: {
+        serializePrompt: jest.fn(),
+      },
+    }),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when metabot is disabled", () => {
+    beforeEach(() => {
+      PLUGIN_METABOT.isEnabled = jest.fn(() => false);
+    });
+
+    it("should show disabled button with tooltip", async () => {
+      const settings = mockSettings({
+        "token-features": createMockTokenFeatures({
+          metabot_v3: false,
+        }),
+      });
+
+      renderWithProviders(<MetabotComponent {...defaultProps} />, {
+        storeInitialState: createMockState({
+          settings,
+        }),
+      });
+
+      const runButton = screen.getByRole("button", { name: /run/i });
+      expect(runButton).toBeDisabled();
+
+      await userEvent.hover(runButton);
+      const tooltip = await screen.findByRole("tooltip");
+      expect(
+        within(tooltip).getByText("Metabot is disabled"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when metabot is enabled", () => {
+    beforeEach(() => {
+      PLUGIN_METABOT.isEnabled = jest.fn(() => true);
+    });
+
+    it("should show enabled button without tooltip", async () => {
+      const settings = mockSettings({
+        "token-features": createMockTokenFeatures({
+          metabot_v3: true,
+        }),
+      });
+
+      renderWithProviders(<MetabotComponent {...defaultProps} />, {
+        storeInitialState: createMockState({
+          settings,
+        }),
+      });
+
+      const runButton = screen.getByRole("button", { name: /run/i });
+      expect(runButton).toBeEnabled();
+
+      await userEvent.hover(runButton);
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/__support__/editor-mocks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/__support__/editor-mocks.ts
@@ -1,0 +1,19 @@
+import type { Editor } from "@tiptap/react";
+
+export const createMockEditor = (overrides = {}): Editor =>
+  ({
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+    commands: {
+      focus: jest.fn(),
+      insertContentAt: jest.fn(),
+      exitCode: jest.fn(),
+      command: jest.fn(),
+    },
+    state: {
+      selection: { $from: {}, empty: true },
+      doc: { nodeAt: jest.fn(), resolve: jest.fn() },
+    },
+    ...overrides,
+  }) as unknown as Editor;

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/__support__/node-view-mocks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/__support__/node-view-mocks.ts
@@ -1,0 +1,40 @@
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { DecorationSource, EditorView } from "@tiptap/pm/view";
+import type { Extension, NodeViewProps } from "@tiptap/react";
+
+import { createMockEditor } from "./editor-mocks";
+
+export const createMockProseMirrorNode = (overrides = {}): ProseMirrorNode =>
+  ({
+    textContent: "",
+    content: { content: [] },
+    type: { name: "metabot" },
+    attrs: {},
+    marks: [],
+    nodeSize: 1,
+    childCount: 0,
+    ...overrides,
+  }) as unknown as ProseMirrorNode;
+
+export const createMockExtension = (overrides = {}): Extension =>
+  ({
+    name: "my-extension",
+    options: {},
+    ...overrides,
+  }) as unknown as Extension;
+
+export const createMockNodeViewProps = (overrides = {}): NodeViewProps =>
+  ({
+    editor: createMockEditor(),
+    node: createMockProseMirrorNode(),
+    getPos: () => 0,
+    deleteNode: jest.fn(),
+    updateAttributes: jest.fn(),
+    decorations: [],
+    selected: false,
+    view: {} as unknown as EditorView,
+    innerDecorations: {} as unknown as DecorationSource,
+    HTMLAttributes: {},
+    extension: createMockExtension(),
+    ...overrides,
+  }) as NodeViewProps;


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-499/add-access-check-for-ask-metabot-menu-item-visibility

### Description

Hides Metabot in Documents if Metabot feature is disabled.

### How to verify

- Run Metabase EE locally as usual
- In `enterprise/frontend/src/metabase-enterprise/metabot/index.tsx` on line 19 change the expected metabot feature name `hasPremiumFeature("metabot_v3")` to `wrong_metabot_v3` = metabot feature will be disabled
- Ensure you can't insert Metabot nodes into documents

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
