### PR TITLE
fix admin role does not appear until page refresh when adding a new user

### DIFF
--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -183,6 +183,38 @@ describe("scenarios > admin > people", () => {
       cy.contains("Email address already in use.");
     });
 
+    it("should immediately reflect admin privileges when creating user with admin group (metabase#60241)", () => {
+      const { first_name, last_name, email } = TEST_USER;
+      const FULL_NAME = `${first_name} ${last_name}`;
+
+      cy.visit("/admin/people");
+      clickButton("Invite someone");
+
+      // Fill in user details
+      cy.findByLabelText("First name").type(first_name);
+      cy.findByLabelText("Last name").type(last_name);
+      cy.findByLabelText(/Email/).type(email);
+
+      // Add user to Administrators group
+      H.modal().findByText("Default").click();
+      H.popover().findByText("Administrators").click();
+
+      clickButton("Create");
+
+      // Close the success modal
+      H.modal().findByText(`${FULL_NAME} has been added`);
+      H.modal().findByText("Done").click();
+
+      // Verify the user appears in the list with Admin role
+      cy.findByTestId("admin-people-list-table").within(() => {
+        cy.findByText(FULL_NAME)
+          .closest("tr")
+          .within(() => {
+            cy.findByText("Admin").should("exist");
+          });
+      });
+    });
+
     it("'Invite someone' button shouldn't be covered/blocked on smaller screen sizes (metabase#16350)", () => {
       cy.viewport(1000, 600);
 

--- a/frontend/src/metabase/api/user.ts
+++ b/frontend/src/metabase/api/user.ts
@@ -51,7 +51,8 @@ export const userApi = Api.injectEndpoints({
         url: "/api/user",
         body,
       }),
-      invalidatesTags: (_, error) => invalidateTags(error, [listTag("user")]),
+      invalidatesTags: (_, error) =>
+        invalidateTags(error, [listTag("user"), listTag("permissions-group")]),
       onQueryStarted: async (request, { dispatch, queryFulfilled }) => {
         if (request.password) {
           const { data: user } = await queryFulfilled;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/60241

### Description

Fixes admin role does not appear until page refresh when adding a new user and immediately assigning admin role to them.

### How to verify

- Admin -> People
- Create a new user and right in the modal add them to "Admin" group
- Finish creating the user and ensure it is immediately shown with the admin role (no page refresh needed)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
