### PR TITLE
Add UTM tags to documentation links in the embedding hub

### DIFF
--- a/frontend/src/metabase/embedding/embedding-hub/components/DocsLink.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/DocsLink.tsx
@@ -2,16 +2,25 @@ import type { ReactNode } from "react";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks/use-docs-url";
+import type { UtmProps } from "metabase/selectors/settings";
 import { Button, Icon } from "metabase/ui";
 
 interface DocsLinkProps {
   docsPath: string;
+  utm: Required<Pick<UtmProps, "utm_campaign" | "utm_content">>;
   children: ReactNode;
 }
 
-export const DocsLink = ({ docsPath, children }: DocsLinkProps) => {
+export const DocsLink = ({ docsPath, utm, children }: DocsLinkProps) => {
   // eslint-disable-next-line no-unconditional-metabase-links-render -- we are in admin so we must always show the link.
-  const { url } = useDocsUrl(docsPath);
+  const { url } = useDocsUrl(docsPath, {
+    utm: {
+      utm_source: "product",
+      utm_campaign: utm.utm_campaign,
+      utm_medium: "docs",
+      utm_content: utm.utm_content,
+    },
+  });
 
   return (
     <Button

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -34,10 +34,10 @@ export const EmbeddingHub = () => {
   // eslint-disable-next-line no-unconditional-metabase-links-render -- This link only shows for admins.
   const embedJsDocsUrl = useDocsUrl("embedding/embedded-analytics-js", {
     utm: {
-      utm_campaign: "product",
       utm_content: "embed-js-docs",
       utm_medium: "docs",
-      utm_source: "embedding-hub",
+      utm_source: "product",
+      utm_campaign: "embedding-hub",
     },
   });
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -30,8 +30,16 @@ export const EmbeddingHub = () => {
 
   const closeModal = () => setOpenedModal(null);
 
-  // eslint-disable-next-line no-unconditional-metabase-links-render -- This links only shows for admins.
-  const embedJsDocsUrl = useDocsUrl("embedding/embedded-analytics-js");
+  // TODO: will be replaced by a dropdown
+  // eslint-disable-next-line no-unconditional-metabase-links-render -- This link only shows for admins.
+  const embedJsDocsUrl = useDocsUrl("embedding/embedded-analytics-js", {
+    utm: {
+      utm_campaign: "product",
+      utm_content: "embed-js-docs",
+      utm_medium: "docs",
+      utm_source: "embedding-hub",
+    },
+  });
 
   return (
     <Box mih="100%" px="lg" py="xl" bg="bg-white">

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubChecklist.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubChecklist.unit.spec.tsx
@@ -59,14 +59,14 @@ describe("EmbeddingChecklist", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows docs links on call-to-action buttons", async () => {
+  it("shows docs links with utm on call-to-action buttons", async () => {
     setup({ defaultOpenStep: "configure-row-column-security" });
 
     const link = screen.getByRole("link", { name: /Read the docs/ });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute(
       "href",
-      expect.stringContaining("permissions/row-and-column-security"),
+      "https://www.metabase.com/docs/latest/permissions/row-and-column-security.html?utm_source=product&utm_medium=docs&utm_campaign=embedding-hub&utm_content=configure-row-column-security&source_plan=oss",
     );
   });
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubStepActions.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubStepActions.tsx
@@ -33,7 +33,14 @@ export const EmbeddingHubStepActions = ({
 
         if (action.docsPath) {
           return (
-            <DocsLink key={index} docsPath={action.docsPath}>
+            <DocsLink
+              key={index}
+              docsPath={action.docsPath}
+              utm={{
+                utm_campaign: "embedding-hub",
+                utm_content: step.id,
+              }}
+            >
               {action.label}
             </DocsLink>
           );


### PR DESCRIPTION
## Summary
Add UTM tracking parameters to documentation links in the embedding hub for better analytics.

## Changes
- Create DocsLink component with standardized utm parameters
- Update embedding hub to use utm-enabled documentation links

## Test plan
- [x] Unit tests verify UTM parameters are applied correctly

🤖 Generated with [Claude Code](https://claude.ai/code)