### PR TITLE
Semantic search stale index cleanup job

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -88,7 +88,6 @@
   :visibility :internal
   :doc "Number of threads to use for batched index updates, including embedding requests")
 
-<<<<<<< HEAD
 (defsetting ee-search-gate-write-timeout
   (str "Timeout of gate write statements in seconds. Used to determine lag tolerance of the indexer (see the "
        "[[metabase-enterprise.semantic-search.gate/poll]]) in conjunction "

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -88,6 +88,7 @@
   :visibility :internal
   :doc "Number of threads to use for batched index updates, including embedding requests")
 
+<<<<<<< HEAD
 (defsetting ee-search-gate-write-timeout
   (str "Timeout of gate write statements in seconds. Used to determine lag tolerance of the indexer (see the "
        "[[metabase-enterprise.semantic-search.gate/poll]]) in conjunction "
@@ -132,3 +133,12 @@
   :default 2
   :export? false
   :visibility :internal)
+
+(defsetting stale-index-retention-hours
+  (deferred-tru "Number of hours to retain stale semantic search indexes before cleanup.")
+  :type :integer
+  :default 24
+  :encryption :no
+  :export? false
+  :visibility :internal
+  :doc "Number of hours to retain stale semantic search indexes before cleanup.")

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
@@ -58,8 +58,7 @@
         orphaned-table-names (map keyword (orphan-index-tables pgvector index-metadata))
         tables-to-drop       (concat stale-table-names orphaned-table-names)
         drop-table-sql       (sql/format
-                              (apply (partial sql.helpers/drop-table :if-exists)
-                                     (concat stale-table-names orphaned-table-names)))]
+                              (apply sql.helpers/drop-table :if-exists tables-to-drop))]
     (when (seq tables-to-drop)
       (log/infof "Found %d semantic search index tables to clean up" (count tables-to-drop))
       (doseq [table-name stale-table-names]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
@@ -1,0 +1,73 @@
+(ns metabase-enterprise.semantic-search.task.index-cleanup
+  "Task to clean up inactive and stale semantic search indexes."
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [honey.sql :as sql]
+   [java-time.api :as t]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
+   [metabase-enterprise.semantic-search.settings :as semantic.settings]
+   [metabase.app-db.cluster-lock :as cluster-lock]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as jdbc.rs])
+  (:import
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(defn- stale-index-tables
+  [pgvector {:keys [metadata-table-name control-table-name]}]
+  (let [retention-cutoff     (t/minus (t/offset-date-time) (t/hours (semantic.settings/stale-index-retention-hours)))
+        stale-index-sql (-> {:select [:meta.table_name]
+                             :from [[(keyword control-table-name) :control]]
+                             :join [[(keyword metadata-table-name) :meta]
+                                    [:!= :meta.id :control.active_id]]
+                             :where [:and
+                                     [:< :meta.index_created_at retention-cutoff]
+                                     ;; If indexer_last_seen is set, we can use it as a proxy for when the index was
+                                     ;; last used.
+                                     [:or
+                                      [:= :meta.indexer_last_seen nil]
+                                      [:< :meta.indexer_last_seen retention-cutoff]]]}
+                            (sql/format :quoted true))]
+    (->> (jdbc/execute! pgvector stale-index-sql {:builder-fn jdbc.rs/as-unqualified-lower-maps})
+         (map :table_name))))
+
+(defn- cleanup-stale-indexes!
+  []
+  (let [pgvector          (semantic.env/get-pgvector-datasource!)
+        index-metadata    (semantic.env/get-index-metadata)
+        stale-table-names (stale-index-tables pgvector index-metadata)]
+    (doseq [table-name stale-table-names]
+      (log/info "Cleaning up stale semantic search index:" table-name)
+      (jdbc/execute! pgvector
+                     [(str "DROP TABLE IF EXISTS " (name table-name) " CASCADE")]
+                     {:builder-fn jdbc.rs/as-unqualified-lower-maps}))))
+
+(def ^:private cleanup-job-key (jobs/key "metabase.task.semantic-index-cleanup.job"))
+(def ^:private cleanup-trigger-key (triggers/key "metabase.task.semantic-index-cleanup.trigger"))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc "Clean up inactive semantic search index tables"}
+  SemanticIndexCleanup [_ctx]
+  (cluster-lock/with-cluster-lock ::semantic-index-cleanup-lock
+    (cleanup-stale-indexes!)))
+
+(defmethod task/init! ::SemanticIndexCleanup [_]
+  (let [job (jobs/build
+             (jobs/of-type SemanticIndexCleanup)
+             (jobs/with-identity cleanup-job-key))
+        trigger (triggers/build
+                 (triggers/with-identity cleanup-trigger-key)
+                 (triggers/start-now)
+                 (triggers/with-schedule
+                  ;; Run daily at 3 AM
+                  (cron/cron-schedule "0 0 3 * * ? *")))]
+    (task/schedule-task! job trigger)))
+
+(comment
+  (task/job-exists? cleanup-job-key)
+  (task/trigger-now! cleanup-job-key))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/indexer_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/indexer_test.clj
@@ -19,16 +19,6 @@
 
 (use-fixtures :once #'semantic.tu/once-fixture)
 
-(defn- open-metadata! ^Closeable [pgvector index-metadata]
-  (semantic.tu/closeable
-   (semantic.index-metadata/create-tables-if-not-exists! pgvector index-metadata)
-   (fn [_] (semantic.tu/cleanup-index-metadata! pgvector index-metadata))))
-
-(defn- open-index! ^Closeable [pgvector index]
-  (semantic.tu/closeable
-   (semantic.index/create-index-table-if-not-exists! pgvector index)
-   (fn [_] (semantic.index/drop-index-table! pgvector index))))
-
 (defn- get-metadata-row! [pgvector index-metadata index]
   (jdbc/execute-one! pgvector
                      (sql/format {:select [:*]
@@ -53,8 +43,8 @@
         c3             {:model "card" :id "3" :name "Collie" :searchable_text "Dog Training Guide 3"}
         version        semantic.gate/search-doc->gate-doc
         delete         (fn [doc t] (semantic.gate/deleted-search-doc->gate-doc (:model doc) (:id doc) t))]
-    (with-open [_ (open-metadata! pgvector index-metadata)
-                _ (open-index! pgvector index)]
+    (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)
+                _ (semantic.tu/open-index! pgvector index)]
       (semantic.index-metadata/record-new-index-table! pgvector index-metadata index)
 
       (let [metadata-row      (get-metadata-row! pgvector index-metadata index)
@@ -283,8 +273,8 @@
         t1             (ts "2025-01-01T00:01:00Z")
         c1             {:model "card" :id "1" :name "Dog" :searchable_text "Dog Training Guide"}
         version        semantic.gate/search-doc->gate-doc]
-    (with-open [_ (open-metadata! pgvector index-metadata)
-                _ (open-index! pgvector index)]
+    (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)
+                _ (semantic.tu/open-index! pgvector index)]
       (semantic.index-metadata/record-new-index-table! pgvector index-metadata index)
 
       (testing "exits immediately after max run duration elapses"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -1,0 +1,129 @@
+(ns metabase-enterprise.semantic-search.task.index-cleanup-test
+  (:require
+   [clojure.test :refer :all]
+   [honey.sql :as sql]
+   [honey.sql.helpers :as sql.helpers]
+   [java-time.api :as t]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
+   [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
+   [metabase-enterprise.semantic-search.settings :as semantic.settings]
+   [metabase-enterprise.semantic-search.task.index-cleanup :as sut]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.test :as mt]
+   [next.jdbc :as jdbc]))
+
+(use-fixtures :once #'semantic.tu/once-fixture)
+
+(defn- create-test-index
+  "Create a test index object with the given table name and embedding model."
+  [table-name {:keys [provider model-name vector-dimensions]}]
+  {:table-name table-name
+   :version 1
+   :embedding-model {:provider provider
+                     :model-name model-name
+                     :vector-dimensions vector-dimensions}})
+
+(defn- insert-metadata-with-timestamps!
+  "Insert an index using record-new-index-table! and then update timestamps for testing."
+  [pgvector index-metadata {:keys [table-name provider model-name vector-dimensions
+                                   index-created-at indexer-last-seen]}]
+  (let [index (create-test-index table-name
+                                 {:provider provider
+                                  :model-name model-name
+                                  :vector-dimensions vector-dimensions})
+        index-id (semantic.index-metadata/record-new-index-table! pgvector index-metadata index)]
+    ;; Update the timestamps that we need for testing
+    (when (or index-created-at indexer-last-seen)
+      (jdbc/execute! pgvector
+                     (-> (sql.helpers/update (keyword (:metadata-table-name index-metadata)))
+                         (sql.helpers/set (cond-> {}
+                                            index-created-at (assoc :index_created_at index-created-at)
+                                            indexer-last-seen (assoc :indexer_last_seen indexer-last-seen)))
+                         (sql.helpers/where [:= :id index-id])
+                         (sql/format :quoted true))))
+    index-id))
+
+(defn- set-active-index!
+  "Set the active index in the control table."
+  [pgvector control-table-name index-id]
+  (jdbc/execute! pgvector
+                 (-> (sql.helpers/update (keyword control-table-name))
+                     (sql.helpers/set {:active_id index-id
+                                       :active_updated_at [:now]})
+                     (sql/format :quoted true))))
+
+(defn- create-table!
+  "Create a dummy table for testing."
+  [pgvector table-name]
+  (jdbc/execute! pgvector [(str "CREATE TABLE " table-name " (id SERIAL PRIMARY KEY)")]))
+
+(deftest cleanup-stale-indexes!-integration-test
+  (mt/with-premium-features #{:semantic-search}
+    (let [pgvector semantic.tu/db
+          index-metadata (semantic.tu/unique-index-metadata)
+          retention-hours 24
+          old-time (t/minus (t/offset-date-time) (t/hours (inc retention-hours)))
+          cleanup-stale-indexes! #'sut/cleanup-stale-indexes!]
+      (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)]
+        (semantic.index-metadata/ensure-control-row-exists! pgvector index-metadata)
+
+        (testing "drops stale tables and leaves recent ones"
+          (let [stale-table "test_stale_table_1"
+                recent-table "test_recent_table_1"
+                active-table "test_active_table_1"
+                recent-time (t/minus (t/offset-date-time) (t/hours (dec retention-hours)))]
+            (create-table! pgvector stale-table)
+            (create-table! pgvector recent-table)
+            (create-table! pgvector active-table)
+            (insert-metadata-with-timestamps! pgvector index-metadata
+                                              {:table-name stale-table
+                                               :provider "ollama"
+                                               :model-name "test-model"
+                                               :vector-dimensions 1024
+                                               :index-created-at old-time
+                                               :indexer-last-seen nil})
+            (insert-metadata-with-timestamps! pgvector index-metadata
+                                              {:table-name recent-table
+                                               :provider "ollama"
+                                               :model-name "test-model-2"
+                                               :vector-dimensions 1024
+                                               :index-created-at recent-time
+                                               :indexer-last-seen nil})
+            (let [active-index-id (insert-metadata-with-timestamps! pgvector index-metadata
+                                                                    {:table-name active-table
+                                                                     :provider "ollama"
+                                                                     :model-name "test-model-3"
+                                                                     :vector-dimensions 1024
+                                                                     :index-created-at old-time
+                                                                     :indexer-last-seen old-time})]
+              (set-active-index! pgvector (:control-table-name index-metadata) active-index-id))
+            (is (semantic.tu/table-exists-in-db? stale-table))
+            (is (semantic.tu/table-exists-in-db? recent-table))
+            (is (semantic.tu/table-exists-in-db? active-table))
+
+            (with-redefs [semantic.settings/stale-index-retention-hours (constantly retention-hours)
+                          semantic.env/get-pgvector-datasource! (constantly pgvector)
+                          semantic.env/get-index-metadata (constantly index-metadata)]
+              (cleanup-stale-indexes!))
+
+            (is (not (semantic.tu/table-exists-in-db? stale-table)))
+            (is (semantic.tu/table-exists-in-db? recent-table))
+            (is (semantic.tu/table-exists-in-db? active-table))
+
+            (jdbc/execute! pgvector [(str "DROP TABLE IF EXISTS " recent-table)])
+            (jdbc/execute! pgvector [(str "DROP TABLE IF EXISTS " active-table)])))
+
+        (testing "handles non-existent tables gracefully"
+          (let [nonexistent-table "nonexistent_table"]
+            (insert-metadata-with-timestamps! pgvector index-metadata
+                                              {:table-name nonexistent-table
+                                               :provider "ollama"
+                                               :model-name "test-model"
+                                               :vector-dimensions 1024
+                                               :index-created-at old-time
+                                               :indexer-last-seen nil})
+            (is (not (semantic.tu/table-exists-in-db? nonexistent-table)))
+            (with-redefs [semantic.settings/stale-index-retention-hours (constantly retention-hours)
+                          semantic.env/get-pgvector-datasource! (constantly pgvector)
+                          semantic.env/get-index-metadata (constantly index-metadata)]
+              (is (nil? (cleanup-stale-indexes!))))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -379,6 +379,20 @@
        (jdbc/execute! pgvector)
        (mapv :tables/table_name)))
 
+(defn open-metadata!
+  "Create metadata tables and return a closeable that will clean them up when closed."
+  ^Closeable [pgvector index-metadata]
+  (closeable
+   (semantic.index-metadata/create-tables-if-not-exists! pgvector index-metadata)
+   (fn [_] (cleanup-index-metadata! pgvector index-metadata))))
+
+(defn open-index!
+  "Create an index table and return a closeable that will drop it when closed."
+  ^Closeable [pgvector index]
+  (closeable
+   (semantic.index/create-index-table-if-not-exists! pgvector index)
+   (fn [_] (semantic.index/drop-index-table! pgvector index))))
+
 (defn- decode-column
   [row column]
   (update row column #'semantic.index/decode-pgobject))


### PR DESCRIPTION
Cleanup job for stale & orphaned semantic search index tables:
* Stale tables are ones which are not active, are at least 24 hours old, and have not seen the indexer in 24 hours
* Orphaned tables are tables prefixed with `index_table_` which are not tracked by the `index_metadata` table. It's not expected that this query should find orphans, it's more of a fallback in case any occur.

This should ensure that old indexes get garbage collected eventually, but provide enough of a buffer so that we can easily switch back and forth between indexes for experimentation.

Resolves [BOT-332: Drop old search index on model / provider / dimension change](https://linear.app/metabase/issue/BOT-332/drop-old-search-index-on-model-provider-dimension-change)