### PR TITLE
Transform dependencies

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/api/transform-job.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/transform-job.ts
@@ -1,5 +1,6 @@
 import type {
   CreateTransformJobRequest,
+  Transform,
   TransformJob,
   TransformJobId,
   UpdateTransformJobRequest,
@@ -12,6 +13,7 @@ import {
   listTag,
   provideTransformJobListTags,
   provideTransformJobTags,
+  provideTransformTags,
   tag,
 } from "./tags";
 
@@ -31,6 +33,17 @@ export const transformJobApi = EnterpriseApi.injectEndpoints({
         url: `/api/ee/transform-job/${id}`,
       }),
       providesTags: (job) => (job ? provideTransformJobTags(job) : []),
+    }),
+    listTransformJobTransforms: builder.query<Transform[], TransformJobId>({
+      query: (id) => ({
+        method: "GET",
+        url: `/api/ee/transform-job/${id}/transforms`,
+      }),
+      providesTags: (transforms, error, id) =>
+        invalidateTags(error, [
+          idTag("transform-job", id),
+          ...(transforms?.flatMap(provideTransformTags) ?? []),
+        ]),
     }),
     runTransformJob: builder.mutation<void, TransformJobId>({
       query: (id) => ({
@@ -100,6 +113,7 @@ export const transformJobApi = EnterpriseApi.injectEndpoints({
 
 export const {
   useListTransformJobsQuery,
+  useListTransformJobTransformsQuery,
   useGetTransformJobQuery,
   useLazyGetTransformJobQuery,
   useRunTransformJobMutation,

--- a/enterprise/frontend/src/metabase-enterprise/api/transform.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/transform.ts
@@ -48,6 +48,17 @@ export const transformApi = EnterpriseApi.injectEndpoints({
       providesTags: (transform) =>
         transform ? provideTransformTags(transform) : [],
     }),
+    listTransformDependencies: builder.query<Transform[], TransformId>({
+      query: (id) => ({
+        method: "GET",
+        url: `/api/ee/transform/${id}/transform`,
+      }),
+      providesTags: (transforms, error, id) =>
+        invalidateTags(error, [
+          idTag("transform", id),
+          ...(transforms?.flatMap(provideTransformTags) ?? []),
+        ]),
+    }),
     runTransform: builder.mutation<void, TransformId>({
       query: (id) => ({
         method: "POST",
@@ -111,6 +122,7 @@ export const transformApi = EnterpriseApi.injectEndpoints({
 export const {
   useListTransformsQuery,
   useListTransformRunsQuery,
+  useListTransformDependenciesQuery,
   useGetTransformQuery,
   useLazyGetTransformQuery,
   useRunTransformMutation,

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/DependenciesSection/DependenciesSection.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/DependenciesSection/DependenciesSection.module.css
@@ -1,0 +1,3 @@
+.row {
+  cursor: pointer;
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/DependenciesSection/DependenciesSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/DependenciesSection/DependenciesSection.tsx
@@ -1,0 +1,58 @@
+import { push } from "react-router-redux";
+import { t } from "ttag";
+
+import { AdminContentTable } from "metabase/common/components/AdminContentTable";
+import { useDispatch } from "metabase/lib/redux";
+import { Card, Center, Loader } from "metabase/ui";
+import { useListTransformJobTransformsQuery } from "metabase-enterprise/api";
+import type { Transform, TransformJob } from "metabase-types/api";
+
+import { TitleSection } from "../../../components/TitleSection";
+import { getTransformUrl } from "../../../urls";
+
+import S from "./DependenciesSection.module.css";
+
+// TODO: remove this once the api has real data
+const MOCK: Transform[] = [
+  { id: 1, name: "Join Accounts and companies", target: { name: "foo" } },
+  { id: 2, name: "Maz's custom transform", target: { name: "bar" } },
+];
+
+export function DependenciesSection({ job }: { job: TransformJob }) {
+  const { data: transforms = MOCK, isLoading } =
+    useListTransformJobTransformsQuery(job.id);
+  const dispatch = useDispatch();
+
+  if (!isLoading && transforms?.length === 0) {
+    return null;
+  }
+
+  const handleRowClick = (transform: Transform) => {
+    dispatch(push(getTransformUrl(transform.id)));
+  };
+
+  return (
+    <TitleSection label={t`Transforms will be run in this order`}>
+      <Card p={0} shadow="none" withBorder>
+        {isLoading ? (
+          <Center>
+            <Loader m="xl" />
+          </Center>
+        ) : (
+          <AdminContentTable columnTitles={[t`Transform`, t`Target`]}>
+            {transforms?.map((transform) => (
+              <tr
+                key={transform.id}
+                className={S.row}
+                onClick={() => handleRowClick(transform)}
+              >
+                <th>{transform.name}</th>
+                <td>{transform.target.name}</td>
+              </tr>
+            ))}
+          </AdminContentTable>
+        )}
+      </Card>
+    </TitleSection>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/DependenciesSection/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/DependenciesSection/index.ts
@@ -1,0 +1,1 @@
+export * from "./DependenciesSection";

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/JobView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/JobView.tsx
@@ -1,6 +1,7 @@
 import { Stack } from "metabase/ui";
 import type { TransformTagId } from "metabase-types/api";
 
+import { DependenciesSection } from "./DependenciesSection";
 import { HeaderSection } from "./HeaderSection";
 import { ManageSection } from "./ManageSection";
 import { NameSection } from "./NameSection";
@@ -38,6 +39,7 @@ export function JobView({
       <TagSection job={job} onTagsChange={onTagListChange} />
       {job.id != null && <ManageSection job={job} />}
       {job.id == null && <SaveSection job={job} />}
+      <DependenciesSection job={job} />
     </Stack>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/TitleSection/TitleSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/TitleSection/TitleSection.tsx
@@ -1,24 +1,27 @@
 import type { ReactNode } from "react";
 
-import { Group, Stack, Title } from "metabase/ui";
+import { Group, Stack, Text, Title } from "metabase/ui";
 
 type TitleSectionProps = {
   label: string;
+  description?: string;
   rightSection?: ReactNode;
   children?: ReactNode;
 };
 
 export function TitleSection({
   label,
+  description,
   rightSection,
   children,
 }: TitleSectionProps) {
   return (
     <Stack>
       <Group>
-        <Title flex={1} order={4}>
-          {label}
-        </Title>
+        <Stack flex={1}>
+          <Title order={4}>{label}</Title>
+          <Text c="text-secondary">{description}</Text>
+        </Stack>
         {rightSection}
       </Group>
       {children}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/DependenciesSection/DependenciesSection.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/DependenciesSection/DependenciesSection.module.css
@@ -1,0 +1,3 @@
+.row {
+  cursor: pointer;
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/DependenciesSection/DependenciesSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/DependenciesSection/DependenciesSection.tsx
@@ -1,0 +1,61 @@
+import { push } from "react-router-redux";
+import { t } from "ttag";
+
+import { AdminContentTable } from "metabase/common/components/AdminContentTable";
+import { useDispatch } from "metabase/lib/redux";
+import { Card, Center, Loader } from "metabase/ui";
+import { useListTransformDependenciesQuery } from "metabase-enterprise/api";
+import type { Transform } from "metabase-types/api";
+
+import { TitleSection } from "../../../components/TitleSection";
+import { getTransformUrl } from "../../../urls";
+
+import S from "./DependenciesSection.module.css";
+
+// TODO: remove this once the api has real data
+const MOCK = [
+  { id: 1, name: "Join Accounts and companies", target: { name: "foo" } },
+  { id: 2, name: "Maz's custom transform", target: { name: "bar" } },
+];
+
+export function DependenciesSection({ transform }: { transform: Transform }) {
+  const { data: dependencies = MOCK, isLoading } =
+    useListTransformDependenciesQuery(transform.id);
+  const dispatch = useDispatch();
+
+  if (!isLoading && dependencies?.length === 0) {
+    return null;
+  }
+
+  const handleRowClick = (transform: Transform) => {
+    dispatch(push(getTransformUrl(transform.id)));
+  };
+
+  return (
+    <TitleSection
+      label={t`Dependencies`}
+      description={t`This transform depends on the output of the transforms below, so they need to be run first.`}
+    >
+      <Card p={0} shadow="none" withBorder>
+        {isLoading ? (
+          <Center>
+            <Loader m="xl" />
+          </Center>
+        ) : (
+          <AdminContentTable columnTitles={[t`Transform`, t`Target`]}>
+            {dependencies?.map((transform) => (
+              <tr
+                key={transform.id}
+                className={S.row}
+                onClick={() => handleRowClick(transform)}
+              >
+                <th>{transform.name}</th>
+                <td>{transform.target.name}</td>
+              </tr>
+            ))}
+          </AdminContentTable>
+        )}
+      </Card>
+    </TitleSection>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/DependenciesSection/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/DependenciesSection/index.ts
@@ -1,0 +1,1 @@
+export * from "./DependenciesSection";

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TransformPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TransformPage.tsx
@@ -10,6 +10,7 @@ import type { Transform, TransformId } from "metabase-types/api";
 
 import { POLLING_INTERVAL } from "../../constants";
 
+import { DependenciesSection } from "./DependenciesSection";
 import { HeaderSection } from "./HeaderSection";
 import { ManageSection } from "./ManageSection";
 import { NameSection } from "./NameSection";
@@ -60,6 +61,7 @@ export function TransformPage({ params }: TransformPageProps) {
       <RunSection transform={transform} />
       <TargetSection transform={transform} />
       <ManageSection transform={transform} />
+      <DependenciesSection transform={transform} />
     </Stack>
   );
 }


### PR DESCRIPTION
Closes QUE-2149

- Adds dependencies section to transforms page
- Adds transform order section to job page

This PR uses mock data for now, since the API has not been implemented yet.