### PR TITLE
Add the metabase-browser experience to embed flow

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -78,7 +78,7 @@ type NavigateToStepOptions =
       resourceName?: never;
     }
   | {
-      experience: "dashboard" | "chart";
+      experience: "dashboard" | "chart" | "browser";
       dismissEmbedTerms?: boolean;
       resourceName: string;
     };
@@ -96,6 +96,8 @@ export const navigateToEntitySelectionStep = (
     cy.findByText("Chart").click();
   } else if (experience === "exploration") {
     cy.findByText("Exploration").click();
+  } else if (experience === "browser") {
+    cy.findByText("Browser").click();
   }
 
   // exploration template does not have the entity selection step
@@ -112,6 +114,7 @@ export const navigateToEntitySelectionStep = (
     const resourceType = match(experience)
       .with("dashboard", () => "Dashboards")
       .with("chart", () => "Questions")
+      .with("browser", () => "Collections")
       .otherwise(() => "");
 
     cy.log(`searching for ${resourceType} via the picker modal`);
@@ -122,6 +125,11 @@ export const navigateToEntitySelectionStep = (
     entityPickerModal().within(() => {
       cy.findByText(resourceType).click();
       cy.findAllByText(resourceName).first().click();
+
+      // Collection picker requires an explicit confirmation.
+      if (experience === "browser") {
+        cy.findByText("Select").click();
+      }
     });
 
     cy.log(`${resourceType} title should be visible by default`);

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -317,7 +317,7 @@ H.describeWithSnowplow(suiteTitle, () => {
         cy.findByTestId("embed-recent-item-card").should("not.exist");
         cy.findByText("No recent collections").should("be.visible");
 
-        cy.findByText(/search for collections/).click();
+        cy.findByTitle("Browse collections").click();
       });
 
       H.entityPickerModal().within(() => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -237,29 +237,25 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     H.entityPickerModal().within(() => {
       cy.findByText("Select a collection").should("be.visible");
-      cy.findByText("Our analytics").click();
+      cy.findByText("First collection").click();
       cy.findByText("Select").click();
     });
 
-    H.expectUnstructuredSnowplowEvent({
-      event: "embed_wizard_resource_selected",
-      target_id: 1,
-      event_detail: "browser",
-    });
-
-    cy.log(
-      "collection is added to recents list and browser shows collection content",
-    );
+    cy.log("collection is added to recents list");
     getEmbedSidebar().within(() => {
       getRecentItemCards()
-        .should("have.length", 1)
-        .first()
-        .should("contain", "Our analytics")
+        .should("contain", "First collection")
         .should("have.attr", "data-selected", "true");
     });
 
+    cy.log("collection is shown in the breadcrumbs and preview");
     H.getSimpleEmbedIframeContent().within(() => {
-      cy.findAllByText("Our analytics").first().should("be.visible");
+      cy.findByTestId("sdk-breadcrumbs")
+        .findAllByText("First collection")
+        .first()
+        .should("be.visible");
+
+      cy.findByText("Second collection").should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -99,11 +99,15 @@ H.describeWithSnowplow(suiteTitle, () => {
         event_detail: "browser",
       });
 
-      H.waitForSimpleEmbedIframesToLoad();
-
       H.getSimpleEmbedIframeContent().within(() => {
-        cy.log("collection browser is visible");
-        cy.findAllByText("Our analytics").first().should("be.visible");
+        cy.log("collection is visible in breadcrumbs");
+        cy.findByTestId("sdk-breadcrumbs")
+          .findAllByText("Our analytics")
+          .first()
+          .should("be.visible");
+
+        cy.log("collection is visible in browser");
+        cy.findAllByText("Orders in a dashboard").should("be.visible");
       });
     });
   });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -89,6 +89,23 @@ H.describeWithSnowplow(suiteTitle, () => {
         cy.findByText("Pick your starting data").should("be.visible");
       });
     });
