### PR TITLE
enable set to default button

### DIFF
--- a/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts
+++ b/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.ts
@@ -31,7 +31,7 @@ export function getUpdateButtonProps(
     if (isDefaultValue || isEmpty) {
       return {
         label: getResetLabel(),
-        isDisabled: isDefaultValue,
+        isDisabled: isUnchanged,
       };
     }
 

--- a/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.unit.spec.ts
+++ b/frontend/src/metabase/parameters/components/UpdateFilterButton/getUpdateButtonProps.unit.spec.ts
@@ -39,10 +39,12 @@ describe("getUpdateButtonProps", () => {
   });
 
   describe("required parameters", () => {
-    it("without both values, shows reset", () => {
-      expect(getUpdateButtonProps([], [], ["CA", "WA"], true)).toStrictEqual({
+    it("when value equals unsaved equals default, shows disabled reset", () => {
+      expect(
+        getUpdateButtonProps(["CA", "WA"], ["CA", "WA"], ["CA", "WA"], true),
+      ).toStrictEqual({
         label: "Set to default",
-        isDisabled: false,
+        isDisabled: true,
       });
     });
 
@@ -52,6 +54,15 @@ describe("getUpdateButtonProps", () => {
       ).toStrictEqual({
         label: "Set to default",
         isDisabled: true,
+      });
+    });
+
+    it("when value is default but unsaved is empty, shows enabled reset", () => {
+      expect(
+        getUpdateButtonProps(["CA", "WA"], [], ["CA", "WA"], true),
+      ).toStrictEqual({
+        label: "Set to default",
+        isDisabled: false,
       });
     });
 
@@ -85,6 +96,15 @@ describe("getUpdateButtonProps", () => {
     it("when value does not equal default, and unsaved is empty, shows Set to default", () => {
       expect(
         getUpdateButtonProps(["WA"], [], ["CA", "WA"], true),
+      ).toStrictEqual({
+        label: "Set to default",
+        isDisabled: false,
+      });
+    });
+
+    it("when value is different from default and unsaved equals default, shows enabled reset", () => {
+      expect(
+        getUpdateButtonProps(["NY"], ["CA", "WA"], ["CA", "WA"], true),
       ).toStrictEqual({
         label: "Set to default",
         isDisabled: false,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62157

### Description

Enables dashboard filter apply `Set to default` button when a field has a default value and previously applied value is not it and the default value is now selected in the filter popover:
<img width="391" height="302" alt="Screenshot 2025-08-18 at 4 29 37 PM" src="https://github.com/user-attachments/assets/791de182-cea9-4603-bffb-38aedaa4f8d5" />

### How to verify

- Save Products table as a question
- Create a new dashboard, add the question
- Add a text filter, connect it to Category column. The filter should have a default value and be required.
- Save the dashboard
- Set a non-default value as a filter value and apply
- Ensure now when you open the filter popover and select the default value in it `Set to default` button is enabled

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
