### PR TITLE
Fix flaky header popover test

### DIFF
--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -135,6 +135,8 @@ export function visitQuestionAdhoc(
 ) {
   const questionMode = mode === "notebook" ? "/notebook" : "";
 
+  cy.intercept("POST", "/api/dataset/query_metadata").as("queryMetadata");
+
   const [url, alias] = getInterceptDetails(question, mode, autorun);
 
   cy.intercept(url).as(alias);
@@ -144,6 +146,7 @@ export function visitQuestionAdhoc(
   runQueryIfNeeded(question, autorun);
 
   if (mode !== "notebook" && !skipWaiting) {
+    cy.wait("@queryMetadata");
     return cy.wait("@" + alias).then((xhr) => callback && callback(xhr));
   }
 

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1467,7 +1467,7 @@ WHERE NOT (
   });
 });
 
-describe("issue 55673", { tags: "@flaky" }, () => {
+describe("issue 55673", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();


### PR DESCRIPTION
The tests were timing out waiting for `@dataset` aka `/api/dataset`. However, this call wasn't actually taking that long. The problem was that the wait was starting before the request actually fired, due to the metadata call blocking the dataset call.

I think this is a good example of how waiting on network calls has some footguns. My preference would be to simply wait for the table to become available in the UI. However, because this helper is used in a lot of places it's a bigger change.