### PR TITLE
Disable vertica tests until new image is published

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1136,7 +1136,7 @@ jobs:
       - be-tests-sqlite-ee
       - be-tests-sqlserver
       - be-tests-starburst-ee
-      - be-tests-vertica-ee
+      # - be-tests-vertica-ee
       - be-tests-clickhouse-ee
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
### Description

The `vertica/vertica-ce` image we were using has been removed from dockerhub, and so has `opentext/vertica-ce`. See https://github.com/vertica/vertica-containers/issues/64. When there is an image we can use we will re-enable these tests. 

### How to verify

Vertica tests should be skipped.