### PR TITLE
Fix: #62732 Documents editor hijacks browser keyboard shortcuts

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
@@ -4,7 +4,6 @@ import { Placeholder } from "@tiptap/extension-placeholder";
 import type { EditorState } from "@tiptap/pm/state";
 import type { JSONContent, Editor as TiptapEditor } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
 import cx from "classnames";
 import type React from "react";
 import { useEffect, useMemo } from "react";
@@ -24,6 +23,7 @@ import { EditorBubbleMenu } from "./EditorBubbleMenu";
 import { CardEmbed } from "./extensions/CardEmbed/CardEmbedNode";
 import { CommandExtension } from "./extensions/Command/CommandExtension";
 import { CommandSuggestion } from "./extensions/Command/CommandSuggestion";
+import { CustomStarterKit } from "./extensions/CustomStarterKit/CustomStarterKit";
 import { DisableMetabotSidebar } from "./extensions/DisableMetabotSidebar";
 import { MentionExtension } from "./extensions/Mention/MentionExtension";
 import { MentionSuggestion } from "./extensions/Mention/MentionSuggestion";
@@ -95,7 +95,7 @@ export const Editor: React.FC<EditorProps> = ({
 
   const extensions = useMemo(
     () => [
-      StarterKit,
+      CustomStarterKit,
       Image.configure({
         inline: false,
         HTMLAttributes: {

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CustomStarterKit/CustomStarterKit.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CustomStarterKit/CustomStarterKit.tsx
@@ -2,7 +2,6 @@ import type { AnyExtension } from "@tiptap/core";
 import { Blockquote } from "@tiptap/extension-blockquote";
 import { Bold } from "@tiptap/extension-bold";
 import { StarterKit, type StarterKitOptions } from "@tiptap/starter-kit";
-import { omit } from "underscore";
 
 const CustomBlockquote = Blockquote.extend({
   addKeyboardShortcuts() {
@@ -14,7 +13,9 @@ const CustomBold = Bold.extend({
   addKeyboardShortcuts() {
     // "Mod-b" (sans shift key) is fine, "Mod-B" (with shift key) should not be hijacked
     // https://github.com/ueberdosis/tiptap/blob/v3.3.0/packages/extension-bold/src/bold.tsx#L116
-    return omit(this.parent?.(), "Mod-B");
+    return {
+      "Mod-b": () => this.editor.commands.toggleBold(),
+    };
   },
 });
 

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CustomStarterKit/CustomStarterKit.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/CustomStarterKit/CustomStarterKit.tsx
@@ -1,0 +1,61 @@
+import type { AnyExtension } from "@tiptap/core";
+import { Blockquote } from "@tiptap/extension-blockquote";
+import { Bold } from "@tiptap/extension-bold";
+import { StarterKit, type StarterKitOptions } from "@tiptap/starter-kit";
+import { omit } from "underscore";
+
+const CustomBlockquote = Blockquote.extend({
+  addKeyboardShortcuts() {
+    return {};
+  },
+});
+
+const CustomBold = Bold.extend({
+  addKeyboardShortcuts() {
+    // "Mod-b" (sans shift key) is fine, "Mod-B" (with shift key) should not be hijacked
+    // https://github.com/ueberdosis/tiptap/blob/v3.3.0/packages/extension-bold/src/bold.tsx#L116
+    return omit(this.parent?.(), "Mod-B");
+  },
+});
+
+const replaceExtension = <T extends AnyExtension>(
+  extensions: T[],
+  target: T,
+  replacement: T,
+): T[] => {
+  const index = extensions.findIndex((ext) => ext.name === target.name);
+  if (index === -1) {
+    return extensions;
+  }
+  const clone = [...extensions];
+  clone.splice(index, 1, replacement);
+  return clone;
+};
+
+/**
+ * Modified StarterKit so it doesn't hijack browsers' cmd/ctrl+shift+b behavior
+ */
+export const CustomStarterKit = StarterKit.extend<StarterKitOptions>({
+  name: "customStarterKit",
+  addExtensions() {
+    let extensions = this.parent?.() || [];
+
+    if (this.options.blockquote !== false) {
+      extensions = replaceExtension(
+        extensions,
+        Blockquote,
+        CustomBlockquote.configure(this.options.blockquote),
+      );
+    }
+
+    if (this.options.bold !== false) {
+      extensions = replaceExtension(
+        extensions,
+        Bold,
+        CustomBold.configure(this.options.bold),
+      );
+    }
+
+    return extensions;
+  },
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62732
Closes [GIT-7928
](https://linear.app/metabase/issue/GIT-7928)

### Description

Prevents tiptap's StarterKit from hijacking cmd/ctrl+shift+b

### How to verify

1. Navigate to a document
2. Press mod+shift+b
3. Verify it doesn't create a blockquote and the browser's default behavior for the shortcut is retained
  a. E.g. In Chrome, bookmarks bar should be toggled
4. Verify blockquotes can still be added/loaded via "> " and bubble menu
5. Verify text can still be bolded via mod+b and bubble menu

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR

^not sure how to verify we _aren't_ hijacking browser default behavior
