### PR TITLE
docs - fix releases link

### DIFF
--- a/docs/installation-and-operation/upgrading-metabase.md
+++ b/docs/installation-and-operation/upgrading-metabase.md
@@ -8,7 +8,7 @@ redirect_from:
 
 This page covers how to upgrade to a new Metabase release.
 
-- [Announcement posts for major releases](https://www.)
+- [Announcement posts for major releases](https://www.metabase.com/releases)
 - [Changelogs](https://www.metabase.com/changelog).
 - [Release notes on GitHub](https://github.com/metabase/metabase/releases).
 


### PR DESCRIPTION
double backport because this is also in v55 docs