### PR TITLE
Fix vertical legend position for cartesian charts

### DIFF
--- a/frontend/src/metabase/visualizations/components/legend/LegendLayout.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLayout.jsx
@@ -55,38 +55,41 @@ export const LegendLayout = ({
   const minYLabels = items.length > maxYItems ? maxYLabels : items.length;
 
   const isNarrow = width < MIN_LEGEND_WIDTH;
+
   const isVertical = maxXItems < items.length;
+  const isHorizontal = !isVertical;
+
   const isVisible = hasLegend && !(isVertical && isNarrow);
   const visibleLength = isVertical ? minYLabels : items.length;
 
+  const legend = (
+    <LegendContainer isVertical={isVertical} isQueryBuilder={isQueryBuilder}>
+      <Legend
+        items={items}
+        hovered={hovered}
+        visibleLength={visibleLength}
+        isVertical={isVertical}
+        onHoverChange={onHoverChange}
+        onSelectSeries={onSelectSeries}
+        onToggleSeriesVisibility={onToggleSeriesVisibility}
+        isReversed={isReversed}
+      />
+      {!isVertical && actionButtons && (
+        <LegendActions>{actionButtons}</LegendActions>
+      )}
+    </LegendContainer>
+  );
+
   return (
     <LegendLayoutRoot className={className} isVertical={isVertical}>
+      {isVisible && isHorizontal && legend}
       <MainContainer>
         {isVertical && actionButtons && (
           <LegendActions>{actionButtons}</LegendActions>
         )}
         {hasDimensions && <ChartContainer>{children}</ChartContainer>}
       </MainContainer>
-      {isVisible && (
-        <LegendContainer
-          isVertical={isVertical}
-          isQueryBuilder={isQueryBuilder}
-        >
-          <Legend
-            items={items}
-            hovered={hovered}
-            visibleLength={visibleLength}
-            isVertical={isVertical}
-            onHoverChange={onHoverChange}
-            onSelectSeries={onSelectSeries}
-            onToggleSeriesVisibility={onToggleSeriesVisibility}
-            isReversed={isReversed}
-          />
-          {!isVertical && actionButtons && (
-            <LegendActions>{actionButtons}</LegendActions>
-          )}
-        </LegendContainer>
-      )}
+      {isVisible && isVertical && legend}
     </LegendLayoutRoot>
   );
 };


### PR DESCRIPTION
Fixes that cartesian chart   legends can be shown below the chart (a regression caused by #62270)

### Before
<img width="600px" alt="CleanShot 2025-08-22 at 17 33 49@2x" src="https://github.com/user-attachments/assets/cd80afd8-9abf-4e82-9087-b5c44086b500" />


### After
<img width="600px"  alt="CleanShot 2025-08-22 at 17 33 13@2x" src="https://github.com/user-attachments/assets/78743f3e-63f8-486b-9b3b-7813243673d0" />
