### PR TITLE
[ClickHouse] Handle SSH tunneling when checking for `:connection-impersonation` support

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -277,7 +277,8 @@
   [_driver _feature db]
   (if db
     (try (clickhouse-version/is-at-least? 24 4 db)
-         (catch Throwable _e
+         (catch Throwable e
+           (log/warn e "Error checking connection impersonation")
            false))
     false))
 

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -10,6 +10,7 @@
    [metabase.api.common :refer [*current-user-permissions-set*]]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.test-util :as driver.tu]
    [metabase.query-processor :as qp]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
@@ -504,26 +505,6 @@
                     [3 "Artisan"]]
                    (first-three-categories)))))))))
 
-(defn basic-auth-ssh-server ^java.io.Closeable [username password]
-  (try
-    (let [password-auth    (reify org.apache.sshd.server.auth.password.PasswordAuthenticator
-                             (authenticate [_ auth-username auth-password _session]
-                               (and
-                                (= auth-username username)
-                                (= auth-password password))))
-          keypair-provider (org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider.)
-          sshd             (doto (SshServer/setUpDefaultServer)
-                             (.setPort 0)
-                             (.setKeyPairProvider keypair-provider)
-                             (.setPasswordAuthenticator password-auth)
-                             (.setForwardingFilter AcceptAllForwardingFilter/INSTANCE)
-                             .start)]
-      sshd)
-    (catch Throwable e
-      (throw (ex-info (format "Error starting SSH mock server with password")
-                      {:username username :password password}
-                      e)))))
-
 (deftest actions-on-ssh-tunneled-db
   ;; testing actions against dbs with ssh tunnels. Use an in-memory ssh server that just forwards to the correct port
   ;; through localhost. Since it is local, it's possible for the application to ignore the ssh tunnel and just talk to
@@ -532,10 +513,10 @@
   ;; through the ssh tunnel
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :actions) :h2)
     (let [username "username", password "password"]
-      (with-open [ssh-server (basic-auth-ssh-server username password)]
+      (with-open [ssh-server (driver.tu/basic-auth-ssh-server username password)]
         (doseq [[correct-password? ssh-password] [[true password] [false "wrong-password"]]]
           (with-actions-test-data-and-actions-permissively-enabled!
-            (let [ssh-port (.getPort ^SshServer ssh-server)
+            (let [ssh-port (.getPort ssh-server)
                   table-id (mt/id :categories)]
               (let [details (t2/select-one-fn :details 'Database :id (mt/id))]
                 (t2/update! 'Database (mt/id)

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -18,10 +18,7 @@
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2])
-  (:import
-   (org.apache.sshd.server SshServer)
-   (org.apache.sshd.server.forward AcceptAllForwardingFilter)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -150,7 +150,8 @@
             ;; to [[driver.u/supports?]].
             original-supports?       driver.u/supports?
             supports?-fn             (fn [driver feature database]
-                                       (if (and (= driver :clickhouse)
+                                       (if (and #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+                                            (= driver :clickhouse)
                                                 (= feature :connection-impersonation))
                                          true
                                          (original-supports? driver feature database)))]

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -147,7 +147,10 @@
                                        nil)]
         (try
           (sql-jdbc.conn/invalidate-pool-for-db! db)
-          ;; a little bit hacky to redefine the log fn, but it's the most direct way to test
+          ;; HACK: The ClickHouse driver also calls `db->pooled-connection-spec` to answer
+          ;; `driver-supports? :connection-impersonation`. That perturbs the call count below, so we check it once
+          ;; up front before we start counting.
+          (driver/database-supports? driver/*driver* :connection-impersonation db)
           (with-redefs [sql-jdbc.conn/log-jdbc-spec-hash-change-msg! hash-change-fn]
             (let [pool-spec-1 (sql-jdbc.conn/db->pooled-connection-spec db)
                   db-hash-1   (get @@#'sql-jdbc.conn/database-id->jdbc-spec-hash (u/the-id db))]

--- a/test/metabase/driver/test_util.clj
+++ b/test/metabase/driver/test_util.clj
@@ -7,6 +7,8 @@
    (org.apache.sshd.server SshServer)
    (org.apache.sshd.server.forward AcceptAllForwardingFilter)))
 
+(set! *warn-on-reflection* true)
+
 (defn -notify-all-databases-updated! []
   (mb.hawk.parallel/assert-test-is-not-parallel `-notify-all-databases-updated!)
   ;; It makes sense to notify databases only if app db is initialized.

--- a/test/metabase/driver/test_util.clj
+++ b/test/metabase/driver/test_util.clj
@@ -2,7 +2,10 @@
   (:require
    [mb.hawk.parallel]
    [metabase.driver.events.report-timezone-updated]
-   [metabase.test.initialize :as initialize]))
+   [metabase.test.initialize :as initialize])
+  (:import
+   (org.apache.sshd.server SshServer)
+   (org.apache.sshd.server.forward AcceptAllForwardingFilter)))
 
 (defn -notify-all-databases-updated! []
   (mb.hawk.parallel/assert-test-is-not-parallel `-notify-all-databases-updated!)
@@ -19,3 +22,26 @@
        ~@body
        (finally
          (-notify-all-databases-updated!)))))
+
+(defn basic-auth-ssh-server
+  ;^java.io.Closeable
+  ^SshServer
+  [username password]
+  (try
+    (let [password-auth    (reify org.apache.sshd.server.auth.password.PasswordAuthenticator
+                             (authenticate [_ auth-username auth-password _session]
+                               (and
+                                (= auth-username username)
+                                (= auth-password password))))
+          keypair-provider (org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider.)
+          sshd             (doto (SshServer/setUpDefaultServer)
+                             (.setPort 0)
+                             (.setKeyPairProvider keypair-provider)
+                             (.setPasswordAuthenticator password-auth)
+                             (.setForwardingFilter AcceptAllForwardingFilter/INSTANCE)
+                             .start)]
+      sshd)
+    (catch Throwable e
+      (throw (ex-info (format "Error starting SSH mock server with password")
+                      {:username username :password password}
+                      e)))))


### PR DESCRIPTION
Fixes #62377.

### Description

Correctly get a connection to the database while checking the ClickHouse version
(used to check if it supports `:connection-impersonation`). The driver was using the
internal, raw form of getting a connection, which didn't apply the SSH tunnel properly.

I'd like to add a test for this, but I'm not sure we can synthesize the necessary conditions.

### How to verify

Follow the repro steps in #62377. With this change in place, the dialog does not error out,
and nor does the sync process.

There are still warnings about
`WARN api.Client :: Failed to connect to 'clickhouse-alias': No route to host`
but I'm not sure what to make of that. There isn't enough namespace to be certain what class is even
logging the error. (Though it's probably from the inner ClickHouse Java client?)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
