### PR TITLE
Fix: UXW-204 don't show upsells to non-admins on paid plans

### DIFF
--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -9,6 +9,7 @@ import CS from "metabase/css/core/index.css";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut";
 import { getIsPaidPlan } from "metabase/selectors/settings";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { Button, Icon } from "metabase/ui";
 import type { User } from "metabase-types/api";
 import type { AdminPath } from "metabase-types/store";
@@ -41,6 +42,7 @@ export const AdminNavbar = ({
   adminPaths,
 }: AdminNavbarProps) => {
   const isPaidPlan = useSelector(getIsPaidPlan);
+  const isAdmin = useSelector(getUserIsAdmin);
   const dispatch = useDispatch();
 
   useRegisterShortcut(
@@ -91,7 +93,7 @@ export const AdminNavbar = ({
           ))}
         </AdminNavbarItems>
 
-        {!isPaidPlan && <StoreLink />}
+        {!isPaidPlan && isAdmin && <StoreLink />}
         <AdminExitLink
           to="/"
           data-testid="exit-admin"

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -11,7 +11,6 @@ import { useRegisterShortcut } from "metabase/palette/hooks/useRegisterShortcut"
 import { getIsPaidPlan } from "metabase/selectors/settings";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Button, Icon } from "metabase/ui";
-import type { User } from "metabase-types/api";
 import type { AdminPath } from "metabase-types/store";
 
 import StoreLink from "../StoreLink";
@@ -33,7 +32,6 @@ import {
 
 interface AdminNavbarProps {
   path: string;
-  user: User;
   adminPaths: AdminPath[];
 }
 

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.unit.spec.tsx
@@ -1,0 +1,44 @@
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockSettings,
+  createMockTokenStatus,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { AdminNavbar } from "./AdminNavbar";
+
+const setup = ({ isAdmin = false, isPaidPlan = false }) => {
+  const state = createMockState({
+    currentUser: createMockUser({ is_superuser: isAdmin }),
+    settings: mockSettings(
+      createMockSettings({
+        "token-status": createMockTokenStatus({ valid: isPaidPlan }),
+      }),
+    ),
+  });
+
+  return renderWithProviders(<AdminNavbar path="/admin" adminPaths={[]} />, {
+    storeInitialState: state,
+  });
+};
+
+describe("AdminNavbar", () => {
+  describe("StoreLink visibility", () => {
+    it("does not show store link when user is not an admin", () => {
+      setup({ isAdmin: false, isPaidPlan: true });
+      expect(screen.queryByTestId("store-link")).not.toBeInTheDocument();
+    });
+
+    it("shows store link when user is admin and not on paid plan", () => {
+      setup({ isAdmin: true, isPaidPlan: false });
+      expect(screen.getByTestId("store-link")).toBeInTheDocument();
+    });
+
+    it("does not show store link when user is admin and on paid plan", () => {
+      setup({ isAdmin: true, isPaidPlan: true });
+      expect(screen.queryByTestId("store-link")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/nav/components/StoreLink/StoreLink.tsx
+++ b/frontend/src/metabase/nav/components/StoreLink/StoreLink.tsx
@@ -7,7 +7,10 @@ import { StoreIcon, StoreIconRoot, StoreIconWrapper } from "./StoreLink.styled";
 const StoreLink = () => {
   return (
     <Tooltip label={t`Explore paid features`}>
-      <StoreIconRoot href="https://metabase.com/upgrade">
+      <StoreIconRoot
+        href="https://metabase.com/upgrade"
+        data-testid="store-link"
+      >
         <StoreIconWrapper>
           <StoreIcon name="store" size={20} />
         </StoreIconWrapper>

--- a/frontend/src/metabase/nav/containers/Navbar.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.tsx
@@ -40,7 +40,7 @@ function Navbar({ isOpen, user, location, params, adminPaths }: NavbarProps) {
   }
 
   return isAdminApp ? (
-    <AdminNavbar user={user} path={location.pathname} adminPaths={adminPaths} />
+    <AdminNavbar path={location.pathname} adminPaths={adminPaths} />
   ) : (
     <MainNavbar isOpen={isOpen} location={location} params={params} />
   );


### PR DESCRIPTION
Closes [UXW-204](https://linear.app/metabase/issue/UXW-204)

### Description

Prevents non-admins from seeing "Explore paid features" link

### How to verify

1. Run ee and sign in as an admin
2. Navigate to Admin settings
3. Verify store link (padlock with tooltip text "Explore paid features") is NOT shown
4. Sign in as a non-admin
5. Navigate to Admin settings
6. Verify store link is NOT shown
7. Run MB w/o paid plan*
8. Sign in as an admin
9. Navigate to Admin settings
10. Verify store link IS shown

\* - There might be better ways but I just stopped `dev-ee`, commented out the tokens in my env file, opened a new terminal tab (to clear all the old env values) and ran `yarn dev`

### Demo

**BEFORE (non-admin, unpaid)**
<img width="512" height="177" alt="Screenshot 2025-08-27 at 10 39 29 AM" src="https://github.com/user-attachments/assets/378dad5a-7b2e-48ee-949b-034315fc2798" />

**AFTER (non-admin, unpaid)**
<img width="1312" height="375" alt="non-admin-unpaid" src="https://github.com/user-attachments/assets/11367e5e-2f8d-475a-bb92-a04c0c4da8b2" />

**AFTER (admin, paid)**
<img width="1312" height="426" alt="admin-paid" src="https://github.com/user-attachments/assets/5e017261-c27e-4aa5-a623-150779052a5f" />

**AFTER (admin, unpaid)**
<img width="1313" height="376" alt="admin-unpaid" src="https://github.com/user-attachments/assets/dbaec819-7dc8-4170-8b2d-f5c4be3f124e" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
