### PR TITLE
Hide the filter button when there are no parameters

### DIFF
--- a/frontend/src/metabase/nav/components/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.unit.spec.tsx
@@ -1,4 +1,8 @@
-import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockMediaQueryList,
+  renderWithProviders,
+  screen,
+} from "__support__/ui";
 import { createMockUser } from "metabase-types/api/mocks";
 
 import type { AppBarProps } from "./AppBar";
@@ -31,7 +35,9 @@ describe("AppBar", () => {
 
   describe("large screens", () => {
     beforeEach(() => {
-      matchMediaSpy.mockReturnValue(getMediaQuery({ matches: false }));
+      matchMediaSpy.mockReturnValue(
+        createMockMediaQueryList({ matches: false }),
+      );
     });
 
     it("should render the desktop app bar", () => {
@@ -93,7 +99,9 @@ describe("AppBar", () => {
 
   describe("small screens", () => {
     beforeEach(() => {
-      matchMediaSpy.mockReturnValue(getMediaQuery({ matches: true }));
+      matchMediaSpy.mockReturnValue(
+        createMockMediaQueryList({ matches: true }),
+      );
     });
 
     it("should render the mobile app bar", () => {
@@ -159,17 +167,5 @@ const getProps = (opts?: Partial<AppBarProps>): AppBarProps => ({
   onToggleNavbar: jest.fn(),
   onCloseNavbar: jest.fn(),
   onLogout: jest.fn(),
-  ...opts,
-});
-
-const getMediaQuery = (opts?: Partial<MediaQueryList>): MediaQueryList => ({
-  media: "",
-  matches: false,
-  onchange: jest.fn(),
-  dispatchEvent: jest.fn(),
-  addListener: jest.fn(),
-  addEventListener: jest.fn(),
-  removeListener: jest.fn(),
-  removeEventListener: jest.fn(),
   ...opts,
 });

--- a/frontend/src/metabase/query_builder/components/ResponsiveParameterList.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParameterList.unit.spec.tsx
@@ -1,0 +1,89 @@
+import {
+  createMockMediaQueryList,
+  renderWithProviders,
+  screen,
+} from "__support__/ui";
+import { SAMPLE_METADATA } from "metabase-lib/test-helpers";
+import Question from "metabase-lib/v1/Question";
+import type { Parameter } from "metabase-types/api";
+import {
+  createMockNativeDatasetQuery,
+  createMockParameter,
+} from "metabase-types/api/mocks";
+
+import { ResponsiveParametersList } from "./ResponsiveParametersList";
+
+type SetupOpts = {
+  question?: Question;
+  parameters?: Parameter[];
+  enableParameterRequiredBehavior?: boolean;
+};
+
+function setup({
+  question = Question.create({
+    dataset_query: createMockNativeDatasetQuery(),
+    metadata: SAMPLE_METADATA,
+  }),
+  parameters = [],
+  enableParameterRequiredBehavior = false,
+}: SetupOpts) {
+  const setParameterValue = jest.fn();
+  const setParameterIndex = jest.fn();
+
+  renderWithProviders(
+    <ResponsiveParametersList
+      question={question}
+      parameters={parameters}
+      enableParameterRequiredBehavior={enableParameterRequiredBehavior}
+      setParameterValue={setParameterValue}
+      setParameterIndex={setParameterIndex}
+    />,
+  );
+
+  return { setParameterValue, setParameterIndex };
+}
+
+describe("ResponsiveParametersList", () => {
+  const matchMediaSpy = jest.spyOn(window, "matchMedia");
+
+  afterEach(() => {
+    matchMediaSpy.mockRestore();
+  });
+
+  describe("small screens", () => {
+    beforeEach(() => {
+      matchMediaSpy.mockReturnValue(
+        createMockMediaQueryList({ matches: true }),
+      );
+    });
+
+    it("should show the filter button when there are parameters", () => {
+      setup({ parameters: [createMockParameter()] });
+      expect(
+        screen.getByRole("button", { name: /Filters/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("should not show the filter button when there are no parameters", () => {
+      setup({ parameters: [] });
+      expect(
+        screen.queryByRole("button", { name: /Filters/ }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("large screens", () => {
+    beforeEach(() => {
+      matchMediaSpy.mockReturnValue(
+        createMockMediaQueryList({ matches: false }),
+      );
+    });
+
+    it("should not show the filter button for small screens when there are parameters", () => {
+      setup({ parameters: [createMockParameter()] });
+      expect(
+        screen.queryByRole("button", { name: /Filters/ }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
@@ -42,7 +42,7 @@ export const ResponsiveParametersList = ({
       w={isSmallScreen && mobileShowParameterList ? "100%" : undefined}
       style={{ alignSelf: "center" }}
     >
-      {isSmallScreen && (
+      {parameters.length > 0 && isSmallScreen && (
         <Button
           className={ResponsiveParametersListS.filterButton}
           borderless
@@ -66,7 +66,7 @@ export const ResponsiveParametersList = ({
           [ResponsiveParametersListS.isShowingMobile]: mobileShowParameterList,
         })}
       >
-        {isSmallScreen && (
+        {parameters.length > 0 && isSmallScreen && (
           <Flex p="0.75rem 1rem" align="center" justify="space-between">
             <h3>{t`Filters`}</h3>
             <Button

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -413,6 +413,23 @@ export function createMockClipboardData(
   return clipboardData as unknown as DataTransfer;
 }
 
+/**
+ * jsdom doesn't have MediaQueryList
+ */
+export const createMockMediaQueryList = (
+  opts?: Partial<MediaQueryList>,
+): MediaQueryList => ({
+  media: "",
+  matches: false,
+  onchange: jest.fn(),
+  dispatchEvent: jest.fn(),
+  addListener: jest.fn(),
+  addEventListener: jest.fn(),
+  removeListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  ...opts,
+});
+
 const ThemeProviderWrapper = ({
   children,
   ...props


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/58994

How to verify:
- New -> SQL -> `SELECT 1`
- Resize the window to make it small. See that there is no filter button now.

<img width="724" height="281" alt="Screenshot 2025-08-18 at 13 48 08" src="https://github.com/user-attachments/assets/9104e539-418d-4393-9d5f-0349130e0bd3" />
