### PR TITLE
Fix uploads not being immediately editable

### DIFF
--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -539,7 +539,7 @@
         table             (sync/create-table! db {:name         table-name
                                                   :schema       (not-empty schema)
                                                   :display_name display-name})
-        _set_is_upload    (t2/update! :model/Table (:id table) {:is_upload true, :data_authority :authoritative})
+        _set_is_upload    (t2/update! :model/Table (:id table) {:is_upload true, :data_authority :authoritative, :is_writable true})
         _sync             (scan-and-sync-table! db table)
         _set_names        (set-display-names! (:id table) columns)
         ;; Set the display_name of the auto-generated primary key column to the same as its name, so that if users

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -586,6 +586,8 @@
                       (->> (t2/select :model/Field :table_id (:id table))
                            (sort-by :database_position)
                            (map (juxt (comp u/lower-case-en :name) identity))))))
+            (testing "Check that table can be written via data-editing"
+              (= true (t2/select-one-fn :is_writable [:model/Table :is_writable] (:id table))))
             (testing "Check the data was uploaded into the table"
               (is (= 2
                      (count (rows-for-table table)))))))))))

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -587,7 +587,7 @@
                            (sort-by :database_position)
                            (map (juxt (comp u/lower-case-en :name) identity))))))
             (testing "Check that table can be written via data-editing"
-              (= true (t2/select-one-fn :is_writable [:model/Table :is_writable] (:id table))))
+              (true? (t2/select-one-fn :is_writable [:model/Table :is_writable] (:id table))))
             (testing "Check the data was uploaded into the table"
               (is (= 2
                      (count (rows-for-table table)))))))))))


### PR DESCRIPTION
Turns out that the quick sync we perform was not populating is_writable.

Since we created the table, we know we can insert into it. It's a reasonable assumption that we can edit and delete as well.

Closes WRK-838
