### PR TITLE
fix: handle whitespaces in the connection string, decode username and password

### DIFF
--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/database-field-mapper.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/database-field-mapper.ts
@@ -391,7 +391,7 @@ export function mapFieldsToNestedObject(
  * @returns The semicolon-separated string.
  */
 function objectToString(
-  obj: Record<string, string> | undefined,
+  obj: Record<string, string | undefined> | undefined,
   filterProperties: Array<string> = [],
 ) {
   if (!obj) {

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.ts
@@ -197,6 +197,7 @@ export function parseConnectionUriRegex(
   }
 
   const regex = connectionStringRegexes[engineKey];
+  const trimmedString = connectionUri.trim();
 
   if (!regex) {
     return null;
@@ -204,14 +205,14 @@ export function parseConnectionUriRegex(
 
   // Some of engines have more than one matching regex
   const candidate: RegExp | undefined = Array.isArray(regex)
-    ? regex.find((r) => connectionUri.match(r))
+    ? regex.find((r) => trimmedString.match(r))
     : regex;
 
   if (!candidate) {
     return null;
   }
 
-  const match = connectionUri.trim().match(candidate);
+  const match = trimmedString.trim().match(candidate);
 
   if (match) {
     const params = match.groups?.params

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.ts
@@ -197,9 +197,12 @@ export function parseConnectionUriRegex(
   }
 
   const regex = connectionStringRegexes[engineKey];
+
   if (!regex) {
     return null;
   }
+
+  // Some of engines have more than one matching regex
   const candidate: RegExp | undefined = Array.isArray(regex)
     ? regex.find((r) => connectionUri.match(r))
     : regex;
@@ -207,7 +210,9 @@ export function parseConnectionUriRegex(
   if (!candidate) {
     return null;
   }
-  const match = connectionUri.match(candidate);
+
+  const match = connectionUri.trim().match(candidate);
+
   if (match) {
     const params = match.groups?.params
       ? Object.fromEntries(new URLSearchParams(match.groups.params))
@@ -215,6 +220,12 @@ export function parseConnectionUriRegex(
     const semicolonParams = mapSemicolonParams(match.groups?.semicolonParams);
     return {
       ...match.groups,
+      username: match.groups?.username
+        ? decodeURIComponent(match.groups.username)
+        : undefined,
+      password: match.groups?.password
+        ? decodeURIComponent(match.groups.password)
+        : undefined,
       params: params ?? semicolonParams,
       hasJdbcPrefix: Boolean(match.groups?.hasJdbcPrefix),
     };

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.unit.spec.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.unit.spec.ts
@@ -36,7 +36,7 @@ describe("parseConnectionUri - whitespace and encoding", () => {
     );
   });
 
-  it("should handle special characters in user pass", () => {
+  it("should handle special characters in username and password", () => {
     const connectionString =
       "postgres://me%40ry:pe%40ce%26lo%2F3@host:5432/dbname";
     const result = parseConnectionUriRegex(connectionString, "postgres");
@@ -48,6 +48,20 @@ describe("parseConnectionUri - whitespace and encoding", () => {
         database: "dbname",
         username: "me@ry",
         password: "pe@ce&lo/3",
+      }),
+    );
+  });
+
+  it("should handle malformed uri component", () => {
+    const connectionString = "postgres://me%ZZry@host:5432/dbname";
+    const result = parseConnectionUriRegex(connectionString, "postgres");
+    expect(result).toEqual(
+      expect.objectContaining({
+        protocol: "postgres",
+        host: "host",
+        port: "5432",
+        database: "dbname",
+        username: "me%ZZry",
       }),
     );
   });

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.unit.spec.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.unit.spec.ts
@@ -1,6 +1,58 @@
 import { enginesConfig } from "./engines-config";
 import { parseConnectionUriRegex } from "./parse-connection-regex";
 
+describe("parseConnectionUri - whitespace and encoding", () => {
+  it("should parse a connection string with whitespace", () => {
+    const connectionString =
+      " jdbc:mysql://user:pass@host:3306/dbname?ssl=true  ";
+    const result = parseConnectionUriRegex(connectionString, "mysql");
+    expect(result).toEqual(
+      expect.objectContaining({
+        protocol: "mysql",
+        host: "host",
+        port: "3306",
+        database: "dbname",
+        params: {
+          ssl: "true",
+        },
+      }),
+    );
+  });
+
+  it("should parse a connection string with new lines", () => {
+    const connectionString =
+      "\n\njdbc:mysql://user:pass@host:3306/dbname?ssl=true\n";
+    const result = parseConnectionUriRegex(connectionString, "mysql");
+    expect(result).toEqual(
+      expect.objectContaining({
+        protocol: "mysql",
+        host: "host",
+        port: "3306",
+        database: "dbname",
+        params: {
+          ssl: "true",
+        },
+      }),
+    );
+  });
+
+  it("should handle special characters in user pass", () => {
+    const connectionString =
+      "postgres://me%40ry:pe%40ce%26lo%2F3@host:5432/dbname";
+    const result = parseConnectionUriRegex(connectionString, "postgres");
+    expect(result).toEqual(
+      expect.objectContaining({
+        protocol: "postgres",
+        host: "host",
+        port: "5432",
+        database: "dbname",
+        username: "me@ry",
+        password: "pe@ce&lo/3",
+      }),
+    );
+  });
+});
+
 describe("parseConnectionUriRegex - Amazon Athena", () => {
   it("should parse a basic Amazon Athena connection string", () => {
     const connectionString = enginesConfig["athena"];


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-121/improve-handling-of-whitespace-and-encoded-segments-in-connection

### Description

- trim the connection string
- URI decode username and password matches

### How to verify

paste a connection string with leading whitespace - it should be handled correctly

```

postgres://postgres:example_password@localhost:5433/metabase
```
 
### Demo

https://www.loom.com/share/26f4f7ad2a29427aa997c46afdcd8f7a

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
