### PR TITLE
Add bottom padding for "Attach results as files" section

### DIFF
--- a/frontend/src/metabase/notifications/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/notifications/EmailAttachmentPicker.jsx
@@ -269,7 +269,12 @@ export default class EmailAttachmentPicker extends Component {
 
     return (
       <div>
-        <Group className={CS.borderTop} justify="space-between" pt="1.5rem">
+        <Group
+          className={CS.borderTop}
+          justify="space-between"
+          pt="1.5rem"
+          pb="1.5rem"
+        >
           <Group position="left" gap="0">
             <Text fw="bold">{t`Attach results as files`}</Text>
             <Icon


### PR DESCRIPTION
Before
<img width="371" height="202" alt="Screenshot 2025-08-21 at 14 45 44" src="https://github.com/user-attachments/assets/8e4cb916-0c4b-4ec6-ad98-331f1d8318d6" />


After
<img width="378" height="335" alt="Screenshot 2025-08-21 at 14 49 28" src="https://github.com/user-attachments/assets/0d9abfd1-4690-40ce-ab23-a2a5168c630d" />
