### PR TITLE
fix: document search index after update

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/documents/models/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/documents/models/document.clj
@@ -71,10 +71,11 @@
                 update-map)))
 
 (t2/define-after-update :model/Document
-  [{:keys [id collection_id archived archived_directly]}]
+  [{:keys [id collection_id archived archived_directly] :as instance}]
   (sync-document-cards-collection! id collection_id
                                    :archived archived
-                                   :archived-directly archived_directly))
+                                   :archived-directly archived_directly)
+  instance)
 
 ;;; ------------------------------------------------ Serdes Hashing -------------------------------------------------
 


### PR DESCRIPTION
### Description

Fixes documents not being updated for search because we were not returning the row instance from the define-after-update handler in model.document.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
