### PR TITLE
support pin map views across the international date line

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletMarkerPinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMarkerPinMap.jsx
@@ -25,33 +25,71 @@ export default class LeafletMarkerPinMap extends LeafletMap {
     super.componentDidUpdate(prevProps, prevState);
 
     try {
-      const { pinMarkerLayer } = this;
-      const { points } = this.props;
-
-      const markers = pinMarkerLayer.getLayers();
-      const max = Math.max(points.length, markers.length);
-      for (let i = 0; i < max; i++) {
-        if (i >= points.length) {
-          pinMarkerLayer.removeLayer(markers[i]);
-        }
-        if (i >= markers.length) {
-          const marker = this._createMarker(i);
-          pinMarkerLayer.addLayer(marker);
-          markers.push(marker);
-        }
-
-        if (i < points.length) {
-          const { lat, lng } = markers[i].getLatLng();
-          if (lng !== points[i][0] || lat !== points[i][1]) {
-            markers[i].setLatLng(points[i]);
-          }
-        }
-      }
+      this._createMarkers(this.props.points);
     } catch (err) {
       console.error(err);
       this.props.onRenderError(err.message || err);
     }
   }
+
+  _createMarkers = (points) => {
+    const { pinMarkerLayer } = this;
+    if (!this.map) {
+      return;
+    }
+
+    const mapBounds = this.map?.getBounds?.();
+    if (!mapBounds) {
+      return;
+    }
+    const mapWest = mapBounds.getWest();
+    const mapEast = mapBounds.getEast();
+
+    // if map crosses dateline, we need wrapping
+    const crossesLeftDateline = mapWest < -180 && mapEast > -180;
+    const crossesRightDateline = mapWest < 180 && mapEast > 180;
+    const shouldGetWrappedPoints = crossesLeftDateline || crossesRightDateline;
+
+    const wrappedPoints = shouldGetWrappedPoints
+      ? points.flatMap((point) => {
+          const [lat, lng] = point;
+          const points = [point];
+
+          // note: for wide screens, we may need extra copies on both sides
+          if (crossesLeftDateline) {
+            // copy on the left side
+            points.push([lat, lng - 360]);
+          }
+
+          if (crossesRightDateline) {
+            // copy on the right side
+            points.push([lat, lng + 360]);
+          }
+          return points;
+        })
+      : points;
+
+    const markers = pinMarkerLayer.getLayers();
+    const max = Math.max(wrappedPoints.length, markers.length);
+    for (let i = 0; i < max; i++) {
+      if (i >= wrappedPoints.length) {
+        pinMarkerLayer.removeLayer(markers[i]); // remove excess markers
+      }
+      if (i >= markers.length) {
+        // create new markers for new points
+        const marker = this._createMarker(i);
+        pinMarkerLayer.addLayer(marker);
+        markers.push(marker);
+      }
+
+      if (i < wrappedPoints.length) {
+        const { lat, lng } = markers[i].getLatLng();
+        if (lng !== wrappedPoints[i][0] || lat !== wrappedPoints[i][1]) {
+          markers[i].setLatLng(wrappedPoints[i]); // if any marker doesn't match the point, update it
+        }
+      }
+    }
+  };
 
   _createMarker = (rowIndex) => {
     const marker = L.marker([0, 0], { icon: this.pinMarkerIcon });

--- a/frontend/src/metabase/visualizations/components/LeafletMarkerPinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMarkerPinMap.jsx
@@ -79,7 +79,7 @@ export default class LeafletMarkerPinMap extends LeafletMap {
       }
       if (i >= markers.length) {
         // create new markers for new points
-        const index = wrappedPoints[i][2] ?? i;
+        const index = shouldGetWrappedPoints ? wrappedPoints[i][2] : i;
 
         const marker = this._createMarker(index);
         pinMarkerLayer.addLayer(marker);


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #5369
Closes UXW-138

### Description

Our pin maps wrap infinitely around the world map (because the earth is round), but our data points do not wrap infinitely, leading to silly interactions like this:


https://github.com/user-attachments/assets/28b271ad-c9ea-4c44-9920-6d04728e0844

This updates our map component to check if the international date line is in the viewport, and if it is, render data on both sides of it.

. | .
---|---
Before | <img width="6880" height="2108" alt="New question-8_19_2025, 4_11_25 PM" src="https://github.com/user-attachments/assets/d68c60a0-074d-4014-bf9a-5f1724b86a99" />
After | <img width="6880" height="2108" alt="New question-8_19_2025, 4_11_45 PM" src="https://github.com/user-attachments/assets/92d2bf54-0635-42d2-8f87-f633aeaa5c41" />

As you can see, it's still not *perfect* on ultrawide displays fully zoomed out - we draw a max of 3 worlds of data - any more than that seemed excessive.


### How to verify

- Get some location data that spans the international dateline ([like this](https://metaboat.slack.com/archives/C078VLFKM/p1755617548570019))
- see that whether you're zoomed in or out, the data renders on both sides

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
