### PR TITLE
feat(embed js flow): use widget for initial parameters

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
@@ -87,7 +87,8 @@ H.describeWithSnowplow(suiteTitle, () => {
       });
 
       cy.log("set default value for id");
-      getEmbedSidebar().findByLabelText("ID").type("123").blur();
+      getEmbedSidebar().findByLabelText("ID").type("123");
+      H.popover().findByText("Add filter").click();
 
       H.getSimpleEmbedIframeContent()
         .findByTestId("dashboard-parameters-widget-container")
@@ -95,7 +96,8 @@ H.describeWithSnowplow(suiteTitle, () => {
         .should("contain", "123");
 
       cy.log("set default value for product id");
-      getEmbedSidebar().findByLabelText("Product ID").type("456").blur();
+      getEmbedSidebar().findByLabelText("Product ID").type("456");
+      H.popover().findByText("Add filter").click();
 
       H.getSimpleEmbedIframeContent()
         .findByTestId("dashboard-parameters-widget-container")
@@ -114,8 +116,8 @@ H.describeWithSnowplow(suiteTitle, () => {
       getEmbedSidebar().within(() => {
         cy.findByText("Get Code").click();
         codeBlock().should("contain", "initial-parameters=");
-        codeBlock().should("contain", '"id":"123"');
-        codeBlock().should("contain", '"product_id":"456"');
+        codeBlock().should("contain", '"id":[123]');
+        codeBlock().should("contain", '"product_id":[456]');
       });
     });
 
@@ -189,7 +191,8 @@ H.describeWithSnowplow(suiteTitle, () => {
         .should("exist");
 
       getEmbedSidebar().within(() => {
-        cy.findByLabelText("ID").type("123").blur();
+        cy.findByLabelText("ID").type("123");
+        cy.press("Tab"); //.blur() doesn't easily work here
       });
 
       H.getSimpleEmbedIframeContent().within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
@@ -119,6 +119,15 @@ H.describeWithSnowplow(suiteTitle, () => {
         codeBlock().should("contain", '"id":[123]');
         codeBlock().should("contain", '"product_id":[456]');
       });
+
+      cy.get("metabase-dashboard")
+        .invoke("attr", "initial-parameters")
+        .then((attr) => {
+          expect(JSON.parse(attr!)).to.deep.equal({
+            id: [123],
+            product_id: [456],
+          });
+        });
     });
 
     it("can hide dashboard parameters", () => {
@@ -153,6 +162,12 @@ H.describeWithSnowplow(suiteTitle, () => {
         codeBlock().should("contain", '"id"');
         codeBlock().should("contain", '"product_id"');
       });
+
+      cy.get("metabase-dashboard")
+        .invoke("attr", "hidden-parameters")
+        .then((attr) => {
+          expect(JSON.parse(attr!)).to.have.members(["id", "product_id"]);
+        });
     });
   });
 
@@ -214,6 +229,12 @@ H.describeWithSnowplow(suiteTitle, () => {
         codeBlock().should("not.contain", "hidden-parameters="); // not supported for questions yet
         codeBlock().should("contain", '"id":"123"');
       });
+
+      cy.get("metabase-question")
+        .invoke("attr", "initial-sql-parameters")
+        .then((attr) => {
+          expect(JSON.parse(attr!)).to.deep.equal({ id: "123" });
+        });
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ParameterSettings/ParameterSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ParameterSettings/ParameterSettings.tsx
@@ -67,10 +67,7 @@ export const ParameterSettings = () => {
         parameters: availableParameters,
         values: parameterValues,
         defaultRequired: true,
-      }).map((param) => ({
-        ...param,
-        value: parameterValues?.[param.slug] ?? param.value,
-      })),
+      }),
     [availableParameters, parameterValues],
   );
 
@@ -100,10 +97,7 @@ export const ParameterSettings = () => {
                 updateInitialParameterValue(parameter.slug, value)
               }
               setParameterValueToDefault={() => {
-                updateInitialParameterValue(
-                  parameter.slug,
-                  parameter.default as any,
-                );
+                updateInitialParameterValue(parameter.slug, parameter.default);
               }}
               enableParameterRequiredBehavior
             />

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ParameterSettings/ParameterSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ParameterSettings/ParameterSettings.tsx
@@ -94,10 +94,10 @@ export const ParameterSettings = () => {
               parameter={parameter}
               parameters={uiParameters}
               setValue={(value: string) =>
-                updateInitialParameterValue(parameter.slug, value)
+                updateInitialParameterValue(parameter.id, value)
               }
               setParameterValueToDefault={() => {
-                updateInitialParameterValue(parameter.slug, parameter.default);
+                updateInitialParameterValue(parameter.id, parameter.default);
               }}
               enableParameterRequiredBehavior
             />

--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -92,7 +92,6 @@ export const updateFieldValues = (fieldId, fieldValuePairs) => {
 
 export { ADD_FIELDS } from "metabase/entities/fields";
 export const addFields = (fields) => {
-  deprecated("metabase/redux/metadata addFields");
   return Fields.actions.addFields(fields);
 };
 


### PR DESCRIPTION
Closes EMB-708

This changes the embed flow for embed-js the real widgets with dropdowns etc instead of using plain text inputs for the initial filters.

## How to verify:
- go to the embed js flow (`/embed-js` or "+new -> embed")
- select a dashboard, press next until you see the filters

## Demo
<img width="783" height="1160" alt="image" src="https://github.com/user-attachments/assets/eb89fe89-3af5-41b8-ae9d-c632fd421866" />
<img width="505" height="794" alt="image" src="https://github.com/user-attachments/assets/ca43249a-5249-4326-ba01-77543dd1d4c8" />
