### PR TITLE
Fix the UI for partial between parameter values

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -136,4 +136,45 @@ describe("scenarios > dashboard > filters > number", () => {
     H.filterWidget().findByText("2.07");
     H.ensureDashboardCardHasText("37.65");
   });
+
+  it("should allow between filters without min or max (metabase#54364)", () => {
+    const getInput = (index) =>
+      cy
+        .findAllByPlaceholderText("Enter a number")
+        .should("have.length", 2)
+        .eq(index);
+
+    const getMinInput = () => getInput(0);
+    const getMaxInput = () => getInput(1);
+
+    H.setFilter("Number", "Between");
+    H.selectDashboardFilter(H.getDashboardCard(), "Total");
+    H.saveDashboard();
+
+    cy.log("min only");
+    H.filterWidget().click();
+    H.popover().within(() => {
+      getMinInput().type("150");
+      cy.button("Add filter").click();
+    });
+    H.getDashboardCard().within(() => H.assertTableRowsCount(256));
+
+    cy.log("max only");
+    H.filterWidget().click();
+    H.popover().within(() => {
+      getMinInput().clear();
+      getMaxInput().type("20");
+      cy.button("Update filter").click();
+    });
+    H.getDashboardCard().within(() => H.assertTableRowsCount(52));
+
+    cy.log("min and max only");
+    H.filterWidget().click();
+    H.popover().within(() => {
+      getMinInput().clear().type("150");
+      getMaxInput().clear().type("155");
+      cy.button("Update filter").click();
+    });
+    H.getDashboardCard().within(() => H.assertTableRowsCount(166));
+  });
 });

--- a/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/parameter-parsing.ts
@@ -15,6 +15,7 @@ import { getIsMultiSelect } from "metabase-lib/v1/parameters/utils/parameter-val
 import type {
   Parameter,
   ParameterId,
+  ParameterType,
   ParameterValue,
   ParameterValueOrArray,
 } from "metabase-types/api";
