### PR TITLE
Update c3p0 version from 0.10.1 to 0.11.2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -58,7 +58,7 @@
                                             {:mvn/version "2.1.214"}            ; embedded SQL database
   com.ibm.icu/icu4j                         {:mvn/version "77.1"}               ; Used to transliterate Unicode characters into Latin characters
   com.knuddels/jtokkit                      {:mvn/version "1.1.0"}              ; Java tokenizer library for OpenAI models, used for token counting in semantic search
-  com.mchange/c3p0                          {:mvn/version "0.10.1"}             ; DB connection pool
+  com.mchange/c3p0                          {:mvn/version "0.11.2"}             ; DB connection pool
   com.snowplowanalytics/snowplow-java-tracker ^:antq/exclude                    ; 2+ depend on apache httpclient 5.x, but saml and clj-http depend on 4.x
                                             {:mvn/version "1.0.1"}              ; Snowplow analytics
   com.sun.mail/jakarta.mail                 ^:antq/exclude                      ; 2+ changes imports from javax.mail to jakarta.mail


### PR DESCRIPTION
From https://github.com/swaldman/c3p0/blob/0.11.x/CHANGELOG

c3p0-0.11.2
        -- Expose utilities `overwriteJavaBeanProperties` and `overwriteC3P0PrefixedProperties`
	   in the `DataSources` class, and refactor existing functions to use those.
c3p0-0.11.1
	-- in BasicResourcePool, forceKillAcquires() accidentally failed to surrender its lock,
	   leading to deadlocks following a full round of acquisition failures. Many thanks
	   to @pwielgolaski on github for tracking down the issue, to @driseley on github for
	   providing a reproduction of the issue, and to @michalgutkowski on github for providing
	   a pull request with the fix.
c3p0-0.11.0
	-- Additional testing.
c3p0-0.11.0-pre2
	-- Define new property cancelAutomaticallyClosedStatements, which, if true, ensures
	   that Statement.cancel() will be called prior to Statement.close() when c3p0 automatically
	   close()es statements because a client has neglected to, a Connection with open Statements
	   has exceeded its unreturnedConnectionTimeout, or the Statement cache is expiring a PreparedStatement.
	   Thanks to Andreas Dangel (in 2014!) for pointing out scenarios where this might be 
	   helpful, and offering a PR demonstrating the basic fix, and Luis Paolini for reminding me
	   that I flaked 11 years ago and this is still worth pursuing.
c3p0-0.11.0-pre1
	-- Rewrite BasicResourcePool and GooGooStatementCache in terms of
	   ReentrantLock and Condition.{await/signalAll} rather than native
	   monitors and wait()/notifyAll(), because wait() pins loom
	   virtual threads. Many thanks to alex-kormukhin for calling
	   attention to this issue and proposing the fix!
	-- Double check after termination of BasicResourcePool.awaitAvailable(...)
	   that following notification/termination a resource (Connection) remains
	   available. Many thanks to C3Stones and xtb359 on github for calling
	   attention to this issue.
	-- Prevent fragility under non-bootstrap / non-system CLASSLOADERs under
	   Java 8, where references to java.sql.ShardingKey not available under Java 8
	   provoke NoClassDefFoundError. Bifurcate Connection proxies, generate
	   version without sharding key methods under JVMs where ShardingKey is unavailable,
	   full JDBC 4.3 Connection API proxies where ShardingKey is present.
	   Thanks to Force Rs on github for finding the issue and suggesting the
	   solution!
c3p0-0.10.2
	-- Prevent freeze due to re-waiting if a non-Exception Throwable occurs
	   while acquiring a PreparedStatement to cache. Thanks Totyo Totev!

> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
