### PR TITLE
Create schemas if needed for transforms

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
@@ -68,6 +68,7 @@
            transform-details {:transform-type (keyword (:type target))
                               :connection-details (driver/connection-details driver database)
                               :query (transforms.util/compile-source source)
+                              :target target
                               :output-table (transforms.util/qualified-table-name driver target)}
            opts {:overwrite? true}]
        (when-not (driver.u/supports? driver feature database)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1178,6 +1178,13 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
+(defmulti create-schema-if-needed!
+  "Creates a schema if it does not already exist.
+   Used to create new schemas for transforms."
+  {:added "0.57.0" :arglists '([driver details schema])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
 (defmulti connection-details
   "Get connection details for a given driver and db object"
   {:added "0.57.0", :arglists '([driver db])}

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1211,3 +1211,9 @@
 (defmethod sql-jdbc/impl-table-known-to-not-exist? :postgres
   [_ e]
   (= (sql-jdbc/get-sql-state e) "42P01"))
+
+(defmethod driver/create-schema-if-needed! :postgres
+  [driver details schema]
+  (let [schema (driver.sql/normalize-name driver schema)
+        sql [[(format "CREATE SCHEMA IF NOT EXISTS %s;" schema)]]]
+    (driver/execute-raw-queries! driver details sql)))

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -118,9 +118,9 @@
 ;; TODO Although these methods are implemented here, in fact they only work for sql-jdbc drivers, because
 ;; execute-raw-queries! is not in implemented for plain sql drivers.
 (defmethod driver/run-transform! [:sql :table]
-  [driver {:keys [connection-details query output-table]} {:keys [overwrite?]}]
-  (let [driver (keyword driver)
-        queries (cond->> [(driver/compile-transform driver
+  [driver {:keys [connection-details query output-table target]} {:keys [overwrite?]}]
+  (driver/create-schema-if-needed! driver connection-details (:schema target))
+  (let [queries (cond->> [(driver/compile-transform driver
                                                     {:query query
                                                      :output-table output-table})]
                   overwrite? (cons (driver/compile-drop-table driver output-table)))]


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-2155/febe-ability-to-create-a-schema-if-it-does-not-exist

### Description

BE portion of https://github.com/metabase/metabase/pull/62553

Creates schemas if they don't exist when running a transform

### How to verify

You should be able to run a transform in a new schema

### Demo

todo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
