### PR TITLE
Feat: UXW-504 Missing 'New document' action in top nav search bar

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -387,6 +387,21 @@ describe("command palette", () => {
       cy.findByText("Report an issue").should("be.visible");
     });
   });
+
+  describe("ee", () => {
+    beforeEach(() => {
+      H.activateToken("bleeding-edge");
+    });
+
+    it("should have a 'New document' item", () => {
+      cy.visit("/");
+      cy.findByRole("button", { name: /search/ }).click();
+      H.commandPalette().within(() => {
+        cy.findByText("New document").should("be.visible").click();
+        cy.location("pathname").should("eq", "/document/new");
+      });
+    });
+  });
 });
 
 H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {

--- a/frontend/src/metabase/lib/urls/documents.ts
+++ b/frontend/src/metabase/lib/urls/documents.ts
@@ -1,5 +1,9 @@
 import type { Document } from "metabase-types/api";
 
+export function newDocument() {
+  return `/document/new`;
+}
+
 export function document(document: Pick<Document, "id">) {
   return `/document/${document.id}`;
 }

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -11,6 +11,7 @@ import {
 import Collections from "metabase/entities/collections/collections";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { PLUGIN_DOCUMENTS } from "metabase/plugins";
 import { openDiagnostics } from "metabase/redux/app";
 import { closeModal, setOpenModal } from "metabase/redux/ui";
 import {
@@ -117,6 +118,17 @@ export const useCommandPaletteBasicActions = ({
         openNewModal("dashboard");
       },
     });
+    if (PLUGIN_DOCUMENTS.shouldShowDocumentInNewItemMenu()) {
+      actions.push({
+        id: "create-new-document",
+        name: t`New document`,
+        section: "basic",
+        icon: "document",
+        perform: () => {
+          dispatch(push(Urls.newDocument()));
+        },
+      });
+    }
     actions.push({
       id: "create-new-collection",
       name: t`New collection`,

--- a/frontend/src/metabase/palette/shortcuts/global.ts
+++ b/frontend/src/metabase/palette/shortcuts/global.ts
@@ -22,6 +22,13 @@ export const globalShortcuts = {
     shortcut: ["c d"],
     shortcutGroup: "global" as const,
   },
+  "create-new-document": {
+    get name() {
+      return t`Create a document`;
+    },
+    shortcut: ["c t"],
+    shortcutGroup: "global" as const,
+  },
   "create-new-collection": {
     get name() {
       return t`Create a collection`;


### PR DESCRIPTION
Closes [UXW-504](https://linear.app/metabase/issue/UXW-504)

### Description

Adds "New document" action in kbar menu (if feature is enabled)

### How to verify

1. Run EE
2. Verify "New document" is in kbar menu and takes you to "New document" page
3. Run OSS
4. Verify "New document" is NOT in kbar menu

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
