### PR TITLE
Change driver/humanize-connection-error-message to be passed a list messages, not a single message

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -17,6 +17,9 @@ title: Driver interface changelog
   metabase.driver/connection-details, metabase.driver/table-exists?, metabase.driver.sql/normalize-name,
   metabase.driver.sql/default-schema, and metabase.driver.sql/find-table to implement sql transforms.
 
+- `driver/humanize-connection-error-message` now takes a list of all messages in the exception chain,
+  instead of just the top-level message as a string.
+
 ## Metabase 0.56.3
 
 - Added the driver multi-method `driver/describe-database*` that drivers should now implement instead of `driver/describe-database`.

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -188,6 +188,14 @@
   (when table-or-field-name
     (str/replace table-or-field-name #"-" "_")))
 
+(defmethod driver/humanize-connection-error-message :clickhouse
+  [_ messages]
+  (condp re-matches (str/join " -> " messages)
+    #".*AUTHENTICATION_FAILED.*"
+    :username-or-password-incorrect
+
+    (first messages)))
+
 ;;; ------------------------------------------ Connection Impersonation ------------------------------------------
 
 (defmethod driver/upload-type->database-type :clickhouse

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -354,3 +354,9 @@
                               :target [:variable [:template-tag "category_id_2"]]
                               :value  "2"}]
                 :middleware {:format-rows? false}})))))))
+
+(deftest ^:parallel humanize-connection-error-message-test
+  (is (= "random message" (driver/humanize-connection-error-message :clickhouse ["random message"])))
+  (is (= :username-or-password-incorrect (driver/humanize-connection-error-message :clickhouse ["Failed to create connection"
+                                                                                                "Failed to get server info"
+                                                                                                "Code: 516. DB::Exception: asdf: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED) (version 25.7.4.11 (official build))"]))))

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -60,36 +60,37 @@
 
 (defmethod driver/humanize-connection-error-message
   :mongo
-  [_ message]
-  (condp re-matches message
-    #"^Timed out after \d+ ms while waiting for a server .*$"
-    :cannot-connect-check-host-and-port
+  [_ messages]
+  (let [message (first messages)]
+    (condp re-matches message
+      #"^Timed out after \d+ ms while waiting for a server .*$"
+      :cannot-connect-check-host-and-port
 
-    #"^host and port should be specified in host:port format$"
-    :invalid-hostname
+      #"^host and port should be specified in host:port format$"
+      :invalid-hostname
 
-    #"^Password can not be null when the authentication mechanism is unspecified$"
-    :password-required
+      #"^Password can not be null when the authentication mechanism is unspecified$"
+      :password-required
 
-    #"^org.apache.sshd.common.SshException: No more authentication methods available$"
-    :ssh-tunnel-auth-fail
+      #"^org.apache.sshd.common.SshException: No more authentication methods available$"
+      :ssh-tunnel-auth-fail
 
-    #"^java.net.ConnectException: Connection refused$"
-    :ssh-tunnel-connection-fail
+      #"^java.net.ConnectException: Connection refused$"
+      :ssh-tunnel-connection-fail
 
-    #".*javax.net.ssl.SSLHandshakeException: PKIX path building failed.*"
-    :certificate-not-trusted
+      #".*javax.net.ssl.SSLHandshakeException: PKIX path building failed.*"
+      :certificate-not-trusted
 
-    #".*MongoSocketReadException: Prematurely reached end of stream.*"
-    :requires-ssl
+      #".*MongoSocketReadException: Prematurely reached end of stream.*"
+      :requires-ssl
 
-    #".* KeyFactory not available"
-    :unsupported-ssl-key-type
+      #".* KeyFactory not available"
+      :unsupported-ssl-key-type
 
-    #"java.security.InvalidKeyException: invalid key format"
-    :invalid-key-format
+      #"java.security.InvalidKeyException: invalid key format"
+      :invalid-key-format
 
-    message))
+      messages)))
 
 ;;; ### Syncing
 
