### PR TITLE
Limit dashboard name to 254 chars

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -589,16 +589,14 @@ describe("scenarios > dashboard", () => {
         });
       });
 
-      const longTitle =
-        "a really really really really really really really really really really really really really really really really long title";
-
-      it("should prevent entering a title longer than 100 chars", () => {
+      it("should prevent entering a title longer than 254 chars", () => {
+        const longTitle = "A".repeat(256);
         cy.findByTestId("dashboard-name-heading")
           .as("dashboardInput")
           .clear()
           .type(longTitle, { delay: 0 })
           .blur();
-        cy.get("@dashboardInput").invoke("text").should("have.length", 100);
+        cy.get("@dashboardInput").invoke("text").should("have.length", 254);
       });
     });
 

--- a/frontend/src/metabase/dashboard/components/DashboardTitle/DashboardTitle.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTitle/DashboardTitle.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import EditableText from "metabase/common/components/EditableText";
+import { DASHBOARD_NAME_MAX_LENGTH } from "metabase/dashboard/constants";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { useDashboardTitle } from "metabase/dashboard/hooks/use-dashboard-title";
 
@@ -21,7 +22,7 @@ export const DashboardTitle = ({ className }: { className?: string }) => {
       isDisabled={!dashboard?.can_write}
       data-testid="dashboard-name-heading"
       onChange={setTitle}
-      maxLength={100}
+      maxLength={DASHBOARD_NAME_MAX_LENGTH}
     />
   );
 };

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -5,6 +5,7 @@ import type {
 
 import type { EmbedDisplayParams } from "./types";
 
+export const DASHBOARD_NAME_MAX_LENGTH = 254;
 export const DASHBOARD_DESCRIPTION_MAX_LENGTH = 1500;
 
 export const SIDEBAR_NAME: Record<DashboardSidebarName, DashboardSidebarName> =

--- a/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
@@ -23,13 +23,16 @@ import * as Errors from "metabase/lib/errors";
 import type { CollectionId, Dashboard, DashboardId } from "metabase-types/api";
 
 import { DashboardCopyModalShallowCheckboxLabel } from "../components/DashboardCopyModal/DashboardCopyModalShallowCheckboxLabel/DashboardCopyModalShallowCheckboxLabel";
-import { DASHBOARD_DESCRIPTION_MAX_LENGTH } from "../constants";
+import {
+  DASHBOARD_DESCRIPTION_MAX_LENGTH,
+  DASHBOARD_NAME_MAX_LENGTH,
+} from "../constants";
 import { isVirtualDashCard } from "../utils";
 
 const DASHBOARD_SCHEMA = Yup.object({
   name: Yup.string()
     .required(Errors.required)
-    .max(100, Errors.maxLength)
+    .max(DASHBOARD_NAME_MAX_LENGTH, Errors.maxLength)
     .default(""),
   description: Yup.string()
     .nullable()

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardForm.tsx
@@ -20,12 +20,15 @@ import { useSelector } from "metabase/lib/redux";
 import { Button, Stack } from "metabase/ui";
 import type { CollectionId, Dashboard } from "metabase-types/api";
 
-import { DASHBOARD_DESCRIPTION_MAX_LENGTH } from "../constants";
+import {
+  DASHBOARD_DESCRIPTION_MAX_LENGTH,
+  DASHBOARD_NAME_MAX_LENGTH,
+} from "../constants";
 
 const DASHBOARD_SCHEMA = Yup.object({
   name: Yup.string()
     .required(Errors.required)
-    .max(100, Errors.maxLength)
+    .max(DASHBOARD_NAME_MAX_LENGTH, Errors.maxLength)
     .default(""),
   description: Yup.string()
     .nullable()

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -269,4 +269,14 @@ describe("DashboardApp", () => {
       dashboardSearchParams.get("dashboard_load_id"),
     );
   });
+
+  it("should not allow to enter a dashboard name longer than 254 characters", async () => {
+    await setup();
+
+    const input = await screen.findByPlaceholderText("Add title");
+    await userEvent.clear(input);
+    await userEvent.paste("A".repeat(256));
+
+    expect(input).toHaveValue("A".repeat(254));
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/60982

The actual BE constraint is 254 chars, so let's make it work like everywhere else.

Note - the dashboard layout, as well as the QB layout isn't looking great with long names.