### PR TITLE
Native Query Snippets Cycle Detection

### DIFF
--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -43,6 +43,7 @@
    [metabase.lib.stage :as lib.stage]
    [metabase.lib.swap :as lib.swap]
    [metabase.lib.table :as lib.table]
+   [metabase.lib.template-tags :as lib.template-tags]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.util :as lib.util]
    [metabase.util.namespaces :as shared.ns]))
@@ -85,6 +86,7 @@
          lib.stage/keep-me
          lib.swap/keep-me
          lib.table/keep-me
+         lib.template-tags/keep-me
          lib.temporal-bucket/keep-me
          lib.util/keep-me)
 
@@ -326,7 +328,8 @@
   raw-native-query
   recognize-template-tags
   required-native-extras
-  template-tag-card-ids
+  native-query-card-ids
+  native-query-snippet-ids
   template-tags-referenced-cards
   template-tags
   with-different-database
@@ -352,7 +355,7 @@
   can-preview
   can-run
   can-save
-  check-overwrite
+  check-card-overwrite
   preview-query
   query
   query-from-legacy-inner-query
@@ -381,6 +384,9 @@
   has-clauses?]
  [lib.swap
   swap-clauses]
+ [lib.template-tags
+  template-tags->card-ids
+  template-tags->snippet-ids]
  [lib.temporal-bucket
   describe-temporal-unit
   describe-temporal-interval

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -13,6 +13,7 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
+   [metabase.lib.template-tags :as lib.template-tags]
    [metabase.lib.util :as lib.util]
    [metabase.util.humanization :as u.humanization]
    [metabase.util.i18n :as i18n]
@@ -272,10 +273,10 @@
   [query :- ::lib.schema/query]
   (:template-tags (lib.util/query-stage query 0)))
 
-(mu/defn template-tag-card-ids :- [:maybe [:set {:min 1} ::lib.schema.id/card]]
+(mu/defn native-query-card-ids :- [:maybe [:set {:min 1} ::lib.schema.id/card]]
   "Returns the card IDs from the template tags of the native query of `query`."
   [query :- ::lib.schema/query]
-  (not-empty (into #{} (keep (fn [[_k m]] (:card-id m))) (template-tags query))))
+  (lib.template-tags/template-tags->card-ids (template-tags query)))
 
 (mu/defn template-tags-referenced-cards :- [:maybe [:sequential ::lib.schema.metadata/card]]
   "Returns Card instances referenced by the given native `query`."
@@ -283,7 +284,12 @@
   (mapv
    (fn [card-id]
      (lib.metadata/card query card-id))
-   (template-tag-card-ids query)))
+   (native-query-card-ids query)))
+
+(mu/defn native-query-snippet-ids :- [:maybe [:set {:min 1} ::lib.schema.id/native-query-snippet]]
+  "Returns the card IDs from the template tags of the native query of `query`."
+  [query :- ::lib.schema/query]
+  (lib.template-tags/template-tags->snippet-ids (template-tags query)))
 
 (mu/defn has-template-tag-variables? :- :boolean
   "Tests whether `query` has any template-tag variables.

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -511,7 +511,6 @@
         snippet-id (dep/depend from-entity [:snippet snippet-id])
         table-id (dep/depend from-entity [:table table-id]))
       (catch #?(:clj Exception :cljs :default) e
-        ;; Keep the original message for backward compatibility
         (throw (ex-info (i18n/tru "Cannot save card with cycles.") {} e))))))
 
 (defn- build-card-snippet-graph [source-entity metadata-provider a-query]

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -451,10 +451,13 @@
   [a-query]
   (dissoc a-query :lib/metadata))
 
