### PR TITLE
Fix store default value

### DIFF
--- a/src/metabase/cloud_migration/settings.clj
+++ b/src/metabase/cloud_migration/settings.clj
@@ -25,7 +25,7 @@
 (defn- store-url-default
   "Returns the default store URL, with support for environment variable override in dev mode only."
   []
-  (if-some [env-url (and config/is-dev? (config/config-str :mb-store-url))]
+  (if-some [env-url (when config/is-dev? (config/config-str :mb-store-url))]
     (str env-url)
     (str "https://store" (when (default-to-staging?) ".staging") ".metabase.com")))
 

--- a/test/metabase/cloud_migration/models/cloud_migration_test.clj
+++ b/test/metabase/cloud_migration/models/cloud_migration_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase.cloud-migration.models.cloud-migration :as cloud-migration]
    [metabase.cloud-migration.settings :as cloud-migration.settings]
+   [metabase.config.core :as config]
    [metabase.task.core :as task]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
@@ -95,3 +96,28 @@
   (mt/with-temporary-setting-values [read-only-mode true]
     (cloud-migration.settings/read-only-mode! true)
     (mt/client :post 200 "session" (mt/user->credentials :rasta))))
+
+(deftest ^:synchronized store-url-test
+  (testing "When not dev"
+    (testing "get production store"
+      (with-redefs [config/is-dev? false]
+        (is (= "https://store.metabase.com" (#'cloud-migration.settings/store-url-default)))))
+    (testing "Can force it with :mb-store-use-staging"
+      (with-redefs [config/is-dev? false
+                    config/config-bool (fn [k] (when (= k :mb-store-use-staging) true))]
+        (is (= "https://store.staging.metabase.com" (#'cloud-migration.settings/store-url-default))))))
+  (testing "When dev"
+    (with-redefs [config/is-dev? true]
+      (testing "uses staging url"
+        (is (= "https://store.staging.metabase.com" (#'cloud-migration.settings/store-url-default))))
+      (testing "But can force to prod"
+        (with-redefs [config/config-bool (fn [k] (when (= k :mb-store-use-staging) false))]
+          (is (= "https://store.metabase.com" (#'cloud-migration.settings/store-url-default)))))))
+  (testing "with custom url is set"
+    (with-redefs [config/config-str (fn [k] (when (= k :mb-store-url) "https://custom.store.com"))]
+      (testing "in dev is honored"
+        (with-redefs [config/is-dev? true]
+          (is (= "https://custom.store.com" (#'cloud-migration.settings/store-url-default)))))
+      (testing "not in dev is not honored"
+        (with-redefs [config/is-dev? false]
+          (is (= "https://store.metabase.com" (#'cloud-migration.settings/store-url-default))))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/62869

in dev, the default value was the staging store. When not in dev, the default value of this url was "false"

```
❯ http get http://localhost:3056/api/session/properties Cookie:"metabase.SESSION=d10a4524-837e-4aaf-84a3-b2f99bc9ecb2" | jq '."store-url"'
"false"
```

In javascript, most of the store url stuff is through

```javascript
export function useStoreUrl(storePath: StorePaths = "") {
  return useSelector((state) => getStoreUrl(state, storePath));
}
```

which is based on `getStoreUrl` which is

```javascript
const DEFAULT_STORE_URL = "https://store.metabase.com/";

...

export function getStoreUrl(state: State, path: StorePaths = "") {
  try {
    const storeUrl = getSetting(state, "store-url");
    const url = new URL(path, storeUrl);
    return url.toString();
  } catch {
    return DEFAULT_STORE_URL;
  }
}
```

So what happens normally is:
1. in dev, we usually have no setting set for this, so the `when-some` hits nil. If you do have something there, it is honored.
```clojure
(defn- store-url-default
  "Returns the default store URL, with support for environment variable override in dev mode only."
  []
  (if-some [env-url (and config/is-dev? (config/config-str :mb-store-url))]
    ;;                   ^^ boolean     ^^ usually blank
    (str env-url)
    (str "https://store" (when (default-to-staging?) ".staging") ".metabase.com")))
```
That `config/is-dev?` is true and then the `:mb-store-url` is either nil or a valid string. But when `config/is-dev?` is _false_, that's a value so satisfies `if-some` and that value is returned. So rather than the store url we get `false` which is later turned into a string since the setting type is of string.
2. In prod, we read false for the config/is-dev and we use that as the setting value

```clojure
settings=> (with-redefs [config/is-dev? false]
             (store-url-default))
"false"
```

3. There are lots of usages of this on the frontend. But they are all protected by the try/catch and returning the default store. This is LOAD BEARING in production.

```javascript
new URL("false", null)
Uncaught TypeError: Failed to construct 'URL': Invalid base URL
```

4. Cloud migration does something slightly different and so fails to get this load bearing try/catch. It takes a `checkoutUrl` in its props:

```javascript
export const MigrationSuccess = ({
  migration,
  restartMigration,
  isRestarting,
  checkoutUrl,
}: MigrationSuccessProps) => {
```

This manually constructs a url:

```javascript
  const checkoutUrl = useMemo(() => {
    return migration
      ? `${storeUrl}/checkout?migration-id=${migration.external_id}`
      : `${storeUrl}/checkout`;
  }, [migration, storeUrl]);
```

And now we don't have the benefit of the `URL(base, extension)` which would have (dumbly) failed closed. So now we end up with `false/checkout?...` and then get a "We're a bit lost" locally

So to recap:
we do the right thing in dev, and then production is broken. Most pathways were just catching this error, one way constructed a url fragment and therefore was susceptible.

```clojure
settings=> (with-redefs [config/is-dev? false]
             (store-url-default))
"false"
settings=> (store-url-default)
"https://store.staging.metabase.com"
```
