### PR TITLE
Fix Select Visual Bugs

### DIFF
--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.module.css
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.module.css
@@ -1,4 +1,0 @@
-.semanticTypePicker {
-  /* override our own weird default for Select, to prevent scrollbar being shown */
-  overflow: visible;
-}

--- a/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.tsx
+++ b/frontend/src/metabase/metadata/components/SemanticTypePicker/SemanticTypePicker.tsx
@@ -5,7 +5,6 @@ import _ from "underscore";
 import { Select, type SelectProps } from "metabase/ui";
 import type { Field } from "metabase-types/api";
 
-import S from "./SemanticTypePicker.module.css";
 import { getCompatibleSemanticTypes } from "./utils";
 
 const NO_SEMANTIC_TYPE = null;
@@ -39,7 +38,6 @@ export const SemanticTypePicker = ({
 
   return (
     <Select
-      className={S.semanticTypePicker}
       comboboxProps={{
         middlewares: {
           flip: true,

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.config.tsx
@@ -8,7 +8,6 @@ export const selectOverrides = {
   Select: Select.extend({
     defaultProps: {
       size: "md",
-      maxDropdownHeight: 512,
       withScrollArea: false,
       allowDeselect: false,
       inputWrapperOrder: ["label", "description", "input", "error"],

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
@@ -89,12 +89,6 @@
   }
 }
 
-.SelectItems_Options {
-  padding: 0.75rem;
-  max-height: rem(500px);
-  overflow-y: auto;
-}
-
 .SelectItems_Item {
   --combobox-option-padding: 0;
 
@@ -150,9 +144,15 @@
   line-height: var(--select-item-line-height);
 }
 
+.SelectItems_Options {
+  padding: 0.75rem;
+  max-height: none;
+}
+
 .Dropdown {
   background-color: var(--mb-color-background);
   border-color: var(--mb-color-border);
+  max-height: rem(500px);
   overflow: auto;
 }
 

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
@@ -145,14 +145,13 @@
 
 .SelectItems_Options {
   padding: 0.75rem;
-  max-height: none;
 }
 
 .Dropdown {
   background-color: var(--mb-color-background);
   border-color: var(--mb-color-border);
-  max-height: rem(500px);
-  overflow: auto;
+  /* need to override the inline style from Mantine */
+  max-height: rem(500px) !important;
 }
 
 .SelectError {

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
@@ -1,7 +1,6 @@
 .SelectRoot {
   border-color: var(--mb-color-border);
   padding: 0;
-  overflow: auto;
 
   & > div {
     max-height: none !important;

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
@@ -150,8 +150,6 @@
 .Dropdown {
   background-color: var(--mb-color-background);
   border-color: var(--mb-color-border);
-  /* need to override the inline style from Mantine */
-  max-height: rem(500px) !important;
 }
 
 .SelectError {

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.module.css
@@ -145,6 +145,11 @@
 
 .SelectItems_Options {
   padding: 0.75rem;
+  /*
+    this clobbers bottom padding when the content overflows, but it's less bad than
+    double scrollbars or overflowing the viewport, see #62466, #61889
+  */
+  max-height: rem(500px);
 }
 
 .Dropdown {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61189
Follow up to #59644

## Description

### Double scrollbars

- the issue above fixed an issue where when options scrolled, they didn't show bottom padding, but created an issue where we would get double scrollbars on small viewports
- this fixes both by ensuring that only one container controls the height, padding, and scroll (the outer dropdown container)
- i also moved the relevant CSS next to each other

Before | After
---|---
<img width="680" height="572" alt="CleanShot 2025-08-20 at 14 58 47" src="https://github.com/user-attachments/assets/c23396a8-e7a5-4402-9d9d-beb28065f758" /> | <img width="668" height="565" alt="CleanShot 2025-08-20 at 14 57 06" src="https://github.com/user-attachments/assets/9070f11f-699e-4907-9ec2-9fd7e9dd5167" />

### Root overflow scroll

This issue seems to have been fixed. I cannot reproduce it in chrome or firefox. In any event, I removed the overflow: auto from the root element because it could cause issue and I can't see any function it fulfills.

reported bug:
<img width="1142" height="387" alt="b16dd6ad-834e-4182-90d8-535a786a9d61" src="https://github.com/user-attachments/assets/7e60f759-5a43-44cc-94c7-8748c92edb94" />

current behavior:

<img width="464" height="275" alt="CleanShot 2025-08-20 at 16 42 49" src="https://github.com/user-attachments/assets/1feeb5a3-27c5-42f4-9993-2193065bb58e" />

