### PR TITLE
Add user-recency scorer to the semantic search backend

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1834,7 +1834,8 @@
    :api  #{metabase-enterprise.semantic-search.api
            metabase-enterprise.semantic-search.core
            metabase-enterprise.semantic-search.init}
-   :uses #{analytics
+   :uses #{activity-feed
+           analytics
            api
            app-db
            config

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1836,6 +1836,7 @@
            metabase-enterprise.semantic-search.init}
    :uses #{analytics
            api
+           app-db
            config
            connection-pool
            models

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -648,7 +648,7 @@
                                        :regular-docs-count (count regular-docs)
                                        :time-ms time-ms})
 
-    (analytics/inc! :metabase-search/permission-filtering-ms time-ms)
+    (analytics/inc! :metabase-search/semantic-permission-filter-ms time-ms)
 
     result))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -774,35 +774,50 @@
             raw-results (into [] xform reducible)
             db-query-time-ms (u/since-ms db-timer)
 
+            filter-timer (u/start-timer)
             filtered-results (->> raw-results
                                   filter-read-permitted
                                   (apply-collection-filter search-context)
                                   (mapv search/collapse-id))
+            filter-time-ms (u/since-ms filter-timer)
+
+            appdb-scores-timer (u/start-timer)
+            final-results (->> filtered-results
+                               (scoring/with-appdb-scores search-context))
+            appdb-scores-time-ms (u/since-ms appdb-scores-timer)
 
             total-time-ms (u/since-ms timer)]
 
         (log/debug "Semantic search"
                    {:search-string-length (count search-string)
+                    :raw-results-count (count raw-results)
+                    :final-results-count (count final-results)
                     :embedding-time-ms embedding-time-ms
                     :db-query-time-ms db-query-time-ms
-                    :raw-results-count (count raw-results)
-                    :final-results-count (count filtered-results)
+                    :filter-time-ms filter-time-ms
+                    :appdb-scores-time-ms appdb-scores-time-ms
                     :total-time-ms total-time-ms})
 
-        (analytics/inc! :metabase-search/semantic-search-ms
-                        {:embedding-model (:name embedding-model)}
-                        total-time-ms)
         (analytics/inc! :metabase-search/semantic-embedding-ms
                         {:embedding-model (:name embedding-model)}
                         embedding-time-ms)
         (analytics/inc! :metabase-search/semantic-db-query-ms
                         {:embedding-model (:name embedding-model)}
                         db-query-time-ms)
+        (analytics/inc! :metabase-search/semantic-filter-ms
+                        {:embedding-model (:name embedding-model)}
+                        filter-time-ms)
+        (analytics/inc! :metabase-search/semantic-appdb-scores-ms
+                        {:embedding-model (:name embedding-model)}
+                        appdb-scores-time-ms)
+        (analytics/inc! :metabase-search/semantic-search-ms
+                        {:embedding-model (:name embedding-model)}
+                        total-time-ms)
 
         (comment
           (jdbc/execute! db (sql-format-quoted query)))
 
