### PR TITLE
Hide CSV panel with no meaningful uploadable dbs

### DIFF
--- a/e2e/test/scenarios/onboarding/add-initial-data.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/add-initial-data.cy.spec.ts
@@ -383,6 +383,14 @@ describe("Add data modal", () => {
         .should("contain", "value1")
         .and("contain", "value2");
     });
+
+    it("should be hidden for non-admins without upload permissions", () => {
+      cy.signInAsNormalUser();
+      cy.visit("/");
+      cy.findByRole("tab", { name: /^Data/i }).within(() => {
+        cy.findByLabelText("Add data").should("not.exist");
+      });
+    });
   });
 });
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { useListDatabasesQuery } from "metabase/api";
@@ -7,31 +7,46 @@ import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
 import { canAccessSettings, getUserIsAdmin } from "metabase/selectors/user";
-import { Box, Icon, Modal, Tabs } from "metabase/ui";
+import { Box, Icon, type IconName, Modal, Tabs } from "metabase/ui";
 
 import S from "./AddDataModal.module.css";
 import { CSVPanel } from "./Panels/CSVPanel";
 import { DatabasesPanel } from "./Panels/DatabasesPanel";
 import { PanelsHeader } from "./Panels/PanelsHeader";
 import { trackAddDataEvent } from "./analytics";
-import { isValidTab } from "./utils";
+import { isValidTab, shouldShowUploadPanel } from "./utils";
 
 interface AddDataModalProps {
   opened: boolean;
   onClose: () => void;
 }
 
