### PR TITLE
Update document cache with creation result

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -20,11 +20,9 @@ H.describeWithSnowplowEE("documents", () => {
   });
 
   it("should allow you to create a new document from the new button and save", () => {
-    cy.intercept("GET", "/api/ee/document/1", (req) => {
-      req.continue((res) => {
-        res.delay = 2000;
-      });
-    });
+    const getDocumentStub = cy.stub();
+
+    cy.intercept("GET", "/api/ee/document/1", getDocumentStub);
 
     cy.visit("/");
 
@@ -50,11 +48,10 @@ H.describeWithSnowplowEE("documents", () => {
 
     // We should not show a loading state in between creating a document and viewing the created document.
     cy.location("pathname").should("eq", "/document/1");
-    cy.findByTestId("editor-loader", { timeout: 300 }).should("not.exist");
-
     cy.title().should("eq", "Test Document · Metabase");
 
     H.expectUnstructuredSnowplowEvent({ event: "document_created" });
+    cy.wrap(getDocumentStub).should("not.have.been.called");
 
     H.appBar()
       .findByRole("link", { name: /First collection/ })

--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -20,6 +20,12 @@ H.describeWithSnowplowEE("documents", () => {
   });
 
   it("should allow you to create a new document from the new button and save", () => {
+    cy.intercept("GET", "/api/ee/document/1", (req) => {
+      req.continue((res) => {
+        res.delay = 2000;
+      });
+    });
+
     cy.visit("/");
 
     H.newButton("Document").click();
@@ -41,6 +47,11 @@ H.describeWithSnowplowEE("documents", () => {
     );
     H.entityPickerModalItem(1, "First collection").click();
     H.entityPickerModal().findByRole("button", { name: "Select" }).click();
+
+    // We should not show a loading state in between creating a document and viewing the created document.
+    cy.location("pathname").should("eq", "/document/1");
+    cy.findByTestId("editor-loader", { timeout: 300 }).should("not.exist");
+
     cy.title().should("eq", "Test Document · Metabase");
 
     H.expectUnstructuredSnowplowEvent({ event: "document_created" });

--- a/enterprise/frontend/src/metabase-enterprise/api/document.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/document.ts
@@ -26,6 +26,17 @@ export const documentApi = EnterpriseApi.injectEndpoints({
         body,
       }),
       invalidatesTags: (_, error) => (error ? [] : [listTag("document")]),
+      async onQueryStarted(_props, { dispatch, queryFulfilled }) {
+        await queryFulfilled.then(async ({ data }) => {
+          await dispatch(
+            documentApi.util.upsertQueryData(
+              "getDocument",
+              { id: data.id },
+              data,
+            ),
+          );
+        });
+      },
     }),
     updateDocument: builder.mutation<Document, UpdateDocumentRequest>({
       query: (document) => ({

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
@@ -193,7 +193,7 @@ export const Editor: React.FC<EditorProps> = ({
   if (isLoading) {
     return (
       <Box className={cx(S.editor, DND_IGNORE_CLASS_NAME)}>
-        <Loader />
+        <Loader data-testid="editor-loader" />
       </Box>
     );
   }


### PR DESCRIPTION
### Description
Upserts the response from document creation so that when we navigate from `document/new` to `document/:id` we don't need to make an API request for the document content.

### How to verify
This one is a bit tricky to verify, but I think the best indication is that when you create a new document, you'll notice that we update the URL, but in the network tab we don't make a request to get the document at the new `id` because it's already in the cache.

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
