### PR TITLE
Feat: UXW-495 Disable menu when in trash similar to dashboards

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentHeader.tsx
@@ -104,55 +104,57 @@ export const DocumentHeader = ({
             {t`Save`}
           </Button>
         )}
-        <Menu position="bottom-end">
-          <Menu.Target>
-            <ActionIcon
-              variant="subtle"
-              size="md"
-              aria-label={t`More options`}
-              data-hide-on-print
-            >
-              <Icon name="ellipsis" />
-            </ActionIcon>
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Item
-              leftSection={<Icon name="document" />}
-              onClick={handlePrint}
-            >
-              {t`Print Document`}
-            </Menu.Item>
-            {!isNewDocument && (
-              <>
-                {canWrite && (
-                  <Menu.Item
-                    leftSection={<Icon name="move" />}
-                    onClick={onMove}
-                  >
-                    {t`Move`}
-                  </Menu.Item>
-                )}
-                <Menu.Item
-                  leftSection={<Icon name={"bookmark"} />}
-                  onClick={onToggleBookmark}
-                >
-                  {isBookmarked ? t`Remove from Bookmarks` : t`Bookmark`}
-                </Menu.Item>
-                {canWrite && (
-                  <>
-                    <Menu.Divider />
+        {!document?.archived && (
+          <Menu position="bottom-end">
+            <Menu.Target>
+              <ActionIcon
+                variant="subtle"
+                size="md"
+                aria-label={t`More options`}
+                data-hide-on-print
+              >
+                <Icon name="ellipsis" />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown>
+              <Menu.Item
+                leftSection={<Icon name="document" />}
+                onClick={handlePrint}
+              >
+                {t`Print Document`}
+              </Menu.Item>
+              {!isNewDocument && (
+                <>
+                  {canWrite && (
                     <Menu.Item
-                      leftSection={<Icon name="trash" />}
-                      onClick={onArchive}
+                      leftSection={<Icon name="move" />}
+                      onClick={onMove}
                     >
-                      {t`Move to trash`}
+                      {t`Move`}
                     </Menu.Item>
-                  </>
-                )}
-              </>
-            )}
-          </Menu.Dropdown>
-        </Menu>
+                  )}
+                  <Menu.Item
+                    leftSection={<Icon name={"bookmark"} />}
+                    onClick={onToggleBookmark}
+                  >
+                    {isBookmarked ? t`Remove from Bookmarks` : t`Bookmark`}
+                  </Menu.Item>
+                  {canWrite && (
+                    <>
+                      <Menu.Divider />
+                      <Menu.Item
+                        leftSection={<Icon name="trash" />}
+                        onClick={onArchive}
+                      >
+                        {t`Move to trash`}
+                      </Menu.Item>
+                    </>
+                  )}
+                </>
+              )}
+            </Menu.Dropdown>
+          </Menu>
+        )}
       </Flex>
     </Flex>
   );

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentHeader.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentHeader.unit.spec.tsx
@@ -184,5 +184,12 @@ describe("DocumentHeader", () => {
       expect(screen.queryByText("Bookmark")).not.toBeInTheDocument();
       expect(screen.queryByText("Move to trash")).not.toBeInTheDocument();
     });
+
+    it("should not be present when document is archived", () => {
+      setup({
+        document: { ...defaultDocument, archived: true },
+      });
+      expect(screen.queryByLabelText("More options")).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Closes UXW-495

### Description

Hides document header menu when document is in trash

### How to verify

1. New document
2. Verify header (...) menu is present but only allows printing
3. Navigate to saved document
4. Verify header (...) menu is present and allows document operations (printing/moving/bookmarking/trashing)
5. Move document to trash
6. Verify header (...) menu is not present
7. Restore document
8. Verify header (...) menu is present and allows document operations

### Demo

https://github.com/user-attachments/assets/89926732-7bfc-4fef-aab4-eced8c4ae3cc

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
