### PR TITLE
[QP] Don't apply `:coercion-strategy` to joined fields twice

### DIFF
--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -138,7 +138,12 @@
                     ;; we better just add it in to be safe. In #61398 which is pending I actually make this happen
                     ;; automatically in MBQL 5 normalization, so we can take this out eventually.
                     (for [[tag id-or-name opts] fields]
-                      [tag id-or-name (assoc opts :join-alias (:alias join))]))))
+                      [tag id-or-name (assoc opts
+                                             :join-alias         (:alias join)
+                                             ;; Any coercion or temporal bucketing will already have been done in the
+                                             ;; subquery for the join itself. Mark the parent ref to make sure it is
+                                             ;; not double-coerced, which leads to SQL errors.
+                                             :qp/ignore-coercion true)]))))
         joins))
 
 (defn- should-add-join-fields?

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -1470,3 +1470,63 @@
                 :params nil}
                (-> (qp.compile/compile query)
                    (update :query #(str/split-lines (driver/prettify-native-form :h2 %))))))))))
+
+(deftest ^:parallel no-double-coercion-when-joining-coerced-fields-test
+  (testing "Should generate correct SQL when joining a field that has coercion applied"
+    (let [mp    (lib.tu/merged-mock-metadata-provider
+                 meta/metadata-provider
+                 {:fields [(merge (meta/field-metadata :products :id)
+                                  {:coercion-strategy :Coercion/UNIXSeconds->DateTime})]})
+          query {:type       :query
+                 :database   (meta/id)
+                 :query      {:source-table (meta/id :orders)
+                              :joins        [{:source-table (meta/id :products)
+                                              :fields       :all
+                                              :alias        "Products__CREATED_AT"
+                                              :condition
+                                              [:=
+                                               [:field (meta/id :orders :created-at) {:temporal-unit :month}]
+                                               [:field (meta/id :products :created-at) {:temporal-unit :month}]]}]}}]
+      (qp.store/with-metadata-provider mp
+        (is (= {:query  ["SELECT"
+                         "  \"PUBLIC\".\"ORDERS\".\"ID\" AS \"ID\","
+                         "  \"PUBLIC\".\"ORDERS\".\"USER_ID\" AS \"USER_ID\","
+                         "  \"PUBLIC\".\"ORDERS\".\"PRODUCT_ID\" AS \"PRODUCT_ID\","
+                         "  \"PUBLIC\".\"ORDERS\".\"SUBTOTAL\" AS \"SUBTOTAL\","
+                         "  \"PUBLIC\".\"ORDERS\".\"TAX\" AS \"TAX\","
+                         "  \"PUBLIC\".\"ORDERS\".\"TOTAL\" AS \"TOTAL\","
+                         "  \"PUBLIC\".\"ORDERS\".\"DISCOUNT\" AS \"DISCOUNT\","
+                         "  \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" AS \"CREATED_AT\","
+                         "  \"PUBLIC\".\"ORDERS\".\"QUANTITY\" AS \"QUANTITY\","
+                         "  \"Products__CREATED_AT\".\"ID\" AS \"Products__CREATED_AT__ID\","
+                         "  \"Products__CREATED_AT\".\"EAN\" AS \"Products__CREATED_AT__EAN\","
+                         "  \"Products__CREATED_AT\".\"TITLE\" AS \"Products__CREATED_AT__TITLE\","
+                         "  \"Products__CREATED_AT\".\"CATEGORY\" AS \"Products__CREATED_AT__CATEGORY\","
+                         "  \"Products__CREATED_AT\".\"VENDOR\" AS \"Products__CREATED_AT__VENDOR\","
+                         "  \"Products__CREATED_AT\".\"PRICE\" AS \"Products__CREATED_AT__PRICE\","
+                         "  \"Products__CREATED_AT\".\"RATING\" AS \"Products__CREATED_AT__RATING\","
+                         "  \"Products__CREATED_AT\".\"CREATED_AT\" AS \"Products__CREATED_AT__CREATED_AT\""
+                         "FROM"
+                         "  \"PUBLIC\".\"ORDERS\""
+                         "  LEFT JOIN ("
+                         "    SELECT"
+                         "      TIMESTAMPADD("
+                         "        'second',"
+                         "        \"PUBLIC\".\"PRODUCTS\".\"ID\","
+                         "        timestamp '1970-01-01T00:00:00Z'"
+                         "      ) AS \"ID\","
+                         "      \"PUBLIC\".\"PRODUCTS\".\"EAN\" AS \"EAN\","
+                         "      \"PUBLIC\".\"PRODUCTS\".\"TITLE\" AS \"TITLE\","
+                         "      \"PUBLIC\".\"PRODUCTS\".\"CATEGORY\" AS \"CATEGORY\","
+                         "      \"PUBLIC\".\"PRODUCTS\".\"VENDOR\" AS \"VENDOR\","
+                         "      \"PUBLIC\".\"PRODUCTS\".\"PRICE\" AS \"PRICE\","
+                         "      \"PUBLIC\".\"PRODUCTS\".\"RATING\" AS \"RATING\","
+                         "      \"PUBLIC\".\"PRODUCTS\".\"CREATED_AT\" AS \"CREATED_AT\""
+                         "    FROM"
+                         "      \"PUBLIC\".\"PRODUCTS\""
+                         "  ) AS \"Products__CREATED_AT\" ON DATE_TRUNC('month', \"PUBLIC\".\"ORDERS\".\"CREATED_AT\") = DATE_TRUNC('month', \"Products__CREATED_AT\".\"CREATED_AT\")"
+                         "LIMIT"
+                         "  1048575"]
+                :params nil}
+               (-> (qp.compile/compile query)
+                   (update :query #(str/split-lines (driver/prettify-native-form :h2 %))))))))))

--- a/test/metabase/query_processor/middleware/resolve_joins_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_joins_test.clj
@@ -19,10 +19,10 @@
       (resolve-joins/resolve-joins query))))
 
 (deftest ^:parallel joins->fields-test
-  (is (= [[:field 1 {:join-alias "B"}]
-          [:field 2 {:join-alias "B"}]
-          [:field 3 {:join-alias "C"}]
-          [:field 4 {:join-alias "C"}]]
+  (is (= [[:field 1 {:join-alias "B", :qp/ignore-coercion true}]
+          [:field 2 {:join-alias "B", :qp/ignore-coercion true}]
+          [:field 3 {:join-alias "C", :qp/ignore-coercion true}]
+          [:field 4 {:join-alias "C", :qp/ignore-coercion true}]]
          (#'resolve-joins/joins->fields [{:alias "A"
                                           :fields :all}
                                          {:alias "B"
@@ -67,8 +67,10 @@
                                     &c.categories.name]}]
                    :fields [$venues.id
                             $venues.name
-                            &c.categories.id
-                            &c.categories.name]})
+                            [:field %categories.id {:join-alias         "c"
+                                                    :qp/ignore-coercion true}]
+                            [:field %categories.name {:join-alias         "c"
+                                                      :qp/ignore-coercion true}]]})
                 (resolve-joins
                  (mt/mbql-query venues
                    {:fields [$venues.id $venues.name]
@@ -88,7 +90,8 @@
                      :fields       [&c.categories.name]}]
                    :fields [$venues.id
                             $venues.name
-                            &c.categories.name]})
+                            [:field %categories.name {:join-alias         "c"
+                                                      :qp/ignore-coercion true}]]})
                 (resolve-joins
                  (mt/mbql-query venues
                    {:fields [$venues.id $venues.name]
@@ -205,8 +208,8 @@
                               :order-by [[:asc $name]]
                               :limit    3}))]
       (is (query= (mt/mbql-query venues
-                    {:fields   [[:field (mt/id :categories :id) {:join-alias "cat"}]
-                                [:field (mt/id :categories :name) {:join-alias "cat"}]]
+                    {:fields   [[:field (mt/id :categories :id)   {:join-alias "cat", :qp/ignore-coercion true}]
+                                [:field (mt/id :categories :name) {:join-alias "cat", :qp/ignore-coercion true}]]
                      :joins    [{:alias           "cat"
                                  :source-query    {:source-table $$categories}
                                  :source-metadata source-metadata
@@ -280,7 +283,9 @@
                             :fingerprint   {:global {:distinct-count 15, :nil% 0.0}}}]]
       (is (query= (mt/mbql-query users
                     {:fields [$id
-                              [:field "_USER_ID" {:base-type :type/Integer :join-alias "alias"}]]
+                              [:field "_USER_ID" {:base-type          :type/Integer
+                                                  :join-alias         "alias"
+                                                  :qp/ignore-coercion true}]]
                      :joins  [{:fields       [[:field "_USER_ID" {:base-type :type/Integer :join-alias "alias"}]]
                                :alias        "alias"
                                :strategy     :left-join


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62099

### Description

When a Field has a coercion strategy (say, `UnixSeconds->DateTime`) set in the `Table Metadata`,
and then that field is **joined**, it will get double-coerced. The first time in the inner query for the join,
the second at the top level `SELECT`.

Since after the first coercion it will be a `TIMESTAMP` instead of and `INTEGER`, the second coercion is a SQL error.

The solution is to add `:qp/ignore-coercion true` in the `resolve-joins` middleware, when the `:fields` of the outer
query are being populated with joined fields. That prevents the QP from re-applying type coercions and date truncations.

### How to verify

1. Set the `Unix seconds -> datetime` coercion on eg. `Products.ID`
2. Create an MBQL query on `Orders` joined to `Products` **on `CREATED_AT` by month**
    - It will get confused if you use `Orders.PRODUCT_ID = Products.ID` since the latter is coerced to a DateTime.
3. Run that query

It works now, and throws SQL errors before. I've also added a new test that the double-coerced field is correctly formed.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
