### PR TITLE
fix: hide table editing admin setting in some cases

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
@@ -22,6 +22,19 @@ import {
   isDatabaseTableEditingEnabled,
 } from "../settings";
 
+enum DisabledReasonKey {
+  MissingDriverFeature = "driver-feature-missing",
+  NoWriteableTable = "permissions/no-writable-table",
+  SyncInProgress = "database-metadata/sync-in-progress",
+  DatabaseEmtpy = "database-metadata/not-populated",
+}
+
+const VISIBLE_REASONS: string[] = [
+  DisabledReasonKey.NoWriteableTable,
+  DisabledReasonKey.SyncInProgress,
+  DisabledReasonKey.DatabaseEmtpy,
+];
+
 export function AdminDatabaseTableEditingSection({
   database,
   settingsAvailable,
@@ -59,7 +72,10 @@ export function AdminDatabaseTableEditingSection({
       ? dataEditingSetting?.reasons?.[0]
       : undefined;
 
-  if (!dataEditingSetting) {
+  const shouldShowSection =
+    !firstDisabledReason || VISIBLE_REASONS.includes(firstDisabledReason.key);
+
+  if (!dataEditingSetting || !shouldShowSection) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.unit.spec.tsx
@@ -32,12 +32,12 @@ describe("AdminDatabaseTableEditingSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render disabled toggle for disabled reasons", () => {
+  it("should render disabled toggle for specific disabled reasons", () => {
     setup({
       enabled: false,
       reasons: [
         {
-          key: "permissions/no-writeable-tables",
+          key: "permissions/no-writable-table",
           message: "Database connection is read-only",
         },
       ],
@@ -51,5 +51,21 @@ describe("AdminDatabaseTableEditingSection", () => {
     expect(
       screen.getByText("Database connection is read-only"),
     ).toBeInTheDocument();
+  });
+
+  it("should hide section for other disabled reasons", () => {
+    setup({
+      enabled: false,
+      reasons: [
+        {
+          key: "driver-feature-missing",
+          message: "The driver does not support table editing",
+        },
+      ],
+    });
+
+    expect(
+      screen.queryByTestId("database-table-editing-section"),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
As discussed with Chris, we should hide table editing setting in some cases, such as when driver do not support data editing feature.

The desired behavior is to hide the section by default and show it only for VISIBLE_REASONS keys