@@ -175,12 +176,12 @@
 (def ^:private unwind-stages
   "Sequence of stages repeated in _search_ phase of [[describe-table-pipeline]]
     for [[describe-table-query-depth]] times.
-  
+
     Each repetion $unwinds documents having `val` of type \"object\", so those are __swapped__ for sequence
     of their children.
-  
+
     Documents with non-object val are left untouched.
-  
+
     Each document that is processed has path from parent stored in `path`. `indices` represent indices of keys
     in the `path` in parent objects as per $objectToArray."
   [{"$addFields" {"kvs" {"$cond" [{"$eq" [{"$type" "$val"} "object"]} {"$objectToArray" "$val"} nil]}}}
@@ -359,7 +360,7 @@
   first.
 
   The resulting structure will hold at most [[driver.settings/sync-leaf-fields-limit]] leaf fields. That translates
-  to at most [[driver.settings/sync-leaf-fields-limit]] * [[describe-table-query-depth]]. That is 7K fields at the 
+  to at most [[driver.settings/sync-leaf-fields-limit]] * [[describe-table-query-depth]]. That is 7K fields at the
   time of writing hence safe to reside in memory for further operation."
   [dbfields]
   (-> dbfields dbfields->ftree* ftree-reconcile-nodes))

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -90,7 +90,7 @@
       #"java.security.InvalidKeyException: invalid key format"
       :invalid-key-format
 
-      messages)))
+      message)))
 
 ;;; ### Syncing
 

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -571,12 +571,13 @@
   (sql.qp/->honeysql driver [::sql.qp/cast expr "varchar2(256)"]))
 
 (defmethod driver/humanize-connection-error-message :oracle
-  [_ message]
+  [_ messages]
   ;; if the connection error message is caused by the assertion above checking whether sid or service-name is set,
   ;; return a slightly nicer looking version. Otherwise just return message as-is
-  (if (str/includes? message "(or sid service-name)")
-    "You must specify the SID and/or the Service Name."
-    message))
+  (let [message (first messages)]
+    (if (str/includes? message "(or sid service-name)")
+      "You must specify the SID and/or the Service Name."
+      message)))
 
 (defn- remove-rownum-column
   "Remove the `:__rownum__` column from results, if present."

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -104,7 +104,7 @@
            (try (sql-jdbc.conn/connection-details->spec :oracle {:host "localhost"
                                                                  :port 1521})
                 (catch Throwable e
-                  (driver/humanize-connection-error-message :oracle (.getMessage e))))))))
+                  (driver/humanize-connection-error-message :oracle (u/all-ex-messages e))))))))
 
 (deftest connection-properties-test
   (testing "Connection properties should be returned properly (including transformation of secret types)"

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -68,14 +68,15 @@
   (defmethod driver/database-supports? [:snowflake feature] [_driver _feature _db] supported?))
 
 (defmethod driver/humanize-connection-error-message :snowflake
-  [_ message]
-  (log/spy :error (type message))
-  (condp re-matches message
-    #"(?s).*Object does not exist.*$"
-    :database-name-incorrect
+  [_ messages]
+  (let [message (first messages)]
+    (log/spy :error (type message))
+    (condp re-matches message
+      #"(?s).*Object does not exist.*$"
+      :database-name-incorrect
 
-    ; default - the Snowflake errors have a \n in them
-    message))
+      ; default - the Snowflake errors have a \n in them
+      message)))
 
 (defmethod driver/db-start-of-week :snowflake
   [_]

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -842,13 +842,14 @@
   as keywords whenever possible. This provides for both unified error messages and categories which let us point
   users to the erroneous input fields.
   Error messages can also be strings, or localized strings, as returned by [[metabase.util.i18n/trs]] and
-  `metabase.util.i18n/tru`."
-  {:added "0.32.0" :arglists '([this message])}
+  `metabase.util.i18n/tru`.
+  Passed a collection of all non-nil exception messages that were thrown during connection attempt."
+  {:added "0.32.0" :arglists '([this messages])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
-(defmethod humanize-connection-error-message ::driver [_ message]
-  message)
+(defmethod humanize-connection-error-message ::driver [_ messages]
+  (first messages))
 
 (defmulti mbql->native
   "Transpile an MBQL query into the appropriate native query form. `query` will match the schema for an MBQL query in

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -307,18 +307,19 @@
     (dateadd unit amount hsql-form)))
 
 (defmethod driver/humanize-connection-error-message :h2
-  [_ message]
-  (condp re-matches message
-    #"^A file path that is implicitly relative to the current working directory is not allowed in the database URL .*$"
-    :implicitly-relative-db-file-path
+  [_ messages]
+  (let [message (first messages)]
+    (condp re-matches message
+      #"^A file path that is implicitly relative to the current working directory is not allowed in the database URL .*$"
+      :implicitly-relative-db-file-path
 
-    #"^Database .* not found, .*$"
-    :db-file-not-found
+      #"^Database .* not found, .*$"
+      :db-file-not-found
 
-    #"^Wrong user name or password .*$"
-    :username-or-password-incorrect
+      #"^Wrong user name or password .*$"
+      :username-or-password-incorrect
 
-    message))
+      message)))
 
 (defmethod driver/db-default-timezone :h2
   [_driver _database]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -244,22 +244,23 @@
   (h2x/current-datetime-honeysql-form driver))
 
 (defmethod driver/humanize-connection-error-message :mysql
-  [_ message]
-  (condp re-matches message
-    #"^Communications link failure\s+The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.$"
-    :cannot-connect-check-host-and-port
+  [_ messages]
+  (let [message (first messages)]
+    (condp re-matches message
+      #"^Communications link failure\s+The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.$"
+      :cannot-connect-check-host-and-port
 
-    #"^Unknown database .*$"
-    :database-name-incorrect
+      #"^Unknown database .*$"
+      :database-name-incorrect
 
-    #"Access denied for user.*$"
-    :username-or-password-incorrect
+      #"Access denied for user.*$"
+      :username-or-password-incorrect
 
-    #"Must specify port after ':' in connection string"
-    :invalid-hostname
+      #"Must specify port after ':' in connection string"
+      :invalid-hostname
 
-    ;; else
-    message))
+      ;; else
+      message)))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (defmethod sql-jdbc.sync/db-default-timezone :mysql

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -110,28 +110,29 @@
 (defmethod driver/display-name :postgres [_] "PostgreSQL")
 
 (defmethod driver/humanize-connection-error-message :postgres
-  [_ message]
-  (condp re-matches message
-    #"^FATAL: database \".*\" does not exist$"
-    :database-name-incorrect
+  [_ messages]
+  (let [message (first messages)]
+    (condp re-matches message
+      #"^FATAL: database \".*\" does not exist$"
+      :database-name-incorrect
 
-    #"^No suitable driver found for.*$"
-    :invalid-hostname
+      #"^No suitable driver found for.*$"
+      :invalid-hostname
 
-    #"^Connection refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.$"
-    :cannot-connect-check-host-and-port
+      #"^Connection refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.$"
+      :cannot-connect-check-host-and-port
 
-    #"^FATAL: role \".*\" does not exist$"
-    :username-incorrect
+      #"^FATAL: role \".*\" does not exist$"
+      :username-incorrect
 
-    #"^FATAL: password authentication failed for user.*$"
-    :password-incorrect
+      #"^FATAL: password authentication failed for user.*$"
+      :password-incorrect
 
-    #"^FATAL: .*$" ; all other FATAL messages: strip off the 'FATAL' part, capitalize, and add a period
-    (let [[_ message] (re-matches #"^FATAL: (.*$)" message)]
-      (str (str/capitalize message) \.))
+      #"^FATAL: .*$" ; all other FATAL messages: strip off the 'FATAL' part, capitalize, and add a period
+      (let [[_ message] (re-matches #"^FATAL: (.*$)" message)]
+        (str (str/capitalize message) \.))
 
-    message))
+      message)))
 
 (defmethod driver/db-default-timezone :postgres
   [driver database]

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -138,7 +138,7 @@
       ;; first
       (catch Throwable e
         (log/error e "Failed to connect to Database")
-        (throw (if-let [humanized-message (some->> (.getMessage e)
+        (throw (if-let [humanized-message (some->> (u/all-ex-messages e)
                                                    (driver/humanize-connection-error-message driver))]
                  (let [error-data (cond
                                     (keyword? humanized-message)

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -60,6 +60,7 @@
 
 #?(:clj (p/import-vars [u.jvm
                         all-ex-data
+                        all-ex-messages
                         auto-retry
                         string-to-bytes
                         bytes-to-string

--- a/src/metabase/util/jvm.clj
+++ b/src/metabase/util/jvm.clj
@@ -149,6 +149,17 @@
    nil
    (full-exception-chain e)))
 
+(defn all-ex-messages
+  "Returns a list of all non-nil messages in an exception, starting from the outermost and working inward.
+  If no messages are found, returns nil."
+  [^Throwable e]
+  (loop [ex e
+         messages []]
+    (if ex
+      (recur (.getCause ex)
+             (conj messages (.getMessage ex)))
+      (seq (remove nil? messages)))))
+
 (defn do-with-auto-retries
   "Execute `f`, a function that takes no arguments, and return the results.
    If `f` fails with an exception, retry `f` up to `num-retries` times until it succeeds.

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -213,7 +213,7 @@
            (analytics/inc! :metabase-database/status {:driver engine :healthy true})
 
            (catch Throwable e
-             (let [humanized-message (some->> (.getMessage e)
+             (let [humanized-message (some->> (u/all-ex-messages e)
                                               (driver/humanize-connection-error-message driver))
                    reason (if (keyword? humanized-message) "user-input" "exception")]
                (log/error e (u/format-color :red "Health check: failure with error %s {:id %d :reason %s :message %s}"

--- a/test/metabase/util/jvm_test.clj
+++ b/test/metabase/util/jvm_test.clj
@@ -106,3 +106,19 @@
     "¥200."         200.0M
     "$.05"          0.05M
     "0.05"          0.05M))
+
+(deftest ^:parallel all-ex-messages-test
+  (testing "nil exception"
+    (is (nil? (u/all-ex-messages nil))))
+  (testing "one level exception"
+    (is (= ["test string"] (u/all-ex-messages (RuntimeException. "test string"))))
+    (is (nil? (u/all-ex-messages (Exception. nil nil)))))
+  (testing "chained exceptions"
+    (is (= ["test string 1" "test string 2"]
+           (u/all-ex-messages (RuntimeException. "test string 1" (RuntimeException. "test string 2")))))
+    (is (= ["test string 1" "test string 2"]
+           (u/all-ex-messages (RuntimeException. "test string 1" (RuntimeException. nil (RuntimeException. "test string 2"))))))
+    (is (= ["test string 2"]
+           (u/all-ex-messages (RuntimeException. nil (RuntimeException. "test string 2")))))
+    (is (nil?
+         (u/all-ex-messages (RuntimeException. nil (RuntimeException. nil nil)))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60228
### Description

Improves clickhouse error message when passing an invalid username or password.

Because clickhouse has the the relevant message deep in the stack trace, the `humanize-connection-error-message`function had to be modified to take all messages in the stack.

### How to verify

1. Attempt to connect to clickhouse with an invalid username or password

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
