### PR TITLE
clarify text in new-transform menu

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -146,7 +146,7 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
         cy.log("create a new transform");
         visitTransformListPage();
         getTransformListPage().button("Create a transform").click();
-        H.popover().findByText("A saved question").click();
+        H.popover().findByText("A copy of a saved question").click();
         H.expectUnstructuredSnowplowEvent({
           event: "transform_create",
           event_detail: "saved-question",
@@ -284,7 +284,7 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
         cy.log("create a new transform");
         visitTransformListPage();
         getTransformListPage().button("Create a transform").click();
-        H.popover().findByText("A saved question").click();
+        H.popover().findByText("A copy of a saved question").click();
         H.entityPickerModal().within(() => {
           H.entityPickerModalTab(label);
           cy.findAllByTestId("picker-item")

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/CreateTransformMenu/CreateTransformMenu.tsx
@@ -86,10 +86,10 @@ export function CreateTransformMenu() {
                 {t`SQL query`}
               </Menu.Item>
               <Menu.Item
-                leftSection={<Icon name="folder" />}
+                leftSection={<Icon name="copy" />}
                 onClick={handleSavedQuestionClick}
               >
-                {t`A saved question`}
+                {t`A copy of a saved question`}
               </Menu.Item>
             </>
           )}


### PR DESCRIPTION
One of our data people in-house thought that this action was going to keep the transform and the saved question in sync with each other, but it takes a copy of the saved question's query. So this aims to clarify that.

<img width="256" height="249" alt="image" src="https://github.com/user-attachments/assets/630f0eab-3416-43f8-b621-79c322e5454b" />
