### PR TITLE
[DO NOT MERGE] Update SDK nightly version to 0.56.0-hosted-bundle to test on Shoppy

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.56.0-nightly",
+  "version": "0.56.0-hosted-bundle",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {


### PR DESCRIPTION
Update SDK nightly version to 0.56.0-hosted-bundle to test it for Shoppy