### PR TITLE
Create new schema when saving transforms

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/CreateTransformModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/CreateTransformModal.tsx
@@ -8,7 +8,6 @@ import {
   Form,
   FormErrorMessage,
   FormProvider,
-  FormSelect,
   FormSubmitButton,
   FormTextInput,
 } from "metabase/forms";
@@ -21,6 +20,8 @@ import type {
   DatasetQuery,
   Transform,
 } from "metabase-types/api";
+
+import { SchemaFormSelect } from "./SchemaFormSelect";
 
 type CreateTransformModalProps = {
   query: DatasetQuery;
@@ -116,7 +117,11 @@ function CreateTransformForm({
             label={t`Description`}
             placeholder={t`This is optional`}
           />
-          <FormSelect name="targetSchema" label={t`Schema`} data={schemas} />
+          <SchemaFormSelect
+            name="targetSchema"
+            label={t`Schema`}
+            data={schemas}
+          />
           <FormTextInput
             name="targetName"
             label={t`Table name`}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/CreateTransformModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/CreateTransformModal.tsx
@@ -116,9 +116,7 @@ function CreateTransformForm({
             label={t`Description`}
             placeholder={t`This is optional`}
           />
-          {schemas.length > 1 && (
-            <FormSelect name="targetSchema" label={t`Schema`} data={schemas} />
-          )}
+          <FormSelect name="targetSchema" label={t`Schema`} data={schemas} />
           <FormTextInput
             name="targetName"
             label={t`Table name`}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/SchemaFormSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/SchemaFormSelect.tsx
@@ -1,31 +1,43 @@
+import { useField } from "formik";
 import { useState } from "react";
-import { jt } from "ttag";
+import { jt, t } from "ttag";
 import _ from "underscore";
 
-import { FormSelect, type FormSelectProps } from "metabase/forms";
+import { FormField, FormSelect, type FormSelectProps } from "metabase/forms";
 import { SelectItem, Text } from "metabase/ui";
 
 export function SchemaFormSelect(props: FormSelectProps & { data: string[] }) {
-  const { data, ...rest } = props;
+  const { data, name, ...rest } = props;
   const [searchValue, setSearchValue] = useState("");
 
   const dataWithNewItem = _.uniq([...data, searchValue]);
+  const [{ value }] = useField(name);
+
+  const isNewValue = !data.includes(value);
 
   return (
-    <FormSelect
-      {...rest}
-      data={dataWithNewItem}
-      searchable
-      searchValue={searchValue}
-      onSearchChange={setSearchValue}
-      renderOption={({ option }) => {
-        const { value } = option;
-        if (data.includes(value)) {
-          return <ExistingSelectItem value={value} />;
-        }
-        return <NewSelectItem value={value} />;
-      }}
-    />
+    <FormField>
+      <FormSelect
+        {...rest}
+        name={name}
+        data={dataWithNewItem}
+        searchable
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+        renderOption={({ option }) => {
+          const { value } = option;
+          if (data.includes(value)) {
+            return <ExistingSelectItem value={value} />;
+          }
+          return <NewSelectItem value={value} />;
+        }}
+      />
+      {isNewValue && (
+        <Text size="sm" c="text-secondary" mt="sm">
+          {t`This schema will be created the first time the transform runs.`}
+        </Text>
+      )}
+    </FormField>
   );
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/SchemaFormSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/NewTransformQueryPage/CreateTransformModal/SchemaFormSelect.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { jt } from "ttag";
+import _ from "underscore";
+
+import { FormSelect, type FormSelectProps } from "metabase/forms";
+import { SelectItem, Text } from "metabase/ui";
+
+export function SchemaFormSelect(props: FormSelectProps & { data: string[] }) {
+  const { data, ...rest } = props;
+  const [searchValue, setSearchValue] = useState("");
+
+  const dataWithNewItem = _.uniq([...data, searchValue]);
+
+  return (
+    <FormSelect
+      {...rest}
+      data={dataWithNewItem}
+      searchable
+      searchValue={searchValue}
+      onSearchChange={setSearchValue}
+      renderOption={({ option }) => {
+        const { value } = option;
+        if (data.includes(value)) {
+          return <ExistingSelectItem value={value} />;
+        }
+        return <NewSelectItem value={value} />;
+      }}
+    />
+  );
+}
+
+function ExistingSelectItem({ value }: { value: string }) {
+  return <SelectItem>{value}</SelectItem>;
+}
+
+function NewSelectItem({ value }: { value: string }) {
+  return (
+    <SelectItem>
+      <Text c="inherit" lh="inherit">
+        {jt`Create new schema ${(<strong key="value">{value}</strong>)}`}
+      </Text>
+    </SelectItem>
+  );
+}


### PR DESCRIPTION
Closes QUE-2155

#### Front-end
Always shows the schema select on the transform save modal and allows it to create new schema's.