### PR TITLE
Transform tags invalidations

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -321,8 +321,8 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
       H.popover().findByText("New tag").should("be.visible");
 
       cy.log("Navigate to transform B");
-      cy.findByTestId("admin-layout-sidebar").findByText("Transforms").click();
-      H.main().findByText("Transform B").click();
+      getNavSidebar().findByText("Transforms").click();
+      getTransformListPage().findByText("Transform B").click();
 
       cy.log("Remove the new tag from transform B");
       getTagsInput().click();
@@ -337,7 +337,7 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
 
       cy.log("Navigate to transform A");
       cy.findByTestId("admin-layout-sidebar").findByText("Transforms").click();
-      H.main().findByText("Transform A").click();
+      getTransformListPage().findByText("Transform A").click();
 
       cy.log("The tag should be gone");
       getTagsInput()

--- a/enterprise/frontend/src/metabase-enterprise/api/tags.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/tags.ts
@@ -53,7 +53,10 @@ export function invalidateTags(
 export function provideTransformTags(
   transform: Transform,
 ): TagDescription<EnterpriseTagType>[] {
-  return [idTag("transform", transform.id)];
+  return [
+    idTag("transform", transform.id),
+    ...(transform.tag_ids?.flatMap((tag) => idTag("transform-tag", tag)) ?? []),
+  ];
 }
 
 export function provideTransformListTags(

--- a/enterprise/frontend/src/metabase-enterprise/api/transform-tag.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/transform-tag.ts
@@ -52,8 +52,11 @@ export const transformTagApi = EnterpriseApi.injectEndpoints({
         method: "DELETE",
         url: `/api/ee/transform-tag/${id}`,
       }),
-      invalidatesTags: (_, error) =>
-        invalidateTags(error, [listTag("transform-tag")]),
+      invalidatesTags: (_, error, id) =>
+        invalidateTags(error, [
+          listTag("transform-tag"),
+          idTag("transform-tag", id),
+        ]),
     }),
   }),
 });

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/TagSection/TagSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/TagSection/TagSection.unit.spec.tsx
@@ -30,6 +30,6 @@ describe("TagSection", () => {
     const { onTagsChange } = setup({ tags: [tag] });
     await userEvent.click(screen.getByPlaceholderText("Add tags"));
     await userEvent.click(await screen.findByText(tag.name));
-    expect(onTagsChange).toHaveBeenLastCalledWith([tag.id]);
+    expect(onTagsChange).toHaveBeenLastCalledWith([tag.id], true);
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/TagMultiSelect/TagMultiSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/TagMultiSelect/TagMultiSelect.tsx
@@ -28,7 +28,7 @@ type TagModalType = "update" | "delete";
 
 type TagMultiSelectProps = {
   tagIds: TransformTagId[];
-  onChange: (tagIds: TransformTagId[]) => void;
+  onChange: (tagIds: TransformTagId[], undoable?: boolean) => void;
 };
 
 export function TagMultiSelect({ tagIds, onChange }: TagMultiSelectProps) {
@@ -49,7 +49,7 @@ export function TagMultiSelect({ tagIds, onChange }: TagMultiSelectProps) {
     if (!tag) {
       sendErrorToast(t`Failed to create a tag`);
     } else {
-      onChange([...tagIds, tag.id]);
+      onChange([...tagIds, tag.id], true);
     }
   };
 
@@ -57,7 +57,7 @@ export function TagMultiSelect({ tagIds, onChange }: TagMultiSelectProps) {
     if (value.includes(NEW_VALUE)) {
       handleCreate();
     } else {
-      onChange(value.map(getTagId));
+      onChange(value.map(getTagId), true);
     }
   };
 
@@ -82,7 +82,10 @@ export function TagMultiSelect({ tagIds, onChange }: TagMultiSelectProps) {
 
   const handleDelete = () => {
     handleModalClose();
-    onChange(tagIds.filter((tagId) => tagId !== selectedTagId));
+    onChange(
+      tagIds.filter((tagId) => tagId !== selectedTagId),
+      false,
+    );
   };
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.module.css
@@ -1,3 +1,7 @@
 .row {
   cursor: pointer;
 }
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.tsx
@@ -58,12 +58,12 @@ export function JobList() {
             onClick={() => handleRowClick(job)}
           >
             <td>{job.name}</td>
-            <td>
+            <td className={S.nowrap}>
               {job.last_run?.start_time
                 ? parseLocalTimestamp(job.last_run?.start_time).format("lll")
                 : null}
             </td>
-            <td>
+            <td className={S.nowrap}>
               {job.last_run != null ? (
                 <RunStatusInfo
                   status={job.last_run.status}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.module.css
@@ -1,3 +1,7 @@
 .row {
   cursor: pointer;
 }
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.tsx
@@ -65,12 +65,12 @@ export function TransformList() {
           >
             <td>{transform.name}</td>
             <td>{transform.target.name}</td>
-            <td>
+            <td className={S.nowrap}>
               {transform.last_run?.end_time
                 ? parseLocalTimestamp(transform.last_run.end_time).format("lll")
                 : null}
             </td>
-            <td>
+            <td className={S.nowrap}>
               {transform.last_run != null ? (
                 <RunStatusInfo
                   status={transform.last_run.status}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/RunSection/RunSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/RunSection/RunSection.tsx
@@ -174,7 +174,10 @@ function TagSection({ transform }: TagSectionProps) {
   const { sendErrorToast, sendSuccessToast, sendUndoToast } =
     useMetadataToasts();
 
-  const handleTagListChange = async (tagIds: TransformTagId[]) => {
+  const handleTagListChange = async (
+    tagIds: TransformTagId[],
+    undoable: boolean = false,
+  ) => {
     const { error } = await updateTransform({
       id: transform.id,
       tag_ids: tagIds,
@@ -183,13 +186,15 @@ function TagSection({ transform }: TagSectionProps) {
     if (error) {
       sendErrorToast(t`Failed to update transform tags`);
     } else {
-      sendSuccessToast(t`Transform tags updated`, async () => {
+      const undo = async () => {
         const { error } = await updateTransform({
           id: transform.id,
           tag_ids: transform.tag_ids,
         });
         sendUndoToast(error);
-      });
+      };
+
+      sendSuccessToast(t`Transform tags updated`, undoable ? undo : undefined);
     }
   };
 


### PR DESCRIPTION
Closes QUE-2185

### To verify
1. Create two transforms, `A` and `B`
2. On transform `A`, add a tag `foo` (created it if needed)
3. Navigate to transform `B` and edit the tags
4. Delete the `foo` tag
5. Navigate back to transform `A`, it will still show up with a numerical tag (the id of the deleted `foo` tag)

This PR also includes some small cosmetic changes. Ie. how the list of transforms looks when there are long transform names.

<img width="1359" height="829" alt="Screenshot 2025-08-21 at 11 24 34" src="https://github.com/user-attachments/assets/b638908f-5ffb-4cc4-af2e-547cb1ffcef2" />
