### PR TITLE
Only clear card defer if request was not already cancelled

### DIFF
--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -416,7 +416,10 @@ export const fetchCardDataAction = createAsyncThunk<
       );
     }
 
-    setFetchCardDataCancel(card.id, dashcard.id, null);
+    // If the request was not previously cancelled, then clear the defer for the card
+    if (!cancelled) {
+      setFetchCardDataCancel(card.id, dashcard.id, null);
+    }
     clearTimeout(slowCardTimer);
 
     return {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61944
### Description
PR ensures that dashcard data fetching only clears the cancel defer if the request was not cancelled. This prevents us from clearing a cancel defer that actually belongs to a separate request.

### How to verify

1. Set up a card that takes 10 seconds to complete
2. Hook it up to a dashboard with some filters
3. Change the filters to re-trigger data fetching. Only the last completed request data should show

### Demo
*BEFORE*
https://github.com/user-attachments/assets/fa5095b7-4f41-4185-b8b1-d3100289fda5

*AFTER*

https://github.com/user-attachments/assets/e8f6a29b-076b-48c4-9b05-6db6d92c86b0


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
