### PR TITLE
Add missing redefs for semantic.index/model-table-suffix semantic.tu/mock-table-suffix

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.test :as mt]
    [metabase.util :as u]))
 
 (use-fixtures :once #'semantic.tu/once-fixture)
@@ -115,8 +116,9 @@
                   (sut pgvector index-metadata))))))))
 
 (defn- default-index [embedding-model index-metadata]
-  (-> (semantic.index/default-index embedding-model)
-      (semantic.index-metadata/qualify-index index-metadata)))
+  (mt/with-dynamic-fn-redefs [semantic.index/model-table-suffix semantic.tu/mock-table-suffix]
+    (-> (semantic.index/default-index embedding-model)
+        (semantic.index-metadata/qualify-index index-metadata))))
 
 (defn- add-index! [pgvector index-metadata embedding-model]
   (let [index (default-index embedding-model index-metadata)]


### PR DESCRIPTION
### Description

As of #62212 we now append timestamps to the index table name. Fix some tests that flake due to (1) overlong index name, (2) assertions that fail due to expecting stable index table names.

https://metaboat.slack.com/archives/C5XHN8GLW/p1755820635459589

Supersedes #62543