### PR TITLE
Handle nulls in arrays

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -623,7 +623,7 @@
 
 (defn- arrays->vectors
   [obj]
-  (if (.isArray (class obj))
+  (if (and obj (.isArray (class obj)))
     (mapv arrays->vectors obj)
     obj))
 

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -623,7 +623,7 @@
 
 (defn- arrays->vectors
   [obj]
-  (if (and obj (.isArray (class obj)))
+  (if (some-> obj class .isArray)
     (mapv arrays->vectors obj)
     obj))
 

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1806,3 +1806,19 @@
             (finally
               (jdbc/execute! conn "DROP SCHEMA IF EXISTS sync_test_schema CASCADE")
               (jdbc/execute! conn "DROP USER IF EXISTS sync_writable_test_user"))))))))
+
+(deftest ^:parallel null-array-query-test
+  (testing "queries with nulls in arrays should be returned in a readable format"
+    (mt/test-driver :postgres
+      (is (= [[[nil]
+               [nil nil]
+               [1 nil 3]
+               [[nil]]
+               [[nil] [nil]]
+               [[1 nil] [nil 2]]]]
+             (->> (mt/native-query {:query "select array[null], array[null, null],
+                                            array[1, null, 3], array[array[null]],
+                                            array[array[null], array[null]],
+                                            array[array[1, null], array[null, 2]]"})
+                  mt/process-query
+                  mt/rows))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62750

### Description

We need to avoid calling `.isArray` on null values

### How to verify

1. Create a table with an array column.
2. Populate this column with an array that contains a null value
3. You should be able to query this table and get the expected results

### Demo

https://github.com/user-attachments/assets/1da519c3-bf09-460c-a364-01aa398049ce

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
