### PR TITLE
ci(sdk): Adjust release CI workflow to release alpha versions from master branch

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -17,7 +17,7 @@ on:
           - release-x.54.x
           - release-x.55.x
           - release-x.56.x
-          - esbuild-main
+          - hosted-bundle-main
 
 concurrency:
   # We want to ensure only one job is running at a time per branch because
@@ -402,7 +402,7 @@ jobs:
            "release-x.54.x": "54-stable",
            "release-x.55.x": "55-stable",
            "release-x.56.x": "56-stable",
-           "esbuild-main": "56-esbuild"
+           "hosted-bundle-main": "57-hosted-bundle-main"
            }')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.55.x`) deployment

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -17,7 +17,6 @@ on:
           - release-x.54.x
           - release-x.55.x
           - release-x.56.x
-          - hosted-bundle-main
 
 concurrency:
   # We want to ensure only one job is running at a time per branch because
@@ -190,7 +189,7 @@ jobs:
           VERSION=$(jq -r .version ./enterprise/frontend/src/embedding-sdk-package/package.template.json)
           echo "sdk_current_version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Get next SDK patch version
+      - name: Get next SDK patch or pre-release version
         id: new-sdk-version
         uses: actions/github-script@v7
         with:
@@ -198,19 +197,31 @@ jobs:
             const currentVersion = "${{ steps.current-sdk-version.outputs.sdk_current_version }}";
             const [currentVersionWithoutSuffix, suffix] = currentVersion.split("-");
             const versionParts = currentVersionWithoutSuffix.split(".");
-            versionParts[versionParts.length - 1] = parseInt(versionParts.at(-1)) + 1;
-            const newVersion = versionParts.join(".");
             const [_, majorVersion] = versionParts
 