+
+    it("shows browser template when selected", () => {
+      visitNewEmbedPage();
+      getEmbedSidebar().findByText("Browser").click();
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "embed_wizard_experience_selected",
+        event_detail: "browser",
+      });
+
+      H.waitForSimpleEmbedIframesToLoad();
+
+      H.getSimpleEmbedIframeContent().within(() => {
+        cy.log("collection browser is visible");
+        cy.findAllByText("Our analytics").first().should("be.visible");
+      });
+    });
   });
 
   describe("select embed experiences with an empty activity log", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -322,24 +322,19 @@ H.describeWithSnowplow(suiteTitle, () => {
     codeBlock().should("contain", 'is-save-enabled="true"');
   });
 
-  it("shows read-only option checked by default for browser", () => {
-    navigateToEmbedOptionsStep({ experience: "browser" });
+  it("can toggle read-only setting for browser", () => {
+    navigateToEmbedOptionsStep({
+      experience: "browser",
+      resourceName: "First collection",
+    });
 
     getEmbedSidebar()
       .findByLabelText("Allow editing dashboards and questions")
       .should("not.be.checked");
 
-    cy.log(
-      "New Dashboard and New Exploration buttons should not be visible by default",
-    );
     H.getSimpleEmbedIframeContent().within(() => {
       cy.findByText("New Dashboard").should("not.exist");
-      cy.findByText("New Exploration").should("not.exist");
     });
-  });
-
-  it("toggles editing permissions for browser", () => {
-    navigateToEmbedOptionsStep({ experience: "browser" });
 
     cy.log("turn on editing (set read-only to false)");
     getEmbedSidebar()
@@ -354,7 +349,6 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     H.getSimpleEmbedIframeContent().within(() => {
       cy.findByText("New Dashboard").should("be.visible");
-      cy.findByText("New Exploration").should("be.visible");
     });
 
     cy.log("snippet should be updated");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -322,6 +322,46 @@ H.describeWithSnowplow(suiteTitle, () => {
     codeBlock().should("contain", 'is-save-enabled="true"');
   });
 
+  it("shows read-only option checked by default for browser", () => {
+    navigateToEmbedOptionsStep({ experience: "browser" });
+
+    getEmbedSidebar()
+      .findByLabelText("Allow editing dashboards and questions")
+      .should("not.be.checked");
+
+    cy.log(
+      "New Dashboard and New Exploration buttons should not be visible by default",
+    );
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByText("New Dashboard").should("not.exist");
+      cy.findByText("New Exploration").should("not.exist");
+    });
+  });
+
+  it("toggles editing permissions for browser", () => {
+    navigateToEmbedOptionsStep({ experience: "browser" });
+
+    cy.log("turn on editing (set read-only to false)");
+    getEmbedSidebar()
+      .findByLabelText("Allow editing dashboards and questions")
+      .click()
+      .should("be.checked");
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "embed_wizard_option_changed",
+      event_detail: "readOnly",
+    });
+
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByText("New Dashboard").should("be.visible");
+      cy.findByText("New Exploration").should("be.visible");
+    });
+
+    cy.log("snippet should be updated");
+    getEmbedSidebar().findByText("Get Code").click();
+    codeBlock().should("contain", 'read-only="false"');
+  });
+
   it("can change brand color and reset colors", () => {
     navigateToEmbedOptionsStep({
       experience: "dashboard",

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -89,7 +89,8 @@ const SdkIframeEmbedView = ({
         componentName: "metabase-browser",
       },
       (settings) => (
-        <SdkBreadcrumbsProvider>
+        // re-mount breadcrumbs when initial collection changes
+        <SdkBreadcrumbsProvider key={settings.initialCollection}>
           <MetabaseBrowser settings={settings} />
         </SdkBreadcrumbsProvider>
       ),
@@ -155,11 +156,28 @@ const SdkIframeEmbedView = ({
             {...commonProps}
             isSaveEnabled={settings.isSaveEnabled ?? false}
             key={rerenderKey}
-            targetCollection={settings.targetCollection}
-            entityTypes={settings.entityTypes}
           />
         );
       },
+    )
+    .with(
+      {
+        componentName: "metabase-dashboard",
+        dashboardId: P.nonNullable,
+        drills: P.optional(true),
+      },
+      (settings) => (
+        <InteractiveDashboard
+          dashboardId={settings.dashboardId}
+          withTitle={settings.withTitle}
+          withDownloads={settings.withDownloads}
+          initialParameters={settings.initialParameters}
+          hiddenParameters={settings.hiddenParameters}
+          drillThroughQuestionHeight="100%"
+          drillThroughQuestionProps={{ isSaveEnabled: false }}
+          key={rerenderKey}
+        />
+      ),
     )
     .otherwise(() => null);
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -156,28 +156,11 @@ const SdkIframeEmbedView = ({
             {...commonProps}
             isSaveEnabled={settings.isSaveEnabled ?? false}
             key={rerenderKey}
+            targetCollection={settings.targetCollection}
+            entityTypes={settings.entityTypes}
           />
         );
       },
-    )
-    .with(
-      {
-        componentName: "metabase-dashboard",
-        dashboardId: P.nonNullable,
-        drills: P.optional(true),
-      },
-      (settings) => (
-        <InteractiveDashboard
-          dashboardId={settings.dashboardId}
-          withTitle={settings.withTitle}
-          withDownloads={settings.withDownloads}
-          initialParameters={settings.initialParameters}
-          hiddenParameters={settings.hiddenParameters}
-          drillThroughQuestionHeight="100%"
-          drillThroughQuestionProps={{ isSaveEnabled: false }}
-          key={rerenderKey}
-        />
-      ),
     )
     .otherwise(() => null);
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/constants.ts
@@ -1,4 +1,5 @@
 import type {
+  BrowserEmbedOptions,
   DashboardEmbedOptions,
   ExplorationEmbedOptions,
   QuestionEmbedOptions,
@@ -46,6 +47,16 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "targetCollection",
     "entityTypes",
   ] satisfies (keyof ExplorationEmbedOptions)[],
+  browser: [
+    "initialCollection",
+    "readOnly",
+    "collectionVisibleColumns",
+    "collectionEntityTypes",
+    "collectionPageSize",
+    "dataPickerEntityTypes",
+    "withNewQuestion",
+    "withNewDashboard",
+  ] satisfies (keyof BrowserEmbedOptions)[],
 };
 
 // This file is used by embed.js, so we shouldn't import external dependencies.
@@ -56,6 +67,7 @@ export const ALLOWED_EMBED_SETTING_KEYS = uniq([
   ...ALLOWED_EMBED_SETTING_KEYS_MAP.dashboard,
   ...ALLOWED_EMBED_SETTING_KEYS_MAP.chart,
   ...ALLOWED_EMBED_SETTING_KEYS_MAP.exploration,
+  ...ALLOWED_EMBED_SETTING_KEYS_MAP.browser,
 ]) satisfies SdkIframeEmbedSettingKey[];
 
 export type AllowedEmbedSettingKey =

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/ColorCustomizationSection.tsx
@@ -57,7 +57,7 @@ export const ColorCustomizationSection = ({
         )}
       </Group>
 
-      <Group align="start" gap="xl" mb="lg">
+      <Group align="start" gap="xl">
         {getConfigurableThemeColors().map(({ key, name, originalColorKey }) => {
           // Use the default from appearance settings. If not set, use the default Metabase color.
           const originalColor =

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -128,9 +128,6 @@ export const SdkIframeEmbedPreview = () => {
               : undefined,
           }),
         )
-<<<<<<< HEAD
-        .with({ componentName: "metabase-browser" }, () => null)
-=======
         .with({ componentName: "metabase-browser" }, (s) =>
           createElement("metabase-browser", {
             "read-only": s.readOnly,
@@ -140,7 +137,6 @@ export const SdkIframeEmbedPreview = () => {
               : undefined,
           }),
         )
->>>>>>> 3b0e5b76ce9 (add metabase-browser option to embed flow)
         .exhaustive()}
     </Card>
   );

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -1,4 +1,3 @@
-//
 import { createElement, useCallback, useEffect, useMemo } from "react";
 import { useSearchParam } from "react-use";
 import { match } from "ts-pattern";
@@ -129,7 +128,19 @@ export const SdkIframeEmbedPreview = () => {
               : undefined,
           }),
         )
