### PR TITLE
[Metabot] Add option to enable / disable Metabot

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -10,6 +10,7 @@
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
    [metabase-enterprise.metabot-v3.envelope :as metabot-v3.envelope]
    [metabase-enterprise.metabot-v3.reactions :as metabot-v3.reactions]
+   [metabase-enterprise.metabot-v3.settings :refer [assert-metabot-enabled!]]
    [metabase-enterprise.metabot-v3.tools.api :as metabot-v3.tools.api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
@@ -56,6 +57,7 @@
                                           [:conversation_id ms/UUIDString]
                                           [:history [:maybe ::metabot-v3.client.schema/messages]]
                                           [:state :map]]]
+  (assert-metabot-enabled!)
   (metabot-v3.context/log body :llm.log/fe->be)
   (doto (assoc
          (request body)
@@ -90,6 +92,7 @@
             [:conversation_id ms/UUIDString]
             [:history [:maybe ::metabot-v3.client.schema/messages]]
             [:state :map]]]
+  (assert-metabot-enabled!)
   (metabot-v3.context/log body :llm.log/fe->be)
   (streaming-request body))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/document.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.string :as str]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
+   [metabase-enterprise.metabot-v3.settings :refer [+require-metabot-enabled]]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -75,4 +76,4 @@
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/metabot-v3/document` routes."
-  (api.macros/ns-handler *ns* +auth))
+  (api.macros/ns-handler *ns* +auth +require-metabot-enabled))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
@@ -4,6 +4,7 @@
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
    [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
+   [metabase-enterprise.metabot-v3.settings :refer [assert-metabot-enabled-for-non-admins! metabot-feature-enabled]]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -176,6 +177,7 @@
                                        [:sample {:optional true} :boolean]
                                        [:model {:optional true} [:enum "metric" "model"]]
                                        [:model_id {:optional true} pos-int?]]]
+  (assert-metabot-enabled-for-non-admins! api/*is-superuser?*)
   (let [offset (if sample nil (request/offset))
         rand-fn (case (mdb/db-type)
                   :postgres :random

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/metabot.clj
@@ -4,7 +4,7 @@
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
    [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
-   [metabase-enterprise.metabot-v3.settings :refer [assert-metabot-enabled-for-non-admins! metabot-feature-enabled]]
+   [metabase-enterprise.metabot-v3.settings :refer [assert-metabot-enabled-for-non-admins!]]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -12,7 +12,7 @@
    [metabase-enterprise.metabot-v3.client.schema :as metabot-v3.client.schema]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
-   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings :refer [assert-metabot-enabled! metabot-feature-enabled]]
+   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings :refer [assert-metabot-enabled!]]
    [metabase-enterprise.metabot-v3.util :as metabot-v3.u]
    [metabase.api.common :as api]
    [metabase.premium-features.core :as premium-features]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -12,7 +12,8 @@
    [metabase-enterprise.metabot-v3.client.schema :as metabot-v3.client.schema]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
-   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
+   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings :refer [assert-metabot-enabled! metabot-feature-enabled]]
+   [metabase-enterprise.metabot-v3.util :as metabot-v3.u]
    [metabase.api.common :as api]
    [metabase.premium-features.core :as premium-features]
    [metabase.server.streaming-response :as sr]
@@ -123,6 +124,7 @@
        [:session-id :string]
        [:state :map]]]
   (premium-features/assert-has-feature :metabot-v3 "MetaBot")
+  (assert-metabot-enabled!)
   (try
     (let [url      (agent-v2-endpoint-url)
           body     (-> {:messages        messages
@@ -181,6 +183,7 @@
        [:session-id :string]
        [:state :map]]]
   (premium-features/assert-has-feature :metabot-v3 "MetaBot")
+  (assert-metabot-enabled!)
   (try
     (let [url      (agent-v2-streaming-endpoint-url)
           body     (-> {:messages        messages
@@ -225,6 +228,7 @@
   "Make a request to AI Service to select a metric."
   [metrics :- [:sequential ::metabot-v3.client.schema/metric]
    query   :- :string]
+  (assert-metabot-enabled!)
   (try
     (let [url (metric-selection-endpoint-url)
           body {:metrics metrics
@@ -245,6 +249,7 @@
 (mu/defn find-outliers-request
   "Make a request to AI Service to find outliers"
   [values :- [:sequential [:map [:dimension :any] [:value :any]]]]
+  (assert-metabot-enabled!)
   (try
     (let [url (find-outliers-endpoint-url)
           body {:values values}
@@ -268,6 +273,7 @@
             [:dialect :keyword]
             [:error_message :string]
             [:schema_ddl {:optional true} :string]]]
+  (assert-metabot-enabled!)
   (let [url (fix-sql-endpoint)
         options (build-request-options body)
         response (post! url options)]
@@ -291,6 +297,7 @@
                                                            [:name :string]
                                                            [:data_type :string]
                                                            [:description {:optional true} [:maybe :string]]]]]]]]]]
+  (assert-metabot-enabled!)
   (let [url (generate-sql-endpoint)
         options (build-request-options body)
         response (post! url options)]
@@ -305,6 +312,7 @@
   "Ask the AI service to generate a new node for a document."
   [body :- [:map
             [:instructions :string]]]
+  (assert-metabot-enabled!)
   (let [url (document-generate-content-endpoint)
         options (build-request-options body)
         headers (merge (:headers options) {"x-metabase-session-token"  (get-ai-service-token)
@@ -333,6 +341,7 @@
 (mu/defn analyze-chart
   "Ask the AI service to analyze a chart image."
   [chart-data :- chart-analysis-schema]
+  (assert-metabot-enabled!)
   (let [url (analyze-chart-endpoint)
         options (build-request-options chart-data)
         response (post! url options)]
@@ -355,6 +364,7 @@
 (mu/defn analyze-dashboard
   "Ask the AI service to analyze a dashboard image."
   [dashboard-data :- dashboard-analysis-schema]
+  (assert-metabot-enabled!)
   (let [url (analyze-dashboard-endpoint)
         options (build-request-options dashboard-data)
         response (post! url options)]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -13,7 +13,6 @@
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
    [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings :refer [assert-metabot-enabled!]]
-   [metabase-enterprise.metabot-v3.util :as metabot-v3.u]
    [metabase.api.common :as api]
    [metabase.premium-features.core :as premium-features]
    [metabase.server.streaming-response :as sr]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
@@ -57,7 +57,7 @@
   :default    true
   :feature    :metabot-v3
   :doc        false
-  :export?    true)
+  :export?    false)
 
 (defn +require-metabot-enabled
   "Middleware that ensures Metabot feature is enabled before allowing request to proceed."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
@@ -32,6 +32,15 @@
   :export?    true
   :audit      :never)
 
+(defsetting metabot-feature-enabled
+  (deferred-tru "Enable or disable the Metabot feature entirely.")
+  :type       :boolean
+  :visibility :admin
+  :default    true
+  :feature    :metabot-v3
+  :doc        false
+  :export?    true)
+
 (defsetting metabot-id
   (deferred-tru "Override Metabot ID for agent streaming requests.")
   :type       :string

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -12,7 +12,7 @@
    [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
    [metabase-enterprise.metabot-v3.envelope :as envelope]
    [metabase-enterprise.metabot-v3.reactions]
-   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings]
+   [metabase-enterprise.metabot-v3.settings :as metabot-v3.settings :refer [+require-metabot-enabled]]
    [metabase-enterprise.metabot-v3.table-utils :as table-utils]
    [metabase-enterprise.metabot-v3.tools.create-dashboard-subscription
     :as metabot-v3.tools.create-dashboard-subscription]
@@ -916,4 +916,4 @@
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/metabot-tools` routes."
-  (api.macros/ns-handler *ns* +tool-session))
+  (api.macros/ns-handler *ns* +tool-session +require-metabot-enabled))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/document_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/document_test.clj
@@ -1,0 +1,15 @@
+(ns metabase-enterprise.metabot-v3.api.document-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]))
+
+(deftest document-api-feature-toggle-test
+  (testing "Document API endpoints respect metabot feature toggle"
+    (mt/with-premium-features #{:metabot-v3}
+      (testing "when metabot is disabled"
+        (mt/with-temp-env-var-value! ["MB_METABOT_FEATURE_ENABLED" "false"]
+          (testing "POST /api/ee/metabot-v3/document/generate-content returns 403"
+            (is (= {:message "Metabot is disabled."}
+                   (mt/user-http-request :rasta :post 403
+                                         "ee/metabot-v3/document/generate-content"
+                                         {:instructions "Generate a summary of sales data"})))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -453,4 +453,3 @@
           (mt/user-http-request :crowberto :delete 204
                                 (format "ee/metabot-v3/metabot/%d/entities/dataset/%d"
                                         metabot-id 99999)))))))
-

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -69,4 +69,3 @@
             (is (= "Metabot is disabled."
                    (mt/user-http-request :rasta :post 403
                                          "ee/metabot-v3/v2/agent-streaming" request-body)))))))))
