### PR TITLE
Make linking top-level parameters with inline parameters in dashboard work

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions.cy.spec.js
@@ -1,6 +1,7 @@
+const { H } = cy;
+
 import dayjs from "dayjs";
 
-const { H } = cy;
 import {
   SAMPLE_DB_ID,
   SAMPLE_DB_SCHEMA_ID,
@@ -4392,6 +4393,90 @@ describe("issue 48824", { tags: "@skip" }, () => {
     H.filterWidget()
       .findByText("Vorheriger 30 Tage, ab vor 7 tage")
       .should("be.visible");
+  });
+});
+
+describe("issue 62627", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  function toggleLinkedFilter(parameterName) {
+    cy.button(parameterName)
+      .parent()
+      .findByRole("switch")
+      .click({ force: true });
+  }
+
+  it("should properly link inline parameters (metabase#62627)", () => {
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.editDashboard();
+
+    cy.log("add a top-level filter");
+    H.setFilter("Text or Category", "Is");
+    H.selectDashboardFilter(H.getDashboardCard(), "Vendor");
+    H.setDashboardParameterName("Vendor");
+    H.dashboardParameterSidebar().button("Done").click();
+
+    cy.log("add an inline card filter");
+    H.showDashboardCardActions();
+    H.findDashCardAction(H.getDashboardCard(), "Add a filter").click();
+    H.popover().findByText("Text or Category").click();
+    H.selectDashboardFilter(H.getDashboardCard(), "Category");
+    H.setDashboardParameterName("Category");
+    H.dashboardParameterSidebar().within(() => {
+      cy.findByText("Linked filters").click();
+      toggleLinkedFilter("Vendor");
+    });
+    H.saveDashboard();
+
+    cy.log(
+      "verify that the inline parameter is linked to the top-level parameter",
+    );
+    H.dashboardParametersContainer().within(() => H.filterWidget().click());
+    H.popover().within(() => {
+      cy.findByText("Balistreri-Muller").click();
+      cy.button("Add filter").click();
+    });
+    H.getDashboardCard().within(() => H.filterWidget().click());
+    H.popover().within(() => {
+      cy.findByText("Widget").should("be.visible");
+      cy.findByText("Gadget").should("not.exist");
+    });
+
+    cy.log("make the top-level parameter be linked to the inline parameter");
+    H.editDashboard();
+    H.getDashboardCard().findByTestId("editing-parameter-widget").click();
+    H.dashboardParameterSidebar().within(() => {
+      cy.findByText("Linked filters").click();
+      toggleLinkedFilter("Vendor");
+    });
+    H.editingDashboardParametersContainer()
+      .findByTestId("editing-parameter-widget")
+      .click();
+    H.dashboardParameterSidebar().within(() => {
+      cy.findByText("Linked filters").click();
+      toggleLinkedFilter("Category");
+    });
+    H.saveDashboard();
+
+    cy.log(
+      "verify that the top-level parameter is linked to the inline parameter",
+    );
+    H.dashboardParametersContainer().within(() =>
+      H.filterWidget().icon("close").click(),
+    );
+    H.getDashboardCard().within(() => H.filterWidget().click());
+    H.popover().within(() => {
+      cy.findByText("Gadget").click();
+      cy.button("Add filter").click();
+    });
+    H.dashboardParametersContainer().within(() => H.filterWidget().click());
+    H.popover().within(() => {
+      cy.findByText("Barrows-Johns").should("be.visible");
+      cy.findByText("Americo Sipes and Sons").should("not.exist");
+    });
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardParameterList/DashboardParameterList.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { type ComponentProps, forwardRef } from "react";
+import { type ComponentProps, forwardRef, useMemo } from "react";
 
 import {
   setEditingParameter,
@@ -12,6 +12,7 @@ import { useDashboardContext } from "metabase/dashboard/context";
 import { useDispatch } from "metabase/lib/redux";
 import { ParametersList } from "metabase/parameters/components/ParametersList";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
+import { getValuePopulatedParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
 
 export interface DashboardParameterListProps
   extends Pick<
@@ -50,13 +51,25 @@ export const DashboardParameterList = forwardRef<
     isEditing,
     dashboard,
     hideParameters,
+    parameters: dashboardParameters,
+    parameterValues,
   } = useDashboardContext();
+
+  const linkedFilterParameters = useMemo(
+    () =>
+      getValuePopulatedParameters({
+        parameters: dashboardParameters,
+        values: parameterValues,
+      }),
+    [dashboardParameters, parameterValues],
+  );
 
   return (
     <ParametersList
       ref={ref}
       className={cx(DASHBOARD_PARAMETERS_PDF_EXPORT_NODE_CLASSNAME, className)}
       parameters={parameters}
+      linkedFilterParameters={linkedFilterParameters}
       editingParameter={editingParameter}
       hideParameters={hideParameters}
       dashboard={dashboard}

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
@@ -307,7 +307,7 @@ const ParameterItem = ({
         <Button
           c={isCompatible ? "text-primary" : undefined}
           variant="subtle"
-          rightSection={isCompatible && <Icon name="chevrondown" />}
+          rightSection={isCompatible && <Icon name="chevrondown" aria-hidden />}
           disabled={!isCompatible}
           onClick={() => setIsExpanded(!isExpanded)}
         >

--- a/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
+++ b/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
@@ -24,6 +24,7 @@ export const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
       className,
 
       parameters,
+      linkedFilterParameters = parameters,
       question,
       dashboard,
       editingParameter,
@@ -78,7 +79,7 @@ export const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
         isEditing={isEditing}
         isFullscreen={isFullscreen}
         parameter={valuePopulatedParameter}
-        parameters={parameters}
+        parameters={linkedFilterParameters}
         question={question}
         dashboard={dashboard}
         editingParameter={editingParameter}

--- a/frontend/src/metabase/parameters/components/ParametersList/types.ts
+++ b/frontend/src/metabase/parameters/components/ParametersList/types.ts
@@ -17,6 +17,7 @@ export type ParametersListProps = {
     question: Question;
     dashboard: Dashboard | null;
     editingParameter: Parameter | null | undefined;
+    linkedFilterParameters: Parameter[];
 
     isEditing: boolean;
     isSortable?: boolean;


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/62627

Before, linking a inline card parameter to a top-level dashboard parameter had no effect. This PR fixes the issue. 

How to verify:
- Open a dashboard with a question based on Orders
- Add a top-level filter for Vendor
- Add a card-local filter for Category and link it to Vendor
- Save the dashboard
- Set the value for Vendor
- Make sure that the list of categories for Category is limited