### PR TITLE
Use MBQL lib for template tags

### DIFF
--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -699,7 +699,9 @@ class Question {
       return (
         q &&
         new Question(q.card(), this.metadata())
-          .setParameters(getTemplateTagParametersFromCard(q.card()))
+          .setParameters(
+            getTemplateTagParametersFromCard(q.card(), q.metadata()),
+          )
           .setDashboardProps({
             dashboardId: undefined,
             dashcardId: undefined,
@@ -879,7 +881,9 @@ class Question {
       return this;
     }
 
-    return this.setParameters(getTemplateTagParametersFromCard(this.card()));
+    return this.setParameters(
+      getTemplateTagParametersFromCard(this.card(), this.metadata()),
+    );
   }
 
   /**

--- a/frontend/src/metabase-lib/v1/parameters/utils/cards.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/cards.ts
@@ -14,7 +14,7 @@ export function getCardUiParameters(
   card: Card,
   metadata: Metadata,
   parameterValues: { [key: string]: any } = {},
-  parameters = getParametersFromCard(card),
+  parameters = getParametersFromCard(card, metadata),
   collectionPreview?: boolean,
 ): UiParameter[] {
   if (!card) {

--- a/frontend/src/metabase-lib/v1/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/template-tags.ts
@@ -1,5 +1,8 @@
 import _ from "underscore";
 
+import * as Lib from "metabase-lib";
+import Question from "metabase-lib/v1/Question";
+import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { ParameterWithTarget } from "metabase-lib/v1/parameters/types";
 import { getTemplateTagFromTarget } from "metabase-lib/v1/parameters/utils/targets";
 import type {
@@ -84,15 +87,16 @@ export function getTemplateTagParameters(
     .map((tag) => getTemplateTagParameter(tag, parametersById[tag.id]));
 }
 
-export function getTemplateTags(card: Card): TemplateTag[] {
-  return card?.dataset_query?.type === "native" &&
-    card.dataset_query.native["template-tags"]
-    ? Object.values(card.dataset_query.native["template-tags"])
-    : [];
+export function getTemplateTags(card: Card, metadata: Metadata): TemplateTag[] {
+  const question = new Question(card, metadata);
+  const query = question.query();
+  const { isNative } = Lib.queryDisplayInfo(query);
+  return isNative ? Object.values(Lib.templateTags(question.query())) : [];
 }
 
 export function getParametersFromCard(
   card: Card,
+  metadata: Metadata,
 ): Parameter[] | ParameterWithTarget[] {
   if (!card) {
     return [];
@@ -102,11 +106,14 @@ export function getParametersFromCard(
     return card.parameters;
   }
 
-  return getTemplateTagParametersFromCard(card);
+  return getTemplateTagParametersFromCard(card, metadata);
 }
 
-export function getTemplateTagParametersFromCard(card: Card) {
-  const tags = getTemplateTags(card);
+export function getTemplateTagParametersFromCard(
+  card: Card,
+  metadata: Metadata,
+) {
+  const tags = getTemplateTags(card, metadata);
   return getTemplateTagParameters(tags, card.parameters);
 }
 

--- a/frontend/src/metabase-lib/v1/parameters/utils/template-tags.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/template-tags.unit.spec.js
@@ -7,10 +7,6 @@ import { createMockTemplateTag } from "metabase-types/api/mocks";
 
 describe("parameters/utils/cards", () => {
   describe("getTemplateTags", () => {
-    it("should return an empty array for an invalid card", () => {
-      expect(getTemplateTags({})).toEqual([]);
-    });
-
     it("should return an empty array for a non-native query", () => {
       const card = {
         dataset_query: {

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
@@ -194,7 +194,10 @@ function QueryActionContextProvider({
 
   const handleQueryChange = useCallback((nextQuery: NativeQuery) => {
     const nextQuestion = nextQuery.question();
-    const parameters = getTemplateTagParametersFromCard(nextQuestion.card());
+    const parameters = getTemplateTagParametersFromCard(
+      nextQuestion.card(),
+      nextQuestion.metadata(),
+    );
     setQuestion(nextQuestion.setParameters(parameters));
   }, []);
 

--- a/frontend/src/metabase/lib/engine.ts
+++ b/frontend/src/metabase/lib/engine.ts
@@ -20,11 +20,10 @@ function formatJsonQuery(query: JSONQuery) {
   return JSON.stringify(query, null, 2);
 }
 
-export function formatNativeQuery(query?: string | JSONQuery, engine?: string) {
-  if (!query || !engine) {
-    return undefined;
-  }
-
+export function formatNativeQuery(
+  query: string | JSONQuery,
+  engine: string,
+): string {
   const engineType = getEngineNativeType(engine);
 
   if (typeof query === "string" && engineType === "sql") {
@@ -35,7 +34,7 @@ export function formatNativeQuery(query?: string | JSONQuery, engine?: string) {
     return typeof query === "object" ? formatJsonQuery(query) : query;
   }
 
-  return undefined;
+  return typeof query === "string" ? query : formatJsonQuery(query);
 }
 
 export function isDeprecatedEngine(
@@ -46,16 +45,13 @@ export function isDeprecatedEngine(
 }
 
 function formatSQL(sql: string) {
-  if (typeof sql === "string") {
-    sql = sql.replace(/\sFROM/, "\nFROM");
-    sql = sql.replace(/\sLEFT JOIN/, "\nLEFT JOIN");
-    sql = sql.replace(/\sWHERE/, "\nWHERE");
-    sql = sql.replace(/\sGROUP BY/, "\nGROUP BY");
-    sql = sql.replace(/\sORDER BY/, "\nORDER BY");
-    sql = sql.replace(/\sLIMIT/, "\nLIMIT");
-    sql = sql.replace(/\sAND\s/, "\n   AND ");
-    sql = sql.replace(/\sOR\s/, "\n    OR ");
-
-    return sql;
-  }
+  sql = sql.replace(/\sFROM/, "\nFROM");
+  sql = sql.replace(/\sLEFT JOIN/, "\nLEFT JOIN");
+  sql = sql.replace(/\sWHERE/, "\nWHERE");
+  sql = sql.replace(/\sGROUP BY/, "\nGROUP BY");
+  sql = sql.replace(/\sORDER BY/, "\nORDER BY");
+  sql = sql.replace(/\sLIMIT/, "\nLIMIT");
+  sql = sql.replace(/\sAND\s/, "\n   AND ");
+  sql = sql.replace(/\sOR\s/, "\n    OR ");
+  return sql;
 }

--- a/frontend/src/metabase/lib/engine.unit.spec.ts
+++ b/frontend/src/metabase/lib/engine.unit.spec.ts
@@ -37,46 +37,6 @@ describe("getNativeQueryLanguage", () => {
 });
 
 describe("formatNativeQuery", () => {
-  it("should return `undefined` when neither query nor engine are provided", () => {
-    expect(formatNativeQuery()).toBeUndefined();
-  });
-
-  it("should return `undefined` when the query exists, but engine is `undefined`", () => {
-    expect(formatNativeQuery("")).toBeUndefined();
-    expect(formatNativeQuery("select 1")).toBeUndefined();
-
-    expect(formatNativeQuery({})).toBeUndefined();
-    expect(formatNativeQuery([])).toBeUndefined();
-    expect(formatNativeQuery([{}, { a: 1 }])).toBeUndefined();
-  });
-
-  it("should return `undefined` when the query exists, but engine is an empty string", () => {
-    expect(formatNativeQuery("", "")).toBeUndefined();
-    expect(formatNativeQuery("select 1", "")).toBeUndefined();
-
-    expect(formatNativeQuery({}, "")).toBeUndefined();
-    expect(formatNativeQuery([], "")).toBeUndefined();
-    expect(formatNativeQuery([{}, { a: 1 }], "")).toBeUndefined();
-  });
-
-  it("should return `undefined` when engine is passed as the only argument", () => {
-    // Because parameters are positional, passing an engine as the only argument
-    // will be treated as a query, and the engine will be `undefined`.
-    expect(formatNativeQuery("mongo")).toBeUndefined();
-    expect(formatNativeQuery("postgres")).toBeUndefined();
-
-    expect(formatNativeQuery("mongo", "")).toBeUndefined();
-    expect(formatNativeQuery("postgres", "")).toBeUndefined();
-  });
-
-  it("should return `undefined` when the query and the engine don't match", () => {
-    expect(formatNativeQuery({}, "postgres")).toBeUndefined();
-    expect(formatNativeQuery([], "postgres")).toBeUndefined();
-    expect(formatNativeQuery([{}], "postgres")).toBeUndefined();
-    expect(formatNativeQuery({ a: 1 }, "postgres")).toBeUndefined();
-    expect(formatNativeQuery([{ a: 1 }], "postgres")).toBeUndefined();
-  });
-
   it("should return formatted SQL", () => {
     expect(formatNativeQuery("select 1", "postgres")).toEqual("select 1");
     expect(

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -119,7 +119,8 @@ export const PublicOrEmbeddedQuestion = ({
       return;
     }
 
-    const parameters = card.parameters || getParametersFromCard(card);
+    const parameters =
+      card.parameters || getParametersFromCard(card, metadataRef.current);
 
     try {
       setResult(null);

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
@@ -40,7 +40,10 @@ export const PreviewQueryModal = ({
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
 
   const engine = question.database()?.engine;
-  const formattedQuery = formatNativeQuery(data?.query, engine);
+  const formattedQuery =
+    data != null && engine != null
+      ? formatNativeQuery(data.query, engine)
+      : undefined;
   const formattedError = error ? getResponseErrorMessage(error) : undefined;
 
   return (

--- a/frontend/src/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/src/metabase/query_builder/selectors.unit.spec.js
@@ -16,8 +16,10 @@ import {
   createMockColumn,
   createMockDataset,
   createMockDatasetData,
+  createMockNativeQuery,
   createMockTable,
   createMockTableColumnOrderSetting,
+  createMockTemplateTag,
   createMockVisualizationSettings,
 } from "metabase-types/api/mocks";
 import {
@@ -257,7 +259,9 @@ describe("getIsResultDirty", () => {
 
   describe("native query", () => {
     function getCard(native) {
-      return getBaseCard({ dataset_query: { type: "native", native } });
+      return getBaseCard({
+        dataset_query: { type: "native", native },
+      });
     }
 
     function getState(lastRunCardQuery, cardQuery) {
@@ -274,8 +278,14 @@ describe("getIsResultDirty", () => {
 
     it("should be dirty if template-tags differ", () => {
       const state = getState(
-        { "template-tags": { foo: {} } },
-        { "template-tags": { bar: {} } },
+        createMockNativeQuery({
+          query: "SELECT {{foo}}",
+          "template-tags": { foo: createMockTemplateTag({ name: "foo" }) },
+        }),
+        createMockNativeQuery({
+          query: "SELECT {{bar}}",
+          "template-tags": { bar: createMockTemplateTag({ name: "bar" }) },
+        }),
       );
       expect(getIsResultDirty(state)).toBe(true);
     });

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
@@ -52,11 +52,15 @@ export const NotebookNativePreview = (): JSX.Element => {
   const showEmptySidebar = !canRun;
 
   const newQuestion = createNativeQuestion(question, data);
-  const newQuery = newQuestion.query();
+  const newQuery = newQuestion?.query();
 
   const handleConvertClick = useCallback(() => {
-    dispatch(updateQuestion(newQuestion, { shouldUpdateUrl: true, run: true }));
-    dispatch(setUIControls({ isNativeEditorOpen: true }));
+    if (newQuestion != null) {
+      dispatch(
+        updateQuestion(newQuestion, { shouldUpdateUrl: true, run: true }),
+      );
+      dispatch(setUIControls({ isNativeEditorOpen: true }));
+    }
   }, [newQuestion, dispatch]);
 
   const getErrorMessage = (error: unknown) =>
@@ -103,7 +107,7 @@ export const NotebookNativePreview = (): JSX.Element => {
             <Box mt="sm">{getErrorMessage(error)}</Box>
           </Flex>
         )}
-        {showQuery && <Editor query={newQuery} readOnly />}
+        {showQuery && newQuery != null && <Editor query={newQuery} readOnly />}
       </Flex>
       <Box ta="end" p="1.5rem">
         <Button

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/utils.ts
@@ -1,21 +1,27 @@
 import { formatNativeQuery } from "metabase/lib/engine";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { NativeDatasetResponse } from "metabase-types/api";
 
 export function createNativeQuestion(
   question: Question,
   response: NativeDatasetResponse | undefined,
-) {
+): Question | undefined {
   const database = question.database();
-  const query = formatNativeQuery(response?.query, database?.engine) ?? "";
+  if (response == null || database == null || database.engine == null) {
+    return;
+  }
 
-  return question.setDatasetQuery({
-    type: "native",
-    native: {
-      query,
-      "template-tags": {},
-      ...(response?.collection ? { collection: response.collection } : {}),
-    },
-    database: question.databaseId(),
-  });
+  const metadataProvider = Lib.metadataProvider(
+    database.id,
+    question.metadata(),
+  );
+  const rawQuery = formatNativeQuery(response.query, database.engine);
+  const newQuery = Lib.nativeQuery(database.id, metadataProvider, rawQuery);
+  const newQueryWithCollection =
+    response.collection != null
+      ? Lib.withNativeExtras(newQuery, { collection: response.collection })
+      : newQuery;
+
+  return question.setQuery(newQueryWithCollection);
 }


### PR DESCRIPTION
Converts two places that use `template-tags` directly to MBQL lib.