### PR TITLE
Fix Admin Nested Navlink Behavior

### DIFF
--- a/e2e/test/scenarios/admin-2/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/settings.cy.spec.js
@@ -1459,3 +1459,44 @@ describe("admin > settings > updates", () => {
     });
   });
 });
+
+describe("admin > settings > nav", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    cy.visit("/admin/settings");
+  });
+
+  it("should navigate properly", () => {
+    // sadly we can't test this in unit tests with the current state of react-router and redux 😭
+    cy.log("clicking sidebar nav links should navigate there");
+
+    cy.url().should("include", "/admin/settings/general");
+    cy.findByTestId("admin-layout-sidebar").findByText(/email/i).click();
+    cy.findByTestId("admin-layout-content").findByText(/email/i);
+    cy.url().should("include", "/admin/settings/email");
+
+    cy.log(
+      "clicking folders should expand and collapse them, but not navigate",
+    );
+
+    cy.findByTestId("admin-layout-sidebar")
+      .findByText(/api keys/i)
+      .should("not.be.visible");
+    cy.findByTestId("admin-layout-sidebar")
+      .findByText(/authentication/i)
+      .click();
+    cy.findByTestId("admin-layout-sidebar")
+      .findByText(/api keys/i)
+      .should("be.visible");
+    // still on email page
+    cy.findByTestId("admin-layout-content").findByText(/email/i);
+    cy.url().should("include", "/admin/settings/email");
+    // navigate to sub-item
+    cy.findByTestId("admin-layout-sidebar")
+      .findByText(/api keys/i)
+      .click();
+    cy.findByTestId("admin-layout-content").findByText(/No API keys here yet/i);
+    cy.url().should("include", "/admin/settings/authentication/api-keys");
+  });
+});

