### PR TITLE
Add `background-hover` to custom colors list

### DIFF
--- a/frontend/src/metabase/ui/utils/colors.ts
+++ b/frontend/src/metabase/ui/utils/colors.ts
@@ -51,6 +51,7 @@ const CUSTOM_COLORS = [
   "text-secondary-inverse",
   "text-tertiary",
   "background",
+  "background-hover",
   "background-disabled",
   "accent-gray",
   "accent-gray-light",


### PR DESCRIPTION
[This change breaks](https://github.com/metabase/metabase/pull/61961/files#diff-b4111644f088dd15a98b28189fe9c4ba6a784b9c7e4dff86e710ca5adf90a32bR53) ToolbarButton color (and maybe other places as well?)

Because `theme.fn.getColor` can't return a proper color to set it for a css variable.

The fix is to add `background-hover` to `CUSTOM_COLORS` so the `theme.fn.getColor` can properly return the proper color

Before:
<img width="514" height="218" alt="image" src="https://github.com/user-attachments/assets/95cd862d-dd85-4abe-ae6f-53686fe57374" />


After:
<img width="468" height="216" alt="image" src="https://github.com/user-attachments/assets/55f64352-889b-4653-ae50-34a6eec037a2" />
