### PR TITLE
Fix resolution of incorrect `:field` refs for expressions

### DIFF
--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -393,7 +393,8 @@
                               {:base-type base-type, :effective-type base-type}
                               (cond-> literal (u.number/bigint? literal) str)])))
 
-(mu/defn- expression-metadata :- ::lib.schema.metadata/column
+(mu/defn expression-metadata :- ::lib.schema.metadata/column
+  "Return column metadata for an `expression-definition` MBQL clause."
   [query                 :- ::lib.schema/query
    stage-number          :- :int
    expression-definition :- ::lib.schema.expression/expression]
@@ -407,6 +408,7 @@
         (select-keys [:base-type :effective-type :lib/desired-column-alias
                       :lib/source-column-alias :lib/source-uuid :lib/type])
         (assoc :lib/source          :source/expressions
+               :lib/source-uuid     (lib.options/uuid expression-definition)
                :lib/expression-name expression-name
                :name                expression-name
                :display-name        expression-name))))

--- a/test/metabase/lib/aggregation_test.cljc
+++ b/test/metabase/lib/aggregation_test.cljc
@@ -797,7 +797,8 @@
                   (->> query
                        lib/available-aggregation-operators
                        (m/find-first #(= (:short %) :sum))
-                       lib/aggregation-operator-columns))]
+                       lib/aggregation-operator-columns
+                       (map #(dissoc % :lib/source-uuid))))]
       (is (= (clean built-query)
              (clean converted-query))))))
 

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -753,3 +753,8 @@
                               (lib/filterable-columns query))]
         (assert (some? col))
         (is (lib.types.isa/date-or-datetime? col))))))
+
+(deftest ^:parallel relative-datetime-current-test
+  (testing "Should be able to create a :relative-datetime clause with one arg (:current)"
+    (is (=? [:relative-datetime {:lib/uuid string?} :current]
+            (lib.expression/relative-datetime :current)))))

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -753,8 +753,3 @@
                               (lib/filterable-columns query))]
         (assert (some? col))
         (is (lib.types.isa/date-or-datetime? col))))))
-
-(deftest ^:parallel relative-datetime-current-test
-  (testing "Should be able to create a :relative-datetime clause with one arg (:current)"
-    (is (=? [:relative-datetime {:lib/uuid string?} :current]
-            (lib.expression/relative-datetime :current)))))

--- a/test/metabase/lib/field/resolution_test.cljc
+++ b/test/metabase/lib/field/resolution_test.cljc
@@ -1019,9 +1019,7 @@
       (is (=? {:id                                       (meta/id :products :id)
                :name                                     "ID"
                :table-id                                 (meta/id :products)
-               ;; TODO (Cam 7/29/25) -- maybe we need to add a `:source/indetermiate` option or something. Because
-               ;; this is wrong... but nothing else is right either.
-               :lib/source                               :source/table-defaults
+               :lib/source                               :source/previous-stage
                ::lib.field.resolution/fallback-metadata? true}
               (lib.field.resolution/resolve-field-ref
                query -1

--- a/test/metabase/lib/field/resolution_test.cljc
+++ b/test/metabase/lib/field/resolution_test.cljc
@@ -718,44 +718,6 @@
                    {:display-name "Sum of Total"}]
                   (lib/returned-columns query))))))))
 
