### PR TITLE
Set EMBEDDING_SDK_CONFIG.isEmbeddingSdk to `true` for SDK storybook

### DIFF
--- a/.storybook-sdk/preview.tsx
+++ b/.storybook-sdk/preview.tsx
@@ -6,6 +6,10 @@ import { storybookThemeOptions } from "embedding-sdk/test/storybook-themes";
 import { availableLocales } from "./constants";
 import { defineEmbeddingSdkPackageBuildInfo } from "../frontend/src/metabase/embedding-sdk/lib/define-embedding-sdk-package-build-info";
 import { defineGlobalDependencies } from "../frontend/src/metabase/embedding-sdk/lib/define-global-dependencies";
+import { EMBEDDING_SDK_CONFIG } from "../frontend/src/metabase/embedding-sdk/config";
+
+// Enable SDK mode as we are previewing the SDK code
+EMBEDDING_SDK_CONFIG.isEmbeddingSdk = true;
 
 // To run initialization side effects like Mantine styles, dayjs plugins, etc
 import "metabase/embedding-sdk/vendors-side-effects";


### PR DESCRIPTION
Closes EMB-754
Set EMBEDDING_SDK_CONFIG.isEmbeddingSdk to `true` for SDK storybook to fix `isEmbeddingSdk` check in stories

This PR is a temporary fix, the proper solution is covered by https://linear.app/metabase/issue/EMB-755/move-storybook-sdkconfigs-into-enterprisefrontendsrcembedding-sdk