### PR TITLE
Change view details icon to sidebar_open

### DIFF
--- a/frontend/src/metabase/data-grid/components/RowIdCell/RowIdCell.tsx
+++ b/frontend/src/metabase/data-grid/components/RowIdCell/RowIdCell.tsx
@@ -45,7 +45,7 @@ export const RowIdCell = memo(function RowIdCell({
               h={24}
               className={cx(DataGridS.rowHoverVisible, S.expandButton)}
               size="compact-md"
-              leftSection={<Icon name="expand" size={14} />}
+              leftSection={<Icon name="sidebar_open" />}
             />
           )}
         </BaseCell>


### PR DESCRIPTION
It does the below. (I also tried, unsuccessfully, to get it to be `sidebar_closed` when that particular row is open in a side sheet.)

<img width="411" height="298" alt="image" src="https://github.com/user-attachments/assets/bfa47863-05b3-4309-b51a-284dccdb3dc9" />


