### PR TITLE
docs - fix markdown links in Debian installation guide

### DIFF
--- a/docs/installation-and-operation/running-metabase-on-debian.md
+++ b/docs/installation-and-operation/running-metabase-on-debian.md
@@ -14,13 +14,13 @@ We'll use Debian as an example in this guide, but the steps should apply to most
 
 The core assumptions in this guide:
 
-- You have a [Java Runtime Environment (JRE)](../installation-and-operation/running-the-metabase-jar-file#1-install-java-jre) installed on your system
+- You have a [Java Runtime Environment (JRE)](../installation-and-operation/running-the-metabase-jar-file.md#1-install-java-jre) installed on your system
 - You will run Metabase using the `metabase.jar` file
 - You already have Nginx running on your server
 - You will use environment variables to configure your Metabase instance
 - You have root access on your server
 
-For production setups, you must set up a [PostgreSQL or MySQL/MariaDB application database](/../installation-and-operation/configuring-application-database) as Metabase's application database.
+For production setups, you must set up a [PostgreSQL or MySQL/MariaDB application database](../installation-and-operation/configuring-application-database.md) as Metabase's application database.
 
 ## Create an unprivileged user to run Metabase
 
@@ -56,7 +56,7 @@ sudo -u metabase wget -O /home/metabase/metabase.jar https://downloads.metabase.
 
 We'll create a file to store these environment variables, which we'll use when creating the systemd service for Metabase.
 
-This command will create an environment variable file at `/home/metabase/.env`, which you should update to point to your [PostgreSQL application database](/docs/latest/installation-and-operation/configuring-application-database):
+This command will create an environment variable file at `/home/metabase/.env`, which you should update to point to your [PostgreSQL application database](../installation-and-operation/configuring-application-database.md):
 
 ```bash
 sudo -u metabase cat << EOF > /home/metabase/.env


### PR DESCRIPTION
Like it says on the tin.