### PR TITLE
Fix flaky event sidebar test

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -112,12 +112,15 @@ export function visitQuestion(questionIdOrAlias) {
 function visitQuestionById(id) {
   // In case we use this function multiple times in a test, make sure aliases are unique for each question
   const alias = "cardQuery" + id;
+  const metadataAlias = `${alias}-queryMetadata`;
 
   // We need to use the wildcard because endpoint for pivot tables has the following format: `/api/card/pivot/${id}/query`
   cy.intercept("POST", `/api/card/**/${id}/query`).as(alias);
+  cy.intercept("GET", `/api/card/**/${id}/query_metadata`).as(metadataAlias);
 
   cy.visit(`/question/${id}`);
 
+  cy.wait("@" + metadataAlias);
   cy.wait("@" + alias);
 }
 


### PR DESCRIPTION
Uses the same approach as https://github.com/metabase/metabase/pull/62324

On a slow network, the card query network call was timing it. Even though the actual network request only took 2.7 seconds, it was sitting idle waiting due to the dependency on the metadata query