### PR TITLE
Closes EMB-734 iframe+matchMedia crashing in Safari

### DIFF
--- a/patches/@mantine+hooks+8.0.2.patch
+++ b/patches/@mantine+hooks+8.0.2.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@mantine/hooks/esm/use-media-query/use-media-query.mjs b/node_modules/@mantine/hooks/esm/use-media-query/use-media-query.mjs
+index c175ddb..6460b82 100644
+--- a/node_modules/@mantine/hooks/esm/use-media-query/use-media-query.mjs
++++ b/node_modules/@mantine/hooks/esm/use-media-query/use-media-query.mjs
+@@ -22,12 +22,17 @@ function useMediaQuery(query, initialValue, { getInitialValueInEffect } = {
+   const [matches, setMatches] = useState(
+     getInitialValueInEffect ? initialValue : getInitialValue(query)
+   );
+-  const queryRef = useRef(null);
+   useEffect(() => {
+     if ("matchMedia" in window) {
+-      queryRef.current = window.matchMedia(query);
+-      setMatches(queryRef.current.matches);
+-      return attachMediaListener(queryRef.current, (event) => setMatches(event.matches));
++      try {
++        const mediaQuery = window.matchMedia(query);
++        setMatches(mediaQuery.matches);
++        return attachMediaListener(mediaQuery, (event) => setMatches(event.matches));
++      } catch (e) {
++        // Safari iframe compatibility issue
++        console.warn('MediaQuery not available in iframe:', e);
++        return void 0;
++      }
+     }
+     return void 0;
+   }, [query]);


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62302
Closes [EMB-734: Navigating away on embed before cards load freezes tab in Safari](https://linear.app/metabase/issue/EMB-734/navigating-away-on-embed-before-cards-load-freezes-tab-in-safari)

### Description

The original bug happens when switching tabs in an interactive embedded Metabase. It actually comes from the way Safari implements MediaQueryList event handling. It seems that events are triggered while an iframe is being removed, leading to an RTE. The crash only happening in Safari and also crashing the dev tools prevents from having a look at the error, but a git bisect shows that the issue was introduced in #53447.

The code that throws the error lives in Mantine: https://github.com/mantinedev/mantine/blob/master/packages/@mantine/hooks/src/use-media-query/use-media-query.ts

Unfortunately there's no way of deterministically knowing when the error will be thrown, hence the `try {...} catch()`.

### How to verify

Run Metabase EE with the following config.yml:

```
version: 1
config:
  users:
    - first_name: Susan
      last_name: Calvin
      password: one-two-three
      email: susan-calvin@usrmm.com
  settings:
    anon-tracking-enabled: false
    application-name: Acme From Config File
    embedding-app-origins-interactive: "*"
    embedding-secret-key: "0000000000000000000000000000000000000000000000000000000000000000"
    enable-embedding-interactive: true
    enable-embedding-sdk: true
    enable-embedding-static: true
    enable-public-sharing: true
    jwt-enabled: true
    jwt-identity-provider-uri: "http://localhost:8888/api/sso"
    jwt-shared-secret: "0000000000000000000000000000000000000000000000000000000000000000"
    site-url: "http://localhost:3000"
```

Then run https://github.com/metabase/edumation-embedding-demo with the following changes:

 - in `.env.local` set `METABASE_JWT_SHARED_SECRET` to `0000000000000000000000000000000000000000000000000000000000000000`
 - comment out line 37:50 in `src/components/thirdParty/metabase/JWTIFrame/JWTIFrame.tsx`
 - change `src/components/thirdParty/metabase/utils/index.ts` to it always return `http://localhost:3000`

Open `http://localhost:3003` in Safari and switch rapidly between tabs. It should not freeze.