### PR TITLE
Update Snowplow Micro image

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -138,16 +138,17 @@ e2e_embedding_sdk_compatibility:
   - "e2e/runner/embedding-sdk/**"
   - "e2e/test-host-app/**/*.cy.*.{js,ts}"
 
+snowplow: &snowplow
+  - ".github/workflows/snowplow.yml"
+  - "snowplow/**"
+
 e2e_all:
   - *default
   - *e2e_ci
   - *sources
   - *e2e_specs
   - "e2e/**"
-
-snowplow:
-  - ".github/workflows/snowplow.yml"
-  - "snowplow/**"
+  - *snowplow
 
 documentation:
   - "docs/**"

--- a/snowplow/docker-compose.yml
+++ b/snowplow/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   snowplow-micro:
-    image: snowplow/snowplow-micro:1.2.1
+    image: snowplow/snowplow-micro:2.3.0
     ports:
       - "9090:9090"
     volumes:


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-122/update-the-snowplow-micro-image

### Description

I'm updating snowplow-micro Docker image to the latest version which includes UI for analyzing events.
https://docs.snowplow.io/docs/data-product-studio/data-quality/snowplow-micro/ui/

### How to verify
- `cd snowplow`
- `docker compose up`
-  go to http://localhost:9090/micro/ui

Start Metabase with Snowplow enabled `MB_SNOWPLOW_AVAILABLE=true` `MB_SNOWPLOW_URL=http://localhost:9090`

### Demo
<img width="3456" height="2144" alt="27974" src="https://github.com/user-attachments/assets/8a96af87-3ac5-484d-9b54-318de8c39234" />
