### PR TITLE
Fix: UXW-503 Improve error handling for deleted embedded questions

### DIFF
--- a/e2e/support/helpers/api/createDocument.ts
+++ b/e2e/support/helpers/api/createDocument.ts
@@ -9,11 +9,13 @@ export const createDocument = ({
   collection_id,
   document,
   alias,
+  idAlias,
 }: {
   name: string;
   collection_id?: RegularCollectionId | null;
   document: DocumentContent;
   alias?: string;
+  idAlias?: string;
 }): Cypress.Chainable<Cypress.Response<Document>> => {
   cy.log(`Create a document: ${name}`);
 
@@ -25,7 +27,10 @@ export const createDocument = ({
     })
     .then((response) => {
       if (alias) {
-        cy.wrap(response.body.id).as(alias);
+        cy.wrap(response.body).as(alias);
+      }
+      if (idAlias) {
+        cy.wrap(response.body.id).as(idAlias);
       }
     });
 };

--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -151,22 +151,17 @@ H.describeWithSnowplowEE("documents", () => {
             type: "doc",
           },
           collection_id: null,
-          alias: "documentId",
+          alias: "document",
+          idAlias: "documentId",
         });
       });
 
       it("renders a 'not found' message if the copied card has been permanently deleted", () => {
-        cy.intercept({
-          method: "GET",
-          path: "/api/ee/document/*",
-        }).as("documentGet");
-        cy.get("@documentId").then((id) => cy.visit(`/document/${id}`));
-        cy.wait("@documentGet").then(({ response }) => {
-          const body: Document | undefined = response?.body;
-          const content = body?.document.content;
+        cy.get<Document>("@document").then(({ id, document: { content } }) => {
           const cardEmbed = content?.find((n) => n.type === "cardEmbed");
-          const copiedCardId = cardEmbed?.attrs?.id;
-          cy.request("DELETE", `/api/card/${copiedCardId}`);
+          const clonedCardId = cardEmbed?.attrs?.id;
+          cy.request("DELETE", `/api/card/${clonedCardId}`);
+          cy.visit(`/document/${id}`);
         });
         H.getDocumentCard("Couldn't find this chart.").should("exist");
       });
@@ -234,7 +229,8 @@ H.describeWithSnowplowEE("documents", () => {
           type: "doc",
         },
         collection_id: null,
-        alias: "documentId",
+        alias: "document",
+        idAlias: "documentId",
       });
 
       cy.get("@documentId").then((id) => cy.visit(`/document/${id}`));

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/CardEmbedNode.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/CardEmbedNode.module.css
@@ -47,11 +47,6 @@
   justify-content: center;
 }
 
-.errorContainer {
-  padding: 1rem;
-  color: var(--mb-color-error);
-}
-
 .titleContainer {
   display: flex;
   align-items: center;

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/CardEmbedNode.tsx
@@ -301,9 +301,13 @@ export const CardEmbedComponent = memo(
       return (
         <NodeViewWrapper className={styles.embedWrapper}>
           <Box
-            className={cx(styles.errorContainer, EDITOR_STYLE_BOUNDARY_CLASS)}
+            className={cx(styles.cardEmbed, EDITOR_STYLE_BOUNDARY_CLASS, {
+              [styles.selected]: selected,
+            })}
           >
-            <Text color="error">{t`Failed to load question`}</Text>
+            <Box className={styles.errorContainer}>
+              <Text c="error">{t`Failed to load question`}</Text>
+            </Box>
           </Box>
         </NodeViewWrapper>
       );

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/CardEmbedNode.tsx
@@ -15,6 +15,7 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Flex, Icon, Loader, Menu, Text, TextInput } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
+import { ErrorView } from "metabase/visualizations/components/Visualization/ErrorView/ErrorView";
 import ChartSkeleton from "metabase/visualizations/components/skeletons/ChartSkeleton";
 import { getGenericErrorMessage } from "metabase/visualizations/lib/errors";
 import { trackDocumentReplaceCard } from "metabase-enterprise/documents/analytics";
@@ -305,9 +306,15 @@ export const CardEmbedComponent = memo(
               [styles.selected]: selected,
             })}
           >