-(defn- get-native-stages [native-stage]
-  (for [{:keys [card-id] tag-type :type} (-> native-stage :template-tags vals)
-        :when (= tag-type :card)]
-    {:source-card card-id}))
+(defn- template-tag-stages
+  [template-tags]
+  (for [{:keys [card-id snippet-id] tag-type :type} (vals template-tags)
+        :when (#{:card :snippet} tag-type)]
+    (case tag-type
+      :card {:source-card card-id}
+      :snippet {:source-snippet-id snippet-id})))
 
 (defn- stage-seq* [query-fragment]
   (cond
@@ -467,38 +470,54 @@
 
     (map? query-fragment)
     (if (= (:lib/type query-fragment) :mbql.stage/native)
-      (get-native-stages query-fragment)
+      (-> query-fragment :template-tags template-tag-stages)
       (concat (:stages query-fragment) (mapcat stage-seq* (vals query-fragment))))
 
     :else
     []))
 
-(defn- stage-seq [card-id a-query]
-  (map #(assoc % ::from-card card-id) (stage-seq* a-query)))
+(defn- stage-seq [from-entity a-query]
+  ;; from-entity is [entity-type entity-id] like [:card 123] or [:snippet 456]
+  (map #(assoc % ::from-entity from-entity) (stage-seq* a-query)))
+
+(defn- snippet-seq [from-entity snippet]
+  (map #(assoc % ::from-entity from-entity) (template-tag-stages (:template-tags snippet))))
 
 (defn- expand-stage [metadata-provider stage]
-  (let [card-id (:source-card stage)
-        expanded-query (some->> card-id
-                                (lib.metadata/card metadata-provider)
-                                :dataset-query
-                                (query metadata-provider))]
-    (stage-seq card-id expanded-query)))
+  (let [{card-id    :source-card
+         snippet-id :source-snippet-id} stage]
+    (cond
+      card-id
+      (let [expanded-query (some->> card-id
+                                    (lib.metadata/card metadata-provider)
+                                    :dataset-query
+                                    (query metadata-provider))]
+        (stage-seq [:card card-id] expanded-query))
+
+      snippet-id
+      (when-let [snippet (lib.metadata/native-query-snippet metadata-provider snippet-id)]
+        (snippet-seq [:snippet snippet-id] snippet))
+
+      :else [])))
 
 (defn- add-stage-dep [graph stage]
-  (let [card-id  (:source-card  stage)
-        table-id (:source-table stage)
-        from-id  (::from-card   stage)]
+  (let [{card-id :source-card
+         snippet-id :source-snippet-id
+         table-id :source-table
+         from-entity ::from-entity} stage]
     (try
       (cond-> graph
-        card-id  (dep/depend [:card from-id] [:card  card-id])
-        table-id (dep/depend [:card from-id] [:table table-id]))
+        card-id (dep/depend from-entity [:card card-id])
+        snippet-id (dep/depend from-entity [:snippet snippet-id])
+        table-id (dep/depend from-entity [:table table-id]))
       (catch #?(:clj Exception :cljs :default) e
+        ;; Keep the original message for backward compatibility
         (throw (ex-info (i18n/tru "Cannot save card with cycles.") {} e))))))
 
-(defn- build-graph [source-id metadata-provider a-query]
+(defn- build-card-snippet-graph [source-entity metadata-provider a-query]
   (loop [graph (dep/graph)
          stages-visited 0
-         stages (stage-seq source-id a-query)]
+         stages (stage-seq source-entity a-query)]
     (cond
       (empty? stages)
       graph
@@ -512,12 +531,12 @@
                (inc stages-visited)
                (concat stages (expand-stage metadata-provider stage)))))))
 
-(defn check-overwrite
+(defn check-card-overwrite
   "Returns nil if the card with given `card-id` can be overwritten with `query`.
   Throws `ExceptionInfo` with a user-facing message otherwise.
 
   Currently checks for cycles (self-referencing queries)."
   [card-id new-query]
-  (build-graph card-id new-query new-query)
+  (build-card-snippet-graph [:card card-id] new-query new-query)
   ;; return nil if nothing throws
   nil)

--- a/src/metabase/lib/template_tags.cljc
+++ b/src/metabase/lib/template_tags.cljc
@@ -1,0 +1,15 @@
+(ns metabase.lib.template-tags
+  (:require
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.schema.template-tag :as lib.schema.template-tag]
+   [metabase.util.malli :as mu]))
+
+(mu/defn template-tags->card-ids :- [:maybe [:set {:min 1} ::lib.schema.id/card]]
+  "Returns the card IDs from the sequence of template tags."
+  [template-tags :- [:sequential ::lib.schema.template-tag/template-tag]]
+  (not-empty (into #{} (keep (fn [[_k m]] (:card-id m))) template-tags)))
+
+(mu/defn template-tags->snippet-ids :- [:maybe [:set {:min 1} ::lib.schema.id/native-query-snippet]]
+  "Returns the snippet IDs from the sequence of template tags."
+  [template-tags :- [:sequential ::lib.schema.template-tag/template-tag]]
+  (not-empty (into #{} (keep (fn [[_k m]] (:snippet-id m))) template-tags)))

--- a/src/metabase/lib/template_tags.cljc
+++ b/src/metabase/lib/template_tags.cljc
@@ -7,9 +7,13 @@
 (mu/defn template-tags->card-ids :- [:maybe [:set {:min 1} ::lib.schema.id/card]]
   "Returns the card IDs from the template tags map."
   [template-tags :- [:maybe ::lib.schema.template-tag/template-tag-map]]
-  (not-empty (into #{} (keep (fn [[_k m]] (:card-id m))) template-tags)))
+  (->> template-tags
+       (into #{} (comp (map val) (keep :card-id)))
+       not-empty))
 
 (mu/defn template-tags->snippet-ids :- [:maybe [:set {:min 1} ::lib.schema.id/native-query-snippet]]
   "Returns the snippet IDs from the template tags map."
   [template-tags :- [:maybe ::lib.schema.template-tag/template-tag-map]]
-  (not-empty (into #{} (keep (fn [[_k m]] (:snippet-id m))) template-tags)))
+  (->> template-tags
+       (into #{} (comp (map val) (keep :snippet-id)))
+       not-empty))

--- a/src/metabase/lib/template_tags.cljc
+++ b/src/metabase/lib/template_tags.cljc
@@ -5,11 +5,11 @@
    [metabase.util.malli :as mu]))
 
 (mu/defn template-tags->card-ids :- [:maybe [:set {:min 1} ::lib.schema.id/card]]
-  "Returns the card IDs from the sequence of template tags."
-  [template-tags :- [:sequential ::lib.schema.template-tag/template-tag]]
+  "Returns the card IDs from the template tags map."
+  [template-tags :- [:maybe ::lib.schema.template-tag/template-tag-map]]
   (not-empty (into #{} (keep (fn [[_k m]] (:card-id m))) template-tags)))
 
 (mu/defn template-tags->snippet-ids :- [:maybe [:set {:min 1} ::lib.schema.id/native-query-snippet]]
-  "Returns the snippet IDs from the sequence of template tags."
-  [template-tags :- [:sequential ::lib.schema.template-tag/template-tag]]
+  "Returns the snippet IDs from the template tags map."
+  [template-tags :- [:maybe ::lib.schema.template-tag/template-tag-map]]
   (not-empty (into #{} (keep (fn [[_k m]] (:snippet-id m))) template-tags)))

--- a/src/metabase/native_query_snippets/models/native_query_snippet.clj
+++ b/src/metabase/native_query_snippets/models/native_query_snippet.clj
@@ -1,14 +1,11 @@
 (ns metabase.native-query-snippets.models.native-query-snippet
   (:require
-   [medley.core :as m]
    [metabase.collections.models.collection :as collection]
    [metabase.lib.core :as lib]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.normalize :as lib.normalize]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.native-query-snippets.models.native-query-snippet.permissions :as snippet.perms]
-   [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.malli :as mu]

--- a/src/metabase/queries/api/card.clj
+++ b/src/metabase/queries/api/card.clj
@@ -612,7 +612,7 @@
   (check-if-card-can-be-saved dataset_query type)
   (when-some [query (dataset-query->query dataset_query)]
     (try
-      (lib/check-overwrite id query)
+      (lib/check-card-overwrite id query)
       (catch clojure.lang.ExceptionInfo e
         (throw (ex-info (ex-message e) (assoc (ex-data e) :status-code 400))))))
   (let [card-before-update     (t2/hydrate (api/write-check :model/Card id)

--- a/src/metabase/query_processor/middleware/resolve_referenced.clj
+++ b/src/metabase/query_processor/middleware/resolve_referenced.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.resolve-referenced
   (:require
+   [clojure.set :as set]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
@@ -27,6 +28,31 @@
     (qp.resolve-source-table/resolve-source-tables resolved-query)
     (qp.resolve-fields/resolve-fields resolved-query)))
 
+(mu/defn- expand-snippets-to-card-ids
+  "Recursively expand snippets to find all card IDs they reference.
+   Returns a set of card IDs found within the snippets and their nested snippets."
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   query]
+  (if-let [snippet-ids (lib/native-query-snippet-ids query)]
+    (loop [to-process snippet-ids
+           visited #{}
+           card-ids #{}]
+      (if-let [snippet-id (first to-process)]
+        (if (visited snippet-id)
+          ;; Skip already processed snippet
+          (recur (rest to-process) visited card-ids)
+          ;; Process this snippet
+          (let [snippet (lib.metadata/native-query-snippet metadata-providerable snippet-id)
+                snippet-template-tags (:template-tags snippet)
+                snippet-card-ids (lib/template-tags->card-ids snippet-template-tags)
+                nested-snippet-ids (lib/template-tags->snippet-ids snippet-template-tags)]
+            (recur (into (rest to-process) nested-snippet-ids)
+                   (conj visited snippet-id)
+                   (into card-ids snippet-card-ids))))
+        ;; Nothing left in to-process:
+        card-ids))
+    #{}))
+
 (mu/defn- card-subquery-graph
   [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
    graph                 :- :map
@@ -35,22 +61,26 @@
                             (throw (ex-info (tru "Card {0} does not exist, or is from a different Database." (pr-str card-id))
                                             {:type qp.error-type/invalid-query, :card-id card-id})))
                         (qp.fetch-source-query/normalize-card-query metadata-providerable)
-                        :dataset-query)]
+                        :dataset-query)
+        card-ids (set/union
+                  (lib/native-query-card-ids card-query)
+                  (expand-snippets-to-card-ids metadata-providerable card-query))]
     (reduce
      (fn [g sub-card-id]
        (card-subquery-graph metadata-providerable
                             (dep/depend g card-id sub-card-id)
                             sub-card-id))
      graph
-     (lib/template-tag-card-ids card-query))))
+     card-ids)))
 
 (mu/defn- circular-ref-error :- ::lib.schema.common/non-blank-string
   [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
    from-card             :- ::lib.schema.id/card
    to-card               :- ::lib.schema.id/card]
-  (let [cards     (into {}
-                        (map (juxt :id :name))
-                        (lib.metadata/bulk-metadata metadata-providerable :metadata/card #{from-card to-card}))
+  (let [card-ids (conj #{from-card} to-card) ; card could point to itself, via snippets
+        cards (into {}
+                    (map (juxt :id :name))
+                    (lib.metadata/bulk-metadata metadata-providerable :metadata/card card-ids))
         from-name (or (get cards from-card)
                       (throw (ex-info (tru "Referenced query is from a different database")
                                       {:type qp.error-type/invalid-query, :card-id from-card})))
@@ -67,7 +97,7 @@
   (try
     (reduce (partial card-subquery-graph query)
             (dep/graph)
-            (lib/template-tag-card-ids query))
+            (lib/native-query-card-ids query))
     (catch ExceptionInfo e
       (let [{:keys [reason node dependency]} (ex-data e)]
         (if (= reason :weavejester.dependency/circular-dependency)

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -342,7 +342,7 @@
 (deftest ^:parallel engine-test
   (is (= :h2 (lib/engine (lib.tu/native-query)))))
 
-(deftest ^:parallel template-tag-card-ids-test
+(deftest ^:parallel native-query-card-ids-test
   (let [query (lib/query (lib.tu/metadata-provider-with-mock-cards)
                          {:database (meta/id)
                           :type     :native
@@ -354,7 +354,7 @@
                                                                                 :display-name "Y"
                                                                                 :card-id      2}}}})]
     (is (= #{1 2}
-           (lib/template-tag-card-ids query)))))
+           (lib/native-query-card-ids query)))))
 
 (deftest ^:parallel template-tags-referenced-cards-test
   (testing "returns Card instances from raw query"

--- a/test/metabase/queries/api/card_test.clj
+++ b/test/metabase/queries/api/card_test.clj
@@ -4346,6 +4346,93 @@
                                            {:dataset_query (lib/->legacy-MBQL query-cycle)
                                             :type          :question}))))))))))
 
+(deftest cannot-create-card-snippet-cycle-test
+  (testing "Cannot create card → snippet → card cycle"
+    (mt/with-temp [:model/NativeQuerySnippet snippet {:name "test-snippet"
+                                                      :content "WHERE true"
+                                                      :template_tags {}}
+                   :model/Card card {:dataset_query
+                                     {:database (mt/id)
+                                      :type :native
+                                      :native {:query "SELECT * FROM products"}}}]
+      ;; Update snippet to reference card (creates snippet → card)
+      (t2/update! :model/NativeQuerySnippet (:id snippet)
+                  {:content (str "WHERE id IN ({{#" (:id card) "}})")
+                   :template_tags {(str "card-" (:id card)) {:type :card
+                                                             :card-id (:id card)
+                                                             :name (str "card-" (:id card))
+                                                             :display-name "Card Reference"}}})
+
+      ;; Try to update card to reference snippet (would create card → snippet → card cycle)
+      (is (= "Cannot save card with cycles."
+             (mt/user-http-request :crowberto :put 400 (str "card/" (:id card))
+                                   {:dataset_query
+                                    {:database (mt/id)
+                                     :type :native
+                                     :native {:query (str "SELECT * FROM products {{snippet:" (:name snippet) "}}")
+                                              :template-tags {(str "snippet: " (:name snippet))
+                                                              {:type :snippet
+                                                               :snippet-id (:id snippet)
+                                                               :snippet-name (:name snippet)
+                                                               :name (str "snippet:" (:name snippet))
+                                                               :display-name "Test Snippet"}}}}}))))))
+
+(deftest cannot-create-multi-hop-card-snippet-cycle-test
+  (testing "Cannot create cycles through multiple cards and snippets"
+    (mt/with-temp [:model/NativeQuerySnippet snippet-1 {:name "snippet-1"
+                                                        :content "WHERE category = 'Electronics'"
+                                                        :template_tags {}}
+                   :model/NativeQuerySnippet snippet-2 {:name "snippet-2"
+                                                        :content "AND price > 100"
+                                                        :template_tags {}}
+                   :model/Card card-1 {:dataset_query
+                                       {:database (mt/id)
+                                        :type :native
+                                        :native {:query (str "SELECT * FROM products {{snippet:" "snippet-1" "}}")
+                                                 :template-tags {(str "snippet:" "snippet-1")
+                                                                 {:type :snippet
+                                                                  :snippet-id (:id snippet-1)
+                                                                  :snippet-name "snippet-1"
+                                                                  :name (str "snippet:" "snippet-1")
+                                                                  :display-name "Snippet 1"}}}}}
+                   :model/Card card-2 {:dataset_query
+                                       {:database (mt/id)
+                                        :type :native
+                                        :native {:query (format "SELECT * FROM {{#%d}}" (:id card-1))
+                                                 :template-tags {(str "#" (:id card-1))
+                                                                 {:type :card
+                                                                  :card-id (:id card-1)
+                                                                  :name (str "#" (:id card-1))
+                                                                  :display-name "Card 1"}}}}}]
+      ;; Update snippet-2 to reference card-2 (creates snippet-2 → card-2 → card-1 → snippet-1)
+      (t2/update! :model/NativeQuerySnippet (:id snippet-2)
+                  {:content (str "AND id IN ({{#" (:id card-2) "}})")
+                   :template_tags {(str "card-" (:id card-2)) {:type :card
+                                                               :card-id (:id card-2)
+                                                               :name (str "card-" (:id card-2))
+                                                               :display-name "Card 2"}}})
+
+      ;; Try to update card-1 to also reference snippet-2
+      ;; (would create card-1 → snippet-2 → card-2 → card-1 cycle)
+      (is (= "Cannot save card with cycles."
+             (mt/user-http-request :crowberto :put 400 (str "card/" (:id card-1))
+                                   {:dataset_query
+                                    {:database (mt/id)
+                                     :type :native
+                                     :native {:query (str "SELECT * FROM products {{snippet:" "snippet-1" "}} {{snippet:" "snippet-2" "}}")
+                                              :template-tags {(str "snippet:" "snippet-1")
+                                                              {:type :snippet
+                                                               :snippet-id (:id snippet-1)
+                                                               :snippet-name "snippet-1"
+                                                               :name (str "snippet:" "snippet-1")
+                                                               :display-name "Snippet 1"}
+                                                              (str "snippet:" "snippet-2")
+                                                              {:type :snippet
+                                                               :snippet-id (:id snippet-2)
+                                                               :snippet-name "snippet-2"
+                                                               :name (str "snippet:" "snippet-2")
+                                                               :display-name "Snippet 2"}}}}}))))))
+
 (deftest e2e-card-update-invalidates-cache-test
   (testing "Card update invalidates card's cache (#55955)"
     (let [existing-config (t2/select-one :model/CacheConfig :model_id 0 :model "root")]

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -183,44 +183,6 @@
           (is (= 2 (t2/count :model/Action :id [:in [action-id-1 action-id-2]])))
           (is (= 2 (t2/count :model/ImplicitAction :action_id [:in [action-id-1 action-id-2]]))))))))
 
-;;; ------------------------------------------ Circular Reference Detection ------------------------------------------
-
-(defn- card-with-source-table
-  "Generate values for a Card with `source-table` for use with `with-temp`."
-  [source-table & {:as kvs}]
-  (merge {:dataset_query {:database (mt/id)
-                          :type     :query
-                          :query    {:source-table source-table}}}
-         kvs))
-
-(deftest circular-reference-test
-  (testing "Should throw an Exception if saving a Card that references itself"
-    (mt/with-temp [:model/Card card (card-with-source-table (mt/id :venues))]
-      ;; now try to make the Card reference itself. Should throw Exception
-      (is (thrown?
-           Exception
-           (t2/update! :model/Card (u/the-id card)
-                       (card-with-source-table (str "card__" (u/the-id card)))))))))
-
-(deftest circular-reference-test-2
-  (testing "Do the same stuff with circular reference between two Cards... (A -> B -> A)"
-    (mt/with-temp [:model/Card card-a (card-with-source-table (mt/id :venues))
-                   :model/Card card-b (card-with-source-table (str "card__" (u/the-id card-a)))]
-      (is (thrown?
-           Exception
-           (t2/update! :model/Card (u/the-id card-a)
-                       (card-with-source-table (str "card__" (u/the-id card-b)))))))))
-
-(deftest circular-reference-test-3
-  (testing "ok now try it with A -> C -> B -> A"
-    (mt/with-temp [:model/Card card-a (card-with-source-table (mt/id :venues))
-                   :model/Card card-b (card-with-source-table (str "card__" (u/the-id card-a)))
-                   :model/Card card-c (card-with-source-table (str "card__" (u/the-id card-b)))]
-      (is (thrown?
-           Exception
-           (t2/update! :model/Card (u/the-id card-a)
-                       (card-with-source-table (str "card__" (u/the-id card-c)))))))))
-
 (deftest validate-collection-namespace-test
   (mt/with-temp [:model/Collection {collection-id :id} {:namespace "currency"}]
     (testing "Shouldn't be able to create a Card in a non-normal Collection"

--- a/test/metabase/query_processor/middleware/resolve_referenced_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_referenced_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.resolve-referenced-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
@@ -88,39 +89,63 @@
             (is (= (#'qp.resolve-referenced/circular-ref-error entrypoint-query 2 1)
                    (ex-message e)))))))))
 
+(defn- make-card-template-tag
+  "Helper to create a card template tag with proper display-name"
+  [card-id & [tag-name]]
+  (let [name (or tag-name (str "#" card-id))]
+    {name {:name         name
+           :display-name (str "Card " card-id)
+           :type         :card
+           :card-id      card-id}}))
+
+(defn- make-snippet-template-tag
+  "Helper to create a snippet template tag with proper display-name"
+  [snippet-id snippet-name & [tag-name]]
+  (let [name (or tag-name (str "snippet: " snippet-name))]
+    {name {:name         name
+           :display-name snippet-name
+           :type         :snippet
+           :snippet-name snippet-name
+           :snippet-id   snippet-id}}))
+
+(defn- make-snippet
+  "Helper to create a snippet with properly formatted template tags"
+  [{:keys [id name content card-refs snippet-refs]}]
+  (let [card-tags    (reduce merge {} (map make-card-template-tag card-refs))
+        snippet-tags (reduce merge {} (map (fn [[snippet-id snippet-name]]
+                                             (make-snippet-template-tag snippet-id snippet-name))
+                                           snippet-refs))]
+    {:id            id
+     :name          name
+     :content       content
+     :template-tags (merge card-tags snippet-tags)}))
+
 (deftest ^:parallel card-snippet-card-circular-reference-test
   (testing "Detects card→snippet→card circular references"
     (testing "Card 1 → Snippet A → Card 1 (direct cycle)"
       (let [metadata-provider (lib.tu/metadata-provider-with-cards-for-queries
                                meta/metadata-provider
                                [{:database (meta/id)
-                                 :type :native
-                                 :native {:query "SELECT * FROM {{snippet: snippet-a}}"
-                                          :template-tags {"snippet: snippet-a"
-                                                          {:name "snippet: snippet-a"
-                                                           :display-name "Snippet A"
-                                                           :type :snippet
-                                                           :snippet-name "snippet-a"
-                                                           :snippet-id 100}}}}])
+                                 :type     :native
+                                 :native   {:query         "SELECT * FROM {{snippet: snippet-a}}"
+                                            :template-tags (make-snippet-template-tag 100 "snippet-a")}}])
             ;; Add snippet to metadata provider using the correct key
             metadata-provider-with-snippet
             (lib.tu/mock-metadata-provider
              metadata-provider
-             {:native-query-snippets [{:id 100
-                                       :name "snippet-a"
-                                       :content "WHERE id IN (SELECT id FROM {{#1}})"
-                                       :template-tags {"#1" {:name "#1"
-                                                             :display-name "Card 1"
-                                                             :type :card
-                                                             :card-id 1}}}]})
+             {:native-query-snippets [(make-snippet {:id           100
+                                                     :name         "snippet-a"
+                                                     :content      "WHERE id IN (SELECT id FROM {{#1}})"
+                                                     :card-refs    [1]
+                                                     :snippet-refs []})]})
 
             ;; Create the query that starts the cycle
             entrypoint-query (lib/query
                               metadata-provider-with-snippet
-                              {:database (meta/id)
-                               :type :native
-                               :native {:query "SELECT * FROM {{#1}}"
-                                        :template-tags (card-template-tags [1])}})]
+                               {:database (meta/id)
+                                :type     :native
+                                :native   {:query         "SELECT * FROM {{#1}}"
+                                           :template-tags (card-template-tags [1])}})]
 
         (testing "Should throw an exception for circular reference"
           (is (thrown-with-msg?
@@ -136,64 +161,44 @@
                                meta/metadata-provider
                                [;; Card A (id 1) references snippet-1
                                 {:database (meta/id)
-                                 :type :native
-                                 :native {:query "SELECT * FROM {{snippet: snippet-1}}"
-                                          :template-tags {"snippet: snippet-1"
-                                                          {:name "snippet: snippet-1"
-                                                           :display-name "Snippet 1"
-                                                           :type :snippet
-                                                           :snippet-name "snippet-1"
-                                                           :snippet-id 101}}}}
+                                 :type     :native
+                                 :native   {:query         "SELECT * FROM {{snippet: snippet-1}}"
+                                            :template-tags (make-snippet-template-tag 101 "snippet-1")}}
                                 ;; Card B (id 2) references snippet-3
                                 {:database (meta/id)
-                                 :type :native
-                                 :native {:query "SELECT * FROM {{snippet: snippet-3}}"
-                                          :template-tags {"snippet: snippet-3"
-                                                          {:name "snippet: snippet-3"
-                                                           :display-name "Snippet 3"
-                                                           :type :snippet
-                                                           :snippet-name "snippet-3"
-                                                           :snippet-id 103}}}}])
+                                 :type     :native
+                                 :native   {:query         "SELECT * FROM {{snippet: snippet-3}}"
+                                            :template-tags (make-snippet-template-tag 103 "snippet-3")}}])
             ;; Add all three snippets to the metadata provider
             metadata-provider-with-snippets
             (lib.tu/mock-metadata-provider
              metadata-provider
              {:native-query-snippets [;; Snippet 1 references snippet-2
-                                      {:id 101
-                                       :name "snippet-1"
-                                       :content "WHERE x IN ({{snippet: snippet-2}})"
-                                       :template-tags {"snippet: snippet-2"
-                                                       {:name "snippet: snippet-2"
-                                                        :display-name "Snippet 2"
-                                                        :type :snippet
-                                                        :snippet-name "snippet-2"
-                                                        :snippet-id 102}}}
+                                      (make-snippet {:id           101
+                                                     :name         "snippet-1"
+                                                     :content      "WHERE x IN ({{snippet: snippet-2}})"
+                                                     :card-refs    []
+                                                     :snippet-refs [[102 "snippet-2"]]})
                                       ;; Snippet 2 references Card B (id 2)
-                                      {:id 102
-                                       :name "snippet-2"
-                                       :content "SELECT y FROM {{#2}}"
-                                       :template-tags {"#2"
-                                                       {:name "#2"
-                                                        :display-name "Card B"
-                                                        :type :card
-                                                        :card-id 2}}}
+                                      (make-snippet {:id           102
+                                                     :name         "snippet-2"
+                                                     :content      "SELECT y FROM {{#2}}"
+                                                     :card-refs    [2]
+                                                     :snippet-refs []})
                                       ;; Snippet 3 references Card A (id 1), completing the cycle
-                                      {:id 103
-                                       :name "snippet-3"
-                                       :content "SELECT z FROM {{#1}}"
-                                       :template-tags {"#1"
-                                                       {:name "#1"
-                                                        :display-name "Card A"
-                                                        :type :card
-                                                        :card-id 1}}}]})
+                                      (make-snippet {:id           103
+                                                     :name         "snippet-3"
+                                                     :content      "SELECT z FROM {{#1}}"
+                                                     :card-refs    [1]
+                                                     :snippet-refs []})]})
 
             ;; Create the query that starts with Card A
             entrypoint-query (lib/query
                               metadata-provider-with-snippets
-                              {:database (meta/id)
-                               :type :native
-                               :native {:query "SELECT * FROM {{#1}}"
-                                        :template-tags (card-template-tags [1])}})]
+                               {:database (meta/id)
+                                :type     :native
+                                :native   {:query         "SELECT * FROM {{#1}}"
+                                           :template-tags (card-template-tags [1])}})]
 
         (testing "Should throw an exception for circular reference"
           (is (thrown-with-msg?
@@ -205,10 +210,10 @@
           ;; Starting from Card B should also detect the cycle
           (let [card-b-query (lib/query
                               metadata-provider-with-snippets
-                              {:database (meta/id)
-                               :type :native
-                               :native {:query "SELECT * FROM {{#2}}"
-                                        :template-tags (card-template-tags [2])}})]
+                               {:database (meta/id)
+                                :type     :native
+                                :native   {:query         "SELECT * FROM {{#2}}"
+                                           :template-tags (card-template-tags [2])}})]
             (is (thrown-with-msg?
                  ExceptionInfo
                  #"circular|cycle"

--- a/test/metabase/query_processor/middleware/resolve_referenced_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_referenced_test.clj
@@ -87,3 +87,125 @@
           (testing e
             (is (= (#'qp.resolve-referenced/circular-ref-error entrypoint-query 2 1)
                    (ex-message e)))))))))
