### PR TITLE
Reset parameter values if all parameters are equal to new values, not per parameter

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior-reproductions.cy.spec.ts
@@ -1,0 +1,135 @@
+const { H } = cy;
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type { StructuredQuestionDetails } from "e2e/support/helpers";
+
+const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+describe("issue 59049", () => {
+  const questionDetails: StructuredQuestionDetails = {
+    query: {
+      "source-table": PRODUCTS_ID,
+    },
+  };
+
+  const categoryParameter = {
+    id: "1b9cd9f1",
+    name: "Category",
+    slug: "category",
+    type: "string/=",
+    sectionId: "string",
+  };
+
+  const vendorParameter = {
+    id: "1b9cd9f2",
+    name: "Vendor",
+    slug: "vendor",
+    type: "string/=",
+    sectionId: "string",
+  };
+
+  const dashboardDetails = {
+    parameters: [categoryParameter, vendorParameter],
+  };
+
+  function createDashboard() {
+    H.createQuestionAndDashboard({
+      questionDetails,
+      dashboardDetails,
+    }).then(({ body: card, questionId }) => {
+      H.addOrUpdateDashboardCard({
+        dashboard_id: card.dashboard_id,
+        card_id: questionId,
+        card: {
+          id: card.id,
+          parameter_mappings: [
+            {
+              card_id: questionId,
+              parameter_id: categoryParameter.id,
+              target: [
+                "dimension",
+                ["field", PRODUCTS.CATEGORY, null],
+                { "stage-number": 0 },
+              ],
+            },
+            {
+              card_id: questionId,
+              parameter_id: vendorParameter.id,
+              target: [
+                "dimension",
+                ["field", PRODUCTS.VENDOR, null],
+                { "stage-number": 0 },
+              ],
+            },
+          ],
+          visualization_settings: {
+            column_settings: {
+              '["name","CATEGORY"]': {
+                click_behavior: {
+                  parameterMapping: {
+                    [categoryParameter.id]: {
+                      id: categoryParameter.id,
+                      source: {
+                        type: "column",
+                        id: "CATEGORY",
+                        name: "Category",
+                      },
+                      target: {
+                        type: "parameter",
+                        id: categoryParameter.id,
+                      },
+                    },
+                    [vendorParameter.id]: {
+                      id: vendorParameter.id,
+                      source: {
+                        type: "column",
+                        id: "VENDOR",
+                        name: "Vendor",
+                      },
+                      target: {
+                        type: "parameter",
+                        id: vendorParameter.id,
+                      },
+                    },
+                  },
+                  type: "crossfilter",
+                },
+              },
+            },
+          },
+        },
+      });
+      cy.wrap(card.dashboard_id).as("dashboardId");
+    });
+  }
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not reset parameter values in click behaviors when they are partially equal to the new values (metabase#59049)", () => {
+    createDashboard();
+    H.visitDashboard("@dashboardId");
+
+    cy.log(
+      "when not all old parameter values are equal to new values, do not reset",
+    );
+    H.filterWidget().first().click();
+    H.popover().within(() => {
+      cy.findByText("Gadget").click();
+      cy.button("Add filter").click();
+    });
+    H.assertTableRowsCount(53);
+    H.getDashboardCard().findAllByText("Gadget").first().click();
+    H.filterWidget().eq(0).should("contain", "Gadget");
+    H.filterWidget().eq(1).should("contain", "Price, Schultz and Daniel");
+    H.assertTableRowsCount(1);
+
+    cy.log("when all old parameter values are equal to new values, reset");
+    H.getDashboardCard().findAllByText("Gadget").first().click();
+    H.filterWidget().eq(0).should("not.contain", "Gadget");
+    H.filterWidget().eq(1).should("not.contain", "Price, Schultz and Daniel");
+    H.assertTableRowsCount(200);
+  });
+});

--- a/frontend/src/metabase/dashboard/actions/parameters.tsx
+++ b/frontend/src/metabase/dashboard/actions/parameters.tsx
@@ -955,13 +955,11 @@ export const setOrUnsetParameterValues =
   (parameterIdValuePairs: any[][]) =>
   (dispatch: Dispatch, getState: GetState) => {
     const parameterValues = getParameterValues(getState());
+    const isAllSet = parameterIdValuePairs.every(([id, value]) =>
+      _.isEqual(value, parameterValues[id]),
+    );
     parameterIdValuePairs
-      .map(([id, value]) =>
-        setParameterValue(
-          id,
-          _.isEqual(value, parameterValues[id]) ? null : value,
-        ),
-      )
+      .map(([id, value]) => setParameterValue(id, isAllSet ? null : value))
       .forEach(dispatch);
   };
 

--- a/frontend/src/metabase/dashboard/actions/parameters.tsx
+++ b/frontend/src/metabase/dashboard/actions/parameters.tsx
@@ -955,11 +955,11 @@ export const setOrUnsetParameterValues =
   (parameterIdValuePairs: any[][]) =>
   (dispatch: Dispatch, getState: GetState) => {
     const parameterValues = getParameterValues(getState());
-    const isAllSet = parameterIdValuePairs.every(([id, value]) =>
+    const areAllSet = parameterIdValuePairs.every(([id, value]) =>
       _.isEqual(value, parameterValues[id]),
     );
     parameterIdValuePairs
-      .map(([id, value]) => setParameterValue(id, isAllSet ? null : value))
+      .map(([id, value]) => setParameterValue(id, areAllSet ? null : value))
       .forEach(dispatch);
   };
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/59049

When there is a click behavior that updates parameter values for the current dashboard, we check if all parameters have the new values, and if that's the case, we reset all of them. Before, this logic worked per parameter, so if you had a click action that updated two parameters or more, it could lead to partial updates.

How to verify:
- New -> Dashboard -> Save
- Edit -> New question -> Products -> Save
- Add a Text parameter -> Connect to Category
- Add a Text parameter -> Connect to Vendor
- Click behavior for the card -> Category column -> Update dashboard filters -> Map both parameters to their columns
- Save the dashboard
- Set the value for the Category parameter manually, e.g. to `Gadget`
- Now click on any Category value in the table. Parameters will be set to both values (before the first parameter will be reset, and the second one was set).
- Click on the same call again. Now both parameters will be reset.

Demo https://www.loom.com/share/2fb250f291a347afa36652a43b5b33b1

<img width="1225" height="614" alt="Screenshot 2025-08-26 at 13 13 21" src="https://github.com/user-attachments/assets/666c4413-1ec7-4326-ae38-5cdfe10236af" />
<img width="615" height="495" alt="Screenshot 2025-08-26 at 13 13 11" src="https://github.com/user-attachments/assets/06359052-d4e8-4b34-9f4c-c8a42cc0b37b" />
