### PR TITLE
Better branch detection if relevant files are changed for CI

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -44,7 +44,7 @@ jobs:
             echo "A relevant team label is present. Tier 3 driver tests will run."
           else
             echo "Checking for changes in relevant folders..."
-            CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
+            CHANGED_FILES=$(git diff --name-only $(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.sha }}) ${{ github.sha }})
 
             # Initialize an empty array to store folders with changes
             CHANGED_FOLDERS=()


### PR DESCRIPTION
I noticed that
https://github.com/metabase/metabase/pull/62513/files?file-filters%5B%5D=.clj&show-viewed-files=true that the third tier drivers were running. Checking the action output https://github.com/metabase/metabase/actions/runs/17220604727/job/48854867380?pr=62513 i see :

```
Is master or release: false
Has '.Team/Drivers' or '.Team/Querying' or '.Team/SemanticLayer' label: false
Checking for changes in relevant folders...
Changes detected in the following folders: src/metabase/lib src/metabase/query_processor.
Tier 3 driver tests will run.
```

So it thinks that something changed in src/metabase/lib/* and src/metabase/query_processor/*

This branch
ds/clo-4370-button-in-metabase-admin-section-to-purchase-metabot-ai-add targets master. And the diff is checking the diff of files between the state of master and the PR. Which means if any changes have landed in master affecting those areas this diff will report positive.

At the time of this writing this is:
```
❯ git diff --name-only c6a9193bff49517f767467ba6699c8baf790dd81 462d83c5c25 | wc -l
    1259
```

Where c6a9 is master and 462 is the branch.

A better option is to find where the branch and the merge target share a common ancestor and then check for changes from there.

```
❯ git diff --name-only $(git merge-base c6a9193bff4 462d83c5c25) 462d83c5c25 | wc -l
      32
```

So we use `git merge-base <master> <branch>` and then diff that sha against the branch.

```
git diff --name-only (git merge-base <base> <pr-branch>) <pr-branch>
```

And we get:

```
❯ git merge-base c6a9193bff4 462d83c5c25
37e6eee3116d33cd48821d8dc2afb1e2dcfef4e5

❯ git show 37e6eee3116d33cd48821d8dc2afb1e2dcfef4e5
commit 37e6eee3116d33cd48821d8dc2afb1e2dcfef4e5
Author: Phoomparin Mano <poom@metabase.com>
Date:   Wed Aug 20 01:40:19 2025 +0700

    Add the metabase-browser custom element to Embed JS (#60828)

    Co-authored-by: cubic-dev-ai[bot]
    <191113872+cubic-dev-ai[bot]@users.noreply.github.com>
```

Which is the common root. Then the diff from there:

```
❯  git diff --name-only $(git merge-base c6a9193bff4 462d83c5c25) 462d83c5c25
.clj-kondo/config/modules/config.edn
enterprise/backend/src/metabase_enterprise/api/routes.clj
enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
enterprise/backend/src/metabase_enterprise/harbormaster/client.clj
enterprise/backend/test/metabase_enterprise/api/session_test.clj
enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage.tsx
enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage.unit.spec.tsx
enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchaseSettingUpModal.tsx
enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
frontend/src/metabase-types/api/metabot.ts
frontend/src/metabase-types/api/mocks/settings.ts
frontend/src/metabase-types/api/settings.ts
frontend/src/metabase/admin/app/reducers.ts
frontend/src/metabase/admin/routes.jsx
frontend/src/metabase/api/metabot.ts
frontend/src/metabase/api/utils/use-token-refresh.ts
frontend/src/metabase/common/components/AdminLayout/AdminSettingsLayout.tsx
frontend/src/metabase/plugins/index.ts
resources/frontend_client/app/assets/img/metabot-cloud-96x96.svg
src/metabase/cloud_migration/core.clj
src/metabase/cloud_migration/models/cloud_migration.clj
src/metabase/cloud_migration/settings.clj
src/metabase/core/init.clj
src/metabase/premium_features/core.clj
src/metabase/premium_features/settings.clj
src/metabase/premium_features/token_check.clj
src/metabase/server/middleware/security.clj
src/metabase/store_api/core.clj
src/metabase/store_api/init.clj
src/metabase/store_api/settings.clj
test/metabase/analytics/stats_test.clj
```

And now we have a correct list of files changed in that PR, not just files different between current master and current PR.
