### PR TITLE
fix: table editing bugs

### DIFF
--- a/e2e/test/scenarios/table-editing/table-editing.cy.spec.ts
+++ b/e2e/test/scenarios/table-editing/table-editing.cy.spec.ts
@@ -366,17 +366,22 @@ describe("scenarios > table-editing", () => {
       });
 
       it("should handle errors", () => {
+        cy.visit(
+          `/browse/databases/${SAMPLE_DB_ID}/tables/${PRODUCTS_ID}/edit`,
+        );
+
         cy.findByTestId("table-root")
           .findAllByRole("row")
           .eq(1)
           .within(() => {
-            cy.get("[data-column-id='TAX']")
+            cy.get("[data-column-id='EAN']")
               .as("targetCell")
               .click({
                 scrollBehavior: false,
               })
               .find("input")
-              .type("{selectAll}{backspace}aaa", {
+              // Should be more than 13 characters to trigger the error
+              .type("{selectAll}{backspace}aaaaaaaaaaaaaaaaaaaaaaaaa", {
                 scrollBehavior: false,
               }) // Enter the new value
               .blur(); // Trigger the save action by blurring the input

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/ParameterActionInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/ParameterActionInput.tsx
@@ -55,7 +55,7 @@ export function ParameterActionInput(props: ParameterActionInputProps) {
 
     case TableActionFormInputType.Boolean:
       return (
-        <TableActionInputBoolean {...rest} isNullable={parameter.optional} />
+        <TableActionInputBoolean {...rest} isNullable={parameter.nullable} />
       );
 
     case TableActionFormInputType.Integer:

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputNumber.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputNumber.tsx
@@ -60,6 +60,7 @@ export const TableActionInputNumber = ({
       defaultValue={(initialValue ?? "").toString()}
       autoFocus={autoFocus}
       onKeyUp={handleKeyUp}
+      // Somehow onChange triggers on the first blur, so we rely on onValueChange instead
       onChange={handleChange}
       onValueChange={handleChangeValue}
       onBlur={handleBlur}
@@ -73,5 +74,9 @@ export const TableActionInputNumber = ({
 };
 
 function numberToRawValue(value: string | number) {
-  return typeof value === "number" ? value.toString() : value;
+  if (value === "") {
+    return null;
+  }
+
+  return value.toString();
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/CreateRowActionFormModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/CreateRowActionFormModal.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 
 import { LeaveConfirmModal } from "metabase/common/components/LeaveConfirmModal";
 import Animation from "metabase/css/core/animation.module.css";
-import { Button, Center, Flex, Loader, Modal } from "metabase/ui";
+import { Box, Button, Center, Flex, Loader, Modal } from "metabase/ui";
 import type { RowValue } from "metabase-types/api";
 
 import type {
@@ -118,28 +118,31 @@ export function CreateRowActionFormModal({
               <Modal.Title>{t`Create a new record`}</Modal.Title>
             </Modal.Header>
             <Modal.Body px="xl" py="lg" className={cx(S.modalBody)}>
-              {!description ? (
-                <Center className={S.modalBodyLoader}>
-                  <Loader />
-                </Center>
-              ) : (
-                description.parameters.map((parameter) => {
-                  return (
-                    <TableActionFormModalParameter
-                      key={parameter.id}
-                      parameter={parameter}
-                    >
-                      <ModalFormInput
-                        initialValue={
-                          values[parameter.id] ?? initialValues?.[parameter.id]
-                        }
+              <Box className={S.modalBodyGrid}>
+                {!description ? (
+                  <Center className={S.modalBodyLoader}>
+                    <Loader />
+                  </Center>
+                ) : (
+                  description.parameters.map((parameter) => {
+                    return (
+                      <TableActionFormModalParameter
+                        key={parameter.id}
                         parameter={parameter}
-                        onChange={setFieldValue}
-                      />
-                    </TableActionFormModalParameter>
-                  );
-                })
-              )}
+                      >
+                        <ModalFormInput
+                          initialValue={
+                            values[parameter.id] ??
+                            initialValues?.[parameter.id]
+                          }
+                          parameter={parameter}
+                          onChange={setFieldValue}
+                        />
+                      </TableActionFormModalParameter>
+                    );
+                  })
+                )}
+              </Box>
             </Modal.Body>
             <Flex px="xl" className={S.modalFooter} gap="lg" justify="flex-end">
               <Button variant="subtle" onClick={handleClose}>

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModal.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/TableActionFormModal.module.css
@@ -17,13 +17,15 @@
 }
 
 .modalBody {
-  display: grid;
-  grid-template-columns: 35% auto;
-  grid-template-rows: repeat(auto-fill, rem(40));
-  row-gap: rem(24);
-  column-gap: rem(16);
   height: calc(100dvh - rem(80) - rem(72) /* header + footer */);
   overflow-y: scroll;
+}
+
+.modalBodyGrid {
+  display: grid;
+  grid-template-columns: 35% auto;
+  row-gap: rem(24);
+  column-gap: rem(16);
 }
 
 .modalBodyLoader {

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/UpdateRowActionFormModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/modals/UpdateRowActionFormModal.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 
 import { LeaveConfirmModal } from "metabase/common/components/LeaveConfirmModal";
 import Animation from "metabase/css/core/animation.module.css";
-import { Button, Center, Flex, Loader, Modal } from "metabase/ui";
+import { Box, Button, Center, Flex, Loader, Modal } from "metabase/ui";
 import type { RowValue } from "metabase-types/api";
 
 import type {
@@ -127,28 +127,31 @@ export function UpdateRowActionFormModal({
               <Modal.Title>{t`Edit record`}</Modal.Title>
             </Modal.Header>
             <Modal.Body px="xl" py="lg" className={cx(S.modalBody)}>
-              {!description ? (
-                <Center className={S.modalBodyLoader}>
-                  <Loader />
-                </Center>
-              ) : (
-                description.parameters.map((parameter) => {
-                  return (
-                    <TableActionFormModalParameter
-                      key={parameter.id}
-                      parameter={parameter}
-                    >
-                      <ModalFormInput
-                        initialValue={
-                          values[parameter.id] ?? initialValues?.[parameter.id]
-                        }
+              <Box className={S.modalBodyGrid}>
+                {!description ? (
+                  <Center className={S.modalBodyLoader}>
+                    <Loader />
+                  </Center>
+                ) : (
+                  description.parameters.map((parameter) => {
+                    return (
+                      <TableActionFormModalParameter
+                        key={parameter.id}
                         parameter={parameter}
-                        onChange={setFieldValue}
-                      />
-                    </TableActionFormModalParameter>
-                  );
-                })
-              )}
+                      >
+                        <ModalFormInput
+                          initialValue={
+                            values[parameter.id] ??
+                            initialValues?.[parameter.id]
+                          }
+                          parameter={parameter}
+                          onChange={setFieldValue}
+                        />
+                      </TableActionFormModalParameter>
+                    );
+                  })
+                )}
+              </Box>
             </Modal.Body>
             <Flex px="xl" className={S.modalFooter} gap="lg" justify="flex-end">
               <Button variant="subtle" onClick={handleClose}>


### PR DESCRIPTION
Resolves [WRK-837](https://linear.app/metabase/issue/WRK-837/table-cell-save-fails-with-unknown-error-due-to-empty-discount-field) and:
* numeric fields can't be cleared because an empty string is sent instead of null;
* clicking in and out of a field without making any changes, shouldn't send changes to the api
* Multi-line inputs aren't pushing down the fields displayed beneath them in Safari