### PR TITLE
[Vertica] Support Vertica UUID columns as `:type/UUID`

### DIFF
--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -34,6 +34,7 @@
                               :expression-literals       true
                               :now                       true
                               :identifiers-with-spaces   true
+                              :uuid-type                 true
                               :percentile-aggregations   false
                               :test/jvm-timezone-setting false
                               :database-routing          false}]
@@ -56,6 +57,7 @@
     :Numeric                   :type/Decimal
     :Double                    :type/Decimal
     :Float                     :type/Float
+    :Uuid                      :type/UUID
     :Date                      :type/Date
     :Time                      :type/Time
     :TimeTz                    :type/TimeWithLocalTZ

--- a/modules/drivers/vertica/test/metabase/test/data/vertica.clj
+++ b/modules/drivers/vertica/test/metabase/test/data/vertica.clj
@@ -49,7 +49,8 @@
                               :type/Integer        "INTEGER"
                               :type/Text           "VARCHAR(1024)"
                               :type/Time           "TIME"
-                              :type/TimeWithTZ     "TIMETZ"}]
+                              :type/TimeWithTZ     "TIMETZ"
+                              :type/UUID           "UUID"}]
   (defmethod sql.tx/field-base-type->sql-type [:vertica base-type] [_ _] sql-type))
 
 (mu/defn- db-name :- :string
@@ -122,7 +123,7 @@
   [{:keys [field-definitions rows]} ^String filename]
   (try
     (let [has-custom-pk? (when-let [pk (not-empty (sql.tx/fielddefs->pk-field-names field-definitions))]
-                           (not= ["id"] pk))
+                           (= ["id"] pk))
           column-names   (cond->> (mapv :field-name field-definitions)
                            (not has-custom-pk?)
                            (cons "id"))

--- a/modules/drivers/vertica/test/metabase/test/data/vertica.clj
+++ b/modules/drivers/vertica/test/metabase/test/data/vertica.clj
@@ -122,16 +122,13 @@
   "Dump a sequence of rows (as vectors) to a CSV file."
   [{:keys [field-definitions rows]} ^String filename]
   (try
-    (let [has-custom-pk? (when-let [pk (not-empty (sql.tx/fielddefs->pk-field-names field-definitions))]
-                           (= ["id"] pk))
+    (let [needs-pk?      (empty? (sql.tx/fielddefs->pk-field-names field-definitions))
           column-names   (cond->> (mapv :field-name field-definitions)
-                           (not has-custom-pk?)
-                           (cons "id"))
+                           needs-pk? (cons "id"))
           rows-with-id (for [[i row] (m/indexed rows)]
                          (cond->> (for [v row]
                                     (value->csv v))
-                           (not has-custom-pk?)
-                           (cons (inc i))))
+                           needs-pk? (cons (inc i))))
 
           csv-rows     (cons column-names rows-with-id)]
       (try


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62337 and #58915.

### Description

Vertica has a `UUID` column type and it works nicely in Metabase. This enables the `:uuid-type` feature and maps the
type to `:type/UUID` for the Vertica driver.

### How to verify

Follow the repro steps - add a UUID column to a Vertica database and try to filter based on it.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