-;;; adapted from [[metabase.queries.api.card-test/model-card-test-2]]
-(deftest ^:parallel preserve-model-metadata-test
-  (let [mp        (metabase.lib.card-test/preserve-edited-metadata-test-mock-metadata-provider
-                   {:result-metadata-style :metabase.lib.card-test/legacy-snake-case-qp})
-        edited-mp (lib.tu/merged-mock-metadata-provider
-                   mp
-                   {:cards [{:id              3
-                             :result-metadata (for [col (:result-metadata (lib.metadata/card mp 3))]
-                                                (assoc col :description "user description", :display_name "user display name"))}]})]
-    (testing "card metadata (sanity check)"
-      (is (=? {:name "NAME", :description "user description", :display_name "user display name"}
-              (m/find-first #(= (:name %) "NAME")
-                            (:result-metadata (lib.metadata/card edited-mp 3))))))
-    (testing "field resolution"
-      (let [query     (lib/query
-                       edited-mp
-                       {:database (meta/id)
-                        :type     :query
-                        :query    {:qp/stage-had-source-card 3
-                                   :source-query/model?      true
-                                   :source-query             {:qp/stage-is-from-source-card 3
-                                                              :native                       "select * from venues"}
-                                   :source-metadata          (:result-metadata (lib.metadata/card edited-mp 3))
-                                   :fields                   [[:field (meta/id :venues :id) nil]
-                                                              [:field (meta/id :venues :name) nil]
-                                                              [:field (meta/id :venues :category-id) nil]
-                                                              [:field (meta/id :venues :latitude) nil]
-                                                              [:field (meta/id :venues :longitude) nil]
-                                                              [:field (meta/id :venues :price) nil]]}})
-            field-ref [:field {:lib/uuid (str (random-uuid))} (meta/id :venues :name)]]
-        (testing `lib.field.resolution/resolve-column-in-previous-stage-metadata
-          (let [stage-cols (get-in (lib.util/query-stage query 0) [:lib/stage-metadata :columns])]
-            (is (=? {:name "NAME", :description "user description", :display-name "user display name"}
-                    (#'lib.field.resolution/resolve-column-in-previous-stage-metadata query field-ref stage-cols)))))
-        (testing `lib.field.resolution/resolve-field-ref
-          (is (=? {:name "NAME", :description "user description", :display-name "user display name"}
-                  (lib.field.resolution/resolve-field-ref query -1 field-ref))))))))
-
 (deftest ^:parallel use-unknown-name-for-display-name-for-fields-that-cant-be-resolved-test
   (let [query     (lib/query meta/metadata-provider (meta/table-metadata :venues))
         field-ref [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 123456789]]

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -83,7 +83,7 @@
       (mu/disable-enforcement
         (is (=? {:name              "Unknown Field"
                  :display-name      "Unknown Field" #_"join → Unknown Field" ; either answer can be considered correct I guess
-                 :long-display-name "join → Unknown Field"}
+                 :long-display-name "Unknown Field"}
                 (lib/display-info query [:field {:join-alias "join"} field-id])))))))
 
 (defn- visible-columns-with-desired-aliases

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -1194,3 +1194,31 @@
              (-> (mt/native-query {:query (tx/native-null-array-query driver/*driver*)})
                  mt/process-query
                  mt/rows))))))
+
+(deftest ^:parallel invalid-field-ref-for-an-expression-test
+  (testing "#62663"
+    (is (= [[1
+             "1018947080336"
+             "Rustic Paper Wallet"
+             "Gizmo"
+             "Swaniawski, Casper and Hilll"
+             29.46
+             4.6
+             "2017-07-19T19:44:56.582Z"
+             "Gizmo111"]
+            [10
+             "1807963902339"
+             "Mediocre Wooden Table"
+             "Gizmo"
+             "Larson, Pfeffer and Klocko"
+             31.79
+             4.3
+             "2017-01-09T09:51:20.352Z"
+             "Gizmo111"]]
+           (mt/rows
+            (qp/process-query
+             (mt/mbql-query products
+               {:expressions {"Cat_1" [:concat $category "111"]}
+                :filter      [:= [:field "Cat_1" {:base-type :type/Text}] "Gizmo111"]
+                :order-by    [[:asc $id]]
+                :limit       2})))))))


### PR DESCRIPTION
I already fixed this in `master` so this PR just copies the updated version of `lib.field.resolution` (minor updates) from `master` and adds a little hack to `add-alias-info` to the 56.x branch (`master` is fixed but it has a pure-Lib version of `add-alias-info` that I don't want to backport to a point release)

Fixes #62663