### PR TITLE
Fix failing pgvector-api-test/query-test due to an overlong mock index name

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
@@ -163,7 +163,7 @@
     (let [pgvector       semantic.tu/db
           index-metadata (semantic.tu/unique-index-metadata)
           model1         semantic.tu/mock-embedding-model
-          model2         (assoc semantic.tu/mock-embedding-model :model-name "judge-embedd")
+          model2         (assoc semantic.tu/mock-embedding-model :model-name "judge-embed")
           remove-scores  (fn [rows] (mapv #(dissoc % :score :all-scores) rows)) ; scores have time-sensitives components
           sut*           semantic.pgvector-api/query
           sut            #(remove-scores (:results (mt/as-admin (apply sut* %&)))) ; see notes below about perms


### PR DESCRIPTION
### Description

Fix failing `pgvector-api-test/query-test` due to an overlong mock index name.

Not sure how this made it through CI, but this test started failing locally for me after pulling master.

```
clojure.lang.ExceptionInfo: Index name exceeds PostgreSQL limit
        length: 64
         limit: 63
    table-name: "mock_index_mock_judge_d_4_5817332_133447565942875_embed_hnsw_idx"
                                                          metabase-enterprise.semantic-search.index/throw-if-max-pg-len              index.clj:  208
                                                                   metabase-enterprise.semantic-search.index/index-name              index.clj:  376
                                                              metabase-enterprise.semantic-search.index/hnsw-index-name              index.clj:  383
                                            metabase-enterprise.semantic-search.index/create-index-table-if-not-exists!              index.clj:  423
                                            metabase-enterprise.semantic-search.index/create-index-table-if-not-exists!              index.clj:  403
                                                                                                                    ...
                                                     metabase-enterprise.semantic-search.pgvector-api/initialize-index!       pgvector_api.clj:   69
```