-export const AddDataModal = ({ opened, onClose }: AddDataModalProps) => {
-  const { data: databaseResponse } = useListDatabasesQuery();
+interface Tabs {
+  name: string;
+  value: "csv" | "db" | "gsheets";
+  isVisible: boolean;
+  iconName: IconName;
+}
 
-  const [activeTab, setActiveTab] = useState<string | null>("csv");
+export const AddDataModal = ({ opened, onClose }: AddDataModalProps) => {
+  const { data: databasesResponse } = useListDatabasesQuery();
+  const { data: uploadableDatabasesResponse } = useListDatabasesQuery({
+    include_only_uploadable: true,
+  });
+
+  const shouldShowUploadsPanel = shouldShowUploadPanel({
+    allDatabases: databasesResponse?.data,
+    allUploadableDatabases: uploadableDatabasesResponse?.data,
+  });
+
+  const [activeTab, setActiveTab] = useState<Tabs["value"] | null>(null);
 
   const isHosted = useSetting("is-hosted?");
 
   const isAdmin = useSelector(getUserIsAdmin);
   const userCanAccessSettings = useSelector(canAccessSettings);
 
-  const databases = databaseResponse?.data;
+  const databases = databasesResponse?.data;
   const uploadDbId = useSetting("uploads-settings")?.db_id;
   const uploadDB = databases?.find((db) => db.id === uploadDbId);
 
@@ -58,6 +73,31 @@ export const AddDataModal = ({ opened, onClose }: AddDataModalProps) => {
     setActiveTab(tabValue);
   };
 
+  const tabs = useMemo(() => {
+    return [
+      {
+        name: t`CSV`,
+        value: "csv",
+        isVisible: shouldShowUploadsPanel,
+        iconName: "table2",
+      },
+      { name: t`Database`, value: "db", isVisible: true, iconName: "database" },
+      {
+        name: t`Google Sheets`,
+        value: "gsheets",
+        isVisible: isHosted,
+        iconName: "document",
+      },
+    ] satisfies Tabs[];
+  }, [shouldShowUploadsPanel, isHosted]);
+
+  useEffect(() => {
+    const firstVisibleTab = tabs.find((tab) => tab.isVisible);
+    if (firstVisibleTab) {
+      setActiveTab(firstVisibleTab.value);
+    }
+  }, [tabs]);
+
   return (
     <Modal.Root opened={opened} onClose={onClose} size="auto">
       <Modal.Overlay />
@@ -79,20 +119,17 @@ export const AddDataModal = ({ opened, onClose }: AddDataModalProps) => {
               <Modal.Title fz="lg">{t`Add data`}</Modal.Title>
             </Box>
             <Tabs.List px="md" pb="lg">
-              <Tabs.Tab value="csv" leftSection={<Icon name="table2" />}>
-                {t`CSV`}
-              </Tabs.Tab>
-              <Tabs.Tab value="db" leftSection={<Icon name="database" />}>
-                {t`Database`}
-              </Tabs.Tab>
-              {isHosted && (
-                <Tabs.Tab
-                  value="gsheets"
-                  leftSection={<Icon name="document" />}
-                >
-                  {t`Google Sheets`}
-                </Tabs.Tab>
-              )}
+              {tabs
+                .filter((tab) => tab.isVisible)
+                .map((tab) => (
+                  <Tabs.Tab
+                    key={tab.value}
+                    value={tab.value}
+                    leftSection={<Icon name={tab.iconName} />}
+                  >
+                    {tab.name}
+                  </Tabs.Tab>
+                ))}
             </Tabs.List>
           </Box>
           <Box component="main" w="30rem" className={S.panelContainer}>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
@@ -13,7 +13,7 @@ import { DatabasesPanel } from "./Panels/DatabasesPanel";
 import { PanelsHeader } from "./Panels/PanelsHeader";
 import { trackAddDataEvent } from "./analytics";
 import { useAddDataPermissions } from "./use-add-data-permission";
-import { isValidTab, shouldShowUploadPanel } from "./utils";
+import { hasMeaningfulUploadableDatabases, isValidTab } from "./utils";
 
 interface AddDataModalProps {
   opened: boolean;
@@ -36,10 +36,12 @@ export const AddDataModal = ({ opened, onClose }: AddDataModalProps) => {
     include_only_uploadable: true,
   });
 
-  const shouldShowUploadsPanel = shouldShowUploadPanel({
+  const hasUploadableDatabases = hasMeaningfulUploadableDatabases({
     allDatabases: databasesResponse?.data,
     allUploadableDatabases: uploadableDatabasesResponse?.data,
   });
+
+  const shouldShowUploadsPanel = hasUploadableDatabases || canUploadToDatabase;
 
   const [activeTab, setActiveTab] = useState<Tabs["value"] | null>(null);
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/common.unit.spec.tsx
@@ -38,10 +38,10 @@ describe("AddDataModal", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should have csv tab selected by default", () => {
+  it("should have csv tab selected by default", async () => {
     setup();
 
-    const csvTab = screen.getByRole("tab", { name: /CSV$/ });
+    const csvTab = await screen.findByRole("tab", { name: /CSV$/ });
     expect(csvTab).toHaveAttribute("data-active", "true");
   });
 
@@ -49,7 +49,7 @@ describe("AddDataModal", () => {
     setup();
 
     const databaseTab = screen.getByRole("tab", { name: /Database$/ });
-    const csvTab = screen.getByRole("tab", { name: /CSV$/ });
+    const csvTab = await screen.findByRole("tab", { name: /CSV$/ });
 
     expect(csvTab).toHaveAttribute("data-active", "true");
     await userEvent.click(screen.getByRole("tab", { name: /Database$/ }));
@@ -60,7 +60,7 @@ describe("AddDataModal", () => {
   it("should maintain the tab selection state", async () => {
     setup();
 
-    const csvTab = screen.getByRole("tab", { name: /CSV$/ });
+    const csvTab = await screen.findByRole("tab", { name: /CSV$/ });
     expect(csvTab).toHaveAttribute("data-active", "true");
 
     await userEvent.click(csvTab);
@@ -72,6 +72,9 @@ describe("AddDataModal", () => {
     it("should show database panel for admin users", async () => {
       setup({ isAdmin: true });
 
+      expect(
+        await screen.findByRole("tab", { name: /CSV$/ }),
+      ).toBeInTheDocument();
       await userEvent.click(screen.getByRole("tab", { name: /Database$/ }));
       expect(
         screen.getByRole("tab", { name: /Database$/ }),
@@ -88,6 +91,9 @@ describe("AddDataModal", () => {
     it("should show limited view for non-admin users", async () => {
       setup({ isAdmin: false });
 
+      expect(
+        await screen.findByRole("tab", { name: /CSV$/ }),
+      ).toBeInTheDocument();
       await userEvent.click(screen.getByRole("tab", { name: /Database$/ }));
       expect(
         screen.getByRole("tab", { name: /Database$/ }),
@@ -117,12 +123,16 @@ describe("AddDataModal", () => {
     it("doesn't show admin email when there isn't one", async () => {
       setup({ isAdmin: false, adminEmail: null });
 
+      expect(
+        await screen.findByRole("tab", { name: /CSV$/ }),
+      ).toBeInTheDocument();
+
       await userEvent.click(screen.getByRole("tab", { name: /Database$/ }));
 
       const alert = screen.getByRole("alert");
       expect(alert).toBeInTheDocument();
       expect(
-        within(alert).getByText(
+        await within(alert).findByText(
           "To add a new database, please contact your administrator.",
         ),
       ).toBeInTheDocument();
@@ -136,7 +146,7 @@ describe("AddDataModal", () => {
     it("should show CSV panel for admin users", async () => {
       setup({ isAdmin: true, uploadsEnabled: true });
 
-      expect(screen.getByText("Manage uploads")).toBeInTheDocument();
+      expect(await screen.findByText("Manage uploads")).toBeInTheDocument();
 
       expect(
         await screen.findByText("Drag and drop a file here"),
@@ -151,7 +161,7 @@ describe("AddDataModal", () => {
     it("should prompt the admin to enable uploads", async () => {
       setup({ isAdmin: true, uploadsEnabled: false });
 
-      expect(screen.getByText("Manage uploads")).toBeInTheDocument();
+      expect(await screen.findByText("Manage uploads")).toBeInTheDocument();
       expect(
         screen.getByRole("heading", { name: "Upload CSV files" }),
       ).toBeInTheDocument();
@@ -168,9 +178,11 @@ describe("AddDataModal", () => {
     it("should prompt the admin to enable uploads with an upsell on a hosted instance", async () => {
       setup({ isAdmin: true, uploadsEnabled: false, isHosted: true });
 
-      expect(screen.getByText("Manage uploads")).toBeInTheDocument();
-      expect(screen.getByText("Enable uploads")).toBeInTheDocument();
-      expect(screen.getByText("Add Metabase Storage")).toBeInTheDocument();
+      expect(await screen.findByText("Manage uploads")).toBeInTheDocument();
+      expect(await screen.findByText("Enable uploads")).toBeInTheDocument();
+      expect(
+        await screen.findByText("Add Metabase Storage"),
+      ).toBeInTheDocument();
     });
 
     it("regular user should be instructed to contact their admin in order to enable uploads", async () => {
@@ -178,7 +190,7 @@ describe("AddDataModal", () => {
 
       expect(screen.queryByText("Manage uploads")).not.toBeInTheDocument();
       expect(
-        screen.getByRole("heading", { name: "Upload CSV files" }),
+        await screen.findByRole("heading", { name: "Upload CSV files" }),
       ).toBeInTheDocument();
       expect(
         screen.getByText(
@@ -202,7 +214,7 @@ describe("AddDataModal", () => {
 
       expect(screen.queryByText("Manage uploads")).not.toBeInTheDocument();
       expect(
-        screen.getByRole("heading", { name: "Upload CSV files" }),
+        await screen.findByRole("heading", { name: "Upload CSV files" }),
       ).toBeInTheDocument();
       expect(
         screen.getByText(
@@ -389,14 +401,16 @@ describe("AddDataModal", () => {
   });
 
   describe("Google Sheets panel", () => {
-    it("should not exist in OSS binaries", () => {
+    it("should not exist in OSS binaries", async () => {
       // Hosting is a premium feature
       setup({ isHosted: false });
 
       expect(
         screen.getByRole("tab", { name: /Database$/ }),
       ).toBeInTheDocument();
-      expect(screen.getByRole("tab", { name: /CSV$/ })).toBeInTheDocument();
+      expect(
+        await screen.findByRole("tab", { name: /CSV$/ }),
+      ).toBeInTheDocument();
       expect(
         screen.queryByRole("tab", { name: /Google Sheets$/ }),
       ).not.toBeInTheDocument();

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/enterprise.unit.spec.tsx
@@ -4,13 +4,15 @@ import { setup } from "./setup";
 
 describe("AddDataModal (Unactivated enterprise binary)", () => {
   describe("Google Sheets panel", () => {
-    it("should not exist on self-hosted instances", () => {
+    it("should not exist on self-hosted instances", async () => {
       setup({ hasEnterprisePlugins: true, isHosted: false });
 
       expect(
         screen.getByRole("tab", { name: /Database$/ }),
       ).toBeInTheDocument();
-      expect(screen.getByRole("tab", { name: /CSV$/ })).toBeInTheDocument();
+      expect(
+        await screen.findByRole("tab", { name: /CSV$/ }),
+      ).toBeInTheDocument();
       expect(
         screen.queryByRole("tab", { name: /Google Sheets$/ }),
       ).not.toBeInTheDocument();

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-advanced-permissions.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-advanced-permissions.unit.spec.tsx
@@ -26,8 +26,8 @@ describe("Add data modal (EE with token)", () => {
         canUpload: true,
       });
 
-      expect(screen.getByText("Manage uploads")).toBeInTheDocument();
-      expect(screen.getByText("Enable uploads")).toBeInTheDocument();
+      expect(await screen.findByText("Manage uploads")).toBeInTheDocument();
+      expect(await screen.findByText("Enable uploads")).toBeInTheDocument();
     });
 
     it("should offer a setting manager to manage (csv) uploads", async () => {
@@ -38,7 +38,7 @@ describe("Add data modal (EE with token)", () => {
         canUpload: true,
       });
 
-      expect(screen.getByText("Manage uploads")).toBeInTheDocument();
+      expect(await screen.findByText("Manage uploads")).toBeInTheDocument();
     });
 
     /**
@@ -57,7 +57,7 @@ describe("Add data modal (EE with token)", () => {
         canUpload: false,
       });
 
-      expect(screen.getByText("Manage uploads")).toBeInTheDocument();
+      expect(await screen.findByText("Manage uploads")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/tests/premium-hosting-upload.unit.spec.tsx
@@ -108,6 +108,9 @@ describe("Add data modal (Pro: hosted instance with the attached DWH)", () => {
       enableGoogleSheets: true,
       status: "error",
     });
+    expect(
+      await screen.findByRole("tab", { name: /CSV$/ }),
+    ).toBeInTheDocument();
     await assertSheetsOpened();
 
     const connectButton = await screen.findByRole("button", {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/use-add-data-permission.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/use-add-data-permission.ts
@@ -1,0 +1,31 @@
+import { useListDatabasesQuery } from "metabase/api";
+import { useSetting } from "metabase/common/hooks";
+import { useSelector } from "metabase/lib/redux";
+import { canAccessSettings, getUserIsAdmin } from "metabase/selectors/user";
+
+export function useAddDataPermissions() {
+  const { data: databasesResponse } = useListDatabasesQuery();
+  const userCanAccessSettings = useSelector(canAccessSettings);
+  const isAdmin = useSelector(getUserIsAdmin);
+  const databases = databasesResponse?.data;
+  const uploadDbId = useSetting("uploads-settings")?.db_id;
+  const uploadDB = databases?.find((db) => db.id === uploadDbId);
+
+  /**
+   * This covers the case where instance has the attached dwh. In such cases
+   * uploads are enabled by default.
+   */
+  const areUploadsEnabled = !!uploadDbId;
+  const canUploadToDatabase = !!uploadDB?.can_upload;
+  const canManageUploads = userCanAccessSettings;
+  const canPerformMeaningfulActions =
+    canUploadToDatabase || canManageUploads || isAdmin;
+
+  return {
+    areUploadsEnabled,
+    canUploadToDatabase,
+    canManageUploads,
+    canPerformMeaningfulActions,
+    isAdmin,
+  };
+}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/use-add-data-permission.unit.spec.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/use-add-data-permission.unit.spec.ts
@@ -1,0 +1,96 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import {
+  setupDatabaseListEndpoint,
+  setupTokenStatusEndpoint,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { createMockEntitiesState } from "__support__/store";
+import { renderHookWithProviders, waitFor } from "__support__/ui";
+import type { UserWithApplicationPermissions } from "metabase/plugins";
+import {
+  createMockDatabase,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { useAddDataPermissions } from "./use-add-data-permission";
+
+function setup({
+  isSuperUser = false,
+  canUpload = false,
+  canAccessSettings = false,
+}) {
+  const database = createMockDatabase({
+    uploads_enabled: canUpload,
+    can_upload: canUpload,
+  });
+  const currentUser = createMockUser({
+    is_superuser: isSuperUser,
+  });
+
+  if (canAccessSettings) {
+    (currentUser as UserWithApplicationPermissions).permissions = {
+      can_access_setting: true,
+      can_access_monitoring: false,
+      can_access_subscription: false,
+    };
+  }
+  setupTokenStatusEndpoint({ valid: true });
+
+  if (canAccessSettings) {
+    // enterprise plugin is needed for advanced permissions to be returned
+    setupEnterprisePlugins();
+  }
+
+  const storeInitialState = createMockState({
+    currentUser,
+    entities: createMockEntitiesState({
+      databases: [database],
+      collections: [],
+    }),
+    settings: mockSettings({
+      "token-features": createMockTokenFeatures({
+        advanced_permissions: true,
+      }),
+      "uploads-settings": {
+        db_id: database.id,
+        schema_name: "uploads",
+        table_prefix: "uploaded_",
+      },
+    }),
+  });
+
+  setupDatabaseListEndpoint([database]);
+
+  return renderHookWithProviders(() => useAddDataPermissions(), {
+    storeInitialState,
+  });
+}
+
+describe("correctly sets canPerformMeaningfulActions", () => {
+  const testCases = [
+    {
+      description: "admin user can perform meaningful actions",
+      data: { isSuperUser: true },
+    },
+    {
+      description: "user who can upload can perform meaningful actions",
+      data: { canUpload: true },
+    },
+    {
+      description: "user with settings access can perform meaningful actions",
+      data: { canAccessSettings: true },
+    },
+  ];
+
+  it.each(testCases)("$description", async (testCase) => {
+    const { result } = setup(testCase.data);
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({ canPerformMeaningfulActions: true }),
+      );
+    });
+  });
+});

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.ts
@@ -1,3 +1,5 @@
+import type { Database } from "metabase-types/api";
+
 const validTabArray = ["db", "csv", "gsheets"] as const;
 const validTabs = new Set<string>(validTabArray);
 
@@ -5,3 +7,29 @@ type AddDataTab = (typeof validTabArray)[number];
 
 export const isValidTab = (v: string | null): v is AddDataTab =>
   typeof v === "string" && validTabs.has(v);
+
+export function shouldShowUploadPanel({
+  allDatabases = [],
+  allUploadableDatabases = [],
+}: {
+  allDatabases: Database[] | undefined;
+  allUploadableDatabases: Database[] | undefined;
+}) {
+  if (!allUploadableDatabases || !allDatabases) {
+    return false;
+  }
+
+  if (allUploadableDatabases.length === 0) {
+    return false;
+  }
+
+  if (
+    allUploadableDatabases.length === 1 &&
+    allDatabases.length > 1 &&
+    allUploadableDatabases[0]?.engine === "h2"
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.ts
@@ -8,17 +8,19 @@ type AddDataTab = (typeof validTabArray)[number];
 export const isValidTab = (v: string | null): v is AddDataTab =>
   typeof v === "string" && validTabs.has(v);
 
-export function shouldShowUploadPanel({
+export function hasMeaningfulUploadableDatabases({
   allDatabases = [],
   allUploadableDatabases = [],
 }: {
   allDatabases: Database[] | undefined;
   allUploadableDatabases: Database[] | undefined;
 }) {
+  // if there are no uploadable databases or no databases, return false
   if (!allUploadableDatabases?.length || !allDatabases) {
     return false;
   }
 
+  // if we have more than one database and the only uploadable database is h2, return false
   if (
     allUploadableDatabases.length === 1 &&
     allDatabases.length > 1 &&
@@ -27,5 +29,6 @@ export function shouldShowUploadPanel({
     return false;
   }
 
+  // we have some meaningful uploadable databases, return true
   return true;
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.ts
@@ -15,11 +15,7 @@ export function shouldShowUploadPanel({
   allDatabases: Database[] | undefined;
   allUploadableDatabases: Database[] | undefined;
 }) {
-  if (!allUploadableDatabases || !allDatabases) {
-    return false;
-  }
-
-  if (allUploadableDatabases.length === 0) {
+  if (!allUploadableDatabases?.length || !allDatabases) {
     return false;
   }
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.unit.spec.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.unit.spec.ts
@@ -1,6 +1,6 @@
 import { createMockDatabase } from "metabase-types/api/mocks";
 
-import { shouldShowUploadPanel } from "./utils";
+import { hasMeaningfulUploadableDatabases } from "./utils";
 
 const h2 = createMockDatabase({
   id: 1,
@@ -55,11 +55,11 @@ const testCases = [
   },
 ];
 
-describe("useShowUploadPanel", () => {
+describe("hasMeaningfulUploadableDatabases", () => {
   it.each(testCases)(
     "should return $result when $description",
     ({ result, data }) => {
-      expect(shouldShowUploadPanel(data)).toBe(result);
+      expect(hasMeaningfulUploadableDatabases(data)).toBe(result);
     },
   );
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.unit.spec.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils.unit.spec.ts
@@ -1,0 +1,65 @@
+import { createMockDatabase } from "metabase-types/api/mocks";
+
+import { shouldShowUploadPanel } from "./utils";
+
+const h2 = createMockDatabase({
+  id: 1,
+  name: "Db Uno",
+  engine: "h2",
+});
+
+const postgres = createMockDatabase({
+  id: 2,
+  name: "Db Dos",
+  engine: "postgres",
+});
+
+const athena = createMockDatabase({
+  id: 3,
+  name: "Db Tres",
+  engine: "athena",
+});
+
+const testCases = [
+  {
+    description: "there are no uploadable databases",
+    result: false,
+    data: {
+      allDatabases: [],
+      allUploadableDatabases: [],
+    },
+  },
+  {
+    description: "there is only one uploadable database and it is h2",
+    result: true,
+    data: {
+      allDatabases: [h2],
+      allUploadableDatabases: [h2],
+    },
+  },
+  {
+    description: "multiple databases but h2 is only uploadable",
+    result: false,
+    data: {
+      allDatabases: [h2, athena],
+      allUploadableDatabases: [h2],
+    },
+  },
+  {
+    description: "with non-h2 uploadable databases",
+    result: true,
+    data: {
+      allDatabases: [postgres, athena],
+      allUploadableDatabases: [postgres],
+    },
+  },
+];
+
+describe("useShowUploadPanel", () => {
+  it.each(testCases)(
+    "should return $result when $description",
+    ({ result, data }) => {
+      expect(shouldShowUploadPanel(data)).toBe(result);
+    },
+  );
+});

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BrowseNavSection.tsx
@@ -19,6 +19,8 @@ import { PaddedSidebarLink, SidebarHeading } from "../MainNavbar.styled";
 import { trackAddDataModalOpened } from "../analytics";
 import type { SelectedItem } from "../types";
 
+import { useAddDataPermissions } from "./AddDataModal/use-add-data-permission";
+
 export const BrowseNavSection = ({
   nonEntityItem,
   onItemSelect,
@@ -38,8 +40,8 @@ export const BrowseNavSection = ({
     "expand-browse-in-nav",
   );
 
+  const { canPerformMeaningfulActions } = useAddDataPermissions();
   const [opened, { toggle }] = useDisclosure(expandBrowse);
-
   const entityTypes = useSelector(getEntityTypes);
   const isEmbeddingIframe = useSelector(getIsEmbeddingIframe);
 
@@ -47,6 +49,8 @@ export const BrowseNavSection = ({
     toggle();
     setExpandBrowse(!opened);
   };
+
+  const showAddDataButton = canPerformMeaningfulActions && !isEmbeddingIframe;
 
   return (
     <div aria-selected={opened} role="tab">
@@ -64,7 +68,7 @@ export const BrowseNavSection = ({
           </SidebarHeading>
           <Icon name={opened ? "chevrondown" : "chevronright"} size={8} />
         </Group>
-        {!isEmbeddingIframe && (
+        {showAddDataButton && (
           <Button
             aria-label="Add data"
             variant="subtle"

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/GettingStartedSection.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/GettingStartedSection.tsx
@@ -9,6 +9,8 @@ import { PaddedSidebarLink, SidebarHeading } from "../MainNavbar.styled";
 import { trackOnboardingChecklistOpened } from "../analytics";
 import type { SelectedItem } from "../types";
 
+import { useAddDataPermissions } from "./AddDataModal/use-add-data-permission";
+
 export const GettingStartedSection = ({
   nonEntityItem,
   onAddDataModalOpen,
@@ -17,6 +19,7 @@ export const GettingStartedSection = ({
   nonEntityItem: SelectedItem;
   onAddDataModalOpen: () => void;
 }>) => {
+  const { canPerformMeaningfulActions } = useAddDataPermissions();
   const [opened, { toggle }] = useDisclosure(true);
 
   const ONBOARDING_URL = "/getting-started";
@@ -43,9 +46,11 @@ export const GettingStartedSection = ({
         role="tabpanel"
         aria-expanded={opened}
       >
-        <PaddedSidebarLink icon="add_data" onClick={onAddDataModalOpen}>
-          {t`Add data`}
-        </PaddedSidebarLink>
+        {canPerformMeaningfulActions && (
+          <PaddedSidebarLink icon="add_data" onClick={onAddDataModalOpen}>
+            {t`Add data`}
+          </PaddedSidebarLink>
+        )}
 
         <PaddedSidebarLink
           icon="learn"

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/GettingStartedSection.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/GettingStartedSection.unit.spec.tsx
@@ -1,14 +1,17 @@
 import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
+import { createMockUser } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
 import { GettingStartedSection } from "./GettingStartedSection";
 
 const setup = ({
   hasChildren = true,
+  isAdmin = true,
 }: {
   hasChildren?: boolean;
+  isAdmin?: boolean;
 } = {}) => {
   const onAddDataModalOpen = jest.fn();
 
@@ -19,7 +22,11 @@ const setup = ({
     >
       {hasChildren && "Child"}
     </GettingStartedSection>,
-    { storeInitialState: createMockState() },
+    {
+      storeInitialState: createMockState({
+        currentUser: createMockUser({ is_superuser: isAdmin }),
+      }),
+    },
   );
 
   return { onAddDataModalOpen };
@@ -51,6 +58,11 @@ describe("GettingStartedSection", () => {
   it("should render the 'Add data' button", () => {
     setup();
     expect(screen.getByLabelText("Add data")).toBeInTheDocument();
+  });
+
+  it("should not render the 'Add data' button if the user is not an admin", () => {
+    setup({ isAdmin: false });
+    expect(screen.queryByLabelText("Add data")).not.toBeInTheDocument();
   });
 
   it("should trigger the modal on 'Add data' click", async () => {


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-125/remove-csv-upload-option-for-dbs-that-dont-have-csv-upload-support

### Description

- introduce rules that hide/show CSV panel depending on connected dbs that support uploads
- refactor AddDataModal tabs

### How to verify

- see if the panel is visible for H2 only
- see if the panel is hidden for a db that doesn't support uploads (e.g. Athena) and H2
- see if panel is visible if DB that supports uploads is added (e.g. Postgres)

Additionally we hide add data panel completely, when user cannot do anything meaningful there. What does _meaningful_ mean:
- upload data to already setup DB 
- adjust settings that would of DBS (add database, allow enable data upload).

### Demo

https://www.loom.com/share/71a3b29555494eb6979ebb5f025b475b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
