### PR TITLE
Improve disabled settings warnings

### DIFF
--- a/src/metabase/actions/settings.clj
+++ b/src/metabase/actions/settings.clj
@@ -16,26 +16,27 @@
 ;; reasons for disabling table editing
 
 (def ^:private db-routing-reason
-  {:key :setting/database-routing
+  {:key     :setting/database-routing
+   :type    :error
    :message (i18n/deferred-tru "Table editing is not supported with database routing.")})
 
 (def ^:private no-writable-tables-reason
-  {:key :permissions/no-writable-table
+  {:key     :permissions/no-writable-table
+   :type    :error
    :message (i18n/deferred-tru "Table editing requires at least one table with INSERT, UPDATE, and DELETE support.")})
 
 (def ^:private busy-sync-reason
   {:key     :database-metadata/sync-in-progress
+   :type    :warning
    :message (i18n/deferred-tru "Unable to determine whether the database connection is readonly, as it is still syncing.")})
 
 (def ^:private missing-permissions-reason
   {:key     :database-metadata/not-populated
+   :type    :warning
    :message (i18n/deferred-tru "Unable to determine whether the database connection is readonly, as we are missing metadata from sync.")})
 
 ;; Marking reasons as warnings allow the user to proactively set the configuration, but it will only come into
 ;; effect once the warning is resolved.
-
-(derive :database-metadata/sync-in-progress :setting/disabled-warning)
-(derive :database-metadata/not-populated :setting/disabled-warning)
 
 (setting/defsetting database-enable-table-editing
   (i18n/deferred-tru "Whether to enable table data editing for a specific Database.")

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -155,6 +155,11 @@
                                 (.getCanonicalName ^Class klass))
                         {:tag klass}))))))
 
+(defn- warning?
+  "Warnings don't block you saving a setting, but the value won't be used until the warning is resolved."
+  [reason]
+  (isa? (:key reason) :setting/disabled-warning))
+
 (defn disabled-for-db-reasons
   "Return the reasons, if any, for the given setting being disabled."
   [setting-def database]
@@ -166,10 +171,8 @@
            (or (:setting/disabled-reasons (ex-data e))
                (throw e))))))
 