+<<<<<<< HEAD
         .with({ componentName: "metabase-browser" }, () => null)
+=======
+        .with({ componentName: "metabase-browser" }, (s) =>
+          createElement("metabase-browser", {
+            "read-only": s.readOnly,
+            "initial-collection": s.initialCollection,
+            "collection-visible-columns": s.collectionVisibleColumns
+              ? JSON.stringify(s.collectionVisibleColumns)
+              : undefined,
+          }),
+        )
+>>>>>>> 3b0e5b76ce9 (add metabase-browser option to embed flow)
         .exhaustive()}
     </Card>
   );

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -5,7 +5,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { P, match } from "ts-pattern";
+import { match } from "ts-pattern";
 import _ from "underscore";
 
 import { useUserSetting } from "metabase/common/hooks";
@@ -42,8 +42,13 @@ export const SdkIframeEmbedSetupProvider = ({
 
   // We don't want to re-fetch the recent items every time we switch between
   // steps, therefore we load recent items once in the provider.
-  const { recentDashboards, recentQuestions, addRecentItem, isRecentsLoading } =
-    useRecentItems();
+  const {
+    recentDashboards,
+    recentQuestions,
+    recentCollections,
+    addRecentItem,
+    isRecentsLoading,
+  } = useRecentItems();
 
   const defaultSettings = useMemo(() => {
     return getDefaultSdkIframeEmbedSettings(
@@ -65,8 +70,10 @@ export const SdkIframeEmbedSetupProvider = ({
         settings,
       )
         .with({ template: "exploration" }, () => "exploration")
-        .with({ questionId: P.nonNullable }, () => "chart")
-        .otherwise(() => "dashboard"),
+        .with({ componentName: "metabase-question" }, () => "chart")
+        .with({ componentName: "metabase-browser" }, () => "browser")
+        .with({ componentName: "metabase-dashboard" }, () => "dashboard")
+        .exhaustive(),
     [settings],
   );
 
@@ -119,6 +126,7 @@ export const SdkIframeEmbedSetupProvider = ({
     updateSettings,
     recentDashboards,
     recentQuestions,
+    recentCollections,
     addRecentItem,
     isEmbedSettingsLoaded,
     isLoadingParameters,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedExperienceStep.tsx
@@ -7,9 +7,9 @@ import { ALLOWED_EMBED_SETTING_KEYS_MAP } from "metabase-enterprise/embedding_if
 
 import { trackEmbedWizardExperienceSelected } from "../analytics";
 import {
-  EMBED_EXPERIENCES,
   EMBED_FALLBACK_DASHBOARD_ID,
   EMBED_FALLBACK_QUESTION_ID,
+  getEmbedExperiences,
 } from "../constants";
 import { useSdkIframeEmbedSetupContext } from "../context";
 import type { SdkIframeEmbedSetupExperience } from "../types";
@@ -43,6 +43,7 @@ export const SelectEmbedExperienceStep = () => {
         () => recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID,
       )
       .with("exploration", () => 0) // resource id does not apply
+      .with("browser", () => 0) // resource id does not apply
       .exhaustive();
 
     replaceSettings({
@@ -69,7 +70,7 @@ export const SelectEmbedExperienceStep = () => {
         }
       >
         <Stack gap="md">
-          {EMBED_EXPERIENCES.map((experience) => (
+          {getEmbedExperiences().map((experience) => (
             <Radio
               key={experience.value}
               value={experience.value}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedOptionsStep.tsx
@@ -20,6 +20,7 @@ export const SelectEmbedOptionsStep = () => {
     (experience === "chart" && settings.questionId);
 
   const isExplorationEmbed = settings.template === "exploration";
+  const isBrowserEmbed = settings.componentName === "metabase-browser";
 
   const updateColors = useCallback(
     (nextColors: Partial<MetabaseColors>) => {
@@ -66,6 +67,14 @@ export const SelectEmbedOptionsStep = () => {
               }
             />
           )}
+
+          {isBrowserEmbed && (
+            <Checkbox
+              label={t`Allow editing dashboards and questions`}
+              checked={!settings.readOnly}
+              onChange={(e) => updateSettings({ readOnly: !e.target.checked })}
+            />
+          )}
         </Stack>
       </Card>
 
@@ -94,7 +103,7 @@ export const SelectEmbedOptionsStep = () => {
 
         {isQuestionOrDashboardEmbed && (
           <>
-            <Divider mb="md" />
+            <Divider mt="lg" mb="md" />
 
             <Checkbox
               label={t`Show ${experience} title`}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceMissingRecents.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceMissingRecents.tsx
@@ -1,7 +1,7 @@
 import { match } from "ts-pattern";
 import { c, t } from "ttag";
 
-import { Anchor, Icon, Stack, Text } from "metabase/ui";
+import { Anchor, Icon, type IconName, Stack, Text } from "metabase/ui";
 
 import type { SdkIframeEmbedSetupExperience } from "../types";
 
@@ -12,7 +12,10 @@ export const SelectEmbedResourceMissingRecents = ({
   experience: SdkIframeEmbedSetupExperience;
   openPicker: () => void;
 }) => {
-  const embedIcon = experience === "dashboard" ? "dashboard" : "bar";
+  const embedIcon = match<SdkIframeEmbedSetupExperience, IconName>(experience)
+    .with("dashboard", () => "dashboard")
+    .with("browser", () => "collection")
+    .otherwise(() => "bar");
 
   return (
     <Stack
@@ -40,16 +43,18 @@ export const SelectEmbedResourceMissingRecents = ({
   );
 };
 
-const getEmptyStateTitle = (experience: string) =>
+const getEmptyStateTitle = (experience: SdkIframeEmbedSetupExperience) =>
   match(experience)
     .with("dashboard", () => t`No recent dashboards`)
     .with("chart", () => t`No recent charts`)
+    .with("browser", () => t`No recent collections`)
     .otherwise(() => null);
 
 const getEmptyStateDescription = (experience: SdkIframeEmbedSetupExperience) =>
   match(experience)
     .with("dashboard", () => t`You haven't visited any dashboards recently.`)
     .with("chart", () => t`You haven't visited any charts recently.`)
+    .with("browser", () => t`You haven't visited any collections recently.`)
     .otherwise(() => null);
 
 const getSearchLink = (

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceRecentItemCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceRecentItemCard.tsx
@@ -53,4 +53,6 @@ const getCardIcon = (experience: SdkIframeEmbedSetupExperience): IconName =>
   match<SdkIframeEmbedSetupExperience, IconName>(experience)
     .with("chart", () => "bar")
     .with("dashboard", () => "dashboard")
-    .otherwise(() => "bar");
+    .with("browser", () => "collection")
+    .with("exploration", () => "question") // not possible
+    .exhaustive();

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceStep.tsx
@@ -66,7 +66,12 @@ export const SelectEmbedResourceStep = () => {
       return;
     }
 
-    trackEmbedWizardResourceSelected(Number(id), experience);
+    const numericResourceId = typeof id === "string" ? parseInt(id) : id;
+
+    // Only track the resource id if it is a valid numeric id.
+    if (!isNaN(numericResourceId)) {
+      trackEmbedWizardResourceSelected(numericResourceId, experience);
+    }
 
     if (experience === "dashboard") {
       updateSettings({

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
@@ -1,3 +1,5 @@
+import { t } from "ttag";
+
 import { GetCodeStep } from "./components/GetCodeStep";
 import { SelectEmbedExperienceStep } from "./components/SelectEmbedExperienceStep";
 import { SelectEmbedOptionsStep } from "./components/SelectEmbedOptionsStep";
@@ -10,23 +12,33 @@ import type {
 /** The maximum number of recent items to show in the resource selection step. */
 export const EMBED_RESOURCE_LIST_MAX_RECENTS = 6;
 
-export const EMBED_EXPERIENCES = [
-  {
-    value: "dashboard" as SdkIframeEmbedSetupExperience,
-    title: "Dashboard",
-    description: "Embed an entire dashboard with multiple charts and filters",
-  },
-  {
-    value: "chart" as SdkIframeEmbedSetupExperience,
-    title: "Chart",
-    description: "Embed a single chart or visualization",
-  },
-  {
-    value: "exploration" as SdkIframeEmbedSetupExperience,
-    title: "Exploration",
-    description: "Embed an interactive data exploration experience",
-  },
-];
+export const getEmbedExperiences = () =>
+  [
+    {
+      value: "dashboard",
+      title: t`Dashboard`,
+      description: `Embed an entire dashboard with multiple charts and filters`,
+    },
+    {
+      value: "chart",
+      title: t`Chart`,
+      description: t`Embed a single chart or visualization`,
+    },
+    {
+      value: "exploration",
+      title: "Exploration",
+      description: "Embed an interactive data exploration experience",
+    },
+    {
+      value: "browser",
+      title: t`Browser`,
+      description: t`Embed a browser to manage dashboards and questions`,
+    },
+  ] satisfies {
+    title: string;
+    description: string;
+    value: SdkIframeEmbedSetupExperience;
+  }[];
 
 type EmbedStepConfig = {
   id: SdkIframeEmbedSetupStep;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/constants.ts
@@ -17,7 +17,7 @@ export const getEmbedExperiences = () =>
     {
       value: "dashboard",
       title: t`Dashboard`,
-      description: `Embed an entire dashboard with multiple charts and filters`,
+      description: t`Embed an entire dashboard with multiple charts and filters`,
     },
     {
       value: "chart",
@@ -26,8 +26,8 @@ export const getEmbedExperiences = () =>
     },
     {
       value: "exploration",
-      title: "Exploration",
-      description: "Embed an interactive data exploration experience",
+      title: t`Exploration`,
+      description: t`Embed an interactive data exploration experience`,
     },
     {
       value: "browser",

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/context.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/context.ts
@@ -24,8 +24,9 @@ export interface SdkIframeEmbedSetupContextType {
   // Recent items
   recentDashboards: SdkIframeEmbedSetupRecentItem[];
   recentQuestions: SdkIframeEmbedSetupRecentItem[];
+  recentCollections: SdkIframeEmbedSetupRecentItem[];
   addRecentItem: (
-    type: "dashboard" | "question",
+    type: "dashboard" | "question" | "collection",
     recentItem: SdkIframeEmbedSetupRecentItem,
   ) => void;
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/context.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/context.ts
@@ -5,6 +5,7 @@ import type { Parameter } from "metabase-types/api";
 import type {
   SdkIframeEmbedSetupExperience,
   SdkIframeEmbedSetupRecentItem,
+  SdkIframeEmbedSetupRecentItemType,
   SdkIframeEmbedSetupSettings,
   SdkIframeEmbedSetupStep,
 } from "./types";
@@ -26,7 +27,7 @@ export interface SdkIframeEmbedSetupContextType {
   recentQuestions: SdkIframeEmbedSetupRecentItem[];
   recentCollections: SdkIframeEmbedSetupRecentItem[];
   addRecentItem: (
-    type: "dashboard" | "question" | "collection",
+    type: SdkIframeEmbedSetupRecentItemType,
     recentItem: SdkIframeEmbedSetupRecentItem,
   ) => void;
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
@@ -16,6 +16,11 @@ export type SdkIframeEmbedSetupStep =
   | "select-embed-options"
   | "get-code";
 
+export type SdkIframeEmbedSetupRecentItemType =
+  | "dashboard"
+  | "question"
+  | "collection";
+
 export type SdkIframeEmbedSetupRecentItem = Pick<
   BaseRecentItem,
   "name" | "description"

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/types.ts
@@ -7,7 +7,8 @@ import type { BaseRecentItem } from "metabase-types/api";
 export type SdkIframeEmbedSetupExperience =
   | "dashboard"
   | "chart"
-  | "exploration";
+  | "exploration"
+  | "browser";
 
 export type SdkIframeEmbedSetupStep =
   | "select-embed-experience"

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
@@ -52,7 +52,6 @@ export const getDefaultSdkIframeEmbedSettings = (
         componentName: "metabase-browser",
         initialCollection: "root",
         readOnly: true,
-        collectionVisibleColumns: ["type", "name"],
       }),
     )
     .exhaustive();

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
@@ -1,6 +1,7 @@
 import { match } from "ts-pattern";
 
 import type {
+  BrowserEmbedOptions,
   DashboardEmbedOptions,
   ExplorationEmbedOptions,
   QuestionEmbedOptions,
@@ -43,6 +44,15 @@ export const getDefaultSdkIframeEmbedSettings = (
         componentName: "metabase-question",
         template: "exploration",
         isSaveEnabled: false,
+      }),
+    )
+    .with(
+      "browser",
+      (): BrowserEmbedOptions => ({
+        componentName: "metabase-browser",
+        initialCollection: "root",
+        readOnly: true,
+        collectionVisibleColumns: ["type", "name"],
       }),
     )
     .exhaustive();

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
@@ -48,16 +48,15 @@ ${getEmbedCustomElementSnippet({ settings, experience })}`;
 export function getEmbedCustomElementSnippet({
   settings,
   experience,
-  id,
 }: {
   settings: SdkIframeEmbedSetupSettings;
   experience: SdkIframeEmbedSetupExperience;
-  id?: string;
 }): string {
   const elementName = match(experience)
     .with("dashboard", () => "metabase-dashboard")
     .with("chart", () => "metabase-question")
     .with("exploration", () => "metabase-question")
+    .with("browser", () => "metabase-browser")
     .exhaustive();
 
   const settingsWithExplorationOverride = match(experience)
@@ -77,7 +76,7 @@ export function getEmbedCustomElementSnippet({
     ALLOWED_EMBED_SETTING_KEYS_MAP[experience],
   );
 
-  return `<${elementName} ${attributes} ${id ? `id="${id}"` : ""}></${elementName}>`;
+  return `<${elementName} ${attributes}></${elementName}>`;
 }
 
 // Convert camelCase keys to lower-dash-case for web components

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -219,7 +219,8 @@ export type DashboardFilterMovedEvent = ValidateEvent<{
 export type SdkIframeEmbedSetupExperience =
   | "dashboard"
   | "chart"
-  | "exploration";
+  | "exploration"
+  | "browser";
 
 export type EmbedWizardExperienceSelectedEvent = ValidateEvent<{
   event: "embed_wizard_experience_selected";


### PR DESCRIPTION
Closes EMB-736

Adds the Browser experience to embed flow with the option to allow toggling `read-only` property.

### Changes

- Add Browser experience option in embed template selection
- Implement collection browser E2E tests with selection and navigation
- Add entity picker for collection selection with confirmation step
- Support read-only mode toggle for browser template
- Add localization for untranslated embed experience strings

### How to verify

- Go to "+ New > Embed"
- Select "Browser" experience. Click Next.
- Select a collection using the entity picker. Click Select, then Next.
- Verify collection browser shows in preview
- Toggle read-only setting and verify "New Dashboard" button shows up

### Demo

<img width="2244" height="1600" alt="CleanShot 2568-08-20 at 04 46 55@2x" src="https://github.com/user-attachments/assets/f406eeb0-c9d8-468e-b8a3-4b1711adcdd5" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR