### PR TITLE
feat: add numeric input types to table editing

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/api/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/api/types.ts
@@ -55,6 +55,8 @@ export enum TableActionFormInputType {
   DateTime = "datetime",
   Dropdown = "dropdown",
   Boolean = "boolean",
+  Integer = "integer",
+  Float = "float",
 }
 
 export type TableActionFormParameter = {

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/ParameterActionInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/ParameterActionInput.tsx
@@ -14,6 +14,10 @@ import {
   type TableActionInputDateTimeProps,
 } from "./TableActionInputDateTime";
 import {
+  TableActionInputNumber,
+  type TableActionInputNumberProps,
+} from "./TableActionInputNumber";
+import {
   TableActionInputSearchableSelect,
   type TableActionInputSearchableSelectProps,
 } from "./TableActionInputSearchableSelect";
@@ -32,7 +36,8 @@ type TableActionInputProps =
   | TableActionInputTextProps
   | TableActionInputTextareaProps
   | TableActionInputSearchableSelectProps
-  | TableActionInputBooleanProps;
+  | TableActionInputBooleanProps
+  | TableActionInputNumberProps;
 
 export type ParameterActionInputProps = TableActionInputProps & {
   parameter: TableActionFormParameter;
@@ -52,6 +57,12 @@ export function ParameterActionInput(props: ParameterActionInputProps) {
       return (
         <TableActionInputBoolean {...rest} isNullable={parameter.optional} />
       );
+
+    case TableActionFormInputType.Integer:
+      return <TableActionInputNumber {...rest} allowDecimal={false} />;
+
+    case TableActionFormInputType.Float:
+      return <TableActionInputNumber {...rest} allowDecimal={true} />;
 
     case TableActionFormInputType.Textarea:
       return <TableActionInputTextarea {...rest} />;

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputNumber.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputNumber.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useState } from "react";
+
+import { NumberInput } from "metabase/ui";
+
+import type { TableActionInputSharedProps } from "./types";
+
+export type TableActionInputNumberProps = TableActionInputSharedProps & {
+  allowDecimal?: boolean;
+  classNames?: {
+    wrapper?: string;
+    numberInputElement?: string;
+  };
+};
+
+export const TableActionInputNumber = ({
+  allowDecimal,
+  autoFocus,
+  inputProps,
+  initialValue,
+  classNames,
+  onEscape,
+  onEnter,
+  onBlur,
+  onChange,
+}: TableActionInputNumberProps) => {
+  const [value, setValue] = useState<string | number>(initialValue ?? "");
+
+  const handleChange = useCallback(
+    (value: string | number) => {
+      setValue(value);
+      onChange?.(numberToRawValue(value));
+    },
+    [onChange],
+  );
+
+  const handleBlur = useCallback(() => {
+    onBlur?.(numberToRawValue(value));
+  }, [onBlur, value]);
+
+  const handleKeyUp = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Escape") {
+        onEscape?.(numberToRawValue(value));
+      } else if (event.key === "Enter") {
+        onEnter?.(numberToRawValue(value));
+      }
+    },
+    [onEscape, onEnter, value],
+  );
+
+  return (
+    <NumberInput
+      allowDecimal={allowDecimal}
+      defaultValue={(initialValue ?? "").toString()}
+      autoFocus={autoFocus}
+      onKeyUp={handleKeyUp}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      classNames={{
+        wrapper: classNames?.wrapper,
+        input: classNames?.numberInputElement,
+      }}
+      {...inputProps}
+    />
+  );
+};
+
+function numberToRawValue(value: string | number) {
+  return typeof value === "number" ? value.toString() : value;
+}

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/getEditingCellTemplate.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/getEditingCellTemplate.tsx
@@ -29,6 +29,7 @@ export function getEditingCellTemplate({
         }}
         classNames={{
           textInputElement: S.inlineEditingTextInput,
+          numberInputElement: S.inlineEditingTextInput,
           selectTextInputElement: S.inlineEditingTextInput,
           dateTextInputElement: S.inlineEditingTextInput,
           selectLabel: S.selectLabel,

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/ModalParameterActionInput.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/ModalParameterActionInput.module.css
@@ -1,0 +1,17 @@
+.textInputElement {
+  width: 100%;
+}
+
+.numberInputElement {
+  width: 10rem;
+}
+
+.selectTextInputElement {
+  width: auto;
+  min-width: 10rem;
+}
+
+.dateTextInputElement {
+  width: auto;
+  min-width: 10rem;
+}

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/ModalParameterActionInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/ModalParameterActionInput.tsx
@@ -5,6 +5,8 @@ import {
   type ParameterActionInputProps,
 } from "../../inputs/ParameterActionInput";
 
+import S from "./ModalParameterActionInput.module.css";
+
 export function ModalParameterActionInput(props: ParameterActionInputProps) {
   const { parameter, ...rest } = props;
 
@@ -28,6 +30,12 @@ export function ModalParameterActionInput(props: ParameterActionInputProps) {
       {...rest}
       inputProps={inputProps}
       parameter={parameter}
+      classNames={{
+        textInputElement: S.textInputElement,
+        numberInputElement: S.numberInputElement,
+        selectTextInputElement: S.selectTextInputElement,
+        dateTextInputElement: S.dateTextInputElement,
+      }}
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModal.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModal.module.css
@@ -21,6 +21,7 @@
   grid-template-columns: 35% auto;
   grid-template-rows: repeat(auto-fill, rem(40));
   row-gap: rem(24);
+  column-gap: rem(16);
   height: calc(100dvh - rem(80) - rem(72) /* header + footer */);
   overflow-y: scroll;
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModalParameter.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModalParameter.tsx
@@ -32,8 +32,8 @@ export function TableActionFormModalParameter({
   return (
     <>
       <Group h="2.5rem" align="center">
-        <Stack gap="0" className={S.modalBodyColumn}>
-          <Text>
+        <Stack gap="0" className={S.modalBodyColumn} maw="100%">
+          <Text truncate maw="100%">
             {parameter.display_name}
             {!parameter.optional && (
               <Text component="span" c="error">

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModalParameter.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModalParameter.tsx
@@ -1,7 +1,6 @@
 import type { PropsWithChildren } from "react";
 
-import { FIELD_SEMANTIC_TYPES_MAP } from "metabase/lib/core";
-import { Group, Icon, type IconName, Text } from "metabase/ui";
+import { Group, Stack, Text } from "metabase/ui";
 
 import {
   TableActionFormInputType,
@@ -14,39 +13,38 @@ type ActionFormModalParameterProps = PropsWithChildren<{
   parameter: TableActionFormParameter;
 }>;
 
-const DEFAULT_PARAMETER_ICON = "string";
-const PARAMETER_ICON_MAP: Record<TableActionFormInputType, IconName> = {
-  [TableActionFormInputType.Text]: "string",
-  [TableActionFormInputType.Textarea]: "string",
-  [TableActionFormInputType.Date]: "calendar",
-  [TableActionFormInputType.DateTime]: "calendar",
-  [TableActionFormInputType.Dropdown]: "string",
-  [TableActionFormInputType.Boolean]: "string",
-};
+const INPUT_TYPE_TO_DISPLAY_TYPE_MAP: Record<TableActionFormInputType, string> =
+  {
+    [TableActionFormInputType.Text]: "text",
+    [TableActionFormInputType.Textarea]: "description",
+    [TableActionFormInputType.Date]: "date",
+    [TableActionFormInputType.DateTime]: "date",
+    [TableActionFormInputType.Dropdown]: "category",
+    [TableActionFormInputType.Boolean]: "boolean",
+    [TableActionFormInputType.Integer]: "integer",
+    [TableActionFormInputType.Float]: "float",
+  };
 
 export function TableActionFormModalParameter({
   parameter,
   children,
 }: ActionFormModalParameterProps) {
-  const iconName = parameter.semantic_type
-    ? FIELD_SEMANTIC_TYPES_MAP[parameter.semantic_type].icon
-    : PARAMETER_ICON_MAP[parameter.input_type];
-
   return (
     <>
       <Group h="2.5rem" align="center">
-        <Icon
-          className={S.modalBodyColumn}
-          name={iconName ?? DEFAULT_PARAMETER_ICON}
-        />
-        <Text className={S.modalBodyColumn}>
-          {parameter.display_name}
-          {!parameter.optional && (
-            <Text component="span" c="error">
-              *
-            </Text>
-          )}
-        </Text>
+        <Stack gap="0" className={S.modalBodyColumn}>
+          <Text>
+            {parameter.display_name}
+            {!parameter.optional && (
+              <Text component="span" c="error">
+                *
+              </Text>
+            )}
+          </Text>
+          <Text fz="sm" c="text-secondary" lh={1.1}>
+            {INPUT_TYPE_TO_DISPLAY_TYPE_MAP[parameter.input_type] ?? "text"}
+          </Text>
+        </Stack>
       </Group>
       {children}
     </>


### PR DESCRIPTION
Resolves [WRK-800](https://linear.app/metabase/issue/WRK-800/fe-validate-user-input)
As well as some items from [WRK-626](https://linear.app/metabase/issue/WRK-626/update-grid-design):
* Add data types underneath field names
* Variable field widths based on the data type: longer fields for texts, shorter for numeric inputs - 160px for ints and floats, wide big inputs for descriptions, auto-width for dates, and stuff we are handling as dropdowns, etc.
<img width="1430" height="856" alt="image" src="https://github.com/user-attachments/assets/63989a39-1215-4220-b7b8-e8647a200745" />