@@ -55,7 +56,7 @@ export function parseParameterValue(value: any, parameter: Parameter) {
   // TODO this casting should be removed as we tidy up Parameter types
   const { fields } = parameter as FieldFilterUiParameter;
   if (Array.isArray(fields) && fields.length > 0) {
-    return parseParameterValueForFields(coercedValue, fields);
+    return parseParameterValueForFields(type, coercedValue, fields);
   }
 
   // Note:
@@ -64,7 +65,7 @@ export function parseParameterValue(value: any, parameter: Parameter) {
   // We cannot properly deserialize their values by checking the parameter type only
   switch (type) {
     case "number":
-      return parseParameterValueForNumber(coercedValue);
+      return parseParameterValueForNumber(type, coercedValue);
     case "location":
       return normalizeStringParameterValue(coercedValue);
     case "date":
@@ -78,7 +79,10 @@ export function parseParameterValue(value: any, parameter: Parameter) {
   return coercedValue;
 }
 
-function parseParameterValueForNumber(value: ParameterValueOrArray) {
+function parseParameterValueForNumber(
+  type: ParameterType,
+  value: ParameterValueOrArray,
+) {
   // HACK to support multiple values for SQL parameters
   // https://github.com/metabase/metabase/issues/25374#issuecomment-1272520560
   if (typeof value === "string") {
@@ -98,16 +102,17 @@ function parseParameterValueForNumber(value: ParameterValueOrArray) {
     }
   }
 
-  return normalizeNumberParameterValue(value);
+  return normalizeNumberParameterValue(type, value);
 }
 
 function parseParameterValueForFields(
+  type: ParameterType,
   value: ParameterValueOrArray,
   fields: Field[],
 ): ParameterValueOrArray {
   // unix dates fields are numeric but query params shouldn't be parsed as numbers
   if (fields.every((f) => f.isNumeric() && !f.isDate())) {
-    return normalizeNumberParameterValue(value);
+    return normalizeNumberParameterValue(type, value);
   }
 
   if (fields.every((f) => f.isBoolean())) {

--- a/frontend/src/metabase-types/api/parameters.ts
+++ b/frontend/src/metabase-types/api/parameters.ts
@@ -104,7 +104,7 @@ export type ParameterValueOrArray =
   | string
   | number
   | boolean
-  | Array<string | number | boolean>;
+  | Array<string | number | boolean | null>;
 
 export type HumanReadableParameterValue = string;
 export type NotRemappedParameterValue = [RowValue];

--- a/frontend/src/metabase/actions/components/ActionViz/utils.ts
+++ b/frontend/src/metabase/actions/components/ActionViz/utils.ts
@@ -17,7 +17,7 @@ import type {
 type ActionParameterTuple = [ParameterId, ActionParameterValue];
 
 function formatParameterValue(value: ParameterValueOrArray) {
-  return Array.isArray(value) ? value[0] : value;
+  return Array.isArray(value) ? value.filter(isNotNull)[0] : value;
 }
 
 function prepareParameter(

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -47,13 +47,10 @@ export function NumberInputWidget({
 }: NumberInputWidgetProps) {
   const arrayValue = deserializeNumberParameterValue(value);
   const [unsavedArrayValue, setUnsavedArrayValue] =
-    useState<(NumberValue | undefined)[]>(arrayValue);
+    useState<(NumberValue | null)[]>(arrayValue);
 
-  const allValuesUnset = unsavedArrayValue.every(_.isUndefined);
-  const allValuesSet = unsavedArrayValue.every(isNotNull);
-  const isValid =
-    (arity === "n" || unsavedArrayValue.length <= arity) &&
-    (allValuesUnset || allValuesSet);
+  const isValid = getIsValid(unsavedArrayValue, arity);
+  const allValuesUnset = !unsavedArrayValue.some(isNotNull);
   const isEmpty = unsavedArrayValue.length === 0 || allValuesUnset;
   const isRequired = parameter?.required;
 
@@ -131,7 +128,7 @@ export function NumberInputWidget({
               onChange={(_newValue, newValueText) => {
                 setUnsavedArrayValue((unsavedArrayValue) => {
                   const newUnsavedValue = [...unsavedArrayValue];
-                  newUnsavedValue[i] = parseNumber(newValueText) ?? undefined;
+                  newUnsavedValue[i] = parseNumber(newValueText);
                   return newUnsavedValue;
                 });
               }}
@@ -179,4 +176,16 @@ function getValue(option: string | number | ParameterValue) {
     return option[0];
   }
   return String(option);
+}
+
+function getIsValid(value: (NumberValue | null)[], arity: number | "n") {
+  if (arity === 1) {
+    return value.length === 1 && value.every(isNotNull);
+  }
+  if (arity === 2) {
+    return value.length > 0 && value.some(isNotNull);
+  }
+  if (arity === "n") {
+    return value.length > 0 && value.every(isNotNull);
+  }
 }

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -50,7 +50,6 @@ export function NumberInputWidget({
   const [unsavedArrayValue, setUnsavedArrayValue] =
     useState<NumberFilterValue[]>(arrayValue);
 
-  const isValid = getIsValid(unsavedArrayValue, arity);
   const allValuesUnset = !unsavedArrayValue.some(isNotNull);
   const isEmpty = unsavedArrayValue.length === 0 || allValuesUnset;
   const isRequired = parameter?.required;
@@ -79,10 +78,6 @@ export function NumberInputWidget({
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
-    if (!isValid) {
-      return;
-    }
-
     if (isRequired && isEmpty) {
       if (hasValue(parameter.default)) {
         setValue(parameter.default);
@@ -147,7 +142,7 @@ export function NumberInputWidget({
           unsavedValue={unsavedArrayValue}
           defaultValue={parameter?.default}
           isValueRequired={parameter?.required ?? false}
-          isValid={isValid}
+          isValid
         />
       </Footer>
     </Box>
@@ -177,16 +172,4 @@ function getValue(option: string | number | ParameterValue) {
     return option[0];
   }
   return String(option);
-}
-
-function getIsValid(value: NumberFilterValue[], arity: number | "n") {
-  if (arity === 1) {
-    return value.length === 1 && value.every(isNotNull);
-  }
-  if (arity === 2) {
-    return value.length > 0 && value.some(isNotNull);
-  }
-  if (arity === "n") {
-    return value.length > 0 && value.every(isNotNull);
-  }
 }

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -4,9 +4,10 @@ import _ from "underscore";
 
 import NumericInput from "metabase/common/components/NumericInput";
 import CS from "metabase/css/core/index.css";
-import { type NumberValue, parseNumber } from "metabase/lib/number";
+import { parseNumber } from "metabase/lib/number";
 import { isNotNull } from "metabase/lib/types";
 import { UpdateFilterButton } from "metabase/parameters/components/UpdateFilterButton";
+import type { NumberFilterValue } from "metabase/querying/parameters/types";
 import {
   deserializeNumberParameterValue,
   serializeNumberParameterValue,
@@ -47,7 +48,7 @@ export function NumberInputWidget({
 }: NumberInputWidgetProps) {
   const arrayValue = deserializeNumberParameterValue(value);
   const [unsavedArrayValue, setUnsavedArrayValue] =
-    useState<(NumberValue | null)[]>(arrayValue);
+    useState<NumberFilterValue[]>(arrayValue);
 
   const isValid = getIsValid(unsavedArrayValue, arity);
   const allValuesUnset = !unsavedArrayValue.some(isNotNull);
@@ -178,7 +179,7 @@ function getValue(option: string | number | ParameterValue) {
   return String(option);
 }
 
-function getIsValid(value: (NumberValue | null)[], arity: number | "n") {
+function getIsValid(value: NumberFilterValue[], arity: number | "n") {
   if (arity === 1) {
     return value.length === 1 && value.every(isNotNull);
   }

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -32,7 +32,7 @@ export type NumberInputWidgetProps = {
   autoFocus?: boolean;
   placeholder?: string;
   label?: string;
-  parameter?: Parameter;
+  parameter: Parameter;
 };
 
 export function NumberInputWidget({
@@ -46,7 +46,7 @@ export function NumberInputWidget({
   label,
   parameter,
 }: NumberInputWidgetProps) {
-  const arrayValue = deserializeNumberParameterValue(value);
+  const arrayValue = deserializeNumberParameterValue(parameter.type, value);
   const [unsavedArrayValue, setUnsavedArrayValue] =
     useState<NumberFilterValue[]>(arrayValue);
 

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -50,7 +50,7 @@ export function NumberInputWidget({
   const [unsavedArrayValue, setUnsavedArrayValue] =
     useState<NumberFilterValue[]>(arrayValue);
 
-  const allValuesUnset = !unsavedArrayValue.some(isNotNull);
+  const allValuesUnset = unsavedArrayValue.every((value) => value == null);
   const isEmpty = unsavedArrayValue.length === 0 || allValuesUnset;
   const isRequired = parameter?.required;
 

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.unit.spec.tsx
@@ -117,16 +117,29 @@ describe("NumberInputWidget", () => {
       expect(textbox2).toHaveValue("456");
     });
 
-    it("should be invalid when one of the inputs is empty", async () => {
-      setup({ value: [123, 456], arity: 2 });
+    it("should allow to submit a value without min", async () => {
+      const { setValue } = setup({ value: [123, 456], arity: 2 });
 
       const [textbox1] = screen.getAllByRole("textbox");
       await userEvent.clear(textbox1);
       const button = screen.getByRole("button", { name: "Update filter" });
-      expect(button).toBeDisabled();
+      await userEvent.click(button);
+
+      expect(setValue).toHaveBeenCalledWith([null, 456]);
     });
 
-    it("should be settable", async () => {
+    it("should allow to submit a value without max", async () => {
+      const { setValue } = setup({ value: [123, 456], arity: 2 });
+
+      const [_textbox1, textbox2] = screen.getAllByRole("textbox");
+      await userEvent.clear(textbox2);
+      const button = screen.getByRole("button", { name: "Update filter" });
+      await userEvent.click(button);
+
+      expect(setValue).toHaveBeenCalledWith([123, null]);
+    });
+
+    it("should allow to submit a value with both min and max", async () => {
       const { setValue } = setup({ value: undefined, arity: 2 });
 
       const [textbox1, textbox2] = screen.getAllByRole("textbox");
@@ -137,6 +150,24 @@ describe("NumberInputWidget", () => {
       await userEvent.click(button);
 
       expect(setValue).toHaveBeenCalledWith([1, 2]);
+    });
+
+    it("should allow to clear an existing filter", async () => {
+      const { setValue } = setup({ value: [1, 2], arity: 2 });
+
+      const [textbox1, textbox2] = screen.getAllByRole("textbox");
+      await userEvent.clear(textbox1);
+      await userEvent.clear(textbox2);
+      const button = screen.getByRole("button", { name: "Update filter" });
+      await userEvent.click(button);
+
+      expect(setValue).toHaveBeenCalledWith(undefined);
+    });
+
+    it("should allow to submit an empty value for an existing filter", async () => {
+      setup({ value: [], arity: 2 });
+      const button = screen.getByRole("button", { name: "Add filter" });
+      expect(button).toBeDisabled();
     });
 
     it("should correctly parse big integers", async () => {

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.unit.spec.tsx
@@ -9,7 +9,7 @@ import {
   type NumberInputWidgetProps,
 } from "./NumberInputWidget";
 
-type SetupOpts = Omit<NumberInputWidgetProps, "setValue"> & {
+type SetupOpts = Omit<NumberInputWidgetProps, "parameter" | "setValue"> & {
   parameter?: Parameter;
 };
 

--- a/frontend/src/metabase/querying/filters/types.ts
+++ b/frontend/src/metabase/querying/filters/types.ts
@@ -1,4 +1,3 @@
-import type { NumberValue } from "metabase/lib/number";
 import type * as Lib from "metabase-lib";
 
 import type {
@@ -115,5 +114,3 @@ export type DateFilterDisplayOpts = {
 };
 
 export type BooleanFilterValue = "true" | "false" | "is-null" | "not-null";
-
-export type NumberFilterValue = NumberValue | null;

--- a/frontend/src/metabase/querying/filters/types.ts
+++ b/frontend/src/metabase/querying/filters/types.ts
@@ -1,4 +1,4 @@
-import type { IconName } from "metabase/ui";
+import type { NumberValue } from "metabase/lib/number";
 import type * as Lib from "metabase-lib";
 
 import type {
@@ -20,14 +20,6 @@ export interface SegmentItem {
   displayName: string;
   stageIndex: number;
   filterPositions: number[];
-}
-
-export interface GroupItem {
-  key: string;
-  displayName: string;
-  icon: IconName;
-  columnItems: ColumnItem[];
-  segmentItems: SegmentItem[];
 }
 
 export type FilterOperatorOption<T extends Lib.FilterOperatorName> = {
@@ -123,3 +115,5 @@ export type DateFilterDisplayOpts = {
 };
 
 export type BooleanFilterValue = "true" | "false" | "is-null" | "not-null";
+
+export type NumberFilterValue = NumberValue | null;

--- a/frontend/src/metabase/querying/filters/types.ts
+++ b/frontend/src/metabase/querying/filters/types.ts
@@ -14,13 +14,6 @@ export interface ColumnItem {
   stageIndex: number;
 }
 
-export interface SegmentItem {
-  segment: Lib.SegmentMetadata;
-  displayName: string;
-  stageIndex: number;
-  filterPositions: number[];
-}
-
 export type FilterOperatorOption<T extends Lib.FilterOperatorName> = {
   operator: T;
 };

--- a/frontend/src/metabase/querying/parameters/types.ts
+++ b/frontend/src/metabase/querying/parameters/types.ts
@@ -1,0 +1,3 @@
+import type { NumberValue } from "metabase/lib/number";
+
+export type NumberFilterValue = NumberValue | null;

--- a/frontend/src/metabase/querying/parameters/utils/parsing.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.ts
@@ -32,28 +32,34 @@ export function normalizeStringParameterValue(
 }
 
 export function serializeNumberParameterValue(
-  value: NumberValue[],
+  value: (NumberValue | null)[],
 ): ParameterValueOrArray {
   return value.map((item) => {
-    return typeof item === "number" ? item : String(item);
+    return typeof item === "bigint" ? String(item) : item;
   });
 }
 
 export function deserializeNumberParameterValue(
   value: ParameterValueOrArray | null | undefined,
-): NumberValue[] {
-  return normalizeArray(value).reduce((values: NumberValue[], item) => {
-    if (typeof item === "number" && Number.isFinite(item)) {
-      values.push(item);
-    }
-    if (typeof item === "string") {
-      const number = parseNumber(item);
-      if (number != null) {
-        values.push(number);
+): (NumberValue | null)[] {
+  return normalizeArray(value).reduce(
+    (values: (NumberValue | null)[], item) => {
+      if (item === null) {
+        values.push(null);
       }
-    }
-    return values;
-  }, []);
+      if (typeof item === "number" && Number.isFinite(item)) {
+        values.push(item);
+      }
+      if (typeof item === "string") {
+        const number = parseNumber(item);
+        if (number != null) {
+          values.push(number);
+        }
+      }
+      return values;
+    },
+    [],
+  );
 }
 
 export function normalizeNumberParameterValue(

--- a/frontend/src/metabase/querying/parameters/utils/parsing.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.ts
@@ -46,10 +46,7 @@ export function deserializeNumberParameterValue(
   value: ParameterValueOrArray | null | undefined,
 ): NumberFilterValue[] {
   const normalizedValue = normalizeArray(value);
-  return normalizeArray(value).reduce((values: NumberFilterValue[], item) => {
-    if (item === null && normalizedValue.length > 1) {
-      values.push(null);
-    }
+  return normalizedValue.reduce((values: NumberFilterValue[], item) => {
     if (typeof item === "number" && Number.isFinite(item)) {
       values.push(item);
     }
@@ -58,6 +55,9 @@ export function deserializeNumberParameterValue(
       if (number != null) {
         values.push(number);
       }
+    }
+    if (item === null && normalizedValue.length > 1) {
+      values.push(null);
     }
     return values;
   }, []);

--- a/frontend/src/metabase/querying/parameters/utils/parsing.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.ts
@@ -1,13 +1,12 @@
 import dayjs from "dayjs";
 
 import { parseNumber } from "metabase/lib/number";
-import type {
-  DateFilterValue,
-  NumberFilterValue,
-} from "metabase/querying/filters/types";
+import type { DateFilterValue } from "metabase/querying/filters/types";
 import { isDatePickerTruncationUnit } from "metabase/querying/filters/utils/dates";
 import * as Lib from "metabase-lib";
 import type { ParameterValueOrArray, TemporalUnit } from "metabase-types/api";
+
+import type { NumberFilterValue } from "../types";
 
 function normalizeArray(value: ParameterValueOrArray | null | undefined) {
   if (value == null) {
@@ -56,7 +55,7 @@ export function deserializeNumberParameterValue(
         values.push(number);
       }
     }
-    if (item === null && normalizedValue.length > 1) {
+    if (item === null && normalizedValue.length === 2) {
       values.push(null);
     }
     return values;

--- a/frontend/src/metabase/querying/parameters/utils/parsing.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.ts
@@ -45,19 +45,25 @@ export function serializeNumberParameterValue(
 export function deserializeNumberParameterValue(
   value: ParameterValueOrArray | null | undefined,
 ): NumberFilterValue[] {
-  const parsedValue = normalizeArray(value).map((item) => {
-    if (typeof item === "number" && Number.isFinite(item)) {
-      return item;
-    }
-    if (typeof item === "string") {
-      const number = parseNumber(item);
-      if (number != null) {
-        return number;
+  const parsedValue = normalizeArray(value).reduce(
+    (values: NumberFilterValue[], item) => {
+      if (typeof item === "number" && Number.isFinite(item)) {
+        values.push(item);
+      } else if (typeof item === "string") {
+        const number = parseNumber(item);
+        if (number != null) {
+          values.push(number);
+        }
+      } else if (item === null) {
+        values.push(null);
       }
-    }
-    return null;
-  });
+      return values;
+    },
+    [],
+  );
 
+  // allow "between" values without min or max, e.g. `[1, null]` and `[null, 2]`
+  // only when an explicit `null` is passed
   return parsedValue.length === 2 && parsedValue.some(isNotNull)
     ? parsedValue
     : parsedValue.filter(isNotNull);

--- a/frontend/src/metabase/querying/parameters/utils/parsing.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.ts
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
 
 import { parseNumber } from "metabase/lib/number";
+import { isNotNull } from "metabase/lib/types";
 import type { DateFilterValue } from "metabase/querying/filters/types";
 import { isDatePickerTruncationUnit } from "metabase/querying/filters/utils/dates";
 import * as Lib from "metabase-lib";
@@ -44,22 +45,22 @@ export function serializeNumberParameterValue(
 export function deserializeNumberParameterValue(
   value: ParameterValueOrArray | null | undefined,
 ): NumberFilterValue[] {
-  const normalizedValue = normalizeArray(value);
-  return normalizedValue.reduce((values: NumberFilterValue[], item) => {
+  const parsedValue = normalizeArray(value).map((item) => {
     if (typeof item === "number" && Number.isFinite(item)) {
-      values.push(item);
+      return item;
     }
     if (typeof item === "string") {
       const number = parseNumber(item);
       if (number != null) {
-        values.push(number);
+        return number;
       }
     }
-    if (item === null && normalizedValue.length === 2) {
-      values.push(null);
-    }
-    return values;
-  }, []);
+    return null;
+  });
+
+  return parsedValue.length === 2 && parsedValue.some(isNotNull)
+    ? parsedValue
+    : parsedValue.filter(isNotNull);
 }
 
 export function normalizeNumberParameterValue(

--- a/frontend/src/metabase/querying/parameters/utils/parsing.unit.spec.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.unit.spec.ts
@@ -38,6 +38,9 @@ describe("number parameters", () => {
     { value: [10.1], expectedValue: [10.1] },
     { value: [-10.1], expectedValue: [-10.1] },
     { value: [10, 9007199254740993n], expectedValue: [10, "9007199254740993"] },
+    { value: [10, 20], expectedValue: [10, 20] },
+    { value: [10, null], expectedValue: [10, null] },
+    { value: [null, 20], expectedValue: [null, 20] },
   ])("should serialize $value", ({ value, expectedValue }) => {
     expect(serializeNumberParameterValue(value)).toEqual(expectedValue);
   });
@@ -50,6 +53,10 @@ describe("number parameters", () => {
     { value: [1, 2, 3], expectedValue: [1, 2, 3] },
     { value: ["1", "2", "3"], expectedValue: [1, 2, 3] },
     { value: [10, "9007199254740993"], expectedValue: [10, 9007199254740993n] },
+    { value: [null, null], expectedValue: [] },
+    { value: [10, 20], expectedValue: [10, 20] },
+    { value: [10, null], expectedValue: [10, null] },
+    { value: [null, 20], expectedValue: [null, 20] },
   ])("should deserialize $value", ({ value, expectedValue }) => {
     expect(deserializeNumberParameterValue(value)).toEqual(expectedValue);
   });
@@ -61,6 +68,7 @@ describe("number parameters", () => {
       value: [0, "1", 1.5, "abc", "9007199254740993"],
       expectedValue: [0, 1, 1.5, "9007199254740993"],
     },
+    { value: [null, null], expectedValue: [] },
   ])("should normalize $value", ({ value, expectedValue }) => {
     expect(normalizeNumberParameterValue(value)).toEqual(expectedValue);
   });

--- a/frontend/src/metabase/querying/parameters/utils/parsing.unit.spec.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.unit.spec.ts
@@ -45,44 +45,90 @@ describe("number parameters", () => {
     expect(serializeNumberParameterValue(value)).toEqual(expectedValue);
   });
 
-  it.each([
-    { value: 1, expectedValue: [1] },
-    { value: "1", expectedValue: [1] },
-    { value: 1.5, expectedValue: [1.5] },
-    { value: "1.5", expectedValue: [1.5] },
-    { value: [1, 2, 3], expectedValue: [1, 2, 3] },
-    { value: ["1", "2", "3"], expectedValue: [1, 2, 3] },
-    {
-      value: ["9007199254740993", "9007199254740995"],
-      expectedValue: [9007199254740993n, 9007199254740995n],
+  describe.each(["number/=", "number/!=", "number/>=", "number/<="])(
+    "%s",
+    (type) => {
+      it.each([
+        { value: 1, expectedValue: [1] },
+        { value: "1", expectedValue: [1] },
+        { value: 1.5, expectedValue: [1.5] },
+        { value: "1.5", expectedValue: [1.5] },
+        {
+          value: ["9007199254740993"],
+          expectedValue: [9007199254740993n],
+        },
+      ])("should deserialize $value", ({ value, expectedValue }) => {
+        expect(deserializeNumberParameterValue(type, value)).toEqual(
+          expectedValue,
+        );
+      });
     },
-    { value: [10, "9007199254740993"], expectedValue: [10, 9007199254740993n] },
-    { value: [null, null], expectedValue: [] },
-    { value: [10, 20], expectedValue: [10, 20] },
-    { value: [10, null], expectedValue: [10, null] },
-    { value: [null, 20], expectedValue: [null, 20] },
-    { value: [10, "abc"], expectedValue: [10] },
-    { value: ["abc", 20], expectedValue: [20] },
-  ])("should deserialize $value", ({ value, expectedValue }) => {
-    expect(deserializeNumberParameterValue(value)).toEqual(expectedValue);
+  );
+
+  describe.each(["number/=", "number/!="])("%s", (type) => {
+    it.each([
+      { value: [1, 2, 3], expectedValue: [1, 2, 3] },
+      { value: ["1", "2", "3"], expectedValue: [1, 2, 3] },
+      {
+        value: ["9007199254740993", "9007199254740995"],
+        expectedValue: [9007199254740993n, 9007199254740995n],
+      },
+      {
+        value: [10, "9007199254740993"],
+        expectedValue: [10, 9007199254740993n],
+      },
+    ])("should deserialize $value", ({ value, expectedValue }) => {
+      expect(deserializeNumberParameterValue(type, value)).toEqual(
+        expectedValue,
+      );
+    });
   });
 
-  it.each([
-    { value: undefined, expectedValue: [] },
-    { value: null, expectedValue: [] },
-    {
-      value: [0, "1", 1.5, "abc", "9007199254740993"],
-      expectedValue: [0, 1, 1.5, "9007199254740993"],
-    },
-    { value: [null, null], expectedValue: [] },
-  ])("should normalize $value", ({ value, expectedValue }) => {
-    expect(normalizeNumberParameterValue(value)).toEqual(expectedValue);
+  describe.each(["number/between"])("%s", (type) => {
+    it.each([
+      {
+        value: [10, "9007199254740993"],
+        expectedValue: [10, 9007199254740993n],
+      },
+      {
+        value: ["9007199254740993", "9007199254740995"],
+        expectedValue: [9007199254740993n, 9007199254740995n],
+      },
+      { value: [10, 20], expectedValue: [10, 20] },
+      { value: [10, null], expectedValue: [10, null] },
+      {
+        value: ["9007199254740993", null],
+        expectedValue: [9007199254740993n, null],
+      },
+      { value: [null, 20], expectedValue: [null, 20] },
+      {
+        value: [null, "9007199254740993"],
+        expectedValue: [null, 9007199254740993n],
+      },
+    ])("should deserialize $value", ({ value, expectedValue }) => {
+      expect(normalizeNumberParameterValue(type, value)).toEqual(value);
+      expect(deserializeNumberParameterValue(type, value)).toEqual(
+        expectedValue,
+      );
+    });
   });
 
-  it.each([null, undefined, "", [""], ["abc"], NaN, [NaN], [true, false]])(
-    "should ignore invalid value %s",
-    (value) => {
-      expect(deserializeNumberParameterValue(value)).toEqual([]);
+  describe.each(["number/=", "number/!=", "number/>=", "number/<="])(
+    "%s",
+    (type) => {
+      it.each([
+        null,
+        undefined,
+        "",
+        [""],
+        ["abc"],
+        NaN,
+        [NaN],
+        [true, false],
+        [null, null],
+      ])("should ignore invalid value %s", (value) => {
+        expect(deserializeNumberParameterValue(type, value)).toEqual([]);
+      });
     },
   );
 });

--- a/frontend/src/metabase/querying/parameters/utils/parsing.unit.spec.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.unit.spec.ts
@@ -52,11 +52,17 @@ describe("number parameters", () => {
     { value: "1.5", expectedValue: [1.5] },
     { value: [1, 2, 3], expectedValue: [1, 2, 3] },
     { value: ["1", "2", "3"], expectedValue: [1, 2, 3] },
+    {
+      value: ["9007199254740993", "9007199254740995"],
+      expectedValue: [9007199254740993n, 9007199254740995n],
+    },
     { value: [10, "9007199254740993"], expectedValue: [10, 9007199254740993n] },
     { value: [null, null], expectedValue: [] },
     { value: [10, 20], expectedValue: [10, 20] },
     { value: [10, null], expectedValue: [10, null] },
     { value: [null, 20], expectedValue: [null, 20] },
+    { value: [10, "abc"], expectedValue: [10] },
+    { value: ["abc", 20], expectedValue: [20] },
   ])("should deserialize $value", ({ value, expectedValue }) => {
     expect(deserializeNumberParameterValue(value)).toEqual(expectedValue);
   });

--- a/frontend/src/metabase/querying/parameters/utils/parsing.unit.spec.ts
+++ b/frontend/src/metabase/querying/parameters/utils/parsing.unit.spec.ts
@@ -7,7 +7,6 @@ import {
   deserializeNumberParameterValue,
   deserializeStringParameterValue,
   deserializeTemporalUnitParameterValue,
-  normalizeNumberParameterValue,
   serializeDateParameterValue,
   serializeNumberParameterValue,
 } from "./parsing";
@@ -106,7 +105,6 @@ describe("number parameters", () => {
         expectedValue: [null, 9007199254740993n],
       },
     ])("should deserialize $value", ({ value, expectedValue }) => {
-      expect(normalizeNumberParameterValue(type, value)).toEqual(value);
       expect(deserializeNumberParameterValue(type, value)).toEqual(
         expectedValue,
       );

--- a/frontend/src/metabase/querying/parameters/utils/query.ts
+++ b/frontend/src/metabase/querying/parameters/utils/query.ts
@@ -162,10 +162,20 @@ function getNumberParameterFilterClause(
   const operator = NUMBER_OPERATORS[type] ?? "=";
   return match({ operator, values })
     .with(
-      { operator: P.union("=", "!=") },
-      { operator: P.union(">=", "<="), values: [P._] },
-      { operator: "between", values: [P._, P._] },
-      () => Lib.numberFilterClause({ operator, column, values }),
+      { operator: P.union("=", "!="), values: [] },
+      { operator: P.union(">=", "<="), values: [P.nonNullable] },
+      { operator: "between", values: [P.nonNullable, P.nonNullable] },
+      ({ values }) => Lib.numberFilterClause({ operator, column, values }),
+    )
+    .with(
+      { operator: "between", values: [P.nonNullable, P.nullish] },
+      ({ values: [minValue] }) =>
+        Lib.numberFilterClause({ operator: ">=", column, values: [minValue] }),
+    )
+    .with(
+      { operator: "between", values: [P.nullish, P.nonNullable] },
+      ({ values: [_minValue, maxValue] }) =>
+        Lib.numberFilterClause({ operator: "<=", column, values: [maxValue] }),
     )
     .otherwise(() => undefined);
 }

--- a/frontend/src/metabase/querying/parameters/utils/query.ts
+++ b/frontend/src/metabase/querying/parameters/utils/query.ts
@@ -162,7 +162,7 @@ function getNumberParameterFilterClause(
   const operator = NUMBER_OPERATORS[type] ?? "=";
   return match({ operator, values })
     .with(
-      { operator: P.union("=", "!="), values: [] },
+      { operator: P.union("=", "!="), values: P.array(P.nonNullable) },
       { operator: P.union(">=", "<="), values: [P.nonNullable] },
       { operator: "between", values: [P.nonNullable, P.nonNullable] },
       ({ values }) => Lib.numberFilterClause({ operator, column, values }),

--- a/frontend/src/metabase/querying/parameters/utils/query.ts
+++ b/frontend/src/metabase/querying/parameters/utils/query.ts
@@ -154,7 +154,7 @@ function getNumberParameterFilterClause(
   column: Lib.ColumnMetadata,
   value: ParameterValueOrArray,
 ): Lib.ExpressionClause | undefined {
-  const values = deserializeNumberParameterValue(value);
+  const values = deserializeNumberParameterValue(type, value);
   if (values.length === 0) {
     return;
   }

--- a/frontend/src/metabase/querying/parameters/utils/query.ts
+++ b/frontend/src/metabase/querying/parameters/utils/query.ts
@@ -168,7 +168,10 @@ function getNumberParameterFilterClause(
       ({ values }) => Lib.numberFilterClause({ operator, column, values }),
     )
     .with(
-      { operator: "between", values: [P.nonNullable, P.nullish] },
+      {
+        operator: "between",
+        values: P.union([P.nonNullable], [P.nonNullable, P.nullish]),
+      },
       ({ values: [minValue] }) =>
         Lib.numberFilterClause({ operator: ">=", column, values: [minValue] }),
     )

--- a/frontend/src/metabase/querying/parameters/utils/query.unit.spec.ts
+++ b/frontend/src/metabase/querying/parameters/utils/query.unit.spec.ts
@@ -240,6 +240,24 @@ describe("applyParameter", () => {
           "ID is between -9223372036854775808 and 9223372036854775807",
       },
       {
+        type: "number/between",
+        target: getFilterColumnTarget("ORDERS", "ID"),
+        value: [1],
+        expectedDisplayName: "ID is greater than or equal to 1",
+      },
+      {
+        type: "number/between",
+        target: getFilterColumnTarget("ORDERS", "ID"),
+        value: [1, null],
+        expectedDisplayName: "ID is greater than or equal to 1",
+      },
+      {
+        type: "number/between",
+        target: getFilterColumnTarget("ORDERS", "ID"),
+        value: [null, 2],
+        expectedDisplayName: "ID is less than or equal to 2",
+      },
+      {
         type: "id",
         target: getFilterColumnTarget("ORDERS", "IS_TRIAL"),
         value: [true],


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/54364

Properly handle `Between` dashboard filters without either `min` or `max`.

How to verify:
 - New -> Dashboard -> Save
 - Edit -> New Question -> Reviews -> Save
 - Filter -> Number -> Between -> Connect to Rating -> Save
 - Try partial values without min or max in the widget

<img width="611" height="558" alt="Screenshot 2025-08-27 at 11 08 06" src="https://github.com/user-attachments/assets/5c832699-1766-4e46-bf35-f58ac755f404" />
