### PR TITLE
Set minPoolSize to 0 to avoid periodically waking up serverless DBs

### DIFF
--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -94,10 +94,10 @@
    "acquireRetryAttempts"         (if driver-api/is-test? 1 0)
    ;; [From dox] Seconds a Connection can remain pooled but unused before being discarded.
    "maxIdleTime"                  (* 3 60 60) ; 3 hours
-   ;; In the case of serverless databases, we don't want to periodically 
+   ;; In the case of serverless databases, we don't want to periodically
    ;; wake them up to keep a connection open (#58373).
    "minPoolSize"                  0
-   "initialPoolSize"              0 
+   "initialPoolSize"              0
    "maxPoolSize"                  (driver.settings/jdbc-data-warehouse-max-connection-pool-size)
    ;; [From dox] If true, an operation will be performed at every connection checkout to verify that the connection is
    ;; valid. [...] ;; Testing Connections in checkout is the simplest and most reliable form of Connection testing,
@@ -147,12 +147,12 @@
    ;; stack trace, but clj-memory-meter reports ~800 bytes for a fresh Exception created at the REPL (which presumably
    ;; has a smaller-than-average stack).
    "debugUnreturnedConnectionStackTraces" (u/prog1 (driver.settings/jdbc-data-warehouse-debug-unreturned-connection-stack-traces)
-                                            (when (and <> (not (driver-api/level-enabled? 'com.mchange Level/INFO)))
-                                              (log/warn "jdbc-data-warehouse-debug-unreturned-connection-stack-traces"
-                                                        "is enabled, but INFO logging is not enabled for the"
-                                                        "com.mchange namespace. You must raise the log level for"
-                                                        "com.mchange to INFO via a custom log4j config in order to"
-                                                        "see stacktraces in the logs.")))
+                                                   (when (and <> (not (driver-api/level-enabled? 'com.mchange Level/INFO)))
+                                                     (log/warn "jdbc-data-warehouse-debug-unreturned-connection-stack-traces"
+                                                               "is enabled, but INFO logging is not enabled for the"
+                                                               "com.mchange namespace. You must raise the log level for"
+                                                               "com.mchange to INFO via a custom log4j config in order to"
+                                                               "see stacktraces in the logs.")))
    ;; Set the data source name so that the c3p0 JMX bean has a useful identifier, which incorporates the DB ID, driver,
    ;; and name from the details
    "dataSourceName"               (format "db-%d-%s-%s"
@@ -325,7 +325,7 @@
           (get-fn database-id false)
           ;; create a new pool and add it to our cache, then return it
           (u/prog1 (create-pool! db)
-            (set-pool! database-id <> db))))))
+                   (set-pool! database-id <> db))))))
 
     ;; already a `clojure.java.jdbc` spec map
     (map? db-or-id-or-spec)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -147,12 +147,12 @@
    ;; stack trace, but clj-memory-meter reports ~800 bytes for a fresh Exception created at the REPL (which presumably
    ;; has a smaller-than-average stack).
    "debugUnreturnedConnectionStackTraces" (u/prog1 (driver.settings/jdbc-data-warehouse-debug-unreturned-connection-stack-traces)
-                                                (when (and <> (not (driver-api/level-enabled? 'com.mchange Level/INFO)))
-                                                  (log/warn "jdbc-data-warehouse-debug-unreturned-connection-stack-traces"
-                                                            "is enabled, but INFO logging is not enabled for the"
-                                                            "com.mchange namespace. You must raise the log level for"
-                                                            "com.mchange to INFO via a custom log4j config in order to"
-                                                            "see stacktraces in the logs.")))
+                                            (when (and <> (not (driver-api/level-enabled? 'com.mchange Level/INFO)))
+                                              (log/warn "jdbc-data-warehouse-debug-unreturned-connection-stack-traces"
+                                                        "is enabled, but INFO logging is not enabled for the"
+                                                        "com.mchange namespace. You must raise the log level for"
+                                                        "com.mchange to INFO via a custom log4j config in order to"
+                                                        "see stacktraces in the logs.")))
    ;; Set the data source name so that the c3p0 JMX bean has a useful identifier, which incorporates the DB ID, driver,
    ;; and name from the details
    "dataSourceName"               (format "db-%d-%s-%s"
@@ -325,7 +325,7 @@
           (get-fn database-id false)
           ;; create a new pool and add it to our cache, then return it
           (u/prog1 (create-pool! db)
-             (set-pool! database-id <> db))))))
+            (set-pool! database-id <> db))))))
 
     ;; already a `clojure.java.jdbc` spec map
     (map? db-or-id-or-spec)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -147,12 +147,12 @@
    ;; stack trace, but clj-memory-meter reports ~800 bytes for a fresh Exception created at the REPL (which presumably
    ;; has a smaller-than-average stack).
    "debugUnreturnedConnectionStackTraces" (u/prog1 (driver.settings/jdbc-data-warehouse-debug-unreturned-connection-stack-traces)
-                                                   (when (and <> (not (driver-api/level-enabled? 'com.mchange Level/INFO)))
-                                                     (log/warn "jdbc-data-warehouse-debug-unreturned-connection-stack-traces"
-                                                               "is enabled, but INFO logging is not enabled for the"
-                                                               "com.mchange namespace. You must raise the log level for"
-                                                               "com.mchange to INFO via a custom log4j config in order to"
-                                                               "see stacktraces in the logs.")))
+                                                (when (and <> (not (driver-api/level-enabled? 'com.mchange Level/INFO)))
+                                                  (log/warn "jdbc-data-warehouse-debug-unreturned-connection-stack-traces"
+                                                            "is enabled, but INFO logging is not enabled for the"
+                                                            "com.mchange namespace. You must raise the log level for"
+                                                            "com.mchange to INFO via a custom log4j config in order to"
+                                                            "see stacktraces in the logs.")))
    ;; Set the data source name so that the c3p0 JMX bean has a useful identifier, which incorporates the DB ID, driver,
    ;; and name from the details
    "dataSourceName"               (format "db-%d-%s-%s"
@@ -325,7 +325,7 @@
           (get-fn database-id false)
           ;; create a new pool and add it to our cache, then return it
           (u/prog1 (create-pool! db)
-                   (set-pool! database-id <> db))))))
+             (set-pool! database-id <> db))))))
 
     ;; already a `clojure.java.jdbc` spec map
     (map? db-or-id-or-spec)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -94,10 +94,10 @@
    "acquireRetryAttempts"         (if driver-api/is-test? 1 0)
    ;; [From dox] Seconds a Connection can remain pooled but unused before being discarded.
    "maxIdleTime"                  (* 3 60 60) ; 3 hours
