### PR TITLE
Add gate table tombstone cleanup to semantic search index cleanup task

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index_metadata.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index_metadata.clj
@@ -361,7 +361,4 @@
   (-> (get-active-index-state pgvector index-metadata)
       :metadata-row
       :indexer_last_poll
-      class)
-  (find-best-index! pgvector index-metadata embedding-model)
-  (record-new-index-table! pgvector index-metadata (:index (find-best-index! pgvector index-metadata embedding-model)))
-  (activate-index! pgvector index-metadata (:id (:metadata-row (find-best-index! pgvector index-metadata embedding-model)))))
+      class))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index_metadata.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index_metadata.clj
@@ -152,6 +152,15 @@
        [(keyword (str (:gate-table-name index-metadata) "_gated_at")) :if-not-exists]
        [(keyword (:gate-table-name index-metadata)) :gated_at :id])
       :quoted true))
+    (log/info "Creating gate table tombstone cleanup index if not exists")
+    ;; Partial index on nil documents in the gate table to optimize identification of old tombstones
+    (jdbc/execute!
+     pgvector
+     (sql/format
+      {:create-index [(keyword (str (:gate-table-name index-metadata) "_tombstone_cleanup")) :if-not-exists]
+       :on [(keyword (:gate-table-name index-metadata)) :gated_at]
+       :where [:and [:= :document nil] [:= :document_hash nil]]}
+      :quoted true))
     nil))
 
 (defn drop-tables-if-exists!

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index_metadata.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index_metadata.clj
@@ -157,8 +157,9 @@
     (jdbc/execute!
      pgvector
      (sql/format
-      {:create-index [(keyword (str (:gate-table-name index-metadata) "_tombstone_cleanup")) :if-not-exists]
-       :on [(keyword (:gate-table-name index-metadata)) :gated_at]
+      {:create-index
+       [[(keyword (str (:gate-table-name index-metadata) "_tombstone_cleanup")) :if-not-exists]
+        [(keyword (:gate-table-name index-metadata)) :gated_at]]
        :where [:and [:= :document nil] [:= :document_hash nil]]}
       :quoted true))
     nil))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -141,3 +141,11 @@
   :export? false
   :visibility :internal
   :doc "Number of hours to retain stale semantic search indexes before cleanup.")
+
+(defsetting tombstone-retention-hours
+  (deferred-tru "Number of hours to retain tombstone records in the gate table before cleanup.")
+  :type :integer
+  :default 24
+  :encryption :no
+  :export? false
+  :visibility :internal)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
@@ -14,8 +14,6 @@
    [next.jdbc :as jdbc]
    [next.jdbc.result-set :as jdbc.rs])
   (:import
-   (java.sql Timestamp)
-   (java.time Instant)
    (org.quartz DisallowConcurrentExecution)))
 
 (set! *warn-on-reflection* true)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
@@ -61,9 +61,9 @@
   "Check if the indexer has run within the specified number of hours."
   [metadata-row hours-ago]
   (when-let [last-poll-inst (t/instant (:indexer_last_poll metadata-row))]
-    (.isAfter
+    (t/after?
      last-poll-inst
-     (t/minus (Instant/now) (t/hours hours-ago)))))
+     (t/minus (t/instant) (t/hours hours-ago)))))
 
 (defn- get-active-index-metadata-row
   "Get the metadata row for the currently active index."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -224,4 +224,3 @@
                                                      {:builder-fn jdbc.rs/as-unqualified-lower-maps})
                     remaining-ids (map :id remaining-records)]
                 (is (= #{"recent-tombstone" "non-tombstone"} (set remaining-ids)))))))))))
-

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -176,7 +176,7 @@
               (jdbc/execute! pgvector
                              (-> {:update (keyword metadata-table-name)
                                   :set {:indexer_last_poll recent-time}
-                                  :where [:= :id (-> active-index-metadata :metadasta-row :id)]}
+                                  :where [:= :id (-> active-index-metadata :metadata-row :id)]}
                                  (sql/format :quoted true))))
             (let [gate-table-name (:gate-table-name index-metadata)]
               (jdbc/execute! pgvector

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -32,7 +32,7 @@
 (defn- insert-metadata-with-timestamps!
   "Insert an index metadata row using record-new-index-table! and then update timestamps for testing."
   [pgvector index-metadata {:keys [table-name provider model-name vector-dimensions
-                                   index-created-at indexer-last-seen]
+                                   index-created-at indexer-last-poll]
                             :or {provider "ollama"
                                  model-name "test-model"
                                  vector-dimensions 1024}}]
@@ -42,12 +42,12 @@
                                   :vector-dimensions vector-dimensions})
         index-id (semantic.index-metadata/record-new-index-table! pgvector index-metadata index)]
     ;; Update the timestamps that we need for testing
