### PR TITLE
feat(sdk): Fix and improve Metabot for SDK

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -1,0 +1,88 @@
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+
+const { H } = cy;
+
+import { MetabotQuestion } from "@metabase/embedding-sdk-react";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
+import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
+import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const query = {
+  "source-table": ORDERS_ID,
+  aggregation: [["max", ["field", ORDERS.QUANTITY, null]]],
+  breakout: [["field", ORDERS.PRODUCT_ID, null]],
+  limit: 2,
+};
+const adHocQuestionPath = `/question#${btoa(
+  JSON.stringify({
+    dataset_query: { database: 1, type: "query", query },
+    display: "table",
+    displayIsLocked: true,
+    visualization_settings: {},
+  }),
+)}`;
+
+const metabotResponse = `0:"Here is the [question link](${adHocQuestionPath})"`;
+const metabotResponseWithNavigateTo = `${metabotResponse}
+2:{"type":"navigate_to","version":1,"value":"${adHocQuestionPath}"}`;
+
+describe("scenarios > embedding-sdk > metabot-question", () => {
+  const setup = (response: string) => {
+    signInAsAdminAndEnableEmbeddingSdk();
+
+    H.mockMetabotResponse({
+      statusCode: 200,
+      body: response,
+    });
+
+    H.createQuestion({
+      name: "1",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["max", ["field", ORDERS.QUANTITY, null]]],
+        breakout: [["field", ORDERS.PRODUCT_ID, null]],
+        limit: 2,
+      },
+    }).then(({ body: question }) => {
+      cy.wrap(question.id).as("questionId");
+      cy.wrap(question.entity_id).as("questionEntityId");
+    });
+
+    cy.signOut();
+    mockAuthProviderAndJwtSignIn();
+  };
+
+  it("should automatically show the ad-hoc question for the last agent message containing ad-hoc question link", () => {
+    setup(metabotResponseWithNavigateTo);
+
+    mountSdkContent(<MetabotQuestion />);
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("metabot-chat-input").type("Show orders {enter}");
+
+      cy.findByTestId("visualization-root").should("exist");
+    });
+  });
+
+  it("should show the ad-hoc question when clicking its link", () => {
+    setup(metabotResponse);
+
+    mountSdkContent(<MetabotQuestion />);
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("metabot-chat-input").type("Show orders {enter}");
+
+      cy.findAllByTestId("metabot-chat-message")
+        .should("have.length", 2)
+        .last()
+        .findByText("question link")
+        .click();
+
+      cy.findByTestId("visualization-root").should("exist");
+    });
+  });
+});

--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -1,10 +1,9 @@
-import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
-
 const { H } = cy;
 
 import { MetabotQuestion } from "@metabase/embedding-sdk-react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";

--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -30,6 +30,8 @@ const metabotResponse = `0:"Here is the [question link](${adHocQuestionPath})"`;
 const metabotResponseWithNavigateTo = `${metabotResponse}
 2:{"type":"navigate_to","version":1,"value":"${adHocQuestionPath}"}`;
 
+const metabotRetryResponse = `0:"Retry: Here is the [question link](${adHocQuestionPath})"`;
+
 describe("scenarios > embedding-sdk > metabot-question", () => {
   const setup = (response: string) => {
     signInAsAdminAndEnableEmbeddingSdk();
@@ -83,6 +85,33 @@ describe("scenarios > embedding-sdk > metabot-question", () => {
         .click();
 
       cy.findByTestId("visualization-root").should("exist");
+    });
+  });
+
+  it("should retry a message when clicking the retry button", () => {
+    setup(metabotResponse);
+
+    mountSdkContent(<MetabotQuestion />);
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("metabot-chat-input").type("Show orders {enter}");
+
+      H.mockMetabotResponse({
+        statusCode: 200,
+        body: metabotRetryResponse,
+      });
+
+      cy.findAllByTestId("metabot-chat-message")
+        .should("have.length", 2)
+        .last()
+        .findByTestId("metabot-chat-message-retry")
+        .click();
+
+      cy.findAllByTestId("metabot-chat-message")
+        .should("have.length", 2)
+        .last()
+        .findByText(/Retry: Here is the/)
+        .should("exist");
     });
   });
 });

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -42,10 +42,7 @@ export const MetabotChatEmbedding = () => {
     }
 
     setMessage("");
-    const metabotRequestPromise = metabot.submitInput(
-      trimmedInput,
-      metabot.metabotRequestId,
-    );
+    const metabotRequestPromise = metabot.submitInput(trimmedInput);
 
     metabotRequestPromise
       .catch((err) => console.error(err))

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -13,7 +13,10 @@ import {
   UnstyledButton,
 } from "metabase/ui";
 import { MetabotIcon } from "metabase-enterprise/metabot/components/MetabotIcon";
