### PR TITLE
Use SQL SECURITY INVOKER for mysql views

### DIFF
--- a/resources/migrations/057_update_migrations.yaml
+++ b/resources/migrations/057_update_migrations.yaml
@@ -1502,6 +1502,146 @@ databaseChangeLog:
                   value: 'cron/raw'
             where: built_in_type IS NOT NULL
 
+  - changeSet:
+      id: v57.2025-09-23T14:32:02
+      author: johnswanson
+      comment: Fix MySQL alerts view to use SQL SECURITY INVOKER (issue #45641)
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: instance_analytics_views/alerts/v5/mysql-alerts.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            path: instance_analytics_views/alerts/v4/mysql-alerts.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v57.2025-09-23T14:32:08
+      author: johnswanson
+      comment: Fix MySQL audit_log view to use SQL SECURITY INVOKER (issue #45641)
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: instance_analytics_views/audit_log/v3/mysql-audit_log.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            path: instance_analytics_views/audit_log/v2/mysql-audit_log.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v57.2025-09-23T14:32:11
+      author: johnswanson
+      comment: Fix MySQL content view to use SQL SECURITY INVOKER (issue #45641)
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: instance_analytics_views/content/v4/mysql-content.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            path: instance_analytics_views/content/v3/mysql-content.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v57.2025-09-23T14:32:13
+      author: johnswanson
+      comment: Fix MySQL fields view to use SQL SECURITY INVOKER (issue #45641)
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: instance_analytics_views/fields/v2/mysql-fields.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            path: instance_analytics_views/fields/v1/mysql-fields.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v57.2025-09-23T14:32:16
+      author: johnswanson
+      comment: Fix MySQL query_log view to use SQL SECURITY INVOKER (issue #45641)
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: instance_analytics_views/query_log/v3/mysql-query_log.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            path: instance_analytics_views/query_log/v2/mysql-query_log.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v57.2025-09-23T14:32:19
+      author: johnswanson
+      comment: Fix MySQL subscriptions view to use SQL SECURITY INVOKER (issue #45641)
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: instance_analytics_views/subscriptions/v2/mysql-subscriptions.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            path: instance_analytics_views/subscriptions/v1/mysql-subscriptions.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v57.2025-09-23T14:32:22
+      author: johnswanson
+      comment: Fix MySQL tables view to use SQL SECURITY INVOKER (issue #45641)
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: instance_analytics_views/tables/v2/mysql-tables.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            path: instance_analytics_views/tables/v1/mysql-tables.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v57.2025-09-23T14:32:25
+      author: johnswanson
+      comment: Fix MySQL tasks view to use SQL SECURITY INVOKER (issue #45641)
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: instance_analytics_views/tasks/v3/mysql-tasks.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            path: instance_analytics_views/tasks/v2/mysql-tasks.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v57.2025-09-23T14:32:28
+      author: johnswanson
+      comment: Fix MySQL users view to use SQL SECURITY INVOKER (issue #45641)
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: instance_analytics_views/users/v4/mysql-users.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            path: instance_analytics_views/users/v3/mysql-users.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v57.2025-09-23T14:32:31
+      author: johnswanson
+      comment: Fix MySQL view_log view to use SQL SECURITY INVOKER (issue #45641)
+      dbms: mysql,mariadb
+      changes:
+        - sqlFile:
+            path: instance_analytics_views/view_log/v3/mysql-view_log.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            path: instance_analytics_views/view_log/v2/mysql-view_log.sql
+            relativeToChangelogFile: true
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/instance_analytics_views/alerts/v5/mysql-alerts.sql
+++ b/resources/migrations/instance_analytics_views/alerts/v5/mysql-alerts.sql
@@ -1,0 +1,90 @@
+drop view if exists v_alerts;
+
+create 
+SQL SECURITY INVOKER 
+view v_alerts as
+with parsed_cron as (
+    select
+        n.id,
+        ns.cron_schedule,
+        ns.ui_display_type,
+        substring_index(substring_index(ns.cron_schedule, ' ', 2), ' ', -1) as minutes,
+        substring_index(substring_index(ns.cron_schedule, ' ', 3), ' ', -1) as hours,
+        substring_index(substring_index(ns.cron_schedule, ' ', 4), ' ', -1) as day_of_month,
+        substring_index(substring_index(ns.cron_schedule, ' ', 6), ' ', -1) as day_of_week
+    from notification n
+    join notification_subscription ns on n.id = ns.notification_id
+    where n.payload_type = 'notification/card'
+    and ns.type = 'notification-subscription/cron'
+),
+schedule_info as (
+    select
+        id,
+        case
+            when ui_display_type = 'cron/raw' then 'custom'
+            when minutes REGEXP '^\\*$' or minutes REGEXP '^[0-9]+/[0-9]+$' then 'by the minute'
+            when day_of_month != '*' and
+                 (day_of_week = '?' or
+                  day_of_week REGEXP '^[0-9]#1$' or
+                  day_of_week REGEXP '^[0-9]L$') then 'monthly'
+            when day_of_week != '?' and day_of_week != '*' then 'weekly'
+            when hours != '*' then 'daily'
+            else 'hourly'
+        end as schedule_type,
+        case
+            when day_of_week REGEXP '^1' then 'sun'
+            when day_of_week REGEXP '^2' then 'mon'
+            when day_of_week REGEXP '^3' then 'tue'
+            when day_of_week REGEXP '^4' then 'wed'
+            when day_of_week REGEXP '^5' then 'thu'
+            when day_of_week REGEXP '^6' then 'fri'
+            when day_of_week REGEXP '^7' then 'sat'
+            else null
+        end as schedule_day,
+        case
+            when hours = '*' then null
+            when hours REGEXP '^[0-9]+$' then cast(hours as signed)
+            when hours REGEXP '^([0-9]+)/[0-9]+$' then cast(substring_index(hours, '/', 1) as signed)
+            else null
+        end as schedule_hour
+    from parsed_cron
+),
+agg_recipients as (
+    select
+        nr.notification_handler_id,
+        group_concat(cu.email) as recipients,
+        group_concat(
+            case
+                when nr.type = 'notification-recipient/raw-value' then nr.details
+                else null
+            end
+        ) as recipient_external
+    FROM notification_recipient nr
+    left join core_user cu on nr.user_id = cu.id and nr.type = 'notification-recipient/user'
+    group by nr.notification_handler_id
+)
+select
+    n.id as entity_id,
+    concat('notification_', n.id) as entity_qualified_id,
+    n.created_at,
+    n.updated_at,
+    n.creator_id,
+    nc.card_id,
+    concat('card_', nc.card_id) as card_qualified_id,
+    case
+        when nc.send_condition = 'has_result' then 'rows'
+        when nc.send_condition in ('goal_above', 'goal_below') then 'goal'
+    end as alert_condition,
+    si.schedule_type,
+    si.schedule_day,
+    si.schedule_hour,
+    not n.active as archived,
+    nh.channel_type as recipient_type,
+    ar.recipients,
+    ar.recipient_external
+from notification n
+join notification_card nc on n.payload_id = nc.id
+join schedule_info si on n.id = si.id
+left join notification_handler nh on n.id = nh.notification_id
+left join agg_recipients ar on nh.id = ar.notification_handler_id
+where n.payload_type = 'notification/card';

--- a/resources/migrations/instance_analytics_views/audit_log/v3/mysql-audit_log.sql
+++ b/resources/migrations/instance_analytics_views/audit_log/v3/mysql-audit_log.sql
@@ -1,0 +1,29 @@
+DROP VIEW IF EXISTS v_audit_log;
+
+
+CREATE OR REPLACE 
+SQL SECURITY INVOKER 
+VIEW v_audit_log AS
+  (SELECT id,
+          CASE
+              WHEN topic = 'card-create' THEN 'card-create'
+              WHEN topic = 'card-delete' THEN 'card-delete'
+              WHEN topic = 'card-update' THEN 'card-update'
+              WHEN topic = 'pulse-create' THEN 'subscription-create'
+              WHEN topic = 'pulse-delete' THEN 'subscription-delete'
+              ELSE topic
+          END AS topic, timestamp, NULL AS end_timestamp,
+                                   coalesce(user_id, 0) AS user_id,
+                                   lower(model) AS entity_type,
+                                   model_id AS entity_id,
+                                   CASE
+                                       WHEN model = 'Dataset' THEN (concat('card_', model_id))
+                                       WHEN model_id IS NULL THEN NULL
+                                       ELSE (concat(lower(model), '_', model_id))
+                                   END AS entity_qualified_id, -- this definition must match the table functional index idx_audit_log_entity_qualified_id
+ details
+   FROM audit_log
+   WHERE topic NOT IN ('card-read',
+                       'card-query',
+                       'dashboard-read',
+                       'dashboard-query') )

--- a/resources/migrations/instance_analytics_views/content/v4/mysql-content.sql
+++ b/resources/migrations/instance_analytics_views/content/v4/mysql-content.sql
@@ -1,0 +1,139 @@
+drop view if exists v_content;
+
+create or replace 
+SQL SECURITY INVOKER 
+view v_content as
+select
+    action.id as entity_id,
+    concat('action_', action.id) as entity_qualified_id,
+    'action' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    null as collection_id,
+    made_public_by_id as made_public_by_user,
+    null as is_embedding_enabled,
+    null as is_verified,
+    archived,
+    type as action_type,
+    model_id as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from action
+union
+select
+    collection.id as entity_id,
+    concat('collection_', collection.id) as entity_qualified_id,
+    'collection' as entity_type,
+    created_at,
+    null as updated_at,
+    null as creator_id,
+    name,
+    description,
+    null as collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    null as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    case when authority_level='official' then true else false end as collection_is_official,
+    case when personal_owner_id is not null then true else false end as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from collection
+union
+select
+    report_card.id as entity_id,
+    concat('card_', report_card.id) as entity_qualified_id,
+    type as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    collection_id as collection_id,
+    made_public_by_id as made_public_by_user,
+    enable_embedding as is_embedding_enabled,
+    case when is_verified then true else false end as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    display as question_viz_type,
+    concat('database_', database_id) as question_database_id,
+    case when query_type='native' then true else false end as question_is_native,
+    null as event_timestamp
+    from report_card
+        left join (
+            select
+                concat(moderated_item_type, '_', moderated_item_id) as entity_qualified_id,
+                case when status = 'verified' then true else false end as is_verified
+            from moderation_review
+            where most_recent
+        ) as moderation on concat('card_', report_card.id) = moderation.entity_qualified_id
+union
+select
+    report_dashboard.id as entity_id,
+    concat('dashboard_', report_dashboard.id) as entity_qualified_id,
+    'dashboard' as entity_type,
+    created_at,
+    updated_at,
+    creator_id,
+    name,
+    description,
+    collection_id as collection_id,
+    made_public_by_id as made_public_by_user,
+    enable_embedding as is_embedding_enabled,
+    case when is_verified then true else false end as is_verified,
+    archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    null as event_timestamp
+    from report_dashboard
+        left join (
+            select
+                concat(moderated_item_type, '_', moderated_item_id) as entity_qualified_id,
+                case when status = 'verified' then true else false end as is_verified
+            from moderation_review
+            where most_recent
+        ) as moderation on concat('card_', report_dashboard.id) = moderation.entity_qualified_id
+union
+select
+    event.id as entity_id,
+    concat('event_', event.id) as entity_qualified_id,
+    'event' as entity_type,
+    event.created_at,
+    event.updated_at,
+    event.creator_id,
+    event.name,
+    event.description,
+    timeline.collection_id,
+    null as made_public_by_user,
+    null as is_embedding_enabled,
+    null as is_verified,
+    event.archived,
+    null as action_type,
+    null as action_model_id,
+    null as collection_is_official,
+    null as collection_is_personal,
+    null as question_viz_type,
+    null as question_database_id,
+    null as question_is_native,
+    timestamp as event_timestamp
+    from timeline_event event
+        left join timeline on event.timeline_id = timeline.id

--- a/resources/migrations/instance_analytics_views/fields/v2/mysql-fields.sql
+++ b/resources/migrations/instance_analytics_views/fields/v2/mysql-fields.sql
@@ -1,0 +1,20 @@
+drop view if exists v_fields;
+
+create or replace 
+SQL SECURITY INVOKER 
+view v_fields as
+select
+    id as entity_id,
+    concat('field_', id) as entity_qualified_id, -- should match idx_field_entity_qualified_id
+    created_at,
+    updated_at,
+    name,
+    display_name,
+    description,
+    base_type,
+    visibility_type,
+    fk_target_field_id,
+    has_field_values,
+    active,
+    table_id as table_id
+from metabase_field;

--- a/resources/migrations/instance_analytics_views/query_log/v3/mysql-query_log.sql
+++ b/resources/migrations/instance_analytics_views/query_log/v3/mysql-query_log.sql
@@ -1,0 +1,27 @@
+DROP VIEW IF EXISTS v_query_log;
+
+
+CREATE OR REPLACE 
+SQL SECURITY INVOKER 
+VIEW v_query_log AS
+SELECT id AS entity_id,
+       started_at,
+       cast(running_time AS DOUBLE) / 1000 AS running_time_seconds,
+       result_rows,
+       native AS is_native,
+       context AS query_source,
+       error,
+       coalesce(executor_id, 0) AS user_id,
+       card_id,
+       concat('card_', card_id) AS card_qualified_id,
+       dashboard_id,
+       concat('dashboard_', dashboard_id) AS dashboard_qualified_id,
+       pulse_id,
+       database_id,
+       concat('database_', database_id) AS database_qualified_id,
+       cache_hit,
+       action_id,
+       concat('action_', action_id) AS action_qualified_id,
+       query
+FROM query_execution
+    LEFT JOIN query ON query_execution.hash = query.query_hash;

--- a/resources/migrations/instance_analytics_views/subscriptions/v2/mysql-subscriptions.sql
+++ b/resources/migrations/instance_analytics_views/subscriptions/v2/mysql-subscriptions.sql
@@ -1,0 +1,32 @@
+drop view if exists v_subscriptions;
+
+create or replace 
+SQL SECURITY INVOKER 
+view v_subscriptions as
+with agg_recipients as (
+    select
+        pulse_channel_id,
+        group_concat(core_user.email) as recipients
+    from pulse_channel_recipient
+        left join core_user on pulse_channel_recipient.user_id = core_user.id
+    group by pulse_channel_id
+)
+select
+    pulse.id as entity_id,
+    concat('pulse_', pulse.id) as entity_qualified_id,
+    pulse.created_at,
+    pulse.updated_at,
+    creator_id,
+    archived,
+    concat('dashboard_', dashboard_id) as dashboard_qualified_id,
+    pulse_channel.schedule_type,
+    pulse_channel.schedule_day,
+    pulse_channel.schedule_hour,
+    channel_type as recipient_type,
+    agg_recipients.recipients,
+    details as recipient_external,
+    parameters
+    from pulse
+        left join pulse_channel on pulse.id = pulse_channel.pulse_id
+        left join agg_recipients on pulse_channel.id = agg_recipients.pulse_channel_id
+    where alert_condition is null

--- a/resources/migrations/instance_analytics_views/tables/v2/mysql-tables.sql
+++ b/resources/migrations/instance_analytics_views/tables/v2/mysql-tables.sql
@@ -1,0 +1,18 @@
+drop view if exists v_tables;
+
+CREATE OR REPLACE 
+SQL SECURITY INVOKER 
+VIEW v_tables AS
+select
+    id as entity_id,
+    concat('table_', id) as entity_qualified_id,
+    created_at,
+    updated_at,
+    name,
+    display_name,
+    description,
+    active,
+    db_id as database_id,
+    "schema",
+    is_upload
+from metabase_table;

--- a/resources/migrations/instance_analytics_views/tasks/v3/mysql-tasks.sql
+++ b/resources/migrations/instance_analytics_views/tasks/v3/mysql-tasks.sql
@@ -1,0 +1,15 @@
+drop view if exists v_tasks;
+
+CREATE OR REPLACE 
+SQL SECURITY INVOKER 
+VIEW v_tasks AS
+select
+    id,
+    task,
+    status,
+    concat('database_', db_id) as database_qualified_id,
+    started_at,
+    ended_at,
+    cast(duration as double) / 1000 as duration_seconds,
+    task_details as details
+from task_history;

--- a/resources/migrations/instance_analytics_views/users/v4/mysql-users.sql
+++ b/resources/migrations/instance_analytics_views/users/v4/mysql-users.sql
@@ -1,0 +1,35 @@
+CREATE OR REPLACE 
+SQL SECURITY INVOKER 
+VIEW v_users AS
+SELECT id AS user_id,
+       concat('user_', id) AS entity_qualified_id,
+       type,
+       CASE WHEN type = 'api-key' THEN null ELSE email END as email,
+       first_name,
+       last_name,
+       COALESCE(concat(first_name, ' ', last_name),
+                first_name,
+                last_name) as full_name,
+       date_joined,
+       last_login,
+       updated_at,
+       is_superuser AS is_admin,
+       is_active,
+       sso_source,
+       locale
+FROM core_user
+UNION
+SELECT 0 AS user_id,
+       'user_0' AS entity_qualified_id,
+       'anonymous' as type,
+       NULL AS email,
+       'External' AS first_name,
+       'User' AS last_name,
+       'External User' AS full_name,
+       NULL AS date_joined,
+       NULL AS last_login,
+       NULL AS updated_at,
+       FALSE AS is_admin,
+                NULL AS is_active,
+                NULL AS sso_source,
+                NULL AS locale ;

--- a/resources/migrations/instance_analytics_views/users/v4/mysql.sql
+++ b/resources/migrations/instance_analytics_views/users/v4/mysql.sql
@@ -1,0 +1,34 @@
+CREATE OR REPLACE SQL SECURITY INVOKER
+VIEW v_users AS
+SELECT id AS user_id,
+       concat('user_', id) AS entity_qualified_id,
+       type,
+       CASE WHEN type = 'api-key' THEN null ELSE email END as email,
+       first_name,
+       last_name,
+       COALESCE(concat(first_name, ' ', last_name),
+                first_name,
+                last_name) as full_name,
+       date_joined,
+       last_login,
+       updated_at,
+       is_superuser AS is_admin,
+       is_active,
+       sso_source,
+       locale
+FROM core_user
+UNION
+SELECT 0 AS user_id,
+       'user_0' AS entity_qualified_id,
+       'anonymous' as type,
+       NULL AS email,
+       'External' AS first_name,
+       'User' AS last_name,
+       'External User' AS full_name,
+       NULL AS date_joined,
+       NULL AS last_login,
+       NULL AS updated_at,
+       FALSE AS is_admin,
+                NULL AS is_active,
+                NULL AS sso_source,
+                NULL AS locale ;

--- a/resources/migrations/instance_analytics_views/view_log/v3/mysql-view_log.sql
+++ b/resources/migrations/instance_analytics_views/view_log/v3/mysql-view_log.sql
@@ -1,0 +1,11 @@
+DROP VIEW IF EXISTS v_view_log;
+
+
+CREATE OR REPLACE 
+SQL SECURITY INVOKER 
+VIEW v_view_log AS
+  (SELECT id, timestamp, coalesce(user_id, 0) as user_id,
+                         model AS entity_type,
+                         model_id AS entity_id,
+                         concat(model, '_', model_id) AS entity_qualified_id
+   FROM view_log)


### PR DESCRIPTION
[UXW-263: Aurora MySQL AppDB can't create Metabase Analytics views without using `SQL SECURITY
INVOKER`](https://linear.app/metabase/issue/UXW-263/aurora-mysql-appdb-cant-create-metabase-analytics-views-without-using)

Updates all the MySQL view creations to use `SQL SECURITY INVOKER`.
