### PR TITLE
Fix conversion of pivot value keys to consistent types

### DIFF
--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -194,7 +194,7 @@
   (let [col-and-row-indexes (into (vec col-indexes) row-indexes)]
     (reduce
      (fn [acc row]
-       (let [value-key  (ensure-consistent-type (select-indexes row col-and-row-indexes))
+       (let [value-key  (mapv ensure-consistent-type (select-indexes row col-and-row-indexes))
              values     (select-indexes row val-indexes)
              data       (into []
                               (map-indexed

--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -194,7 +194,7 @@
   (let [col-and-row-indexes (into (vec col-indexes) row-indexes)]
     (reduce
      (fn [acc row]
-       (let [value-key  (mapv ensure-consistent-type (select-indexes row col-and-row-indexes))
+       (let [value-key  (perf/mapv ensure-consistent-type (select-indexes row col-and-row-indexes))
              values     (select-indexes row val-indexes)
              data       (into []
                               (map-indexed


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/62724

`ensure-consistent-type` needs to be mapped over the values from a pivot table result row to ensure BigInts/BigDecimals get normalized. This was inadvertently introduced by #61384 because `json-roundtrip` worked when applied to an entire vector, but `ensure-consistent-type` does not.

Also added a repro integration test on the BE. Wasn't covered before because we need to specifically bin `rating` in the test query for the QP to return BigDecimals. (I don't know exactly why the QP has different output types in this case, but this seems to trigger it)