-   "minPoolSize"                  (if (:router-database-id database)
-                                    0 1)
-   "initialPoolSize"              (if (:router-database-id database)
-                                    0 1)
+   ;; In the case of serverless databases, we don't want to periodically 
+   ;; wake them up to keep a connection open (#58373).
+   "minPoolSize"                  0
+   "initialPoolSize"              0 
    "maxPoolSize"                  (driver.settings/jdbc-data-warehouse-max-connection-pool-size)
    ;; [From dox] If true, an operation will be performed at every connection checkout to verify that the connection is
    ;; valid. [...] ;; Testing Connections in checkout is the simplest and most reliable form of Connection testing,


### PR DESCRIPTION
Closes #58373 
Our c3p0 pool originally had `minPoolSize` set to 1, so every `maxIdleTime` (3h) we check out a new connection with each data warehouse and test it with, for example, `SELECT 1`. This has the unintended effect of waking up Serverless DBs like Aurora/Databricks and as a consequence, increased billing costs due to this check.
This was detailed in a feature request [here](https://github.com/metabase/metabase/issues/58373)

It makes sense to just reduce `minPoolSize` to 0 to avoid this. The original advantage of having one connection alive at all times was to have the first query (after a period of inactivity) to the warehouse run faster, but it doesn't seem really worth it to speed up this single solitary query by waking up the database all the time. 
Also, the pool size will reach 0 only after 3 hours of complete inactivity in the warehouse, which seems reasonable.

Discussion [here](https://metaboat.slack.com/archives/C05MPF0TM3L/p1755790827373539)