### PR TITLE
skip flaky loki row chart tests

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.stories.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.stories.tsx
@@ -52,6 +52,10 @@ export const Default: StoryFn<{ series: RawSeries }> = ({
   );
 };
 
+Default.parameters = {
+  loki: { skip: true },
+};
+
 export const WithLongNames = () => {
   const [series, setSeries] = useState([
     {
@@ -95,4 +99,8 @@ export const WithLongNames = () => {
       </Box>
     </VisualizationWrapper>
   );
+};
+
+WithLongNames.parameters = {
+  loki: { skip: true },
 };


### PR DESCRIPTION
Example failures https://github.com/metabase/metabase/actions/runs/17144646452/job/48638413606?pr=62521

Recreating snapshots does not help so I unblocking other PRs by skipping these specs.
Unskip task: https://linear.app/metabase/issue/VIZ-1346/flaky-loki-test-rowchart-visualization-tests
