### PR TITLE
Fix: UXW-564 CMD-Z on an existing Document removes all content (+ other edge case)

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -215,6 +215,34 @@ H.describeWithSnowplowEE("documents", () => {
           });
         });
       });
+
+      it("should handle undo/redo properly, resetting the history whenever a different document is viewed", () => {
+        const isMac = Cypress.platform === "darwin";
+        const metaKey = isMac ? "Meta" : "Control";
+        cy.get("@documentId").then((id) => cy.visit(`/document/${id}`));
+        H.getDocumentCard("Orders").should("exist");
+        H.documentContent().within(() => {
+          const originalText = "Lorem Ipsum and some more words";
+          const originalExact = new RegExp(`^${originalText}$`);
+          cy.contains(originalExact).click();
+          cy.realPress([metaKey, "z"]);
+          cy.contains(originalExact);
+
+          const modification = " etc.";
+          const modifiedExact = new RegExp(`^${originalText}${modification}$`);
+          H.addToDocument(modification, false);
+          cy.contains(modifiedExact);
+          cy.realPress([metaKey, "z"]);
+          cy.contains(originalExact);
+          cy.realPress(["Shift", metaKey, "z"]);
+          cy.contains(modifiedExact);
+          cy.realPress([metaKey, "z"]); // revert to prevent "unsaved changes" dialog
+        });
+        H.newButton("Document").click();
+        H.documentContent().should("have.text", "");
+        cy.realPress([metaKey, "z"]);
+        H.documentContent().should("have.text", "");
+      });
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
@@ -164,7 +164,11 @@ export const Editor: React.FC<EditorProps> = ({
     if (editor && initialContent !== undefined) {
       // Use Promise.resolve() to avoid flushSync warning
       Promise.resolve().then(() => {
-        editor.commands.setContent(initialContent || "");
+        editor
+          .chain()
+          .setMeta("addToHistory", false)
+          .setContent(initialContent || "")
+          .run();
       });
     }
   }, [editor, initialContent]);


### PR DESCRIPTION
Closes [UXW-564](https://linear.app/metabase/issue/UXW-564)

### Description

Resets document undo/redo history when a new one loads in

### How to verify

1. Bookmark a couple documents (not strictly necessary, but makes testing easier)
2. Navigate to a document
3. Press cmd/ctrl+z
4. Verify no changes were made
5. Make some edits
6. Hold cmd/ctrl+z until all edits were reverted
7. Verify document appears as it did when it was loaded
8. Navigate to a different document (e.g. via bookmarks in the hamburger menu)
9. Press cmd/ctrl+z
10. Verify no changes were made
11. New -> Document
12. Press cmd/ctrl+z
13. Verify no changes were made

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
