### PR TITLE
Update Command Suggestion selected index on MouseEnter

### DIFF
--- a/e2e/support/helpers/e2e-document-helpers.ts
+++ b/e2e/support/helpers/e2e-document-helpers.ts
@@ -10,6 +10,10 @@ export const addToDocument = (text: string, newLine: boolean = true) => {
   }
 };
 
+export const clearDocumentContent = () => {
+  documentContent().type("{selectAll}{backspace}");
+};
+
 export const documentSuggestionDialog = () =>
   cy.findByRole("dialog", { name: "Mention Dialog" });
 
@@ -18,6 +22,12 @@ export const documentSuggestionItem = (name: RegExp | string) =>
 
 export const commandSuggestionDialog = () =>
   cy.findByRole("dialog", { name: "Command Dialog" });
+
+export const documentMetabotDialog = () =>
+  cy.findByRole("dialog", { name: "Metabot dialog" });
+
+export const documentMetabotSuggestionItem = (name: RegExp | string) =>
+  documentMetabotDialog().findByRole("option", { name });
 
 export const commandSuggestionItem = (name: RegExp | string) =>
   commandSuggestionDialog().findByRole("option", { name });

--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -329,6 +329,39 @@ describe("documents", () => {
         });
       });
 
+      it("should support keyboard and mouse selection in suggestions without double highlight", () => {
+        H.documentContent().click();
+        H.addToDocument("/", false);
+
+        assertOnlyOneOptionActive(/Ask Metabot/);
+
+        cy.realPress("{downarrow}");
+        cy.realPress("{downarrow}");
+
+        //Link should be active
+        assertOnlyOneOptionActive("Link");
+
+        // Hover over Quote
+        H.commandSuggestionDialog()
+          .findByRole("option", { name: /Quote/ })
+          .realHover();
+
+        assertOnlyOneOptionActive(/Quote/);
+
+        H.addToDocument("pro", false);
+
+        assertOnlyOneOptionActive(/Products by Category/);
+
+        cy.realPress("{downarrow}");
+        assertOnlyOneOptionActive(/Products average/);
+
+        H.commandSuggestionDialog()
+          .findByRole("option", { name: /Products by Category/ })
+          .realHover();
+
+        assertOnlyOneOptionActive(/Products by Category/);
+      });
+
       it("should support adding cards and updating viz settings", () => {
         H.documentContent().click();
         H.addToDocument("/", false);
@@ -509,3 +542,14 @@ describe("documents", () => {
     });
   });
 });
+
+const assertOnlyOneOptionActive = (name: string | RegExp) => {
+  H.commandSuggestionDialog()
+    .findByRole("option", { name })
+    .should("have.attr", "aria-selected", "true");
+
+  H.commandSuggestionDialog()
+    .findAllByRole("option")
+    .filter("[aria-selected=true]")
+    .should("have.length", 1);
+};

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.tsx
@@ -1,5 +1,6 @@
 import type { Editor, Range } from "@tiptap/core";
 import {
+  type DOMAttributes,
   forwardRef,
   useCallback,
   useEffect,
@@ -79,8 +80,8 @@ const CommandMenuItem = forwardRef<
     option: CommandOption;
     isSelected?: boolean;
     onClick?: () => void;
-  }
->(function CommandMenuItem({ option, isSelected, onClick }, ref) {
+  } & DOMAttributes<HTMLButtonElement>
+>(function CommandMenuItem({ option, isSelected, onClick, ...rest }, ref) {
   return (
     <UnstyledButton
       ref={ref}
@@ -89,6 +90,7 @@ const CommandMenuItem = forwardRef<
       role="option"
       aria-selected={isSelected}
       aria-label={option.label}
+      {...rest}
     >
       <Group gap="sm" wrap="nowrap" align="center">
         {option.icon ? (
@@ -389,6 +391,7 @@ export const CommandSuggestion = forwardRef<
           menuItems={searchMenuItems}
           selectedIndex={entitySelectedIndex}
           onItemSelect={entityHandlers.selectItem}
+          onItemHover={entityHandlers.hoverHandler}
           onFooterClick={entityHandlers.openModal}
           query={query}
           searchResults={searchResults}
@@ -409,7 +412,8 @@ export const CommandSuggestion = forwardRef<
                       key={`search-${index}`}
                       item={item}
                       isSelected={selectedIndex === index}
-                      onClick={() => selectItem(index)}
+                      onClick={() => setSelectedIndex(index)}
+                      onMouseEnter={() => setSelectedIndex(index)}
                     />
                   ))}
                   {searchMenuItems.length > 0 && commandOptions.length > 0 && (
@@ -424,6 +428,7 @@ export const CommandSuggestion = forwardRef<
                         option={option}
                         isSelected={selectedIndex === index}
                         onClick={() => selectItem(index)}
+                        onMouseEnter={() => setSelectedIndex(index)}
                       />
                     );
                   })}
@@ -463,6 +468,7 @@ export const CommandSuggestion = forwardRef<
                             option={option}
                             isSelected={selectedIndex === index}
                             onClick={() => selectItem(index)}
+                            onMouseEnter={() => setSelectedIndex(index)}
                           />
                         );
                       })}

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.tsx
@@ -412,7 +412,7 @@ export const CommandSuggestion = forwardRef<
                       key={`search-${index}`}
                       item={item}
                       isSelected={selectedIndex === index}
