### PR TITLE
Fix: UXW-42 Debounce on the visualization resize is causing layout jumping

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/combo.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/combo.cy.spec.js
@@ -78,6 +78,7 @@ describe("scenarios > visualizations > combo", () => {
     });
 
     H.openVizSettingsSidebar();
+    H.ensureChartIsActive();
     cy.findByTestId("chartsettings-sidebar").within(() => {
       cy.findByText("Display").click();
       cy.findByText("Stack").click();

--- a/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
@@ -137,6 +137,7 @@ export const ViewMainContainer = (props: ViewMainContainerProps) => {
       <DebouncedFrame
         className={ViewMainContainerS.StyledDebouncedFrame}
         enabled={!isLiveResizable}
+        resetKey={props.isRunning}
       >
         <QueryVisualization
           {...props}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/54147
Closes UXW-42

### Description

Tweaks DebouncedFrame so it accepts a resetKey prop which can be used to trigger an immediate update rather than a debounced one without remounting.

### How to verify

See https://github.com/metabase/metabase/issues/54147 for repro steps.

Check for resize regressions anywhere DebouncedFrame is used.

### Demo

**BEFORE**

https://github.com/user-attachments/assets/b0c59d30-7e9f-428f-b777-a80f60275559

**AFTER**

https://github.com/user-attachments/assets/7a62196b-ed91-4b9d-83f9-7ff826f632f1

**BEFORE (dashboard)**

https://github.com/user-attachments/assets/6bb9b33a-7732-4e0c-b61b-b1379169c0e0

**AFTER (dashboard)**

https://github.com/user-attachments/assets/6b15f0f8-c800-47ae-a1a2-405a3dcbeb49

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
