### PR TITLE
[BOT-284] BE for notebook query tool table support

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -242,10 +242,11 @@
     [:limit {:optional true} [:maybe :int]]]
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
-(mr/def ::query-table-arguments
+(mr/def ::query-datasource-arguments
   [:and
    [:map
-    [:table_id [:or :int :string]]  ; Support both int and string table IDs
+    [:table_id {:optional true} :int]
+    [:model_id {:optional true} :int]
     [:fields {:optional true} [:maybe [:sequential ::field]]]
     [:filters {:optional true} [:maybe [:sequential ::filter]]]
     [:aggregations {:optional true} [:maybe [:sequential ::aggregation]]]
@@ -254,6 +255,8 @@
                                                       [:field ::field]
                                                       [:direction [:enum {:encode/tool-api-request keyword} "asc" "desc"]]]]]]
     [:limit {:optional true} [:maybe :int]]]
+   [:fn {:error/message "Exactly one of table_id and model_id required"}
+    #(= (count (select-keys % [:table_id :model_id])) 1)]
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
 (mr/def ::count
@@ -991,18 +994,19 @@
               (assoc :conversation_id conversation_id))
       (metabot-v3.context/log :llm.log/be->llm))))
 
-(api.macros/defendpoint :post "/query-table" :- [:merge ::filtering-result ::tool-request]
-  "Construct a query from a table."
+;; TODO tsplude - drop the `/query-model` endpoint and filter logic in favor of this
+(api.macros/defendpoint :post "/query-datasource" :- [:merge ::filtering-result ::tool-request]
+  "Construct a query from a model or table data source."
   [_route-params
    _query-params
    {:keys [arguments conversation_id] :as body} :- [:merge
-                                                    [:map [:arguments ::query-table-arguments]]
+                                                    [:map [:arguments ::query-datasource-arguments]]
                                                     ::tool-request]]
-  (metabot-v3.context/log (assoc body :api :query-table) :llm.log/llm->be)
-  (let [arguments (mc/encode ::query-table-arguments
+  (metabot-v3.context/log (assoc body :api :query-datasource) :llm.log/llm->be)
+  (let [arguments (mc/encode ::query-datasource-arguments
                              arguments (mtx/transformer {:name :tool-api-request}))]
     (doto (-> (mc/decode ::filtering-result
-                         (metabot-v3.tools.filters/query-table arguments)
+                         (metabot-v3.tools.filters/query-datasource arguments)
                          (mtx/transformer {:name :tool-api-response}))
               (assoc :conversation_id conversation_id))
       (metabot-v3.context/log :llm.log/be->llm))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -320,6 +320,7 @@
         returned-cols (lib/returned-columns query)]
     {:type :query
      :query-id query-id
+     ;; existing usage, don't do this going forward -- use Lib instead and persist MBQL 5 to the app DB
      :query #_{:clj-kondo/ignore [:discouraged-var]} (lib/->legacy-MBQL query)
      :result-columns (into []
                            (map-indexed #(metabot-v3.tools.u/->result-column query %2 %1 query-field-id-prefix))
@@ -330,6 +331,7 @@
   [{:keys [table-id model-id] :as arguments}]
   (try
     (cond
+      (and table-id model-id) (throw (ex-info "Cannot provide both table_id and model_id" {:agent-error? true}))
       (int? model-id) {:structured-output (query-datasource* arguments)}
       (int? table-id) {:structured-output (query-datasource* arguments)}
       model-id        {:output (str "Invalid model_id " model-id)}

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -284,16 +284,10 @@
   [{:keys [table-id model-id]}]
   (cond
     model-id
-    (let [card (metabot-v3.tools.u/get-card model-id)
-          mp (lib.metadata.jvm/application-database-metadata-provider (:database_id card))
-          base-query (lib/query mp (lib.metadata/card mp model-id))]
-      [(metabot-v3.tools.u/card-field-id-prefix model-id) base-query])
+    [(metabot-v3.tools.u/card-field-id-prefix model-id) (metabot-v3.tools.u/card-query model-id)]
 
     table-id
-    (let [table (metabot-v3.tools.u/get-table table-id :db_id)
-          mp (lib.metadata.jvm/application-database-metadata-provider (:db_id table))
-          base-query (lib/query mp (lib.metadata/table mp table-id))]
-      [(metabot-v3.tools.u/table-field-id-prefix table-id) base-query])
+    [(metabot-v3.tools.u/table-field-id-prefix table-id) (metabot-v3.tools.u/table-query table-id)]
 
     :else
     (throw (ex-info "Either table-id or model-id must be provided" {:agent-error? true}))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/config_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/config_test.clj
@@ -36,9 +36,9 @@
                    (metabot-v3.config/resolve-dynamic-profile-id nil "any-metabot-id")))))
 
         (testing "metabot-id mapping takes third precedence"
-          (is (= "experimental"
+          (is (= "internal"
                  (metabot-v3.config/resolve-dynamic-profile-id nil metabot-v3.config/internal-metabot-id)))
-          (is (= "default"
+          (is (= "embedding"
                  (metabot-v3.config/resolve-dynamic-profile-id nil metabot-v3.config/embedded-metabot-id))))
 
         (testing "falls back to default when no matches"
@@ -47,7 +47,7 @@
 
         (testing "single arity version uses dynamic metabot resolution"
           (mt/with-temporary-setting-values [metabot-v3.settings/metabot-id metabot-v3.config/embedded-metabot-id]
-            (is (= "default"
+            (is (= "embedding"
                    (metabot-v3.config/resolve-dynamic-profile-id nil)))))))))
 
 (deftest integrated-resolution-test
@@ -75,4 +75,4 @@
           (let [metabot-id (metabot-v3.config/resolve-dynamic-metabot-id nil)
                 profile-id (metabot-v3.config/resolve-dynamic-profile-id nil metabot-id)]
             (is (= metabot-v3.config/internal-metabot-id metabot-id))
-            (is (= "experimental" profile-id))))))))
+            (is (= "internal" profile-id))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -489,3 +489,227 @@
           (is (=? expected
                   (metabot-v3.tools.filters/filter-records
                    (assoc input :data-source (select-keys query-details [:query]))))))))))
+
+(deftest ^:parallel query-datasource-table-test
+  (mt/with-current-user (mt/user->id :crowberto)
+    (let [mp (mt/metadata-provider)
+          table-id (mt/id :orders)
+          table-details (#'metabot-v3.dummy-tools/table-details table-id {:metadata-provider mp})
+          ->field-id #(u/prog1 (-> table-details :fields (by-name %) :field-id)
+                        (when-not <>
+                          (throw (ex-info (str "Column " % " not found") {:column %}))))]
+      (testing "Basic table query works"
+        (is (=? {:structured-output {:type :query
+                                     :query-id string?
+                                     :query {:database (mt/id)
+                                             :type :query
+                                             :query {:source-table table-id}}}}
+                (metabot-v3.tools.filters/query-datasource
+                 {:table-id table-id}))))
+
+      (testing "Table query with fields selection"
+        (is (=? {:structured-output {:type :query
+                                     :query-id string?
+                                     :query {:database (mt/id)
+                                             :type :query
+                                             :query {:source-table table-id
+                                                     :fields [[:field (mt/id :orders :created_at) {:base-type :type/DateTimeWithLocalTZ}]
+                                                              [:field (mt/id :orders :total) {:base-type :type/Float}]]}}}}
+                (metabot-v3.tools.filters/query-datasource
+                 {:table-id table-id
+                  :fields [{:field-id (->field-id "Created At")}
+                           {:field-id (->field-id "Total")}]}))))
+
+      (testing "Table query with filters"
+        (is (=? {:structured-output {:type :query
+                                     :query-id string?
+                                     :query {:database (mt/id)
+                                             :type :query
+                                             :query {:source-table table-id
+                                                     :filter [:and
+                                                              [:> [:field (mt/id :orders :discount) {:base-type :type/Float}] 3]
+                                                              [:= [:field (mt/id :orders :user_id) {:base-type :type/Integer}] 10]]}}}}
+                (metabot-v3.tools.filters/query-datasource
+                 {:table-id table-id
+                  :filters [{:field-id (->field-id "Discount")
+                             :operation :number-greater-than
+                             :value 3}
+                            {:field-id (->field-id "User ID")
+                             :operation :equals
+                             :value 10}]}))))
+
+      (testing "Table query with aggregations and grouping"
+        (is (=? {:structured-output {:type :query
+                                     :query-id string?
+                                     :query {:database (mt/id)
+                                             :type :query
+                                             :query {:source-table table-id
+                                                     :aggregation [[:sum [:field (mt/id :orders :subtotal) {:base-type :type/Float}]]
+                                                                   [:avg [:field (mt/id :orders :discount) {:base-type :type/Float}]]]
+                                                     :breakout [[:field (mt/id :orders :product_id) {:base-type :type/Integer}]]}}}}
+                (metabot-v3.tools.filters/query-datasource
+                 {:table-id table-id
+                  :aggregations [{:field-id (->field-id "Subtotal")
+                                  :function :sum}
+                                 {:field-id (->field-id "Discount")
+                                  :function :avg}]
+                  :group-by [{:field-id (->field-id "Product ID")}]}))))
+
+      (testing "Table query with order by and limit"
+        (is (=? {:structured-output {:type :query
+                                     :query-id string?
+                                     :query {:database (mt/id)
+                                             :type :query
+                                             :query {:source-table table-id
+                                                     :order-by [[:asc [:field (mt/id :orders :created_at) {:base-type :type/DateTimeWithLocalTZ}]]
+                                                                [:desc [:field (mt/id :orders :total) {:base-type :type/Float}]]]
+                                                     :limit 100}}}}
+                (metabot-v3.tools.filters/query-datasource
+                 {:table-id table-id
+                  :order-by [{:field {:field-id (->field-id "Created At")}
+                              :direction :asc}
+                             {:field {:field-id (->field-id "Total")}
+                              :direction :desc}]
+                  :limit 100}))))
+
+      (testing "Table query with temporal bucketing"
+        (is (=? {:structured-output {:type :query
+                                     :query-id string?
+                                     :query {:database (mt/id)
+                                             :type :query
+                                             :query {:source-table table-id
+                                                     :aggregation [[:count]]
+                                                     :breakout [[:field (mt/id :orders :created_at)
+                                                                 {:base-type :type/DateTimeWithLocalTZ
+                                                                  :temporal-unit :month}]]}}}}
+                (metabot-v3.tools.filters/query-datasource
+                 {:table-id table-id
+                  :aggregations [{:field-id (->field-id "Product ID")
+                                  :function :count}]
+                  :group-by [{:field-id (->field-id "Created At")
+                              :field-granularity :month}]})))))))
+
+(deftest ^:parallel query-datasource-model-test
+  (mt/with-temp [:model/Card {model-id :id} {:dataset_query (mt/mbql-query orders {})
+                                             :database_id (mt/id)
+                                             :name "Orders Model"
+                                             :description "Test model for orders"
+                                             :type :model}]
+    (mt/with-current-user (mt/user->id :crowberto)
+      (let [model-details (-> (metabot-v3.dummy-tools/get-table-details {:model-id model-id})
+                              :structured-output)
+            model-card-id (str "card__" model-id)
+            ->field-id #(u/prog1 (-> model-details :fields (by-name %) :field-id)
+                          (when-not <>
+                            (throw (ex-info (str "Column " % " not found") {:column %}))))]
+        (testing "Basic model query works"
+          (is (=? {:structured-output {:type :query
+                                       :query-id string?
+                                       :query (mt/mbql-query orders {:source-table model-card-id})}}
+                  (metabot-v3.tools.filters/query-datasource
+                   {:model-id model-id}))))
+
+        (testing "Model query with fields selection"
+          (is (=? {:structured-output {:type :query
+                                       :query-id string?
+                                       :query (mt/mbql-query orders
+                                                {:source-table model-card-id
+                                                 :fields [[:field "CREATED_AT" {:base-type :type/DateTimeWithLocalTZ}]
+                                                          [:field "TOTAL" {:base-type :type/Float}]]})}}
+                  (metabot-v3.tools.filters/query-datasource
+                   {:model-id model-id
+                    :fields [{:field-id (->field-id "Created At")}
+                             {:field-id (->field-id "Total")}]}))))
+
+        (testing "Model query with filters"
+          (is (=? {:structured-output {:type :query
+                                       :query-id string?
+                                       :query (mt/mbql-query orders
+                                                {:source-table model-card-id
+                                                 :filter [:and
+                                                          [:> [:field "DISCOUNT" {:base-type :type/Float}] 5]
+                                                          [:< [:field "SUBTOTAL" {:base-type :type/Float}] 100]]})}}
+                  (metabot-v3.tools.filters/query-datasource
+                   {:model-id model-id
+                    :filters [{:field-id (->field-id "Discount")
+                               :operation :number-greater-than
+                               :value 5}
+                              {:field-id (->field-id "Subtotal")
+                               :operation :number-less-than
+                               :value 100}]}))))
+
+        (testing "Model query with aggregations and grouping"
+          (is (=? {:structured-output {:type :query
+                                       :query-id string?
+                                       :query (mt/mbql-query orders
+                                                {:source-table model-card-id
+                                                 :aggregation [[:count]
+                                                               [:max [:field "TOTAL" {:base-type :type/Float}]]]
+                                                 :breakout [[:field "USER_ID" {:base-type :type/Integer}]]})}}
+                  (metabot-v3.tools.filters/query-datasource
+                   {:model-id model-id
+                    :aggregations [{:field-id (->field-id "Product ID")
+                                    :function :count}
+                                   {:field-id (->field-id "Total")
+                                    :function :max}]
+                    :group-by [{:field-id (->field-id "User ID")}]}))))
+
+        (testing "Model query with order by and limit"
+          (is (=? {:structured-output {:type :query
+                                       :query-id string?
+                                       :query (mt/mbql-query orders
+                                                {:source-table model-card-id
+                                                 :order-by [[:desc [:field "CREATED_AT" {:base-type :type/DateTimeWithLocalTZ}]]]
+                                                 :limit 50})}}
+                  (metabot-v3.tools.filters/query-datasource
+                   {:model-id model-id
+                    :order-by [{:field {:field-id (->field-id "Created At")}
+                                :direction :desc}]
+                    :limit 50}))))))))
+
+(deftest ^:parallel query-datasource-validation-test
+  (mt/with-current-user (mt/user->id :crowberto)
+    (testing "Error when neither table-id nor model-id provided"
+      (is (= {:output "Either table_id or model_id must be provided"}
+             (metabot-v3.tools.filters/query-datasource {}))))
+
+    (testing "Error when both table-id and model-id provided"
+      (is (= {:output "Cannot provide both table_id and model_id"}
+             (metabot-v3.tools.filters/query-datasource
+              {:table-id (mt/id :orders)
+               :model-id 123}))))
+
+    (testing "Error with invalid table-id"
+      (is (= {:output "Invalid table_id not-a-number"}
+             (metabot-v3.tools.filters/query-datasource
+              {:table-id "not-a-number"}))))
+
+    (testing "Error with invalid model-id"
+      (is (= {:output "Invalid model_id not-a-number"}
+             (metabot-v3.tools.filters/query-datasource
+              {:model-id "not-a-number"}))))
+
+    (testing "Error with non-existent table"
+      (is (= {:output (str "No table found with table_id " Integer/MAX_VALUE)}
+             (metabot-v3.tools.filters/query-datasource
+              {:table-id Integer/MAX_VALUE}))))
+
+    (testing "Error with non-existent model"
+      (is (= {:output (str "No model found with model_id " Integer/MAX_VALUE)}
+             (metabot-v3.tools.filters/query-datasource
+              {:model-id Integer/MAX_VALUE}))))))
+
+(deftest ^:parallel query-datasource-permissions-test
+  (mt/with-temp [:model/Card {model-id :id} {:dataset_query (mt/mbql-query orders {})
+                                             :database_id (mt/id)
+                                             :name "Orders Model"
+                                             :type :model}]
+    (testing "User without permissions gets error for table"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that."
+                            (metabot-v3.tools.filters/query-datasource
+                             {:table-id (mt/id :orders)}))))
+
+    (testing "User without permissions gets error for model"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that."
+                            (metabot-v3.tools.filters/query-datasource
+                             {:model-id model-id}))))))


### PR DESCRIPTION
New BE endpoint for supporting tables in ai-service notebook query tool
Corresponding [ai-service PR](https://github.com/metabase/ai-service/pull/323)

### Changes
- New `/query-datasource` tools endpoint. Supports both model-id and table-id as the input datasource ID
  - Idea is to drop the `/query-model` and related logic in favor of this unified codepath