### PR TITLE
wait up to 10 seconds for worker to stop

### DIFF
--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -19,7 +19,15 @@
    [metabase.util.malli.schema :as ms])
   (:import
    (java.time Duration Instant)
-   (java.util.concurrent ArrayBlockingQueue BlockingQueue DelayQueue Delayed ScheduledExecutorService SynchronousQueue TimeUnit)))
+   (java.util.concurrent
+    ArrayBlockingQueue
+    BlockingQueue
+    DelayQueue
+    Delayed
+    ExecutorService
+    ScheduledExecutorService
+    SynchronousQueue
+    TimeUnit)))
 
 (set! *warn-on-reflection* true)
 
@@ -193,12 +201,12 @@
   "Stops the listener previously started with (listen!).
   If there is no running listener with the given name, it is a no-op"
   [listener-name :- :string]
-  (if-let [executor (get @listeners listener-name)]
+  (if-let [^ExecutorService executor (get @listeners listener-name)]
     (do
       (log/infof "Stopping listener %s..." listener-name)
       (cp/shutdown! executor)
       ;; wait up to 10 seconds for executor to stop. Largely for CI/tests FAIL in (listener-handler-test) (queue_test.clj:178)
-      (java.util.concurrent.ExecutorService/.awaitTermination executor 10 java.util.concurrent.TimeUnit/SECONDS)
+      (.awaitTermination executor 10 TimeUnit/SECONDS)
 
       (swap! listeners dissoc listener-name)
       (log/infof "Stopping listener %s...done" listener-name))

--- a/src/metabase/util/queue.clj
+++ b/src/metabase/util/queue.clj
@@ -197,6 +197,8 @@
     (do
       (log/infof "Stopping listener %s..." listener-name)
       (cp/shutdown! executor)
+      ;; wait up to 10 seconds for executor to stop. Largely for CI/tests FAIL in (listener-handler-test) (queue_test.clj:178)
+      (java.util.concurrent.ExecutorService/.awaitTermination executor 10 java.util.concurrent.TimeUnit/SECONDS)
 
       (swap! listeners dissoc listener-name)
       (log/infof "Stopping listener %s...done" listener-name))

--- a/test/metabase/channel/email_test.clj
+++ b/test/metabase/channel/email_test.clj
@@ -139,6 +139,11 @@
         emails  (get @inbox address)]
     (boolean (some #(re-find regex %) (map :subject emails)))))
 
+(defn email-subjects
+  [user-or-email]
+  (let [address (if (string? user-or-email) user-or-email (:username (test.users/user->credentials user-or-email)))]
+    (into #{} (map :subject) (get @inbox address))))
+
 (defn received-email-body?
   "Indicate whether a user received an email whose body matches the `regex`. First argument should be a keyword
   like :rasta, or an email address string."

--- a/test/metabase/session/models/session_test.clj
+++ b/test/metabase/session/models/session_test.clj
@@ -120,7 +120,7 @@
 (deftest login-email-fall-back-name-test
   (mt/test-helpers-set-global-values!
     (let [original-maybe-send (var-get #'metabase.login-history.record/maybe-send-login-from-new-device-email)
-          new-login-email (fn [user-id]
+          new-login-email (fn [user-id email]
                             (mt/with-fake-inbox
                               (with-redefs [request/geocode-ip-addresses (fn [ip-addresses]
                                                                            (into {} (for [ip-address ip-addresses]
@@ -143,25 +143,24 @@
                                       :device_id device
                                       :timestamp #t "2021-04-02T15:52:00-07:00[US/Pacific]"
                                       :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML  like Gecko) Chrome/89.0.4389.86 Safari/537.36"})
-                                    (ffirst (vals @mt/inbox)))))))]
+                                    (mt/email-subjects email))))))]
       (testing "Use first name if exists"
-        (mt/with-temp [:model/User {user-id :id} {:first_name "Ngoc"
-                                                  :last_name  "Khuat"}]
-          (is (= "We've Noticed a New Metabase Login, Ngoc"
-                 (:subject (new-login-email user-id))))))
+        (mt/with-temp [:model/User {user-id :id
+                                    email :email} {:first_name "Ngoc"
+                                                   :last_name  "Khuat"}]
+          (is (contains? (new-login-email user-id email) "We've Noticed a New Metabase Login, Ngoc"))))
 
       (testing "fallback to last name if user has no first_name"
-        (mt/with-temp [:model/User {user-id :id} {:first_name nil
-                                                  :last_name  "Khuat"}]
-          (is (= "We've Noticed a New Metabase Login, Khuat"
-                 (:subject (new-login-email user-id))))))
+        (mt/with-temp [:model/User {user-id :id email :email} {:first_name nil :last_name  "Khuat"}]
+          (is (contains? (new-login-email user-id email)
+                         "We've Noticed a New Metabase Login, Khuat"))))
 
       (testing "Else Use email if both first_name and last_name are null"
-        (mt/with-temp [:model/User {user-id :id} {:first_name nil
-                                                  :last_name  nil
-                                                  :email      "cto@metabase.com"}]
-          (is (= "We've Noticed a New Metabase Login, cto@metabase.com"
-                 (:subject (new-login-email user-id)))))))))
+        (mt/with-temp [:model/User {user-id :id email :email} {:first_name nil
+                                                               :last_name  nil
+                                                               :email      "cto@metabase.com"}]
+          (is (contains? (new-login-email user-id email)
+                         "We've Noticed a New Metabase Login, cto@metabase.com")))))))
 
 (deftest create-session-test
   (mt/with-temp [:model/User {user-id :id}]

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -147,6 +147,7 @@
   received-email-body?
   received-email-subject?
   regex-email-bodies
+  email-subjects
   reset-inbox!
   summarize-multipart-email
   summarize-multipart-single-email


### PR DESCRIPTION
in CI getting lots of flakes. Here's reproduction locally:

```
queue-test=> (dotimes [_ 20] (listener-handler-test))

FAIL in (listener-handler-test) (queue_test.clj:178) ;; 1
Standard behavior with a handler
expected: (not (thread-name-running? thread-name))
  actual: (not (not true))

FAIL in (listener-handler-test) (queue_test.clj:178) ;; 2
Standard behavior with a handler
expected: (not (thread-name-running? thread-name))
  actual: (not (not true))

,,,

FAIL in (listener-handler-test) (queue_test.clj:178) ;; 18
Standard behavior with a handler
expected: (not (thread-name-running? thread-name))
  actual: (not (not true))
nil
```

and after:

```
queue-test=> (dotimes [_ 20] (listener-handler-test))
nil
```

I picked 10 seconds which sounds goldilocks long enough to not really matter and tasks naturally finish on their own and short enough such that if anything weird is actually going on we won't wait for hours
