### PR TITLE
fix overflowing text in tables

### DIFF
--- a/frontend/src/metabase/lib/formatting/email.tsx
+++ b/frontend/src/metabase/lib/formatting/email.tsx
@@ -2,6 +2,7 @@ import ExternalLink from "metabase/common/components/ExternalLink";
 import { getDataFromClicked } from "metabase-lib/v1/parameters/utils/click-behavior";
 
 import { renderLinkTextForClick } from "./link";
+import { removeNewLines } from "./strings";
 import type { OptionsType } from "./types";
 
 // https://github.com/angular/angular.js/blob/v1.6.3/src/ng/directive/input.js#L27
@@ -10,7 +11,14 @@ const EMAIL_ALLOW_LIST_REGEX =
 
 export function formatEmail(
   value: string,
-  { jsx, rich, view_as = "auto", link_text, clicked }: OptionsType = {},
+  {
+    jsx,
+    rich,
+    view_as = "auto",
+    link_text,
+    clicked,
+    collapseNewlines,
+  }: OptionsType = {},
 ) {
   const email = String(value);
   const label =
@@ -24,10 +32,12 @@ export function formatEmail(
     (view_as === "email_link" || view_as === "auto") &&
     EMAIL_ALLOW_LIST_REGEX.test(email)
   ) {
-    return (
-      <ExternalLink href={"mailto:" + email}>{label || email}</ExternalLink>
-    );
+    let displayText = label || email;
+    if (collapseNewlines) {
+      displayText = removeNewLines(displayText);
+    }
+    return <ExternalLink href={"mailto:" + email}>{displayText}</ExternalLink>;
   } else {
-    return email;
+    return collapseNewlines ? removeNewLines(email) : email;
   }
 }

--- a/frontend/src/metabase/lib/formatting/strings.ts
+++ b/frontend/src/metabase/lib/formatting/strings.ts
@@ -52,7 +52,7 @@ export function removeNewLines<T>(value: T) {
   if (typeof value === "string") {
     // Replace all common newline sequences with a single space
     // Handles: \r\n (Windows), \r (old Mac), \n (Unix), and Unicode line/paragraph separators
-    return value.replace(/\r\n|\r|\n|\u2028|\u2029/g, " ");
+    return value.replace(/\r\n|\r|\n|\u0085|\u2028|\u2029/g, " ");
   }
   return value;
 }

--- a/frontend/src/metabase/lib/formatting/strings.ts
+++ b/frontend/src/metabase/lib/formatting/strings.ts
@@ -47,3 +47,12 @@ export function conjunct(list: string[], conjunction: string) {
 export function stripId(name: string) {
   return name?.replace(/ id$/i, "").trim();
 }
+
+export function removeNewLines<T>(value: T) {
+  if (typeof value === "string") {
+    // Replace all common newline sequences with a single space
+    // Handles: \r\n (Windows), \r (old Mac), \n (Unix), and Unicode line/paragraph separators
+    return value.replace(/\r\n|\r|\n|\u2028|\u2029/g, " ");
+  }
+  return value;
+}

--- a/frontend/src/metabase/lib/formatting/types.ts
+++ b/frontend/src/metabase/lib/formatting/types.ts
@@ -39,4 +39,5 @@ export interface OptionsType extends TimeOnlyOptions {
   type?: string;
   view_as?: string | null;
   weekday_enabled?: boolean;
+  collapseNewlines?: boolean;
 }

--- a/frontend/src/metabase/lib/formatting/url.tsx
+++ b/frontend/src/metabase/lib/formatting/url.tsx
@@ -9,6 +9,7 @@ import { getDataFromClicked } from "metabase-lib/v1/parameters/utils/click-behav
 import { isURL } from "metabase-lib/v1/types/utils/isa";
 
 import { renderLinkTextForClick, renderLinkURLForClick } from "./link";
+import { removeNewLines } from "./strings";
 import type { OptionsType } from "./types";
 import { formatValue, getRemappedValue } from "./value";
 
@@ -34,7 +35,7 @@ export function getUrlProtocol(url: string) {
 }
 
 export function formatUrl(value: string, options: OptionsType = {}) {
-  const { jsx, rich, column } = options;
+  const { jsx, rich, column, collapseNewlines } = options;
 
   const url = getLinkUrl(value, options);
 
@@ -63,27 +64,29 @@ export function formatUrl(value: string, options: OptionsType = {}) {
     // Even when no URL is found, return a formatted value
     return formatValue(value, { ...options, view_as: null });
   } else {
-    return value;
+    return collapseNewlines ? removeNewLines(value) : value;
   }
 }
 
 function getLinkText(value: string, options: OptionsType) {
-  const { view_as, link_text, clicked } = options;
+  const { view_as, link_text, clicked, collapseNewlines } = options;
 
   const isExplicitLink = view_as === "link";
   const hasCustomizedText = link_text && clicked;
 
+  let text;
   if (isExplicitLink && hasCustomizedText) {
-    return renderLinkTextForClick(
+    text = renderLinkTextForClick(
       link_text,
       getDataFromClicked(clicked) as any,
     );
+  } else {
+    text =
+      getRemappedValue(value, options) ||
+      formatValue(value, { ...options, view_as: null });
   }
 
-  return (
-    getRemappedValue(value, options) ||
-    formatValue(value, { ...options, view_as: null })
-  );
+  return collapseNewlines ? removeNewLines(text) : text;
 }
 
 function getLinkUrl(

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -30,6 +30,7 @@ import { formatEmail } from "./email";
 import { formatCoordinate } from "./geography";
 import { formatImage } from "./image";
 import { formatNumber } from "./numbers";
+import { removeNewLines } from "./strings";
 import { formatTime } from "./time";
 import type { OptionsType } from "./types";
 import { formatUrl } from "./url";
@@ -125,6 +126,9 @@ function formatStringFallback(value: any, options: OptionsType = {}) {
       value = formatImage(value, options);
     }
   }
+  if (typeof value === "string" && options.collapseNewlines) {
+    value = removeNewLines(value);
+  }
   return value;
 }
 
@@ -206,7 +210,7 @@ export function formatValueRaw(
       return formatImage(value, options);
     }
     if (column?.semantic_type) {
-      return value;
+      return options.collapseNewlines ? removeNewLines(value) : value;
     }
     return formatStringFallback(value, options);
   } else if (typeof value === "number" && isCoordinate(column)) {
@@ -231,7 +235,8 @@ export function formatValueRaw(
     // no extra whitespace for table cells
     return JSON.stringify(value);
   } else {
-    return String(value);
+    const strValue = String(value);
+    return options.collapseNewlines ? removeNewLines(strValue) : strValue;
   }
 }
 

