### PR TITLE
Feat: UXW-522 Document names should populate the title attribute for the page

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -22,6 +22,7 @@ describe("documents", () => {
     cy.visit("/");
 
     H.newButton("Document").click();
+    cy.title().should("eq", "New document · Metabase");
 
     cy.findByRole("textbox", { name: "Document Title" })
       .should("be.focused")
@@ -39,6 +40,7 @@ describe("documents", () => {
     );
     H.entityPickerModalItem(1, "First collection").click();
     H.entityPickerModal().findByRole("button", { name: "Select" }).click();
+    cy.title().should("eq", "Test Document · Metabase");
 
     H.appBar()
       .findByRole("link", { name: /First collection/ })

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -20,6 +20,7 @@ import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmM
 import { CollectionPickerModal } from "metabase/common/components/Pickers/CollectionPicker";
 import { useToast } from "metabase/common/hooks";
 import { useCallbackEffect } from "metabase/common/hooks/use-callback-effect";
+import { SetTitle } from "metabase/hoc/Title";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { extractEntityId } from "metabase/lib/urls";
 import { setErrorPage } from "metabase/redux/app";
@@ -364,6 +365,7 @@ export const DocumentPage = ({
 
   return (
     <Box className={styles.documentPage}>
+      <SetTitle title={documentData?.name || t`New document`} />
       {documentData?.archived && <DocumentArchivedEntityBanner />}
       <Box className={styles.contentArea}>
         <Box className={styles.mainContent}>

--- a/frontend/src/metabase/hoc/Title.jsx
+++ b/frontend/src/metabase/hoc/Title.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { Component, cloneElement } from "react";
+import { Component, cloneElement, memo } from "react";
 import { Route as _Route } from "react-router";
 import _ from "underscore";
 
@@ -78,12 +78,12 @@ export default title;
 
 /**
  * Component version of the title HOC
- * @param {string} props.title
+ * @type {(props: { title: string }) => ReactNode}
  */
-export const SetTitle = (props) => {
+export const SetTitle = memo(function SetTitle(props) {
   const Component = title(props.title)(() => null);
   return <Component />;
-};
+});
 
 SetTitle.propTypes = {
   title: PropTypes.string,


### PR DESCRIPTION
Closes [UXW-522](https://linear.app/metabase/issue/UXW-522)

### Description

Uses `SetTitle` component to update page title with document name.

### How to verify

Verify page title matches saved document name (or includes "New document" if new).

### Demo

https://github.com/user-attachments/assets/4396ffd6-14c2-4b4d-aae4-7e7acca67025

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
