### PR TITLE
convert mysql booleans to real booleans during semantic indexing

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -105,7 +105,7 @@
 
 (defn- to-boolean
   "MySQL booleans are represented as 0/1, so we must ensure we're casting them to
-   real booleans when inserting them int our postgres db"
+   real booleans when inserting them into our postgres db"
   [b]
   {:pre [(some? b)]}
   (cond

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -103,6 +103,17 @@
 
     :else (Instant/ofEpochMilli (inst-ms document-timestamp))))
 
+(defn- to-boolean
+  "MySQL booleans are represented as 0/1, so we must ensure we're casting them to
+   real booleans when inserting them int our postgres db"
+  [b]
+  {:pre [(some? b)]}
+  (cond
+    (boolean? b) b
+    (= 0 b) false
+    (= 1 b) true
+    :else (throw (ex-info "Unexpected boolean value" {:v b}))))
+
 (defn- doc->db-record
   "Convert a document to a database record with a provided embedding."
   [embedding-vec {:keys [model id searchable_text created_at creator_id updated_at
@@ -117,10 +128,10 @@
    :name                (:name doc)
    :content             searchable_text
    :display_type        display_type
-   :archived            archived
-   :official_collection official_collection
-   :pinned              pinned
-   :verified            verified
+   :archived            (some-> archived to-boolean)
+   :official_collection (some-> official_collection to-boolean)
+   :pinned              (some-> pinned to-boolean)
+   :verified            (some-> verified to-boolean)
    :dashboardcard_count dashboardcard_count
    :view_count          view_count
    :model_created_at    (some-> created_at to-instant)


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-357/convert-mysql-booleans-to-real-booleans-before-inserting-into-semantic

An alternative approach would be to convert the "booleans" on the way in the gating table, i.e. in `metabase-enterprise.semantic-search.gate/search-doc->gate-doc`, but IMO keeping the real data in there is preferrable, and doing it in `doc->db-record` keeps it symmetric with other casting done (e.g. `to-instant`)