### PR TITLE
Add the add data and new dashboard modals to embedding hub

### DIFF
--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -1,10 +1,12 @@
 import cx from "classnames";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { c, t } from "ttag";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
+import { CreateDashboardModal } from "metabase/dashboard/containers/CreateDashboardModal";
+import { AddDataModal } from "metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal";
 import { Box, Text, Title } from "metabase/ui";
 
 import { useCompletedEmbeddingHubSteps } from "../hooks";
@@ -16,13 +18,26 @@ export const EmbeddingHub = () => {
   const embeddingSteps = useMemo(() => getEmbeddingHubSteps(), []);
   const completedSteps = useCompletedEmbeddingHubSteps();
 
+  // Modal state
+  const [openModal, setOpenModal] = useState<
+    "add-data" | "new-dashboard" | null
+  >(null);
+
   // Find the first unchecked step to open by default.
   // This is undefined when every step has been completed.
   const firstUncompletedStep = embeddingSteps.find(
     (step) => !completedSteps[step.id],
   );
 
-  // eslint-disable-next-line no-unconditional-metabase-links-render -- This link only shows for admins.
+  const handleModalAction = (modalType: "add-data" | "new-dashboard") => {
+    setOpenModal(modalType);
+  };
+
+  const closeModal = () => {
+    setOpenModal(null);
+  };
+
+  // eslint-disable-next-line no-unconditional-metabase-links-render -- This links only shows for admins.
   const embedJsDocsUrl = useDocsUrl("embedding/embedded-analytics-js");
 
   return (
@@ -39,6 +54,14 @@ export const EmbeddingHub = () => {
           steps={embeddingSteps}
           completedSteps={completedSteps}
           defaultOpenStep={firstUncompletedStep?.id}
+          onModalAction={handleModalAction}
+        />
+
+        <AddDataModal opened={openModal === "add-data"} onClose={closeModal} />
+
+        <CreateDashboardModal
+          opened={openModal === "new-dashboard"}
+          onClose={closeModal}
         />
       </Box>
     </Box>

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -19,9 +19,8 @@ export const EmbeddingHub = () => {
   const embeddingSteps = useMemo(() => getEmbeddingHubSteps(), []);
   const completedSteps = useCompletedEmbeddingHubSteps();
 
-  const [openModal, setOpenModal] = useState<EmbeddingHubModalToTrigger | null>(
-    null,
-  );
+  const [openedModal, setOpenedModal] =
+    useState<EmbeddingHubModalToTrigger | null>(null);
 
   // Find the first unchecked step to open by default.
   // This is undefined when every step has been completed.
@@ -29,7 +28,7 @@ export const EmbeddingHub = () => {
     (step) => !completedSteps[step.id],
   );
 
-  const closeModal = () => setOpenModal(null);
+  const closeModal = () => setOpenedModal(null);
 
   // eslint-disable-next-line no-unconditional-metabase-links-render -- This links only shows for admins.
   const embedJsDocsUrl = useDocsUrl("embedding/embedded-analytics-js");
@@ -48,19 +47,21 @@ export const EmbeddingHub = () => {
           steps={embeddingSteps}
           completedSteps={completedSteps}
           defaultOpenStep={firstUncompletedStep?.id}
-          onModalAction={setOpenModal}
+          onModalAction={setOpenedModal}
         />
 
         <AddDataModal
-          opened={openModal?.type === "add-data"}
+          opened={openedModal?.type === "add-data"}
           onClose={closeModal}
           initialTab={
-            openModal?.type === "add-data" ? openModal?.initialTab : undefined
+            openedModal?.type === "add-data"
+              ? openedModal?.initialTab
+              : undefined
           }
         />
 
         <CreateDashboardModal
-          opened={openModal?.type === "new-dashboard"}
+          opened={openedModal?.type === "new-dashboard"}
           onClose={closeModal}
         />
       </Box>

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -10,6 +10,7 @@ import { AddDataModal } from "metabase/nav/containers/MainNavbar/MainNavbarConta
 import { Box, Text, Title } from "metabase/ui";
 
 import { useCompletedEmbeddingHubSteps } from "../hooks";
+import type { EmbeddingHubModalToTrigger } from "../types/embedding-checklist";
 import { getEmbeddingHubSteps } from "../utils";
 
 import { EmbeddingHubChecklist } from "./EmbeddingHubChecklist";
@@ -18,10 +19,9 @@ export const EmbeddingHub = () => {
   const embeddingSteps = useMemo(() => getEmbeddingHubSteps(), []);
   const completedSteps = useCompletedEmbeddingHubSteps();
 
-  // Modal state
-  const [openModal, setOpenModal] = useState<
-    "add-data" | "new-dashboard" | null
-  >(null);
+  const [openModal, setOpenModal] = useState<EmbeddingHubModalToTrigger | null>(
+    null,
+  );
 
   // Find the first unchecked step to open by default.
   // This is undefined when every step has been completed.
@@ -29,13 +29,7 @@ export const EmbeddingHub = () => {
     (step) => !completedSteps[step.id],
   );
 
-  const handleModalAction = (modalType: "add-data" | "new-dashboard") => {
-    setOpenModal(modalType);
-  };
-
-  const closeModal = () => {
-    setOpenModal(null);
-  };
+  const closeModal = () => setOpenModal(null);
 
   // eslint-disable-next-line no-unconditional-metabase-links-render -- This links only shows for admins.
   const embedJsDocsUrl = useDocsUrl("embedding/embedded-analytics-js");
@@ -54,13 +48,19 @@ export const EmbeddingHub = () => {
           steps={embeddingSteps}
           completedSteps={completedSteps}
           defaultOpenStep={firstUncompletedStep?.id}
-          onModalAction={handleModalAction}
+          onModalAction={setOpenModal}
         />
 
-        <AddDataModal opened={openModal === "add-data"} onClose={closeModal} />
+        <AddDataModal
+          opened={openModal?.type === "add-data"}
+          onClose={closeModal}
+          initialTab={
+            openModal?.type === "add-data" ? openModal?.initialTab : undefined
+          }
+        />
 
         <CreateDashboardModal
-          opened={openModal === "new-dashboard"}
+          opened={openModal?.type === "new-dashboard"}
           onClose={closeModal}
         />
       </Box>

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -1,0 +1,47 @@
+import userEvent from "@testing-library/user-event";
+
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { createMockUser } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { EmbeddingHub } from "./EmbeddingHub";
+
+const setup = ({ isAdmin = true } = {}) => {
+  const state = createMockState({
+    currentUser: createMockUser({ is_superuser: isAdmin }),
+    settings: mockSettings({
+      "show-metabase-links": true,
+    }),
+  });
+
+  return renderWithProviders(<EmbeddingHub />, { storeInitialState: state });
+};
+
+describe("EmbeddingHub", () => {
+  it("opens AddDataModal when 'Add data' button is clicked", async () => {
+    setup();
+
+    await userEvent.click(screen.getByText("Add your data"));
+    await userEvent.click(screen.getByText("Add data"));
+
+    const dialog = within(screen.getByRole("dialog"));
+
+    expect(
+      dialog.getByRole("heading", { name: "Add data" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens CreateDashboardModal when 'Build your own' button is clicked", async () => {
+    setup();
+
+    await userEvent.click(screen.getByText("Create a dashboard"));
+    await userEvent.click(screen.getByText("Build your own"));
+
+    const dialog = within(screen.getByRole("dialog"));
+
+    expect(
+      dialog.getByRole("heading", { name: "New dashboard" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubChecklist.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubChecklist.tsx
@@ -3,7 +3,11 @@ import { useMemo } from "react";
 import { Accordion, Icon, Stack, Text } from "metabase/ui";
 
 import { useScrollListItemIntoView } from "../../hooks/use-scroll-list-item-into-view";
-import type { EmbeddingHubStep, EmbeddingHubStepId } from "../../types";
+import type {
+  EmbeddingHubModalToTrigger,
+  EmbeddingHubStep,
+  EmbeddingHubStepId,
+} from "../../types";
 
 import AccordionS from "./EmbeddingHubAccordion.module.css";
 import S from "./EmbeddingHubChecklist.module.css";
@@ -15,7 +19,7 @@ interface EmbeddingHubChecklistProps {
 
   defaultOpenStep?: EmbeddingHubStepId;
   completedSteps?: Partial<Record<EmbeddingHubStepId, boolean>>;
-  onModalAction?: (modalType: "add-data" | "new-dashboard") => void;
+  onModalAction?: (modal: EmbeddingHubModalToTrigger) => void;
 }
 
 export const EmbeddingHubChecklist = ({

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubChecklist.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubChecklist.tsx
@@ -15,6 +15,7 @@ interface EmbeddingHubChecklistProps {
 
   defaultOpenStep?: EmbeddingHubStepId;
   completedSteps?: Partial<Record<EmbeddingHubStepId, boolean>>;
+  onModalAction?: (modalType: "add-data" | "new-dashboard") => void;
 }
 
 export const EmbeddingHubChecklist = ({
@@ -22,6 +23,7 @@ export const EmbeddingHubChecklist = ({
 
   defaultOpenStep,
   completedSteps = {},
+  onModalAction,
 }: EmbeddingHubChecklistProps) => {
   const stepIds = useMemo(() => steps.map((step) => step.id), [steps]);
 
@@ -84,7 +86,10 @@ export const EmbeddingHubChecklist = ({
 
                 <Text>{step.description}</Text>
 
-                <EmbeddingHubStepActions step={step} />
+                <EmbeddingHubStepActions
+                  step={step}
+                  onModalAction={onModalAction}
+                />
               </Stack>
             </Accordion.Panel>
           </Accordion.Item>

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubStepActions.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubStepActions.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router";
 
 import { Button, Group } from "metabase/ui";
 
-import type { EmbeddingHubStep } from "../../types";
+import type { EmbeddingHubModalToTrigger, EmbeddingHubStep } from "../../types";
 import { DocsLink } from "../DocsLink";
 
 export const EmbeddingHubStepActions = ({
@@ -10,7 +10,7 @@ export const EmbeddingHubStepActions = ({
   onModalAction,
 }: {
   step: EmbeddingHubStep;
-  onModalAction?: (modalType: "add-data" | "new-dashboard") => void;
+  onModalAction?: (modal: EmbeddingHubModalToTrigger) => void;
 }) => {
   if (!step.actions?.length) {
     return null;

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubStepActions.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubStepActions.tsx
@@ -7,8 +7,10 @@ import { DocsLink } from "../DocsLink";
 
 export const EmbeddingHubStepActions = ({
   step,
+  onModalAction,
 }: {
   step: EmbeddingHubStep;
+  onModalAction?: (modalType: "add-data" | "new-dashboard") => void;
 }) => {
   if (!step.actions?.length) {
     return null;
@@ -17,6 +19,18 @@ export const EmbeddingHubStepActions = ({
   return (
     <Group gap="sm">
       {step.actions.map((action, index) => {
+        if (action.modal) {
+          return (
+            <Button
+              key={index}
+              variant={action.variant || "outline"}
+              onClick={() => onModalAction?.(action.modal!)}
+            >
+              {action.label}
+            </Button>
+          );
+        }
+
         if (action.docsPath) {
           return (
             <DocsLink key={index} docsPath={action.docsPath}>

--- a/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
@@ -1,3 +1,4 @@
+import type { AddDataTab } from "metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils";
 import type { IconName } from "metabase/ui";
 
 export type EmbeddingHubStepId =
@@ -19,6 +20,10 @@ export interface EmbeddingHubStep {
   actions?: EmbeddingHubAction[];
 }
 
+export type EmbeddingHubModalToTrigger =
+  | { type: "add-data"; initialTab: AddDataTab }
+  | { type: "new-dashboard" };
+
 interface EmbeddingHubAction {
   label: string;
 
@@ -32,7 +37,7 @@ interface EmbeddingHubAction {
   variant?: "outline" | "subtle" | "filled";
 
   /** Which modal to trigger? */
-  modal?: "add-data" | "new-dashboard";
+  modal?: EmbeddingHubModalToTrigger;
 }
 
 interface EmbeddingHubImage {

--- a/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
@@ -30,6 +30,9 @@ interface EmbeddingHubAction {
 
   /** CTA button variant. */
   variant?: "outline" | "subtle" | "filled";
+
+  /** Which modal to trigger? */
+  modal?: "add-data" | "new-dashboard";
 }
 
 interface EmbeddingHubImage {

--- a/frontend/src/metabase/embedding/embedding-hub/types/index.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/index.ts
@@ -1,4 +1,5 @@
 export type {
   EmbeddingHubStep,
   EmbeddingHubStepId,
+  EmbeddingHubModalToTrigger,
 } from "./embedding-checklist";

--- a/frontend/src/metabase/embedding/embedding-hub/utils/embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/utils/embedding-hub-steps.ts
@@ -36,7 +36,7 @@ export const getEmbeddingHubSteps = (): EmbeddingHubStep[] => {
     actions: [
       {
         label: t`Add data`,
-        to: "/admin/databases/create",
+        modal: "add-data",
         variant: "outline",
       },
     ],
@@ -59,6 +59,11 @@ export const getEmbeddingHubSteps = (): EmbeddingHubStep[] => {
         // TODO(EMB-741): use a wizard
         to: "/auto/dashboard/table/1",
         variant: "outline",
+      },
+      {
+        label: t`Build your own`,
+        modal: "new-dashboard",
+        variant: "subtle",
       },
     ],
   };

--- a/frontend/src/metabase/embedding/embedding-hub/utils/embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/utils/embedding-hub-steps.ts
@@ -39,11 +39,6 @@ export const getEmbeddingHubSteps = (): EmbeddingHubStep[] => {
         modal: { type: "add-data", initialTab: "db" },
         variant: "outline",
       },
-      {
-        label: t`Upload a CSV`,
-        modal: { type: "add-data", initialTab: "csv" },
-        variant: "subtle",
-      },
     ],
   };
 

--- a/frontend/src/metabase/embedding/embedding-hub/utils/embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/utils/embedding-hub-steps.ts
@@ -36,8 +36,13 @@ export const getEmbeddingHubSteps = (): EmbeddingHubStep[] => {
     actions: [
       {
         label: t`Add data`,
-        modal: "add-data",
+        modal: { type: "add-data", initialTab: "db" },
         variant: "outline",
+      },
+      {
+        label: t`Upload a CSV`,
+        modal: { type: "add-data", initialTab: "csv" },
+        variant: "subtle",
       },
     ],
   };
@@ -62,7 +67,7 @@ export const getEmbeddingHubSteps = (): EmbeddingHubStep[] => {
       },
       {
         label: t`Build your own`,
-        modal: "new-dashboard",
+        modal: { type: "new-dashboard" },
         variant: "subtle",
       },
     ],

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { useListDatabasesQuery } from "metabase/api";
@@ -14,17 +14,23 @@ import { CSVPanel } from "./Panels/CSVPanel";
 import { DatabasesPanel } from "./Panels/DatabasesPanel";
 import { PanelsHeader } from "./Panels/PanelsHeader";
 import { trackAddDataEvent } from "./analytics";
-import { isValidTab } from "./utils";
+import { type AddDataTab, isValidTab } from "./utils";
 
 interface AddDataModalProps {
   opened: boolean;
   onClose: () => void;
+
+  initialTab?: AddDataTab;
 }
 
-export const AddDataModal = ({ opened, onClose }: AddDataModalProps) => {
+export const AddDataModal = ({
+  opened,
+  onClose,
+  initialTab = "csv",
+}: AddDataModalProps) => {
   const { data: databaseResponse } = useListDatabasesQuery();
 
-  const [activeTab, setActiveTab] = useState<string | null>("csv");
+  const [activeTab, setActiveTab] = useState<AddDataTab | null>(initialTab);
 
   const isHosted = useSetting("is-hosted?");
 
@@ -52,11 +58,15 @@ export const AddDataModal = ({ opened, onClose }: AddDataModalProps) => {
       db: "database_tab_clicked",
       csv: "csv_tab_clicked",
       gsheets: "sheets_tab_clicked",
-    } as const;
+    } as const satisfies Record<AddDataTab, string>;
 
     trackAddDataEvent(eventMapping[tabValue]);
     setActiveTab(tabValue);
   };
+
+  useEffect(() => {
+    setActiveTab(initialTab);
+  }, [initialTab]);
 
   return (
     <Modal.Root opened={opened} onClose={onClose} size="auto">

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.ts
@@ -1,7 +1,7 @@
 const validTabArray = ["db", "csv", "gsheets"] as const;
 const validTabs = new Set<string>(validTabArray);
 
-type AddDataTab = (typeof validTabArray)[number];
+export type AddDataTab = (typeof validTabArray)[number];
 
 export const isValidTab = (v: string | null): v is AddDataTab =>
   typeof v === "string" && validTabs.has(v);


### PR DESCRIPTION
### Description

Adds the "add data" and "new dashboard" modal into the Embedding Hub's call to action buttons on checklist.

### How to verify

1. Go to Embedding Hub as an admin
2. Expand the "Add your data" step in the checklist
3. Click the "Add data" button → Verify the "Add data" modal opens with the **database** tab selected
4. Close the modal and expand the "Create a dashboard" step
5. Click the "Build your own" button → Verify the "New dashboard" modal opens
6. Verify that both modals can be closed and reopened without issues

### Demo

<img width="2246" height="1608" alt="CleanShot 2568-08-26 at 13 00 52@2x" src="https://github.com/user-attachments/assets/e46d9bab-545e-4846-89b3-6776173bccab" />

<img width="2234" height="1602" alt="CleanShot 2568-08-26 at 13 00 48@2x" src="https://github.com/user-attachments/assets/d4f30885-60ce-442f-907f-9846fe8a3e99" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
