### PR TITLE
dashboard auto-refresh should reload only dashcards

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/buttons/DashboardActionMenu.tsx
@@ -41,7 +41,6 @@ const DashboardActionMenuInner = ({
   const { refreshDashboard } = useRefreshDashboard({
     dashboardId: dashboard?.id ?? null,
     parameterQueryParams: location?.query,
-    refetchData: false,
   });
 
   const moderationItems = PLUGIN_MODERATION.useDashboardMenuItems(

--- a/frontend/src/metabase/dashboard/context/context.tsx
+++ b/frontend/src/metabase/dashboard/context/context.tsx
@@ -173,13 +173,13 @@ const DashboardContextProviderInner = forwardRef(
     const previousTabId = usePrevious(selectedTabId);
     const previousParameterValues = usePrevious(parameterValues);
 
-    const { refreshDashboard } = useRefreshDashboard({
+    const { refreshDashboardCardData } = useRefreshDashboard({
       dashboardId,
       parameterQueryParams,
     });
 
     const { onRefreshPeriodChange, refreshPeriod, setRefreshElapsedHook } =
-      useDashboardRefreshPeriod({ onRefresh: refreshDashboard });
+      useDashboardRefreshPeriod({ onRefresh: refreshDashboardCardData });
 
     const {
       isFullscreen,

--- a/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-refresh-dashboard.ts
@@ -8,39 +8,47 @@ import {
 import { useDispatch } from "metabase/lib/redux";
 import type { DashboardId } from "metabase-types/api";
 
+interface UseRefreshDashboardProps {
+  dashboardId: DashboardId | null;
+  parameterQueryParams: Query;
+}
+
 export const useRefreshDashboard = ({
   dashboardId,
   parameterQueryParams,
-  refetchData = true,
-}: {
-  dashboardId: DashboardId | null;
-  parameterQueryParams: Record<string, unknown>;
-  refetchData?: boolean;
-}): {
+}: UseRefreshDashboardProps): {
   refreshDashboard: () => Promise<void>;
+  refreshDashboardCardData: () => Promise<void>;
 } => {
   const dispatch = useDispatch();
 
   const refreshDashboard = useCallback(async () => {
-    if (dashboardId) {
-      await dispatch(
-        fetchDashboard({
-          dashId: dashboardId,
-          queryParams: parameterQueryParams as Query,
-          options: { preserveParameters: true },
-        }),
-      );
-      if (refetchData) {
-        dispatch(
-          fetchDashboardCardData({
-            isRefreshing: true,
-            reload: true,
-            clearCache: false,
-          }),
-        );
-      }
+    if (!dashboardId) {
+      return;
     }
-  }, [dashboardId, dispatch, parameterQueryParams, refetchData]);
 
-  return { refreshDashboard };
+    await dispatch(
+      fetchDashboard({
+        dashId: dashboardId,
+        queryParams: parameterQueryParams,
+        options: { preserveParameters: true },
+      }),
+    );
+  }, [dashboardId, dispatch, parameterQueryParams]);
+
+  const refreshDashboardCardData = useCallback(async () => {
+    if (!dashboardId) {
+      return;
+    }
+
+    await dispatch(
+      fetchDashboardCardData({
+        isRefreshing: true,
+        reload: true,
+        clearCache: false,
+      }),
+    );
+  }, [dashboardId, dispatch]);
+
+  return { refreshDashboard, refreshDashboardCardData };
 };


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62170
Closes https://linear.app/metabase/issue/UXW-560/auto-refresh-reloads-entire-dashboard-since-release-56

### Description

Dashboard auto-refresh feature should reload only dashcards data and not the entire dashboard

### How to verify

- Open a dashboard with cards `http://localhost:3000/dashboard/:dashboardId#refresh=5` with 5 second auto-refresh
- Open the network tab and ensure the timer reloads only cards data and not the entire dashboard

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
