### PR TITLE
handle new document to new document nav

### DIFF
--- a/e2e/support/helpers/e2e-document-helpers.ts
+++ b/e2e/support/helpers/e2e-document-helpers.ts
@@ -1,5 +1,8 @@
 export const documentContent = () => cy.findByTestId("document-content");
 
+export const documentSaveButton = () =>
+  cy.findByRole("button", { name: "Save" });
+
 export const documentFormattingMenu = () =>
   cy.findByTestId("document-formatting-menu");
 

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -626,3 +626,7 @@ export function mapPinIcon() {
 export function waitForLoaderToBeRemoved() {
   cy.findByTestId("loading-indicator").should("not.exist");
 }
+
+export function leaveConfirmationModal() {
+  return cy.findByTestId("leave-confirmation");
+}

--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -87,7 +87,7 @@ describe("documents", () => {
 
     H.openNavigationSidebar();
 
-    // Force the cliock since this is hidden behind a toast notification
+    // Force the click since this is hidden behind a toast notification
     H.navigationSidebar().findByText("Trash").click({ force: true });
     H.getUnpinnedSection().findByText("Test Document").should("exist");
   });

--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -87,8 +87,34 @@ describe("documents", () => {
 
     H.openNavigationSidebar();
 
-    H.navigationSidebar().findByText("Trash").click();
+    // Force the cliock since this is hidden behind a toast notification
+    H.navigationSidebar().findByText("Trash").click({ force: true });
     H.getUnpinnedSection().findByText("Test Document").should("exist");
+  });
+
+  it("should handle navigating from /new to /new gracefully", () => {
+    cy.visit("/");
+    H.newButton("Document").click();
+    cy.title().should("eq", "New document · Metabase");
+    H.documentContent().click();
+
+    H.documentSaveButton().should("not.exist");
+
+    H.addToDocument("This is some content");
+
+    H.documentSaveButton().should("exist");
+
+    H.newButton("Document").click();
+    H.leaveConfirmationModal().findByRole("button", { name: "Cancel" }).click();
+
+    H.documentContent().should("have.text", "This is some content");
+
+    H.newButton("Document").click();
+    H.leaveConfirmationModal()
+      .findByRole("button", { name: "Discard changes" })
+      .click();
+    H.documentContent().should("have.text", "");
+    H.documentSaveButton().should("not.exist");
   });
 
   describe("document editing", () => {

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -164,16 +164,14 @@ export const DocumentPage = ({
   ]);
 
   // Reset state when we navigate back to /new
-  const resetDocument = () => {
-    if (isNewDocument && previousLocationKey !== location.key) {
-      setDocumentTitle("");
-      setDocumentContent(null);
-      setHasUnsavedEditorChanges(false);
-      editorInstance?.commands.clearContent();
-      editorInstance?.commands.focus();
-      dispatch(resetDocuments());
-    }
-  };
+  const resetDocument = useCallback(() => {
+    setDocumentTitle("");
+    setDocumentContent(null);
+    setHasUnsavedEditorChanges(false);
+    editorInstance?.commands.clearContent();
+    editorInstance?.commands.focus();
+    dispatch(resetDocuments());
+  }, [dispatch, editorInstance, setDocumentContent, setDocumentTitle]);
 
   // Reset dirty state when document content loads from API
   useEffect(() => {

--- a/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveConfirmModal.tsx
+++ b/frontend/src/metabase/common/components/LeaveConfirmModal/LeaveConfirmModal.tsx
@@ -5,7 +5,6 @@ import { ConfirmModal } from "metabase/common/components/ConfirmModal/ConfirmMod
 
 interface Props {
   onConfirm?: () => void;
-  onCancel?: () => void;
   onClose?: () => void;
   opened: boolean | undefined;
 }


### PR DESCRIPTION
### Description
Updates the `DocumentPage` component to handle `/new` to `/new` navigation, complete with leave confirmation modal. I'm not sure how we feel about relying on `location.key` though... I'm open to suggestions haha

### How to verify

1. New -> Document. The save button should not be present
2. Clicking New -> Document again should not bring up a leave confirmation modal
3. Add some content. The save button should be visible
4. New -> Document. Leave confirmation modal should now be visible. Canceling should dismiss the modal, and discarding changes should clear the document

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
