### PR TITLE
BE work for clearer timezones

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -28,7 +28,8 @@
 (p/import-vars
  [metabase.driver.settings
   report-timezone
-  report-timezone!])
+  report-timezone!
+  report-timezone-long])
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                 Current Driver                                                 |

--- a/src/metabase/model_persistence/task/persist_refresh.clj
+++ b/src/metabase/model_persistence/task/persist_refresh.clj
@@ -14,7 +14,6 @@
    [metabase.model-persistence.models.persisted-info :as persisted-info]
    [metabase.model-persistence.settings :as model-persistence.settings]
    [metabase.query-processor.middleware.limit :as limit]
-   [metabase.query-processor.timezone :as qp.timezone]
    [metabase.task-history.core :as task-history]
    [metabase.task.core :as task]
    [metabase.util :as u]
@@ -292,9 +291,7 @@
   [cron-spec]
   (cron/schedule
    (cron/cron-schedule cron-spec)
-   (cron/in-time-zone (TimeZone/getTimeZone (or (driver/report-timezone)
-                                                (qp.timezone/system-timezone-id)
-                                                "UTC")))
+   (cron/in-time-zone (TimeZone/getTimeZone (driver/report-timezone-long)))
    (cron/with-misfire-handling-instruction-do-nothing)))
 
 (comment

--- a/src/metabase/sync/task/sync_databases.clj
+++ b/src/metabase/sync/task/sync_databases.clj
@@ -28,6 +28,7 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2])
   (:import
+   (java.util TimeZone)
    (org.quartz
     CronTrigger
     JobDetail
@@ -251,6 +252,7 @@
      (triggers/with-schedule
       (cron/schedule
        (cron/cron-schedule task-schedule)
+       (cron/in-time-zone (TimeZone/getTimeZone (driver.settings/report-timezone-long)))
         ;; if we miss a sync for one reason or another (such as system being down) do not try to run the sync again.
         ;; Just wait until the next sync cycle.
         ;;


### PR DESCRIPTION
[UXW-209: Timezone used in Metabase system processes like sync, scanning, model persistence should be clearer](https://linear.app/metabase/issue/UXW-209/timezone-used-in-metabase-system-processes-like-sync-scanning-model)

I think this will be an improvement over the status quo, but we should strongly consider the possibility of just converting all cron jobs to UTC.

For database sync and model persistence, just use the `report-default-long` time zone (aka the long version of the `report-default` time zone). This is guaranteed to be non-nil (defaulting to the system timezone).

This way we can tell users, for all of Database Caching, Model Persistence, and Database Sync, that they're setting up a cron job in the report timezone. We already do this for Database Caching so it hopefully will be a quick job on the FE to report the same thing for Model Persistence and DB Sync.

Is this perfect? No, there are a few issues:

- one, it's better to use UTC for cron things like this. Jobs might fire twice for DST, for example.

- two, this may report an incorrect time zone for existing cron jobs. If you set up a cron job when the time zone is `America/Los_Angeles` and then change the time zone to `UTC`, we'll tell you that your job is scheduled for 8am UTC when it's actually scheduled for 8am Pacific.

That said, I think it's still a big improvement over the status quo, and these are all existing issues with the current implementation as well, which is worse because have no good way to report to the user what the time zone they're working with is.