--- a/frontend/src/metabase/admin/components/AdminNav/AdminNav.tsx
+++ b/frontend/src/metabase/admin/components/AdminNav/AdminNav.tsx
@@ -34,13 +34,16 @@ export const AdminNavWrapper = ({
 };
 
 export type AdminNavItemProps = {
-  path: string;
+  path?: string;
+  /* folderPath is used to highlight the folder when one of its children is active, but doesn't navigate */
+  folderPattern?: string;
   icon?: IconName;
   onClick?: () => void;
 } & Omit<NavLinkProps, "href">;
 
 export function AdminNavItem({
   path,
+  folderPattern,
   label,
   icon,
   ...navLinkProps
@@ -50,9 +53,9 @@ export function AdminNavItem({
 
   return (
     <NavLink
-      component={Link}
-      to={path}
-      defaultOpened={subpath.includes(path)}
+      component={path ? Link : undefined}
+      to={path ?? ""}
+      defaultOpened={folderPattern ? subpath.includes(folderPattern) : false}
       active={path === subpath}
       variant="admin-nav"
       label={label}

--- a/frontend/src/metabase/admin/people/components/PeopleNav.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleNav.tsx
@@ -41,7 +41,7 @@ const PeopleNavItem = (props: AdminNavItemProps) => {
 
   // we want to highlight the groups nav item if it's showing a details subpage
   const isActive =
-    (props.path.includes("groups") && subpath.includes(props.path)) ||
+    (props.path?.includes("groups") && subpath.includes(props.path)) ||
     props.path === subpath;
 
   return <AdminNavItem {...props} active={isActive} />;

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -28,7 +28,11 @@ export function SettingsNav() {
   return (
     <AdminNavWrapper>
       <SettingsNavItem path="general" label={t`General`} icon="gear" />
-      <SettingsNavItem label={t`Authentication`} path="auth" icon="lock">
+      <SettingsNavItem
+        label={t`Authentication`}
+        icon="lock"
+        folderPattern="auth"
+      >
         <SettingsNavItem path="authentication" label={t`Overview`} />
         {hasScim && (
           <SettingsNavItem
@@ -59,6 +63,7 @@ export function SettingsNav() {
       <SettingsNavItem path="maps" label={t`Maps`} icon="pinmap" />
       <SettingsNavItem
         path="whitelabel"
+        folderPattern="whitelabel"
         label={
           <Flex gap="sm" align="center">
             <span>{t`Appearance`}</span>
@@ -88,7 +93,11 @@ export function SettingsNav() {
         label={t`Public sharing`}
         icon="share"
       />
-      <SettingsNavItem path="embedding" label={t`Embedding`} icon="embed">
+      <SettingsNavItem
+        label={t`Embedding`}
+        icon="embed"
+        folderPattern="embedding"
+      >
         <SettingsNavItem
           path="embedding-in-other-applications"
           label={t`Overview`}
@@ -130,13 +139,17 @@ const hasActiveChild = (children: ReactElement[], pathname: string) =>
     (child) => child?.props?.path && pathname.includes(child.props.path),
   );
 
-export function SettingsNavItem({ path, ...navItemProps }: AdminNavItemProps) {
+export function SettingsNavItem({
+  path,
+  folderPattern,
+  ...navItemProps
+}: AdminNavItemProps) {
   const children = React.Children.toArray(
     navItemProps.children,
   ) as ReactElement[];
   const currentPath: string = useSelector(getLocation)?.pathname ?? "";
   const [isOpen, { toggle: toggleOpen }] = useDisclosure(
-    currentPath.includes(path),
+    folderPattern ? currentPath.includes(folderPattern) : false,
   );
 
   const showActive =
@@ -146,7 +159,8 @@ export function SettingsNavItem({ path, ...navItemProps }: AdminNavItemProps) {
   return (
     <AdminNavItem
       data-testid={`settings-sidebar-link`}
-      path={`/admin/settings/${path}`}
+      path={path ? `/admin/settings/${path}` : ""}
+      folderPattern={folderPattern}
       opened={isOpen}
       active={showActive}
       onClick={toggleOpen}

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -62,7 +62,7 @@ export function SettingsNav() {
       />
       <SettingsNavItem path="maps" label={t`Maps`} icon="pinmap" />
       <SettingsNavItem
-        path="whitelabel"
+        path={!hasWhitelabel ? "whitelabel" : undefined}
         folderPattern="whitelabel"
         label={
           <Flex gap="sm" align="center">

--- a/frontend/src/metabase/admin/tools/components/ToolsApp.tsx
+++ b/frontend/src/metabase/admin/tools/components/ToolsApp.tsx
@@ -60,7 +60,7 @@ const ToolsNavItem = (props: AdminNavItemProps) => {
   const subpath = location?.pathname;
 
   // we want to highlight the nav item even if a subpath is active
-  const isActive = subpath.includes(props.path);
+  const isActive = !!props.path && subpath.includes(props.path);
 
   return <AdminNavItem {...props} active={isActive} />;
 };


### PR DESCRIPTION
Closes UXW-585
Closes #62780 

### Description

Previously, Mantine NavLinks would ignore click events if the NavLink contained other items. That changed somewhere between mantine 8.0 and 8.2. 

Previously, our SettingsNavItem component relied on the inactive `path` prop to handle highlighting behavior, relying on the fact that it would not navigate. Now that that is no longer true, I have introduced another prop: `folderPattern` - which will handle folder highlighting behavior more explicitly. (e.g. if a folder is collapsed while you're on a subpage, we should highlight the top level folder). That behavior was probably a bug and we shouldn't have relied on it in the first place.

<img width="249" height="211" alt="CleanShot 2025-08-26 at 13 14 51" src="https://github.com/user-attachments/assets/9a7e2db7-4aaf-4f47-922e-ac7e4ab2b347" />

### Checklist

I spent a bunch of time trying to get this tested in jest, and I think it's just not possible to write a meaningful navigation test with the current state of react-router + redux, so I did it in cypress.

- [x] Tests have been added/updated to cover changes in this PR
