### PR TITLE
Auto-mark 'secure your embeds' step as done when either JWT or SAML is configured

### DIFF
--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
@@ -1,5 +1,7 @@
 import { useMemo } from "react";
 
+import { useSetting } from "metabase/common/hooks";
+
 import type { EmbeddingHubStepId } from "../types";
 
 /**
@@ -11,14 +13,22 @@ export const useCompletedEmbeddingHubSteps = (): Record<
   EmbeddingHubStepId,
   boolean
 > => {
+  const isJwtEnabled = useSetting("jwt-enabled");
+  const isSamlEnabled = useSetting("saml-enabled");
+  const isJwtConfigured = useSetting("jwt-configured");
+  const isSamlConfigured = useSetting("saml-configured");
+
+  const isSsoReady =
+    (isJwtEnabled && isJwtConfigured) || (isSamlEnabled && isSamlConfigured);
+
   return useMemo(() => {
     return {
       "create-test-embed": true,
       "add-data": false,
       "create-dashboard": false,
       "configure-row-column-security": false,
-      "secure-embeds": false,
+      "secure-embeds": isSsoReady,
       "embed-production": false,
     };
-  }, []);
+  }, [isSsoReady]);
 };

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.unit.spec.tsx
@@ -42,7 +42,7 @@ describe("useCompletedEmbeddingHubSteps", () => {
       ],
       [{ jwtEnabled: true, samlEnabled: true }, false],
       [{}, false],
-    ])("should be %p with config %j", (config, expected) => {
+    ])("config %j should return %p", (config, expected) => {
       const { result } = setup(config);
 
       expect(result.current["secure-embeds"]).toBe(expected);

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.unit.spec.tsx
@@ -1,0 +1,51 @@
+import { mockSettings } from "__support__/settings";
+import { renderHookWithProviders } from "__support__/ui";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { useCompletedEmbeddingHubSteps } from "./use-completed-embedding-hub-steps";
+
+const setup = ({
+  jwtEnabled = false,
+  jwtConfigured = false,
+  samlEnabled = false,
+  samlConfigured = false,
+} = {}) => {
+  const state = createMockState({
+    settings: mockSettings({
+      "jwt-enabled": jwtEnabled,
+      "jwt-configured": jwtConfigured,
+      "saml-enabled": samlEnabled,
+      "saml-configured": samlConfigured,
+    }),
+  });
+
+  return renderHookWithProviders(() => useCompletedEmbeddingHubSteps(), {
+    storeInitialState: state,
+  });
+};
+
+describe("useCompletedEmbeddingHubSteps", () => {
+  describe("mark secure-embeds step to be true if either JWT or SAML is enabled and configured", () => {
+    it.each([
+      [{ jwtEnabled: true, jwtConfigured: true }, true],
+      [{ jwtEnabled: true }, false],
+      [{ samlEnabled: true, samlConfigured: true }, true],
+      [{ samlEnabled: true }, false],
+      [
+        {
+          jwtEnabled: true,
+          jwtConfigured: true,
+          samlEnabled: true,
+          samlConfigured: true,
+        },
+        true,
+      ],
+      [{ jwtEnabled: true, samlEnabled: true }, false],
+      [{}, false],
+    ])("should be %p with config %j", (config, expected) => {
+      const { result } = setup(config);
+
+      expect(result.current["secure-embeds"]).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
Closes EMB-744

### Description

Makes the `useCompletedEmbeddingHubSteps` hook mark `secure-embeds` as completed when either JWT or SAML is configured and enabled.

### How to verify

1. Navigate to `/embedding-hub` as an admin user with embedding feature enabled
2. Observe the step-by-step checklist with images, videos, and action buttons
3. Configure either JWT or SAML authentication in admin settings
4. Verify the "Secure your embeds" step shows as completed with a check icon
5. Test navigation links to documentation and internal pages

### Demo

JWT paused

<img width="1226" height="1106" alt="CleanShot 2568-08-26 at 20 46 57@2x" src="https://github.com/user-attachments/assets/edeb8c79-5ad1-4620-8609-ea8550ffe420" />

JWT resumed

<img width="1258" height="1164" alt="CleanShot 2568-08-26 at 20 45 07@2x" src="https://github.com/user-attachments/assets/76b0f64c-a2ea-43e8-b303-06362093179d" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - hook test