### PR TITLE
fix: remove helpers from the types of `cy`

### DIFF
--- a/e2e/support/index.ts
+++ b/e2e/support/index.ts
@@ -5,8 +5,8 @@ type HelperTypes = typeof H;
 
 declare global {
   namespace Cypress {
-    interface Chainable extends HelperTypes {
-      H: typeof H;
+    interface Chainable {
+      H: HelperTypes;
     }
   }
 }


### PR DESCRIPTION
https://metaboat.slack.com/archives/C084XNEPH6K/p1756116882020669

We get autocomplete for them but they are not there:
<img width="753" height="130" alt="image" src="https://github.com/user-attachments/assets/be2382f7-7c06-47f7-bf99-a691676b8b5f" />

<img width="417" height="313" alt="image" src="https://github.com/user-attachments/assets/014d4972-8fd4-4bc5-94b9-870b5a027027" />

That should be `H.activateToken`