### PR TITLE
Closes EMB-665:  do not try to change embedding_params if dashboard is not embedded

### DIFF
--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -37,7 +37,7 @@ import type {
 import type { SelectedTabId } from "metabase-types/store";
 
 export function syncParametersAndEmbeddingParams(before: any, after: any) {
-  if (after.parameters && before.embedding_params) {
+  if (after.parameters && before.embedding_params && before.enable_embedding) {
     return Object.keys(before.embedding_params).reduce((memo, embedSlug) => {
       const slugParam = _.find(before.parameters, (param) => {
         return param.slug === embedSlug;

--- a/frontend/src/metabase/dashboard/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/utils.unit.spec.ts
@@ -106,10 +106,11 @@ describe("Dashboard utils", () => {
   });
 
   describe("syncParametersAndEmbeddingParams", () => {
-    it("should rename `embedding_parameters` that are renamed in `parameters`", () => {
+    it("should rename `embedding_params` that are renamed in `parameters`", () => {
       const before = {
         embedding_params: { id: "required" },
         parameters: [{ slug: "id", id: "unique-param-id" }],
+        enable_embedding: true,
       };
       const after = {
         parameters: [{ slug: "new_id", id: "unique-param-id" }],
@@ -121,10 +122,11 @@ describe("Dashboard utils", () => {
       expect(result).toEqual(expectation);
     });
 
-    it("should remove `embedding_parameters` that are removed from `parameters`", () => {
+    it("should remove `embedding_params` that are removed from `parameters`", () => {
       const before = {
         embedding_params: { id: "required" },
         parameters: [{ slug: "id", id: "unique-param-id" }],
+        enable_embedding: true,
       };
       const after = {
         parameters: [],
@@ -136,10 +138,27 @@ describe("Dashboard utils", () => {
       expect(result).toEqual(expectation);
     });
 
-    it("should not change `embedding_parameters` when `parameters` hasn't changed", () => {
+    it("should not change `embedding_params` when `parameters` hasn't changed", () => {
       const before = {
         embedding_params: { id: "required" },
         parameters: [{ slug: "id", id: "unique-param-id" }],
+        enable_embedding: true,
+      };
+      const after = {
+        parameters: [{ slug: "id", id: "unique-param-id" }],
+      };
+
+      const expectation = { id: "required" };
+
+      const result = syncParametersAndEmbeddingParams(before, after);
+      expect(result).toEqual(expectation);
+    });
+
+    it("should not try to change `embedding_params` if `enable_embedding` is false (metabase#61516)", () => {
+      const before = {
+        embedding_params: { id: "required" },
+        parameters: [{ slug: "id", id: "unique-param-id" }],
+        enable_embedding: false,
       };
       const after = {
         parameters: [{ slug: "id", id: "unique-param-id" }],


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61516
Closes [EMB-665: User who created Dashboard unable to change filters after Dashboard embedded with static embedding after embedding unpublished](https://linear.app/metabase/issue/EMB-665/user-who-created-dashboard-unable-to-change-filters-after-dashboard)

### Description

In https://github.com/metabase/metabase/pull/4271/files#diff-43280a518e697803eb6c0cfa4ff5ec096e6ee07e389274a8b1905cfdc2009323R84 we made it so `embedding_params` cannot be changed by a non admin, which means parameters in general canot be changed either (because `embedding_params` are synced with parameters). That's alright because these typically affect embedded dashboards. However, if a dashboard is published _then_ unpublished, we still prevent non-admin from modifying the parameters and that's not alright.

### How to verify

1. As a non-admin, create a Dashboard with one Question using the Sample Database
2. As the same non-admin, add a filter to that Dashboard and save.
3. As an admin, publish the Dashboard with either Editable or Locked filter
4. As an admin, unpublish the Dashboard
5. As the non-admin user, try to change the name of one of the filters.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
