### PR TITLE
fix: h2-tables-are-writable tests

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-3.cy.spec.js
@@ -2415,8 +2415,8 @@ describe("issue 50038", () => {
                   strategy: "left-join",
                   condition: [
                     "=",
-                    ["field", ORDERS_ID, {}],
-                    ["field", PRODUCTS_ID, {}],
+                    ["field", PRODUCTS.ID, null],
+                    ["field", ORDERS.PRODUCT_ID, { "join-alias": "Orders" }],
                   ],
                 },
               ],


### PR DESCRIPTION
The test named:
```
should not break data source and join source buttons when the source names are too long (metabase#50038)
```

Seems to be poorly written, since it fails when sample data PRODUCT table ID is equal to any field ID from ORDER table.