-import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
+import {
+  useMetabotAgent,
+  useMetabotChat,
+} from "metabase-enterprise/metabot/hooks";
 import {
   cancelInflightAgentRequests,
   resetConversationId,
@@ -25,27 +28,12 @@ const MIN_INPUT_HEIGHT = 42;
 
 export const MetabotChatEmbedding = () => {
   const metabot = useMetabotAgent();
-  const { setPrompt } = metabot;
+  const { handleSubmitInput, handleResetInput } = useMetabotChat();
 
   const resetInput = useCallback(() => {
-    setPrompt("");
+    handleResetInput();
     setInputExpanded(false);
-  }, [setPrompt]);
-
-  const handleSend = (input: string) => {
-    if (metabot.isDoingScience) {
-      return;
-    }
-
-    const trimmedInput = input.trim();
-    if (!trimmedInput.length || metabot.isDoingScience) {
-      return;
-    }
-
-    metabot.setPrompt("");
-    metabot.promptInputRef?.current?.focus();
-    metabot.submitInput(trimmedInput).catch((err) => console.error(err));
-  };
+  }, [handleResetInput]);
 
   const [inputExpanded, setInputExpanded] = useState(false);
   const handleMaybeExpandInput = () => {
@@ -131,7 +119,7 @@ export const MetabotChatEmbedding = () => {
               // prevent event from inserting new line + interacting with other content
               e.preventDefault();
               e.stopPropagation();
-              handleSend(metabot.prompt);
+              handleSubmitInput(metabot.prompt);
             }
           }}
         />

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -15,7 +15,7 @@ import {
 import { MetabotIcon } from "metabase-enterprise/metabot/components/MetabotIcon";
 import {
   useMetabotAgent,
-  useMetabotChat,
+  useMetabotChatHandlers,
 } from "metabase-enterprise/metabot/hooks";
 import {
   cancelInflightAgentRequests,
@@ -28,8 +28,7 @@ const MIN_INPUT_HEIGHT = 42;
 
 export const MetabotChatEmbedding = () => {
   const metabot = useMetabotAgent();
-  const { isDoingScience, handleSubmitInput, handleResetInput } =
-    useMetabotChat();
+  const { handleSubmitInput, handleResetInput } = useMetabotChatHandlers();
 
   const resetInput = useCallback(() => {
     handleResetInput();
@@ -53,7 +52,9 @@ export const MetabotChatEmbedding = () => {
   };
 
   const inputPlaceholder = t`Tell me to do something, or ask a question`;
-  const placeholder = isDoingScience ? t`Doing science...` : inputPlaceholder;
+  const placeholder = metabot.isDoingScience
+    ? t`Doing science...`
+    : inputPlaceholder;
 
   function cancelRequest() {
     dispatch(cancelInflightAgentRequests());
@@ -70,7 +71,7 @@ export const MetabotChatEmbedding = () => {
       <Flex
         className={cx(
           Styles.innerContainer,
-          isDoingScience && Styles.innerContainerLoading,
+          metabot.isDoingScience && Styles.innerContainerLoading,
           inputExpanded && Styles.innerContainerExpanded,
         )}
         gap="sm"
@@ -83,7 +84,7 @@ export const MetabotChatEmbedding = () => {
           }}
           justify="center"
         >
-          {isDoingScience ? (
+          {metabot.isDoingScience ? (
             <Loader size="sm" />
           ) : (
             <MetabotIcon isLoading={false} />
@@ -99,11 +100,11 @@ export const MetabotChatEmbedding = () => {
           ref={metabot.promptInputRef}
           autoFocus
           value={metabot.prompt}
-          disabled={isDoingScience}
+          disabled={metabot.isDoingScience}
           className={cx(
             Styles.textarea,
             inputExpanded && Styles.textareaExpanded,
-            isDoingScience && Styles.textareaLoading,
+            metabot.isDoingScience && Styles.textareaLoading,
           )}
           placeholder={placeholder}
           onChange={(e) => metabot.setPrompt(e.target.value)}
@@ -122,7 +123,7 @@ export const MetabotChatEmbedding = () => {
             }
           }}
         />
-        {isDoingScience ? (
+        {metabot.isDoingScience ? (
           <UnstyledButton
             h="1rem"
             data-testid="metabot-cancel-request"

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -23,8 +23,6 @@ import Styles from "./MetabotChatEmbedding.module.css";
 
 const MIN_INPUT_HEIGHT = 42;
 
-const EMBEDDING_METABOT_ID = "c61bf5f5-1025-47b6-9298-bf1827105bb6";
-
 export const MetabotChatEmbedding = () => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -46,7 +44,7 @@ export const MetabotChatEmbedding = () => {
     setMessage("");
     const metabotRequestPromise = metabot.submitInput(
       trimmedInput,
-      EMBEDDING_METABOT_ID,
+      metabot.metabotRequestId,
     );
 
     metabotRequestPromise

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -13,7 +13,6 @@ import {
   UnstyledButton,
 } from "metabase/ui";
 import { MetabotIcon } from "metabase-enterprise/metabot/components/MetabotIcon";
-import { METABOT_RESULTS_MESSAGE } from "metabase-enterprise/metabot/constants";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 import {
   cancelInflightAgentRequests,
@@ -24,17 +23,9 @@ import Styles from "./MetabotChatEmbedding.module.css";
 
 const MIN_INPUT_HEIGHT = 42;
 
-interface MetabotChatEmbeddingProps {
-  onRedirectUrl: (result: string) => void;
-  onMessages: (messages: string[]) => void;
-}
-
 const EMBEDDING_METABOT_ID = "c61bf5f5-1025-47b6-9298-bf1827105bb6";
 
-export const MetabotChatEmbedding = ({
-  onRedirectUrl,
-  onMessages,
-}: MetabotChatEmbeddingProps) => {
+export const MetabotChatEmbedding = () => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const [input, setMessage] = useState("");
@@ -51,6 +42,7 @@ export const MetabotChatEmbedding = ({
     if (!trimmedInput.length || metabot.isDoingScience) {
       return;
     }
+
     setMessage("");
     const metabotRequestPromise = metabot.submitInput(
       trimmedInput,
@@ -58,15 +50,6 @@ export const MetabotChatEmbedding = ({
     );
 
     metabotRequestPromise
-      .then((result) => {
-        const redirectUrl = (result.payload as any)?.data?.reactions?.find(
-          (reaction: { type: string; url: string }) =>
-            reaction.type === "metabot.reaction/redirect",
-        )?.url;
-        if (redirectUrl) {
-          onRedirectUrl(redirectUrl);
-        }
-      })
       .catch((err) => console.error(err))
       .finally(() => textareaRef.current?.focus());
   };
@@ -100,16 +83,10 @@ export const MetabotChatEmbedding = ({
   }
 
   const dispatch = useSdkDispatch();
+
   useEffect(() => {
     dispatch(resetConversationId());
   }, [dispatch]);
-
-  useEffect(() => {
-    const normalizedMessages = metabot.lastAgentMessages.filter(
-      (message) => message !== METABOT_RESULTS_MESSAGE,
-    );
-    onMessages(normalizedMessages);
-  }, [metabot.lastAgentMessages, onMessages]);
 
   return (
     <Box className={Styles.container} data-testid="metabot-chat">

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotChatEmbedding.tsx
@@ -28,7 +28,8 @@ const MIN_INPUT_HEIGHT = 42;
 
 export const MetabotChatEmbedding = () => {
   const metabot = useMetabotAgent();
-  const { handleSubmitInput, handleResetInput } = useMetabotChat();
+  const { isDoingScience, handleSubmitInput, handleResetInput } =
+    useMetabotChat();
 
   const resetInput = useCallback(() => {
     handleResetInput();
@@ -52,9 +53,7 @@ export const MetabotChatEmbedding = () => {
   };
 
   const inputPlaceholder = t`Tell me to do something, or ask a question`;
-  const placeholder = metabot.isDoingScience
-    ? t`Doing science...`
-    : inputPlaceholder;
+  const placeholder = isDoingScience ? t`Doing science...` : inputPlaceholder;
 
   function cancelRequest() {
     dispatch(cancelInflightAgentRequests());
@@ -71,7 +70,7 @@ export const MetabotChatEmbedding = () => {
       <Flex
         className={cx(
           Styles.innerContainer,
-          metabot.isDoingScience && Styles.innerContainerLoading,
+          isDoingScience && Styles.innerContainerLoading,
           inputExpanded && Styles.innerContainerExpanded,
         )}
         gap="sm"
@@ -84,7 +83,7 @@ export const MetabotChatEmbedding = () => {
           }}
           justify="center"
         >
-          {metabot.isDoingScience ? (
+          {isDoingScience ? (
             <Loader size="sm" />
           ) : (
             <MetabotIcon isLoading={false} />
@@ -100,11 +99,11 @@ export const MetabotChatEmbedding = () => {
           ref={metabot.promptInputRef}
           autoFocus
           value={metabot.prompt}
-          disabled={metabot.isDoingScience}
+          disabled={isDoingScience}
           className={cx(
             Styles.textarea,
             inputExpanded && Styles.textareaExpanded,
-            metabot.isDoingScience && Styles.textareaLoading,
+            isDoingScience && Styles.textareaLoading,
           )}
           placeholder={placeholder}
           onChange={(e) => metabot.setPrompt(e.target.value)}
@@ -123,7 +122,7 @@ export const MetabotChatEmbedding = () => {
             }
           }}
         />
-        {metabot.isDoingScience ? (
+        {isDoingScience ? (
           <UnstyledButton
             h="1rem"
             data-testid="metabot-cancel-request"

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.stories.tsx
@@ -3,6 +3,10 @@ import { HttpResponse, http } from "msw";
 import type { ComponentProps } from "react";
 
 import { CommonSdkStoryWrapper } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
+import {
+  MOCK_AD_HOC_QUESTION_ID,
+  mockStreamResponse,
+} from "embedding-sdk-shared/test/mocks/mock-metabot-response";
 import { Box } from "metabase/ui";
 
 import { MetabotQuestion } from "./MetabotQuestion";
@@ -40,267 +44,11 @@ export const RedirectReaction = {
   parameters: {
     msw: {
       handlers: [
-        http.post("*/api/ee/metabot-v3/v2/agent", () => {
-          return HttpResponse.json({
-            reactions: [
-              {
-                type: "metabot.reaction/message",
-                "repl/message_color": "green",
-                "repl/message_emoji": "🤖",
-                message: "Here are the results",
-              },
-              {
-                type: "metabot.reaction/redirect",
-                url: "/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjJ9fSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e30sInR5cGUiOiJxdWVzdGlvbiJ9",
-              },
-            ],
-            history: [
-              {
-                role: "user",
-                content: "best selling products in 2024",
-              },
-              {
-                role: "assistant",
-                "tool-calls": [
-                  {
-                    id: "call_5PU7OwgEiDnYKr9A2FTiNAfp",
-                    name: "query",
-                    arguments:
-                      '{"query_plan":{"user_message_analysis":"The user is asking for the best selling products in 2024, which implies a need for sales data filtered by year.","candidate_metrics":[],"candidate_tables":["card__139","card__140"],"conclusion":"I will use the Orders table to analyze the total quantity sold for each product in 2024."},"query":"Show the total quantity sold for each product in 2024, grouped by Product ID.","source":{"table_id":"card__139"}}',
-                  },
-                ],
-              },
-              {
-                content: "Success!",
-                role: "tool",
-                "tool-call-id": "call_5PU7OwgEiDnYKr9A2FTiNAfp",
-              },
-              {
-                content: "Here are the results",
-                role: "assistant",
-                "navigate-to":
-                  "/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjJ9fSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e30sInR5cGUiOiJxdWVzdGlvbiJ9",
-              },
-            ],
-            state: {
-              queries: {
-                "5kt_rzk_792erogqj_oh_ku_5m": {
-                  database: 2,
-                  type: "query",
-                  query: {
-                    aggregation: [
-                      [
-                        "sum",
-                        [
-                          "field",
-                          "quantity",
-                          {
-                            base_type: "type/Decimal",
-                          },
-                        ],
-                      ],
-                    ],
-                    breakout: [
-                      [
-                        "field",
-                        "product_id",
-                        {
-                          base_type: "type/BigInteger",
-                        },
-                      ],
-                    ],
-                    source_table: "card__139",
-                    aggregation_idents: {
-                      "0": "_c5p_PVpsm6A7dOqupLHE",
-                    },
-                    breakout_idents: {
-                      "0": "9URvg0Oy6owTr7qt2UdsZ",
-                    },
-                    filter: [
-                      "=",
-                      [
-                        "get-year",
-                        [
-                          "field",
-                          "created_at",
-                          {
-                            base_type: "type/DateTimeWithLocalTZ",
-                          },
-                        ],
-                      ],
-                      2024,
-                    ],
-                  },
-                },
-                "8zzlkFleApnbGONeqT4sN": {
-                  database: 2,
-                  type: "query",
-                  query: {
-                    aggregation: [
-                      [
-                        "sum",
-                        [
-                          "field",
-                          "quantity",
-                          {
-                            "base-type": "type/Decimal",
-                          },
-                        ],
-                      ],
-                    ],
-                    breakout: [
-                      [
-                        "field",
-                        "product_id",
-                        {
-                          "base-type": "type/BigInteger",
-                        },
-                      ],
-                    ],
-                    "source-table": "card__139",
-                    filter: [
-                      "=",
-                      [
-                        "get-year",
-                        [
-                          "field",
-                          "created_at",
-                          {
-                            "base-type": "type/DateTimeWithLocalTZ",
-                          },
-                        ],
-                      ],
-                      2024,
-                    ],
-                  },
-                },
-              },
-            },
-            conversation_id: "d90328fc-5ed5-1119-03f7-86866d71c488",
-          });
-        }),
-      ],
-    },
-  },
-};
-
-export const MessageReaction = {
-  render: Template,
-  parameters: {
-    msw: {
-      handlers: [
-        http.post("*/api/ee/metabot-v3/v2/agent", () => {
-          return HttpResponse.json({
-            reactions: [
-              {
-                type: "metabot.reaction/message",
-                "repl/message_color": "green",
-                "repl/message_emoji": "🤖",
-                message:
-                  "Do you want to see the products earning the most money or the ones selling most units?",
-              },
-            ],
-            history: [
-              {
-                role: "user",
-                content: "This is what user has typed",
-              },
-              {
-                content:
-                  "Do you want to see the products earning the most money or the ones selling most units?",
-                role: "assistant",
-              },
-            ],
-            state: {
-              queries: {},
-            },
-            conversation_id: "c7635bd0-84f3-f06d-1db8-571db7ff0cf6",
-          });
-        }),
-      ],
-    },
-  },
-};
-
-export const LongMessageReaction = {
-  render: Template,
-  parameters: {
-    msw: {
-      handlers: [
-        http.post("*/api/ee/metabot-v3/v2/agent", () => {
-          return HttpResponse.json({
-            reactions: [
-              {
-                type: "metabot.reaction/message",
-                "repl/message_color": "green",
-                "repl/message_emoji": "🤖",
-                message:
-                  "lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum",
-              },
-            ],
-            history: [
-              {
-                role: "user",
-                content: "This is what user has typed",
-              },
-              {
-                content:
-                  "lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum",
-                role: "assistant",
-              },
-            ],
-            state: {
-              queries: {},
-            },
-            conversation_id: "c7635bd0-84f3-f06d-1db8-571db7ff0cf6",
-          });
-        }),
-      ],
-    },
-  },
-};
-
-export const MultipleMessagesReaction = {
-  render: Template,
-  parameters: {
-    msw: {
-      handlers: [
-        http.post("*/api/ee/metabot-v3/v2/agent", () => {
-          return HttpResponse.json({
-            reactions: [
-              {
-                type: "metabot.reaction/message",
-                "repl/message_color": "green",
-                "repl/message_emoji": "🤖",
-                message: "This is the first message",
-              },
-              {
-                type: "metabot.reaction/message",
-                "repl/message_color": "green",
-                "repl/message_emoji": "🤖",
-                message: "This is the second message",
-              },
-            ],
-            history: [
-              {
-                role: "user",
-                content: "This is what user has typed",
-              },
-              {
-                content: "This is the first message",
-                role: "assistant",
-              },
-              {
-                content: "This is the second message",
-                role: "assistant",
-              },
-            ],
-            state: {
-              queries: {},
-            },
-            conversation_id: "c7635bd0-84f3-f06d-1db8-571db7ff0cf6",
-          });
-        }),
+        mockStreamResponse([
+          `0:"Here is the [question link](${MOCK_AD_HOC_QUESTION_ID})"`,
+          `2:{"type":"navigate_to","version":1,"value":"${MOCK_AD_HOC_QUESTION_ID}"}
+`,
+        ]),
       ],
     },
   },
@@ -311,7 +59,7 @@ export const MetabotError = {
   parameters: {
     msw: {
       handlers: [
-        http.post("*/api/ee/metabot-v3/v2/agent", () => {
+        http.post("*/api/ee/metabot-v3/v2/agent-streaming", () => {
           return new HttpResponse(null, {
             status: 500,
           });
@@ -319,4 +67,13 @@ export const MetabotError = {
       ],
     },
   },
+};
+
+export const MultipleInstances = {
+  render: () => (
+    <>
+      <Template />
+      <Template />
+    </>
+  ),
 };

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -60,7 +60,8 @@ const MetabotQuestionInner = () => {
 function MetabotMessages() {
   const metabot = useMetabotAgent();
   const { messages, errorMessages } = metabot;
-  const { handleRetryMessage, setNavigateToPath } = useMetabotChat();
+  const { isDoingScience, handleRetryMessage, setNavigateToPath } =
+    useMetabotChat();
 
   if (!messages.length && !errorMessages.length) {
     return null;
@@ -73,7 +74,7 @@ function MetabotMessages() {
           messages={messages}
           errorMessages={errorMessages}
           onRetryMessage={handleRetryMessage}
-          isDoingScience={metabot.isDoingScience}
+          isDoingScience={isDoingScience}
           showFeedbackButtons={false}
           onInternalLinkClick={setNavigateToPath}
         />

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -15,6 +15,7 @@ import {
   useMetabotAgent,
   useMetabotChat,
 } from "metabase-enterprise/metabot/hooks";
+import { useMetabotReactions } from "metabase-enterprise/metabot/hooks/use-metabot-reactions";
 
 import { MetabotChatEmbedding } from "./MetabotChatEmbedding";
 import { QuestionDetails } from "./QuestionDetails";
@@ -22,7 +23,7 @@ import { QuestionTitle } from "./QuestionTitle";
 
 const MetabotQuestionInner = () => {
   const { isLocaleLoading } = useLocale();
-  const { navigateToPath } = useMetabotChat();
+  const { navigateToPath } = useMetabotReactions();
 
   if (isLocaleLoading) {
     return <SdkLoader />;
@@ -60,8 +61,8 @@ const MetabotQuestionInner = () => {
 function MetabotMessages() {
   const metabot = useMetabotAgent();
   const { messages, errorMessages } = metabot;
-  const { isDoingScience, handleRetryMessage, setNavigateToPath } =
-    useMetabotChat();
+  const { isDoingScience, handleRetryMessage } = useMetabotChat();
+  const { setNavigateToPath } = useMetabotReactions();
 
   if (!messages.length && !errorMessages.length) {
     return null;

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -11,7 +11,10 @@ import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSing
 import { useLocale } from "metabase/common/hooks/use-locale";
 import { Flex, Paper, Stack, Text } from "metabase/ui";
 import { Messages } from "metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage";
-import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
+import {
+  useMetabotAgent,
+  useMetabotChat,
+} from "metabase-enterprise/metabot/hooks";
 
 import { MetabotChatEmbedding } from "./MetabotChatEmbedding";
 import { QuestionDetails } from "./QuestionDetails";
@@ -56,7 +59,8 @@ const MetabotQuestionInner = () => {
 
 function MetabotMessages() {
   const metabot = useMetabotAgent();
-  const { messages, errorMessages, setNavigateToPath, retryMessage } = metabot;
+  const { messages, errorMessages, setNavigateToPath } = metabot;
+  const { handleRetryMessage } = useMetabotChat();
 
   if (!messages.length && !errorMessages.length) {
     return null;
@@ -68,7 +72,7 @@ function MetabotMessages() {
         <Messages
           messages={messages}
           errorMessages={errorMessages}
-          onRetryMessage={retryMessage}
+          onRetryMessage={handleRetryMessage}
           isDoingScience={metabot.isDoingScience}
           showFeedbackButtons={false}
           onInternalLinkClick={setNavigateToPath}

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -13,7 +13,7 @@ import { Flex, Paper, Stack, Text } from "metabase/ui";
 import { Messages } from "metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage";
 import {
   useMetabotAgent,
-  useMetabotChat,
+  useMetabotChatHandlers,
 } from "metabase-enterprise/metabot/hooks";
 import { useMetabotReactions } from "metabase-enterprise/metabot/hooks/use-metabot-reactions";
 
@@ -61,7 +61,7 @@ const MetabotQuestionInner = () => {
 function MetabotMessages() {
   const metabot = useMetabotAgent();
   const { messages, errorMessages } = metabot;
-  const { isDoingScience, handleRetryMessage } = useMetabotChat();
+  const { handleRetryMessage } = useMetabotChatHandlers();
   const { setNavigateToPath } = useMetabotReactions();
 
   if (!messages.length && !errorMessages.length) {
@@ -75,7 +75,7 @@ function MetabotMessages() {
           messages={messages}
           errorMessages={errorMessages}
           onRetryMessage={handleRetryMessage}
-          isDoingScience={isDoingScience}
+          isDoingScience={metabot.isDoingScience}
           showFeedbackButtons={false}
           onInternalLinkClick={setNavigateToPath}
         />

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -22,7 +22,7 @@ import { QuestionTitle } from "./QuestionTitle";
 
 const MetabotQuestionInner = () => {
   const { isLocaleLoading } = useLocale();
-  const metabot = useMetabotAgent();
+  const { navigateToPath } = useMetabotChat();
 
   if (isLocaleLoading) {
     return <SdkLoader />;
@@ -34,9 +34,9 @@ const MetabotQuestionInner = () => {
 
       <MetabotChatEmbedding />
 
-      {!!metabot.navigateToPath && (
+      {!!navigateToPath && (
         <SdkAdHocQuestion
-          questionPath={metabot.navigateToPath}
+          questionPath={navigateToPath}
           title={false}
           isSaveEnabled={false}
         >
@@ -59,8 +59,8 @@ const MetabotQuestionInner = () => {
 
 function MetabotMessages() {
   const metabot = useMetabotAgent();
-  const { messages, errorMessages, setNavigateToPath } = metabot;
-  const { handleRetryMessage } = useMetabotChat();
+  const { messages, errorMessages } = metabot;
+  const { handleRetryMessage, setNavigateToPath } = useMetabotChat();
 
   if (!messages.length && !errorMessages.length) {
     return null;

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from "react";
+import { useId } from "react";
 import { t } from "ttag";
 
 import {
@@ -7,13 +7,11 @@ import {
 } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
 import { SdkAdHocQuestion } from "embedding-sdk-bundle/components/private/SdkAdHocQuestion";
 import { SdkQuestionDefaultView } from "embedding-sdk-bundle/components/private/SdkQuestionDefaultView";
-import { useSdkDispatch } from "embedding-sdk-bundle/store";
 import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSingleInstance/EnsureSingleInstance";
 import { useLocale } from "metabase/common/hooks/use-locale";
 import { Flex, Paper, Stack, Text } from "metabase/ui";
 import { Messages } from "metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
-import { addNavigateToHandler } from "metabase-enterprise/metabot/state";
 
 import { MetabotChatEmbedding } from "./MetabotChatEmbedding";
 import { QuestionDetails } from "./QuestionDetails";
@@ -21,12 +19,7 @@ import { QuestionTitle } from "./QuestionTitle";
 
 const MetabotQuestionInner = () => {
   const { isLocaleLoading } = useLocale();
-  const [adHocQuestionUrl, setAdHocQuestionUrl] = useState<string>("");
-  const dispatch = useSdkDispatch();
-
-  useEffect(() => {
-    dispatch(addNavigateToHandler(setAdHocQuestionUrl));
-  }, [dispatch]);
+  const metabot = useMetabotAgent();
 
   if (isLocaleLoading) {
     return <SdkLoader />;
@@ -34,13 +27,13 @@ const MetabotQuestionInner = () => {
 
   return (
     <Flex direction="column" align="center" gap="md">
-      <MetabotMessages handleAdHocQuestionLink={setAdHocQuestionUrl} />
+      <MetabotMessages />
 
       <MetabotChatEmbedding />
 
-      {adHocQuestionUrl && (
+      {!!metabot.navigateToPath && (
         <SdkAdHocQuestion
-          questionPath={adHocQuestionUrl}
+          questionPath={metabot.navigateToPath}
           title={false}
           isSaveEnabled={false}
         >
@@ -61,11 +54,7 @@ const MetabotQuestionInner = () => {
   );
 };
 
-interface MessageProps {
-  handleAdHocQuestionLink: (queryLink: string) => void;
-}
-
-function MetabotMessages({ handleAdHocQuestionLink }: MessageProps) {
+function MetabotMessages() {
   const metabot = useMetabotAgent();
   const { messages, errorMessages } = metabot;
 
@@ -81,7 +70,6 @@ function MetabotMessages({ handleAdHocQuestionLink }: MessageProps) {
           errorMessages={errorMessages}
           isDoingScience={metabot.isDoingScience}
           showFeedbackButtons={false}
-          onInternalLinkClick={handleAdHocQuestionLink}
         />
       </Flex>
     </Paper>

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -20,11 +20,11 @@ import { QuestionTitle } from "./QuestionTitle";
 
 const MetabotQuestionInner = () => {
   const { isLocaleLoading } = useLocale();
-  const [redirectUrl, setRedirectUrl] = useState<string>("");
+  const [adHocQuestionUrl, setAdHocQuestionUrl] = useState<string>("");
   const dispatch = useSdkDispatch();
 
   useEffect(() => {
-    dispatch(addNavigateToHandler(setRedirectUrl));
+    dispatch(addNavigateToHandler(setAdHocQuestionUrl));
   }, [dispatch]);
 
   if (isLocaleLoading) {
@@ -33,15 +33,13 @@ const MetabotQuestionInner = () => {
 
   return (
     <Flex direction="column" align="center" gap="md">
-      <MetabotMessages handleQueryLink={setRedirectUrl} />
+      <MetabotMessages handleAdHocQuestionLink={setAdHocQuestionUrl} />
 
       <MetabotChatEmbedding />
 
-      <Disclaimer />
-
-      {redirectUrl && (
+      {adHocQuestionUrl && (
         <SdkAdHocQuestion
-          questionPath={redirectUrl}
+          questionPath={adHocQuestionUrl}
           title={false}
           isSaveEnabled={false}
         >
@@ -56,15 +54,17 @@ const MetabotQuestionInner = () => {
           />
         </SdkAdHocQuestion>
       )}
+
+      <Disclaimer />
     </Flex>
   );
 };
 
 interface MessageProps {
-  handleQueryLink: (queryLink: string) => void;
+  handleAdHocQuestionLink: (queryLink: string) => void;
 }
 
-function MetabotMessages({ handleQueryLink }: MessageProps) {
+function MetabotMessages({ handleAdHocQuestionLink }: MessageProps) {
   const metabot = useMetabotAgent();
   const { messages, errorMessages } = metabot;
 
@@ -80,7 +80,7 @@ function MetabotMessages({ handleQueryLink }: MessageProps) {
           errorMessages={errorMessages}
           isDoingScience={metabot.isDoingScience}
           showFeedbackButtons={false}
-          onInternalLinkClick={handleQueryLink}
+          onInternalLinkClick={handleAdHocQuestionLink}
         />
       </Flex>
     </Paper>

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { t } from "ttag";
 
 import {
@@ -8,6 +8,7 @@ import {
 import { SdkAdHocQuestion } from "embedding-sdk-bundle/components/private/SdkAdHocQuestion";
 import { SdkQuestionDefaultView } from "embedding-sdk-bundle/components/private/SdkQuestionDefaultView";
 import { useSdkDispatch } from "embedding-sdk-bundle/store";
+import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSingleInstance/EnsureSingleInstance";
 import { useLocale } from "metabase/common/hooks/use-locale";
 import { Flex, Paper, Stack, Text } from "metabase/ui";
 import { Messages } from "metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage";
@@ -93,4 +94,22 @@ function Disclaimer() {
   );
 }
 
-export const MetabotQuestion = withPublicComponentWrapper(MetabotQuestionInner);
+const MetabotQuestionWrapped = () => {
+  const ensureSingleInstanceId = useId();
+
+  return (
+    <EnsureSingleInstance
+      groupId="metabot-question"
+      instanceId={ensureSingleInstanceId}
+      multipleRegisteredInstancesWarningMessage={
+        "Multiple instances of MetabotQuestion detected. Ensure only one instance of MetabotQuestion is rendered at a time."
+      }
+    >
+      <MetabotQuestionInner />
+    </EnsureSingleInstance>
+  );
+};
+
+export const MetabotQuestion = withPublicComponentWrapper(
+  MetabotQuestionWrapped,
+);

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -56,7 +56,7 @@ const MetabotQuestionInner = () => {
 
 function MetabotMessages() {
   const metabot = useMetabotAgent();
-  const { messages, errorMessages } = metabot;
+  const { messages, errorMessages, setNavigateToPath, retryMessage } = metabot;
 
   if (!messages.length && !errorMessages.length) {
     return null;
@@ -68,8 +68,10 @@ function MetabotMessages() {
         <Messages
           messages={messages}
           errorMessages={errorMessages}
+          onRetryMessage={retryMessage}
           isDoingScience={metabot.isDoingScience}
           showFeedbackButtons={false}
+          onInternalLinkClick={setNavigateToPath}
         />
       </Flex>
     </Paper>

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -11,6 +11,7 @@ import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSing
 import { useLocale } from "metabase/common/hooks/use-locale";
 import { Flex, Paper, Stack, Text } from "metabase/ui";
 import { Messages } from "metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage";
+import { MetabotResetLongChatButton } from "metabase-enterprise/metabot/components/MetabotChat/MetabotResetLongChatButton";
 import {
   useMetabotAgent,
   useMetabotChatHandlers,
@@ -80,6 +81,8 @@ function MetabotMessages() {
           onInternalLinkClick={setNavigateToPath}
         />
       </Flex>
+
+      {metabot.isLongConversation && <MetabotResetLongChatButton />}
     </Paper>
   );
 }

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/MetabotQuestion/MetabotQuestion.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/MetabotQuestion/MetabotQuestion.stories.tsx
@@ -1,5 +1,9 @@
 import { getStorybookSdkAuthConfigForUser } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
 import { getHostedBundleStoryDecorator } from "embedding-sdk-package/test/getHostedBundleStoryDecorator";
+import {
+  MOCK_AD_HOC_QUESTION_ID,
+  mockStreamResponse,
+} from "embedding-sdk-shared/test/mocks/mock-metabot-response";
 
 import { MetabaseProvider } from "../MetabaseProvider";
 
@@ -11,6 +15,15 @@ export default {
   title: "EmbeddingSDK/MetabotQuestion/public",
   parameters: {
     layout: "fullscreen",
+    msw: {
+      handlers: [
+        mockStreamResponse([
+          `0:"Here is the [question link](${MOCK_AD_HOC_QUESTION_ID})"`,
+          `2:{"type":"navigate_to","version":1,"value":"${MOCK_AD_HOC_QUESTION_ID}"}
+`,
+        ]),
+      ],
+    },
   },
   decorators: [getHostedBundleStoryDecorator()],
 };

--- a/enterprise/frontend/src/embedding-sdk-shared/test/mocks/mock-metabot-response.ts
+++ b/enterprise/frontend/src/embedding-sdk-shared/test/mocks/mock-metabot-response.ts
@@ -1,0 +1,38 @@
+import { http } from "msw";
+
+export const MOCK_AD_HOC_QUESTION_ID =
+  "/question#eyJkYXRhc2V0X3F1ZXJ5IjogeyJkYXRhYmFzZSI6IDEsICJ0eXBlIjogInF1ZXJ5IiwgInF1ZXJ5IjogeyJzb3VyY2UtdGFibGUiOiAiY2FyZF9fMSJ9fSwgImRpc3BsYXkiOiAidGFibGUiLCAiZGlzcGxheUlzTG9ja2VkIjogdHJ1ZSwgInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOiB7fX0=";
+
+export const mockStreamResponse = (chunks: string[]) => {
+  return http.post("*/api/ee/metabot-v3/v2/agent-streaming", () => {
+    const encoder = new TextEncoder();
+
+    const stream = new ReadableStream({
+      start(controller) {
+        let i = 0;
+
+        const pushNext = () => {
+          if (i < chunks.length) {
+            controller.enqueue(encoder.encode(`${chunks[i]}\n`));
+            i++;
+            setTimeout(pushNext, 100);
+          } else {
+            controller.close();
+          }
+        };
+
+        pushNext();
+      },
+    });
+
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream; charset=utf-8",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+        "Transfer-Encoding": "chunked",
+      },
+    });
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.ts
@@ -43,7 +43,8 @@ export async function aiStreamingQuery(
     }
     inflightAiStreamingRequests.set(reqId, { abortController });
 
-    const response = await fetch(req.url, {
+    // The basename is needed to work within the Embedding SDK
+    const response = await fetch(`${api.basename}${req.url}`, {
       method: "POST",
       headers: {
         ...api.getClientHeaders(),

--- a/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/ai-streaming/requests.unit.spec.ts
@@ -1,22 +1,51 @@
 import fetchMock from "fetch-mock";
 
+import api from "metabase/lib/api";
+
 import { aiStreamingQuery, getInflightRequestsForUrl } from "./requests";
 import { mockStreamedEndpoint } from "./test-utils";
 
-const ENDPOINT = "/some-streamed-endpoint";
+const endpoint = "/some-streamed-endpoint";
+const fakeBasename = "http://example.com";
+const originalBasename = api.basename;
 
 describe("ai requests", () => {
+  beforeAll(() => {
+    api.basename = fakeBasename;
+  });
+
+  afterAll(() => {
+    api.basename = originalBasename;
+  });
+
   describe("aiStreamingQuery", () => {
-    it("should return full result of a successful request", async () => {
-      mockStreamedEndpoint(ENDPOINT, {
+    it("should call a request with a baseurl", async () => {
+      const fetchSpy = jest.spyOn(global, "fetch");
+
+      mockStreamedEndpoint(endpoint, {
         textChunks: whoIsYourFavoriteResponse,
       });
-      const result = await aiStreamingQuery({ url: ENDPOINT, body: {} });
+
+      await aiStreamingQuery({ url: endpoint, body: {} });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "http://example.com/some-streamed-endpoint",
+        expect.anything(),
+      );
+
+      fetchSpy.mockRestore();
+    });
+
+    it("should return full result of a successful request", async () => {
+      mockStreamedEndpoint(endpoint, {
+        textChunks: whoIsYourFavoriteResponse,
+      });
+      const result = await aiStreamingQuery({ url: endpoint, body: {} });
       expect(result).toMatchSnapshot();
     });
 
     it("should call callbacks for relevant chunk types", async () => {
-      mockStreamedEndpoint(ENDPOINT, {
+      mockStreamedEndpoint(endpoint, {
         textChunks: [
           `0:"Testing"`,
           `2:{"type":"state","version":1,"value":{}}`,
@@ -34,14 +63,14 @@ describe("ai requests", () => {
         onError: jest.fn(),
       };
 
-      await aiStreamingQuery({ url: ENDPOINT, body: {} }, successCbs);
+      await aiStreamingQuery({ url: endpoint, body: {} }, successCbs);
       expect(successCbs.onTextPart).toHaveBeenCalled();
       expect(successCbs.onDataPart).toHaveBeenCalled();
       expect(successCbs.onToolCallPart).toHaveBeenCalled();
       expect(successCbs.onToolResultPart).toHaveBeenCalled();
       expect(successCbs.onError).not.toHaveBeenCalled();
 
-      mockStreamedEndpoint(ENDPOINT, {
+      mockStreamedEndpoint(endpoint, {
         textChunks: [
           `3:{}`, // error after finish to trigger all callbacks
         ],
@@ -51,33 +80,33 @@ describe("ai requests", () => {
         onError: jest.fn(),
       };
       try {
-        await aiStreamingQuery({ url: ENDPOINT, body: {} }, failureCbs);
+        await aiStreamingQuery({ url: endpoint, body: {} }, failureCbs);
       } catch (_) {}
       expect(failureCbs.onError).toHaveBeenCalled();
     });
 
     it("throw error if bad http status code", async () => {
-      fetchMock.post(`path:${ENDPOINT}`, 500);
+      fetchMock.post(`path:${endpoint}`, 500);
       await expect(
-        aiStreamingQuery({ url: ENDPOINT, body: {} }),
+        aiStreamingQuery({ url: endpoint, body: {} }),
       ).rejects.toThrow(/Response status: 500/);
     });
 
     it("throw error if no response", async () => {
-      mockStreamedEndpoint(ENDPOINT, {
+      mockStreamedEndpoint(endpoint, {
         textChunks: undefined,
       });
       await expect(
-        aiStreamingQuery({ url: ENDPOINT, body: {} }),
+        aiStreamingQuery({ url: endpoint, body: {} }),
       ).rejects.toThrow(/No response/);
     });
 
     it("should be able abort request via a passed in signal", async () => {
       const controller = new AbortController();
 
-      fetchMock.post(`path:${ENDPOINT}`, { delay: 100, status: 200 });
+      fetchMock.post(`path:${endpoint}`, { delay: 100, status: 200 });
       const promise = aiStreamingQuery({
-        url: ENDPOINT,
+        url: endpoint,
         body: {},
         signal: controller.signal,
       });
@@ -87,29 +116,29 @@ describe("ai requests", () => {
 
     describe("in-flight request tracking", () => {
       it("should register/unregister with inflight requests on a successful request", async () => {
-        mockStreamedEndpoint(ENDPOINT, {
+        mockStreamedEndpoint(endpoint, {
           textChunks: whoIsYourFavoriteResponse,
         });
-        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(0);
-        const promise = aiStreamingQuery({ url: ENDPOINT, body: {} });
-        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(1);
+        expect(getInflightRequestsForUrl(endpoint).length).toBe(0);
+        const promise = aiStreamingQuery({ url: endpoint, body: {} });
+        expect(getInflightRequestsForUrl(endpoint).length).toBe(1);
         await promise;
-        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(0);
+        expect(getInflightRequestsForUrl(endpoint).length).toBe(0);
       });
 
       it("should properly unregister with inflight requests on abort", async () => {
         const controller = new AbortController();
 
-        fetchMock.post(`path:${ENDPOINT}`, { delay: 100, status: 200 });
-        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(0);
+        fetchMock.post(`path:${endpoint}`, { delay: 100, status: 200 });
+        expect(getInflightRequestsForUrl(endpoint).length).toBe(0);
         const promise = aiStreamingQuery({
-          url: ENDPOINT,
+          url: endpoint,
           body: {},
           signal: controller.signal,
         });
-        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(1);
+        expect(getInflightRequestsForUrl(endpoint).length).toBe(1);
         controller.abort();
-        expect(getInflightRequestsForUrl(ENDPOINT).length).toBe(0);
+        expect(getInflightRequestsForUrl(endpoint).length).toBe(0);
         try {
           await promise;
         } catch (err) {}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/AIMarkdown/AIMarkdown.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/AIMarkdown/AIMarkdown.tsx
@@ -32,7 +32,7 @@ const getComponents = ({
       // A custom handler for internal links (use by Embedding SDK)
       if (onInternalLinkClick) {
         return (
-          <a onClick={() => onInternalLinkClick(href)} {...rest}>
+          <a {...rest} onClick={() => onInternalLinkClick(href)}>
             {children}
           </a>
         );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/AIMarkdown/AIMarkdown.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/AIMarkdown/AIMarkdown.tsx
@@ -1,7 +1,7 @@
 // TODO: consolidate this component w/ AIAnalysisContent
 
 import cx from "classnames";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 
 import Link from "metabase/common/components/Link/Link";
 import Markdown, {
@@ -10,7 +10,13 @@ import Markdown, {
 
 import S from "./AIMarkdown.module.css";
 
-const components = {
+type AIMarkdownProps = MarkdownProps & {
+  onInternalLinkClick?: (link: string) => void;
+};
+
+const getComponents = ({
+  onInternalLinkClick,
+}: Pick<AIMarkdownProps, "onInternalLinkClick">) => ({
   a: ({
     href,
     children,
@@ -23,6 +29,15 @@ const components = {
     [key: string]: any;
   }) => {
     if (href && href.startsWith("/")) {
+      // A custom handler for internal links (use by Embedding SDK)
+      if (onInternalLinkClick) {
+        return (
+          <a onClick={() => onInternalLinkClick(href)} {...rest}>
+            {children}
+          </a>
+        );
+      }
+
       return (
         <Link to={href} variant="brand">
           {children}
@@ -37,13 +52,23 @@ const components = {
       </a>
     );
   },
-};
+});
 
-export const AIMarkdown = memo(({ className, ...props }: MarkdownProps) => (
-  <Markdown
-    className={cx(S.aiMarkdown, className)}
-    components={components}
-    {...props}
-  />
-));
+export const AIMarkdown = memo(
+  ({ className, onInternalLinkClick, ...props }: AIMarkdownProps) => {
+    const components = useMemo(
+      () => getComponents({ onInternalLinkClick }),
+      [onInternalLinkClick],
+    );
+
+    return (
+      <Markdown
+        className={cx(S.aiMarkdown, className)}
+        components={components}
+        {...props}
+      />
+    );
+  },
+);
+
 AIMarkdown.displayName = "AIMarkdown";

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -58,6 +58,16 @@ export const MetabotChat = () => {
     metabot.submitInput(trimmedInput).catch((err) => console.error(err));
   };
 
+  const handleRetryMessage = (messageId: string) => {
+    if (metabot.isDoingScience) {
+      return;
+    }
+
+    metabot.setPrompt("");
+    metabot.promptInputRef?.current?.focus();
+    metabot.retryMessage(messageId).catch((err) => console.error(err));
+  };
+
   const handleClose = () => {
     metabot.setPrompt("");
     metabot.setVisible(false);
@@ -149,6 +159,7 @@ export const MetabotChat = () => {
               <Messages
                 messages={metabot.messages}
                 errorMessages={metabot.errorMessages}
+                onRetryMessage={handleRetryMessage}
                 isDoingScience={metabot.isDoingScience}
                 showFeedbackButtons
               />

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -19,7 +19,7 @@ import {
 } from "metabase/ui";
 import { useGetSuggestedMetabotPromptsQuery } from "metabase-enterprise/api";
 
-import { useMetabotAgent } from "../../hooks";
+import { useMetabotAgent, useMetabotChat } from "../../hooks";
 
 import Styles from "./MetabotChat.module.css";
 import { Messages } from "./MetabotChatMessage";
@@ -28,6 +28,8 @@ import { useScrollManager } from "./hooks";
 
 export const MetabotChat = () => {
   const metabot = useMetabotAgent();
+  const { handleSubmitInput, handleRetryMessage, handleResetInput } =
+    useMetabotChat();
 
   const hasMessages =
     metabot.messages.length > 0 || metabot.errorMessages.length > 0;
@@ -44,32 +46,8 @@ export const MetabotChat = () => {
     return suggestedPromptsReq.currentData?.prompts ?? [];
   }, [suggestedPromptsReq.currentData?.prompts]);
 
-  const handleSubmitInput = (input: string) => {
-    if (metabot.isDoingScience) {
-      return;
-    }
-
-    const trimmedInput = input.trim();
-    if (!trimmedInput.length || metabot.isDoingScience) {
-      return;
-    }
-    metabot.setPrompt("");
-    metabot.promptInputRef?.current?.focus();
-    metabot.submitInput(trimmedInput).catch((err) => console.error(err));
-  };
-
-  const handleRetryMessage = (messageId: string) => {
-    if (metabot.isDoingScience) {
-      return;
-    }
-
-    metabot.setPrompt("");
-    metabot.promptInputRef?.current?.focus();
-    metabot.retryMessage(messageId).catch((err) => console.error(err));
-  };
-
   const handleClose = () => {
-    metabot.setPrompt("");
+    handleResetInput();
     metabot.setVisible(false);
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -28,8 +28,12 @@ import { useScrollManager } from "./hooks";
 
 export const MetabotChat = () => {
   const metabot = useMetabotAgent();
-  const { handleSubmitInput, handleRetryMessage, handleResetInput } =
-    useMetabotChat();
+  const {
+    isDoingScience,
+    handleSubmitInput,
+    handleRetryMessage,
+    handleResetInput,
+  } = useMetabotChat();
 
   const hasMessages =
     metabot.messages.length > 0 || metabot.errorMessages.length > 0;
@@ -86,7 +90,7 @@ export const MetabotChat = () => {
           className={Styles.messagesContainer}
           data-testid="metabot-chat-messages"
         >
-          {!hasMessages && !metabot.isDoingScience && (
+          {!hasMessages && !isDoingScience && (
             <>
               {/* empty state */}
               <Flex
@@ -128,7 +132,7 @@ export const MetabotChat = () => {
             </>
           )}
 
-          {(hasMessages || metabot.isDoingScience) && (
+          {(hasMessages || isDoingScience) && (
             <Box
               className={Styles.messages}
               data-testid="metabot-chat-inner-messages"
@@ -138,12 +142,12 @@ export const MetabotChat = () => {
                 messages={metabot.messages}
                 errorMessages={metabot.errorMessages}
                 onRetryMessage={handleRetryMessage}
-                isDoingScience={metabot.isDoingScience}
+                isDoingScience={isDoingScience}
                 showFeedbackButtons
               />
 
               {/* loading */}
-              {metabot.isDoingScience && (
+              {isDoingScience && (
                 <MetabotThinking
                   toolCalls={metabot.toolCalls}
                   hasStartedResponse={
@@ -179,7 +183,7 @@ export const MetabotChat = () => {
           <Paper
             className={cx(
               Styles.inputContainer,
-              metabot.isDoingScience && Styles.inputContainerLoading,
+              isDoingScience && Styles.inputContainerLoading,
             )}
           >
             <Textarea
@@ -199,7 +203,7 @@ export const MetabotChat = () => {
               value={metabot.prompt}
               className={cx(
                 Styles.textarea,
-                metabot.isDoingScience && Styles.textareaLoading,
+                isDoingScience && Styles.textareaLoading,
               )}
               placeholder={t`Tell me to do something, or ask a question`}
               onChange={(e) => metabot.setPrompt(e.target.value)}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -58,16 +58,6 @@ export const MetabotChat = () => {
     metabot.submitInput(trimmedInput).catch((err) => console.error(err));
   };
 
-  const handleRetryMessage = (messageId: string) => {
-    if (metabot.isDoingScience) {
-      return;
-    }
-
-    metabot.setPrompt("");
-    metabot.promptInputRef?.current?.focus();
-    metabot.retryMessage(messageId).catch((err) => console.error(err));
-  };
-
   const handleClose = () => {
     metabot.setPrompt("");
     metabot.setVisible(false);
@@ -159,8 +149,8 @@ export const MetabotChat = () => {
               <Messages
                 messages={metabot.messages}
                 errorMessages={metabot.errorMessages}
-                onRetryMessage={handleRetryMessage}
                 isDoingScience={metabot.isDoingScience}
+                showFeedbackButtons
               />
 
               {/* loading */}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -19,7 +19,7 @@ import {
 } from "metabase/ui";
 import { useGetSuggestedMetabotPromptsQuery } from "metabase-enterprise/api";
 
-import { useMetabotAgent, useMetabotChat } from "../../hooks";
+import { useMetabotAgent, useMetabotChatHandlers } from "../../hooks";
 
 import Styles from "./MetabotChat.module.css";
 import { Messages } from "./MetabotChatMessage";
@@ -28,12 +28,8 @@ import { useScrollManager } from "./hooks";
 
 export const MetabotChat = () => {
   const metabot = useMetabotAgent();
-  const {
-    isDoingScience,
-    handleSubmitInput,
-    handleRetryMessage,
-    handleResetInput,
-  } = useMetabotChat();
+  const { handleSubmitInput, handleRetryMessage, handleResetInput } =
+    useMetabotChatHandlers();
 
   const hasMessages =
     metabot.messages.length > 0 || metabot.errorMessages.length > 0;
@@ -90,7 +86,7 @@ export const MetabotChat = () => {
           className={Styles.messagesContainer}
           data-testid="metabot-chat-messages"
         >
-          {!hasMessages && !isDoingScience && (
+          {!hasMessages && !metabot.isDoingScience && (
             <>
               {/* empty state */}
               <Flex
@@ -132,7 +128,7 @@ export const MetabotChat = () => {
             </>
           )}
 
-          {(hasMessages || isDoingScience) && (
+          {(hasMessages || metabot.isDoingScience) && (
             <Box
               className={Styles.messages}
               data-testid="metabot-chat-inner-messages"
@@ -142,12 +138,12 @@ export const MetabotChat = () => {
                 messages={metabot.messages}
                 errorMessages={metabot.errorMessages}
                 onRetryMessage={handleRetryMessage}
-                isDoingScience={isDoingScience}
+                isDoingScience={metabot.isDoingScience}
                 showFeedbackButtons
               />
 
               {/* loading */}
-              {isDoingScience && (
+              {metabot.isDoingScience && (
                 <MetabotThinking
                   toolCalls={metabot.toolCalls}
                   hasStartedResponse={
@@ -183,7 +179,7 @@ export const MetabotChat = () => {
           <Paper
             className={cx(
               Styles.inputContainer,
-              isDoingScience && Styles.inputContainerLoading,
+              metabot.isDoingScience && Styles.inputContainerLoading,
             )}
           >
             <Textarea
@@ -203,7 +199,7 @@ export const MetabotChat = () => {
               value={metabot.prompt}
               className={cx(
                 Styles.textarea,
-                isDoingScience && Styles.textareaLoading,
+                metabot.isDoingScience && Styles.textareaLoading,
               )}
               placeholder={t`Tell me to do something, or ask a question`}
               onChange={(e) => metabot.setPrompt(e.target.value)}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -1,6 +1,6 @@
 import cx from "classnames";
 import { useMemo } from "react";
-import { c, jt, t } from "ttag";
+import { t } from "ttag";
 import _ from "underscore";
 
 import EmptyDashboardBot from "assets/img/dashboard-empty.svg?component";
@@ -15,9 +15,9 @@ import {
   Stack,
   Text,
   Textarea,
-  UnstyledButton,
 } from "metabase/ui";
 import { useGetSuggestedMetabotPromptsQuery } from "metabase-enterprise/api";
+import { MetabotResetLongChatButton } from "metabase-enterprise/metabot/components/MetabotChat/MetabotResetLongChatButton";
 
 import { useMetabotAgent, useMetabotChatHandlers } from "../../hooks";
 
@@ -156,21 +156,7 @@ export const MetabotChat = () => {
               <div ref={fillerRef} data-testid="metabot-message-filler" />
 
               {/* long convo warning */}
-              {metabot.isLongConversation && (
-                <Text lh={1} c="text-light" m={0} ta="center">
-                  {jt`This chat is getting long. You can ${(
-                    <UnstyledButton
-                      key="reset"
-                      data-testid="metabot-reset-long-chat"
-                      display="inline"
-                      c="brand"
-                      td="underline"
-                      onClick={() => metabot.resetConversation()}
-                    >{c("'it' refers to a chat with an AI agent")
-                      .t`clear it`}</UnstyledButton>
-                  )}.`}
-                </Text>
-              )}
+              {metabot.isLongConversation && <MetabotResetLongChatButton />}
             </Box>
           )}
         </Box>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -105,10 +105,11 @@ const FeedbackButton = ({
 );
 
 interface AgentMessageProps extends BaseMessageProps {
-  onRetry: (messageId: string) => void;
+  onRetry?: (messageId: string) => void;
   onCopy: (messageId: string) => void;
   setFeedbackMessage?: (data: { messageId: string; positive: boolean }) => void;
   submittedFeedback: "positive" | "negative" | undefined;
+  onInternalLinkClick?: (link: string) => void;
 }
 
 export const AgentMessage = ({
@@ -118,11 +119,18 @@ export const AgentMessage = ({
   onRetry,
   setFeedbackMessage,
   submittedFeedback,
+  onInternalLinkClick,
   hideActions,
   ...props
 }: AgentMessageProps) => (
   <MessageContainer chatRole={message.role} {...props}>
-    <AIMarkdown className={Styles.message}>{message.message}</AIMarkdown>
+    <AIMarkdown
+      className={Styles.message}
+      onInternalLinkClick={onInternalLinkClick}
+    >
+      {message.message}
+    </AIMarkdown>
+
     <Flex className={Styles.messageActions}>
       {!hideActions && (
         <>
@@ -161,13 +169,16 @@ export const AgentMessage = ({
               />
             </>
           )}
-          <ActionIcon
-            onClick={() => onRetry(message.id)}
-            h="sm"
-            data-testid="metabot-chat-message-retry"
-          >
-            <Icon name="revert" size="1rem" />
-          </ActionIcon>
+
+          {onRetry && (
+            <ActionIcon
+              onClick={() => onRetry(message.id)}
+              h="sm"
+              data-testid="metabot-chat-message-retry"
+            >
+              <Icon name="revert" size="1rem" />
+            </ActionIcon>
+          )}
         </>
       )}
     </Flex>
@@ -228,11 +239,13 @@ export const Messages = ({
   errorMessages,
   onRetryMessage,
   isDoingScience,
+  onInternalLinkClick,
 }: {
   messages: MetabotChatMessage[];
   errorMessages: MetabotErrorMessage[];
-  onRetryMessage: (messageId: string) => void;
+  onRetryMessage?: (messageId: string) => void;
   isDoingScience: boolean;
+  onInternalLinkClick?: (link: string) => void;
 }) => {
   const clipboard = useClipboard();
   const [sendToast] = useToast();
@@ -288,6 +301,7 @@ export const Messages = ({
             setFeedbackMessage={setFeedbackModal}
             submittedFeedback={feedbackState.submitted[message.id]}
             hideActions={messages[index + 1]?.role === "agent"}
+            onInternalLinkClick={onInternalLinkClick}
           />
         ) : (
           <UserMessage

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -240,15 +240,15 @@ export const Messages = ({
   errorMessages,
   isDoingScience,
   showFeedbackButtons,
-  onInternalLinkClick,
 }: {
   messages: MetabotChatMessage[];
   errorMessages: MetabotErrorMessage[];
   isDoingScience: boolean;
   showFeedbackButtons: boolean;
-  onInternalLinkClick?: (link: string) => void;
 }) => {
   const metabot = useMetabotAgent();
+  const { setNavigateToPath } = metabot;
+
   const clipboard = useClipboard();
   const [sendToast] = useToast();
 
@@ -320,7 +320,7 @@ export const Messages = ({
             setFeedbackMessage={setFeedbackModal}
             submittedFeedback={feedbackState.submitted[message.id]}
             hideActions={messages[index + 1]?.role === "agent"}
-            onInternalLinkClick={onInternalLinkClick}
+            onInternalLinkClick={setNavigateToPath}
           />
         ) : (
           <UserMessage

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -267,9 +267,7 @@ export const Messages = ({
 
     metabot.setPrompt("");
     metabot.promptInputRef?.current?.focus();
-    metabot
-      .retryMessage(messageId, metabot.metabotRequestId)
-      .catch((err) => console.error(err));
+    metabot.retryMessage(messageId).catch((err) => console.error(err));
   };
 
   const submitFeedback = async (metabotFeedback: MetabotFeedback) => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -12,7 +12,6 @@ import {
   type IconName,
   Text,
 } from "metabase/ui";
-import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 import type {
   MetabotChatMessage,
   MetabotErrorMessage,
@@ -238,17 +237,18 @@ export const getFullAgentReply = (
 export const Messages = ({
   messages,
   errorMessages,
+  onRetryMessage,
   isDoingScience,
   showFeedbackButtons,
+  onInternalLinkClick,
 }: {
   messages: MetabotChatMessage[];
   errorMessages: MetabotErrorMessage[];
+  onRetryMessage: (messageId: string) => void;
   isDoingScience: boolean;
   showFeedbackButtons: boolean;
+  onInternalLinkClick?: (navigateToPath: string) => void;
 }) => {
-  const metabot = useMetabotAgent();
-  const { setNavigateToPath } = metabot;
-
   const clipboard = useClipboard();
   const [sendToast] = useToast();
 
@@ -259,16 +259,6 @@ export const Messages = ({
     submitted: {},
     modal: undefined,
   });
-
-  const handleRetryMessage = (messageId: string) => {
-    if (metabot.isDoingScience) {
-      return;
-    }
-
-    metabot.setPrompt("");
-    metabot.promptInputRef?.current?.focus();
-    metabot.retryMessage(messageId).catch((err) => console.error(err));
-  };
 
   const submitFeedback = async (metabotFeedback: MetabotFeedback) => {
     const { message_id, positive } = metabotFeedback.feedback;
@@ -312,13 +302,13 @@ export const Messages = ({
             key={"msg-" + index}
             data-testid="metabot-chat-message"
             message={message}
-            onRetry={handleRetryMessage}
+            onRetry={onRetryMessage}
             onCopy={onAgentMessageCopy}
             showFeedbackButtons={showFeedbackButtons}
             setFeedbackMessage={setFeedbackModal}
             submittedFeedback={feedbackState.submitted[message.id]}
             hideActions={messages[index + 1]?.role === "agent"}
-            onInternalLinkClick={setNavigateToPath}
+            onInternalLinkClick={onInternalLinkClick}
           />
         ) : (
           <UserMessage

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotResetLongChatButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotResetLongChatButton.tsx
@@ -1,0 +1,24 @@
+import { c, jt } from "ttag";
+
+import { Text, UnstyledButton } from "metabase/ui";
+import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
+
+export const MetabotResetLongChatButton = () => {
+  const metabot = useMetabotAgent();
+
+  return (
+    <Text lh={1} c="text-light" m={0} ta="center">
+      {jt`This chat is getting long. You can ${(
+        <UnstyledButton
+          key="reset"
+          data-testid="metabot-reset-long-chat"
+          display="inline"
+          c="brand"
+          td="underline"
+          onClick={() => metabot.resetConversation()}
+        >{c("'it' refers to a chat with an AI agent")
+          .t`clear it`}</UnstyledButton>
+      )}.`}
+    </Text>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
@@ -8,6 +8,10 @@ export const FIXED_METABOT_IDS = {
   EMBEDDED: 2 as const,
 };
 
+export const METABOT_REQUEST_IDS = {
+  EMBEDDED: "c61bf5f5-1025-47b6-9298-bf1827105bb6",
+};
+
 export const METABOT_ERR_MSG = {
   get default() {
     return t`Sorry, I ran into an error. Could you please try that again?`;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
@@ -17,9 +17,6 @@ export const METABOT_ERR_MSG = {
   },
 };
 
-// We don't need to translate this yet, as it's from ai-service which isn't translated
-export const METABOT_RESULTS_MESSAGE = "Here are the results";
-
 export const TOOL_CALL_MESSAGES: Record<string, string | undefined> = {
   get construct_notebook_query() {
     return t`Creating a query`;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -14,9 +14,11 @@ import {
   getMetabotId,
   getMetabotRequestId,
   getMetabotVisible,
+  getNavigateToPath,
   getToolCalls,
   resetConversation as resetConversationAction,
   retryPrompt,
+  setNavigateToPath as setNavigateToPathAction,
   setVisible as setVisibleAction,
   submitInput as submitInputAction,
 } from "./state";
@@ -47,6 +49,10 @@ export const useMetabotAgent = () => {
   const metabotRequestId = useSelector(
     getMetabotRequestId as any,
   ) as ReturnType<typeof getMetabotRequestId>;
+
+  const navigateToPath = useSelector(getNavigateToPath as any) as ReturnType<
+    typeof getNavigateToPath
+  >;
 
   const setVisible = useCallback(
     (isVisible: boolean) => dispatch(setVisibleAction(isVisible)),
@@ -121,6 +127,13 @@ export const useMetabotAgent = () => {
     [submitInput, resetConversation, setVisible, promptInputRef],
   );
 
+  const setNavigateToPath = useCallback(
+    async (navigateToPath: string) => {
+      dispatch(setNavigateToPathAction(navigateToPath));
+    },
+    [dispatch],
+  );
+
   return {
     prompt,
     setPrompt,
@@ -130,6 +143,7 @@ export const useMetabotAgent = () => {
     visible,
     messages,
     errorMessages,
+    navigateToPath,
     lastAgentMessages: useSelector(
       getLastAgentMessagesByType as any,
     ) as ReturnType<typeof getLastAgentMessagesByType>,
@@ -137,6 +151,7 @@ export const useMetabotAgent = () => {
       getIsLongMetabotConversation as any,
     ) as ReturnType<typeof getIsLongMetabotConversation>,
     resetConversation,
+    setNavigateToPath,
     setVisible,
     startNewConversation,
     submitInput,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -75,7 +75,7 @@ export const useMetabotAgent = () => {
   );
 
   const submitInput = useCallback(
-    async (prompt: string, metabotRequestId?: string) => {
+    async (prompt: string) => {
       if (!visible) {
         setVisible(true);
       }
@@ -95,11 +95,18 @@ export const useMetabotAgent = () => {
 
       return action;
     },
-    [dispatch, getChatContext, prepareRetryIfUnsuccesful, setVisible, visible],
+    [
+      dispatch,
+      getChatContext,
+      metabotRequestId,
+      prepareRetryIfUnsuccesful,
+      setVisible,
+      visible,
+    ],
   );
 
   const retryMessage = useCallback(
-    async (messageId: string, metabotRequestId?: string) => {
+    async (messageId: string) => {
       const context = await getChatContext();
       const action = await dispatch(
         retryPrompt({
@@ -112,19 +119,19 @@ export const useMetabotAgent = () => {
         prepareRetryIfUnsuccesful(action.payload);
       }
     },
-    [dispatch, getChatContext, prepareRetryIfUnsuccesful],
+    [dispatch, getChatContext, metabotRequestId, prepareRetryIfUnsuccesful],
   );
 
   const startNewConversation = useCallback(
-    async (message: string, metabotId?: string) => {
+    async (message: string) => {
       await resetConversation();
       setVisible(true);
       if (message) {
-        submitInput(message, metabotId);
+        submitInput(message);
       }
       promptInputRef?.current?.focus();
     },
-    [submitInput, resetConversation, setVisible, promptInputRef],
+    [resetConversation, setVisible, promptInputRef, submitInput],
   );
 
   const setNavigateToPath = useCallback(
@@ -139,7 +146,6 @@ export const useMetabotAgent = () => {
     setPrompt,
     promptInputRef,
     metabotId,
-    metabotRequestId,
     visible,
     messages,
     errorMessages,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -69,7 +69,7 @@ export const useMetabotAgent = () => {
   );
 
   const submitInput = useCallback(
-    async (prompt: string, metabotId?: string) => {
+    async (prompt: string, metabotRequestId?: string) => {
       if (!visible) {
         setVisible(true);
       }
@@ -79,7 +79,7 @@ export const useMetabotAgent = () => {
         submitInputAction({
           message: prompt,
           context,
-          metabot_id: metabotId,
+          metabot_id: metabotRequestId,
         }),
       );
 
@@ -93,13 +93,13 @@ export const useMetabotAgent = () => {
   );
 
   const retryMessage = useCallback(
-    async (messageId: string, metabotId?: string) => {
+    async (messageId: string, metabotRequestId?: string) => {
       const context = await getChatContext();
       const action = await dispatch(
         retryPrompt({
           messageId,
           context,
-          metabot_id: metabotId,
+          metabot_id: metabotRequestId,
         }),
       );
       if (isFulfilled(action)) {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks.ts
@@ -12,6 +12,7 @@ import {
   getLastAgentMessagesByType,
   getMessages,
   getMetabotId,
+  getMetabotRequestId,
   getMetabotVisible,
   getToolCalls,
   resetConversation as resetConversationAction,
@@ -39,6 +40,13 @@ export const useMetabotAgent = () => {
   const visible = useSelector(getMetabotVisible as any) as ReturnType<
     typeof getMetabotVisible
   >;
+
+  const metabotId = useSelector(getMetabotId as any) as ReturnType<
+    typeof getMetabotId
+  >;
+  const metabotRequestId = useSelector(
+    getMetabotRequestId as any,
+  ) as ReturnType<typeof getMetabotRequestId>;
 
   const setVisible = useCallback(
     (isVisible: boolean) => dispatch(setVisibleAction(isVisible)),
@@ -117,9 +125,8 @@ export const useMetabotAgent = () => {
     prompt,
     setPrompt,
     promptInputRef,
-    metabotId: useSelector(getMetabotId as any) as ReturnType<
-      typeof getMetabotId
-    >,
+    metabotId,
+    metabotRequestId,
     visible,
     messages,
     errorMessages,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useMetabotAgent } from "./use-metabot-agent";

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useMetabotAgent } from "./use-metabot-agent";
+export { useMetabotChat } from "./use-metabot-chat";

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/index.ts
@@ -1,2 +1,2 @@
 export { useMetabotAgent } from "./use-metabot-agent";
-export { useMetabotChat } from "./use-metabot-chat";
+export { useMetabotChatHandlers } from "./use-metabot-chat-handlers";

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -21,7 +21,7 @@ import {
   setNavigateToPath as setNavigateToPathAction,
   setVisible as setVisibleAction,
   submitInput as submitInputAction,
-} from "./state";
+} from "../state";
 
 export const useMetabotAgent = () => {
   const dispatch = useDispatch();

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -8,7 +8,6 @@ import {
   type MetabotPromptSubmissionResult,
   getAgentErrorMessages,
   getIsLongMetabotConversation,
-  getIsProcessing,
   getLastAgentMessagesByType,
   getMessages,
   getMetabotId,
@@ -30,12 +29,17 @@ export const useMetabotAgent = () => {
   const messages = useSelector(getMessages as any) as ReturnType<
     typeof getMessages
   >;
+  const lastAgentMessages = useSelector(
+    getLastAgentMessagesByType as any,
+  ) as ReturnType<typeof getLastAgentMessagesByType>;
+
   const errorMessages = useSelector(getAgentErrorMessages as any) as ReturnType<
     typeof getAgentErrorMessages
   >;
-  const isProcessing = useSelector(getIsProcessing as any) as ReturnType<
-    typeof getIsProcessing
-  >;
+
+  const isLongConversation = useSelector(
+    getIsLongMetabotConversation as any,
+  ) as ReturnType<typeof getIsLongMetabotConversation>;
 
   const visible = useSelector(getMetabotVisible as any) as ReturnType<
     typeof getMetabotVisible
@@ -47,6 +51,10 @@ export const useMetabotAgent = () => {
   const metabotRequestId = useSelector(
     getMetabotRequestId as any,
   ) as ReturnType<typeof getMetabotRequestId>;
+
+  const toolCalls = useSelector(getToolCalls as any) as ReturnType<
+    typeof getToolCalls
+  >;
 
   const setVisible = useCallback(
     (isVisible: boolean) => dispatch(setVisibleAction(isVisible)),
@@ -135,21 +143,14 @@ export const useMetabotAgent = () => {
     metabotId,
     visible,
     messages,
+    lastAgentMessages,
     errorMessages,
-    lastAgentMessages: useSelector(
-      getLastAgentMessagesByType as any,
-    ) as ReturnType<typeof getLastAgentMessagesByType>,
-    isLongConversation: useSelector(
-      getIsLongMetabotConversation as any,
-    ) as ReturnType<typeof getIsLongMetabotConversation>,
+    isLongConversation,
     resetConversation,
     setVisible,
     startNewConversation,
     submitInput,
-    isDoingScience: isProcessing,
-    toolCalls: useSelector(getToolCalls as any) as ReturnType<
-      typeof getToolCalls
-    >,
     retryMessage,
+    toolCalls,
   };
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -14,11 +14,9 @@ import {
   getMetabotId,
   getMetabotRequestId,
   getMetabotVisible,
-  getNavigateToPath,
   getToolCalls,
   resetConversation as resetConversationAction,
   retryPrompt,
-  setNavigateToPath as setNavigateToPathAction,
   setVisible as setVisibleAction,
   submitInput as submitInputAction,
 } from "../state";
@@ -49,10 +47,6 @@ export const useMetabotAgent = () => {
   const metabotRequestId = useSelector(
     getMetabotRequestId as any,
   ) as ReturnType<typeof getMetabotRequestId>;
-
-  const navigateToPath = useSelector(getNavigateToPath as any) as ReturnType<
-    typeof getNavigateToPath
-  >;
 
   const setVisible = useCallback(
     (isVisible: boolean) => dispatch(setVisibleAction(isVisible)),
@@ -134,13 +128,6 @@ export const useMetabotAgent = () => {
     [resetConversation, setVisible, promptInputRef, submitInput],
   );
 
-  const setNavigateToPath = useCallback(
-    async (navigateToPath: string) => {
-      dispatch(setNavigateToPathAction(navigateToPath));
-    },
-    [dispatch],
-  );
-
   return {
     prompt,
     setPrompt,
@@ -149,7 +136,6 @@ export const useMetabotAgent = () => {
     visible,
     messages,
     errorMessages,
-    navigateToPath,
     lastAgentMessages: useSelector(
       getLastAgentMessagesByType as any,
     ) as ReturnType<typeof getLastAgentMessagesByType>,
@@ -157,7 +143,6 @@ export const useMetabotAgent = () => {
       getIsLongMetabotConversation as any,
     ) as ReturnType<typeof getIsLongMetabotConversation>,
     resetConversation,
-    setNavigateToPath,
     setVisible,
     startNewConversation,
     submitInput,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -8,6 +8,7 @@ import {
   type MetabotPromptSubmissionResult,
   getAgentErrorMessages,
   getIsLongMetabotConversation,
+  getIsProcessing,
   getLastAgentMessagesByType,
   getMessages,
   getMetabotId,
@@ -24,6 +25,10 @@ export const useMetabotAgent = () => {
   const dispatch = useDispatch();
   const { prompt, setPrompt, promptInputRef, getChatContext } =
     useMetabotContext();
+
+  const isDoingScience = useSelector(getIsProcessing as any) as ReturnType<
+    typeof getIsProcessing
+  >;
 
   // TODO: create an enterprise useSelector
   const messages = useSelector(getMessages as any) as ReturnType<
@@ -137,6 +142,7 @@ export const useMetabotAgent = () => {
   );
 
   return {
+    isDoingScience,
     prompt,
     setPrompt,
     promptInputRef,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-chat-handlers.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-chat-handlers.ts
@@ -1,17 +1,15 @@
 import { useCallback } from "react";
 
-import { useSelector } from "metabase/lib/redux";
-import { getIsProcessing } from "metabase-enterprise/metabot/state";
-
 import { useMetabotAgent } from "./use-metabot-agent";
 
-export const useMetabotChat = () => {
-  const { setPrompt, promptInputRef, submitInput, retryMessage } =
-    useMetabotAgent();
-
-  const isDoingScience = useSelector(getIsProcessing as any) as ReturnType<
-    typeof getIsProcessing
-  >;
+export const useMetabotChatHandlers = () => {
+  const {
+    isDoingScience,
+    setPrompt,
+    promptInputRef,
+    submitInput,
+    retryMessage,
+  } = useMetabotAgent();
 
   const handleSubmitInput = useCallback(
     (input: string) => {
@@ -48,7 +46,6 @@ export const useMetabotChat = () => {
   }, [setPrompt]);
 
   return {
-    isDoingScience,
     handleSubmitInput,
     handleRetryMessage,
     handleResetInput,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-chat.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-chat.ts
@@ -1,0 +1,53 @@
+import { useCallback } from "react";
+
+import { useMetabotAgent } from "./use-metabot-agent";
+
+export const useMetabotChat = () => {
+  const {
+    isDoingScience,
+    setPrompt,
+    promptInputRef,
+    submitInput,
+    retryMessage,
+  } = useMetabotAgent();
+
+  const handleSubmitInput = useCallback(
+    (input: string) => {
+      if (isDoingScience) {
+        return;
+      }
+
+      const trimmedInput = input.trim();
+      if (!trimmedInput.length || isDoingScience) {
+        return;
+      }
+      setPrompt("");
+      promptInputRef?.current?.focus();
+      submitInput(trimmedInput).catch((err) => console.error(err));
+    },
+    [isDoingScience, promptInputRef, setPrompt, submitInput],
+  );
+
+  const handleRetryMessage = useCallback(
+    (messageId: string) => {
+      if (isDoingScience) {
+        return;
+      }
+
+      setPrompt("");
+      promptInputRef?.current?.focus();
+      retryMessage(messageId).catch((err) => console.error(err));
+    },
+    [isDoingScience, promptInputRef, retryMessage, setPrompt],
+  );
+
+  const handleResetInput = useCallback(() => {
+    setPrompt("");
+  }, [setPrompt]);
+
+  return {
+    handleSubmitInput,
+    handleRetryMessage,
+    handleResetInput,
+  };
+};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-chat.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-chat.ts
@@ -1,23 +1,13 @@
 import { useCallback } from "react";
 
-import { useDispatch, useSelector } from "metabase/lib/redux";
-import {
-  getIsProcessing,
-  getMetabotReactionsState,
-  setNavigateToPath as setNavigateToPathAction,
-} from "metabase-enterprise/metabot/state";
+import { useSelector } from "metabase/lib/redux";
+import { getIsProcessing } from "metabase-enterprise/metabot/state";
 
 import { useMetabotAgent } from "./use-metabot-agent";
 
 export const useMetabotChat = () => {
-  const dispatch = useDispatch();
-
   const { setPrompt, promptInputRef, submitInput, retryMessage } =
     useMetabotAgent();
-
-  const { navigateToPath } = useSelector(
-    getMetabotReactionsState as any,
-  ) as ReturnType<typeof getMetabotReactionsState>;
 
   const isDoingScience = useSelector(getIsProcessing as any) as ReturnType<
     typeof getIsProcessing
@@ -57,19 +47,10 @@ export const useMetabotChat = () => {
     setPrompt("");
   }, [setPrompt]);
 
-  const setNavigateToPath = useCallback(
-    async (navigateToPath: string) => {
-      dispatch(setNavigateToPathAction(navigateToPath));
-    },
-    [dispatch],
-  );
-
   return {
     isDoingScience,
     handleSubmitInput,
     handleRetryMessage,
     handleResetInput,
-    navigateToPath,
-    setNavigateToPath,
   };
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-chat.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-chat.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
+  getIsProcessing,
   getMetabotReactionsState,
   setNavigateToPath as setNavigateToPathAction,
 } from "metabase-enterprise/metabot/state";
@@ -11,17 +12,16 @@ import { useMetabotAgent } from "./use-metabot-agent";
 export const useMetabotChat = () => {
   const dispatch = useDispatch();
 
-  const {
-    isDoingScience,
-    setPrompt,
-    promptInputRef,
-    submitInput,
-    retryMessage,
-  } = useMetabotAgent();
+  const { setPrompt, promptInputRef, submitInput, retryMessage } =
+    useMetabotAgent();
 
   const { navigateToPath } = useSelector(
     getMetabotReactionsState as any,
   ) as ReturnType<typeof getMetabotReactionsState>;
+
+  const isDoingScience = useSelector(getIsProcessing as any) as ReturnType<
+    typeof getIsProcessing
+  >;
 
   const handleSubmitInput = useCallback(
     (input: string) => {
@@ -65,6 +65,7 @@ export const useMetabotChat = () => {
   );
 
   return {
+    isDoingScience,
     handleSubmitInput,
     handleRetryMessage,
     handleResetInput,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-chat.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-chat.ts
@@ -1,8 +1,16 @@
 import { useCallback } from "react";
 
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import {
+  getMetabotReactionsState,
+  setNavigateToPath as setNavigateToPathAction,
+} from "metabase-enterprise/metabot/state";
+
 import { useMetabotAgent } from "./use-metabot-agent";
 
 export const useMetabotChat = () => {
+  const dispatch = useDispatch();
+
   const {
     isDoingScience,
     setPrompt,
@@ -10,6 +18,10 @@ export const useMetabotChat = () => {
     submitInput,
     retryMessage,
   } = useMetabotAgent();
+
+  const { navigateToPath } = useSelector(
+    getMetabotReactionsState as any,
+  ) as ReturnType<typeof getMetabotReactionsState>;
 
   const handleSubmitInput = useCallback(
     (input: string) => {
@@ -45,9 +57,18 @@ export const useMetabotChat = () => {
     setPrompt("");
   }, [setPrompt]);
 
+  const setNavigateToPath = useCallback(
+    async (navigateToPath: string) => {
+      dispatch(setNavigateToPathAction(navigateToPath));
+    },
+    [dispatch],
+  );
+
   return {
     handleSubmitInput,
     handleRetryMessage,
     handleResetInput,
+    navigateToPath,
+    setNavigateToPath,
   };
 };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-reactions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-reactions.ts
@@ -1,0 +1,27 @@
+import { useCallback } from "react";
+
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import {
+  getMetabotReactionsState,
+  setNavigateToPath as setNavigateToPathAction,
+} from "metabase-enterprise/metabot/state";
+
+export const useMetabotReactions = () => {
+  const dispatch = useDispatch();
+
+  const { navigateToPath } = useSelector(
+    getMetabotReactionsState as any,
+  ) as ReturnType<typeof getMetabotReactionsState>;
+
+  const setNavigateToPath = useCallback(
+    async (navigateToPath: string) => {
+      dispatch(setNavigateToPathAction(navigateToPath));
+    },
+    [dispatch],
+  );
+
+  return {
+    navigateToPath,
+    setNavigateToPath,
+  };
+};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -37,6 +37,7 @@ export interface MetabotState {
   history: MetabotHistory;
   state: any;
   toolCalls: MetabotToolCall[];
+  navigateToHandler: ((url: string) => void) | null;
 }
 
 export const getMetabotInitialState = (): MetabotState => ({
@@ -48,6 +49,7 @@ export const getMetabotInitialState = (): MetabotState => ({
   history: [],
   state: {},
   toolCalls: [],
+  navigateToHandler: null,
 });
 
 export const metabot = createSlice({
@@ -97,6 +99,12 @@ export const metabot = createSlice({
       }
 
       state.toolCalls = hasToolCalls ? [] : state.toolCalls;
+    },
+    addNavigateToHandler: (
+      state,
+      action: PayloadAction<(url: string) => void>,
+    ) => {
+      state.navigateToHandler = action.payload;
     },
     toolCallStart: (
       state,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -28,7 +28,7 @@ export type MetabotToolCall = {
   status: "started" | "ended";
 };
 
-export type MetabotUIState = {
+export type MetabotReactionsState = {
   navigateToPath: string | null;
 };
 
@@ -40,7 +40,7 @@ export interface MetabotState {
   visible: boolean;
   history: MetabotHistory;
   state: any;
-  uiState: MetabotUIState;
+  reactions: MetabotReactionsState;
   toolCalls: MetabotToolCall[];
 }
 
@@ -52,7 +52,7 @@ export const getMetabotInitialState = (): MetabotState => ({
   visible: false,
   history: [],
   state: {},
-  uiState: {
+  reactions: {
     navigateToPath: null,
   },
   toolCalls: [],
@@ -156,7 +156,7 @@ export const metabot = createSlice({
       state.isProcessing = action.payload;
     },
     setNavigateToPath: (state, action: PayloadAction<string>) => {
-      state.uiState.navigateToPath = action.payload;
+      state.reactions.navigateToPath = action.payload;
     },
     setVisible: (state, action: PayloadAction<boolean>) => {
       state.visible = action.payload;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -37,7 +37,7 @@ export interface MetabotState {
   history: MetabotHistory;
   state: any;
   toolCalls: MetabotToolCall[];
-  navigateToHandler: ((url: string) => void) | null;
+  navigateToPath: string | null;
 }
 
 export const getMetabotInitialState = (): MetabotState => ({
@@ -49,7 +49,7 @@ export const getMetabotInitialState = (): MetabotState => ({
   history: [],
   state: {},
   toolCalls: [],
-  navigateToHandler: null,
+  navigateToPath: null,
 });
 
 export const metabot = createSlice({
@@ -100,12 +100,6 @@ export const metabot = createSlice({
 
       state.toolCalls = hasToolCalls ? [] : state.toolCalls;
     },
-    addNavigateToHandler: (
-      state,
-      action: PayloadAction<(url: string) => void>,
-    ) => {
-      state.navigateToHandler = action.payload;
-    },
     toolCallStart: (
       state,
       action: PayloadAction<{ toolCallId: string; toolName: string }>,
@@ -154,6 +148,9 @@ export const metabot = createSlice({
     },
     setIsProcessing: (state, action: PayloadAction<boolean>) => {
       state.isProcessing = action.payload;
+    },
+    setNavigateToPath: (state, action: PayloadAction<string>) => {
+      state.navigateToPath = action.payload;
     },
     setVisible: (state, action: PayloadAction<boolean>) => {
       state.visible = action.payload;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -28,6 +28,10 @@ export type MetabotToolCall = {
   status: "started" | "ended";
 };
 
+export type MetabotUIState = {
+  navigateToPath: string | null;
+};
+
 export interface MetabotState {
   isProcessing: boolean;
   conversationId: string;
@@ -36,8 +40,8 @@ export interface MetabotState {
   visible: boolean;
   history: MetabotHistory;
   state: any;
+  uiState: MetabotUIState;
   toolCalls: MetabotToolCall[];
-  navigateToPath: string | null;
 }
 
 export const getMetabotInitialState = (): MetabotState => ({
@@ -48,8 +52,10 @@ export const getMetabotInitialState = (): MetabotState => ({
   visible: false,
   history: [],
   state: {},
+  uiState: {
+    navigateToPath: null,
+  },
   toolCalls: [],
-  navigateToPath: null,
 });
 
 export const metabot = createSlice({
@@ -150,7 +156,7 @@ export const metabot = createSlice({
       state.isProcessing = action.payload;
     },
     setNavigateToPath: (state, action: PayloadAction<string>) => {
-      state.navigateToPath = action.payload;
+      state.uiState.navigateToPath = action.payload;
     },
     setVisible: (state, action: PayloadAction<boolean>) => {
       state.visible = action.payload;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -122,7 +122,7 @@ export const getAgentRequestMetadata = createSelector(
   }),
 );
 
-export const getNavigateToHandler = createSelector(
+export const getNavigateToPath = createSelector(
   getMetabot,
-  (state) => state.navigateToHandler,
+  (state) => state.navigateToPath,
 );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -6,12 +6,14 @@ import { getIsEmbedding } from "metabase/selectors/embed";
 import {
   FIXED_METABOT_IDS,
   LONG_CONVO_MSG_LENGTH_THRESHOLD,
+  METABOT_REQUEST_IDS,
 } from "../constants";
 
 import type { MetabotStoreState } from "./types";
 
-export const getMetabot = (state: MetabotStoreState) =>
-  state.plugins.metabotPlugin;
+export const getMetabot = (state: MetabotStoreState) => {
+  return state.plugins.metabotPlugin;
+};
 
 export const getMetabotVisible = createSelector(
   getMetabot,
@@ -103,6 +105,11 @@ export const getMetabotId = createSelector(getIsEmbedding, (isEmbedding) =>
   isEmbedding ? FIXED_METABOT_IDS.EMBEDDED : FIXED_METABOT_IDS.DEFAULT,
 );
 
+export const getMetabotRequestId = createSelector(
+  getIsEmbedding,
+  (isEmbedding) => (isEmbedding ? METABOT_REQUEST_IDS.EMBEDDED : undefined),
+);
+
 export const getAgentRequestMetadata = createSelector(
   getHistory,
   getMetabotState,
@@ -113,4 +120,9 @@ export const getAgentRequestMetadata = createSelector(
       h.id && h.id.startsWith(`msg_`) ? _.omit(h, "id") : h,
     ),
   }),
+);
+
+export const getNavigateToHandler = createSelector(
+  getMetabot,
+  (state) => state.navigateToHandler,
 );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -91,9 +91,9 @@ export const getMetabotState = createSelector(
   (metabot) => metabot.state,
 );
 
-export const getMetabotUiState = createSelector(
+export const getMetabotReactionsState = createSelector(
   getMetabot,
-  (metabot) => metabot.uiState,
+  (metabot) => metabot.reactions,
 );
 
 export const getIsLongMetabotConversation = createSelector(
@@ -128,6 +128,6 @@ export const getAgentRequestMetadata = createSelector(
 );
 
 export const getNavigateToPath = createSelector(
-  getMetabotUiState,
-  (uiState) => uiState.navigateToPath,
+  getMetabotReactionsState,
+  (reactionsState) => reactionsState.navigateToPath,
 );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -91,6 +91,11 @@ export const getMetabotState = createSelector(
   (metabot) => metabot.state,
 );
 
+export const getMetabotUiState = createSelector(
+  getMetabot,
+  (metabot) => metabot.uiState,
+);
+
 export const getIsLongMetabotConversation = createSelector(
   getMessages,
   (messages) => {
@@ -123,6 +128,6 @@ export const getAgentRequestMetadata = createSelector(
 );
 
 export const getNavigateToPath = createSelector(
-  getMetabot,
-  (state) => state.navigateToPath,
+  getMetabotUiState,
+  (uiState) => uiState.navigateToPath,
 );


### PR DESCRIPTION
This PR fixes and improves Metabot for SDK
Now it properly displays AdHoc questions and also supports the proper conversation instead of a single message.

The PR must be merged after https://github.com/metabase/ai-service/pull/319#pullrequestreview-3161657170 is merged and deployed

<img width="1520" height="484" alt="image" src="https://github.com/user-attachments/assets/7557cd5a-82da-4797-ae2b-b0fbf74aa1bf" />

<img width="2344" height="1494" alt="image" src="https://github.com/user-attachments/assets/d83288e8-17a9-47d2-9c33-26178b5299e7" />

<img width="1626" height="1496" alt="image" src="https://github.com/user-attachments/assets/8db59bbe-5032-4638-978e-c36179067e6b" />

How to verify:
- run the AI-service locally from the `fix-embedding-querying` branch
- run `yarn dev-ee`
- run `yarn storybook-embedding-sdk`
- Navigate to the `MetabotQuestion` component
- play with metabot, like `show orders`.
- when it responds with a new message containing a link to an ad-hoc question - it should be automatically displayed
- if you have some old messages with links, clicking it should replace the currently shown ad-hoc question with the clicked on
- click the `retry` button on a received `metabot` message, it should retry this question, be sure that if after the retry the new message contains a link to the ad-hoc question - the question MUST automatically shown
- play with themes in storybook