### PR TITLE
Migrate remaining clj-time usages to clojure.java-time

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -28,7 +28,8 @@
                                                            commons-io/commons-io
                                                            slingshot/slingshot]}
   clojure.java-time/clojure.java-time       {:mvn/version "1.4.3"}              ; java.time utilities
-  clojurewerkz/quartzite                    {:mvn/version "2.2.0"               ; scheduling library
+  clojurewerkz/quartzite                    {:git/sha "a1caa514494b2d4d97a71f2f9355e6bae4c51a87"    ;; Clojure wrapper around Quartz scheduler
+                                             :git/url "https://github.com/michaelklishin/quartzite"
                                              :exclusions  [com.mchange.c3p0/c3p0
                                                            com.zaxxer/HikariCP-java7]}
   colorize/colorize                         {:mvn/version "0.1.1"               ; string output with ANSI color codes (for logging)

--- a/deps.edn
+++ b/deps.edn
@@ -28,8 +28,7 @@
                                                            commons-io/commons-io
                                                            slingshot/slingshot]}
   clojure.java-time/clojure.java-time       {:mvn/version "1.4.3"}              ; java.time utilities
-  clojurewerkz/quartzite                    {:git/sha "a1caa514494b2d4d97a71f2f9355e6bae4c51a87"    ;; Clojure wrapper around Quartz scheduler
-                                             :git/url "https://github.com/michaelklishin/quartzite"
+  clojurewerkz/quartzite                    {:mvn/version "2.2.0"               ; scheduling library
                                              :exclusions  [com.mchange.c3p0/c3p0
                                                            com.zaxxer/HikariCP-java7]}
   colorize/colorize                         {:mvn/version "0.1.1"               ; string output with ANSI color codes (for logging)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -3,10 +3,10 @@
    [buddy.core.hash :as buddy-hash]
    [buddy.sign.jwt :as jwt]
    [clj-http.client :as http]
-   [clj-time.core :as time]
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
+   [java-time.api :as t]
    [malli.core :as mc]
    [malli.transform :as mtx]
    [metabase-enterprise.metabot-v3.client.schema :as metabot-v3.client.schema]
@@ -38,7 +38,7 @@
   ([user-id metabot-id]
    (let [secret (buddy-hash/sha256 (metabot-v3.settings/site-uuid-for-metabot-tools))
          claims {:user       user-id
-                 :exp        (time/plus (time/now) (time/seconds (metabot-v3.settings/metabot-ai-service-token-ttl)))
+                 :exp        (t/plus (t/instant) (t/seconds (metabot-v3.settings/metabot-ai-service-token-ttl)))
                  :metabot-id metabot-id}]
      (jwt/encrypt claims secret {:alg :dir, :enc :a128cbc-hs256}))))
 

--- a/src/metabase/logger/core.clj
+++ b/src/metabase/logger/core.clj
@@ -4,12 +4,11 @@
   logger that clojure.tools.logging uses."
   (:require
    [amalloy.ring-buffer :refer [ring-buffer]]
-   [clj-time.coerce :as time.coerce]
-   [clj-time.format :as time.format]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [clojure.tools.logging :as log]
    [clojure.tools.logging.impl :as log.impl]
    [flatland.ordered.map :as ordered-map]
+   [java-time.api :as t]
    [metabase.classloader.core :as classloader]
    [metabase.config.core :as config])
   (:import
@@ -39,8 +38,7 @@
     s))
 
 (defn- event->log-data [^LogEvent event]
-  {:timestamp    (time.format/unparse (time.format/formatter :date-time)
-                                      (time.coerce/from-long (.getTimeMillis event)))
+  {:timestamp    (t/format :iso-instant (t/instant (.getTimeMillis event)))
    :level        (.getLevel event)
    :fqns         (.getLoggerName event)
    :msg          (elide-string (str (.getMessage event)) 4000)

--- a/src/metabase/revisions/models/revision/last_edit.clj
+++ b/src/metabase/revisions/models/revision/last_edit.clj
@@ -8,8 +8,8 @@
   `:email`. It is not a full User object (missing some superuser metadata, last login time, and a common name). This
   was done to prevent another db call and hooking up timestamps to users but this can be added if preferred."
   (:require
-   [clj-time.core :as time]
    [clojure.set :as set]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -69,7 +69,7 @@
   last-edit-info, you must construct it from `@api/*current-user*` and the current timestamp rather than checking the
   revisions table as those revisions may not be present yet."
   [user]
-  (merge {:timestamp (time/now)}
+  (merge {:timestamp (t/instant)}
          (select-keys user [:id :first_name :last_name :email])))
 
 (def ^:private CollectionLastEditInfo

--- a/test/metabase/embedding/api/embed_test.clj
+++ b/test/metabase/embedding/api/embed_test.clj
@@ -3,13 +3,13 @@
   (:require
    [buddy.sign.jwt :as jwt]
    [buddy.sign.util :as buddy-util]
-   [clj-time.core :as time]
    [clojure.data.csv :as csv]
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [crypto.random :as crypto-random]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
+   [java-time.api :as t]
    [metabase.config.core :as config]
    [metabase.dashboards.api-test :as api.dashboard-test]
    [metabase.embedding.api.common :as api.embed.common]
@@ -158,7 +158,7 @@
   {:auto_apply_filters true, :description nil, :parameters [], :dashcards [], :tabs [],
    :param_fields {} :width "fixed"})
 
-(def ^:private yesterday (time/minus (time/now) (time/days 1)))
+(def ^:private yesterday (t/minus (t/instant) (t/days 1)))
 
 ;;; ------------------------------------------- GET /api/embed/card/:token -------------------------------------------
 

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -1,10 +1,10 @@
 (ns ^:mb/driver-tests metabase.query-processor.pivot-test
   "Tests for pivot table actions for the query processor"
   (:require
-   [clj-time.core :as time]
    [clojure.set :as set]
    [clojure.test :refer :all]
    [clojure.walk :as walk]
+   [java-time.api :as t]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -130,7 +130,7 @@
               :filter       [:and
                              [:= $user_id->people.source "Facebook" "Google"]
                              [:= $product_id->products.category "Doohickey" "Gizmo"]
-                             [:time-interval $created_at (- 2019 (.getYear (time/now))) :year {}]]})
+                             [:time-interval $created_at (- 2019 (t/as (t/local-date) :year)) :year {}]]})
            {:pivot-rows [0 1 2]
             :pivot-cols []})))
 

