### PR TITLE
Use Flexbox container to avoid CLS when on Collection Items Page

### DIFF
--- a/frontend/src/metabase/common/components/CheckBox/CheckBox.tsx
+++ b/frontend/src/metabase/common/components/CheckBox/CheckBox.tsx
@@ -8,7 +8,7 @@ import type {
 } from "react";
 import { forwardRef, isValidElement, useRef } from "react";
 
-import { Tooltip } from "metabase/ui";
+import { Flex, Tooltip } from "metabase/ui";
 
 import {
   CheckBoxContainer,
@@ -85,7 +85,7 @@ const BaseCheckBox = forwardRef<HTMLLabelElement, CheckBoxProps>(
           hasTooltip={!!(labelEllipsis && hasLabelEllipsis)}
           tooltipLabel={label}
         >
-          <div>
+          <Flex>
             {/* the div is needed because CheckTooltip requires 1 child when hasTooltip is true */}
             <CheckBoxInput
               id={id ?? name}
@@ -126,7 +126,7 @@ const BaseCheckBox = forwardRef<HTMLLabelElement, CheckBoxProps>(
                   </CheckBoxLabel>
                 ))}
             </CheckBoxContainer>
-          </div>
+          </Flex>
         </CheckboxTooltip>
       </CheckBoxRoot>
     );


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62725
### Description
I don't actually know why this fixes the issue, but by guess is that the child of a tooltip needs to have a component with a ref as a child to work properly, and the base `<div>` does not.

### How to verify

1. Go to a collection
2. Select some items
3. The header should no longer shrink by 2 pixels, and @kamilmielnik should happily be able to select and deselect as he wishes.

### Demo

https://github.com/user-attachments/assets/d25b309a-64bf-4907-9af9-b64f494dec67

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ - No clue how to test this
