### PR TITLE
Build uberjar container image also when pushing a PR branch

### DIFF
--- a/.github/workflows/uberjar-containerize-labeled.yml
+++ b/.github/workflows/uberjar-containerize-labeled.yml
@@ -2,7 +2,7 @@ name: Uberjar Containerize labeled
 
 on:
   pull_request:
-    types: [ labeled ]
+    types: [ labeled, opened, synchronize, reopened ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,12 +10,12 @@ concurrency:
 
 jobs:
   uberjar:
-    if: ${{ github.event.label.name == 'build-docker-uberjar' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'build-docker-uberjar') || github.event.label.name == 'build-docker-uberjar' }}
     uses: ./.github/workflows/uberjar.yml
     secrets: inherit
 
   containerize:
     needs: [uberjar]
-    if: ${{ github.event.label.name == 'build-docker-uberjar' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'build-docker-uberjar') || github.event.label.name == 'build-docker-uberjar' }}
     uses: ./.github/workflows/containerize-uberjar.yml
     secrets: inherit


### PR DESCRIPTION
Before, it would only build when the `build-docker-uberjar` label was
added.  To build the latest commit you'd have to remove and re-add the
label.

Instead, also build the uberjar container image when the PR is
initially `opened` or later `reopened`, and when pushing commits
(`synchronized`).

Fixes: 22507a963a26c36c223d03ca94571e9e93a7cd0b
