### PR TITLE
docs: translations limitations

### DIFF
--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -216,7 +216,7 @@ If you have multiple parameters, separate them with an ampersand (`&`):
 category=Gadget&state=Vermont#theme=night&locale=ko
 ```
 
-The `locale` param only changes the language for Metabase UI elements. The _content_'s language is defined by whomever created the item. So for example Metabase wouldn't translate the name of a question, but Metabase _would_ translate the UI text "Export to PDF".
+The `locale` param will change the language for Metabase UI elements, like the label of "Export to PDF" button. To change the _content_'s language (like names of questions and dashboards), you'll need to [upload a translation dictionary](./translations.md).
 
 ## Transparent backgrounds for embeds
 

--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -216,7 +216,7 @@ If you have multiple parameters, separate them with an ampersand (`&`):
 category=Gadget&state=Vermont#theme=night&locale=ko
 ```
 
-The `locale` param will change the language for Metabase UI elements, like the label of "Export to PDF" button. To change the _content_'s language (like names of questions and dashboards), you'll need to [upload a translation dictionary](./translations.md).
+The `locale` parameter changes the language for Metabase UI elements, like the label of "Export to PDF" button. To change the _content_'s language in a static embed (like names of questions and dashboards), you'll need to [upload a translation dictionary](./translations.md).
 
 ## Transparent backgrounds for embeds
 

