### PR TITLE
Skip loading field values when possible in Table metadata

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -38,6 +38,7 @@ describe("scenarios > admin > datamodel", () => {
     cy.intercept("GET", "/api/table/*/query_metadata*").as("metadata");
     cy.intercept("GET", "/api/database/*/schema/*").as("schema");
     cy.intercept("POST", "/api/dataset*").as("dataset");
+    cy.intercept("GET", "/api/field/*/values").as("fieldValues");
     cy.intercept("PUT", "/api/field/*", cy.spy().as("updateFieldSpy")).as(
       "updateField",
     );
@@ -1599,6 +1600,24 @@ describe("scenarios > admin > datamodel", () => {
 
         cy.realPress("Escape");
         H.modal().should("not.exist");
+      });
+
+      it("should not automatically re-fetch field values when they are discarded unless 'Custom mapping' is used (metabase#62626)", () => {
+        H.DataModel.visit({
+          databaseId: SAMPLE_DB_ID,
+          schemaId: SAMPLE_DB_SCHEMA_ID,
+          tableId: PRODUCTS_ID,
+          fieldId: PRODUCTS.CATEGORY,
+        });
+
+        FieldSection.getFieldValuesButton().click();
+        H.modal().within(() => {
+          cy.button("Discard cached field values").click();
+          cy.button("Discard triggered!").should("be.visible");
+          cy.button("Discard triggered!").should("not.exist");
+        });
+
+        cy.get("@fieldValues.all").should("have.length", 0);
       });
     });
 

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection/RemappingPicker/DisplayValuesPicker/DisplayValuesPicker.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection/RemappingPicker/DisplayValuesPicker/DisplayValuesPicker.module.css
@@ -22,5 +22,6 @@
 }
 
 .infoIcon {
+  display: block;
   pointer-events: all;
 }

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection/RemappingPicker/RemappingPicker.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection/RemappingPicker/RemappingPicker.tsx
@@ -329,6 +329,7 @@ export const RemappingPicker = ({
                   p={0}
                   size="compact-xs"
                   variant="subtle"
+                  disabled={isLoadingFieldValues}
                   onClick={() => setIsCustomMappingOpen(true)}
                 >
                   {t`Edit mapping`}

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection/RemappingPicker/RemappingPicker.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection/RemappingPicker/RemappingPicker.tsx
@@ -62,11 +62,10 @@ export const RemappingPicker = ({
   const [hasChanged, setHasChanged] = useState(false);
   const [isCustomMappingOpen, setIsCustomMappingOpen] = useState(false);
   const [isFkTargetTouched, setIsFkTargetTouched] = useState(false);
+  const [isChoosingType, setIsChoosingType] = useState(false);
   const [isChoosingInitialFkTarget, setIsChoosingInitialFkTarget] =
     useState(false);
   const id = getRawTableFieldId(field);
-  const { data: fieldValues, error: fieldValuesError } =
-    useGetFieldValuesQuery(id);
   const { data: fkTargetField } = useGetFieldQuery(
     field.fk_target_field_id == null
       ? skipToken
@@ -91,6 +90,13 @@ export const RemappingPicker = ({
   const tables = useMemo(() => [fkTargetTable], [fkTargetTable]);
 
   const value = useMemo(() => getValue(field), [field]);
+  const {
+    data: fieldValues,
+    error: fieldValuesError,
+    isLoading: isLoadingFieldValues,
+  } = useGetFieldValuesQuery(id, {
+    skip: value !== "custom" && !isChoosingType,
+  });
   const options = useMemo(() => {
     return getOptions(field, fieldValues?.values, fkTargetTable);
   }, [field, fieldValues, fkTargetTable]);
@@ -241,8 +247,12 @@ export const RemappingPicker = ({
   return (
     <Stack gap={0}>
       <DisplayValuesPicker
-        options={options}
         value={isFkMapping ? "foreign" : value}
+        options={options}
+        isLoadingFieldValues={isLoadingFieldValues}
+        dropdownOpened={isChoosingType}
+        onDropdownOpen={() => setIsChoosingType(true)}
+        onDropdownClose={() => setIsChoosingType(false)}
         onChange={handleDisplayValueChange}
         {...props}
       />

--- a/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection/RemappingPicker/RemappingPicker.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/FieldSection/BehaviorSection/RemappingPicker/RemappingPicker.tsx
@@ -62,7 +62,7 @@ export const RemappingPicker = ({
   const [hasChanged, setHasChanged] = useState(false);
   const [isCustomMappingOpen, setIsCustomMappingOpen] = useState(false);
   const [isFkTargetTouched, setIsFkTargetTouched] = useState(false);
-  const [isChoosingType, setIsChoosingType] = useState(false);
+  const [isChoosingDisplayValue, setIsChoosingDisplayValue] = useState(false);
   const [isChoosingInitialFkTarget, setIsChoosingInitialFkTarget] =
     useState(false);
   const id = getRawTableFieldId(field);
@@ -95,7 +95,7 @@ export const RemappingPicker = ({
     error: fieldValuesError,
     isLoading: isLoadingFieldValues,
   } = useGetFieldValuesQuery(id, {
-    skip: value !== "custom" && !isChoosingType,
+    skip: value !== "custom" && !isChoosingDisplayValue,
   });
   const options = useMemo(() => {
     return getOptions(field, fieldValues?.values, fkTargetTable);
@@ -250,9 +250,9 @@ export const RemappingPicker = ({
         value={isFkMapping ? "foreign" : value}
         options={options}
         isLoadingFieldValues={isLoadingFieldValues}
-        dropdownOpened={isChoosingType}
-        onDropdownOpen={() => setIsChoosingType(true)}
-        onDropdownClose={() => setIsChoosingType(false)}
+        dropdownOpened={isChoosingDisplayValue}
+        onDropdownOpen={() => setIsChoosingDisplayValue(true)}
+        onDropdownClose={() => setIsChoosingDisplayValue(false)}
         onChange={handleDisplayValueChange}
         {...props}
       />


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/62626

Delays loading field values until either the "Filtering type" picker is opened, or the value is `Custom mapping`. This avoids the issue that we refetch the field values immediately after discarding them in all cases.

We still need to fetch field values for `custom` values in all cases because we show a special error message even before the modal for editing values can be opened.

<img width="397" height="255" alt="Screenshot 2025-08-25 at 15 33 44" src="https://github.com/user-attachments/assets/e4e84258-0955-4f18-a59e-90fe669393a2" />
