### PR TITLE
Add table reference for implicitly joinable fields in context injection

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -9,7 +9,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.types.isa :as lib.types.isa]
-   [metabase.lib.util :as lib.util]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
    [metabase.util.humanization :as u.humanization]
@@ -65,14 +64,6 @@
       (map #(m/assoc-some % :field-values (some->> % :id (get-field-values id->values))) cols))
     cols))
 
-(defn- add-table-reference
-  [query col]
-  (cond-> col
-    (and (:fk-field-id col)
-         (:table-id col))
-    (assoc :table-reference (-> (lib/display-name query (lib.metadata/field query (:fk-field-id col)))
-                                lib.util/strip-id))))
-
 (defn metric-details
   "Get metric details as returned by tools."
   ([id] (metric-details id nil))
@@ -93,7 +84,7 @@
                       (lib/remove-all-breakouts metric-query))
          visible-cols (when query-needed?
                         (->> (lib/visible-columns base-query)
-                             (map #(add-table-reference base-query %))))
+                             (map #(metabot-v3.tools.u/add-table-reference base-query %))))
          col->index (when query-needed?
                       (into {} (map-indexed (fn [i col] [col i])) visible-cols))
          col-index (when query-needed?
@@ -117,7 +108,7 @@
               :verified (verified-review? id "card")}
        with-queryable-dimensions?
        (assoc :queryable-dimensions (into []
-                                          (comp (map #(add-table-reference base-query %))
+                                          (comp (map #(metabot-v3.tools.u/add-table-reference base-query %))
                                                 (map #(metabot-v3.tools.u/->result-column
                                                        metric-query % (col-index %) field-id-prefix)))
                                           (->> (lib/filterable-columns base-query)
@@ -156,7 +147,7 @@
            cols (when with-fields?
                   (->> (lib/visible-columns table-query)
                        field-values-fn
-                       (map #(add-table-reference table-query %))))
+                       (map #(metabot-v3.tools.u/add-table-reference table-query %))))
            field-id-prefix (when with-fields?
                              (metabot-v3.tools.u/table-field-id-prefix id))]
        (-> {:id id
@@ -201,7 +192,7 @@
          cols (when with-fields?
                 (->> (lib/visible-columns card-query)
                      field-values-fn
-                     (map #(add-table-reference card-query %))))
+                     (map #(metabot-v3.tools.u/add-table-reference card-query %))))
          field-id-prefix (metabot-v3.tools.u/card-field-id-prefix id)]
      (-> {:id id
           :type card-type

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/table_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/table_utils.clj
@@ -106,7 +106,8 @@
              _ (lib.metadata/bulk-metadata mp :metadata/table table-ids)]
          (mapv (fn [{:keys [id name schema description]}]
                  (let [table-query (lib/query mp (lib.metadata/table mp id))
-                       cols (lib/visible-columns table-query)
+                       cols (->> (lib/visible-columns table-query)
+                                 (map #(metabot-v3.tools.u/add-table-reference table-query %)))
                        field-id-prefix (metabot-v3.tools.u/table-field-id-prefix id)]
                    {:id id
                     :type :table

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -8,6 +8,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.types.isa :as lib.types.isa]
+   [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
@@ -29,6 +30,15 @@
       (isa? (:effective-type column) :type/DateTime) :datetime
       (isa? (:effective-type column) :type/Time)     :time
       (lib.types.isa/temporal? column)               :date)))
+
+(defn add-table-reference
+  "Add table-reference to columns that have FK relationships."
+  [query col]
+  (cond-> col
+    (and (:fk-field-id col)
+         (:table-id col))
+    (assoc :table-reference (-> (lib/display-name query (lib.metadata/field query (:fk-field-id col)))
+                                lib.util/strip-id))))
 
 (defn table-field-id-prefix
   "Return the field ID prefix for `table-id`."

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/table_utils_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/table_utils_test.clj
@@ -268,9 +268,10 @@
     (mt/with-temp [:model/Database {db-id :id} {}
                    :model/Table    {table1-id :id} {:db_id db-id, :name "users", :schema "public", :active true, :visibility_type nil}
                    :model/Table    {table2-id :id} {:db_id db-id, :name "orders", :schema "public", :active true, :visibility_type nil}
-                   :model/Field    {} {:table_id table1-id, :name "id", :database_type "INTEGER", :base_type :type/Integer}
+                   :model/Field    {user-id-field :id} {:table_id table1-id, :name "id", :database_type "INTEGER", :base_type :type/Integer, :semantic_type :type/PK}
                    :model/Field    {} {:table_id table1-id, :name "name", :database_type "VARCHAR", :base_type :type/Text}
-                   :model/Field    {} {:table_id table2-id, :name "id", :database_type "INTEGER", :base_type :type/Integer}
+                   :model/Field    {} {:table_id table2-id, :name "id", :database_type "INTEGER", :base_type :type/Integer, :semantic_type :type/PK}
+                   :model/Field    {} {:table_id table2-id, :name "user_id", :database_type "INTEGER", :base_type :type/Integer, :semantic_type :type/FK, :fk_target_field_id user-id-field}
                    :model/Field    {} {:table_id table2-id, :name "total", :database_type "DECIMAL", :base_type :type/Decimal}]
 
       (testing "returns tables with new enhanced formatting"
@@ -287,6 +288,21 @@
             (is (every? #(every? (fn [field] (contains? field :name)) (:fields %)) tables))
             (is (every? #(every? (fn [field] (contains? field :type)) (:fields %)) tables))
             (is (every? #(contains? % :metrics) tables)))))
+
+      (testing "includes table-reference for implicitly joined fields"
+        (mt/dataset test-data
+          (mt/with-current-user (mt/user->id :crowberto)
+            (let [test-db-id (mt/id)
+                  tables (table-utils/enhanced-database-tables test-db-id)
+                  orders-table (first (filter #(= "ORDERS" (:name %)) tables))
+                  all-fields (:fields orders-table)
+                  user-fields (filter #(= "User" (:table-reference %)) all-fields)
+                  product-fields (filter #(= "Product" (:table-reference %)) all-fields)]
+              (is (some? orders-table) "Expected to find ORDERS table")
+              (is (seq user-fields) "Expected to find fields with table-reference 'User' from implicit join")
+              (is (some #(= "NAME" (:name %)) user-fields) "Expected to find User NAME field from implicit join")
+              (is (seq product-fields) "Expected to find fields with table-reference 'Product' from implicit join")
+              (is (some #(= "TITLE" (:name %)) product-fields) "Expected to find Product TITLE field from implicit join")))))
 
       (testing "enhanced format respects all-tables-limit option"
         (mt/with-current-user (mt/user->id :crowberto)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -15,6 +15,7 @@
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase-enterprise.metabot-v3.util :as metabot-v3.u]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
+   [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
@@ -268,16 +269,16 @@
                    {:type "query"
                     :query_id string?
                     :query (mt/mbql-query products
-                                          {:aggregation [[:metric metric-id]]
-                                           :breakout [!week.products.created_at !day.products.created_at]
-                                           :filter [:and
-                                                    [:> [:field %id {}] 50]
-                                                    [:= [:field %title {}] "3" "4"]
-                                                    [:!= [:field %rating {}] 3 4]
-                                                    [:= [:get-month [:field %created_at {}]] 4 5 9]
-                                                    [:!= [:get-day [:field %products.created_at {}]] 14 15 19]
-                                                    [:= [:get-day-of-week [:field %created_at {}] :iso] 1 7]
-                                                    [:= [:get-year [:field %created_at {}]] 2008]]})
+                             {:aggregation [[:metric metric-id]]
+                              :breakout [!week.products.created_at !day.products.created_at]
+                              :filter [:and
+                                       [:> [:field %id {}] 50]
+                                       [:= [:field %title {}] "3" "4"]
+                                       [:!= [:field %rating {}] 3 4]
+                                       [:= [:get-month [:field %created_at {}]] 4 5 9]
+                                       [:!= [:get-day [:field %products.created_at {}]] 14 15 19]
+                                       [:= [:get-day-of-week [:field %created_at {}] :iso] 1 7]
+                                       [:= [:get-year [:field %created_at {}]] 2008]]})
                     :result_columns
                     [{:field_id (str "q" query-id "/0")
                       :name "CREATED_AT"
@@ -803,9 +804,9 @@
       (mt/with-temp [:model/Card {model-id :id}  model-data
                      :model/Card {metric-id :id} (assoc metric-data :dataset_query
                                                         (mt/mbql-query orders
-                                                                       {:source-table (str "card__" model-id)
-                                                                        :aggregation [[:count]]
-                                                                        :breakout [!month.*created_at *quantity]}))]
+                                                          {:source-table (str "card__" model-id)
+                                                           :aggregation [[:count]]
+                                                           :breakout [!month.*created_at *quantity]}))]
         (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
@@ -840,9 +841,9 @@
       (mt/with-temp [:model/Card {model-id :id}  model-data
                      :model/Card {metric-id :id} (assoc metric-data :dataset_query
                                                         (mt/mbql-query orders
-                                                                       {:source-table (str "card__" model-id)
-                                                                        :aggregation [[:count]]
-                                                                        :breakout [!month.*created_at *quantity]}))]
+                                                          {:source-table (str "card__" model-id)
+                                                           :aggregation [[:count]]
+                                                           :breakout [!month.*created_at *quantity]}))]
         (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
@@ -878,9 +879,9 @@
       (mt/with-temp [:model/Card {model-id :id}  model-data
                      :model/Card {metric-id :id} (assoc metric-data :dataset_query
                                                         (mt/mbql-query orders
-                                                                       {:source-table (str "card__" model-id)
-                                                                        :aggregation [[:count]]
-                                                                        :breakout [!month.*created_at *quantity]}))]
+                                                          {:source-table (str "card__" model-id)
+                                                           :aggregation [[:count]]
+                                                           :breakout [!month.*created_at *quantity]}))]
         (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
@@ -912,9 +913,9 @@
       (mt/with-temp [:model/Card {model-id :id}  model-data
                      :model/Card {metric-id :id} (assoc metric-data :dataset_query
                                                         (mt/mbql-query orders
-                                                                       {:source-table (str "card__" model-id)
-                                                                        :aggregation [[:count]]
-                                                                        :breakout [!month.*created_at *quantity]}))]
+                                                          {:source-table (str "card__" model-id)
+                                                           :aggregation [[:count]]
+                                                           :breakout [!month.*created_at *quantity]}))]
         (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
@@ -948,9 +949,9 @@
       (mt/with-temp [:model/Card {model-id :id}  model-data
                      :model/Card {_metric-id :id} (assoc (:metric-data (model-test-fixtures)) :dataset_query
                                                          (mt/mbql-query orders
-                                                                        {:source-table (str "card__" model-id)
-                                                                         :aggregation [[:count]]
-                                                                         :breakout [!month.*created_at *quantity]}))]
+                                                           {:source-table (str "card__" model-id)
+                                                            :aggregation [[:count]]
+                                                            :breakout [!month.*created_at *quantity]}))]
         (with-redefs [metabot-v3.tools.dummy-tools/verified-review? (constantly true)]
           (let [request (fn [arguments]
                           (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-table-details"
@@ -1051,9 +1052,9 @@
                                            :conversation_id conversation-id}))]
       (mt/with-temp [:model/Card {metric-id :id} (assoc metric-data :dataset_query
                                                         (mt/mbql-query orders
-                                                                       {:source-table table-id
-                                                                        :aggregation [[:count]]
-                                                                        :breakout [!month.created_at $quantity]}))]
+                                                          {:source-table table-id
+                                                           :aggregation [[:count]]
+                                                           :breakout [!month.created_at $quantity]}))]
         (testing "Normal call"
           (doseq [arg-id [table-id (str table-id)]]
             (is (=? {:structured_output {:name "ORDERS"


### PR DESCRIPTION
## Context

There is a bug where we don't include the `table-reference` info on the implicitly joinable columns in the `used_tables` of the Metabot context. In ai-service this leads to those columns being processed as if they were part of the table (e.g. orders tables now having fields from peoples table)

## What changed

* I tried to adjust the logic that it works the same as the get-table-details and other endpoints