-                      onClick={() => setSelectedIndex(index)}
+                      onClick={() => selectItem(index)}
                       onMouseEnter={() => setSelectedIndex(index)}
                     />
                   ))}

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Mention/MentionSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Mention/MentionSuggestion.tsx
@@ -79,6 +79,7 @@ const MentionSuggestionComponent = forwardRef<
         modal={modal}
         onModalSelect={handlers.handleModalSelect}
         onModalClose={handlers.handleModalClose}
+        onItemHover={handlers.hoverHandler}
       />
     </SuggestionPaper>
   );

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotMention/MetabotSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotMention/MetabotSuggestion.tsx
@@ -146,6 +146,7 @@ const MetabotMentionSuggestionComponent = forwardRef<
               item={item}
               isSelected={selectedIndex === index}
               onClick={() => selectItem(index)}
+              onMouseEnter={() => setSelectedIndex(index)}
             />
           ))}
           {query.length > 0 && totalItems === 0 && !isLoading ? (

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/EntitySearchSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/EntitySearchSection.tsx
@@ -56,6 +56,7 @@ export function EntitySearchSection({
       <SearchResultsFooter
         isSelected={selectedIndex === menuItems.length}
         onClick={onFooterClick}
+        onMouseEnter={() => onItemHover(menuItems.length)}
       />
 
       {modal === "question-picker" && (

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/EntitySearchSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/EntitySearchSection.tsx
@@ -21,6 +21,7 @@ interface EntitySearchSectionProps {
   modal: "question-picker" | null;
   onModalSelect: (item: QuestionPickerValueItem) => void;
   onModalClose: () => void;
+  onItemHover: (index: number) => void;
 }
 
 export function EntitySearchSection({
@@ -33,6 +34,7 @@ export function EntitySearchSection({
   modal,
   onModalSelect,
   onModalClose,
+  onItemHover,
 }: EntitySearchSectionProps) {
   return (
     <>
@@ -42,6 +44,7 @@ export function EntitySearchSection({
           item={item}
           isSelected={selectedIndex === index}
           onClick={() => onItemSelect(index)}
+          onMouseEnter={() => onItemHover(index)}
         />
       ))}
       {query.length > 0 && searchResults.length === 0 ? (

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/useEntitySuggestions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/shared/useEntitySuggestions.ts
@@ -30,6 +30,7 @@ interface UseEntitySuggestionsResult {
     handleModalSelect: (item: QuestionPickerValueItem) => void;
     handleModalClose: () => void;
     openModal: () => void;
+    hoverHandler: (index: number) => void;
   };
 }
 
@@ -96,6 +97,11 @@ export function useEntitySuggestions({
     selectItem(selectedIndex);
   }, [selectItem, selectedIndex]);
 
+  const hoverHandler = useCallback(
+    (index: number) => setSelectedIndex(index),
+    [],
+  );
+
   const onKeyDown = useCallback(
     ({ event }: { event: KeyboardEvent }) => {
       if (event.key === "ArrowUp") {
@@ -160,6 +166,7 @@ export function useEntitySuggestions({
       handleModalSelect,
       handleModalClose,
       openModal,
+      hoverHandler,
     },
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/shared/MenuComponents.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/shared/MenuComponents.tsx
@@ -13,7 +13,7 @@ import type { SearchModel } from "metabase-types/api";
 
 import S from "./MenuItems.module.css";
 
-interface ExtraItemProps {
+interface ExtraItemProps extends DOMAttributes<HTMLButtonElement> {
   isSelected?: boolean;
   onClick?: () => void;
 }
@@ -64,12 +64,14 @@ export const MenuItemComponent = ({
 export const SearchResultsFooter = ({
   isSelected,
   onClick,
+  ...rest
 }: ExtraItemProps) => (
   <UnstyledButton
     className={S.menuItem}
     onClick={onClick}
     role="option"
     aria-selected={isSelected}
+    {...rest}
   >
     <Group gap="sm" wrap="nowrap" align="center">
       <Icon name="search" size={16} color="inherit" />

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/shared/MenuComponents.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/shared/MenuComponents.tsx
@@ -1,3 +1,4 @@
+import type { DOMAttributes } from "react";
 import { t } from "ttag";
 
 import {
@@ -31,16 +32,18 @@ export const MenuItemComponent = ({
   item,
   isSelected,
   onClick,
+  ...rest
 }: {
   item: MenuItem;
   isSelected?: boolean;
   onClick?: () => void;
-}) => (
+} & DOMAttributes<HTMLButtonElement>) => (
   <UnstyledButton
     className={S.menuItem}
     onClick={onClick || item.action}
     role="option"
     aria-selected={isSelected}
+    {...rest}
   >
     <Group gap="sm" wrap="nowrap" align="center">
       <Icon name={item.icon} size={16} color={item.iconColor || "inherit"} />

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/shared/MenuItems.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/shared/MenuItems.module.css
@@ -12,7 +12,6 @@
   border-radius: 6px;
 }
 
-.menuItem:hover,
 .menuItem[aria-selected="true"] {
   color: var(--mb-color-brand);
   background-color: var(--mb-color-background-hover);


### PR DESCRIPTION
### Description
Removes the hover class for background color on command suggestions and searches, and instead updates the selectedIndex on MouseEnter for items in the list.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open a document, and open the command menu
2. Use the keyboard to navigate the list
3. Switch to mouse navigation, the selected index should update rather than show 2 highlighted items
4. do the same when searching for an entity, as that's a different component
5. Do the same when using the mention shortcut `@`, as that's also a different component

### Demo

https://github.com/user-attachments/assets/2413f047-db46-4d8f-8b18-de1e50f2f3bd

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