-            <Box className={styles.errorContainer}>
-              <Text c="error">{t`Failed to load question`}</Text>
-            </Box>
+            <Flex className={styles.questionResults}>
+              <ErrorView
+                error={
+                  error === "not found"
+                    ? t`Couldn't find this chart.`
+                    : t`Failed to load question.`
+                }
+              />
+            </Flex>
           </Box>
         </NodeViewWrapper>
       );

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CardEmbed/CardEmbedNode.tsx
@@ -300,7 +300,10 @@ export const CardEmbedComponent = memo(
 
     if (error) {
       return (
-        <NodeViewWrapper className={styles.embedWrapper}>
+        <NodeViewWrapper
+          className={styles.embedWrapper}
+          data-testid="document-card-embed"
+        >
           <Box
             className={cx(styles.cardEmbed, EDITOR_STYLE_BOUNDARY_CLASS, {
               [styles.selected]: selected,

--- a/enterprise/frontend/src/metabase-enterprise/documents/hooks/use-card-data.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/hooks/use-card-data.ts
@@ -86,10 +86,11 @@ export function useCardData({ id }: UseCardDataProps): UseCardDataResult {
   const isDraft = id < 0;
   const shouldSkipSavedCard = !id || isDraft;
 
-  const { data: card, isLoading: isLoadingCard } = useGetCardQuery(
-    { id },
-    { skip: shouldSkipSavedCard },
-  );
+  const {
+    data: card,
+    isLoading: isLoadingCard,
+    error: cardError,
+  } = useGetCardQuery({ id }, { skip: shouldSkipSavedCard });
 
   const cardWithDraft = useSelector((state) =>
     getCardWithDraft(state, id, card),
@@ -167,7 +168,8 @@ export function useCardData({ id }: UseCardDataProps): UseCardDataResult {
 
   const hasTriedToLoad =
     cardToUse !== undefined || isLoadingCard || isLoadingDataset;
-  const hasFailedToLoadCard = hasTriedToLoad && !isLoading && id && !cardToUse;
+  const hasFailedToLoadCard =
+    !!cardError || (hasTriedToLoad && !isLoading && id && !cardToUse);
   const error = hasFailedToLoadCard ? "Failed to load question" : null;
 
   return {

--- a/enterprise/frontend/src/metabase-enterprise/documents/hooks/use-card-data.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/hooks/use-card-data.ts
@@ -170,14 +170,15 @@ export function useCardData({ id }: UseCardDataProps): UseCardDataResult {
   const hasTriedToLoad =
     cardToUse !== undefined || isLoadingCard || isLoadingDataset;
   const hasFailedToLoadCard = hasTriedToLoad && !isLoading && id && !cardToUse;
-  const error = useMemo(() => {
+  const getError = () => {
     if (isObject(cardError) && cardError.status === 404) {
       return "not found";
     }
     if (hasFailedToLoadCard) {
       return "unknown";
     }
-  }, [cardError, hasFailedToLoadCard]);
+  };
+  const error = getError();
 
   return {
     card: cardToUse,

--- a/frontend/src/metabase/visualizations/components/Visualization/ErrorView/ErrorView.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/ErrorView/ErrorView.styled.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 
-export const Root = styled.div<{ isDashboard: boolean }>`
+export const Root = styled.div<{ isDashboard?: boolean }>`
   display: flex;
   flex: 1 0 auto;
   flex-direction: column;

--- a/frontend/src/metabase/visualizations/components/Visualization/ErrorView/ErrorView.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/ErrorView/ErrorView.tsx
@@ -7,8 +7,8 @@ import { Root, ShortMessage, StyledIcon } from "./ErrorView.styled";
 interface ErrorViewProps {
   error: ReactNode;
   icon?: IconName;
-  isDashboard: boolean;
-  isSmall: boolean;
+  isDashboard?: boolean;
+  isSmall?: boolean;
 }
 
 export const ErrorView = forwardRef<HTMLDivElement, ErrorViewProps>(


### PR DESCRIPTION
Closes [UXW-503](https://linear.app/metabase/issue/UXW-503)

### Description

* Triggers error state when underlying card has been deleted
* Updates general error state per design feedback (less of a jump between loading and error state, fewer different error visuals) ([slack thread](https://metaboat.slack.com/archives/C096M2BBGHH/p1755878853422129?thread_ts=1755876108.471199&cid=C096M2BBGHH))

### How to verify

1. Add a chart to a document and save it
2. Click the chart's title -> move the question to trash -> delete the question permanently
3. Navigate to the document from step 1
4. Verify the deleted chart doesn't spin forever, has an appropriate error message

### Demo

https://github.com/user-attachments/assets/d5a98ed8-6c96-4932-a458-38da215b2800

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
