### PR TITLE
adding documents to smart links

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.tsx
@@ -117,20 +117,7 @@ export const CommandSuggestion = forwardRef<
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [showLinkSearch, setShowLinkSearch] = useState(false);
   const [showEmbedSearch, setShowEmbedSearch] = useState(false);
-  const [pendingLinkMode, setPendingLinkMode] = useState(false);
-  const [pendingEmbedMode, setPendingEmbedMode] = useState(false);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
-
-  useEffect(() => {
-    if (pendingLinkMode) {
-      setShowLinkSearch(true);
-      setPendingLinkMode(false);
-    }
-    if (pendingEmbedMode) {
-      setShowEmbedSearch(true);
-      setPendingEmbedMode(false);
-    }
-  }, [pendingLinkMode, pendingEmbedMode]);
 
   const allCommandSections: CommandSection[] = useMemo(
     () => [
@@ -243,20 +230,20 @@ export const CommandSuggestion = forwardRef<
 
   const executeCommand = (commandName: string) => {
     if (commandName === "linkTo") {
-      setPendingLinkMode(true);
       command({
         clearQuery: true,
         switchToLinkMode: true,
       });
+      setShowLinkSearch(true);
       return;
     }
 
     if (commandName === "embedQuestion") {
-      setPendingEmbedMode(true);
       command({
         clearQuery: true,
         switchToEmbedMode: true,
       });
+      setShowEmbedSearch(true);
       return;
     }
 

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.unit.spec.tsx
@@ -1,82 +1,405 @@
-import { mockSettings } from "__support__/settings";
-import { renderWithProviders, screen } from "__support__/ui";
-import { PLUGIN_METABOT } from "metabase/plugins";
-import { createMockTokenFeatures } from "metabase-types/api/mocks";
-import { createMockState } from "metabase-types/store/mocks";
+import userEvent from "@testing-library/user-event";
+import type { Editor } from "@tiptap/core";
+import { useState } from "react";
 
-import { CommandSuggestion } from "./CommandSuggestion";
+import {
+  setupRecentViewsEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { Input } from "metabase/ui";
+import registerVisualizations from "metabase/visualizations/register";
+import { type RecentItem, isRecentTableItem } from "metabase-types/api";
+import {
+  createMockRecentCollectionItem,
+  createMockRecentTableItem,
+  createMockSearchResult,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
+
+import {
+  CommandSuggestion,
+  type CommandSuggestionProps,
+} from "./CommandSuggestion";
+import { createMockState } from "metabase-types/store/mocks";
+import { SettingsState } from "metabase-types/store";
+import { mockSettings } from "__support__/settings";
+import { PLUGIN_METABOT } from "metabase/plugins";
+
+registerVisualizations();
+
+const SEARCH_ITEMS = [
+  createMockSearchResult({
+    name: "Orders by product",
+    model: "card",
+    display: "bar",
+    id: 1,
+  }),
+  createMockSearchResult({
+    name: "Orders by category",
+    model: "card",
+    display: "pie",
+    id: 2,
+  }),
+  createMockSearchResult({
+    name: "Total accounts",
+    model: "card",
+    display: "scalar",
+    id: 3,
+  }),
+  createMockSearchResult({
+    name: "Orders report",
+    model: "document",
+    id: 4,
+  }),
+  createMockSearchResult({
+    name: "Account quotes",
+    model: "card",
+    id: 5,
+  }),
+];
+
+const RECENT_ITEMS = [
+  createMockRecentCollectionItem({
+    id: 6,
+    name: "Recent Card",
+    model: "card",
+    display: "bar",
+  }),
+  createMockRecentCollectionItem({
+    id: 7,
+    name: "Recent Document",
+    model: "document",
+  }),
+  createMockRecentTableItem({
+    id: 8,
+    display_name: "Recent Table",
+    name: "recent_table",
+    model: "table",
+  }),
+];
+
+const getRecentItemName = (item: RecentItem) =>
+  isRecentTableItem(item) ? (item.display_name ?? item.name) : item.name;
+
+const TestWrapper = (props: CommandSuggestionProps) => {
+  const [query, setQuery] = useState(props.query);
+
+  return (
+    <>
+      <Input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        aria-label="test-input"
+      />
+      <CommandSuggestion {...props} query={query} />
+    </>
+  );
+};
+
+type SetupProps = {
+  query?: string;
+  settings?: SettingsState;
+};
+
+const setup = ({
+  query = "",
+  settings = mockSettings({}),
+}: SetupProps = {}) => {
+  const command = jest.fn();
+
+  const editor = {
+    commands: {
+      focus: jest.fn(),
+    },
+  };
+
+  setupSearchEndpoints(SEARCH_ITEMS);
+  setupRecentViewsEndpoints(RECENT_ITEMS);
+
+  renderWithProviders(
+    <TestWrapper
+      command={command}
+      editor={editor as unknown as Editor}
+      query={query}
+      items={[]}
+      range={{ from: 0, to: 0 }}
+    />,
+    { storeInitialState: createMockState({ settings }) },
+  );
+
+  return {
+    command,
+  };
+};
 
 describe("CommandSuggestion", () => {
-  const defaultProps = {
-    items: [],
-    command: jest.fn(),
-    editor: {} as any,
-    query: "",
-    range: { from: 0, to: 0 },
-  };
+  it("renders with default commands", async () => {
+    setup();
 
-  const expectStandardCommandsToBePresent = () => {
-    // Main commands
-    expect(screen.getByText("Chart")).toBeInTheDocument();
-    expect(screen.getByText("Link")).toBeInTheDocument();
+    // Custom Commands
+    expect(
+      await screen.findByRole("option", { name: "Ask Metabot" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Chart" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Link" }),
+    ).toBeInTheDocument();
 
-    // Formatting commands
-    expect(screen.getByText("Heading 1")).toBeInTheDocument();
-    expect(screen.getByText("Heading 2")).toBeInTheDocument();
-    expect(screen.getByText("Heading 3")).toBeInTheDocument();
-    expect(screen.getByText("Bullet list")).toBeInTheDocument();
-    expect(screen.getByText("Numbered list")).toBeInTheDocument();
-    expect(screen.getByText("Quote")).toBeInTheDocument();
-    expect(screen.getByText("Code block")).toBeInTheDocument();
-  };
+    // Formatting Commands
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+    expect(
+      await screen.findByRole("option", { name: "Heading 1" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Heading 2" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Heading 3" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Bullet list" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Numbered list" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Quote" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Code block" }),
+    ).toBeInTheDocument();
   });
 
-  describe("when metabot is disabled", () => {
-    beforeEach(() => {
-      PLUGIN_METABOT.isEnabled = jest.fn(() => false);
-    });
+  it("searches for possible card embeds by default", async () => {
+    const { command } = setup({ query: "Ord" });
 
-    it("should show all available commands except Metabot", () => {
-      const settings = mockSettings({
-        "token-features": createMockTokenFeatures({
-          metabot_v3: false,
-        }),
-      });
+    // Find cards what were searched for, with apropriate icons
+    expect(
+      within(
+        await screen.findByRole("option", { name: /Orders by product/ }),
+      ).getByRole("img", { name: /bar/ }),
+    ).toBeInTheDocument();
 
-      renderWithProviders(<CommandSuggestion {...defaultProps} />, {
-        storeInitialState: createMockState({
-          settings,
-        }),
-      });
+    expect(
+      within(
+        await screen.findByRole("option", { name: /Orders by category/ }),
+      ).getByRole("img", { name: /pie/ }),
+    ).toBeInTheDocument();
 
-      expect(screen.queryByText("Ask Metabot")).not.toBeInTheDocument();
-      expectStandardCommandsToBePresent();
+    // Should not find things that cannot be embedded as a card
+    expect(
+      screen.queryByRole("option", { name: /Orders report/ }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("option", { name: /Orders by category/ }),
+    );
+
+    // Expect a call with embedItem. This tells us it was a chart embed
+    expect(command).toHaveBeenCalledWith({
+      embedItem: true,
+      entityId: 2,
+      model: "card",
     });
   });
 
-  describe("when metabot is enabled", () => {
+  it("supports embedding links", async () => {
+    const { command } = setup();
+
+    await userEvent.click(await screen.findByRole("option", { name: "Link" }));
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: "test-input" }),
+      "Ord",
+    );
+
+    expect(
+      await screen.findByRole("option", { name: /Orders by product/ }),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole("option", { name: /Orders report/ }),
+    ).toBeInTheDocument();
+
+    // Clicking on an option should execute the select item command
+    await userEvent.click(
+      screen.getByRole("option", { name: /Orders report/ }),
+    );
+
+    // Expect a call with embedItem. This tells us it was a chart embed
+    expect(command).toHaveBeenCalledWith({
+      selectItem: true,
+      entityId: 4,
+      model: "document",
+    });
+  });
+
+  it("Default Search should include formatting commands, Chart search should not", async () => {
+    const { command } = setup({ query: "Quo" });
+
+    expect(
+      await screen.findByRole("option", { name: /Account quotes/ }),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole("option", { name: "Quote" }),
+    ).toBeInTheDocument();
+
+    await userEvent.clear(screen.getByRole("textbox", { name: "test-input" }));
+
+    await userEvent.click(await screen.findByRole("option", { name: "Chart" }));
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: "test-input" }),
+      "Quo",
+    );
+
+    expect(
+      await screen.findByRole("option", { name: /Account quotes/ }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("option", { name: "Quote" }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("option", { name: /Account quotes/ }),
+    );
+
+    expect(command).toHaveBeenCalledWith({
+      embedItem: true,
+      entityId: 5,
+      model: "card",
+    });
+  });
+
+  it("should display recent embeddable items when in embed mode with an empty query", async () => {
+    const { command } = setup({ query: "" });
+
+    await userEvent.click(await screen.findByRole("option", { name: "Chart" }));
+
+    expect(
+      await screen.findByRole("option", {
+        name: new RegExp(getRecentItemName(RECENT_ITEMS[0])),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", {
+        name: new RegExp(getRecentItemName(RECENT_ITEMS[1])),
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", {
+        name: new RegExp(getRecentItemName(RECENT_ITEMS[2])),
+      }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("option", {
+        name: new RegExp(getRecentItemName(RECENT_ITEMS[0])),
+      }),
+    );
+
+    expect(command).toHaveBeenCalledWith({
+      embedItem: true,
+      entityId: 6,
+      model: "card",
+    });
+  });
+
+  it("should display recent linkable items when in link mode with an empty query", async () => {
+    const { command } = setup({ query: "" });
+
+    await userEvent.click(await screen.findByRole("option", { name: "Link" }));
+
+    expect(
+      await screen.findByRole("option", {
+        name: new RegExp(getRecentItemName(RECENT_ITEMS[0])),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", {
+        name: new RegExp(getRecentItemName(RECENT_ITEMS[1])),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", {
+        name: new RegExp(getRecentItemName(RECENT_ITEMS[2])),
+      }),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("option", {
+        name: new RegExp(getRecentItemName(RECENT_ITEMS[2])),
+      }),
+    );
+
+    expect(command).toHaveBeenCalledWith({
+      selectItem: true,
+      entityId: 8,
+      model: "table",
+    });
+  });
+
+  describe("metabot", () => {
+    const expectStandardCommandsToBePresent = () => {
+      // Main commands
+      expect(screen.getByText("Chart")).toBeInTheDocument();
+      expect(screen.getByText("Link")).toBeInTheDocument();
+
+      // Formatting commands
+      expect(screen.getByText("Heading 1")).toBeInTheDocument();
+      expect(screen.getByText("Heading 2")).toBeInTheDocument();
+      expect(screen.getByText("Heading 3")).toBeInTheDocument();
+      expect(screen.getByText("Bullet list")).toBeInTheDocument();
+      expect(screen.getByText("Numbered list")).toBeInTheDocument();
+      expect(screen.getByText("Quote")).toBeInTheDocument();
+      expect(screen.getByText("Code block")).toBeInTheDocument();
+    };
+
     beforeEach(() => {
-      PLUGIN_METABOT.isEnabled = jest.fn(() => true);
+      jest.clearAllMocks();
     });
 
-    it("should show all available commands including Metabot", () => {
-      const settings = mockSettings({
-        "token-features": createMockTokenFeatures({
-          metabot_v3: true,
-        }),
+    describe("when metabot is disabled", () => {
+      beforeEach(() => {
+        PLUGIN_METABOT.isEnabled = jest.fn(() => false);
       });
 
-      renderWithProviders(<CommandSuggestion {...defaultProps} />, {
-        storeInitialState: createMockState({
-          settings,
-        }),
+      it("should show all available commands except Metabot", () => {
+        const settings = mockSettings({
+          "token-features": createMockTokenFeatures({
+            metabot_v3: false,
+          }),
+        });
+
+        setup({ settings });
+
+        expect(screen.queryByText("Ask Metabot")).not.toBeInTheDocument();
+        expectStandardCommandsToBePresent();
+      });
+    });
+
+    describe("when metabot is enabled", () => {
+      beforeEach(() => {
+        PLUGIN_METABOT.isEnabled = jest.fn(() => true);
       });
 
-      expect(screen.getByText("Ask Metabot")).toBeInTheDocument();
-      expectStandardCommandsToBePresent();
+      it("should show all available commands including Metabot", () => {
+        const settings = mockSettings({
+          "token-features": createMockTokenFeatures({
+            metabot_v3: true,
+          }),
+        });
+
+        setup({ settings });
+
+        expect(screen.getByText("Ask Metabot")).toBeInTheDocument();
+        expectStandardCommandsToBePresent();
+      });
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.unit.spec.tsx
@@ -237,7 +237,7 @@ describe("CommandSuggestion", () => {
     });
   });
 
-  it("Default Search should include formatting commands, Chart search should not", async () => {
+  it("should include formatting commands for default search, not for Chart search", async () => {
     const { command } = setup({ query: "Quo" });
 
     expect(

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.unit.spec.tsx
@@ -6,7 +6,9 @@ import {
   setupRecentViewsEndpoints,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen, within } from "__support__/ui";
+import { PLUGIN_METABOT } from "metabase/plugins";
 import { Input } from "metabase/ui";
 import registerVisualizations from "metabase/visualizations/register";
 import { type RecentItem, isRecentTableItem } from "metabase-types/api";
@@ -16,15 +18,13 @@ import {
   createMockSearchResult,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
+import type { SettingsState } from "metabase-types/store";
+import { createMockState } from "metabase-types/store/mocks";
 
 import {
   CommandSuggestion,
   type CommandSuggestionProps,
 } from "./CommandSuggestion";
-import { createMockState } from "metabase-types/store/mocks";
-import { SettingsState } from "metabase-types/store";
-import { mockSettings } from "__support__/settings";
-import { PLUGIN_METABOT } from "metabase/plugins";
 
 registerVisualizations();
 
@@ -137,40 +137,7 @@ describe("CommandSuggestion", () => {
   it("renders with default commands", async () => {
     setup();
 
-    // Custom Commands
-    expect(
-      await screen.findByRole("option", { name: "Ask Metabot" }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Chart" }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Link" }),
-    ).toBeInTheDocument();
-
-    // Formatting Commands
-
-    expect(
-      await screen.findByRole("option", { name: "Heading 1" }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Heading 2" }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Heading 3" }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Bullet list" }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Numbered list" }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Quote" }),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("option", { name: "Code block" }),
-    ).toBeInTheDocument();
+    await expectStandardCommandsToBePresent();
   });
 
   it("searches for possible card embeds by default", async () => {
@@ -345,21 +312,6 @@ describe("CommandSuggestion", () => {
   });
 
   describe("metabot", () => {
-    const expectStandardCommandsToBePresent = () => {
-      // Main commands
-      expect(screen.getByText("Chart")).toBeInTheDocument();
-      expect(screen.getByText("Link")).toBeInTheDocument();
-
-      // Formatting commands
-      expect(screen.getByText("Heading 1")).toBeInTheDocument();
-      expect(screen.getByText("Heading 2")).toBeInTheDocument();
-      expect(screen.getByText("Heading 3")).toBeInTheDocument();
-      expect(screen.getByText("Bullet list")).toBeInTheDocument();
-      expect(screen.getByText("Numbered list")).toBeInTheDocument();
-      expect(screen.getByText("Quote")).toBeInTheDocument();
-      expect(screen.getByText("Code block")).toBeInTheDocument();
-    };
-
     beforeEach(() => {
       jest.clearAllMocks();
     });
@@ -369,7 +321,7 @@ describe("CommandSuggestion", () => {
         PLUGIN_METABOT.isEnabled = jest.fn(() => false);
       });
 
-      it("should show all available commands except Metabot", () => {
+      it("should show all available commands except Metabot", async () => {
         const settings = mockSettings({
           "token-features": createMockTokenFeatures({
             metabot_v3: false,
@@ -379,7 +331,7 @@ describe("CommandSuggestion", () => {
         setup({ settings });
 
         expect(screen.queryByText("Ask Metabot")).not.toBeInTheDocument();
-        expectStandardCommandsToBePresent();
+        await expectStandardCommandsToBePresent();
       });
     });
 
@@ -388,7 +340,7 @@ describe("CommandSuggestion", () => {
         PLUGIN_METABOT.isEnabled = jest.fn(() => true);
       });
 
-      it("should show all available commands including Metabot", () => {
+      it("should show all available commands including Metabot", async () => {
         const settings = mockSettings({
           "token-features": createMockTokenFeatures({
             metabot_v3: true,
@@ -398,8 +350,42 @@ describe("CommandSuggestion", () => {
         setup({ settings });
 
         expect(screen.getByText("Ask Metabot")).toBeInTheDocument();
-        expectStandardCommandsToBePresent();
+        await expectStandardCommandsToBePresent();
       });
     });
   });
 });
+
+const expectStandardCommandsToBePresent = async () => {
+  // Custom Commands
+  expect(
+    await screen.findByRole("option", { name: "Chart" }),
+  ).toBeInTheDocument();
+  expect(
+    await screen.findByRole("option", { name: "Link" }),
+  ).toBeInTheDocument();
+
+  // Formatting Commands
+
+  expect(
+    await screen.findByRole("option", { name: "Heading 1" }),
+  ).toBeInTheDocument();
+  expect(
+    await screen.findByRole("option", { name: "Heading 2" }),
+  ).toBeInTheDocument();
+  expect(
+    await screen.findByRole("option", { name: "Heading 3" }),
+  ).toBeInTheDocument();
+  expect(
+    await screen.findByRole("option", { name: "Bullet list" }),
+  ).toBeInTheDocument();
+  expect(
+    await screen.findByRole("option", { name: "Numbered list" }),
+  ).toBeInTheDocument();
+  expect(
+    await screen.findByRole("option", { name: "Quote" }),
+  ).toBeInTheDocument();
+  expect(
+    await screen.findByRole("option", { name: "Code block" }),
+  ).toBeInTheDocument();
+};

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/constants.ts
@@ -8,6 +8,7 @@ export const LINK_SEARCH_MODELS: SearchModel[] = [
   "database",
   "table",
   "collection",
+  "document",
 ];
 
 export const EMBED_SEARCH_MODELS: SearchModel[] = ["card", "dataset"];

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/suggestionUtils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/suggestionUtils.ts
@@ -15,6 +15,9 @@ export const isRecentQuestion = (
 ): item is RecentCollectionItem & { model: "card" | "dataset" } =>
   item.model === "card" || item.model === "dataset";
 
+export const filterRecents = (item: RecentItem, models: SearchModel[]) =>
+  models.includes(item.model);
+
 export function buildSearchMenuItems(
   searchResults: SearchResult[],
   onSelect: (result: SearchResult) => void,
@@ -35,14 +38,11 @@ export function buildSearchMenuItems(
 }
 
 export function buildRecentsMenuItems(
-  recents: Array<RecentCollectionItem & { model: "card" | "dataset" }>,
-  onSelect: (recent: RecentCollectionItem) => void,
+  recents: Array<RecentItem>,
+  onSelect: (recent: RecentItem) => void,
 ): MenuItem[] {
   return recents.map((recent) => {
-    const iconData = getIcon({
-      model: recent.model,
-      display: recent.display ?? undefined,
-    });
+    const iconData = getIcon(recent);
     return {
       icon: iconData.name,
       label: getName(recent),

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/suggestionUtils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/suggestionUtils.ts
@@ -2,18 +2,12 @@ import { getIcon } from "metabase/lib/icon";
 import { getName } from "metabase/lib/name";
 import type {
   Database,
-  RecentCollectionItem,
   RecentItem,
   SearchModel,
   SearchResult,
 } from "metabase-types/api";
 
 import type { MenuItem } from "../../shared/MenuComponents";
-
-export const isRecentQuestion = (
-  item: RecentItem,
-): item is RecentCollectionItem & { model: "card" | "dataset" } =>
-  item.model === "card" || item.model === "dataset";
 
 export const filterRecents = (item: RecentItem, models: SearchModel[]) =>
   models.includes(item.model);

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/useEntitySearch.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/useEntitySearch.ts
@@ -9,7 +9,7 @@ import { LINK_SEARCH_LIMIT, LINK_SEARCH_MODELS } from "./constants";
 import {
   buildRecentsMenuItems,
   buildSearchMenuItems,
-  isRecentQuestion,
+  filterRecents,
 } from "./suggestionUtils";
 
 interface UseEntitySearchOptions {
@@ -44,9 +44,11 @@ export function useEntitySearch({
   const filteredRecents = useMemo(
     () =>
       shouldFetchRecents
-        ? recents.filter(isRecentQuestion).slice(0, LINK_SEARCH_LIMIT)
+        ? recents
+            .filter((recent) => filterRecents(recent, searchModels))
+            .slice(0, LINK_SEARCH_LIMIT)
         : [],
-    [recents, shouldFetchRecents],
+    [recents, shouldFetchRecents, searchModels],
   );
 
   const { data: searchResponse, isLoading: isSearchLoading } = useSearchQuery(

--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -48,7 +48,13 @@ export type RecentTableItem = BaseRecentItem & {
 };
 
 export type RecentCollectionItem = BaseRecentItem & {
-  model: "collection" | "dashboard" | "card" | "dataset" | "metric";
+  model:
+    | "collection"
+    | "dashboard"
+    | "card"
+    | "dataset"
+    | "metric"
+    | "document";
   can_write: boolean;
   database_id?: DatabaseId; // for models and questions
   parent_collection: {


### PR DESCRIPTION
### Description
Adds the ability to link documents in other documents. This also refactors a bit of the `CommandSuggestions` component to make fewer API requests and simplify things a bit, as well as a unit test suite for command suggestions

### How to verify

1. Open a new or existing document
2. Open the command menu and hit `/`
3. Select Link, if you have any documents in your recent items, they should be displayed now
4. Typing will enable you to search and include documents in the results
5. Select a document, and it should link successfully

### Demo

https://github.com/user-attachments/assets/35166f3f-0d69-4cd1-b7c5-a447760f8bdb

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
