### PR TITLE
Better handling of deleting used cancelations

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform_run_cancelation.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform_run_cancelation.clj
@@ -32,7 +32,10 @@
   "Delete a cancelation once it has been handled."
   [run-id]
   (t2/delete! :model/TransformRunCancelation
-              :run_id run-id))
+              :run_id run-id
+              :run_id [:not-in {:select :wr.id
+                                :from   [[:transform_run :wr]]
+                                :where  :wr.is_active}]))
 
 (defn delete-old-canceling-runs!
   "Delete cancelations for runs that are no longer running."


### PR DESCRIPTION
Slightly better handling of deleting cancelations once they've been processed. Prevents cancelations from accidentally getting deleted before they are processed.