### PR TITLE
Refactor browse hover actions to use ActionIcon

### DIFF
--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.jsx
@@ -8,13 +8,12 @@ import { BrowserCrumbs } from "metabase/common/components/BrowserCrumbs";
 import Link from "metabase/common/components/Link";
 import CS from "metabase/css/core/index.css";
 import { trackSimpleEvent } from "metabase/lib/analytics";
-import { color } from "metabase/lib/colors";
 import { useSelector } from "metabase/lib/redux";
 import { isSyncInProgress } from "metabase/lib/syncing";
 import { PLUGIN_TABLE_EDITING } from "metabase/plugins";
 import { getDatabases } from "metabase/reference/selectors";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { Group, Icon, Loader, Paper } from "metabase/ui";
+import { ActionIcon, Group, Icon, Loader, Paper } from "metabase/ui";
 import { isVirtualCardId } from "metabase-lib/v1/metadata/utils/saved-questions";
 
 import { BrowseHeaderContent } from "../../components/BrowseHeader.styled";
@@ -149,36 +148,43 @@ const TableBrowserItemButtons = ({
 
   return (
     <Paper p="sm" className={cx(CS.hoverChild, S.tableBrowserItemButtons)}>
-      <Group gap="md">
+      <Group gap="sm">
         {xraysEnabled && (
-          <Link to={`/auto/dashboard/table/${tableId}`}>
-            <Icon
-              name="bolt_filled"
-              tooltip={t`X-ray this table`}
-              color={color("warning")}
-            />
-          </Link>
+          <ActionIcon
+            component={Link}
+            to={`/auto/dashboard/table/${tableId}`}
+            size="sm"
+            tooltip={t`X-ray this table`}
+            color="warning"
+            aria-label={t`X-ray this table`}
+          >
+            <Icon name="bolt" />
+          </ActionIcon>
         )}
         {canEditTables && (
-          <Link
+          <ActionIcon
+            component={Link}
             to={PLUGIN_TABLE_EDITING.getTableEditUrl(tableId, dbId)}
             onClick={handleEditTableClicked}
+            size="sm"
+            tooltip={t`Edit this table`}
+            color="text-medium"
+            aria-label={t`Edit this table`}
             data-testid="edit-table-icon"
           >
-            <Icon
-              name="pencil"
-              tooltip={t`Edit this table`}
-              color={"var(--mb-color-text-medium)"}
-            />
-          </Link>
+            <Icon name="pencil" />
+          </ActionIcon>
         )}
-        <Link to={`/reference/databases/${dbId}/tables/${tableId}`}>
-          <Icon
-            name="reference"
-            tooltip={t`Learn about this table`}
-            color={color("text-medium")}
-          />
-        </Link>
+        <ActionIcon
+          component={Link}
+          to={`/reference/databases/${dbId}/tables/${tableId}`}
+          size="sm"
+          tooltip={t`Learn about this table`}
+          color="text-medium"
+          aria-label={t`Learn about this table`}
+        >
+          <Icon name="reference" />
+        </ActionIcon>
       </Group>
     </Paper>
   );

--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.unit.spec.js
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.unit.spec.js
@@ -21,7 +21,7 @@ describe("TableBrowser", () => {
     setup({ id: 1, name: "Orders", initial_sync_status: "complete" });
 
     expect(screen.getByText("Orders")).toBeInTheDocument();
-    expect(screen.getByLabelText("bolt_filled icon")).toBeInTheDocument();
+    expect(screen.getByLabelText("bolt icon")).toBeInTheDocument();
     expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
   });
 
@@ -29,7 +29,7 @@ describe("TableBrowser", () => {
     setup({ id: 1, name: "Orders", initial_sync_status: "incomplete" });
 
     expect(screen.getByText("Orders")).toBeInTheDocument();
-    expect(screen.queryByLabelText("bolt_filled icon")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("bolt icon")).not.toBeInTheDocument();
     expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
   });
 
@@ -37,7 +37,7 @@ describe("TableBrowser", () => {
     setup({ id: 1, name: "Orders", initial_sync_status: "aborted" });
 
     expect(screen.getByText("Orders")).toBeInTheDocument();
-    expect(screen.getByLabelText("bolt_filled icon")).toBeInTheDocument();
+    expect(screen.getByLabelText("bolt icon")).toBeInTheDocument();
     expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- Refactors this new interaction to use `ActionIcon` instead of `Icon` inside of `Link`, so that there's a built-in hover effect.
- Also use `bolt` instead of `bolt_outline` for the x-ray icon.

<img width="350" height="102" alt="image" src="https://github.com/user-attachments/assets/c85c1d15-c1c3-4b6a-b0b2-5aa1e5e61d47" />
