### PR TITLE
Allow entity picker skeleton to grow to top of container

### DIFF
--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntitityPickerModal.module.css
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntitityPickerModal.module.css
@@ -20,3 +20,7 @@
   flex-grow: 1;
   height: 0;
 }
+
+.loadingSkeleton {
+  flex-grow: 1;
+}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -491,7 +491,7 @@ const assertValidProps = (
 };
 
 const EntityPickerLoadingSkeleton = () => (
-  <Box data-testid="loading-indicator">
+  <Box data-testid="loading-indicator" className={S.loadingSkeleton}>
     <Flex px="2rem" gap="1.5rem" mb="3.5rem">
       <Repeat times={3}>
         <Skeleton h="2rem" w="5rem" mb="0.5rem" />


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62279

The issue was caused by the `justify-content: space-between` on the parent. The fix is to make the skeleton grow in the container to avoid space from forming between it and the header.

The issue is only visible in windows that are large enough for the `space-between` to kick in.


<img width="1624" height="1056" alt="Screenshot 2025-08-25 at 17 55 28" src="https://github.com/user-attachments/assets/8497568d-48b2-4313-b671-c1e479e00cea" />
