### PR TITLE
chore(sdk e2e): make the "Invalid Host/Origin header" errors go away

### DIFF
--- a/e2e/support/component-webpack.config.js
+++ b/e2e/support/component-webpack.config.js
@@ -31,6 +31,11 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, "dist"),
   },
+  devServer: {
+    // Makes "Invalid Host/Origin header" errors go away.
+    // Cypress component tests seem to run on `127.0.0.1`
+    allowedHosts: ["localhost", "127.0.0.1"],
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
This should make our mental health degrade a little bit slower when we have to run the tests

Close EMB-701