-        {:results filtered-results
+        {:results final-results
          :raw-count (count raw-results)}))))
 
 (comment

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -4,6 +4,7 @@
    [honey.sql :as sql]
    [honey.sql.helpers :as sql.helpers]
    [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
+   [metabase.activity-feed.core :as activity-feed]
    [metabase.app-db.core :as mdb]
    [metabase.config.core :as config]
    [metabase.premium-features.core :as premium-features]
@@ -145,72 +146,62 @@
 ;;
 
 (defn- search-doc->values
-  [idx {:keys [id model]}]
-  ;; If you don't :inline these, then H2 can't deduce the types from the query params, so the idx and id are returned
-  ;; as text and you get lexicographic ordering on the results idx.
-  [[:inline idx] [:inline id] [:inline model]])
+  [{:keys [id model]}]
+  ;; If we don't :inline these, then H2 can't deduce the types from the query params, so the id is returned
+  ;; as text and you get lexicographic ordering on the results id.
+  [[:inline id] [:inline model]])
 
 (defn- user-recency-query
   [{:keys [current-user-id]} search-results]
-  {:with      [[[:search_docs {:columns [:idx :model_id :model]}]
-                ;; TODO filter to docs with models in rv-models
-                {:values (map-indexed search-doc->values search-results)}]]
-   :select    [[:sd.idx :idx]
-               [:sd.model_id :id]
-               [:sd.model :model]
-               [(search.scoring/inverse-duration [:max :rv.timestamp] [:now] search.config/stale-time-in-days)
-                :user_recency]]
-   :from      [[:search_docs :sd]]
-   :left-join [[:recent_views :rv]
-               [:and
-                [:= :rv.user_id current-user-id]
-                [:= :rv.model_id :sd.model_id]
-                [:=
-                 :rv.model
-                 [:case
-                  [:in :sd.model [[:inline "dataset"] [:inline "metric"]]]
-                  [:inline "card"]
-                  :else
-                  :sd.model]]]]
-   :group-by  [:sd.idx :sd.model_id :sd.model]
-   :order-by  [[:sd.idx :asc]]})
-
-(comment
-  (execute-user-recency-query! {:current-user-id 3}
-                               [{:id 123 :model "dataset"}
-                                {:id 456 :model "dashboard"}
-                                {:id 789 :model "metric"}])
-  (-> (user-recency-query {:current-user-id 3}
-                          [{:id 123 :model "dataset"}
-                           {:id 456 :model "dashboard"}
-                           {:id 789 :model "metric"}])
-      sql/format))
+  {:with     [[[:search_docs {:columns [:model_id :model]}]
+               {:values (map search-doc->values search-results)}]]
+   :select   [[:sd.model_id :id]
+              [:sd.model :model]
+              [(search.scoring/inverse-duration [:max :rv.timestamp] [:now] search.config/stale-time-in-days)
+               :user_recency]]
+   :from     [[:search_docs :sd]]
+   :join     [[:recent_views :rv]
+              [:and
+               [:= :rv.user_id current-user-id]
+               [:= :rv.model_id :sd.model_id]
+               [:=
+                :rv.model
+                [:case
+                 [:in :sd.model [[:inline "dataset"] [:inline "metric"]]]
+                 [:inline "card"]
+                 :else
+                 :sd.model]]]]
+   :group-by [:sd.model_id :sd.model]})
 
 (defn- execute-user-recency-query!
   [search-ctx search-results]
   (t2/query (user-recency-query search-ctx search-results)))
 
 (defn- update-result-with-user-recency
-  [weight search-result user-recency-result]
-  ;; TODO remove
-  (assert (= (:id search-result) (:id user-recency-result)))
-  (assert (= (:model search-result) (:model user-recency-result)))
-  (if-let [user-recency (:user_recency user-recency-result)]
-    (let [contribution (* weight user-recency)]
-      (-> search-result
-          (update :score + contribution)
-          (update :all-scores conj {:score user-recency
-                                    :name :user-recency
-                                    :weight weight
-                                    :contribution contribution})))
-    search-result))
+  [weight grouped-recency-results search-result]
+  (let [id-model-key ((juxt :id :model) search-result)
+        user-recency-rows (get grouped-recency-results id-model-key)
+        _ (assert (>= 1 (count user-recency-rows))) ; TODO m/index-by and remove
+        user-recency (-> user-recency-rows first (:user_recency 0))
+        contribution (* weight user-recency)]
+    (-> search-result
+        (update :score + contribution)
+        (update :all-scores conj {:score user-recency
+                                  :name :user-recency
+                                  :weight weight
+                                  :contribution contribution}))))
 
 (defn- update-results-with-user-recency
   [search-ctx search-results user-recency-results]
-  (map (let [weight (search.config/weight (:context search-ctx) :user-recency)]
-         (partial update-result-with-user-recency weight))
-       search-results
-       user-recency-results))
+  (if-not (seq user-recency-results)
+    search-results
+    (map (let [weight (search.config/weight (:context search-ctx) :user-recency)
+               grouped-recency-results (group-by (juxt :id :model) user-recency-results)]
+           (partial update-result-with-user-recency weight grouped-recency-results))
+         search-results)))
+
+(def ^:private recent-views-models
+  (into #{} (map name activity-feed/rv-models)))
 
 (defn with-appdb-scores
   "Add appdb-based scores to `search-results` and re-rank the results based on the new combined scores.
@@ -219,11 +210,30 @@
   additional scorers, combine those with the existing `:score` and `:all-scores` in the `search-results`, then
   re-order the results by the new combined `:score`."
   [search-ctx search-results]
-  (if-not (and (seq search-results)
-               ;; The user-recency-query needs to be modified to work with mysql / mariadb
-               (#{:postgres :h2} (mdb/db-type)))
-    search-results
-    (->> (execute-user-recency-query! search-ctx search-results)
-         (update-results-with-user-recency search-ctx search-results)
-         (sort-by :score >)
-         vec)))
+  ;; filtered-search-results are the search-results that have models that are tracked in the recent_views table,
+  ;; i.e. results that might possibly have user-recency info.
+  (let [filtered-search-results (filter (comp recent-views-models :model) search-results)]
+    (if-not (and (seq filtered-search-results)
+                 ;; The user-recency-query needs to be modified to work with mysql / mariadb
+                 (#{:postgres :h2} (mdb/db-type)))
+      search-results
+      (->> (execute-user-recency-query! search-ctx filtered-search-results)
+           (update-results-with-user-recency search-ctx search-results)
+           (sort-by :score >)
+           vec))))
+
+(comment
+  (def search-ctx {:current-user-id 3})
+  (def search-docs (-> (map-indexed
+                        (fn [idx doc]
+                          (assoc doc :score idx :all-scores []))
+                        [{:id 1 :model "dataset"}
+                         {:id 1 :model "dashboard"}
+                         {:id 2 :model "table"}
+                         {:id 2 :model "card"}
+                         {:id 4 :model "indexed-entity"}
+                         {:id 7 :model "card"}])
+                       vec))
+  (with-appdb-scores search-ctx search-docs)
+  (->> (execute-user-recency-query! search-ctx search-docs)
+       (update-results-with-user-recency search-ctx search-docs)))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -346,7 +346,7 @@
                 (semantic.index/query-index semantic.tu/db semantic.tu/mock-index
                                             {:search-string "dog training"}))
 
-              (let [permission-calls (filter #(= :metabase-search/permission-filtering-ms (first %)) @analytics-calls)]
+              (let [permission-calls (filter #(= :metabase-search/semantic-permission-filter-ms (first %)) @analytics-calls)]
                 (is (= 1 (count permission-calls)))
                 (let [time-ms (first (second (first permission-calls)))]
                   (is (number? time-ms))
@@ -363,7 +363,7 @@
                 (is (contains? metric-names :metabase-search/semantic-search-ms))
                 (is (contains? metric-names :metabase-search/semantic-embedding-ms))
                 (is (contains? metric-names :metabase-search/semantic-db-query-ms))
-                (is (contains? metric-names :metabase-search/permission-filtering-ms))
+                (is (contains? metric-names :metabase-search/semantic-permission-filter-ms))
                 (is (contains? metric-names :metabase-search/semantic-collection-filter-ms))
                 (is (contains? metric-names :metabase-search/semantic-appdb-scores-ms)))
 
@@ -372,10 +372,10 @@
                         :when (#{:metabase-search/semantic-search-ms
                                  :metabase-search/semantic-embedding-ms
                                  :metabase-search/semantic-db-query-ms
-                                 :metabase-search/permission-filtering-ms
+                                 :metabase-search/semantic-permission-filter-ms
                                  :metabase-search/semantic-collection-filter-ms
                                  :metabase-search/semantic-appdb-scores-ms} metric)]
-                  (let [time-ms (if (#{:metabase-search/permission-filtering-ms
+                  (let [time-ms (if (#{:metabase-search/semantic-permission-filter-ms
                                        :metabase-search/semantic-collection-filter-ms
                                        :metabase-search/semantic-appdb-scores-ms}
                                      metric)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -356,21 +356,29 @@
               (reset! analytics-calls [])
               (mt/with-test-user :crowberto
                 (semantic.index/query-index semantic.tu/db semantic.tu/mock-index
-                                            {:search-string "elephant migration"}))
+                                            {:search-string "elephant migration"
+                                             :filter-items-in-personal-collection "only"}))
 
               (let [metric-names (set (map first @analytics-calls))]
                 (is (contains? metric-names :metabase-search/semantic-search-ms))
                 (is (contains? metric-names :metabase-search/semantic-embedding-ms))
                 (is (contains? metric-names :metabase-search/semantic-db-query-ms))
-                (is (contains? metric-names :metabase-search/permission-filtering-ms)))
+                (is (contains? metric-names :metabase-search/permission-filtering-ms))
+                (is (contains? metric-names :metabase-search/semantic-collection-filter-ms))
+                (is (contains? metric-names :metabase-search/semantic-appdb-scores-ms)))
 
               (testing "timing values  are reasonable"
                 (doseq [[metric args] @analytics-calls
                         :when (#{:metabase-search/semantic-search-ms
                                  :metabase-search/semantic-embedding-ms
                                  :metabase-search/semantic-db-query-ms
-                                 :metabase-search/permission-filtering-ms} metric)]
-                  (let [time-ms (if (= metric :metabase-search/permission-filtering-ms)
+                                 :metabase-search/permission-filtering-ms
+                                 :metabase-search/semantic-collection-filter-ms
+                                 :metabase-search/semantic-appdb-scores-ms} metric)]
+                  (let [time-ms (if (#{:metabase-search/permission-filtering-ms
+                                       :metabase-search/semantic-collection-filter-ms
+                                       :metabase-search/semantic-appdb-scores-ms}
+                                     metric)
                                   (first args)
                                   (second args))]
                     (is (number? time-ms) (str "Time for " metric " should be numeric"))

--- a/src/metabase/activity_feed/core.clj
+++ b/src/metabase/activity_feed/core.clj
@@ -9,4 +9,5 @@
 (p/import-vars
  [metabase.activity-feed.models.recent-views
   fill-recent-view-info
+  rv-models
   update-users-recent-views!])

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -297,6 +297,8 @@
                         :labels [:model :provider]})
    (prometheus/counter :metabase-search/permission-filtering-ms
                        {:description "Total number of ms spent filtering readable docs"})
+   (prometheus/counter :metabase-search/semantic-collection-filter-ms
+                       {:description "Total number of ms spent filtering search results by collection"})
    (prometheus/counter :metabase-search/semantic-search-ms
                        {:description "Total number of ms spent performing a semantic search"
                         :labels [:embedding-model]})
@@ -306,12 +308,8 @@
    (prometheus/counter :metabase-search/semantic-db-query-ms
                        {:description "Total number of ms spent querying the search index"
                         :labels [:embedding-model]})
-   (prometheus/counter :metabase-search/semantic-filter-ms
-                       {:description "Total number of ms spent filtering search results"
-                        :labels [:embedding-model]})
    (prometheus/counter :metabase-search/semantic-appdb-scores-ms
-                       {:description "Total number of ms spent adding appdb-based scores"
-                        :labels [:embedding-model]})
+                       {:description "Total number of ms spent adding appdb-based scores"})
    (prometheus/counter :metabase-search/semantic-fallback-triggered
                        {:description "Number of times semantic search triggered fallback to appdb search due to insufficient results"
                         :labels [:fallback-engine]})

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -306,6 +306,12 @@
    (prometheus/counter :metabase-search/semantic-db-query-ms
                        {:description "Total number of ms spent querying the search index"
                         :labels [:embedding-model]})
+   (prometheus/counter :metabase-search/semantic-filter-ms
+                       {:description "Total number of ms spent filtering search results"
+                        :labels [:embedding-model]})
+   (prometheus/counter :metabase-search/semantic-appdb-scores-ms
+                       {:description "Total number of ms spent adding appdb-based scores"
+                        :labels [:embedding-model]})
    (prometheus/counter :metabase-search/semantic-fallback-triggered
                        {:description "Number of times semantic search triggered fallback to appdb search due to insufficient results"
                         :labels [:fallback-engine]})

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -295,7 +295,7 @@
                        {:description (str "Number of tokens consumed by the given embedding model and provider. "
                                           "Not all providers track token use.")
                         :labels [:model :provider]})
-   (prometheus/counter :metabase-search/permission-filtering-ms
+   (prometheus/counter :metabase-search/semantic-permission-filter-ms
                        {:description "Total number of ms spent filtering readable docs"})
    (prometheus/counter :metabase-search/semantic-collection-filter-ms
                        {:description "Total number of ms spent filtering search results by collection"})


### PR DESCRIPTION
Closes BOT-313

### Description

Add user-recency scorer to the semantic search backend. The user-recency scorer increases a result's score if the current user has viewed the item recently. In the appdb search backend, this scorer is implemented as part of the search results query with a join against the appdb's `recent_views` table. This PR implements it for the semantic backend similarly to the collection and user permissions filters: as an in-memory post-processing on search results. We query the appdb to get the user-recency info from the `recent_views` table, update the scores, and re-sort the results.

This PR also adds a new prometheus metric `:metabase-search/semantic-appdb-scores-ms` to track the time spent calculating the appdb-based scores (eventually this will include the bookmarked items score as well).

The expression to calculate the user-recency score is the same as the one used by the appdb backend. It turns out this expression needs some adjustments to work with mysql, so for now this is restricted to postgres and H2, but should be relatively straightforward to port to mysql. Filed [BOT-360](https://linear.app/metabase/issue/BOT-360/port-user-recency-scorer-to-mysql-and-mariadb-appdb) to track this.

Note on perf: generally appdb query time seems to be in the 1-3 ms range for queries against a copy of the stats appdb locally. For example, appdb scoring took about 3.5 ms for a query that returned ~250 docs post filtering and took ~1.3 sec overall.

```
Permission filtering {:before-count 377, :after-count 377, :indexed-entities-count 9, :regular-docs-count 368, :time-ms 277.492875}
Collection filter {:filter exclude-others, :before 377, :after 259, :dropped 118, :time_ms 3.985666}
Semantic search {:search-string-length 7, :raw-results-count 377, :final-results-count 259, :embedding-time-ms 733.641875, :db-query-time-ms 329.995666, :filter-time-ms 282.606541, :appdb-scores-time-ms 3.526167, :total-time-ms 1349.785166}
```

### How to verify

* View a question / model / metric / dashboard
* Search for the item
* observe the `:user-recency` score in the search response

```json
 {
  "score": 0.9999666189035493827160000000000000000000,
  "name": "user-recency",
  "weight": 5,
  "contribution": 4.9998330945177469135800000000000000000000
}
```

### Demo

<img width="1714" height="749" alt="Screenshot 2025-08-20 at 8 43 57 PM" src="https://github.com/user-attachments/assets/fc09352d-49c7-4cfb-82d5-ae898c35184b" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