-    (when (or index-created-at indexer-last-seen)
+    (when (or index-created-at indexer-last-poll)
       (jdbc/execute! pgvector
                      (-> (sql.helpers/update (keyword (:metadata-table-name index-metadata)))
                          (sql.helpers/set (cond-> {}
                                             index-created-at (assoc :index_created_at index-created-at)
-                                            indexer-last-seen (assoc :indexer_last_seen indexer-last-seen)))
+                                            indexer-last-poll (assoc :indexer_last_poll indexer-last-poll)))
                          (sql.helpers/where [:= :id index-id])
                          (sql/format :quoted true))))
     index-id))
@@ -92,8 +92,7 @@
                                                                          :index-created-at recent-time})
               (let [active-index-id (insert-metadata-with-timestamps! pgvector index-metadata
                                                                       {:table-name active-table
-                                                                       :index-created-at old-time
-                                                                       :indexer-last-seen old-time})]
+                                                                       :index-created-at old-time})]
                 (set-active-index! pgvector (:control-table-name index-metadata) active-index-id))
               (is (semantic.tu/table-exists-in-db? stale-table))
               (is (semantic.tu/table-exists-in-db? orphaned-table))
@@ -123,8 +122,7 @@
                                                :provider "ollama"
                                                :model-name "test-model"
                                                :vector-dimensions 1024