--- a/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/value.unit.spec.tsx
@@ -113,4 +113,159 @@ describe("formatValue", () => {
       expect(screen.getByText("200")).toBeInTheDocument();
     });
   });
+
+  describe("collapseNewlines", () => {
+    it("should collapse newlines in plain text when collapseNewlines is true", () => {
+      const result = formatValue("Line 1\nLine 2\nLine 3", {
+        collapseNewlines: true,
+        jsx: false,
+      });
+      expect(result).toBe("Line 1 Line 2 Line 3");
+    });
+
+    it("should preserve newlines when collapseNewlines is false", () => {
+      const result = formatValue("Line 1\nLine 2\nLine 3", {
+        collapseNewlines: false,
+        jsx: false,
+      });
+      expect(result).toBe("Line 1\nLine 2\nLine 3");
+    });
+
+    it("should preserve newlines when collapseNewlines is not specified", () => {
+      const result = formatValue("Line 1\nLine 2\nLine 3", {
+        jsx: false,
+      });
+      expect(result).toBe("Line 1\nLine 2\nLine 3");
+    });
+
+    it("should collapse newlines in jsx link display text", () => {
+      setup("http://example.com", {
+        collapseNewlines: true,
+        jsx: true,
+        rich: true,
+        view_as: "link",
+        link_text: "Display\nText\nWith\nNewlines",
+        clicked: { value: "http://example.com" },
+      });
+      expect(screen.getByRole("link")).toHaveTextContent(
+        "Display Text With Newlines",
+      );
+    });
+
+    it("should collapse newlines in JSX email link display text", () => {
+      const column = createMockColumn({
+        base_type: "type/Text",
+        semantic_type: "type/Email",
+      });
+      setup("user@example.com", {
+        collapseNewlines: true,
+        jsx: true,
+        rich: true,
+        column,
+        link_text: "Contact\nUser",
+        clicked: { value: "user@example.com" },
+      });
+      expect(screen.getByRole("link")).toHaveTextContent("Contact User");
+    });
+
+    it("should collapse newlines with prefix and suffix", () => {
+      setup("Value\nwith\nnewlines", {
+        collapseNewlines: true,
+        prefix: "Prefix:\n ",
+        suffix: " \n:Suffix",
+        jsx: true,
+      });
+      expect(
+        screen.getByText((content) =>
+          content.includes("Prefix: Value with newlines :Suffix"),
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("should handle null values with collapseNewlines", () => {
+      const result = formatValue(null, {
+        collapseNewlines: true,
+        jsx: false,
+      });
+      expect(result).toBe(null);
+    });
+
+    it("should handle numbers with collapseNewlines", () => {
+      const result = formatValue(123.45, {
+        collapseNewlines: true,
+        jsx: false,
+        column: createMockColumn({ base_type: "type/Float" }),
+      });
+      expect(result).toBe("123.45");
+    });
+
+    it("should collapse newlines in remapped values", () => {
+      const column = createMockColumn({
+        base_type: "type/Integer",
+        remapping: new Map([[1, "Value\nwith\nnewlines"]]),
+      } as any);
+      setup(1, {
+        column,
+        collapseNewlines: true,
+        jsx: true,
+      });
+      expect(screen.getByText("Value with newlines")).toBeInTheDocument();
+    });
+
+    it("should collapse multiple consecutive newlines", () => {
+      const result = formatValue("Line 1\n\n\nLine 2", {
+        collapseNewlines: true,
+        jsx: false,
+      });
+      expect(result).toBe("Line 1   Line 2");
+    });
+
+    it("should collapse Windows CRLF newlines", () => {
+      const result = formatValue("Line 1\r\nLine 2\r\nLine 3", {
+        collapseNewlines: true,
+        jsx: false,
+      });
+      expect(result).toBe("Line 1 Line 2 Line 3");
+    });
+
+    it("should collapse old Mac CR newlines", () => {
+      const result = formatValue("Line 1\rLine 2\rLine 3", {
+        collapseNewlines: true,
+        jsx: false,
+      });
+      expect(result).toBe("Line 1 Line 2 Line 3");
+    });
+
+    it("should collapse mixed newline types", () => {
+      const result = formatValue("Line 1\nLine 2\r\nLine 3\rLine 4", {
+        collapseNewlines: true,
+        jsx: false,
+      });
+      expect(result).toBe("Line 1 Line 2 Line 3 Line 4");
+    });
+
+    it("should collapse Unicode line separators", () => {
+      const result = formatValue("Line 1\u2028Line 2\u2029Line 3", {
+        collapseNewlines: true,
+        jsx: false,
+      });
+      expect(result).toBe("Line 1 Line 2 Line 3");
+    });
+
+    it("should collapse newlines in click behavior link text", () => {
+      setup("Text\nwith\nnewlines", {
+        collapseNewlines: true,
+        jsx: true,
+        rich: true,
+        click_behavior: {
+          type: "link",
+          linkType: "url",
+          linkTemplate: "http://example.com",
+        },
+      });
+      expect(screen.getByTestId("link-formatted-text")).toHaveTextContent(
+        "Text with newlines",
+      );
+    });
+  });
 });

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -64,6 +64,7 @@ import type { ClickObject, OrderByDirection } from "metabase-lib/types";
 import type Question from "metabase-lib/v1/Question";
 import { isFK, isID, isPK } from "metabase-lib/v1/types/utils/isa";
 import type {
+  ColumnSettings,
   DatasetColumn,
   RowValue,
   RowValues,
@@ -78,6 +79,15 @@ import {
 import { MiniBarCell } from "./cells/MiniBarCell";
 import { useObjectDetail } from "./hooks/use-object-detail";
 import { useResetWidthsOnColumnsChange } from "./hooks/use-reset-widths-on-columns-change";
+
+const shouldWrap = (
+  settings: VisualizationSettings,
+  columnSettings: ColumnSettings = {},
+) => {
+  return (
+    !settings["table.pagination"] && Boolean(columnSettings["text_wrapping"])
+  );
+};
 
 const getBodyCellVariant = (column: DatasetColumn): BodyCellVariant => {
   const isPill = isPK(column) || isFK(column);
@@ -243,6 +253,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
     return cols.map((col) => {
       const columnSettings = settings.column?.(col);
       const columnIndex = cols.findIndex((c) => c.name === col.name);
+      const wrap = shouldWrap(settings, columnSettings);
 
       const rich: CellFormatter<RowValue> = memoize(
         (untranslatedValue, rowIndex) => {
@@ -256,6 +267,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
             jsx: true,
             rich: true,
             clicked,
+            collapseNewlines: !wrap,
           });
         },
       );
@@ -468,9 +480,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
     return cols.map((col, columnIndex) => {
       const columnSettings = settings.column?.(col) ?? {};
 
-      const wrap =
-        !settings["table.pagination"] &&
-        Boolean(columnSettings["text_wrapping"]);
+      const wrap = shouldWrap(settings, columnSettings);
       const isMinibar = columnSettings["show_mini_bar"];
       const cellVariant = getBodyCellVariant(col);
       const isImage = columnSettings["view_as"] === "image";


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-584/text-fields-overlap-each-other
Closes https://github.com/metabase/metabase/issues/62628

### Description

Fixes new line characters cause table cell content overflow. This PR collapses newline chars when text wrapping is disabled so that white-spaces are still preserved while cell contents are not wrapped.

### How to verify

```sql
select 1 x, 'asd             asd             asd ' y, '1     
a

aa





a'
union all select 1 x, '=============', '=========='
```
Use the query above to verify that when text wrapping is disabled table cells preserve whitespaces but collapse new lines

### Demo

Before
<img width="668" height="506" alt="Screenshot 2025-08-25 at 6 43 23 PM" src="https://github.com/user-attachments/assets/a1b9f6e1-13d6-4cdb-9d38-0a49ecf4a0ba" />

After
<img width="693" height="394" alt="Screenshot 2025-08-25 at 6 42 40 PM" src="https://github.com/user-attachments/assets/93a9086f-f8f2-4507-917b-68b1f4e2e661" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
