### PR TITLE
Make readOnly Notebook non-editable

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -574,8 +574,10 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
       });
 
       cy.log("Data step should be read-only");
-      H.getNotebookStep("data").findByText("Animals").click();
-      assertNoModals();
+      H.getNotebookStep("data")
+        .findByRole("button")
+        .should("contain", "Animals")
+        .should("be.disabled");
 
       cy.log("Join step should be read-only");
       H.getNotebookStep("join")

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -577,6 +577,8 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
         .eq(1)
         .should("have.css", "pointer-events", "none");
 
+      cy.findByLabelText("Change join type").should("be.disabled");
+
       H.getNotebookStep("join")
         .findAllByText("Score")
         .should("have.length", 2)

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -526,7 +526,14 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
                     query: {
                       "source-table": tableId,
                       filter: [">", ["field", ANIMAL_SCORE, {}], 10],
-                      aggregation: [["count"]],
+                      aggregation: [
+                        ["count"],
+                        [
+                          "aggregation-options",
+                          ["+", ["count"], 1],
+                          { name: "Foobar", "display-name": "Foobar" },
+                        ],
+                      ],
                       expressions: {
                         ScorePlusOne: ["+", ["field", ANIMAL_SCORE, {}], 1],
                       },
@@ -617,6 +624,13 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
       cy.log("Summarize step should be read-only");
       H.getNotebookStep("summarize").findByText("Count").click();
       assertNoModals();
+
+      H.getNotebookStep("summarize").findByText("Foobar").click();
+      H.CustomExpressionEditor.value().should("equal", "Count() + 1");
+      H.CustomExpressionEditor.nameInput()
+        .should("have.value", "Foobar")
+        .should("have.attr", "readonly");
+      H.popover().button("Done").click();
 
       H.getNotebookStep("summarize").findByText("Score: 10 bins").click();
       assertNoModals();

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -625,7 +625,11 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
 
       cy.log("Summarize step should be read-only");
       H.getNotebookStep("summarize").findByText("Count").click();
-      assertNoModals();
+      H.CustomExpressionEditor.value().should("equal", "Count()");
+      H.CustomExpressionEditor.nameInput()
+        .should("have.value", "Count")
+        .should("have.attr", "readonly");
+      H.popover().button("Done").click();
 
       H.getNotebookStep("summarize").findByText("Foobar").click();
       H.CustomExpressionEditor.value().should("equal", "Count() + 1");

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryView/QueryView.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryView/QueryView.module.css
@@ -1,0 +1,3 @@
+.nonInteractive {
+  pointer-events: none;
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryView/QueryView.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryView/QueryView.module.css
@@ -1,3 +1,0 @@
-.nonInteractive {
-  pointer-events: none;
-}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryView/QueryView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryView/QueryView.tsx
@@ -5,12 +5,14 @@ import { useSelector } from "metabase/lib/redux";
 import { CodeMirrorEditor as Editor } from "metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor";
 import { Notebook } from "metabase/querying/notebook/components/Notebook";
 import { getMetadata } from "metabase/selectors/metadata";
-import { Center, Loader } from "metabase/ui";
+import { Box, Center, Loader } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 import type { DatasetQuery } from "metabase-types/api";
 
 import { useQueryMetadata } from "../../hooks/use-query-metadata";
+
+import S from "./QueryView.module.css";
 
 type QueryViewProps = {
   query: DatasetQuery;
@@ -39,16 +41,18 @@ export function QueryView({ query }: QueryViewProps) {
   }
 
   return (
-    <Notebook
-      question={question}
-      reportTimezone={reportTimezone}
-      readOnly
-      isDirty={false}
-      isRunnable={false}
-      isResultDirty={false}
-      hasVisualizeButton={false}
-      updateQuestion={() => Promise.resolve()}
-      runQuestionQuery={() => Promise.resolve()}
-    />
+    <Box className={S.nonInteractive}>
+      <Notebook
+        question={question}
+        reportTimezone={reportTimezone}
+        readOnly
+        isDirty={false}
+        isRunnable={false}
+        isResultDirty={false}
+        hasVisualizeButton={false}
+        updateQuestion={() => Promise.resolve()}
+        runQuestionQuery={() => Promise.resolve()}
+      />
+    </Box>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryView/QueryView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryView/QueryView.tsx
@@ -5,14 +5,12 @@ import { useSelector } from "metabase/lib/redux";
 import { CodeMirrorEditor as Editor } from "metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor";
 import { Notebook } from "metabase/querying/notebook/components/Notebook";
 import { getMetadata } from "metabase/selectors/metadata";
-import { Box, Center, Loader } from "metabase/ui";
+import { Center, Loader } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 import type { DatasetQuery } from "metabase-types/api";
 
 import { useQueryMetadata } from "../../hooks/use-query-metadata";
-
-import S from "./QueryView.module.css";
 
 type QueryViewProps = {
   query: DatasetQuery;
@@ -41,18 +39,16 @@ export function QueryView({ query }: QueryViewProps) {
   }
 
   return (
-    <Box className={S.nonInteractive}>
-      <Notebook
-        question={question}
-        reportTimezone={reportTimezone}
-        readOnly
-        isDirty={false}
-        isRunnable={false}
-        isResultDirty={false}
-        hasVisualizeButton={false}
-        updateQuestion={() => Promise.resolve()}
-        runQuestionQuery={() => Promise.resolve()}
-      />
-    </Box>
+    <Notebook
+      question={question}
+      reportTimezone={reportTimezone}
+      readOnly
+      isDirty={false}
+      isRunnable={false}
+      isResultDirty={false}
+      hasVisualizeButton={false}
+      updateQuestion={() => Promise.resolve()}
+      runQuestionQuery={() => Promise.resolve()}
+    />
   );
 }

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -46,6 +46,7 @@ export interface AggregationPickerProps {
   onClose?: () => void;
   onQueryChange: (query: Lib.Query) => void;
   onBack?: () => void;
+  readOnly?: boolean;
 }
 
 type OperatorListItem = Lib.AggregationOperatorDisplayInfo & {
@@ -81,6 +82,7 @@ export function AggregationPicker({
   onClose,
   onQueryChange,
   onBack,
+  readOnly,
 }: AggregationPickerProps) {
   const metadata = useSelector(getMetadata);
   const displayInfo = clause
@@ -309,10 +311,15 @@ export function AggregationPicker({
         withName
         expressionMode="aggregation"
         expressionIndex={clauseIndex}
-        header={<ExpressionWidgetHeader onBack={closeExpressionEditor} />}
+        header={
+          <ExpressionWidgetHeader
+            onBack={readOnly ? undefined : closeExpressionEditor}
+          />
+        }
         onChangeClause={handleClauseChange}
         onClose={closeExpressionEditor}
         initialExpressionClause={initialExpressionClause}
+        readOnly={readOnly}
       />
     );
   }

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -443,7 +443,7 @@ function getInitialOperator(
   return operator ?? null;
 }
 
-function isExpressionEditorInitiallyOpen(
+export function isExpressionEditorInitiallyOpen(
   query: Lib.Query,
   stageIndex: number,
   clause: Lib.AggregationClause | undefined,

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -95,7 +95,13 @@ export function AggregationPicker({
     isEditingExpression,
     { turnOn: openExpressionEditor, turnOff: closeExpressionEditor },
   ] = useToggle(
-    isExpressionEditorInitiallyOpen(query, stageIndex, clause, operators),
+    isExpressionEditorInitiallyOpen({
+      query,
+      stageIndex,
+      clause,
+      operators,
+      readOnly,
+    }),
   );
   const [initialExpressionClause, setInitialExpressionClause] =
     useState<DefinedClauseName | null>(null);
@@ -443,12 +449,23 @@ function getInitialOperator(
   return operator ?? null;
 }
 
-export function isExpressionEditorInitiallyOpen(
-  query: Lib.Query,
-  stageIndex: number,
-  clause: Lib.AggregationClause | undefined,
-  operators: Lib.AggregationOperator[],
-): boolean {
+function isExpressionEditorInitiallyOpen({
+  query,
+  stageIndex,
+  clause,
+  operators,
+  readOnly,
+}: {
+  query: Lib.Query;
+  stageIndex: number;
+  clause: Lib.AggregationClause | undefined;
+  operators: Lib.AggregationOperator[];
+  readOnly?: boolean;
+}): boolean {
+  if (readOnly) {
+    return true;
+  }
+
   if (!clause) {
     return false;
   }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidget.tsx
@@ -36,6 +36,7 @@ export type ExpressionWidgetProps = {
   header?: ReactNode;
   initialExpressionClause?: DefinedClauseName | null;
   availableColumns: Lib.ColumnMetadata[];
+  readOnly?: boolean;
 
   onChangeClause?: (name: string, clause: Lib.ExpressionClause) => void;
   onClose?: () => void;
@@ -56,6 +57,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
     onChangeClause,
     onClose,
     initialExpressionClause,
+    readOnly,
   } = props;
 
   const [name, setName] = useState(initialName || "");
@@ -202,6 +204,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
         hasHeader={Boolean(header)}
         onCloseEditor={onClose}
         initialExpressionClause={initialExpressionClause}
+        readOnly={readOnly}
       />
 
       <LayoutFooter>
@@ -212,10 +215,11 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
               onChange={setName}
               onSubmit={handleSubmit}
               expressionMode={expressionMode}
+              readOnly={readOnly}
             />
           )}
           <Flex py="sm" pr="sm" gap="sm">
-            {onClose && (
+            {onClose && !readOnly && (
               <Button
                 onClick={onClose}
                 variant="subtle"
@@ -228,7 +232,9 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
               onClick={handleSubmit}
               size="xs"
             >
-              {initialName || initialClause ? t`Update` : t`Done`}
+              {(initialName || initialClause) && !readOnly
+                ? t`Update`
+                : t`Done`}
             </Button>
           </Flex>
         </Flex>

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidgetHeader.module.css
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidgetHeader.module.css
@@ -9,8 +9,13 @@
   .HeaderButton {
     color: var(--mb-color-text-light);
 
-    &:hover {
+    &:not(:disabled):hover {
       color: var(--mb-color-brand);
+    }
+
+    &:disabled {
+      opacity: 1;
+      cursor: default;
     }
   }
 }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidgetHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidgetHeader.tsx
@@ -11,7 +11,7 @@ const DEFAULT_SECTION_NAME = t`Custom Expression`;
 interface Props {
   title?: string;
 
-  onBack: () => void;
+  onBack?: () => void;
 }
 
 export const ExpressionWidgetHeader = ({
@@ -22,9 +22,10 @@ export const ExpressionWidgetHeader = ({
     <Flex className={ExpressionWidgetHeaderS.Header}>
       <Button
         className={ExpressionWidgetHeaderS.HeaderButton}
-        icon="chevronleft"
+        icon={onBack ? "chevronleft" : undefined}
         onlyText
         onClick={onBack}
+        disabled={!onBack}
       >
         {title}
       </Button>

--- a/frontend/src/metabase/query_builder/components/expressions/NameInput/NameInput.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/NameInput/NameInput.tsx
@@ -11,11 +11,13 @@ export function NameInput({
   onChange,
   onSubmit,
   expressionMode,
+  readOnly,
 }: {
   value: string;
   onChange: (value: string) => void;
   onSubmit: () => void;
   expressionMode: Lib.ExpressionMode;
+  readOnly?: boolean;
 }) {
   const handleChange = useCallback(
     (evt: ChangeEvent<HTMLInputElement>) => {
@@ -45,6 +47,7 @@ export function NameInput({
       placeholder={getPlaceholder(expressionMode)}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
+      readOnly={readOnly}
       classNames={{
         root: S.root,
         input: S.input,

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
@@ -90,7 +90,6 @@ export function DatePicker({
           renderBackButton={renderBackButton}
           onChange={onChange}
           onSelectType={setType}
-          readOnly={readOnly}
         />
       );
   }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/DatePicker.tsx
@@ -27,6 +27,7 @@ type DatePickerProps = {
   renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   renderBackButton?: () => ReactNode;
   onChange: (value: DatePickerValue) => void;
+  readOnly?: boolean;
 };
 
 export function DatePicker({
@@ -37,6 +38,7 @@ export function DatePicker({
   renderSubmitButton = renderDefaultSubmitButton,
   renderBackButton,
   onChange,
+  readOnly,
 }: DatePickerProps) {
   const [type, setType] = useState(value?.type);
 
@@ -54,6 +56,7 @@ export function DatePicker({
           renderSubmitButton={renderSubmitButton}
           onChange={onChange}
           onBack={handleBack}
+          readOnly={readOnly}
         />
       );
     case "relative":
@@ -64,6 +67,7 @@ export function DatePicker({
           renderSubmitButton={renderSubmitButton}
           onChange={onChange}
           onBack={handleBack}
+          readOnly={readOnly}
         />
       );
     case "exclude":
@@ -75,6 +79,7 @@ export function DatePicker({
           renderSubmitButton={renderSubmitButton}
           onChange={onChange}
           onBack={handleBack}
+          readOnly={readOnly}
         />
       );
     default:
@@ -85,6 +90,7 @@ export function DatePicker({
           renderBackButton={renderBackButton}
           onChange={onChange}
           onSelectType={setType}
+          readOnly={readOnly}
         />
       );
   }

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -119,7 +119,11 @@ export function ExcludeOptionPicker({
 
   return (
     <Box miw={MIN_WIDTH}>
-      {!readOnly && <BackButton onClick={onBack}>{t`Exclude…`}</BackButton>}
+      <BackButton
+        onClick={onBack}
+        disabled={readOnly}
+        withArrow={!readOnly}
+      >{t`Exclude…`}</BackButton>
       <Divider />
       <Box p="sm">
         {unitOptions.map((option, index) => (

--- a/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -41,6 +41,7 @@ export interface ExcludeDatePickerProps {
   renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: ExcludeDatePickerValue) => void;
   onBack: () => void;
+  readOnly?: boolean;
 }
 
 export function ExcludeDatePicker({
@@ -50,6 +51,7 @@ export function ExcludeDatePicker({
   renderSubmitButton = renderDefaultSubmitButton,
   onChange,
   onBack,
+  readOnly,
 }: ExcludeDatePickerProps) {
   const [unit, setUnit] = useState(value?.unit);
   const [values, setValues] = useState(value?.values ?? []);
@@ -70,6 +72,7 @@ export function ExcludeDatePicker({
       renderSubmitButton={renderSubmitButton}
       onChange={onChange}
       onBack={handleBack}
+      readOnly={readOnly}
     />
   ) : (
     <ExcludeOptionPicker
@@ -90,6 +93,7 @@ interface ExcludeOptionPickerProps {
   onChange: (value: ExcludeDatePickerValue) => void;
   onSelectUnit: (unit: DatePickerExtractionUnit) => void;
   onBack: () => void;
+  readOnly?: boolean;
 }
 
 export function ExcludeOptionPicker({
@@ -99,6 +103,7 @@ export function ExcludeOptionPicker({
   onChange,
   onSelectUnit,
   onBack,
+  readOnly,
 }: ExcludeOptionPickerProps) {
   const unitOptions = useMemo(() => {
     return getExcludeUnitOptions(availableOperators, availableUnits);
@@ -114,7 +119,7 @@ export function ExcludeOptionPicker({
 
   return (
     <Box miw={MIN_WIDTH}>
-      <BackButton onClick={onBack}>{t`Exclude…`}</BackButton>
+      {!readOnly && <BackButton onClick={onBack}>{t`Exclude…`}</BackButton>}
       <Divider />
       <Box p="sm">
         {unitOptions.map((option, index) => (
@@ -157,6 +162,7 @@ interface ExcludeValuePickerProps {
   renderSubmitButton: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: ExcludeDatePickerValue) => void;
   onBack: () => void;
+  readOnly?: boolean;
 }
 
 function ExcludeValuePicker({
@@ -165,6 +171,7 @@ function ExcludeValuePicker({
   renderSubmitButton,
   onChange,
   onBack,
+  readOnly,
 }: ExcludeValuePickerProps) {
   const [values, setValues] = useState(initialValues);
   const option = useMemo(() => findExcludeUnitOption(unit), [unit]);
@@ -201,7 +208,7 @@ function ExcludeValuePicker({
 
   return (
     <Box component="form" miw={MIN_WIDTH} onSubmit={handleSubmit}>
-      <BackButton onClick={onBack}>{option?.label}</BackButton>
+      {!readOnly && <BackButton onClick={onBack}>{option?.label}</BackButton>}
       <Divider />
       <Stack p="md">
         <Checkbox

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
@@ -59,7 +59,12 @@ export function RelativeDatePicker({
   return (
     <Tabs value={direction} onChange={handleTabChange}>
       <Flex>
-        <PopoverBackButton p="sm" onClick={onBack} readOnly={readOnly} />
+        <PopoverBackButton
+          p="sm"
+          onClick={onBack}
+          disabled={readOnly}
+          withArrow={!readOnly}
+        />
         <Tabs.List className={S.TabList}>
           {TABS.map((tab) => (
             <Tabs.Tab key={tab.direction} value={tab.direction}>

--- a/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/RelativeDatePicker/RelativeDatePicker.tsx
@@ -27,6 +27,7 @@ interface RelativeDatePickerProps {
   renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: RelativeDatePickerValue) => void;
   onBack: () => void;
+  readOnly?: boolean;
 }
 
 export function RelativeDatePicker({
@@ -35,6 +36,7 @@ export function RelativeDatePicker({
   renderSubmitButton = renderDefaultSubmitButton,
   onChange,
   onBack,
+  readOnly,
 }: RelativeDatePickerProps) {
   const [value, setValue] = useState<RelativeDatePickerValue | undefined>(
     initialValue ?? DEFAULT_VALUE,
@@ -57,7 +59,7 @@ export function RelativeDatePicker({
   return (
     <Tabs value={direction} onChange={handleTabChange}>
       <Flex>
-        <PopoverBackButton p="sm" onClick={onBack} />
+        <PopoverBackButton p="sm" onClick={onBack} readOnly={readOnly} />
         <Tabs.List className={S.TabList}>
           {TABS.map((tab) => (
             <Tabs.Tab key={tab.direction} value={tab.direction}>

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -77,7 +77,12 @@ export function SpecificDatePicker({
   return (
     <Tabs value={value.operator} onChange={handleTabChange}>
       <Flex>
-        <PopoverBackButton p="sm" onClick={onBack} readOnly={readOnly} />
+        <PopoverBackButton
+          p="sm"
+          onClick={onBack}
+          disabled={readOnly}
+          withArrow={!readOnly}
+        />
         <Tabs.List className={S.TabList}>
           {tabs.map((tab) => (
             <Tabs.Tab key={tab.operator} value={tab.operator}>

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SpecificDatePicker.tsx
@@ -35,6 +35,7 @@ interface SpecificDatePickerProps {
   renderSubmitButton?: (props: DatePickerSubmitButtonProps) => ReactNode;
   onChange: (value: SpecificDatePickerValue) => void;
   onBack: () => void;
+  readOnly?: boolean;
 }
 
 export function SpecificDatePicker({
@@ -44,6 +45,7 @@ export function SpecificDatePicker({
   renderSubmitButton = renderDefaultSubmitButton,
   onChange,
   onBack,
+  readOnly,
 }: SpecificDatePickerProps) {
   const tabs = useMemo(() => getTabs(availableOperators), [availableOperators]);
   const [value, setValue] = useState(() => initialValue ?? getDefaultValue());
@@ -75,7 +77,7 @@ export function SpecificDatePicker({
   return (
     <Tabs value={value.operator} onChange={handleTabChange}>
       <Flex>
-        <PopoverBackButton p="sm" onClick={onBack} />
+        <PopoverBackButton p="sm" onClick={onBack} readOnly={readOnly} />
         <Tabs.List className={S.TabList}>
           {tabs.map((tab) => (
             <Tabs.Tab key={tab.operator} value={tab.operator}>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -17,6 +17,7 @@ export function BooleanFilterPicker({
   column,
   filter,
   isNew,
+  readOnly,
   withAddButton,
   withSubmitButton,
   onBack,
@@ -58,6 +59,7 @@ export function BooleanFilterPicker({
         <FilterPickerHeader
           columnName={columnInfo.longDisplayName}
           onBack={onBack}
+          readOnly={readOnly}
         />
       )}
       <BooleanPicker value={value} withEmptyOptions onChange={setValue} />

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -31,6 +31,7 @@ export function CoordinateFilterPicker({
   withSubmitButton,
   onChange,
   onBack,
+  readOnly,
 }: FilterPickerWidgetProps) {
   const columnInfo = useMemo(
     () => Lib.displayInfo(query, stageIndex, column),
@@ -90,6 +91,7 @@ export function CoordinateFilterPicker({
       <FilterPickerHeader
         columnName={columnInfo.longDisplayName}
         onBack={onBack}
+        readOnly={readOnly}
       >
         <FilterOperatorPicker
           value={operator}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -69,6 +69,7 @@ export function DateFilterPicker({
           ) : null
         }
         onChange={handleChange}
+        readOnly={readOnly}
       />
     </div>
   );

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -63,7 +63,12 @@ export function DateFilterPicker({
         }}
         renderBackButton={() =>
           onBack ? (
-            <PopoverBackButton p="sm" onClick={onBack} readOnly={readOnly}>
+            <PopoverBackButton
+              p="sm"
+              onClick={onBack}
+              disabled={readOnly}
+              withArrow={!readOnly}
+            >
               {columnInfo.longDisplayName}
             </PopoverBackButton>
           ) : null

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.tsx
@@ -19,6 +19,7 @@ export function DateFilterPicker({
   withSubmitButton,
   onChange,
   onBack,
+  readOnly,
 }: FilterPickerWidgetProps) {
   const columnInfo = useMemo(() => {
     return Lib.displayInfo(query, stageIndex, column);
@@ -62,7 +63,7 @@ export function DateFilterPicker({
         }}
         renderBackButton={() =>
           onBack ? (
-            <PopoverBackButton p="sm" onClick={onBack}>
+            <PopoverBackButton p="sm" onClick={onBack} readOnly={readOnly}>
               {columnInfo.longDisplayName}
             </PopoverBackButton>
           ) : null

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DefaultFilterPicker/DefaultFilterPicker.tsx
@@ -20,6 +20,7 @@ export function DefaultFilterPicker({
   withSubmitButton,
   onBack,
   onChange,
+  readOnly,
 }: FilterPickerWidgetProps) {
   const columnInfo = useMemo(
     () => Lib.displayInfo(query, stageIndex, column),
@@ -70,6 +71,7 @@ export function DefaultFilterPicker({
       <FilterPickerHeader
         columnName={columnInfo.longDisplayName}
         onBack={onBack}
+        readOnly={readOnly}
       />
       <div>
         <Radio.Group value={operator} onChange={handleOperatorChange}>

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.tsx
@@ -29,6 +29,7 @@ export type FilterPickerProps = {
   onSelect: (filter: Lib.Filterable) => void;
   onClose?: () => void;
   onBack?: () => void;
+  readOnly?: boolean;
 } & Pick<
   FilterColumnPickerProps,
   "withColumnItemIcon" | "withColumnGroupIcon" | "withCustomExpression"
@@ -46,6 +47,7 @@ export function FilterPicker({
   withColumnItemIcon,
   withColumnGroupIcon,
   withCustomExpression,
+  readOnly,
 }: FilterPickerProps) {
   const [filter, setFilter] = useState(initialFilter);
   const [column, setColumn] = useState(
@@ -155,6 +157,7 @@ export function FilterPicker({
       isNew={isNewFilter}
       onChange={handleChange}
       onBack={handleBack}
+      readOnly={readOnly}
     />
   );
 }

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.module.css
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.module.css
@@ -1,0 +1,3 @@
+.readOnly {
+  pointer-events: none;
+}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.tsx
@@ -1,3 +1,6 @@
+import cx from "classnames";
+
+import { Box } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { BooleanFilterPicker } from "../BooleanFilterPicker";
@@ -8,6 +11,8 @@ import { NumberFilterPicker } from "../NumberFilterPicker";
 import { StringFilterPicker } from "../StringFilterPicker";
 import { TimeFilterPicker } from "../TimeFilterPicker";
 import type { FilterChangeOpts } from "../types";
+
+import S from "./FilterPickerBody.module.css";
 
 interface FilterPickerBodyProps {
   autoFocus?: boolean;
@@ -20,6 +25,7 @@ interface FilterPickerBodyProps {
   withSubmitButton?: boolean;
   onChange: (filter: Lib.ExpressionClause, opts: FilterChangeOpts) => void;
   onBack?: () => void;
+  readOnly?: boolean;
 }
 
 export function FilterPickerBody({
@@ -33,6 +39,7 @@ export function FilterPickerBody({
   withSubmitButton = true,
   onChange,
   onBack,
+  readOnly,
 }: FilterPickerBodyProps) {
   const FilterWidget = getFilterWidget(column);
   if (!FilterWidget) {
@@ -40,18 +47,21 @@ export function FilterPickerBody({
   }
 
   return (
-    <FilterWidget
-      autoFocus={autoFocus}
-      query={query}
-      stageIndex={stageIndex}
-      column={column}
-      filter={filter}
-      isNew={isNew}
-      withAddButton={withAddButton}
-      withSubmitButton={withSubmitButton}
-      onChange={onChange}
-      onBack={onBack}
-    />
+    <Box className={cx({ [S.readOnly]: readOnly })}>
+      <FilterWidget
+        autoFocus={autoFocus}
+        query={query}
+        stageIndex={stageIndex}
+        column={column}
+        filter={filter}
+        isNew={isNew}
+        withAddButton={withAddButton}
+        withSubmitButton={withSubmitButton && !readOnly}
+        onChange={onChange}
+        onBack={onBack}
+        readOnly={readOnly}
+      />
+    </Box>
   );
 }
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerHeader/FilterPickerHeader.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerHeader/FilterPickerHeader.tsx
@@ -18,7 +18,12 @@ export function FilterPickerHeader({
   return (
     <Flex px="md" pt="md" justify="space-between">
       {onBack && (
-        <PopoverBackButton pr="md" onClick={onBack} readOnly={readOnly}>
+        <PopoverBackButton
+          pr="md"
+          onClick={onBack}
+          disabled={readOnly}
+          withArrow={!readOnly}
+        >
           {columnName}
         </PopoverBackButton>
       )}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerHeader/FilterPickerHeader.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerHeader/FilterPickerHeader.tsx
@@ -5,18 +5,20 @@ import { Flex, PopoverBackButton } from "metabase/ui";
 interface FilterPickerHeaderProps {
   columnName: string;
   children?: ReactNode;
+  readOnly?: boolean;
   onBack?: () => void;
 }
 
 export function FilterPickerHeader({
   columnName,
   children,
+  readOnly,
   onBack,
 }: FilterPickerHeaderProps) {
   return (
     <Flex px="md" pt="md" justify="space-between">
       {onBack && (
-        <PopoverBackButton pr="md" onClick={onBack}>
+        <PopoverBackButton pr="md" onClick={onBack} readOnly={readOnly}>
           {columnName}
         </PopoverBackButton>
       )}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -29,6 +29,7 @@ export function NumberFilterPicker({
   withSubmitButton,
   onChange,
   onBack,
+  readOnly,
 }: FilterPickerWidgetProps) {
   const columnInfo = useMemo(
     () => Lib.displayInfo(query, stageIndex, column),
@@ -84,6 +85,7 @@ export function NumberFilterPicker({
       <FilterPickerHeader
         columnName={columnInfo.longDisplayName}
         onBack={onBack}
+        readOnly={readOnly}
       >
         <FilterOperatorPicker
           value={operator}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -27,6 +27,7 @@ export function StringFilterPicker({
   withSubmitButton,
   onChange,
   onBack,
+  readOnly,
 }: FilterPickerWidgetProps) {
   const columnInfo = useMemo(
     () => Lib.displayInfo(query, stageIndex, column),
@@ -83,6 +84,7 @@ export function StringFilterPicker({
       <FilterPickerHeader
         columnName={columnInfo.longDisplayName}
         onBack={onBack}
+        readOnly={readOnly}
       >
         <FilterOperatorPicker
           value={operator}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -26,6 +26,7 @@ export function TimeFilterPicker({
   withSubmitButton,
   onChange,
   onBack,
+  readOnly,
 }: FilterPickerWidgetProps) {
   const columnInfo = useMemo(
     () => Lib.displayInfo(query, stageIndex, column),
@@ -79,6 +80,7 @@ export function TimeFilterPicker({
       <FilterPickerHeader
         columnName={columnInfo.longDisplayName}
         onBack={onBack}
+        readOnly={readOnly}
       >
         <FilterOperatorPicker
           value={operator}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/types.ts
@@ -12,6 +12,7 @@ export type FilterPickerWidgetProps = {
   withSubmitButton: boolean;
   onChange: (filter: Lib.ExpressionClause, opts: FilterChangeOpts) => void;
   onBack?: () => void;
+  readOnly?: boolean;
 };
 
 export type FilterChangeOpts = {

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
@@ -96,7 +96,6 @@ export function AggregateStep({
       onReorder={handleReorderAggregation}
       onRemove={handleRemoveAggregation}
       data-testid="aggregate-step"
-      renderPopoverWhenReadOnly
     />
   );
 }

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
@@ -52,8 +52,8 @@ export function AggregateStep({
   const canRenderPopover = (
     query: Lib.Query,
     stageIndex: number,
-    clause: Lib.AggregationClause,
-    clauseIndex,
+    clause?: Lib.AggregationClause,
+    clauseIndex?: number,
   ) => {
     const isUpdate = clause != null && clauseIndex != null;
     const baseOperators = Lib.availableAggregationOperators(query, stageIndex);
@@ -81,7 +81,7 @@ export function AggregateStep({
       hasRemoveButton={hasRemoveButton}
       renderName={renderAggregationName}
       renderPopover={({ item: aggregation, index, onClose }) =>
-        canRenderPopover(query, stageIndex, aggregation, index) && (
+        canRenderPopover(query, stageIndex, aggregation, index) ? (
           <AggregationPopover
             query={query}
             stageIndex={stageIndex}
@@ -91,7 +91,7 @@ export function AggregateStep({
             onClose={onClose}
             readOnly={readOnly}
           />
-        )
+        ) : null
       }
       onReorder={handleReorderAggregation}
       onRemove={handleRemoveAggregation}

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { AggregationPicker } from "metabase/common/components/AggregationPicker";
+import {
+  AggregationPicker,
+  isExpressionEditorInitiallyOpen,
+} from "metabase/common/components/AggregationPicker";
 import * as Lib from "metabase-lib";
 
 import type { NotebookStepProps } from "../../types";
@@ -64,11 +67,13 @@ export function AggregateStep({
           clauseIndex={index}
           onQueryChange={updateQuery}
           onClose={onClose}
+          readOnly={readOnly}
         />
       )}
       onReorder={handleReorderAggregation}
       onRemove={handleRemoveAggregation}
       data-testid="aggregate-step"
+      renderPopoverWhenReadOnly
     />
   );
 }
@@ -80,6 +85,7 @@ interface AggregationPopoverProps {
   clauseIndex?: number;
   onQueryChange: (query: Lib.Query) => void;
   onClose: () => void;
+  readOnly?: boolean;
 }
 
 function AggregationPopover({
@@ -89,6 +95,7 @@ function AggregationPopover({
   clauseIndex,
   onQueryChange,
   onClose,
+  readOnly,
 }: AggregationPopoverProps) {
   const isUpdate = clause != null && clauseIndex != null;
 
@@ -98,6 +105,17 @@ function AggregationPopover({
       ? Lib.selectedAggregationOperators(baseOperators, clause)
       : baseOperators;
   }, [query, clause, stageIndex, isUpdate]);
+
+  const isCustomExpression = isExpressionEditorInitiallyOpen(
+    query,
+    stageIndex,
+    clause,
+    operators,
+  );
+
+  if (readOnly && !isCustomExpression) {
+    return null;
+  }
 
   return (
     <AggregationPicker
@@ -109,6 +127,7 @@ function AggregationPopover({
       allowCustomExpressions
       onQueryChange={onQueryChange}
       onClose={onClose}
+      readOnly={readOnly}
     />
   );
 }

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
@@ -49,6 +49,27 @@ export function AggregateStep({
   const renderAggregationName = (aggregation: Lib.AggregationClause) =>
     Lib.displayInfo(query, stageIndex, aggregation).longDisplayName;
 
+  const canRenderPopover = (
+    query: Lib.Query,
+    stageIndex: number,
+    clause: Lib.AggregationClause,
+    clauseIndex,
+  ) => {
+    const isUpdate = clause != null && clauseIndex != null;
+    const baseOperators = Lib.availableAggregationOperators(query, stageIndex);
+    const operators = isUpdate
+      ? Lib.selectedAggregationOperators(baseOperators, clause)
+      : baseOperators;
+    const isCustomExpression = isExpressionEditorInitiallyOpen(
+      query,
+      stageIndex,
+      clause,
+      operators,
+    );
+
+    return !readOnly || isCustomExpression;
+  };
+
   return (
     <ClauseStep
       items={aggregations}
@@ -59,17 +80,19 @@ export function AggregateStep({
       hasAddButton={hasAddButton}
       hasRemoveButton={hasRemoveButton}
       renderName={renderAggregationName}
-      renderPopover={({ item: aggregation, index, onClose }) => (
-        <AggregationPopover
-          query={query}
-          stageIndex={stageIndex}
-          clause={aggregation}
-          clauseIndex={index}
-          onQueryChange={updateQuery}
-          onClose={onClose}
-          readOnly={readOnly}
-        />
-      )}
+      renderPopover={({ item: aggregation, index, onClose }) =>
+        canRenderPopover(query, stageIndex, aggregation, index) && (
+          <AggregationPopover
+            query={query}
+            stageIndex={stageIndex}
+            clause={aggregation}
+            clauseIndex={index}
+            onQueryChange={updateQuery}
+            onClose={onClose}
+            readOnly={readOnly}
+          />
+        )
+      }
       onReorder={handleReorderAggregation}
       onRemove={handleRemoveAggregation}
       data-testid="aggregate-step"
@@ -105,17 +128,6 @@ function AggregationPopover({
       ? Lib.selectedAggregationOperators(baseOperators, clause)
       : baseOperators;
   }, [query, clause, stageIndex, isUpdate]);
-
-  const isCustomExpression = isExpressionEditorInitiallyOpen(
-    query,
-    stageIndex,
-    clause,
-    operators,
-  );
-
-  if (readOnly && !isCustomExpression) {
-    return null;
-  }
 
   return (
     <AggregationPicker

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.tsx
@@ -1,10 +1,7 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import {
-  AggregationPicker,
-  isExpressionEditorInitiallyOpen,
-} from "metabase/common/components/AggregationPicker";
+import { AggregationPicker } from "metabase/common/components/AggregationPicker";
 import * as Lib from "metabase-lib";
 
 import type { NotebookStepProps } from "../../types";
@@ -49,27 +46,6 @@ export function AggregateStep({
   const renderAggregationName = (aggregation: Lib.AggregationClause) =>
     Lib.displayInfo(query, stageIndex, aggregation).longDisplayName;
 
-  const canRenderPopover = (
-    query: Lib.Query,
-    stageIndex: number,
-    clause?: Lib.AggregationClause,
-    clauseIndex?: number,
-  ) => {
-    const isUpdate = clause != null && clauseIndex != null;
-    const baseOperators = Lib.availableAggregationOperators(query, stageIndex);
-    const operators = isUpdate
-      ? Lib.selectedAggregationOperators(baseOperators, clause)
-      : baseOperators;
-    const isCustomExpression = isExpressionEditorInitiallyOpen(
-      query,
-      stageIndex,
-      clause,
-      operators,
-    );
-
-    return !readOnly || isCustomExpression;
-  };
-
   return (
     <ClauseStep
       items={aggregations}
@@ -80,19 +56,17 @@ export function AggregateStep({
       hasAddButton={hasAddButton}
       hasRemoveButton={hasRemoveButton}
       renderName={renderAggregationName}
-      renderPopover={({ item: aggregation, index, onClose }) =>
-        canRenderPopover(query, stageIndex, aggregation, index) ? (
-          <AggregationPopover
-            query={query}
-            stageIndex={stageIndex}
-            clause={aggregation}
-            clauseIndex={index}
-            onQueryChange={updateQuery}
-            onClose={onClose}
-            readOnly={readOnly}
-          />
-        ) : null
-      }
+      renderPopover={({ item: aggregation, index, onClose }) => (
+        <AggregationPopover
+          query={query}
+          stageIndex={stageIndex}
+          clause={aggregation}
+          clauseIndex={index}
+          onQueryChange={updateQuery}
+          onClose={onClose}
+          readOnly={readOnly}
+        />
+      )}
       onReorder={handleReorderAggregation}
       onRemove={handleRemoveAggregation}
       data-testid="aggregate-step"

--- a/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/BreakoutStep/BreakoutStep.tsx
@@ -80,18 +80,20 @@ export function BreakoutStep({
       hasAddButton={hasAddButton}
       isAddButtonDisabled={isAddButtonDisabled}
       renderName={renderBreakoutName}
-      renderPopover={({ item: breakout, index, onClose }) => (
-        <BreakoutPopover
-          query={query}
-          stageIndex={stageIndex}
-          breakout={breakout}
-          breakoutIndex={index}
-          isMetric={isMetric}
-          onAddBreakout={handleAddBreakout}
-          onUpdateBreakoutColumn={handleUpdateBreakoutColumn}
-          onClose={onClose}
-        />
-      )}
+      renderPopover={({ item: breakout, index, onClose }) =>
+        readOnly ? null : (
+          <BreakoutPopover
+            query={query}
+            stageIndex={stageIndex}
+            breakout={breakout}
+            breakoutIndex={index}
+            isMetric={isMetric}
+            onAddBreakout={handleAddBreakout}
+            onUpdateBreakoutColumn={handleUpdateBreakoutColumn}
+            onClose={onClose}
+          />
+        )
+      }
       onReorder={handleReorderBreakout}
       onRemove={handleRemoveBreakout}
       data-testid="breakout-step"

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -8,7 +8,7 @@ import S from "./ClausePopover.module.css";
 
 interface ClausePopoverProps {
   isInitiallyOpen?: boolean;
-  renderItem: (open: () => void) => JSX.Element | string;
+  renderItem: (open: () => void, hasPopover?: boolean) => JSX.Element | string;
   renderPopover: (close: () => void) => JSX.Element | null;
 }
 
@@ -39,6 +39,7 @@ export function ClausePopover({
   }, [active]);
 
   const content = renderPopover(handleClose);
+  const hasPopover = content !== null;
 
   return (
     <PreventPopoverExitProvider>
@@ -49,9 +50,9 @@ export function ClausePopover({
         trapFocus
         onChange={handleChange}
         classNames={{ dropdown: S.dropdown }}
-        disabled={content === null}
+        disabled={!hasPopover}
       >
-        <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
+        <Popover.Target>{renderItem(handleOpen, hasPopover)}</Popover.Target>
         <Popover.Dropdown data-testid="clause-popover">
           <Box className={S.dropdownContent} data-testid="popover-content">
             {content}

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -40,6 +40,8 @@ export function ClausePopover({
     }
   }, [active]);
 
+  const content = renderPopover(handleClose);
+
   return (
     <PreventPopoverExitProvider>
       <Popover
@@ -49,12 +51,12 @@ export function ClausePopover({
         trapFocus
         onChange={handleChange}
         classNames={{ dropdown: S.dropdown }}
-        disabled={disabled}
+        disabled={disabled || content === false}
       >
         <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
         <Popover.Dropdown data-testid="clause-popover">
           <Box className={S.dropdownContent} data-testid="popover-content">
-            {renderPopover(handleClose)}
+            {content}
           </Box>
         </Popover.Dropdown>
       </Popover>

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -10,14 +10,12 @@ interface ClausePopoverProps {
   isInitiallyOpen?: boolean;
   renderItem: (open: () => void) => JSX.Element | string;
   renderPopover: (close: () => void) => JSX.Element | null;
-  disabled?: boolean;
 }
 
 export function ClausePopover({
   isInitiallyOpen = false,
   renderItem,
   renderPopover,
-  disabled,
 }: ClausePopoverProps) {
   const [isOpen, setIsOpen] = useState(isInitiallyOpen);
   const { active } = useDndContext();
@@ -51,7 +49,7 @@ export function ClausePopover({
         trapFocus
         onChange={handleChange}
         classNames={{ dropdown: S.dropdown }}
-        disabled={disabled || content === null}
+        disabled={content === null}
       >
         <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
         <Popover.Dropdown data-testid="clause-popover">

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -10,12 +10,14 @@ interface ClausePopoverProps {
   isInitiallyOpen?: boolean;
   renderItem: (open: () => void) => JSX.Element | string;
   renderPopover: (close: () => void) => JSX.Element | null;
+  disabled?: boolean;
 }
 
 export function ClausePopover({
   isInitiallyOpen = false,
   renderItem,
   renderPopover,
+  disabled,
 }: ClausePopoverProps) {
   const [isOpen, setIsOpen] = useState(isInitiallyOpen);
   const { active } = useDndContext();
@@ -47,6 +49,7 @@ export function ClausePopover({
         trapFocus
         onChange={handleChange}
         classNames={{ dropdown: S.dropdown }}
+        disabled={disabled}
       >
         <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
         <Popover.Dropdown data-testid="clause-popover">

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClausePopover.tsx
@@ -51,7 +51,7 @@ export function ClausePopover({
         trapFocus
         onChange={handleChange}
         classNames={{ dropdown: S.dropdown }}
-        disabled={disabled || content === false}
+        disabled={disabled || content === null}
       >
         <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
         <Popover.Dropdown data-testid="clause-popover">

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
@@ -22,6 +22,7 @@ type RenderItemOpts<T> = {
   item: T;
   index: number;
   onOpen?: () => void;
+  hasPopover?: boolean;
 };
 
 type RenderPopoverOpts<T> = {
@@ -61,9 +62,19 @@ export const ClauseStep = <T,>({
   onReorder,
   ...props
 }: ClauseStepProps<T>): JSX.Element => {
-  const renderItem = ({ item, index, onOpen }: RenderItemOpts<T>) => (
+  const renderItem = ({
+    item,
+    index,
+    onOpen,
+    hasPopover,
+  }: RenderItemOpts<T>) => (
     <ClauseStepDndItem index={index} readOnly={readOnly}>
-      <NotebookCellItem color={color} readOnly={readOnly} onClick={onOpen}>
+      <NotebookCellItem
+        color={color}
+        readOnly={readOnly}
+        onClick={onOpen}
+        hasPopover={hasPopover}
+      >
         {renderName(item, index)}
         {hasRemoveButton && (
           <Icon
@@ -94,7 +105,9 @@ export const ClauseStep = <T,>({
         {items.map((item, index) => (
           <ClausePopover
             key={index}
-            renderItem={(onOpen) => renderItem({ item, index, onOpen })}
+            renderItem={(onOpen, hasPopover) =>
+              renderItem({ item, index, onOpen, hasPopover })
+            }
             renderPopover={(onClose) => renderPopover({ item, index, onClose })}
           />
         ))}

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
@@ -44,6 +44,7 @@ export type ClauseStepProps<T> = {
   onRemove: (item: T, index: number) => void;
   onReorder: (sourceItem: T, targetItem: T) => void;
   "data-testid"?: string;
+  renderPopoverWhenReadOnly?: boolean;
 };
 
 export const ClauseStep = <T,>({
@@ -59,6 +60,7 @@ export const ClauseStep = <T,>({
   renderPopover,
   onRemove,
   onReorder,
+  renderPopoverWhenReadOnly = false,
   ...props
 }: ClauseStepProps<T>): JSX.Element => {
   const renderItem = ({ item, index, onOpen }: RenderItemOpts<T>) => (
@@ -96,6 +98,7 @@ export const ClauseStep = <T,>({
             key={index}
             renderItem={(onOpen) => renderItem({ item, index, onOpen })}
             renderPopover={(onClose) => renderPopover({ item, index, onClose })}
+            disabled={readOnly && !renderPopoverWhenReadOnly}
           />
         ))}
       </ClauseStepDndContext>
@@ -104,6 +107,7 @@ export const ClauseStep = <T,>({
           isInitiallyOpen={isLastOpened}
           renderItem={(onOpen) => renderNewItem({ onOpen })}
           renderPopover={(onClose) => renderPopover({ onClose })}
+          disabled={readOnly && !renderPopoverWhenReadOnly}
         />
       )}
     </NotebookCell>

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
@@ -44,7 +44,6 @@ export type ClauseStepProps<T> = {
   onRemove: (item: T, index: number) => void;
   onReorder: (sourceItem: T, targetItem: T) => void;
   "data-testid"?: string;
-  renderPopoverWhenReadOnly?: boolean;
 };
 
 export const ClauseStep = <T,>({
@@ -60,7 +59,6 @@ export const ClauseStep = <T,>({
   renderPopover,
   onRemove,
   onReorder,
-  renderPopoverWhenReadOnly = false,
   ...props
 }: ClauseStepProps<T>): JSX.Element => {
   const renderItem = ({ item, index, onOpen }: RenderItemOpts<T>) => (
@@ -98,7 +96,6 @@ export const ClauseStep = <T,>({
             key={index}
             renderItem={(onOpen) => renderItem({ item, index, onOpen })}
             renderPopover={(onClose) => renderPopover({ item, index, onClose })}
-            disabled={readOnly && !renderPopoverWhenReadOnly}
           />
         ))}
       </ClauseStepDndContext>
@@ -107,7 +104,6 @@ export const ClauseStep = <T,>({
           isInitiallyOpen={isLastOpened}
           renderItem={(onOpen) => renderNewItem({ onOpen })}
           renderPopover={(onClose) => renderPopover({ onClose })}
-          disabled={readOnly && !renderPopoverWhenReadOnly}
         />
       )}
     </NotebookCell>

--- a/frontend/src/metabase/querying/notebook/components/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/DataStep/DataStep.tsx
@@ -66,6 +66,7 @@ export const DataStep = ({
         containerStyle={{ padding: 0 }}
         rightContainerStyle={{ width: 37, padding: 0 }}
         data-testid="data-step-cell"
+        disabled={readOnly}
       >
         <NotebookDataPicker
           query={query}

--- a/frontend/src/metabase/querying/notebook/components/ExpressionStep/ExpressionStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ExpressionStep/ExpressionStep.tsx
@@ -64,7 +64,6 @@ export const ExpressionStep = ({
       isLastOpened={isLastOpened}
       onReorder={handleReorderExpression}
       onRemove={handleRemoveExpression}
-      renderPopoverWhenReadOnly
     />
   );
 };

--- a/frontend/src/metabase/querying/notebook/components/ExpressionStep/ExpressionStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ExpressionStep/ExpressionStep.tsx
@@ -58,11 +58,13 @@ export const ExpressionStep = ({
           reportTimezone={reportTimezone}
           updateQuery={updateQuery}
           onClose={onClose}
+          readOnly={readOnly}
         />
       )}
       isLastOpened={isLastOpened}
       onReorder={handleReorderExpression}
       onRemove={handleRemoveExpression}
+      renderPopoverWhenReadOnly
     />
   );
 };
@@ -75,6 +77,7 @@ type ExpressionPopoverProps = {
   reportTimezone: string;
   updateQuery: (query: Lib.Query) => Promise<void>;
   onClose: () => void;
+  readOnly?: boolean;
 };
 
 function ExpressionPopover({
@@ -85,6 +88,7 @@ function ExpressionPopover({
   reportTimezone,
   updateQuery,
   onClose,
+  readOnly,
 }: ExpressionPopoverProps) {
   const expressionInfo = useMemo(
     () =>
@@ -133,6 +137,7 @@ function ExpressionPopover({
       onChangeClause={handleChangeClause}
       reportTimezone={reportTimezone}
       onClose={onClose}
+      readOnly={readOnly}
     />
   );
 }

--- a/frontend/src/metabase/querying/notebook/components/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/FilterStep/FilterStep.tsx
@@ -80,6 +80,7 @@ export function FilterStep({
             onAddFilter={handleAddFilter}
             onUpdateFilter={handleUpdateFilter}
             onClose={onClose}
+            readOnly={readOnly}
           />
         )}
         onReorder={handleReorderFilter}
@@ -100,6 +101,7 @@ interface FilterPopoverProps {
     nextFilter: Lib.Filterable,
   ) => void;
   onClose?: () => void;
+  readOnly?: boolean;
 }
 
 function FilterPopover({
@@ -110,6 +112,7 @@ function FilterPopover({
   onAddFilter,
   onUpdateFilter,
   onClose,
+  readOnly,
 }: FilterPopoverProps) {
   return (
     <FilterPicker
@@ -125,6 +128,7 @@ function FilterPopover({
         }
       }}
       onClose={onClose}
+      readOnly={readOnly}
     />
   );
 }

--- a/frontend/src/metabase/querying/notebook/components/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/FilterStep/FilterStep.tsx
@@ -85,6 +85,7 @@ export function FilterStep({
         )}
         onReorder={handleReorderFilter}
         onRemove={handleRemoveFilter}
+        renderPopoverWhenReadOnly
       />
     </ErrorBoundary>
   );

--- a/frontend/src/metabase/querying/notebook/components/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/FilterStep/FilterStep.tsx
@@ -85,7 +85,6 @@ export function FilterStep({
         )}
         onReorder={handleReorderFilter}
         onRemove={handleRemoveFilter}
-        renderPopoverWhenReadOnly
       />
     </ErrorBoundary>
   );

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStrategyPicker/JoinStrategyPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStrategyPicker/JoinStrategyPicker.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import IconButtonWrapper from "metabase/common/components/IconButtonWrapper";
 import SelectList from "metabase/common/components/SelectList";
-import { Icon, Popover } from "metabase/ui";
+import { Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { getJoinStrategyIcon } from "../utils";
@@ -40,18 +40,19 @@ export function JoinStrategyPicker({
   return (
     <Popover opened={isOpened} position="bottom-start" onChange={setIsOpened}>
       <Popover.Target>
-        <IconButtonWrapper
-          disabled={isReadOnly}
-          aria-label={t`Change join type`}
-          onClick={() => setIsOpened(!isOpened)}
-        >
-          <Icon
-            className={S.JoinStrategyIcon}
-            name={getJoinStrategyIcon(strategyInfo)}
-            tooltip={t`Change join type`}
-            size={32}
-          />
-        </IconButtonWrapper>
+        <Tooltip disabled={isReadOnly} label={t`Change join type`}>
+          <IconButtonWrapper
+            disabled={isReadOnly}
+            aria-label={t`Change join type`}
+            onClick={() => setIsOpened(!isOpened)}
+          >
+            <Icon
+              className={S.JoinStrategyIcon}
+              name={getJoinStrategyIcon(strategyInfo)}
+              size={32}
+            />
+          </IconButtonWrapper>
+        </Tooltip>
       </Popover.Target>
       <Popover.Dropdown>
         <JoinStrategyDropdown

--- a/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStrategyPicker/JoinStrategyPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/JoinStep/JoinStrategyPicker/JoinStrategyPicker.tsx
@@ -38,7 +38,12 @@ export function JoinStrategyPicker({
   };
 
   return (
-    <Popover opened={isOpened} position="bottom-start" onChange={setIsOpened}>
+    <Popover
+      opened={isOpened}
+      position="bottom-start"
+      onChange={setIsOpened}
+      disabled={isReadOnly}
+    >
       <Popover.Target>
         <Tooltip disabled={isReadOnly} label={t`Change join type`}>
           <IconButtonWrapper

--- a/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/LimitStep/LimitStep.tsx
@@ -16,6 +16,7 @@ export function LimitStep({
   step,
   color,
   updateQuery,
+  readOnly,
 }: NotebookStepProps) {
   const { stageIndex } = step;
 
@@ -52,6 +53,7 @@ export function LimitStep({
         small
         onBlur={handleBlur}
         onChange={handleChange}
+        readOnly={readOnly}
       />
     </NotebookCell>
   );

--- a/frontend/src/metabase/querying/notebook/components/NotebookCell/NotebookCell.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookCell/NotebookCell.tsx
@@ -41,6 +41,7 @@ interface NotebookCellItemProps {
   "data-testid"?: string;
   ref?: React.Ref<HTMLDivElement>;
   className?: string;
+  hasPopover?: boolean;
 }
 
 export const NotebookCellItem = forwardRef<
@@ -56,6 +57,7 @@ export const NotebookCellItem = forwardRef<
     rightContainerStyle,
     children,
     readOnly,
+    hasPopover,
     className,
     ...restProps
   },
@@ -71,7 +73,9 @@ export const NotebookCellItem = forwardRef<
           [S.inactive]: inactive,
           [S.disabled]: disabled,
           [S.cursorPointer]:
-            (!inactive || restProps.onClick) && !readOnly && !disabled,
+            (!inactive || restProps.onClick) &&
+            !disabled &&
+            (!readOnly || hasPopover),
         },
         className,
       )}

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -161,7 +161,7 @@ function ModernDataPicker({
     <>
       <Tooltip
         label={t`${METAKEY}+click to open in new tab`}
-        hidden={!table}
+        hidden={!table || isDisabled}
         events={{ hover: true, focus: false, touch: false }}
       >
         <DataPickerTarget

--- a/frontend/src/metabase/querying/notebook/components/SortStep/SortStep.module.css
+++ b/frontend/src/metabase/querying/notebook/components/SortStep/SortStep.module.css
@@ -4,5 +4,8 @@
   gap: 0.5rem;
   color: var(--mb-color-text-white);
   font-weight: 700;
-  cursor: pointer;
+
+  &:not(:disabled) {
+    cursor: pointer;
+  }
 }

--- a/frontend/src/metabase/querying/notebook/components/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/SortStep/SortStep.tsx
@@ -73,17 +73,19 @@ export function SortStep({
           onToggleSortDirection={() => handleToggleOrderByDirection(clause)}
         />
       )}
-      renderPopover={({ item: orderBy, index, onClose }) => (
-        <SortPopover
-          query={query}
-          stageIndex={stageIndex}
-          orderBy={orderBy}
-          orderByIndex={index}
-          onAddOrderBy={handleAddOrderBy}
-          onUpdateOrderByColumn={handleUpdateOrderByColumn}
-          onClose={onClose}
-        />
-      )}
+      renderPopover={({ item: orderBy, index, onClose }) =>
+        readOnly ? null : (
+          <SortPopover
+            query={query}
+            stageIndex={stageIndex}
+            orderBy={orderBy}
+            orderByIndex={index}
+            onAddOrderBy={handleAddOrderBy}
+            onUpdateOrderByColumn={handleUpdateOrderByColumn}
+            onClose={onClose}
+          />
+        )
+      }
       onReorder={handleReorderOrderBy}
       onRemove={handleRemoveOrderBy}
     />

--- a/frontend/src/metabase/querying/notebook/components/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/SortStep/SortStep.tsx
@@ -71,6 +71,7 @@ export function SortStep({
         <SortDisplayName
           displayInfo={Lib.displayInfo(query, stageIndex, clause)}
           onToggleSortDirection={() => handleToggleOrderByDirection(clause)}
+          disabled={readOnly}
         />
       )}
       renderPopover={({ item: orderBy, index, onClose }) =>
@@ -160,11 +161,13 @@ const checkColumnSelected = (
 interface SortDisplayNameProps {
   displayInfo: Lib.OrderByClauseDisplayInfo;
   onToggleSortDirection: () => void;
+  disabled?: boolean;
 }
 
 function SortDisplayName({
   displayInfo,
   onToggleSortDirection,
+  disabled,
 }: SortDisplayNameProps) {
   const icon = displayInfo.direction === "asc" ? "arrow_up" : "arrow_down";
   return (
@@ -175,6 +178,7 @@ function SortDisplayName({
         event.stopPropagation();
         onToggleSortDirection();
       }}
+      disabled={disabled}
     >
       <Icon name={icon} />
       <span>{displayInfo.longDisplayName}</span>

--- a/frontend/src/metabase/querying/notebook/types.ts
+++ b/frontend/src/metabase/querying/notebook/types.ts
@@ -35,6 +35,7 @@ export interface NotebookStep {
   next: NotebookStep | null;
   previous: NotebookStep | null;
   previewQuery?: Lib.Query | null;
+  allowPopoverWhenReadOnly?: boolean;
 }
 
 export interface NotebookStepAction {

--- a/frontend/src/metabase/ui/components/buttons/PopoverBackButton/PopoverBackButton.tsx
+++ b/frontend/src/metabase/ui/components/buttons/PopoverBackButton/PopoverBackButton.tsx
@@ -6,10 +6,11 @@ import { Icon } from "metabase/ui";
 import type { BoxProps } from "../../utils";
 import { Button } from "../Button";
 
-export type PopoverBackButtonProps = BoxProps &
+export type PopoverBackButtonProps = { readOnly?: boolean } & BoxProps &
   ButtonHTMLAttributes<HTMLButtonElement>;
 
 export function PopoverBackButton(props: PopoverBackButtonProps) {
+  const { readOnly, ...rest } = props;
   return (
     <Button
       p={0}
@@ -17,9 +18,10 @@ export function PopoverBackButton(props: PopoverBackButtonProps) {
       c="var(--mb-color-text-primary)"
       fz="1rem"
       lh="1.25rem"
-      {...props}
+      {...rest}
       variant="subtle"
-      leftSection={<Icon name="chevronleft" />}
+      disabled={readOnly}
+      leftSection={!readOnly && <Icon name="chevronleft" />}
     />
   );
 }

--- a/frontend/src/metabase/ui/components/buttons/PopoverBackButton/PopoverBackButton.tsx
+++ b/frontend/src/metabase/ui/components/buttons/PopoverBackButton/PopoverBackButton.tsx
@@ -6,11 +6,11 @@ import { Icon } from "metabase/ui";
 import type { BoxProps } from "../../utils";
 import { Button } from "../Button";
 
-export type PopoverBackButtonProps = { readOnly?: boolean } & BoxProps &
+export type PopoverBackButtonProps = { withArrow?: boolean } & BoxProps &
   ButtonHTMLAttributes<HTMLButtonElement>;
 
 export function PopoverBackButton(props: PopoverBackButtonProps) {
-  const { readOnly, ...rest } = props;
+  const { withArrow = true, ...rest } = props;
   return (
     <Button
       p={0}
@@ -20,8 +20,7 @@ export function PopoverBackButton(props: PopoverBackButtonProps) {
       lh="1.25rem"
       {...rest}
       variant="subtle"
-      disabled={readOnly}
-      leftSection={!readOnly && <Icon name="chevronleft" />}
+      leftSection={withArrow && <Icon name="chevronleft" />}
     />
   );
 }


### PR DESCRIPTION
Closes QUE-2154

Makes the notebook preview completely non-interactive.

This means that users won't be able to open filter popovers to see complex filter values,
but it was decided that it's

> @mazameli probably better to just make it completely non-interactive though than to open the can of worms of creating an interactive-but-read-only rendering of the notebook