-

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -48,3 +48,25 @@
                        :state agent-state
                        :conversation_id conversation-id}
                       response)))))))))
+
+(deftest agent-with-feature-toggle-test
+  (testing "Agent endpoints respect metabot feature toggle"
+    (mt/with-premium-features #{:metabot-v3}
+      (let [request-body {:message "test message"
+                          :context {}
+                          :conversation_id (str (random-uuid))
+                          :history []
+                          :state {}}]
+
+        (testing "agent endpoint 403s if metabot is disabled"
+          (mt/with-temp-env-var-value! ["MB_METABOT_FEATURE_ENABLED" "false"]
+            (testing "should deny access for regular users"
+              (is (= "Metabot is disabled."
+                     (mt/user-http-request :rasta :post 403
+                                           "ee/metabot-v3/v2/agent" request-body))))))
+        (testing "agent-streaming endpoint 403s if metabot is disabled"
+          (mt/with-temp-env-var-value! ["MB_METABOT_FEATURE_ENABLED" "false"]
+            (is (= "Metabot is disabled."
+                   (mt/user-http-request :rasta :post 403
+                                         "ee/metabot-v3/v2/agent-streaming" request-body)))))))))
+

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
@@ -1,0 +1,76 @@
+(ns metabase-enterprise.metabot-v3.client-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
+   [metabase.test :as mt]))
+
+(deftest request-with-feature-toggle-test
+  (testing "request respects metabot feature toggle"
+    (mt/with-premium-features #{:metabot-v3}
+      (let [test-request {:messages []
+                          :context {}
+                          :profile-id "test-profile"
+                          :conversation-id (str (random-uuid))
+                          :session-id (str (random-uuid))
+                          :state {}}]
+
+        (testing "when metabot is disabled"
+          (mt/with-temp-env-var-value! ["MB_METABOT_FEATURE_ENABLED" "false"]
+            (testing "should throw metabot disabled error"
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                    #"Metabot is disabled."
+                                    (metabot-v3.client/request test-request))))))))))
+
+(deftest streaming-request-with-feature-toggle-test
+  (testing "streaming-request respects metabot feature toggle"
+    (mt/with-premium-features #{:metabot-v3}
+      (let [test-request {:messages []
+                          :context {}
+                          :profile-id "test-profile"
+                          :conversation-id (str (random-uuid))
+                          :session-id (str (random-uuid))
+                          :state {}}]
+
+        (testing "when metabot is disabled"
+          (mt/with-temp-env-var-value! ["MB_METABOT_FEATURE_ENABLED" "false"]
+            (testing "should throw metabot disabled error"
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                    #"Metabot is disabled."
+                                    (metabot-v3.client/streaming-request test-request))))))))))
+
+(deftest metric-selection-request-with-feature-toggle-test
+  (testing "metric-selection-request respects metabot feature toggle"
+    (let [test-metrics [{:id 1 :name "Test Metric"}]
+          test-query "Select a metric"]
+
+      (testing "when metabot is disabled"
+        (mt/with-temp-env-var-value! ["MB_METABOT_FEATURE_ENABLED" "false"]
+          (testing "should throw metabot disabled error"
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"Metabot is disabled."
+                                  (metabot-v3.client/metric-selection-request test-metrics test-query)))))))))
+
+(deftest find-outliers-request-with-feature-toggle-test
+  (testing "find-outliers-request respects metabot feature toggle"
+    (let [test-values [{:dimension "A" :value 10}
+                       {:dimension "B" :value 100}]]
+
+      (testing "when metabot is disabled"
+        (mt/with-temp-env-var-value! ["MB_METABOT_FEATURE_ENABLED" "false"]
+          (testing "should throw metabot disabled error"
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"Metabot is disabled."
+                                  (metabot-v3.client/find-outliers-request test-values)))))))))
+
+(deftest sql-gen-request-with-feature-toggle-test
+  (testing "sql-gen-request respects metabot feature toggle"
+    (let [test-request {:prompt "Generate SQL"
+                        :dialect :h2
+                        :error_message "Syntax error"}]
+
+      (testing "when metabot is disabled"
+        (mt/with-temp-env-var-value! ["MB_METABOT_FEATURE_ENABLED" "false"]
+          (testing "should throw metabot disabled error"
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                  #"Metabot is disabled."
+                                  (metabot-v3.client/sql-gen-request test-request)))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
@@ -38,9 +38,9 @@
                                     #"Metabot is disabled."
                                     (metabot-v3.client/streaming-request test-request))))))))))
 
-(deftest metric-selection-request-with-feature-toggle-test
-  (testing "metric-selection-request respects metabot feature toggle"
-    (let [test-metrics [{:id 1 :name "Test Metric"}]
+(deftest select-metric-request-with-feature-toggle-test
+  (testing "select-metric-request respects metabot feature toggle"
+    (let [test-metrics [{:id 1 :name "Test Metric" :description "A test metric"}]
           test-query "Select a metric"]
 
       (testing "when metabot is disabled"
@@ -48,7 +48,7 @@
           (testing "should throw metabot disabled error"
             (is (thrown-with-msg? clojure.lang.ExceptionInfo
                                   #"Metabot is disabled."
-                                  (metabot-v3.client/metric-selection-request test-metrics test-query)))))))))
+                                  (metabot-v3.client/select-metric-request test-metrics test-query)))))))))
 
 (deftest find-outliers-request-with-feature-toggle-test
   (testing "find-outliers-request respects metabot feature toggle"
@@ -62,15 +62,15 @@
                                   #"Metabot is disabled."
                                   (metabot-v3.client/find-outliers-request test-values)))))))))
 
