### PR TITLE
Ignore unsaved parameters when executing dashboard card queries in edit mode

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -4990,3 +4990,49 @@ describe("Issue 46767", () => {
     });
   });
 });
+
+describe("issue 49319", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should ignore parameters that not exist in the saved dashboard in edit mode (metabase#49319)", () => {
+    cy.log("open an existing dashboard");
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+
+    cy.log("add a parameter and save the dashboard");
+    H.editDashboard();
+    H.setFilter("Text or Category", "Is");
+    H.selectDashboardFilter(H.getDashboardCard(), "Vendor");
+    H.saveDashboard();
+
+    cy.log("add another parameter to the dashboard with a default value");
+    H.editDashboard();
+    H.setFilter("Text or Category", "Is");
+    H.selectDashboardFilter(H.getDashboardCard(), "Category");
+    H.dashboardParameterSidebar().findByText("No default").click();
+    H.popover().within(() => {
+      cy.findByText("Gadget").click();
+      cy.button("Add filter").click();
+    });
+    H.dashboardParameterSidebar().button("Done").click();
+
+    cy.log("change the value for the saved parameter");
+    cy.findByTestId("fixed-width-filters").findByText("Text").click();
+    H.dashboardParameterSidebar().findByText("No default").click();
+    H.popover().within(() => {
+      cy.findByText("Americo Sipes and Sons").click();
+      cy.findByText("Barrows-Johns").click();
+      cy.button("Add filter").click();
+    });
+    H.dashboardParameterSidebar().button("Done").click();
+
+    cy.log("the unsaved parameter should be ignored in edit mode");
+    H.assertTableRowsCount(179);
+
+    cy.log("both parameters should be applied when the dashboard is saved");
+    H.saveDashboard();
+    H.assertTableRowsCount(82);
+  });
+});

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -228,8 +228,13 @@ export const fetchCardDataAction = createAsyncThunk<
 
     const dashboardType = getDashboardType(dashcard.dashboard_id);
 
-    const { dashboardId, dashboards, parameterValues, dashcardData } =
-      getState().dashboard;
+    const {
+      dashboardId,
+      dashboards,
+      editingDashboard,
+      parameterValues,
+      dashcardData,
+    } = getState().dashboard;
 
     if (!dashboardId) {
       return;
@@ -237,10 +242,22 @@ export const fetchCardDataAction = createAsyncThunk<
 
     const dashboard = dashboards[dashboardId];
 
+    // if the dashboard is being edited, ignore parameters that do not exist in
+    // the saved dashboard to avoid query errors
+    const savedParameterIds = new Set(
+      editingDashboard?.parameters?.map((parameter) => parameter.id),
+    );
+    const savedParameters =
+      editingDashboard != null
+        ? dashboard.parameters?.filter((parameter) =>
+            savedParameterIds.has(parameter.id),
+          )
+        : dashboard.parameters;
+
     // if we have a parameter, apply it to the card query before we execute
     const datasetQuery = applyParameters(
       card,
-      dashboard.parameters,
+      savedParameters,
       parameterValues,
       dashcard?.parameter_mappings ?? undefined,
     );


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/49319

How to verify:
- New -> Dashboard -> Add a question based on Orders -> Save
- Edit -> Add a Text parameter and connect it to Products.Category -> Set the default value, e.g. Gadget -> Click Done
- You should not see the query error in the dashcard. The parameter should be ignored until it's saved.
- The e2e test covers a more complex case where there are saved and unsaved parameters at the same time.