--- a/docs/embedding/translations.md
+++ b/docs/embedding/translations.md
@@ -11,9 +11,11 @@ For now, translations are only available for [static embeds](./static-embedding.
 
 You can upload a translation dictionary to translate strings both in Metabase content (like dashboard titles) and in the data itself (like column names and values).
 
+## Add a translation dictionary
+
 The dictionary must be a CSV with these columns:
 
-- **Language** with the locale code 
+- **Language** with the locale code
 - **String** with the string to be translated
 - **Translation**
 
@@ -22,6 +24,16 @@ The dictionary must be a CSV with these columns:
 Uploading a new dictionary will replace the existing dictionary.
 
 To remove a translation dictionary, upload a blank dictionary.
+
+## Translate content in static embeds
+
+To translate content in a static embed using the uploaded dictionary, add the [locale parameter](./static-embedding-parameters.md#setting-the-language-for-a-static-embed) to the embed URL:
+
+```
+https://metabase.example.com/public/dashboard/7b6e347b-6928-4aff-a56f-6cfa5b718c6b?category=&city=&state=#locale=ko
+```
+
+Note that Metabase UI elements (like button labels) will be translated automatically - you don't need to add them to the dictionary.
 
 ## Example translation dictionary
 
@@ -34,8 +46,23 @@ Metabase uses these dictionaries to translate user-generated content, like dashb
 | pt-BR    | Another tab | Outra aba    |
 | pt-BR    | Title       | Título       |
 | pt-BR    | Vendor      | Vendedor     |
+| IT       | Examples    | Esempi       |
 
-[See a list of supported locales](../configuring-metabase/localization.md#supported-languages)
+Note that you can use either underscores or hyphens in locales like `pt-BR` in your translation dictionary. If you download the dictionary after uploading it, Metabase will transform `pt-BR` to `pt_BR`. However, the `locale` parameter in static embedding only accepts locales with hyphens `pt-BR`, so we recommend using that format for consistency.
+
+[See a list of supported locales](../configuring-metabase/localization.md#supported-languages).
+
+## Use full phrases in translation dictionaries
+
+Currently, Metabase doesn't tokenize strings for translations, so you should include exact phrases in your translation dictionary.
+
+For example, if you have a dashboard called "Monthly Sales", it's not sufficient to have translations of "Monthly" and "Sales" - you also need to include "Monthly Sales" as a full string.
+
+This also applies to strings using punctuation and special characters. For example, if you have a question title "How many Widgets did we sell this week?", you need to include that exact string (with "?") into the translation dictionary.
+
+## Translation limitations
+
+Currently, strings using markdown formatting will not get translated. You can include markdown formatting into the translation dictionary - for example `**Vendor**` to handle translate bolded string `Vendor`.
 
 ## Further reading
 

--- a/docs/embedding/translations.md
+++ b/docs/embedding/translations.md
@@ -60,9 +60,15 @@ For example, if you have a dashboard called "Monthly Sales", it's not sufficient
 
 Exact translations also apply to strings that use punctuation and special characters. For example, if you have a question title "How many Widgets did we sell this week?", you must include that exact string (with "?") into the translation dictionary. Metabase would treat "How many Widgets did we sell this week" as a different string. Essentially, the strings are keys in a table Metabase looks up, so they must match exactly.
 
-## Translation limitations
+## Include markdown formatting in translation dictionaries
 
-Currently, strings using markdown formatting will not get translated. You can include markdown formatting into the translation dictionary - for example `**Vendor**` to handle translate bolded string `Vendor`.
+If the strings you want to translate include markdown formatting, you'll need to include the formatting in the dictionary. For example:
+
+| Language | String         | Translation    |
+| -------- | -------------- | -------------- |
+| pt-BR    | `**Examples**` | `**Exemplos**` |
+| pt-BR    | `_Examples_`   | `_Exemplos_`   |
+| pt-BR    | `## Examples`  | `## Exemplos`  |
 
 ## Further reading
 

--- a/docs/embedding/translations.md
+++ b/docs/embedding/translations.md
@@ -27,13 +27,13 @@ To remove a translation dictionary, upload a blank dictionary.
 
 ## Translate content in static embeds
 
-To translate content in a static embed using the uploaded dictionary, add the [locale parameter](./static-embedding-parameters.md#setting-the-language-for-a-static-embed) to the embed URL:
+To translate content in a static embed using the uploaded dictionary, add the [`locale` parameter](./static-embedding-parameters.md#setting-the-language-for-a-static-embed) to the embed URL:
 
 ```
 https://metabase.example.com/public/dashboard/7b6e347b-6928-4aff-a56f-6cfa5b718c6b?category=&city=&state=#locale=ko
 ```
 
-Note that Metabase UI elements (like button labels) will be translated automatically - you don't need to add them to the dictionary.
+Metabase UI elements (like button labels) will be translated automatically - you don't need to add translations for them to your dictionary.
 
 ## Example translation dictionary
 
@@ -48,7 +48,7 @@ Metabase uses these dictionaries to translate user-generated content, like dashb
 | pt-BR    | Vendor      | Vendedor     |
 | IT       | Examples    | Esempi       |
 
-Note that you can use either underscores or hyphens in locales like `pt-BR` in your translation dictionary. If you download the dictionary after uploading it, Metabase will transform `pt-BR` to `pt_BR`. However, the `locale` parameter in static embedding only accepts locales with hyphens `pt-BR`, so we recommend using that format for consistency.
+Prefer hyphens in your `pt-BR` in your translation dictionary. Underscores are also acceptable (if you download the dictionary _after_ uploading it, Metabase will transform `pt-BR` to `pt_BR`), but since the `locale` parameter in static embedding only accepts locales with hyphens (like `pt-BR`), we recommend using hyphens for consistency.
 
 [See a list of supported locales](../configuring-metabase/localization.md#supported-languages).
 
@@ -58,7 +58,7 @@ Currently, Metabase doesn't tokenize strings for translations, so you should inc
 
 For example, if you have a dashboard called "Monthly Sales", it's not sufficient to have translations of "Monthly" and "Sales" - you also need to include "Monthly Sales" as a full string.
 
-This also applies to strings using punctuation and special characters. For example, if you have a question title "How many Widgets did we sell this week?", you need to include that exact string (with "?") into the translation dictionary.
+Exact translations also apply to strings that use punctuation and special characters. For example, if you have a question title "How many Widgets did we sell this week?", you must include that exact string (with "?") into the translation dictionary. Metabase would treat "How many Widgets did we sell this week" as a different string. Essentially, the strings are keys in a table Metabase looks up, so they must match exactly.
 
 ## Translation limitations
 


### PR DESCRIPTION
I noticed we didn't tell people how to actually translate content (add a locale)

Also I added a new line to example dictionary to emphasize that you need only one dictionary for all the langs