### PR TITLE
Use scrollable body instead of sticky footer in DB forms

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseConnectionModal.module.css
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseConnectionModal.module.css
@@ -9,20 +9,5 @@
 }
 
 .modalBody {
-  overflow-y: auto;
-  padding-bottom: 0;
-
-  :global {
-    .database-form {
-      position: relative;
-    }
-
-    .database-form-footer {
-      padding-bottom: 2rem;
-      padding-top: 1.25rem;
-      background: var(--mb-color-background);
-      position: sticky;
-      bottom: 0;
-    }
-  }
+  padding-inline: 0;
 }

--- a/frontend/src/metabase/common/components/FormFooter/FormFooter.tsx
+++ b/frontend/src/metabase/common/components/FormFooter/FormFooter.tsx
@@ -3,7 +3,7 @@ import type { PropsWithChildren } from "react";
 
 import CS from "metabase/css/core/index.css";
 import { Group, type GroupProps } from "metabase/ui";
-interface FormFooterProps {
+interface FormFooterProps extends GroupProps {
   hasTopBorder?: boolean;
   justify?: GroupProps["justify"];
   className?: string;
@@ -14,6 +14,7 @@ export const FormFooter = ({
   children,
   justify = "right",
   className,
+  ...extraGroupProps
 }: PropsWithChildren<FormFooterProps>) => {
   const groupProps = hasTopBorder
     ? {
@@ -23,7 +24,13 @@ export const FormFooter = ({
       }
     : { className };
   return (
-    <Group align="center" justify={justify} gap="sm" {...groupProps}>
+    <Group
+      align="center"
+      justify={justify}
+      gap="sm"
+      {...groupProps}
+      {...extraGroupProps}
+    >
       {children}
     </Group>
   );

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -9,7 +9,7 @@ import { Form, FormProvider } from "metabase/forms";
 import { FormErrorMessage } from "metabase/forms/components/FormErrorMessage";
 import { FormSubmitButton } from "metabase/forms/components/FormSubmitButton";
 import { useSelector } from "metabase/lib/redux";
-import { Button, Flex, Text } from "metabase/ui";
+import { Box, Button, Flex, Text } from "metabase/ui";
 import type { DatabaseData, Engine, EngineKey } from "metabase-types/api";
 
 import { getEngines } from "../../selectors";
@@ -176,45 +176,52 @@ const DatabaseFormBody = ({
   }, [engine, values, isAdvanced]);
 
   return (
-    <Form data-testid="database-form" className="database-form">
-      {engineFieldState !== "hidden" && (
-        <>
-          <DatabaseEngineField
-            engineKey={engineKey}
-            engines={engines}
-            isAdvanced={isAdvanced}
-            onChange={onEngineChange}
-            disabled={engineFieldState === "disabled"}
-            showSampleDatabase={showSampleDatabase}
-          />
-          <DatabaseEngineWarning
-            engineKey={engineKey}
-            engines={engines}
-            onChange={onEngineChange}
-          />
-        </>
-      )}
-      <DatabaseConnectionStringField
-        engineKey={engineKey}
-        location={location}
-        setValues={setValues}
-      />
-      {engine && (
-        <DatabaseNameField
-          engine={engine}
-          config={config}
-          autoFocus={autofocusFieldName === "name"}
-        />
-      )}
-      {fields.map((field) => (
-        <DatabaseDetailField
-          key={field.name}
-          field={field}
-          autoFocus={autofocusFieldName === field.name}
-          data-kek={field.name}
+    <Form data-testid="database-form" pt="md">
+      <Box
+        mah="calc(100vh - 20rem)"
+        style={{ overflowY: "auto" }}
+        px={location === "setup" ? "sm" : "xl"}
+        mb="md"
+      >
+        {engineFieldState !== "hidden" && (
+          <>
+            <DatabaseEngineField
+              engineKey={engineKey}
+              engines={engines}
+              isAdvanced={isAdvanced}
+              onChange={onEngineChange}
+              disabled={engineFieldState === "disabled"}
+              showSampleDatabase={showSampleDatabase}
+            />
+            <DatabaseEngineWarning
+              engineKey={engineKey}
+              engines={engines}
+              onChange={onEngineChange}
+            />
+          </>
+        )}
+        <DatabaseConnectionStringField
           engineKey={engineKey}
+          location={location}
+          setValues={setValues}
         />
-      ))}
+        {engine && (
+          <DatabaseNameField
+            engine={engine}
+            config={config}
+            autoFocus={autofocusFieldName === "name"}
+          />
+        )}
+        {fields.map((field) => (
+          <DatabaseDetailField
+            key={field.name}
+            field={field}
+            autoFocus={autofocusFieldName === field.name}
+            data-kek={field.name}
+            engineKey={engineKey}
+          />
+        ))}
+      </Box>
       <DatabaseFormFooter
         isDirty={dirty}
         isAdvanced={isAdvanced}
@@ -249,11 +256,9 @@ const DatabaseFormFooter = ({
 
   const hasSampleDatabase = useSetting("has-sample-database?");
 
-  const className = "database-form-footer";
-
   if (isAdvanced) {
     return (
-      <FormFooter data-testid="form-footer" className={className}>
+      <FormFooter data-testid="form-footer" px="xl">
         <FormErrorMessage />
         <Flex justify="space-between" align="center" w="100%">
           {isNew ? (
@@ -283,7 +288,7 @@ const DatabaseFormFooter = ({
 
   if (values.engine) {
     return (
-      <FormFooter className={className}>
+      <FormFooter>
         <FormErrorMessage inline />
         <Button onClick={onCancel}>{t`Skip`}</Button>
         <FormSubmitButton variant="filled" label={t`Connect database`} />


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60319

Closes UXW-322

### Description

Having a sticky footer allows you to tab to inputs that are behind the footer. 😢  This changes the layout to have a scrollable box for the form body.

✅  Database Modal

https://github.com/user-attachments/assets/3e8f889a-d66e-45f4-a1cd-1ef043af0454


✅  Setup form

<img width="740" height="917" alt="CleanShot 2025-08-21 at 14 46 59" src="https://github.com/user-attachments/assets/2d086f10-30bd-4ec7-9fae-1429edf417a7" />

