### PR TITLE
Fix QB crashing for mongo

### DIFF
--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -175,12 +175,12 @@
     results-metadata          :- [:maybe ::lib.schema.metadata/stage]
     native-extras             :- [:maybe ::native-extras]]
    (let [tags (extract-template-tags sql-or-other-native-query)]
-     (-> (lib.query/query-with-stages metadata-providerable
-                                      [{:lib/type           :mbql.stage/native
-                                        :lib/stage-metadata results-metadata
-                                        :template-tags      tags
-                                        :native             sql-or-other-native-query}])
-         (with-native-extras native-extras)))))
+     (cond-> (lib.query/query-with-stages metadata-providerable
+                                          [{:lib/type           :mbql.stage/native
+                                            :lib/stage-metadata results-metadata
+                                            :template-tags      tags
+                                            :native             sql-or-other-native-query}])
+       native-extras (with-native-extras native-extras)))))
 
 (mu/defn with-different-database :- ::lib.schema/query
   "Changes the database for this query. The first stage must be a native type.

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -271,7 +271,10 @@
        #?(:clj Throwable :cljs :default)
        #"Must be a native query"
        (-> (lib/query (metadata-provider-requiring-collection) (meta/table-metadata :venues))
-           (lib/with-native-extras {:collection "mycollection"})))))
+           (lib/with-native-extras {:collection "mycollection"}))))
+  (testing "should not throw when creating a native query without required extras (metabase#62556)"
+    (is (=? {:stages [{:native "myquery"}]}
+            (-> (lib/native-query (metadata-provider-requiring-collection) "myquery"))))))
 
 (deftest ^:parallel has-write-permission-test
   (testing ":native-permissions in database"

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -274,7 +274,7 @@
            (lib/with-native-extras {:collection "mycollection"}))))
   (testing "should not throw when creating a native query without required extras (metabase#62556)"
     (is (=? {:stages [{:native "myquery"}]}
-            (-> (lib/native-query (metadata-provider-requiring-collection) "myquery"))))))
+            (lib/native-query (metadata-provider-requiring-collection) "myquery")))))
 
 (deftest ^:parallel has-write-permission-test
   (testing ":native-permissions in database"


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/62556
Regression since https://github.com/metabase/metabase/pull/62340

How to verify:
- Run mongo `docker run -e EXPERIMENTAL_DOCKER_DESKTOP_FORCE_QEMU=1 -p 27017:27017 metabase/qa-databases:mongo-sample-6`
- Add it in Admin -> Databases
- New -> Question -> Select any MongoDB table -> Click View native query
- The app should not crash