### PR TITLE
fix(sdk): Add background-light to derived colors for the new embed

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/dynamic-sdk-color-defaults.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/dynamic-sdk-color-defaults.ts
@@ -18,6 +18,10 @@ export const EMBED_FLOW_DERIVED_COLORS_CONFIG: EmbedFlowDerivedDefaultColorConfi
       light: { source: "background", darken: 0.05 },
       dark: { source: "background", lighten: 0.5 },
     },
+    "background-light": {
+      light: { source: "background", darken: 0.02 },
+      dark: { source: "background", lighten: 0.6 },
+    },
     "text-secondary": {
       light: { source: "text-primary", lighten: 0.3 },
       dark: { source: "text-primary", darken: 0.3 },

--- a/frontend/src/metabase/embedding-sdk/theme/MetabaseTheme.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/MetabaseTheme.ts
@@ -64,6 +64,9 @@ export interface MetabaseColors {
   /** Muted background color used for disabled elements, such as disabled buttons and inputs. */
   "background-disabled"?: string;
 
+  /** Light background color used for some controls like a radiogroup. */
+  "background-light"?: string;
+
   /** Color used for borders */
   border?: string;
 

--- a/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
@@ -28,6 +28,7 @@ export type SemanticColorKey =
   | "background-selected"
   | "background-disabled"
   | "background-inverse"
+  | "background-light"
   | "background-brand"
   | "brand-light"
   | "brand-lighter";
@@ -53,6 +54,7 @@ export const SDK_TO_MAIN_APP_COLORS_MAPPING: Record<
   "background-hover": ["bg-light", "background-hover"],
   "background-secondary": ["bg-medium"],
   "background-disabled": ["background-disabled"],
+  "background-light": ["background-light"],
   shadow: ["shadow"],
   positive: ["success"],
   negative: ["danger"],

--- a/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.config.ts
+++ b/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.config.ts
@@ -24,6 +24,7 @@ export const segmentedControlOverrides: MantineThemeOverride["components"] = {
       root: {
         "--sc-active-text-color": props.c ?? "var(--mb-color-text-dark)",
         "--sc-background-color": props.bg ?? "var(--mb-color-bg-medium)",
+        "--sc-color": "var(--mb-color-bg-white)",
         "--sc-padding": getPadding(theme, props),
         "--sc-font-size": theme.fontSizes.md,
       },

--- a/frontend/src/metabase/ui/utils/colors.ts
+++ b/frontend/src/metabase/ui/utils/colors.ts
@@ -53,6 +53,7 @@ const CUSTOM_COLORS = [
   "background",
   "background-hover",
   "background-disabled",
+  "background-light",
   "accent-gray",
   "accent-gray-light",
 ] as const;


### PR DESCRIPTION
Adds background-light to derived colors for the new embed

Context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1755634628018229

Before
<img width="494" height="358" alt="image" src="https://github.com/user-attachments/assets/bde1cbef-4d7d-40b3-b714-2e625a959ff8" />


After
<img width="780" height="728" alt="image" src="https://github.com/user-attachments/assets/602444e1-e9ca-4af4-bac6-fb5e123f6538" />