--- a/test/metabase/query_processor_test/implicit_joins_test.clj
+++ b/test/metabase/query_processor_test/implicit_joins_test.clj
@@ -1,8 +1,8 @@
 (ns ^:mb/driver-tests metabase.query-processor-test.implicit-joins-test
   "Tests for joins that are created automatically when an `:fk->` column is present."
   (:require
-   [clj-time.core :as time]
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.lib.core :as lib]
    [metabase.lib.test-util :as lib.tu]
@@ -166,7 +166,7 @@
                        :filter      [:and
                                      [:= $user_id->people.source "Facebook" "Google"]
                                      [:= $product_id->products.category "Doohickey" "Gizmo"]
-                                     [:time-interval $created_at (- 2020 (.getYear (time/now))) :year]]
+                                     [:time-interval $created_at (- 2020 (t/as (t/local-date) :year)) :year]]
                        :expressions {:pivot-grouping [:abs 0]}
                        :limit       5})]
           (mt/with-native-query-testing-context query

--- a/test/metabase/sync/sync_metadata/sync_timezone_test.clj
+++ b/test/metabase/sync/sync_metadata/sync_timezone_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.sync.sync-metadata.sync-timezone-test
   (:require
-   [clj-time.core :as time]
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
    [java-time.api :as t]
@@ -47,26 +46,32 @@
     (testing (str "This tests populating the timezone field for a given database. The sync happens automatically, so "
                   "this test removes it first to ensure that it gets set when missing")
       (mt/dataset test-data
-        (let [db                               (mt/db)
-              tz-on-load                       (db-timezone db)
-              _                                (t2/update! :model/Database (:id db) {:timezone nil})
-              tz-after-update                  (db-timezone db)
-              ;; It looks like we can get some stale timezone information depending on which thread is used for querying the
-              ;; database in sync. Clearing the connection pool to ensure we get the most updated TZ data
-              _                                (driver/notify-database-updated driver/*driver* db)
-              {:keys [step-info task-history]} (sync.util-test/sync-database! "sync-timezone" db)]
-          (testing "only step keys"
-            (is (= {:timezone-id "UTC"}
-                   (sync.util-test/only-step-keys step-info))))
-          (testing "task details"
-            (is (= {:timezone-id "UTC"}
-                   (:task_details task-history))))
-          (testing "On startup is the timezone specified?"
-            (is (time/time-zone-for-id tz-on-load)))
-          (testing "Check to make sure the test removed the timezone"
-            (is (nil? tz-after-update)))
-          (testing "Check that the value was set again after sync"
-            (is (time/time-zone-for-id (db-timezone db)))))))))
+        (try
+          (let [db                               (mt/db)
+                tz-on-load                       (db-timezone db)
+                _                                (t2/update! :model/Database (:id db) {:timezone nil})
+                tz-after-update                  (db-timezone db)
+                ;; It looks like we can get some stale timezone information depending on which thread is used for querying the
+                ;; database in sync. Clearing the connection pool to ensure we get the most updated TZ data
+                _                                (driver/notify-database-updated driver/*driver* db)
+                {:keys [step-info task-history]} (sync.util-test/sync-database! "sync-timezone" (assoc db :timezone nil))]
+            (testing "only step keys"
+              (is (= {:timezone-id "UTC"}
+                     (sync.util-test/only-step-keys step-info))))
+            (testing "task details"
+              (is (= {:timezone-id "UTC"}
+                     (:task_details task-history))))
+            (testing "On startup is the timezone specified?"
+              (is (not (nil? tz-on-load)))
+              (is (java.time.ZoneId/of tz-on-load)))
+            (testing "Check to make sure the test removed the timezone"
+              (is (nil? tz-after-update)))
+            (testing "Check that the value was set again after sync"
+              (is (not (nil? (db-timezone db))))
+              (is (java.time.ZoneId/of (db-timezone db)))))
+          (finally
+            ;; Make sure to reset the timezone to UTC in case the test failed
+            (t2/update! :model/Database (:id (mt/db)) {:timezone "UTC"})))))))
 
 (deftest sync-timezone-mysql-test
   (mt/test-driver :mysql


### PR DESCRIPTION
Context: https://metaboat.slack.com/archives/CKZEMT1MJ/p1756136655627089

We only have a handful of `clj-time` usages left in the code base, so it's a small push to convert them to `clojure.java-time` and then be able to remove `clj-time` as a dep. 

This PR migrates the remaining usages of `clj-time`. It seems like we only include it as a transitive dep via [quartzite](https://github.com/michaelklishin/quartzite) anyway, and quartzite removes it in its most recent commit [here](https://github.com/michaelklishin/quartzite/pull/47), but 2.3.0 hasn't yet been released.