### PR TITLE
fix breadcrumbs icon shrinks

### DIFF
--- a/frontend/src/metabase/common/components/Badge/Badge.styled.tsx
+++ b/frontend/src/metabase/common/components/Badge/Badge.styled.tsx
@@ -51,6 +51,7 @@ export const BadgeIcon = styled(
   doNotForwardProps("hasMargin", "targetOffsetX"),
 )<{ hasMargin: boolean }>`
   margin-right: ${(props) => (props.hasMargin ? "5px" : 0)};
+  flex-shrink: 0;
 `;
 
 export const BadgeText = styled.span<{ isSingleLine: boolean }>`


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62163

### Description

Fixes breadcrumbs icon shrinks.

### Demo

Before
<img width="793" height="59" alt="Screenshot 2025-08-19 at 4 59 41 PM" src="https://github.com/user-attachments/assets/829a89a6-bd4b-44e4-b0e1-0c2a060930ea" />

After
<img width="731" height="53" alt="Screenshot 2025-08-19 at 4 59 06 PM" src="https://github.com/user-attachments/assets/7fbd8d3c-db36-4f54-9227-41e39ddc26b3" />

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
