### PR TITLE
Respond with HTTP status 500 when Store API request fails during Cloud migration

### DIFF
--- a/src/metabase/cloud_migration/api.clj
+++ b/src/metabase/cloud_migration/api.clj
@@ -32,7 +32,7 @@
         (condp = (-> e ex-data :status)
           404 {:status 404 :body "Could not establish a connection to Metabase Cloud."}
           400 {:status 400 :body "Cannot migrate this Metabase version."}
-          {:status 500})))))
+          {:status 500 :body ""})))))
 
 (api.macros/defendpoint :get "/"
   "Get the latest cloud migration, if any."


### PR DESCRIPTION
`{:status 500}` is rendered as a response with status 200 and a body of
`{"status": 500}`, wheras `{:status 500 :body ""}` is rendered as a
response with status 500 with empty body.

Fixes: b7253af4f2c2c90735dd9d3e2e5c2efd0b6802d8