-(deftest sql-gen-request-with-feature-toggle-test
-  (testing "sql-gen-request respects metabot feature toggle"
-    (let [test-request {:prompt "Generate SQL"
+(deftest generate-sql-with-feature-toggle-test
+  (testing "generate-sql respects metabot feature toggle"
+    (let [test-request {:instructions "Generate SQL"
                         :dialect :h2
-                        :error_message "Syntax error"}]
+                        :tables []}]
 
       (testing "when metabot is disabled"
         (mt/with-temp-env-var-value! ["MB_METABOT_FEATURE_ENABLED" "false"]
           (testing "should throw metabot disabled error"
             (is (thrown-with-msg? clojure.lang.ExceptionInfo
                                   #"Metabot is disabled."
-                                  (metabot-v3.client/sql-gen-request test-request)))))))))
+                                  (metabot-v3.client/generate-sql test-request)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/round_trip_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/round_trip_test.clj
@@ -171,7 +171,7 @@
                 (is (nil? delta)
                     (str "Content mismatch for file: " (strip-base-path source-dir file)))
 
-              ;; Leave behind files for developers to inspect
+                ;; Leave behind files for developers to inspect
                 (when (and (.exists dev-inspect-dir) delta)
                   (vreset! wrote-files? true)
                   (create-files-to-diff! ref-file out-file))))

--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisButton.tsx
@@ -4,9 +4,11 @@ import { ToolbarButton } from "metabase/common/components/ToolbarButton";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
 export const AIQuestionAnalysisButton = () => {
-  const { submitInput } = useMetabotAgent();
+  const { submitInput, isEnabled } = useMetabotAgent();
 
-  const handleClick = () => submitInput("Analyze this chart");
+  if (!isEnabled) {
+    return null;
+  }
 
   const tooltipLabel = t`Explain this chart`;
 
@@ -15,7 +17,7 @@ export const AIQuestionAnalysisButton = () => {
       aria-label={tooltipLabel}
       tooltipLabel={tooltipLabel}
       icon={"metabot"}
-      onClick={handleClick}
+      onClick={() => submitInput("Analyze this chart")}
     />
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisButton.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisButton.unit.spec.tsx
@@ -1,0 +1,36 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupPropertiesEndpoints } from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
+
+import { AIQuestionAnalysisButton } from "./AIQuestionAnalysisButton";
+
+const setup = ({
+  metabotFeatureEnabled,
+}: {
+  metabotFeatureEnabled: boolean;
+}) => {
+  setupEnterprisePlugins();
+  setupPropertiesEndpoints(
+    createMockSettings({ "metabot-feature-enabled": metabotFeatureEnabled }),
+  );
+  renderWithProviders(<AIQuestionAnalysisButton />);
+};
+
+describe("AIQuestionAnalysisButton", () => {
+  it("should render when metabot feature is enabled", async () => {
+    setup({ metabotFeatureEnabled: true });
+
+    expect(
+      await screen.findByRole("button", { name: "Explain this chart" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should not render when metabot feature is disabled", () => {
+    setup({ metabotFeatureEnabled: false });
+
+    expect(
+      screen.queryByRole("button", { name: "Explain this chart" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/index.ts
@@ -28,8 +28,11 @@ if (hasPremiumFeature("ai_entity_analysis")) {
     CHART_ANALYSIS_RENDER_FORMATS;
 
   PLUGIN_DASHCARD_MENU.dashcardMenuItemGetters.push(
-    (question, dashcardId, dispatch) => {
-      if (!PLUGIN_AI_ENTITY_ANALYSIS.canAnalyzeQuestion(question)) {
+    (question, dashcardId, dispatch, { isMetabotEnabled }) => {
+      if (
+        !isMetabotEnabled ||
+        !PLUGIN_AI_ENTITY_ANALYSIS.canAnalyzeQuestion(question)
+      ) {
         return null;
       }
 

--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.tsx
@@ -4,7 +4,11 @@ import { Button } from "metabase/ui";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
 export function FixSqlQueryButton() {
-  const { submitInput } = useMetabotAgent();
+  const { submitInput, isEnabled } = useMetabotAgent();
+
+  if (!isEnabled) {
+    return null;
+  }
 
   const handleClick = () => submitInput("Fix this SQL query");
 

--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.unit.spec.tsx
@@ -1,40 +1,54 @@
 import userEvent from "@testing-library/user-event";
 
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupPropertiesEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
+import { mockStreamedEndpoint } from "metabase-enterprise/api/ai-streaming/test-utils";
+import { createMockSettings } from "metabase-types/api/mocks";
 
 import { FixSqlQueryButton } from "./FixSqlQueryButton";
 
-// Mock the useMetabotAgent hook
-const mockSubmitInput = jest.fn();
-jest.mock("metabase-enterprise/metabot/hooks", () => ({
-  useMetabotAgent: () => ({
-    submitInput: mockSubmitInput,
-  }),
-}));
+const mockAgentEndpoint = (
+  params: Parameters<typeof mockStreamedEndpoint>[1],
+) => mockStreamedEndpoint("/api/ee/metabot-v3/v2/agent-streaming", params);
 
-function setup() {
+const setup = ({ metabotFeatureEnabled = true } = {}) => {
+  setupEnterprisePlugins();
+  setupPropertiesEndpoints(
+    createMockSettings({ "metabot-feature-enabled": metabotFeatureEnabled }),
+  );
   renderWithProviders(<FixSqlQueryButton />);
-}
+};
 
 describe("FixSqlQueryButton", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("should render the button with correct text", () => {
+  it("should render the button with correct text", async () => {
     setup();
     expect(
-      screen.getByRole("button", { name: /Have Metabot fix it/ }),
+      await screen.findByRole("button", { name: /Have Metabot fix it/ }),
     ).toBeInTheDocument();
   });
 
+  // TODO: we should have better tests around this feature, but this is a start
   it("should submit a prompt to the metabot agent when clicked", async () => {
     setup();
+    const spy = mockAgentEndpoint({
+      textChunks: [
+        `0:"Fixed your SQL query!"`,
+        `d:{"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":10}}`,
+      ],
+    });
 
     await userEvent.click(
-      screen.getByRole("button", { name: /Have Metabot fix it/ }),
+      await screen.findByRole("button", { name: /Have Metabot fix it/ }),
     );
 
-    expect(mockSubmitInput).toHaveBeenCalledWith("Fix this SQL query");
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("should not render the button when metabot is disabled", () => {
+    setup({ metabotFeatureEnabled: false });
+    expect(
+      screen.queryByRole("button", { name: /Have Metabot fix it/ }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-generation/components/GenerateSqlQueryButton/GenerateSqlQueryButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-generation/components/GenerateSqlQueryButton/GenerateSqlQueryButton.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import type { GenerateSqlQueryButtonProps } from "metabase/plugins";
 import { Button, Icon, Tooltip } from "metabase/ui";
 import { useLazyGenerateSqlQueryQuery } from "metabase-enterprise/api";
+import { useMetabotEnabled } from "metabase-enterprise/metabot/hooks";
 import * as Lib from "metabase-lib";
 import type { GenerateSqlQueryRequest } from "metabase-types/api";
 
@@ -14,6 +15,11 @@ export function GenerateSqlQueryButton({
 }: GenerateSqlQueryButtonProps) {
   const [generateSql, { isFetching }] = useLazyGenerateSqlQueryQuery();
   const request = getRequest(query, selectedQueryText);
+  const isMetabotEnabled = useMetabotEnabled();
+
+  if (!isMetabotEnabled) {
+    return null;
+  }
 
   const handleClick = async () => {
     if (request == null) {

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.tsx
@@ -12,7 +12,6 @@ import {
 import { t } from "ttag";
 
 import { useSelector } from "metabase/lib/redux";
-import { PLUGIN_METABOT } from "metabase/plugins";
 import {
   Box,
   Divider,
@@ -24,6 +23,7 @@ import {
   UnstyledButton,
 } from "metabase/ui";
 import { getCurrentDocument } from "metabase-enterprise/documents/selectors";
+import { useMetabotEnabled } from "metabase-enterprise/metabot/hooks";
 import type { SearchResult } from "metabase-types/api";
 
 import {
@@ -126,11 +126,13 @@ export const CommandSuggestion = forwardRef<
   const [showEmbedSearch, setShowEmbedSearch] = useState(false);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
+  const isMetabotEnabled = useMetabotEnabled();
+
   const allCommandSections: CommandSection[] = useMemo(
     () => [
       {
         items: [
-          ...(PLUGIN_METABOT.isEnabled()
+          ...(isMetabotEnabled
             ? ([
                 {
                   icon: "metabot",
@@ -192,7 +194,7 @@ export const CommandSuggestion = forwardRef<
         ],
       },
     ],
-    [],
+    [isMetabotEnabled],
   );
 
   const allCommandOptions = useMemo(

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/Command/CommandSuggestion.unit.spec.tsx
@@ -3,6 +3,7 @@ import type { Editor } from "@tiptap/core";
 import { useState } from "react";
 
 import {
+  setupPropertiesEndpoints,
   setupRecentViewsEndpoints,
   setupSearchEndpoints,
 } from "__support__/server-mocks";
@@ -116,6 +117,7 @@ const setup = ({
 
   setupSearchEndpoints(SEARCH_ITEMS);
   setupRecentViewsEndpoints(RECENT_ITEMS);
+  setupPropertiesEndpoints(settings.values);
 
   renderWithProviders(
     <TestWrapper
@@ -321,9 +323,10 @@ describe("CommandSuggestion", () => {
       jest.clearAllMocks();
     });
 
+    // TODO: add checks for setting, not just token feature
     describe("when metabot is disabled", () => {
       beforeEach(() => {
-        PLUGIN_METABOT.isEnabled = jest.fn(() => false);
+        PLUGIN_METABOT.useMetabotEnabled = jest.fn(() => false);
       });
 
       it("should show all available commands except Metabot", async () => {
@@ -342,7 +345,7 @@ describe("CommandSuggestion", () => {
 
     describe("when metabot is enabled", () => {
       beforeEach(() => {
-        PLUGIN_METABOT.isEnabled = jest.fn(() => true);
+        PLUGIN_METABOT.useMetabotEnabled = jest.fn(() => true);
       });
 
       it("should show all available commands including Metabot", async () => {
@@ -354,7 +357,7 @@ describe("CommandSuggestion", () => {
 
         setup({ settings });
 
-        expect(screen.getByText("Ask Metabot")).toBeInTheDocument();
+        expect(await screen.findByText("Ask Metabot")).toBeInTheDocument();
         await expectStandardCommandsToBePresent();
       });
     });

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.tsx
@@ -152,7 +152,7 @@ export const MetabotComponent = memo(
     const [isLoading, setIsLoading] = useState(false);
     const [errorText, setErrorText] = useState("");
     const [queryMetabot] = useLazyMetabotGenerateContentQuery();
-    const isMetabotEnabled = PLUGIN_METABOT.isEnabled();
+    const isMetabotEnabled = PLUGIN_METABOT.useMetabotEnabled();
 
     const handleRunMetabot = async () => {
       const serializePrompt =

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/extensions/MetabotEmbed/MetabotEmbed.unit.spec.tsx
@@ -32,7 +32,7 @@ describe("MetabotEmbed", () => {
 
   describe("when metabot is disabled", () => {
     beforeEach(() => {
-      PLUGIN_METABOT.isEnabled = jest.fn(() => false);
+      PLUGIN_METABOT.useMetabotEnabled = jest.fn(() => false);
     });
 
     it("should show disabled button with tooltip", async () => {
@@ -61,7 +61,7 @@ describe("MetabotEmbed", () => {
 
   describe("when metabot is enabled", () => {
     beforeEach(() => {
-      PLUGIN_METABOT.isEnabled = jest.fn(() => true);
+      PLUGIN_METABOT.useMetabotEnabled = jest.fn(() => true);
     });
 
     it("should show enabled button without tooltip", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -14,16 +14,18 @@ export interface MetabotProps {
 }
 
 export const MetabotAuthenticated = ({ hide }: MetabotProps) => {
-  const { visible, setVisible } = useMetabotAgent();
+  const { visible, setVisible, isEnabled } = useMetabotAgent();
 
   useEffect(() => {
-    return tinykeys(window, {
-      "$mod+b": (e) => {
-        e.preventDefault(); // prevent FF from opening bookmark menu
-        setVisible(!visible);
-      },
-    });
-  }, [visible, setVisible]);
+    if (isEnabled) {
+      return tinykeys(window, {
+        "$mod+b": (e) => {
+          e.preventDefault(); // prevent FF from opening bookmark menu
+          setVisible(!visible);
+        },
+      });
+    }
+  }, [visible, setVisible, isEnabled]);
 
   useEffect(
     function closeViaPropChange() {
@@ -34,7 +36,7 @@ export const MetabotAuthenticated = ({ hide }: MetabotProps) => {
     [hide, setVisible],
   );
 
-  if (!visible || hide) {
+  if (!visible || hide || !isEnabled) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAgentSettingsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAgentSettingsPage.tsx
@@ -1,15 +1,9 @@
 import { useDisclosure } from "@mantine/hooks";
-import { useEffect, useMemo } from "react";
-import { push } from "react-router-redux";
 import { match } from "ts-pattern";
 import { c, t } from "ttag";
 import _ from "underscore";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
-import {
-  AdminNavItem,
-  AdminNavWrapper,
-} from "metabase/admin/components/AdminNav";
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
 import { skipToken, useGetCollectionQuery } from "metabase/api";
@@ -19,7 +13,6 @@ import { CollectionPickerModal } from "metabase/common/components/Pickers/Collec
 import { useToast } from "metabase/common/hooks";
 import { color } from "metabase/lib/colors";
 import { getIcon } from "metabase/lib/icon";
-import { useDispatch } from "metabase/lib/redux";
 import { Box, Button, Flex, Icon, Loader, Text } from "metabase/ui";
 import {
   useDeleteMetabotEntitiesMutation,
@@ -34,9 +27,10 @@ import type {
 } from "metabase-types/api";
 
 import { MetabotPromptSuggestionPane } from "./MetabotAdminSuggestedPrompts";
+import { MetabotNavPane } from "./MetabotNavPane";
 import { useMetabotIdPath } from "./utils";
 
-export function MetabotAdminPage() {
+export function MetabotAgentSettingsPage() {
   const metabotId = useMetabotIdPath();
   const { data, isLoading, error } = useListMetabotsQuery();
   const metabotName =
@@ -92,41 +86,6 @@ export function MetabotAdminPage() {
         </SettingsSection>
       </ErrorBoundary>
     </AdminSettingsLayout>
-  );
-}
-
-function MetabotNavPane() {
-  const { data, isLoading } = useListMetabotsQuery();
-  const metabotId = useMetabotIdPath();
-  const dispatch = useDispatch();
-
-  const metabots = useMemo(() => _.sortBy(data?.items ?? [], "id"), [data]);
-
-  useEffect(() => {
-    const hasMetabotId = metabots?.some((metabot) => metabot.id === metabotId);
-
-    if (!hasMetabotId && metabots?.length) {
-      dispatch(push(`/admin/metabot/${metabots[0]?.id}`));
-    }
-  }, [metabots, metabotId, dispatch]);
-
-  if (isLoading || !data) {
-    return null;
-  }
-
-  return (
-    <Flex direction="column" w="266px" flex="0 0 auto">
-      <AdminNavWrapper>
-        {metabots?.map((metabot) => (
-          <AdminNavItem
-            key={metabot.id}
-            icon="metabot"
-            label={metabot.name}
-            path={`/admin/metabot/${metabot.id}`}
-          />
-        ))}
-      </AdminNavWrapper>
-    </Flex>
   );
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAgentSettingsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAgentSettingsPage.tsx
@@ -1,7 +1,6 @@
 import { useDisclosure } from "@mantine/hooks";
-import { Link } from "react-router";
 import { match } from "ts-pattern";
-import { c, jt, t } from "ttag";
+import { c, t } from "ttag";
 import _ from "underscore";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
@@ -60,13 +59,7 @@ export function MetabotAgentSettingsPage() {
         <SettingsSection>
           {!isMetabotEnabled && (
             <Alert color="warning" icon={<Icon name="info" />}>
-              <Text>
-                {jt`Metabot is disabled, but you can enable it on the ${(
-                  <Text component={Link} c="brand" to="/admin/metabot/general">
-                    {t`General Metabot Settings`}
-                  </Text>
-                )} page.`}
-              </Text>
+              <Text>{t`Metabot is disabled, but you can enable it.`}</Text>
             </Alert>
           )}
           <Box>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAgentSettingsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAgentSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useDisclosure } from "@mantine/hooks";
+import { Link } from "react-router";
 import { match } from "ts-pattern";
-import { c, t } from "ttag";
+import { c, jt, t } from "ttag";
 import _ from "underscore";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
@@ -13,13 +14,14 @@ import { CollectionPickerModal } from "metabase/common/components/Pickers/Collec
 import { useToast } from "metabase/common/hooks";
 import { color } from "metabase/lib/colors";
 import { getIcon } from "metabase/lib/icon";
-import { Box, Button, Flex, Icon, Loader, Text } from "metabase/ui";
+import { Alert, Box, Button, Flex, Icon, Loader, Text } from "metabase/ui";
 import {
   useDeleteMetabotEntitiesMutation,
   useListMetabotsEntitiesQuery,
   useListMetabotsQuery,
   useUpdateMetabotEntitiesMutation,
 } from "metabase-enterprise/api";
+import { useMetabotEnabled } from "metabase-enterprise/metabot/hooks";
 import type {
   CollectionEssentials,
   MetabotEntity,
@@ -36,6 +38,7 @@ export function MetabotAgentSettingsPage() {
   const metabotName =
     data?.items?.find((bot) => bot.id === metabotId)?.name ?? t`Metabot`;
   const isEmbeddedMetabot = metabotName.toLowerCase().includes("embed");
+  const isMetabotEnabled = useMetabotEnabled();
 
   const { data: entityList } = useListMetabotsEntitiesQuery(
     metabotId ? { id: metabotId } : skipToken,
@@ -55,6 +58,17 @@ export function MetabotAgentSettingsPage() {
     <AdminSettingsLayout sidebar={<MetabotNavPane />}>
       <ErrorBoundary>
         <SettingsSection>
+          {!isMetabotEnabled && (
+            <Alert color="warning" icon={<Icon name="info" />}>
+              <Text>
+                {jt`Metabot is disabled, but you can enable it on the ${(
+                  <Text component={Link} c="brand" to="/admin/metabot/general">
+                    {t`General Metabot Settings`}
+                  </Text>
+                )} page.`}
+              </Text>
+            </Alert>
+          )}
           <Box>
             <SettingHeader
               id="configure-metabot"

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAgentSettingsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotAgentSettingsPage.unit.spec.tsx
@@ -25,7 +25,7 @@ import type {
 } from "metabase-types/api";
 import { createMockCollection } from "metabase-types/api/mocks";
 
-import { MetabotAdminPage } from "./MetabotAdminPage";
+import { MetabotAgentSettingsPage } from "./MetabotAgentSettingsPage";
 import * as hooks from "./utils";
 
 const mockPathParam = (id: MetabotId) => {
@@ -125,7 +125,7 @@ const setup = async (
   );
 
   renderWithProviders(
-    <Route path="/admin/metabot*" component={MetabotAdminPage} />,
+    <Route path="/admin/metabot*" component={MetabotAgentSettingsPage} />,
     {
       withRouter: true,
       initialRoute: `/admin/metabot/${initialPathParam}`,
@@ -137,7 +137,7 @@ const setup = async (
   }
 };
 
-describe("MetabotAdminPage", () => {
+describe("MetabotAgentSettingsPage", () => {
   it("should render the page", async () => {
     await setup();
     expect(screen.getByText(/Configure Metabot/)).toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotGeneralSettingsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotGeneralSettingsPage.tsx
@@ -44,7 +44,7 @@ function MetabotEnabledPane() {
       <SettingHeader
         id="enable-metabot"
         title={t`Enable Metabot`}
-        description={t`When enabled, Metabot will be available throughout your Metabase instance to help users create queries, analyze data, and answer questions about your data. When disabled, all Metabot functionality will be turned off.`} // eslint-disable-line no-literal-metabase-strings -- admin UI context
+        description={t`Metabot is Metabase's AI assistant. When enabled, Metabot will be available to help users create queries, analyze data, and answer questions about your data.`} // eslint-disable-line no-literal-metabase-strings -- admin UI context
       />
       <Flex align="center" gap="md" mt="md">
         <Switch

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotGeneralSettingsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotGeneralSettingsPage.tsx
@@ -5,6 +5,7 @@ import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
 import { useAdminSetting } from "metabase/api/utils";
 import { AdminSettingsLayout } from "metabase/common/components/AdminLayout/AdminSettingsLayout";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { Box, Flex, Switch, Text } from "metabase/ui";
 
 import { MetabotNavPane } from "./MetabotNavPane";
@@ -26,6 +27,7 @@ function MetabotEnabledPane() {
     value: isEnabled,
     updateSetting,
     isLoading,
+    error,
   } = useAdminSetting("metabot-feature-enabled");
 
   const handleToggle = async (checked: boolean) => {
@@ -35,8 +37,13 @@ function MetabotEnabledPane() {
     });
   };
 
-  if (isLoading) {
-    return null;
+  if (isLoading || error) {
+    return (
+      <LoadingAndErrorWrapper
+        loading={isLoading}
+        error={error ? t`Error loading Metabot settings` : null}
+      />
+    );
   }
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotGeneralSettingsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotGeneralSettingsPage.tsx
@@ -1,0 +1,61 @@
+import { t } from "ttag";
+
+import ErrorBoundary from "metabase/ErrorBoundary";
+import { SettingsSection } from "metabase/admin/components/SettingsSection";
+import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
+import { useAdminSetting } from "metabase/api/utils";
+import { AdminSettingsLayout } from "metabase/common/components/AdminLayout/AdminSettingsLayout";
+import { Box, Flex, Switch, Text } from "metabase/ui";
+
+import { MetabotNavPane } from "./MetabotNavPane";
+
+export function MetabotGeneralSettingsPage() {
+  return (
+    <AdminSettingsLayout sidebar={<MetabotNavPane />}>
+      <ErrorBoundary>
+        <SettingsSection title={t`Metabot`}>
+          <MetabotEnabledPane />
+        </SettingsSection>
+      </ErrorBoundary>
+    </AdminSettingsLayout>
+  );
+}
+
+function MetabotEnabledPane() {
+  const {
+    value: isEnabled,
+    updateSetting,
+    isLoading,
+  } = useAdminSetting("metabot-feature-enabled");
+
+  const handleToggle = async (checked: boolean) => {
+    await updateSetting({
+      key: "metabot-feature-enabled",
+      value: checked,
+    });
+  };
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <Box>
+      <SettingHeader
+        id="enable-metabot"
+        title={t`Enable Metabot`}
+        description={t`When enabled, Metabot will be available throughout your Metabase instance to help users create queries, analyze data, and answer questions about your data. When disabled, all Metabot functionality will be turned off.`} // eslint-disable-line no-literal-metabase-strings -- admin UI context
+      />
+      <Flex align="center" gap="md" mt="md">
+        <Switch
+          checked={Boolean(isEnabled)}
+          onChange={(event) => handleToggle(event.currentTarget.checked)}
+          size="sm"
+        />
+        <Text c={isEnabled ? "text-dark" : "text-medium"} fw="500">
+          {isEnabled ? t`Metabot is enabled` : t`Metabot is disabled`}
+        </Text>
+      </Flex>
+    </Box>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotGeneralSettingsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotGeneralSettingsPage.unit.spec.tsx
@@ -1,0 +1,90 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import {
+  findRequests,
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+  setupUpdateSettingEndpoint,
+} from "__support__/server-mocks";
+import { setupMetabotsEndpoint } from "__support__/server-mocks/metabot";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockSettingDefinition,
+  createMockSettings,
+} from "metabase-types/api/mocks";
+
+import { MetabotGeneralSettingsPage } from "./MetabotGeneralSettingsPage";
+
+const switchElement = () => screen.findByRole("switch");
+
+const setup = async ({ metabotFeatureEnabled = true } = {}) => {
+  setupEnterprisePlugins();
+  setupPropertiesEndpoints(
+    createMockSettings({
+      "metabot-feature-enabled": metabotFeatureEnabled,
+    }),
+  );
+  setupSettingsEndpoints([
+    createMockSettingDefinition({
+      key: "metabot-feature-enabled",
+      value: metabotFeatureEnabled,
+    }),
+  ]);
+  setupUpdateSettingEndpoint();
+  setupMetabotsEndpoint([]);
+
+  renderWithProviders(
+    <Route
+      path="/admin/metabot/general"
+      component={MetabotGeneralSettingsPage}
+    />,
+    {
+      withRouter: true,
+      initialRoute: "/admin/metabot/general",
+    },
+  );
+
+  await screen.findByText("Metabot");
+};
+
+describe("MetabotGeneralSettingsPage", () => {
+  it("should render the page with Metabot settings", async () => {
+    await setup();
+
+    expect(await screen.findByText("Metabot")).toBeInTheDocument();
+    expect(await screen.findByText("Enable Metabot")).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Metabot is Metabase's AI assistant/),
+    ).toBeInTheDocument();
+  });
+
+  it("should show switch as enabled when metabot-feature-enabled is true", async () => {
+    await setup({ metabotFeatureEnabled: true });
+
+    expect(await switchElement()).toBeChecked();
+    expect(await screen.findByText("Metabot is enabled")).toBeInTheDocument();
+  });
+
+  it("should show switch as disabled when metabot-feature-enabled is false", async () => {
+    await setup({ metabotFeatureEnabled: false });
+
+    expect(await switchElement()).not.toBeChecked();
+    expect(await screen.findByText("Metabot is disabled")).toBeInTheDocument();
+  });
+
+  it("should toggle the setting when switch is clicked", async () => {
+    await setup({ metabotFeatureEnabled: false });
+
+    const switchEl = await switchElement();
+    expect(switchEl).not.toBeChecked();
+
+    await userEvent.click(switchEl);
+
+    // Verify the API call was made with correct payload
+    const [putRequest] = await findRequests("PUT");
+    expect(putRequest.url).toMatch(/api\/setting\/metabot-feature-enabled$/);
+    expect(putRequest.body).toEqual({ value: true });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotNavPane.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabotNavPane.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useMemo } from "react";
+import { push } from "react-router-redux";
+import { t } from "ttag";
+import _ from "underscore";
+
+import {
+  AdminNavItem,
+  AdminNavWrapper,
+} from "metabase/admin/components/AdminNav";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { getLocation } from "metabase/selectors/routing";
+import { Divider, Flex } from "metabase/ui";
+import { useListMetabotsQuery } from "metabase-enterprise/api";
+
+import { useMetabotIdPath } from "./utils";
+
+export function MetabotNavPane() {
+  const { data, isLoading } = useListMetabotsQuery();
+
+  const location = useSelector(getLocation);
+
+  const metabotId = useMetabotIdPath();
+  const dispatch = useDispatch();
+
+  const metabots = useMemo(() => _.sortBy(data?.items ?? [], "id"), [data]);
+
+  useEffect(() => {
+    const isOnGeneralSettings = location.pathname === "/admin/metabot/general";
+    if (!metabotId && !isOnGeneralSettings) {
+      dispatch(push("/admin/metabot/general"));
+    }
+  }, [metabotId, location, dispatch]);
+
+  if (isLoading || !data) {
+    return null;
+  }
+  return (
+    <Flex direction="column" w="266px" flex="0 0 auto">
+      <AdminNavWrapper>
+        <AdminNavItem
+          key="general"
+          path="/admin/metabot/general"
+          label={t`General`}
+          icon="gear"
+        />
+        <Divider my="sm" />
+        {metabots?.map((metabot) => (
+          <AdminNavItem
+            key={metabot.id}
+            icon="metabot"
+            label={metabot.name}
+            path={`/admin/metabot/${metabot.id}`}
+          />
+        ))}
+      </AdminNavWrapper>
+    </Flex>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotSearchButton/MetabotSearchButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotSearchButton/MetabotSearchButton.tsx
@@ -4,6 +4,7 @@ import { c, t } from "ttag";
 
 import useIsSmallScreen from "metabase/common/hooks/use-is-small-screen";
 import { METAKEY } from "metabase/lib/browser";
+import { SearchButton } from "metabase/nav/components/search/SearchButton";
 import S from "metabase/nav/components/search/SearchButton/SearchButton.module.css";
 import { Button, Flex, Icon, Text, Tooltip, UnstyledButton } from "metabase/ui";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
@@ -19,6 +20,10 @@ export const MetabotSearchButton = () => {
   }, [setVisualState]);
 
   const isSmallScreen = useIsSmallScreen();
+
+  if (!metabot.isEnabled) {
+    return <SearchButton />;
+  }
 
   const label = c("'Search' here is a verb").t`Ask Metabot or search`;
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotSearchButton/MetabotSearchButton.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotSearchButton/MetabotSearchButton.unit.spec.tsx
@@ -1,0 +1,55 @@
+import { KBarProvider } from "kbar";
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupPropertiesEndpoints } from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
+
+import { MetabotSearchButton } from "./MetabotSearchButton";
+
+const setup = ({
+  metabotFeatureEnabled,
+}: {
+  metabotFeatureEnabled: boolean;
+}) => {
+  setupEnterprisePlugins();
+  setupPropertiesEndpoints(
+    createMockSettings({ "metabot-feature-enabled": metabotFeatureEnabled }),
+  );
+  renderWithProviders(
+    <KBarProvider actions={[]}>
+      <MetabotSearchButton />
+    </KBarProvider>,
+  );
+};
+
+describe("MetabotSearchButton Feature Toggle", () => {
+  it("should render metabot search interface when feature is enabled", async () => {
+    setup({ metabotFeatureEnabled: true });
+
+    // should show the metabot icon and search text
+    expect(
+      await screen.findByRole("button", { name: "Metabot" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "Ask Metabot or search" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render regular search button when feature is disabled", async () => {
+    setup({ metabotFeatureEnabled: false });
+
+    // should show regular search button instead
+    expect(
+      await screen.findByRole("button", { name: "Search" }),
+    ).toBeInTheDocument();
+
+    // should not show metabot-specific elements
+    expect(
+      screen.queryByRole("button", { name: "Metabot" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Ask Metabot or search" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/index.ts
@@ -1,2 +1,4 @@
 export { useMetabotAgent } from "./use-metabot-agent";
 export { useMetabotChatHandlers } from "./use-metabot-chat-handlers";
+export { useMetabotEnabled } from "./use-metabot-enabled";
+export { useMetabotPaletteActions } from "./use-metabot-palette-actions";

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -1,6 +1,7 @@
 import { isFulfilled } from "@reduxjs/toolkit";
 import { useCallback } from "react";
 
+import { useAdminSetting } from "metabase/api/utils";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { useMetabotContext } from "metabase/metabot";
 
@@ -21,8 +22,15 @@ import {
   submitInput as submitInputAction,
 } from "../state";
 
+export const useMetabotEnabled = () => {
+  const { value: isEnabled } = useAdminSetting("metabot-feature-enabled");
+
+  return !!isEnabled;
+};
+
 export const useMetabotAgent = () => {
   const dispatch = useDispatch();
+  const isEnabled = useMetabotEnabled();
   const { prompt, setPrompt, promptInputRef, getChatContext } =
     useMetabotContext();
 
@@ -143,6 +151,7 @@ export const useMetabotAgent = () => {
 
   return {
     isDoingScience,
+    isEnabled,
     prompt,
     setPrompt,
     promptInputRef,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -1,7 +1,6 @@
 import { isFulfilled } from "@reduxjs/toolkit";
 import { useCallback } from "react";
 
-import { useAdminSetting } from "metabase/api/utils";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { useMetabotContext } from "metabase/metabot";
 
@@ -22,11 +21,7 @@ import {
   submitInput as submitInputAction,
 } from "../state";
 
-export const useMetabotEnabled = () => {
-  const { value: isEnabled } = useAdminSetting("metabot-feature-enabled");
-
-  return !!isEnabled;
-};
+import { useMetabotEnabled } from "./use-metabot-enabled";
 
 export const useMetabotAgent = () => {
   const dispatch = useDispatch();

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-enabled.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-enabled.ts
@@ -1,0 +1,7 @@
+import { useAdminSetting } from "metabase/api/utils";
+
+export const useMetabotEnabled = () => {
+  const { value: isEnabled } = useAdminSetting("metabot-feature-enabled");
+
+  return !!isEnabled;
+};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-enabled.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-enabled.unit.spec.tsx
@@ -1,0 +1,41 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupPropertiesEndpoints } from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
+
+import { useMetabotEnabled } from "./use-metabot-enabled";
+
+const TestComponent = () => {
+  const isEnabled = useMetabotEnabled();
+  return <div data-testid="metabot-enabled">{String(isEnabled)}</div>;
+};
+
+const setup = ({
+  metabotFeatureEnabled,
+}: {
+  metabotFeatureEnabled: boolean;
+}) => {
+  setupEnterprisePlugins();
+  setupPropertiesEndpoints(
+    createMockSettings({ "metabot-feature-enabled": metabotFeatureEnabled }),
+  );
+  renderWithProviders(<TestComponent />);
+};
+
+describe("useMetabotEnabled", () => {
+  it("should return true when metabot-feature-enabled setting is true", async () => {
+    setup({ metabotFeatureEnabled: true });
+
+    expect(await screen.findByTestId("metabot-enabled")).toHaveTextContent(
+      "true",
+    );
+  });
+
+  it("should return false when metabot-feature-enabled setting is false", async () => {
+    setup({ metabotFeatureEnabled: false });
+
+    expect(await screen.findByTestId("metabot-enabled")).toHaveTextContent(
+      "false",
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-palette-actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-palette-actions.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+import { t } from "ttag";
+
+import type { PaletteAction } from "metabase/palette/types";
+
+import { useMetabotAgent } from "./use-metabot-agent";
+
+export const useMetabotPaletteActions = (searchText: string) => {
+  const { startNewConversation, isEnabled } = useMetabotAgent();
+
+  return useMemo(() => {
+    if (!isEnabled) {
+      return [];
+    }
+
+    const ret: PaletteAction[] = [
+      {
+        id: "initialize_metabot",
+        name: searchText
+          ? t`Ask Metabot, "${searchText}"`
+          : t`Ask me to do something, or ask me a question`,
+        section: "metabot",
+        keywords: searchText,
+        icon: "metabot",
+        perform: () => startNewConversation(searchText),
+      },
+    ];
+    return ret;
+  }, [searchText, startNewConversation, isEnabled]);
+};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-palette-actions.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-palette-actions.unit.spec.tsx
@@ -1,0 +1,42 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupPropertiesEndpoints } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderHookWithProviders, waitFor } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { useMetabotPaletteActions } from "./use-metabot-palette-actions";
+
+const setup = ({
+  metabotFeatureEnabled = true,
+}: {
+  metabotFeatureEnabled?: boolean;
+} = {}) => {
+  const settings = createMockSettings({
+    "metabot-feature-enabled": metabotFeatureEnabled,
+  });
+
+  setupEnterprisePlugins();
+  setupPropertiesEndpoints(settings);
+
+  return renderHookWithProviders(() => useMetabotPaletteActions(""), {
+    storeInitialState: createMockState({
+      settings: mockSettings(settings),
+    }),
+  });
+};
+
+describe("useMetabotPaletteActions", () => {
+  it("should return no actions when metabot is disabled", async () => {
+    const { result } = setup({ metabotFeatureEnabled: false });
+    expect(result.current).toEqual([]);
+  });
+
+  it("should return one action when metabot is enabled", async () => {
+    const { result } = setup({ metabotFeatureEnabled: true });
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
@@ -16,11 +16,12 @@ import { MetabotGeneralSettingsPage } from "./components/MetabotAdmin/MetabotGen
 import { getMetabotQuickLinks } from "./components/MetabotQuickLinks";
 import { MetabotSearchButton } from "./components/MetabotSearchButton";
 import { MetabotContext, MetabotProvider, defaultContext } from "./context";
-import { useMetabotAgent } from "./hooks";
+import { useMetabotAgent, useMetabotEnabled } from "./hooks";
 import { getMetabotVisible, metabotReducer } from "./state";
 
 if (hasPremiumFeature("metabot_v3")) {
-  PLUGIN_METABOT.isEnabled = () => true;
+  PLUGIN_METABOT.useMetabotEnabled = useMetabotEnabled;
+
   PLUGIN_METABOT.Metabot = Metabot;
 
   PLUGIN_METABOT.getMetabotRoutes = getMetabotQuickLinks;
@@ -51,9 +52,13 @@ if (hasPremiumFeature("metabot_v3")) {
   PLUGIN_METABOT.getMetabotVisible =
     getMetabotVisible as unknown as typeof PLUGIN_METABOT.getMetabotVisible;
   PLUGIN_METABOT.useMetabotPalletteActions = (searchText: string) => {
-    const { startNewConversation } = useMetabotAgent();
+    const { startNewConversation, isEnabled } = useMetabotAgent();
 
     return useMemo(() => {
+      if (!isEnabled) {
+        return [];
+      }
+
       const ret: PaletteAction[] = [
         {
           id: "initialize_metabot",
@@ -67,7 +72,7 @@ if (hasPremiumFeature("metabot_v3")) {
         },
       ];
       return ret;
-    }, [searchText, startNewConversation]);
+    }, [searchText, startNewConversation, isEnabled]);
   };
 
   PLUGIN_METABOT.SearchButton = MetabotSearchButton;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
@@ -11,7 +11,8 @@ import { MetabotPurchasePage } from "metabase-enterprise/metabot/components/Meta
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { Metabot } from "./components/Metabot";
-import { MetabotAdminPage } from "./components/MetabotAdmin/MetabotAdminPage";
+import { MetabotAgentSettingsPage } from "./components/MetabotAdmin/MetabotAgentSettingsPage";
+import { MetabotGeneralSettingsPage } from "./components/MetabotAdmin/MetabotGeneralSettingsPage";
 import { getMetabotQuickLinks } from "./components/MetabotQuickLinks";
 import { MetabotSearchButton } from "./components/MetabotSearchButton";
 import { MetabotContext, MetabotProvider, defaultContext } from "./context";
@@ -37,8 +38,9 @@ if (hasPremiumFeature("metabot_v3")) {
       path="metabot"
       component={createAdminRouteGuard("metabot")}
     >
-      <IndexRoute component={MetabotAdminPage} />
-      <Route path=":metabotId" component={MetabotAdminPage} />
+      <IndexRoute component={MetabotGeneralSettingsPage} />
+      <Route path="general" component={MetabotGeneralSettingsPage} />
+      <Route path=":metabotId" component={MetabotAgentSettingsPage} />
     </Route>
   );
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
@@ -1,11 +1,9 @@
-import { useMemo } from "react";
 import { IndexRoute } from "react-router";
 import { t } from "ttag";
 
 import { createAdminRouteGuard } from "metabase/admin/utils";
 import { AdminSettingsLayout } from "metabase/common/components/AdminLayout/AdminSettingsLayout";
 import { Route } from "metabase/hoc/Title";
-import type { PaletteAction } from "metabase/palette/types";
 import { PLUGIN_METABOT, PLUGIN_REDUCERS } from "metabase/plugins";
 import { MetabotPurchasePage } from "metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
@@ -16,7 +14,7 @@ import { MetabotGeneralSettingsPage } from "./components/MetabotAdmin/MetabotGen
 import { getMetabotQuickLinks } from "./components/MetabotQuickLinks";
 import { MetabotSearchButton } from "./components/MetabotSearchButton";
 import { MetabotContext, MetabotProvider, defaultContext } from "./context";
-import { useMetabotAgent, useMetabotEnabled } from "./hooks";
+import { useMetabotEnabled, useMetabotPaletteActions } from "./hooks";
 import { getMetabotVisible, metabotReducer } from "./state";
 
 if (hasPremiumFeature("metabot_v3")) {
@@ -51,29 +49,7 @@ if (hasPremiumFeature("metabot_v3")) {
   // TODO: make enterprise store + fix type
   PLUGIN_METABOT.getMetabotVisible =
     getMetabotVisible as unknown as typeof PLUGIN_METABOT.getMetabotVisible;
-  PLUGIN_METABOT.useMetabotPalletteActions = (searchText: string) => {
-    const { startNewConversation, isEnabled } = useMetabotAgent();
-
-    return useMemo(() => {
-      if (!isEnabled) {
-        return [];
-      }
-
-      const ret: PaletteAction[] = [
-        {
-          id: "initialize_metabot",
-          name: searchText
-            ? t`Ask Metabot, "${searchText}"`
-            : t`Ask me to do something, or ask me a question`,
-          section: "metabot",
-          keywords: searchText,
-          icon: "metabot",
-          perform: () => startNewConversation(searchText),
-        },
-      ];
-      return ret;
-    }, [searchText, startNewConversation, isEnabled]);
-  };
+  PLUGIN_METABOT.useMetabotPalletteActions = useMetabotPaletteActions;
 
   PLUGIN_METABOT.SearchButton = MetabotSearchButton;
 

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -355,6 +355,7 @@ export const createMockSettings = (
   "show-metabase-links": true,
   "show-metabot": true,
   "show-updated-permission-modal": false,
+  "metabot-feature-enabled": true,
   "show-updated-permission-banner": false,
   "site-locale": "en",
   "site-name": "Metabae",

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -452,6 +452,7 @@ interface AdminSettings {
   "store-url": string;
   gsheets: Partial<GdrivePayload>;
   "license-token-missing-banner-dismissal-timestamp"?: Array<string>;
+  "metabot-feature-enabled": boolean;
 }
 interface SettingsManagerSettings {
   "bcc-enabled?": boolean;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenuItems.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenuItems.tsx
@@ -10,7 +10,7 @@ import { useDashboardContext } from "metabase/dashboard/context";
 import type { DashboardCardCustomMenuItem } from "metabase/embedding-sdk/types/plugins";
 import { useDispatch } from "metabase/lib/redux";
 import { isNotNull } from "metabase/lib/types";
-import { PLUGIN_DASHCARD_MENU } from "metabase/plugins";
+import { PLUGIN_DASHCARD_MENU, PLUGIN_METABOT } from "metabase/plugins";
 import { Icon, Menu } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type { DashCardId, Dataset } from "metabase-types/api";
@@ -37,6 +37,7 @@ export const DashCardMenuItems = ({
   canEdit,
 }: DashCardMenuItemsProps) => {
   const dispatch = useDispatch();
+  const isMetabotEnabled = PLUGIN_METABOT.useMetabotEnabled();
 
   const {
     onEditQuestion = (question, mode = "notebook") =>
@@ -107,7 +108,9 @@ export const DashCardMenuItems = ({
 
     items.push(
       ...PLUGIN_DASHCARD_MENU.dashcardMenuItemGetters
-        .map((itemGetter) => itemGetter(question, dashcardId, dispatch))
+        .map((itemGetter) =>
+          itemGetter(question, dashcardId, dispatch, { isMetabotEnabled }),
+        )
         .filter(isNotNull),
     );
 
@@ -141,6 +144,7 @@ export const DashCardMenuItems = ({
     dashcardId,
     dispatch,
     canEdit,
+    isMetabotEnabled,
   ]);
 
   return menuItems.map((item) => {

--- a/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-ee.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/PaletteResults-ee.unit.spec.tsx
@@ -1,6 +1,8 @@
 import fetchMock from "fetch-mock";
 
+import { setupPropertiesEndpoints } from "__support__/server-mocks";
 import { screen, within } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
 
 import { type CommonSetupProps, commonSetup } from "./setup";
 
@@ -8,6 +10,8 @@ const setup = (props: CommonSetupProps = {}) => {
   fetchMock.get("path:/api/ee/metabot-v3/v2/prompt-suggestions", {
     prompts: [],
   });
+
+  setupPropertiesEndpoints(createMockSettings({}));
 
   commonSetup({ ...props, isEE: true });
 };

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -713,7 +713,7 @@ export const PLUGIN_AI_ENTITY_ANALYSIS: PluginAIEntityAnalysis = {
 };
 
 export const PLUGIN_METABOT = {
-  isEnabled: () => false,
+  useMetabotEnabled: (): boolean => false,
   Metabot: (_props: { hide?: boolean }) => null as React.ReactElement | null,
   defaultMetabotContextValue,
   MetabotContext: React.createContext(defaultMetabotContextValue),
@@ -738,6 +738,7 @@ type DashCardMenuItemGetter = (
   question: Question,
   dashcardId: DashCardId | undefined,
   dispatch: ReduxDispatch,
+  options: { isMetabotEnabled: boolean },
 ) => (DashCardMenuItem & { key: string }) | null;
 
 export type PluginDashcardMenu = {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -730,7 +730,6 @@ export const PLUGIN_METABOT = {
   getAdminPaths: () => [] as AdminPath[],
   getAdminRoutes: () => PluginPlaceholder as unknown as React.ReactElement,
   getMetabotRoutes: () => null as React.ReactElement | null,
-  MetabotAdminPage: () => `placeholder`,
   getMetabotVisible: (_state: State) => false,
   SearchButton: SearchButton,
 };

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -14,6 +14,7 @@ import {
   type CodeMirrorRef,
 } from "metabase/common/components/CodeMirror";
 import { isEventOverElement } from "metabase/lib/dom";
+import { PLUGIN_METABOT } from "metabase/plugins";
 import * as Lib from "metabase-lib";
 import type { CardId } from "metabase-types/api";
 
@@ -52,7 +53,7 @@ export const CodeMirrorEditor = forwardRef<
   {
     query,
     highlightedLineNumbers,
-    placeholder = getPlaceholderText(Lib.engine(query)),
+    placeholder,
     readOnly,
     onChange,
     onRunQuery,
@@ -65,6 +66,12 @@ export const CodeMirrorEditor = forwardRef<
 ) {
   const editorRef = useRef<CodeMirrorRef>(null);
   const extensions = useExtensions({ query, onRunQuery });
+  const isMetabotEnabled = PLUGIN_METABOT.useMetabotEnabled();
+
+  const fallbackPlaceholder = getPlaceholderText(
+    Lib.engine(query),
+    isMetabotEnabled,
+  );
 
   useImperativeHandle(ref, () => {
     return {
@@ -141,7 +148,7 @@ export const CodeMirrorEditor = forwardRef<
       onUpdate={handleUpdate}
       autoFocus
       autoCorrect="off"
-      placeholder={placeholder}
+      placeholder={placeholder ?? fallbackPlaceholder}
       highlightRanges={highlightedRanges}
       onFormat={onFormatQuery}
     />

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.tsx
@@ -254,7 +254,10 @@ export const getReferencedCardIds = createSelector(
   },
 );
 
-export const getPlaceholderText = (engine?: string | null): string => {
+export const getPlaceholderText = (
+  engine?: string | null,
+  metabotEnabled?: boolean,
+): string => {
   if (!engine) {
     return "";
   }
@@ -264,10 +267,8 @@ export const getPlaceholderText = (engine?: string | null): string => {
 
   const engineType = getEngineNativeType(engine);
 
-  if (PLUGIN_AI_SQL_GENERATION.isEnabled()) {
-    if (engineType === "sql") {
-      return PLUGIN_AI_SQL_GENERATION.getPlaceholderText();
-    }
+  if (metabotEnabled && engineType === "sql") {
+    return PLUGIN_AI_SQL_GENERATION.getPlaceholderText();
   }
 
   switch (true) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/util.unit.spec.tsx
@@ -186,13 +186,13 @@ describe("getPlaceholderText", () => {
     });
 
     it("should return metabot placeholder text for sql", () => {
-      expect(getPlaceholderText("sql")).toBe(
+      expect(getPlaceholderText("sql", true)).toBe(
         "Write and select text to generate SQL with Metabot, or type SQL directly",
       );
     });
 
     it("should return regular placeholder text for nosql", () => {
-      expect(getPlaceholderText("mongo")).toBe(
+      expect(getPlaceholderText("mongo", true)).toBe(
         '[ { "$project": { "_id": "$_id" } } ]',
       );
     });

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.tsx
@@ -202,19 +202,21 @@ const getChartConfigs = async ({
 };
 
 export const registerQueryBuilderMetabotContextFn = async ({
+  isMetabotEnabled,
   question,
   series,
   visualizationSettings,
   timelineEvents,
   queryResult,
 }: {
+  isMetabotEnabled: boolean;
   question: Question | undefined;
   series: RawSeries;
   visualizationSettings: ComputedVisualizationSettings | undefined;
   timelineEvents: TimelineEvent[];
   queryResult: any;
 }) => {
-  if (!PLUGIN_METABOT.isEnabled()) {
+  if (!isMetabotEnabled) {
     return {};
   }
   if (!question) {
@@ -252,6 +254,8 @@ export const registerQueryBuilderMetabotContextFn = async ({
 };
 
 export const useRegisterQueryBuilderMetabotContext = () => {
+  const isMetabotEnabled = PLUGIN_METABOT.useMetabotEnabled();
+
   useRegisterMetabotContextProvider(async (state) => {
     const question = getQuestion(state);
     const series = getTransformedSeries(state);
@@ -260,6 +264,7 @@ export const useRegisterQueryBuilderMetabotContext = () => {
     const queryResult = getFirstQueryResult(state);
 
     return registerQueryBuilderMetabotContextFn({
+      isMetabotEnabled,
       question,
       series,
       visualizationSettings,

--- a/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/use-register-query-builder-metabot-context.unit.spec.tsx
@@ -54,6 +54,7 @@ function createMockData(opts: {
   series?: RawSeries | TransformedSeries;
   visualizationSettings?: ComputedVisualizationSettings;
   timelineEvents?: TimelineEvent[];
+  isMetabotEnabled?: boolean;
 }) {
   const question = opts.question;
   const card = question?.card();
@@ -87,6 +88,7 @@ function createMockData(opts: {
     visualizationSettings: question?.settings() ?? {},
     timelineEvents: [],
     queryResult: undefined,
+    isMetabotEnabled: true,
     ...opts,
   };
 }
@@ -253,8 +255,6 @@ describe("registerQueryBuilderMetabotContextFn", () => {
 });
 
 it("should return empty result when metabot is disabled", async () => {
-  PLUGIN_METABOT.isEnabled = jest.fn(() => false);
-
   const card = createMockCard({
     name: "Count by name",
     display: "table",
@@ -263,15 +263,16 @@ it("should return empty result when metabot is disabled", async () => {
       "graph.metrics": ["count"],
     }),
   });
-  const data = createMockData({ question: new Question(card) });
+  const data = createMockData({
+    question: new Question(card),
+    isMetabotEnabled: false,
+  });
   const result = await registerQueryBuilderMetabotContextFn(data);
 
   expect(getUserIsViewing(result)).toBeUndefined();
 });
 
 it("should return populated context when metabot is enabled", async () => {
-  PLUGIN_METABOT.isEnabled = jest.fn(() => true);
-
   const card = createMockCard({
     name: "Count by name",
     display: "table",
@@ -287,7 +288,7 @@ it("should return populated context when metabot is enabled", async () => {
 });
 
 it("should register without throwing", () => {
-  PLUGIN_METABOT.isEnabled = jest.fn(() => true);
+  PLUGIN_METABOT.useMetabotEnabled = jest.fn(() => true);
 
   expect(() => {
     renderHook(() => useRegisterQueryBuilderMetabotContext());

--- a/test_resources/serialization_baseline/settings.yaml
+++ b/test_resources/serialization_baseline/settings.yaml
@@ -33,6 +33,7 @@ loading-message: null
 login-page-illustration: null
 login-page-illustration-custom: null
 metabot-ai-service-token-ttl: null
+metabot-feature-enabled: null
 native-query-autocomplete-match-style: null
 no-data-illustration: null
 no-data-illustration-custom: null


### PR DESCRIPTION
Closes [BOT-200](https://linear.app/metabase/issue/BOT-200/add-ability-to-turn-off-metabot-from-admin)

### Description

Adds the ability to enable / disable the Metabot feature.

<img width="2942" height="814" alt="CleanShot 2025-08-28 at 21 39 46@2x" src="https://github.com/user-attachments/assets/4de436f6-45b6-4962-bd71-8f0ffd07b2da" />

<img width="2940" height="952" alt="CleanShot 2025-08-28 at 21 39 58@2x" src="https://github.com/user-attachments/assets/384b1d36-f9d9-4b2c-8d4e-ac821d308729" />

This PR:
- Prevents showing any Metabot related feature in the UI and adds test coverage for this
- Prevents appropriate endpoints from working if the feature is disabled

### Demo

https://github.com/user-attachments/assets/eeacda35-fded-4141-a598-095011ea0db0

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
WIP still needs BE tests