### PR TITLE
Fix: UXW-569 Add Error message for failed document saves

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -689,6 +689,51 @@ H.describeWithSnowplowEE("documents", () => {
       });
     });
   });
+
+  describe("error handling", () => {
+    it("should display an error toast when creating a new document fails", () => {
+      // setup
+      cy.intercept("POST", "/api/ee/document", { statusCode: 500 });
+      cy.visit("/document/new");
+
+      // make changes and attempt to save
+      cy.findByRole("textbox", { name: "Document Title" }).type("Title");
+      H.documentSaveButton().click();
+      H.entityPickerModalTab("Collections").click();
+      H.entityPickerModalItem(0, "Our analytics")
+        .should("have.attr", "data-active", "true")
+        .click();
+      H.entityPickerModal().findByRole("button", { name: "Select" }).click();
+
+      // assert error toast is visible and user can reattempt save
+      cy.findByTestId("toast-undo")
+        .should("be.visible")
+        .and("contain.text", "Error saving document");
+      H.documentSaveButton().should("be.visible");
+    });
+
+    it("should display an error toast when updating a document fails", () => {
+      // setup
+      cy.intercept("PUT", "/api/ee/document/*", { statusCode: 500 });
+      H.createDocument({
+        name: "Test Document",
+        document: { type: "doc", content: [] },
+        idAlias: "documentId",
+      });
+      cy.get("@documentId").then((id) => cy.visit(`/document/${id}`));
+
+      // make changes and attempt to save
+      H.documentContent().click();
+      H.addToDocument("aaa");
+      H.documentSaveButton().click();
+
+      // assert error toast is visible and user can reattempt save
+      cy.findByTestId("toast-undo")
+        .should("be.visible")
+        .and("contain.text", "Error saving document");
+      H.documentSaveButton().should("be.visible");
+    });
+  });
 });
 
 const assertOnlyOneOptionActive = (

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -291,7 +291,7 @@ export const DocumentPage = ({
                     dispatch(push(`/document/${_document.id}`));
                   });
                 }
-                return response.data;
+                return response;
               },
             )
           : createDocument({
@@ -305,16 +305,18 @@ export const DocumentPage = ({
                   dispatch(replace(`/document/${_document.id}`));
                 });
               }
-              return response.data;
+              return response;
             }));
 
-        if (result) {
+        if (result.data) {
           sendToast({
             message: documentData?.id ? t`Document saved` : t`Document created`,
           });
           dispatch(clearDraftCards());
           // Mark document as clean
           setHasUnsavedEditorChanges(false);
+        } else if (result.error) {
+          throw result.error;
         }
       } catch (error) {
         console.error("Failed to save document:", error);


### PR DESCRIPTION
Closes [UXW-569](https://linear.app/metabase/issue/UXW-569)

### Description

Displays error toast when saving or creating a document fails

### How to verify

Verify error toast appears when creating/updating a document fails.

### Demo

https://github.com/user-attachments/assets/c482e40d-314b-436c-9627-9dfe82189c0d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