-                                               :index-created-at old-time
-                                               :indexer-last-seen nil})
+                                               :index-created-at old-time})
             (is (not (semantic.tu/table-exists-in-db? nonexistent-table)))
             (with-redefs [semantic.settings/stale-index-retention-hours (constantly retention-hours)
                           semantic.env/get-pgvector-datasource! (constantly pgvector)
@@ -141,45 +139,28 @@
           recent-time (t/minus (t/offset-date-time) (t/hours (dec retention-hours)))
           cleanup-old-tombstones! #'sut/cleanup-old-gate-tombstones!]
       (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)]
-        (testing "cleans up old tombstone records and preserves recent ones and non-tombstones"
-          (let [gate-table-name (:gate-table-name index-metadata)]
+        (semantic.index-metadata/ensure-control-row-exists! pgvector index-metadata)
+        (let [active-index-id (insert-metadata-with-timestamps! pgvector index-metadata
+                                                                {:table-name "tombstone_cleanup_3test_index"
+                                                                 :index-created-at old-time
+                                                                 :indexer-last-poll old-time})]
+          (set-active-index! pgvector (:control-table-name index-metadata) active-index-id))
+        (let [{:keys [gate-table-name metadata-table-name]} index-metadata]
+          (testing "when indexer has not run recently, skips cleanup of old tombstone records"
             (jdbc/execute! pgvector
                            (-> (sql.helpers/insert-into (keyword gate-table-name))
                                (sql.helpers/values
                                 [{:id "old-tombstone-1"
                                   :model "card"
-                                  :model_id "123"
+                                  :model_id "321"
                                   :updated_at old-time
                                   :gated_at old-time
                                   :document nil
-                                  :document_hash nil}
-                                 {:id "old-tombstone-2"
-                                  :model "dashboard"
-                                  :model_id "456"
-                                  :updated_at old-time
-                                  :gated_at old-time
-                                  :document nil
-                                  :document_hash nil}
-                                 {:id "recent-tombstone"
-                                  :model "card"
-                                  :model_id "789"
-                                  :updated_at recent-time
-                                  :gated_at recent-time
-                                  :document nil
-                                  :document_hash nil}
-                                 {:id "non-tombstone"
-                                  :model "card"
-                                  :model_id "101"
-                                  :updated_at old-time
-                                  :gated_at old-time
-                                  :document (doto (PGobject.)
-                                              (.setType "jsonb")
-                                              (.setValue (json/encode {:content "some content"})))
-                                  :document_hash "hash123"}])
+                                  :document_hash nil}])
                                (sql/format :quoted true)))
             (cleanup-old-tombstones! pgvector index-metadata)
 
-            ;; Verify only old tombstones were deleted after cleanup task runs
+            ;; Verify no records were deleted since indexer hasn't run recently
             (let [remaining-records (jdbc/execute! pgvector
                                                    (-> (sql.helpers/select [:*])
                                                        (sql.helpers/from (keyword gate-table-name))
@@ -187,4 +168,60 @@
                                                        (sql/format :quoted true))
                                                    {:builder-fn jdbc.rs/as-unqualified-lower-maps})
                   remaining-ids (map :id remaining-records)]
-              (is (= #{"recent-tombstone" "non-tombstone"} (set remaining-ids))))))))))
+              (is (contains? (set remaining-ids) "old-tombstone-1"))))
+
+          (testing "when indexer has run recently, cleans up old tombstone records and preserves recent ones and non-tombstones"
+            ;; Update metadata for active index to have recent indexer_last_poll time
+            (let [active-index-metadata (semantic.index-metadata/get-active-index-state pgvector index-metadata)]
+              (jdbc/execute! pgvector
+                             (-> {:update (keyword metadata-table-name)
+                                  :set {:indexer_last_poll recent-time}
+                                  :where [:= :id (-> active-index-metadata :metadasta-row :id)]}
+                                 (sql/format :quoted true))))
+            (let [gate-table-name (:gate-table-name index-metadata)]
+              (jdbc/execute! pgvector
+                             (-> (sql.helpers/insert-into (keyword gate-table-name))
+                                 (sql.helpers/values
+                                  [{:id "old-tombstone-2"
+                                    :model "card"
+                                    :model_id "123"
+                                    :updated_at old-time
+                                    :gated_at old-time
+                                    :document nil
+                                    :document_hash nil}
+                                   {:id "old-tombstone-3"
+                                    :model "dashboard"
+                                    :model_id "456"
+                                    :updated_at old-time
+                                    :gated_at old-time
+                                    :document nil
+                                    :document_hash nil}
+                                   {:id "recent-tombstone"
+                                    :model "card"
+                                    :model_id "789"
+                                    :updated_at recent-time
+                                    :gated_at recent-time
+                                    :document nil
+                                    :document_hash nil}
+                                   {:id "non-tombstone"
+                                    :model "card"
+                                    :model_id "101"
+                                    :updated_at old-time
+                                    :gated_at old-time
+                                    :document (doto (PGobject.)
+                                                (.setType "jsonb")
+                                                (.setValue (json/encode {:content "some content"})))
+                                    :document_hash "hash123"}])
+                                 (sql/format :quoted true)))
+              (cleanup-old-tombstones! pgvector index-metadata)
+
+              ;; Verify only old tombstones were deleted after cleanup task runs
+              (let [remaining-records (jdbc/execute! pgvector
+                                                     (-> (sql.helpers/select [:*])
+                                                         (sql.helpers/from (keyword gate-table-name))
+                                                         (sql.helpers/order-by :id)
+                                                         (sql/format :quoted true))
+                                                     {:builder-fn jdbc.rs/as-unqualified-lower-maps})
+                    remaining-ids (map :id remaining-records)]
+                (is (= #{"recent-tombstone" "non-tombstone"} (set remaining-ids)))))))))))
+

--- a/test/metabase/warehouse_schema/api/table_test.clj
+++ b/test/metabase/warehouse_schema/api/table_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [metabase.api.response :as api.response]
    [metabase.api.test-util :as api.test-util]
+   [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.events.core :as events]
    [metabase.permissions.models.data-permissions :as data-perms]


### PR DESCRIPTION
Adds a cleanup job for old tombstones in the gate table that runs as part of the existing index cleanup Quartz job. I've set the cutoff at 24 hours since the tombstones were gated, configurable via env var, but I don't have particular thoughts about the correct retention period. This seems safe enough but I can up the retention if anyone has concerns.

I've also added a partial index on `gated_at` for just the tombstone rows to avoid scanning through the entire gate table. Not sure if this is needed in practice but it seems like it wouldn't hurt. I don't have a migration for this since it's not a breaking change & I'm not fully sure how the migration system works yet so I figured I can create this manually on the stats gate table if needed. 

Resolves [BOT-318: GC very old gate tombstones](https://linear.app/metabase/issue/BOT-318/gc-very-old-gate-tombstones)