### PR TITLE
Fix: UXW-511 Up/down keys not functioning in a Document that contains detail views

### DIFF
--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.tsx
@@ -164,7 +164,7 @@ export function ObjectDetailView({
   });
 
   useEffect(() => {
-    if (hasNotFoundError) {
+    if (hasNotFoundError || !showControls) {
       return;
     }
 
@@ -185,6 +185,7 @@ export function ObjectDetailView({
     return () => window.removeEventListener("keydown", onKeyDown, true);
   }, [
     hasNotFoundError,
+    showControls,
     viewPreviousObjectDetail,
     viewNextObjectDetail,
     closeObjectDetail,

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
@@ -513,6 +513,44 @@ describe("ObjectDetailView", () => {
       "Are you sure you want to delete this row?",
     );
   });
+
+  describe("keyboard bindings", () => {
+    it("should be added when showControls is true", async () => {
+      const mockViewPreviousObjectDetail = jest.fn();
+      const mockViewNextObjectDetail = jest.fn();
+
+      setup({
+        question: mockQuestion,
+        showControls: true,
+        viewPreviousObjectDetail: mockViewPreviousObjectDetail,
+        viewNextObjectDetail: mockViewNextObjectDetail,
+      });
+
+      await userEvent.keyboard("{ArrowUp}");
+      expect(mockViewPreviousObjectDetail).toHaveBeenCalledTimes(1);
+
+      await userEvent.keyboard("{ArrowDown}");
+      expect(mockViewNextObjectDetail).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not be added when showControls is false", async () => {
+      const mockViewPreviousObjectDetail = jest.fn();
+      const mockViewNextObjectDetail = jest.fn();
+
+      setup({
+        question: mockQuestion,
+        showControls: false,
+        viewPreviousObjectDetail: mockViewPreviousObjectDetail,
+        viewNextObjectDetail: mockViewNextObjectDetail,
+      });
+
+      await userEvent.keyboard("{ArrowUp}");
+      expect(mockViewPreviousObjectDetail).not.toHaveBeenCalled();
+
+      await userEvent.keyboard("{ArrowDown}");
+      expect(mockViewNextObjectDetail).not.toHaveBeenCalled();
+    });
+  });
 });
 
 async function findActionInActionMenu({ name }: Pick<WritebackAction, "name">) {


### PR DESCRIPTION
Closes [UXW-511](https://linear.app/metabase/issue/UXW-511)

### Description

Only enables keyboard bindings in ObjectDetailView when its controls are shown.

AFAIK this is the only place the "controls" that `showControls` refers to are used:

<img width="1312" height="744" alt="Screenshot 2025-08-19 at 11 56 04 AM" src="https://github.com/user-attachments/assets/d7361fe6-a7b5-42be-9064-6e17cb6ee12c" />

So I think we _should_ be safe to disable the keyboard bindings whenever `showControls` is false, but lemme know if I'm missing anything. And that should fix up/down behavior for documents as well as dashboards that contain detail views.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Navigate to a new or existing document
2. Add a detail chart
3. Press down/up keys
4. Verify caret moves down/up
5. Navigate to a table view in the question editor, e.g. Sample Database > Accounts
6. Click an ID
7. Press down/up keys
8. Verify they function the same as the down/up buttons in the modal header

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
