### PR TITLE
Fix: UXW-502 UXW-506 Documents styling tweaks

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.module.css
@@ -68,6 +68,14 @@
   }
 }
 
+@media not print {
+  .documentContainer {
+    [data-show-on-print] {
+      display: none;
+    }
+  }
+}
+
 .sidebar {
   width: 360px;
   flex-shrink: 0;

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.module.css
@@ -57,6 +57,7 @@
       padding: 0;
     }
 
+    :global(.node-metabot),
     :global(.node-cardEmbed) {
       break-inside: avoid;
     }

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/CardEmbedNode.tsx
@@ -370,7 +370,7 @@ export const CardEmbedComponent = memo(
                   </Box>
                 )}
                 {!isEditingTitle && (
-                  <Menu withinPortal position="bottom-end">
+                  <Menu withinPortal position="bottom-end" data-hide-on-print>
                     <Menu.Target>
                       <Flex
                         component="button"

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/NativeQueryModal.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/NativeQueryModal.module.css
@@ -12,6 +12,14 @@
   overflow: hidden;
 }
 
+.errorContainer {
+  overflow: auto;
+}
+
+.errorMessage {
+  margin: auto;
+}
+
 .loadingOverlay {
   z-index: 10;
 }

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/NativeQueryModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/NativeQueryModal.tsx
@@ -383,12 +383,15 @@ export const NativeQueryModal = ({
                   <Loader size="lg" />
                 </Flex>
               ) : failedDataset || queryError ? (
-                <ErrorMessage
-                  type="serverError"
-                  title={t`Query execution failed`}
-                  message={getErrorMessage(failedDataset, queryError)}
-                  action={null}
-                />
+                <Flex h="100%" className={S.errorContainer}>
+                  <ErrorMessage
+                    type="serverError"
+                    title={t`Query execution failed`}
+                    message={getErrorMessage(failedDataset, queryError)}
+                    action={null}
+                    className={S.errorMessage}
+                  />
+                </Flex>
               ) : hasEmptyResults(datasetToUse) ? (
                 <QueryExecutionEmptyState hasInitialData={!!datasetToUse} />
               ) : rawSeries ? (

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.tsx
@@ -304,6 +304,7 @@ export const MetabotComponent = memo(
             onClick={() => deleteNode()}
           >
             <Icon name="close" data-hide-on-print />
+            <Icon name="metabot" data-show-on-print />
           </Button>
           <Flex flex={1} direction="column" className={S.contentWrapper}>
             <Box

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.tsx
@@ -303,7 +303,7 @@ export const MetabotComponent = memo(
             className={S.closeButton}
             onClick={() => deleteNode()}
           >
-            <Icon name="close" />
+            <Icon name="close" data-hide-on-print />
           </Button>
           <Flex flex={1} direction="column" className={S.contentWrapper}>
             <Box
@@ -350,6 +350,7 @@ export const MetabotComponent = memo(
                 classNames={{
                   label: CS.flex, // ensures icon is vertically centered
                 }}
+                data-hide-on-print
               >
                 {isLoading ? <Icon name="close" /> : t`Run`}
               </Button>


### PR DESCRIPTION
Closes [UXW-502](https://linear.app/metabase/issue/UXW-502) - Error message cut off in native query without scroll option
Closes [UXW-506](https://linear.app/metabase/issue/UXW-506) - Hide extra UI from Download as PDF

### Description

* [UXW-502](https://linear.app/metabase/issue/UXW-502) Makes sql error scrollable. Also makes it vertically centered when not scrollable.
* [UXW-506](https://linear.app/metabase/issue/UXW-506) Hides some UI from Download as PDF

### How to verify

**UXW-502**
1. Add a sql question to a document -> open the embedded card's [...] menu -> Edit query
2. Make the sql invalid and rerun the query
3. Error message should be scrollable if there's not enough room, vertically centered if there is

**UXW-506**
1. Add a chart and a metabot block to a document
2. Open the header's [...] menu -> Print Document
3. The chart's [...] icon and metabot UI should be hidden

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
