### PR TITLE
ci(sdk): Make SDK backward-compatibility tests required

### DIFF
--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -160,7 +160,7 @@ jobs:
       - embedding-sdk-docs-snippets-type-check
       - embedding-sdk-api-documentation-generation-validation
       - sdk-e2e-tests
-      # - e2e-component-tests-embedding-sdk-backward-compatibility
+      - e2e-component-tests-embedding-sdk-backward-compatibility
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
Seems new backward-compatibility tests work well on master, so enable them as required