-(defn- warning?
-  "Warnings don't block you saving a setting, but the value won't be used until the warning is resolved."
-  [reason]
-  (isa? (:key reason) :setting/disabled-warning))
+(defn- disabled-for-db-reasons? [setting-def database]
+  (seq (remove warning? (disabled-for-db-reasons setting-def database))))
 
 (defn custom-disabled-reasons!
   "Expose custom reasons for a setting being disabled to the admin panel.
@@ -704,7 +707,7 @@
 
     (if (or (and feature (not (has-feature? feature)))
             (and enabled? (not (enabled?)))
-            (and *database* (disabled-for-db-reasons setting-def *database*)))
+            (and *database* (disabled-for-db-reasons? setting-def *database*)))
       (:default setting-def)
       (if (= config/*disable-setting-cache* disable-cache?) ;; Optimization: only bind dynvar if necessary.
         (getter)
@@ -955,11 +958,12 @@
                        :database-id (:id database)})))
     ;; Warnings are only for display and shouldn't block writing the setting.
     ;; They imply that the setting won't work until the issue is resolved, but often it is a transient problem.
-    (when-let [reasons (seq (remove warning? (disabled-for-db-reasons setting database)))]
-      (throw (ex-info (tru "Setting {0} is not enabled for this database" s-name)
-                      {:setting     s-name
-                       :database-id (:id database)
-                       :reasons     reasons})))))
+    (let [reasons (disabled-for-db-reasons setting database)]
+      (when (seq (remove warning? (disabled-for-db-reasons setting database)))
+        (throw (ex-info (tru "Setting {0} is not enabled for this database" s-name)
+                        {:setting     s-name
+                         :database-id (:id database)
+                         :reasons     reasons}))))))
 
 (defn set!
   "Set the value of `setting-definition-or-name`. What this means depends on the Setting's `:setter`; by default, this

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -959,8 +959,8 @@
                        :database-id (:id database)})))
     ;; Warnings are only for display and shouldn't block writing the setting.
     ;; They imply that the setting won't work until the issue is resolved, but often it is a transient problem.
-    (let [reasons (disabled-for-db-reasons setting database)]
-      (when (seq (remove warning? (disabled-for-db-reasons setting database)))
+    (when-let [reasons (disabled-for-db-reasons setting database)]
+      (when (not-every? warning? (disabled-for-db-reasons setting database))
         (throw (ex-info (tru "Setting {0} is not enabled for this database" s-name)
                         {:setting     s-name
                          :database-id (:id database)

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -158,7 +158,7 @@
 (defn- warning?
   "Warnings don't block you saving a setting, but the value won't be used until the warning is resolved."
   [reason]
-  (isa? (:key reason) :setting/disabled-warning))
+  (= (:type reason) :warning))
 
 (defn disabled-for-db-reasons
   "Return the reasons, if any, for the given setting being disabled."
@@ -166,6 +166,7 @@
   (when-let [f (:enabled-for-db? setting-def)]
     (try (when-not (f database)
            [{:key     :disabled-for-db
+             :type    :error
              :message (tru "This database does not support this setting")}])
          (catch ExceptionInfo e
            (or (:setting/disabled-reasons (ex-data e))

--- a/src/metabase/warehouses/api.clj
+++ b/src/metabase/warehouses/api.clj
@@ -1302,31 +1302,33 @@
              (let [reasons (cond-> []
                              (and enabled? (not (enabled?)))
                              (conj {:key     :setting-disabled
+                                    :type    :error
                                     :message "This setting is disabled for all databases."})
 
                              (and driver-feature (not (driver-supports? driver-feature)))
                              (conj {:key     :driver-feature-missing
+                                    :type    :error
                                     :message (format "The %s driver does not support the `%s` feature"
                                                      (driver/display-name driver)
                                                      (name driver-feature))})
 
                              true
-                             (into (setting/disabled-for-db-reasons setting-def database)))]
+                             (into (setting/disabled-for-db-reasons setting-def database)))
+                   enabled? (empty? (remove (comp #{:warning} :type) reasons))]
                (if (empty? reasons)
-                 {:enabled true}
-                 {:enabled false, :reasons reasons}))]))))
+                 {:enabled enabled?}
+                 {:enabled enabled?, :reasons reasons}))]))))
 
 (mr/def ::available-settings
   [:map-of
    :keyword
-   [:multi {:dispatch :enabled}
-    [true [:map [:enabled [:= true]]]]
-    [false [:map
-            [:enabled [:= false]]
-            [:reasons
-             [:sequential [:map
-                           [:key :keyword]
-                           [:message [:or :string [:fn i18n/localized-string?]]]]]]]]]])
+   [:map
+    [:enabled :boolean]
+    [:reasons {:optional true}
+     [:sequential [:map
+                   [:key :keyword]
+                   [:type [:enum :error :warning]]
+                   [:message [:or :string [:fn i18n/localized-string?]]]]]]]])
 
 (api.macros/defendpoint :get "/:id/settings-available" :- [:map [:settings ::available-settings]]
   "Get all database-local settings and their availability for the given database."

--- a/src/metabase/warehouses/api.clj
+++ b/src/metabase/warehouses/api.clj
@@ -1314,7 +1314,7 @@
 
                              true
                              (into (setting/disabled-for-db-reasons setting-def database)))
-                   enabled? (empty? (remove (comp #{:warning} :type) reasons))]
+                   enabled? (every? (comp #{:warning} :type) reasons)]
                (if (empty? reasons)
                  {:enabled enabled?}
                  {:enabled enabled?, :reasons reasons}))]))))

--- a/test/metabase/warehouses/api_test.clj
+++ b/test/metabase/warehouses/api_test.clj
@@ -2379,8 +2379,8 @@
   :type :boolean
   :database-local :only
   :enabled-for-db? (fn [_]
-                     (setting/custom-disabled-reasons! [{:key :custom/one, :message "Because..."}
-                                                        {:key :custom/two, :message "Also..."}])))
+                     (setting/custom-disabled-reasons! [{:key :custom/one, :type :warning, :message "Because..."}
+                                                        {:key :custom/two, :type :warning, :message "Also..."}])))
 
 (setting/defsetting api-test-disabled-for-multiple-reasons
   "A feature used for testing /settings-available (5)"
@@ -2389,7 +2389,7 @@
   ;; Something h2 will never support
   :driver-feature :test/jvm-timezone-setting
   :enabled-for-db? (fn [_]
-                     (setting/custom-disabled-reasons! [{:key :custom/three, :message "Never"}])))
+                     (setting/custom-disabled-reasons! [{:key :custom/three, :type :error, :message "Never"}])))
 
 (deftest settings-available-test
   (testing "GET /api/database/:id/settings-available"
@@ -2403,23 +2403,27 @@
                     :api-test-missing-driver-feature
                     {:enabled false
                      :reasons [{:key     "driver-feature-missing"
+                                :type    "error"
                                 :message "The H2 driver does not support the `jvm-timezone-setting` feature"}]}
 
                     :api-test-disabled-for-database
                     {:enabled false
                      :reasons [{:key     "disabled-for-db"
+                                :type    "error"
                                 :message "This database does not support this setting"}]}
 
                     :api-test-disabled-for-custom-reasons
-                    {:enabled false
-                     :reasons [{:key "custom/one", :message "Because..."}
-                               {:key "custom/two", :message "Also..."}]}
+                    {:enabled true
+                     :reasons [{:key "custom/one", :type "warning", :message "Because..."}
+                               {:key "custom/two", :type "warning", :message "Also..."}]}
 
                     :api-test-disabled-for-multiple-reasons
                     {:enabled false
                      :reasons [{:key     "driver-feature-missing"
+                                :type    "error"
                                 :message "The H2 driver does not support the `jvm-timezone-setting` feature"}
                                {:key     "custom/three"
+                                :type    "error"
                                 :message "Never"}]}}
 
                    (select-keys settings [:unaggregated-query-row-limit


### PR DESCRIPTION
This PR smoothes some rough edges around settings warnings.

1. Tell the FE which reasons are warnings versus errors.
2. Allow settings to be used even if there are warnings.

This simplifies the code and semantics a fair bit.
