### PR TITLE
Fix references to pre-56 Troubleshooting admin menu

### DIFF
--- a/docs/configuring-metabase/log-configuration.md
+++ b/docs/configuring-metabase/log-configuration.md
@@ -11,7 +11,7 @@ Metabase logs quite a bit of information by default. Metabase uses [Log4j 2](htt
 
 ## View and download Metabase logs
 
-You can find Metabase logs in **Admin settings** > **Troubleshooting** > **Logs**. You can filter the logs by keywords (for example, "sync") and download them as a text file.
+You can find Metabase logs in **Admin settings** > **Tools** > **Logs**. You can filter the logs by keywords (for example, "sync") and download them as a text file.
 
 If you're running self-hosted Metabase, you'll also be able see the logs in the terminal.
 
@@ -25,7 +25,7 @@ Metabase uses [log4j](https://logging.apache.org/log4j/2.x/)for logging configur
 
 ### Temporary override logging configuration
 
-To temporarily adjust the logging configuration, go to **Admin settings** > **Troubleshooting** > **Logs** and click on **Customize log levels**.
+To temporarily adjust the logging configuration, go to **Admin settings** > **Tools** > **Logs** and click on **Customize log levels**.
 
 You can select from log level presets for common troubleshooting tasks (for example, troubleshooting sync issues), or provide your own configuration as a JSON. For example, here's an override configuration that increases logging for troubleshooting linked filters:
 

--- a/docs/installation-and-operation/running-metabase-on-azure.md
+++ b/docs/installation-and-operation/running-metabase-on-azure.md
@@ -165,7 +165,7 @@ Change the version of the container to the new version in the **Full Image Name 
 
 Visit your web app in Azure, and navigate to **Monitoring -> Log stream**.
 
-You should be able to see the logs as well inside Metabase by going to Settings -> Admin -> Troubleshooting -> Logs.
+You should be able to see the logs as well inside Metabase by going to Settings -> Admin -> Tools -> Logs.
 
 ### Performance tuning
 

--- a/docs/troubleshooting-guide/cant-send-email.md
+++ b/docs/troubleshooting-guide/cant-send-email.md
@@ -20,7 +20,7 @@ Before any other troubleshooting, try sending a test email to isolate the proble
 2. Confirm that your host, port, email address, and password are entered correctly. If they are, click **Save changes**. If your changes have successfully saved, you'll see an option to **Send test email**.
 3. Click **Send test email**. The test email will go the address associated with your Metabase account.
 4. Verify that the email is delivered to your account.
-5. If the message is not sent or an error message is displayed in Metabase, try to use the same account credentials in another email program and see if they work. See the logs for more detailed error by navigating to **Troubleshooting** and click **Logs** in the left sidebar.
+5. If the message is not sent or an error message is displayed in Metabase, try to use the same account credentials in another email program and see if they work. See the logs for more detailed error by navigating to **Tools** and click **Logs** in the left sidebar.
 
 ## Is the mail server actually sending the message?
 

--- a/docs/troubleshooting-guide/db-connection.md
+++ b/docs/troubleshooting-guide/db-connection.md
@@ -18,7 +18,7 @@ If your database connection is successful, but the tables aren't showing up in t
 
    - If Metabase is taking a long time to sync, go to [Troubleshooting syncs and scans](./sync-fingerprint-scan.md).
 
-2. Go to **Admin** > **Troubleshooting** > **Logs** to check if Metabase failed to sync [due to an error](#common-database-connection-errors).
+2. Go to **Admin** > **Tools** > **Logs** to check if Metabase failed to sync [due to an error](#common-database-connection-errors).
 
    - If the logs feel overwhelming, check out [How to read the server logs](./server-logs.md).
 
@@ -52,7 +52,7 @@ If you see this error message in the Metabase interface, go to [Troubleshooting 
 
 ### Connections cannot be acquired from the underlying database
 
-If you see this error messages in the [logs](./server-logs.md) (**Admin** > **Troubleshooting** > **Logs**):
+If you see this error messages in the [logs](./server-logs.md) (**Admin** > **Tools** > **Logs**):
 
 1. Go to **Admin** > **Databases** and select your database.
 2. Go to **Advanced options** > **Additional JDBC connection string options** and add `trustServerCertificate=true`.

--- a/docs/troubleshooting-guide/diagnostic-info.md
+++ b/docs/troubleshooting-guide/diagnostic-info.md
@@ -23,7 +23,7 @@ What data Metabase captures depends on the page you're on when you request diagn
 
 Metabase will log errors, both on the server and in the browser console, depending on where the error occurs, which can help you track down an issue. Administrators will have access to the server logs, and everyone with a browser can open the developer tools to see the console logs.
 
-**Accessing the Metabase server logs**: You can look for the logs that Metabase leaves on the server's file system (or wherever else you collect logs). If you're logged into Metabase with an Admin account, you can also access the logs by going to the top right of the screen and clicking on the **gear** icon > **Admin settings** > **Troubleshooting** > **Logs**. Check out [How to read the server logs](./server-logs.md)
+**Accessing the Metabase server logs**: You can look for the logs that Metabase leaves on the server's file system (or wherever else you collect logs). If you're logged into Metabase with an Admin account, you can also access the logs by going to the top right of the screen and clicking on the **gear** icon > **Admin settings** > **Tools** > **Logs**. Check out [How to read the server logs](./server-logs.md)
 
 **Checking for Javascript console errors:** Metabase will send debugging information and errors to your browser's developer console. To open the developer console, follow the instructions for your web browser:
 

--- a/docs/troubleshooting-guide/loading-from-h2.md
+++ b/docs/troubleshooting-guide/loading-from-h2.md
@@ -18,7 +18,7 @@ You've installed Metabase, but:
 
 **Steps to take:**
 
-1. To check what you're using as the app database, go to **Admin Panel**, open the **Troubleshooting** tab, scroll down to "Diagnostic Info", and look for the `application-database` key in the JSON it displays.
+1. To check what you're using as the app database, go to **Admin Panel**, open the **Tools** tab, scroll down to "Diagnostic Info", and look for the `application-database` key in the JSON it displays.
 2. See [Migrating from H2](../installation-and-operation/migrating-from-h2.md) for instructions on how to migrate to a more robust app database.
 
 ## Are you trying to migrate the application database from H2 to something else?

--- a/docs/troubleshooting-guide/saml.md
+++ b/docs/troubleshooting-guide/saml.md
@@ -14,7 +14,7 @@ Verify that the application you created in your IdP supports SAML. Sometimes oth
 
 ## Is the issuer or Entity ID correct?
 
-After filling out the authentication form with your identity provider, you're taken back to Metabase but it throws an error. To see the error, go to **Admin settings** > **Troubleshooting** > **Logs**. You'll see an error that says something like **Incorrect response <issuer\>**.
+After filling out the authentication form with your identity provider, you're taken back to Metabase but it throws an error. To see the error, go to **Admin settings** > **Tools** > **Logs**. You'll see an error that says something like **Incorrect response <issuer\>**.
 
 **Root cause**: Your issuer or Entity ID is incorrect.
 
@@ -29,7 +29,7 @@ After filling out the authentication form with your identity provider, you're ta
 
 ## Is the SAML identity provider certificate value correct?
 
-After filling out the authentication form with your identity provider, you go back to Metabase but it throws an error. Go to **Admin settings** > **Troubleshooting** > **Logs**. You'll see an error that says something like **Invalid assertion error <issuer\>**.
+After filling out the authentication form with your identity provider, you go back to Metabase but it throws an error. Go to **Admin settings** > **Tools** > **Logs**. You'll see an error that says something like **Invalid assertion error <issuer\>**.
 
 **Root cause**: The certificate value you entered is incorrect.
 

--- a/docs/troubleshooting-guide/sync-fingerprint-scan.md
+++ b/docs/troubleshooting-guide/sync-fingerprint-scan.md
@@ -19,7 +19,7 @@ Once you've confirmed that you're looking at a non-cached view of your tables an
 ## Syncing
 
 1. Make sure your database driver is up to date.
-2. Go to **Admin** > **Troubleshooting** > **Logs** to check the status of the sync.
+2. Go to **Admin** > **Tools** > **Logs** to check the status of the sync.
 3. Run a query against your database from the Metabase SQL editor to check for database connection or database privilege errors that aren't listed in the logs:
 
    ```sql
@@ -66,7 +66,7 @@ If the [connection is failing](./db-connection.md) or the database privileges ar
 
 **Explanation**
 
-Metabase will try to unfold JSON and JSONB records during the sync process, which can take up a decent chunk of query execution time. If you have a lot of JSON records, try disabling the automatic unfolding option to pull the sync out of slow-motion. Remember that you can follow the status of the sync from **Admin** > **Troubleshooting** > **Logs**.
+Metabase will try to unfold JSON and JSONB records during the sync process, which can take up a decent chunk of query execution time. If you have a lot of JSON records, try disabling the automatic unfolding option to pull the sync out of slow-motion. Remember that you can follow the status of the sync from **Admin** > **Tools** > **Logs**.
 
 ## Scanning
 
@@ -75,11 +75,11 @@ Metabase will try to unfold JSON and JSONB records during the sync process, whic
 3. Go to the column you want to update, and click the **gear** icon.
 4. Click **Discard cached field values**.
 5. Click **Re-scan this field**.
-6. Go to **Admin** > **Troubleshooting** > **Logs** to follow the status of the scan and debug errors from there.
+6. Go to **Admin** > **Tools** > **Logs** to follow the status of the scan and debug errors from there.
 
 ### Special cases
 
-If you're waiting for the initial scan to run after connecting a database, make sure the initial sync has completed first (remember you can check the status from **Admin** > **Troubleshooting** > **Logs**).
+If you're waiting for the initial scan to run after connecting a database, make sure the initial sync has completed first (remember you can check the status from **Admin** > **Tools** > **Logs**).
 
 **Explanation**
 
@@ -119,7 +119,7 @@ To manually re-trigger a fingerprinting query for a given column:
 
 ### Special cases
 
-If you're waiting for the initial fingerprinting query to run after connecting a database, make sure the initial sync has completed first (remember you can check the status from **Admin** > **Troubleshooting** > **Logs**).
+If you're waiting for the initial fingerprinting query to run after connecting a database, make sure the initial sync has completed first (remember you can check the status from **Admin** > **Tools** > **Logs**).
 
 If you're using MongoDB, Metabase fingerprints the first 10,000 documents per collection. If you're not seeing all of your fields, it's because those fields might not exist in those first 10,000 documents. For more info, see our [MongoDB reference doc](../databases/connections/mongodb.md#i-added-fields-to-my-database-but-dont-see-them-in-metabase).
 


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

### Description

In https://github.com/metabase/metabase/pull/59668, which shipped in 56, we removed the `Troubleshooting` section of Admin settings, and named it `Tools` instead, but the docs were not updated to reflect that. This PR fixes it.

### How to verify

View the docs.

### Demo

N/A

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
