### PR TITLE
WIP/Help Needed: Fix other column of row chart

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/other-series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/other-series.ts
@@ -83,10 +83,19 @@ export const getAggregatedOtherSeriesValue = (
   aggregationType: AggregationType = "sum",
   datum: Datum,
 ): number => {
-  const aggregation = AGGREGATION_FN_MAP[aggregationType];
   const values = seriesModels.map((model) =>
     checkNumber(datum[model.dataKey] ?? 0),
   );
+
+  return getAggregationByValues(values, aggregationType);
+};
+
+export const getAggregationByValues = (
+  values: number[],
+  aggregationType: AggregationType = "sum",
+): number => {
+  const aggregation = AGGREGATION_FN_MAP[aggregationType];
+
   return aggregation.fn(values);
 };
 

--- a/frontend/src/metabase/visualizations/shared/types/data.ts
+++ b/frontend/src/metabase/visualizations/shared/types/data.ts
@@ -1,5 +1,6 @@
 import type { DatasetColumn, RowValue, RowValues } from "metabase-types/api";
 
+// todo: SeriesInfo needs the aggregation type
 export type SeriesInfo = {
   metricColumn: DatasetColumn;
   dimensionColumn: DatasetColumn;


### PR DESCRIPTION
This references: https://github.com/metabase/metabase/issues/39146

The frontend is not calculating the "Other" column(s) correctly when there is an overflow. The reason is that we're not using the `AggregationType` and just defaulting to sum. 

The code I have in place _works_ but is not the real solution. 

### Help Wanted:
 When we get the dataset we map the rows from the db to columns. When we do this if there are 2 averages we map one to "avg" and the other to "avg_2" without any reference to its original aggregation type (clearly they're both of type "avg" but it would be nice to have this ON the metric object)

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

> Describe the overall approach and the problem being solved.

There is front end code that already takes a row of data and an aggregationType and returns the aggregatedValue. 
This solution takes all the rows that need to be grouped together, and makes a list of the values. Then uses the pre-existing function to calculate what the row value should be. 



### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