-            if (!suffix) {
+            if (branch === "master") {
+              if (!suffix) {
+                throw new Error("Expected pre-release suffix on master branch, got: " + currentVersion);
+              }
+
+              const suffixParts = suffix ? suffix.split(".") : [];
+
+              const preReleaseLabel = suffixParts[0] ?? "";
+              const preReleaseVersion = suffixParts[1] ? parseInt(suffixParts[1]) : 0;
+              const nextPreReleaseVersion = preReleaseVersion + 1;
+
               return {
-                version: newVersion,
-                majorVersion
+                version: `${currentVersionWithoutSuffix}-${preReleaseLabel}.${nextPreReleaseVersion}`,
+                "pre-release-label": preReleaseLabel,
+                majorVersion,
               };
             }
 
+            versionParts[versionParts.length - 1] = parseInt(versionParts.at(-1)) + 1;
+            const newVersion = versionParts.join(".");
+
             return {
-              version: `${newVersion}-${suffix}`,
+              version: suffix ? `${newVersion}-${suffix}` : newVersion,
               majorVersion
             }
 
@@ -336,6 +347,7 @@ jobs:
           git config --global user.name "Metabase Automation"
 
       - name: Update readme
+        if: inputs.branch != 'master'
         run: |
           bash ./bin/embedding-sdk/release_utils.bash update_readme ${{ env.sdk_version }}
 
@@ -354,6 +366,7 @@ jobs:
           mv new-changelog enterprise/frontend/src/embedding-sdk-bundle/CHANGELOG.md
 
       - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
+        if: inputs.branch != 'master'
         run: |
           git checkout -b update-sdk-version-${{ env.sdk_version }}
           git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
@@ -366,18 +379,21 @@ jobs:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Edit PR adding useful information (using Metabase bot app)
+        if: inputs.branch != 'master'
         run: |
           gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Auto approve PR (using GitHub Actions account)
+        if: inputs.branch != 'master'
         run: |
           gh pr review --approve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
+        if: inputs.branche != 'master'
         run: |
           gh pr merge --auto --squash
         env:
@@ -395,14 +411,13 @@ jobs:
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           # Please keep the value in sync with `inputs.branch`'s release branch
           npm publish --tag ${{fromJson('{
-           "master": "nightly",
+           "master": "${{ needs.determine-sdk-version.outputs.pre-release-label || 'nightly' }}",
            "release-x.51.x": "51-stable",
            "release-x.52.x": "52-stable",
            "release-x.53.x": "53-stable",
            "release-x.54.x": "54-stable",
            "release-x.55.x": "55-stable",
-           "release-x.56.x": "56-stable",
-           "hosted-bundle-main": "57-hosted-bundle-main"
+           "release-x.56.x": "56-stable"
            }')[inputs.branch]}}
 
       - name: Add `latest` tag to the latest release branch (`release-x.55.x`) deployment

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -356,44 +356,53 @@ jobs:
           bash ./bin/embedding-sdk/release_utils.bash update_package_json_template ${{ env.sdk_version }}
 
       - name: Retrieve SDK changelog diff
+        if: inputs.branch != 'master'
         uses: actions/download-artifact@v4
         with:
           name: sdk-changelog-diff
 
       - name: Update changelog
+        if: inputs.branch != 'master'
         run: |
           cat changelog-diff enterprise/frontend/src/embedding-sdk-bundle/CHANGELOG.md > new-changelog
           mv new-changelog enterprise/frontend/src/embedding-sdk-bundle/CHANGELOG.md
 
       - name: Create a PR updating readme + published version, and changelog (using GitHub Metabase Automation account)
-        if: inputs.branch != 'master'
         run: |
           git checkout -b update-sdk-version-${{ env.sdk_version }}
-          git commit -a -m 'Update Readme version references and published npm version to ${{ env.sdk_version }}'
+
+          if [ "${{ inputs.branch }}" = "master" ]; then
+            COMMIT_MSG="chore(sdk): Update published npm version to ${{ env.sdk_version }}"
+            PR_TITLE="chore(sdk): Update SDK version to ${{ env.sdk_version }}"
+            PR_BODY="Update published npm package version to ${{ env.sdk_version }}"
+          else
+            COMMIT_MSG="docs(sdk): Update Readme version references and published npm version to ${{ env.sdk_version }}"
+            PR_TITLE="docs(sdk): Update SDK version to ${{ env.sdk_version }}"
+            PR_BODY="Update Readme version references and published npm package version to ${{ env.sdk_version }}"
+          fi
+
+          git commit -a -m "$COMMIT_MSG"
           git push origin HEAD
-          gh pr create --base ${{ inputs.branch }}\
-                       --assignee "${GITHUB_ACTOR}"\
-                       --title "docs(sdk): Update SDK version to ${{ env.sdk_version }}"\
-                       --body "Update Readme version references and published npm package version to ${{ env.sdk_version }}"
+          gh pr create --base "${{ inputs.branch }}" \
+                       --assignee "${GITHUB_ACTOR}" \
+                       --title "$PR_TITLE" \
+                       --body "$PR_BODY"
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Edit PR adding useful information (using Metabase bot app)
-        if: inputs.branch != 'master'
         run: |
           gh pr edit --add-reviewer @metabase/embedding,albertoperdomo --add-label no-backport
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Auto approve PR (using GitHub Actions account)
-        if: inputs.branch != 'master'
         run: |
           gh pr review --approve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable Pull request auto-merge (using GitHub Metabase Automation account)
-        if: inputs.branche != 'master'
         run: |
           gh pr merge --auto --squash
         env:

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -204,6 +204,10 @@ jobs:
                 throw new Error("Expected pre-release suffix on master branch, got: " + currentVersion);
               }
 
+              // When the `currentVersion` is `0.57.0-alpha.1`
+              // The `suffix` is `alpha.1`
+              // The `preReleaseLabel is `alpha`
+              // The `preReleaseVersion` is `1`
               const suffixParts = suffix ? suffix.split(".") : [];
 
               const preReleaseLabel = suffixParts[0] ?? "";
@@ -217,6 +221,8 @@ jobs:
               };
             }
 
+            // 0.57.0 => 0.57.1
+            // 0.57.0-alpha -> 0.57.1-alpha
             versionParts[versionParts.length - 1] = parseInt(versionParts.at(-1)) + 1;
             const newVersion = versionParts.join(".");
 

--- a/enterprise/frontend/src/embedding-sdk-package/package.template.json
+++ b/enterprise/frontend/src/embedding-sdk-package/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabase/embedding-sdk-react",
-  "version": "0.56.0-nightly",
+  "version": "0.57.0-alpha",
   "description": "Metabase Embedding SDK for React",
   "bin": "./dist/cli.js",
   "repository": {
@@ -22,7 +22,9 @@
   },
   "typesVersions": {
     "*": {
-      "next": ["./dist/next.d.ts"]
+      "next": [
+        "./dist/next.d.ts"
+      ]
     }
   },
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Adjust release CI workflow to release alpha versions from master branch

context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1755790508445949

We want to be able easily release pre-release versions from the master branch.

We decided on the following format:
- 0.57.0-alpha - we define it initially in the package.template.json
- 0.57.0-alpha.0 - ftheirst released to npm pre-release version
- 0.57.0-alpha.1 - etc

`alpha` is the `pre-release` label and can be any like `beta`, `nightly`, etc
The pre-release label is used to tag the release made from the `master` branch.

Also the PR disabled the update of README/CHANGELOG when the release is done from `master` branch, but the PR that updates the version number in `package.template.json` still should happen