### PR TITLE
Preserve viz settings when doing drills in the raw table mode

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -1125,6 +1125,36 @@ describe("issue 55487", () => {
   });
 });
 
+describe("issue 42723", () => {
+  const questionDetails: StructuredQuestionDetails = {
+    display: "line",
+    query: {
+      "source-table": PRODUCTS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        ["field", PRODUCTS.CREATED_AT, { "base-type": "type/DateTime" }],
+        ["field", PRODUCTS.CATEGORY, { "base-type": "type/Text" }],
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should be able to change the query without loosing the viz type (metabase#42723)", () => {
+    H.createQuestion(questionDetails, { visitQuestion: true });
+    H.queryBuilderFooter().findByLabelText("Switch to data").click();
+    H.tableHeaderClick("Count");
+    H.popover().icon("arrow_up").click();
+    H.tableInteractiveHeader().icon("chevronup").should("be.visible");
+
+    H.queryBuilderFooter().findByLabelText("Switch to visualization").click();
+    H.ensureChartIsActive();
+  });
+});
+
 describe("issue 58628", () => {
   beforeEach(() => {
     H.restore();

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -36,6 +36,7 @@ import { trackNewQuestionSaved } from "../../analytics";
 import {
   getCard,
   getIsResultDirty,
+  getIsShowingRawTable,
   getOriginalQuestion,
   getParameters,
   getQuestion,
@@ -152,19 +153,33 @@ export const navigateToNewCardInsideQB = createThunkAction(
           ),
         );
       } else {
-        const card = getCardAfterVisualizationClick(nextCard, previousCard);
-        const url = Urls.serializedQuestion(card);
+        // when navigating in the "raw" table mode, preserve the original viz settings
+        const isRawTable = getIsShowingRawTable(getState());
+        const currentCard = getCard(getState());
+        const adjustedNextCard =
+          isRawTable && currentCard != null
+            ? {
+                ...nextCard,
+                display: currentCard.display,
+                visualization_settings: currentCard.visualization_settings,
+              }
+            : nextCard;
+        const cardAfterClick = getCardAfterVisualizationClick(
+          adjustedNextCard,
+          previousCard,
+        );
+        const url = Urls.serializedQuestion(cardAfterClick);
         if (shouldOpenInBlankWindow(url, { blankOnMetaOrCtrlKey: true })) {
           dispatch(openUrl(url));
         } else {
           dispatch(onCloseSidebars());
-          if (!cardQueryIsEquivalent(previousCard, nextCard)) {
+          if (!cardQueryIsEquivalent(previousCard, adjustedNextCard)) {
             // clear the query result so we don't try to display the new visualization before running the new query
             dispatch(clearQueryResult());
           }
           // When the dataset query changes, we should change the type,
           // to start building a new ad-hoc question based on a dataset
-          dispatch(setCardAndRun({ ...card, type: "question" }));
+          dispatch(setCardAndRun({ ...cardAfterClick, type: "question" }));
         }
 
         if (objectId !== undefined) {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/42723

How to verify:
- New -> Question -> Products -> Count, Group by Created At, Category -> Visualize
- You should see a split line chart
- Go to the raw table mode (toggle at the bottom), click on a column (e.g. Count), and apply sorting
- The viz toggle at the bottom should not disappear. Your viz settings should not be lost.