### PR TITLE
fix(sdk): Properly calculate the `dirty` state for the `InteractiveQuestion.SaveButton` button

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -586,7 +586,9 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
         cy.findByText("Trend").click();
       });
 
-      cy.findByTestId("sdk-question-save-button").should("exist");
+      cy.findByTestId("interactive-question-top-toolbar").within(() => {
+        cy.findByText("Save").should("exist");
+      });
     });
   });
 
@@ -602,7 +604,9 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
         cy.findByTestId("User ID-hide-button").click();
       });
 
-      cy.findByTestId("sdk-question-save-button").should("exist");
+      cy.findByTestId("interactive-question-top-toolbar").within(() => {
+        cy.findByText("Save").should("exist");
+      });
     });
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -9,6 +9,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   FIRST_COLLECTION_ENTITY_ID,
   FIRST_COLLECTION_ID,
+  ORDERS_QUESTION_ID,
   SECOND_COLLECTION_ENTITY_ID,
   THIRD_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
@@ -570,6 +571,38 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       cy.log("back to previous result button should not be visible");
       cy.findByText("No results!").should("be.visible");
       cy.findByText("Back to previous results").should("not.exist");
+    });
+  });
+
+  it("should show the `Save` button when a visualization type was changed (metabase#62396)", () => {
+    mountSdkContent(<InteractiveQuestion questionId={ORDERS_QUESTION_ID} />);
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("chart-type-selector-button").click();
+
+      cy.findByTestId("sdk-question-save-button").should("not.exist");
+
+      cy.findByRole("menu").within(() => {
+        cy.findByText("Trend").click();
+      });
+
+      cy.findByTestId("sdk-question-save-button").should("exist");
+    });
+  });
+
+  it("should show the `Save` button when a visualization setting was changed (metabase#62396)", () => {
+    mountSdkContent(<InteractiveQuestion questionId={ORDERS_QUESTION_ID} />);
+
+    getSdkRoot().within(() => {
+      H.openVizSettingsSidebar();
+
+      cy.findByTestId("sdk-question-save-button").should("not.exist");
+
+      cy.findByTestId("chartsettings-sidebar").within(() => {
+        cy.findByTestId("User ID-hide-button").click();
+      });
+
+      cy.findByTestId("sdk-question-save-button").should("exist");
     });
   });
 });

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SaveButton.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SaveButton.tsx
@@ -57,7 +57,6 @@ export const SaveButton = ({ ...buttonProps }: SaveButtonProps = {}) => {
     <ToolbarButton
       label={t`Save`}
       disabled={!isSaveButtonEnabled}
-      data-testid="sdk-question-save-button"
       {...buttonProps}
     />
   );

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SaveButton.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SaveButton.tsx
@@ -2,6 +2,7 @@ import type { MouseEventHandler } from "react";
 import { t } from "ttag";
 
 import type { ButtonProps } from "embedding-sdk-bundle/types/ui";
+import { isQuestionDirty } from "metabase/query_builder/utils/question";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 
@@ -29,7 +30,7 @@ export const shouldShowSaveButton = ({
 }) => {
   const canSave = question && Lib.canSave(question.query(), question.type());
   const isQuestionChanged = originalQuestion
-    ? question?.isDirtyComparedToWithoutParameters(originalQuestion)
+    ? isQuestionDirty(question, originalQuestion)
     : true;
 
   return Boolean(isQuestionChanged && canSave);

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SaveButton.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SaveButton.tsx
@@ -29,7 +29,7 @@ export const shouldShowSaveButton = ({
 }) => {
   const canSave = question && Lib.canSave(question.query(), question.type());
   const isQuestionChanged = originalQuestion
-    ? question && question.isQueryDirtyComparedTo(originalQuestion)
+    ? question?.isDirtyComparedToWithoutParameters(originalQuestion)
     : true;
 
   return Boolean(isQuestionChanged && canSave);
@@ -56,6 +56,7 @@ export const SaveButton = ({ ...buttonProps }: SaveButtonProps = {}) => {
     <ToolbarButton
       label={t`Save`}
       disabled={!isSaveButtonEnabled}
+      data-testid="sdk-question-save-button"
       {...buttonProps}
     />
   );

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -164,7 +164,11 @@ export const SdkQuestionDefaultView = ({
       style={style}
     >
       <Stack className={InteractiveQuestionS.TopBar} gap="sm" p="md">
-        <Group justify="space-between" align="flex-end">
+        <Group
+          justify="space-between"
+          align="flex-end"
+          data-testid="interactive-question-top-toolbar"
+        >
           <Group gap="xs">
             <Box mr="sm">
               <BackButton />


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62396
Properly calculate the `dirty` state for the `InteractiveQuestion.SaveButton` button

- we have to use isDirtyComparedToWithoutParameters instead of isQueryDirtyComparedTo
- isDirtyComparedToWithoutParameters  is used in the main app for the Save button

How to verify:
- CI is green