+
+(deftest ^:parallel card-snippet-card-circular-reference-test
+  (testing "Detects card→snippet→card circular references"
+    (testing "Card 1 → Snippet A → Card 1 (direct cycle)"
+      (let [metadata-provider (lib.tu/metadata-provider-with-cards-for-queries
+                               meta/metadata-provider
+                               [{:database (meta/id)
+                                 :type :native
+                                 :native {:query "SELECT * FROM {{snippet: snippet-a}}"
+                                          :template-tags {"snippet: snippet-a"
+                                                          {:name "snippet: snippet-a"
+                                                           :display-name "Snippet A"
+                                                           :type :snippet
+                                                           :snippet-name "snippet-a"
+                                                           :snippet-id 100}}}}])
+            ;; Add snippet to metadata provider using the correct key
+            metadata-provider-with-snippet
+            (lib.tu/mock-metadata-provider
+             metadata-provider
+             {:native-query-snippets [{:id 100
+                                       :name "snippet-a"
+                                       :content "WHERE id IN (SELECT id FROM {{#1}})"
+                                       :template-tags {"#1" {:name "#1"
+                                                             :type :card
+                                                             :card-id 1}}}]})
+
+            ;; Create the query that starts the cycle
+            entrypoint-query (lib/query
+                              metadata-provider-with-snippet
+                              {:database (meta/id)
+                               :type :native
+                               :native {:query "SELECT * FROM {{#1}}"
+                                        :template-tags (card-template-tags [1])}})]
+
+        (testing "Should throw an exception for circular reference"
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"circular|cycle"
+               (#'qp.resolve-referenced/check-for-circular-references entrypoint-query))))))))
+
+(deftest ^:parallel complex-card-snippet-cycle-test
+  (testing "Detects complex card→snippet→snippet→card→snippet→card circular references"
+    (testing "Card A → Snippet 1 → Snippet 2 → Card B → Snippet 3 → Card A"
+      (let [;; Set up the metadata provider with both cards
+            metadata-provider (lib.tu/metadata-provider-with-cards-for-queries
+                               meta/metadata-provider
+                               [;; Card A (id 1) references snippet-1
+                                {:database (meta/id)
+                                 :type :native
+                                 :native {:query "SELECT * FROM {{snippet: snippet-1}}"
+                                          :template-tags {"snippet: snippet-1"
+                                                          {:name "snippet: snippet-1"
+                                                           :display-name "Snippet 1"
+                                                           :type :snippet
+                                                           :snippet-name "snippet-1"
+                                                           :snippet-id 101}}}}
+                                ;; Card B (id 2) references snippet-3
+                                {:database (meta/id)
+                                 :type :native
+                                 :native {:query "SELECT * FROM {{snippet: snippet-3}}"
+                                          :template-tags {"snippet: snippet-3"
+                                                          {:name "snippet: snippet-3"
+                                                           :display-name "Snippet 3"
+                                                           :type :snippet
+                                                           :snippet-name "snippet-3"
+                                                           :snippet-id 103}}}}])
+            ;; Add all three snippets to the metadata provider
+            metadata-provider-with-snippets
+            (lib.tu/mock-metadata-provider
+             metadata-provider
+             {:native-query-snippets [;; Snippet 1 references snippet-2
+                                      {:id 101
+                                       :name "snippet-1"
+                                       :content "WHERE x IN ({{snippet: snippet-2}})"
+                                       :template-tags {"snippet: snippet-2"
+                                                       {:name "snippet: snippet-2"
+                                                        :type :snippet
+                                                        :snippet-name "snippet-2"
+                                                        :snippet-id 102}}}
+                                      ;; Snippet 2 references Card B (id 2)
+                                      {:id 102
+                                       :name "snippet-2"
+                                       :content "SELECT y FROM {{#2}}"
+                                       :template-tags {"#2"
+                                                       {:name "#2"
+                                                        :type :card
+                                                        :card-id 2}}}
+                                      ;; Snippet 3 references Card A (id 1), completing the cycle
+                                      {:id 103
+                                       :name "snippet-3"
+                                       :content "SELECT z FROM {{#1}}"
+                                       :template-tags {"#1"
+                                                       {:name "#1"
+                                                        :type :card
+                                                        :card-id 1}}}]})
+
+            ;; Create the query that starts with Card A
+            entrypoint-query (lib/query
+                              metadata-provider-with-snippets
+                              {:database (meta/id)
+                               :type :native
+                               :native {:query "SELECT * FROM {{#1}}"
+                                        :template-tags (card-template-tags [1])}})]
+
+        (testing "Should throw an exception for circular reference"
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"circular|cycle"
+               (#'qp.resolve-referenced/check-for-circular-references entrypoint-query))))
+
+        (testing "The cycle detection should work from any entry point"
+          ;; Starting from Card B should also detect the cycle
+          (let [card-b-query (lib/query
+                              metadata-provider-with-snippets
+                              {:database (meta/id)
+                               :type :native
+                               :native {:query "SELECT * FROM {{#2}}"
+                                        :template-tags (card-template-tags [2])}})]
+            (is (thrown-with-msg?
+                 ExceptionInfo
+                 #"circular|cycle"
+                 (#'qp.resolve-referenced/check-for-circular-references card-b-query)))))))))

--- a/test/metabase/query_processor/middleware/resolve_referenced_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_referenced_test.clj
@@ -110,6 +110,7 @@
                                        :name "snippet-a"
                                        :content "WHERE id IN (SELECT id FROM {{#1}})"
                                        :template-tags {"#1" {:name "#1"
+                                                             :display-name "Card 1"
                                                              :type :card
                                                              :card-id 1}}}]})
 
@@ -163,6 +164,7 @@
                                        :content "WHERE x IN ({{snippet: snippet-2}})"
                                        :template-tags {"snippet: snippet-2"
                                                        {:name "snippet: snippet-2"
+                                                        :display-name "Snippet 2"
                                                         :type :snippet
                                                         :snippet-name "snippet-2"
                                                         :snippet-id 102}}}
@@ -172,6 +174,7 @@
                                        :content "SELECT y FROM {{#2}}"
                                        :template-tags {"#2"
                                                        {:name "#2"
+                                                        :display-name "Card B"
                                                         :type :card
                                                         :card-id 2}}}
                                       ;; Snippet 3 references Card A (id 1), completing the cycle
@@ -180,6 +183,7 @@
                                        :content "SELECT z FROM {{#1}}"
                                        :template-tags {"#1"
                                                        {:name "#1"
+                                                        :display-name "Card A"
                                                         :type :card
                                                         :card-id 1}}}]})
 

--- a/test/metabase/query_processor/middleware/resolve_referenced_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_referenced_test.clj
@@ -129,7 +129,7 @@
                                  :type     :native
                                  :native   {:query         "SELECT * FROM {{snippet: snippet-a}}"
                                             :template-tags (make-snippet-template-tag 100 "snippet-a")}}])
-            ;; Add snippet to metadata provider using the correct key
+            ;; Add snippet to metadata provider
             metadata-provider-with-snippet
             (lib.tu/mock-metadata-provider
              metadata-provider


### PR DESCRIPTION
Context: Many conversations in and around [here](https://metaboat.slack.com/archives/C09AYQRVCDA/p1755818330200759).

### Card/Snippet Cycle Detection
1. Deleted `check-for-circular-source-query-references` from `models.card` as superfluous -- `lib.queries` is already doing this.
2. Augmented existing `metabase.lib.query` cycle checking to understand snippets too.
3. Augmented existing `query-processor.middleware.resolve-referenced` cycle checking to understand snippets too.
4. Added & deleted tests appropriately.

### Housekeeping
1. Renamed `template-tag-card-ids` to `native-query-card-ids` since it takes a `query` argument.
5. Added `native-query-snippet-ids`.
6. Renamed `lib/check-overwrite` to `lib/check-card-overwrite` for disambiguation.