### PR TITLE
[Mongo] Fix type inference for columns returned by native queries

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -122,12 +122,15 @@
                                           :field_ref    [:field "count" {:base-type :type/Integer}]}]
                       :native_form      {:collection "venues"
                                          :query      native-query}
-                      :results_timezone "UTC"}}
+                      :results_timezone "UTC"
+                      :results_metadata {:columns [{:name           "count"
+                                                    :base_type      :type/Integer
+                                                    :effective_type :type/Integer}]}}}
          (-> (qp/process-query {:native   {:query      native-query
                                            :collection "venues"}
                                 :type     :native
                                 :database (mt/id)})
-             (m/dissoc-in [:data :results_metadata] [:data :insights]))))))
+             (m/dissoc-in [:data :insights]))))))
 
 (deftest ^:parallel nested-native-query-test
   (mt/test-driver :mongo

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -92,7 +92,12 @@
   [final-col-metadata insights-col-metadata]
   ;; the two metadatas will both be in order that matches the column order of the results
   (mapv
-   (fn [{final-base-type :base_type, :as final-col} {our-base-type :base_type, :as insights-col}]
+   (fn [{final-base-type      :base_type
+         final-effective-type :effective_type
+         :as final-col}
+        {our-base-type      :base_type
+         our-effective-type :effective_type
+         :as insights-col}]
      (merge
       (select-keys final-col [:id :description :display_name :semantic_type :fk_target_field_id
                               :settings :field_ref :base_type :effective_type :database_type
@@ -101,7 +106,9 @@
       insights-col
       {:name (:name final-col)} ; The final cols have correctly disambiguated ID_2 names, but the insights cols don't.
       (when (= our-base-type :type/*)
-        {:base_type final-base-type})))
+        {:base_type final-base-type})
+      (when (= our-effective-type :type/*)
+        {:effective_type final-effective-type})))
    final-col-metadata
    insights-col-metadata))
 


### PR DESCRIPTION
Closes #62397.

### Description

This was working for `:base_type`s but not `:effective_type`s.
The `:result_metadata` for a native Mongo query always had
`:effective_type :type/*` even when we correctly inferred the
`:base_type`.

### How to verify

1. Create a native Mongo query that returns some columns.
2. Observe that previous to this PR, the `:result_metadata` had `:effective_type :type/*`, breaking a bunch of things.
3. With this PR, `:effective_type` is set properly along with `:base_type`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
