### PR TITLE
Fix the default value for `case-sensitive` for string filter clauses

### DIFF
--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -291,7 +291,7 @@
   (expression-clause-with-in operator (into [column] values)
                              (if (#{:is-empty :not-empty := :!=} operator)
                                {}
-                               options)))
+                               {:case-sensitive (:case-sensitive options false)})))
 
 (mu/defn string-filter-parts :- [:maybe StringFilterParts]
   "Destructures a string filter clause created by [[string-filter-clause]]. Returns `nil` if the clause does not match

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -439,7 +439,7 @@
             filter-parts  (lib.fe-util/string-filter-parts query -1 filter-clause)]
         (is (=? {:field-id (meta/id :venues :name)}
                 (lib.field/field-values-search-info query (:column filter-parts))))))
-    (testing "should create case-insensitive filter clauses unless `case-sensitive` is explicitly set to `false`"
+    (testing "should create case-insensitive filter clauses unless `case-sensitive` is explicitly set to `true`"
       (doseq [operator [:contains :does-not-contain :starts-with :ends-with]]
         (are [expected options] (=? expected (lib/options (lib.fe-util/string-filter-clause operator column ["A"] options)))
           {:case-sensitive false} {}

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -438,7 +438,13 @@
             filter-clause (lib/= (m/find-first #(= (:name %) "NAME") (lib/filterable-columns query)) "test")
             filter-parts  (lib.fe-util/string-filter-parts query -1 filter-clause)]
         (is (=? {:field-id (meta/id :venues :name)}
-                (lib.field/field-values-search-info query (:column filter-parts))))))))
+                (lib.field/field-values-search-info query (:column filter-parts))))))
+    (testing "should create case-insensitive filter clauses unless `case-sensitive` is explicitly set to `false`"
+      (doseq [operator [:contains :does-not-contain :starts-with :ends-with]]
+        (are [expected options] (=? expected (lib/options (lib.fe-util/string-filter-clause operator column ["A"] options)))
+          {:case-sensitive false} {}
+          {:case-sensitive false} {:case-sensitive false}
+          {:case-sensitive true} {:case-sensitive true})))))
 
 (deftest ^:parallel number-filter-parts-test
   (let [query         (lib.tu/venues-query)


### PR DESCRIPTION
Fixes https://metaboat.slack.com/archives/C05NXACAG1G/p1756304649942349

Instead of trying to change every place where the FE uses MBQL lib to pass `caseSensitive: false`, this PR fixes the issue in the lib itself.  This is the same as what we do in `string-filter-parts` already https://github.com/metabase/metabase/blob/ee60713c05f9e1700aaf6be81b90855f1e6a8cd8/src/metabase/lib/fe_util.cljc#L322, where we correctly convert `nil` to the actual value