### PR TITLE
Update Metabot profile IDs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
@@ -13,9 +13,9 @@
 
 (def metabot-config
   "The name of the collection exposed by the answer-sources tool."
-  {internal-metabot-id {:profile-id "experimental"
+  {internal-metabot-id {:profile-id "internal"
                         :entity-id "metabotmetabotmetabot"}
-   embedded-metabot-id {:profile-id "default"
+   embedded-metabot-id {:profile-id "embedding"
                         :entity-id "embeddedmetabotmetabo"}})
 
 (defn metabot-profile-id


### PR DESCRIPTION
## Context

Metabot currently uses the `experimental` profile which falls back to a beta customer configuration. That one does NOT include the search tool anymore. 

This PR updates the Metabot profile IDs to new ones where the `internal` one actually uses the search tool