### PR TITLE
[perf] Optimize metabase.lib.field.resolution/merge-metadata

### DIFF
--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.field.resolution
   "Code for resolving field metadata from a field ref. There's a lot of code here, isn't there? This is probably more
   complicated than it needs to be!"
-  (:refer-clojure :exclude [some select-keys])
+  (:refer-clojure :exclude [not-empty some select-keys])
   (:require
    #?@(:clj
        ([metabase.config.core :as config]))
@@ -26,19 +26,20 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some select-keys]]))
+   [metabase.util.performance :refer [not-empty some select-keys]]))
 
 (mr/def ::id-or-name
   [:or :string ::lib.schema.id/field])
 
-(defn- merge-metadata
-  [m & more]
+(defn- merge-metadata [maps]
   (not-empty
-   (into (or m {})
-         (comp cat
-               (filter (fn [[_k v]]
-                         (some? v))))
-         more)))
+   ;; Intentionally using 2-arity clojure.core/reduce here because we want the behavior of taking the first map from
+   ;; the list as the accumulator and adding values from subsequent maps onto it.
+   #_{:clj-kondo/ignore [:reduce-without-init]}
+   (reduce #(reduce-kv (fn [acc k v]
+                         (cond-> acc (some? v) (assoc k v)))
+                       %1 %2)
+           maps)))
 
 (mu/defn- add-parent-column-metadata
   "If this is a nested column, add metadata about the parent column."
@@ -625,10 +626,8 @@
                 (maybe-resolve-expression-in-current-stage query stage-number id-or-name)
                 ;; if we STILL can't find a match, return made-up fallback metadata.
                 (fallback-metadata id-or-name))]
-    (merge-metadata
-     col
-     (when col
-       (additional-metadata-from-source-card query stage-number col)))))
+    (when col
+      (merge-metadata [col (additional-metadata-from-source-card query stage-number col)]))))
 
 (mu/defn resolve-field-ref :- ::lib.metadata.calculation/visible-column
   "Resolve metadata for a `:field` ref. This is part of the implementation
@@ -641,26 +640,26 @@
   (let [stage-number (lib.util/canonical-stage-index query stage-number)]
     (log/debugf "Resolving %s in stage %s" (pr-str id-or-name) (pr-str stage-number))
     (-> (merge-metadata
-         {:lib/type :metadata/column}
-         (or (when join-alias
-               (resolve-in-join query stage-number join-alias source-field id-or-name))
-             (when source-field
-               (resolve-in-implicit-join query stage-number source-field id-or-name))
-             (resolve-from-previous-stage-or-source query stage-number id-or-name)
-             (merge
-              (or (fallback-metadata-for-field query stage-number id-or-name)
-                  (fallback-metadata id-or-name))
-              (when (and join-alias
-                         (contains? (into #{}
-                                          (map :alias)
-                                          (:joins (lib.util/query-stage query stage-number)))
-                                    join-alias))
-                {:lib/source                   :source/joins
-                 :metabase.lib.join/join-alias join-alias})))
-         (options-metadata opts)
-         {:lib/original-ref-style-for-result-metadata-purposes (if (pos-int? id-or-name)
-                                                                 :original-ref-style/id
-                                                                 :original-ref-style/name)})
+         [{:lib/type :metadata/column}
+          (or (when join-alias
+                (resolve-in-join query stage-number join-alias source-field id-or-name))
+              (when source-field
+                (resolve-in-implicit-join query stage-number source-field id-or-name))
+              (resolve-from-previous-stage-or-source query stage-number id-or-name)
+              (merge
+               (or (fallback-metadata-for-field query stage-number id-or-name)
+                   (fallback-metadata id-or-name))
+               (when (and join-alias
+                          (contains? (into #{}
+                                           (map :alias)
+                                           (:joins (lib.util/query-stage query stage-number)))
+                                     join-alias))
+                 {:lib/source                   :source/joins
+                  :metabase.lib.join/join-alias join-alias})))
+          (options-metadata opts)
+          {:lib/original-ref-style-for-result-metadata-purposes (if (pos-int? id-or-name)
+                                                                  :original-ref-style/id
+                                                                  :original-ref-style/name)}])
         (as-> $col (assoc $col :display-name (lib.metadata.calculation/display-name query stage-number $col)))
         ;; `:lib/desired-column-alias` needs to be recalculated in the context of the stage where the ref
         ;; appears, go ahead and remove it so we don't accidentally try to use it when it may or may not be

--- a/src/metabase/util/snake_hating_map.clj
+++ b/src/metabase/util/snake_hating_map.clj
@@ -65,6 +65,9 @@
   (kvreduce [this f init]
     (reduce-kv f init m))
 
+  clojure.lang.Counted
+  (count [this] (count m))
+
   pretty/PrettyPrintable
   (pretty [_this]
     (list `snake-hating-map m)))


### PR DESCRIPTION
Improve the performance of `metabase.lib.field.resolution/resolve-field-ref` by performing more efficient metadata merges.
- Don't use varargs as they are slow to reduce over.
- Implement `perf/not-empty` which tries not to call `seq` on the collection (because some collections don't implement it efficiently, like SnakeHatingMap in this case).
- Implement `clojure.lang.Counted` for SnakeHatingMap (necessary here for the new `not-empty` but will help in other places too).