### PR TITLE
fix: visual blocker for table data editing

### DIFF
--- a/e2e/test/scenarios/table-editing/table-editing.cy.spec.ts
+++ b/e2e/test/scenarios/table-editing/table-editing.cy.spec.ts
@@ -119,7 +119,6 @@ describe("scenarios > table-editing", () => {
       cy.wait("@getTableDataQuery");
 
       cy.findByTestId("filters-visibility-control").should("have.text", "1");
-      cy.findByTestId("filters-visibility-control").click();
 
       cy.findByTestId("qb-filters-panel")
         .should("be.visible")

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputNumber.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputNumber.tsx
@@ -6,6 +6,7 @@ import type { TableActionInputSharedProps } from "./types";
 
 export type TableActionInputNumberProps = TableActionInputSharedProps & {
   allowDecimal?: boolean;
+  hideControls?: boolean;
   classNames?: {
     wrapper?: string;
     numberInputElement?: string;
@@ -14,6 +15,7 @@ export type TableActionInputNumberProps = TableActionInputSharedProps & {
 
 export const TableActionInputNumber = ({
   allowDecimal,
+  hideControls = true,
   autoFocus,
   inputProps,
   initialValue,
@@ -25,9 +27,12 @@ export const TableActionInputNumber = ({
 }: TableActionInputNumberProps) => {
   const [value, setValue] = useState<string | number>(initialValue ?? "");
 
-  const handleChange = useCallback(
-    (value: string | number) => {
-      setValue(value);
+  const handleChange = useCallback((value: string | number) => {
+    setValue(value);
+  }, []);
+
+  const handleChangeValue = useCallback(
+    ({ value }: { value: string }) => {
       onChange?.(numberToRawValue(value));
     },
     [onChange],
@@ -50,11 +55,13 @@ export const TableActionInputNumber = ({
 
   return (
     <NumberInput
+      hideControls={hideControls}
       allowDecimal={allowDecimal}
       defaultValue={(initialValue ?? "").toString()}
       autoFocus={autoFocus}
       onKeyUp={handleKeyUp}
       onChange={handleChange}
+      onValueChange={handleChangeValue}
       onBlur={handleBlur}
       classNames={{
         wrapper: classNames?.wrapper,

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/types.ts
@@ -18,6 +18,8 @@ type InputProps = {
   placeholder?: string;
   disabled?: boolean;
   error?: TextInputProps["error"];
+  leftSection?: TextInputProps["leftSection"];
+  leftSectionPointerEvents?: TextInputProps["leftSectionPointerEvents"];
   rightSection?: TextInputProps["rightSection"];
   rightSectionPointerEvents?: TextInputProps["rightSectionPointerEvents"];
   "data-testid"?: string;

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/EditTableDataHeader.tsx
@@ -1,9 +1,7 @@
 import { useDisclosure } from "@mantine/hooks";
-import { useMemo } from "react";
 import { t } from "ttag";
 
 import { QuestionFiltersHeader } from "metabase/query_builder/components/view/ViewHeader/components";
-import { getFilterItems } from "metabase/querying/filters/components/FilterPanel/utils";
 import { Box, Button, Icon, Stack } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 
@@ -27,16 +25,10 @@ export const EditTableDataHeader = ({
   onQuestionChange,
   onCreate,
 }: EditTableDataHeaderProps) => {
-  const hasFilters = useMemo(
-    () =>
-      question?.query() ? getFilterItems(question.query()).length > 0 : false,
-    [question],
-  );
-
   const [
     areFiltersExpanded,
     { open: onExpandFilters, close: onCollapseFilters },
-  ] = useDisclosure(hasFilters);
+  ] = useDisclosure(true);
 
   return (
     <Stack gap={0}>

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/ModalParameterActionInput.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/ModalParameterActionInput.module.css
@@ -1,17 +1,19 @@
-.textInputElement {
+.inputWrapper,
+.inputWrapperText {
   width: 100%;
 }
 
-.numberInputElement {
+.inputWrapperDate {
+  width: 15rem;
+}
+
+.inputWrapperBoolean,
+.inputWrapperNumber {
   width: 10rem;
 }
 
-.selectTextInputElement {
-  width: auto;
+.inputWrapperDropdown {
+  width: max-content;
   min-width: 10rem;
-}
-
-.dateTextInputElement {
-  width: auto;
-  min-width: 10rem;
+  max-width: 20rem;
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/ModalParameterActionInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/ModalParameterActionInput.tsx
@@ -1,5 +1,8 @@
 import { t } from "ttag";
 
+import { Combobox, Icon } from "metabase/ui";
+import { TableActionFormInputType } from "metabase-enterprise/table-editing/api/types";
+
 import {
   ParameterActionInput,
   type ParameterActionInputProps,
@@ -25,16 +28,45 @@ export function ModalParameterActionInput(props: ParameterActionInputProps) {
     "data-testid": `${parameter.display_name}-field-input`,
   };
 
+  let wrapperClassName = S.inputWrapper;
+  let hideControls;
+
+  switch (parameter.input_type) {
+    case TableActionFormInputType.Text:
+      wrapperClassName = S.inputWrapperText;
+      break;
+
+    case TableActionFormInputType.Integer:
+      hideControls = false;
+      wrapperClassName = S.inputWrapperNumber;
+      break;
+
+    case TableActionFormInputType.Float:
+      wrapperClassName = S.inputWrapperNumber;
+      break;
+
+    case TableActionFormInputType.Date:
+    case TableActionFormInputType.DateTime:
+      wrapperClassName = S.inputWrapperDate;
+      inputProps.leftSection = <Icon name="calendar" />;
+      inputProps.leftSectionPointerEvents = "none";
+      break;
+
+    case TableActionFormInputType.Boolean:
+    case TableActionFormInputType.Dropdown:
+      inputProps.rightSection = <Combobox.Chevron />;
+      inputProps.rightSectionPointerEvents = "none";
+      wrapperClassName = S.inputWrapperDropdown;
+  }
+
   return (
     <ParameterActionInput
       {...rest}
       inputProps={inputProps}
       parameter={parameter}
+      hideControls={hideControls}
       classNames={{
-        textInputElement: S.textInputElement,
-        numberInputElement: S.numberInputElement,
-        selectTextInputElement: S.selectTextInputElement,
-        dateTextInputElement: S.dateTextInputElement,
+        wrapper: wrapperClassName,
       }}
     />
   );

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModalParameter.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModalParameter.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react";
 
-import { Group, Stack, Text } from "metabase/ui";
+import { Box, Group, Stack, Text } from "metabase/ui";
 
 import {
   TableActionFormInputType,
@@ -46,7 +46,7 @@ export function TableActionFormModalParameter({
           </Text>
         </Stack>
       </Group>
-      {children}
+      <Box>{children}</Box>
     </>
   );
 }

--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.jsx
@@ -14,12 +14,13 @@ import { isSyncInProgress } from "metabase/lib/syncing";
 import { PLUGIN_TABLE_EDITING } from "metabase/plugins";
 import { getDatabases } from "metabase/reference/selectors";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { Box, Group, Icon, Loader } from "metabase/ui";
+import { Group, Icon, Loader, Paper } from "metabase/ui";
 import { isVirtualCardId } from "metabase-lib/v1/metadata/utils/saved-questions";
 
 import { BrowseHeaderContent } from "../../components/BrowseHeader.styled";
 import { trackTableClick } from "../analytics";
 
+import S from "./TableBrowser.module.css";
 import { useDatabaseCrumb } from "./useDatabaseCrumb";
 
 const propTypes = {
@@ -147,7 +148,7 @@ const TableBrowserItemButtons = ({
   };
 
   return (
-    <Box className={cx(CS.hoverChild)}>
+    <Paper p="sm" className={cx(CS.hoverChild, S.tableBrowserItemButtons)}>
       <Group gap="md">
         {xraysEnabled && (
           <Link to={`/auto/dashboard/table/${tableId}`}>
@@ -179,7 +180,7 @@ const TableBrowserItemButtons = ({
           />
         </Link>
       </Group>
-    </Box>
+    </Paper>
   );
 };
 

--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.module.css
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.module.css
@@ -1,0 +1,6 @@
+.tableBrowserItemButtons {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 0.5rem;
+}


### PR DESCRIPTION
Changes requested in this comment https://github.com/metabase/metabase/pull/61908#pullrequestreview-3152427417

* If I cancel or navigate away from the Edit Record side modal without making any changes, I wish I didn't see this confirmation dialog

* I think we need to do something different for these actions on hover.
<img width="808" height="340" alt="image" src="https://github.com/user-attachments/assets/a42dad15-218e-46ba-8d76-f3f43ddf83d7" />


* When I add a filter, I'd expect the filter pills to be expanded and visible by default rather than hidden by default:
<img width="1428" height="138" alt="image" src="https://github.com/user-attachments/assets/20e27baf-19bd-4fc4-af9e-09b5fe7cb0e6" />

* Select components should have a down-chevron icon like they do throughout the rest of the app
* A nice-to-have would be using number inputs with up/down increment steppers for integer fields
<img width="725" height="422" alt="image" src="https://github.com/user-attachments/assets/c0a52682-dd47-4ce4-8214-722776589e2f" />

