### PR TITLE
ci: use openldap from legacy registry

### DIFF
--- a/docs/troubleshooting-guide/ldap.md
+++ b/docs/troubleshooting-guide/ldap.md
@@ -36,7 +36,7 @@ services:
       - "MB_LDAP_ATTRIBUTE_FIRSTNAME=uid"
       - "MB_LDAP_ATTRIBUTE_LASTNAME=sn"
   openldap:
-    image: bitnami/openldap:2.4.57
+    image: bitnamilegacy/openldap:2.4.57
     hostname: openldap
     container_name: openldap
     ports:

--- a/e2e/support/helpers/e2e-ldap-helpers.js
+++ b/e2e/support/helpers/e2e-ldap-helpers.js
@@ -6,7 +6,7 @@
       --env LDAP_PASSWORDS=123456,123465 \
       --env LDAP_ROOT=dc=example,dc=org \
       --env LDAP_PORT_NUMBER=389 \
-      bitnami/openldap:2.6.4
+      bitnamilegacy/openldap:2.6.4
  */
 export const setupLdap = () => {
   cy.log("Set up LDAP mock server");

--- a/e2e/test/scenarios/docker-compose.yml
+++ b/e2e/test/scenarios/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - ./maildev-keys:/keys
 
   ldap:
-    image: bitnami/openldap:2.6.4
+    image: bitnamilegacy/openldap:2.6.4
     ports:
       - "389:389"
     environment:


### PR DESCRIPTION
https://hub.docker.com/r/bitnami/openldap
https://github.com/bitnami/containers/issues/83267

TL;DR they moved a package to legacy registry and removed tags from main registry. package will not get updates anymore