### PR TITLE
Use container padding to provide space between items in entity picker 

### DIFF
--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -436,7 +436,7 @@ describe("issue 28106", () => {
           .findByTestId("scroll-container")
           .as("schemasList");
 
-        scrollAllTheWayDown();
+        cy.get("@schemasList").scrollTo("bottom");
 
         // assert scrolling worked and the last item is visible
         H.entityPickerModalItem(1, "Schema Z").should("be.visible");
@@ -455,23 +455,6 @@ describe("issue 28106", () => {
       });
     },
   );
-
-  // The list is virtualized and the scrollbar height changes during scrolling (metabase#44966)
-  // that's why we need to scroll and wait multiple times.
-  function scrollAllTheWayDown() {
-    cy.get("@schemasList").realMouseWheel({ deltaY: 100 });
-    cy.wait(100);
-
-    cy.get("@schemasList").then(($element) => {
-      const list = $element[0];
-      const isScrolledAllTheWayDown =
-        list.scrollHeight - list.scrollTop === list.clientHeight;
-
-      if (!isScrolledAllTheWayDown) {
-        scrollAllTheWayDown();
-      }
-    });
-  }
 });
 
 // Needs to be OSS because EE will always have models due to instance analytics

--- a/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
@@ -7,6 +7,7 @@ import { PLUGIN_MODERATION } from "metabase/plugins";
 import { LoadingAndErrorWrapper } from "metabase/public/containers/PublicAction/PublicAction.styled";
 import {
   Box,
+  type BoxProps,
   Center,
   Flex,
   Icon,
@@ -35,6 +36,7 @@ interface ItemListProps<
   shouldDisableItem?: (item: Item) => boolean;
   shouldShowItem?: (item: Item) => boolean;
   navLinkProps?: (isSelected?: boolean) => NavLinkProps;
+  containerProps?: BoxProps;
 }
 
 export const ItemList = <
@@ -52,6 +54,7 @@ export const ItemList = <
   shouldDisableItem,
   shouldShowItem,
   navLinkProps,
+  containerProps = { pb: "xs" },
 }: ItemListProps<Id, Model, Item>) => {
   const filteredItems =
     items && shouldShowItem ? items.filter(shouldShowItem) : items;
@@ -84,19 +87,28 @@ export const ItemList = <
   }
 
   return (
-    <VirtualizedList Wrapper={PickerColumn} scrollTo={activeItemIndex}>
+    <VirtualizedList
+      Wrapper={PickerColumn}
+      scrollTo={activeItemIndex}
+      estimatedItemSize={37}
+    >
       {filteredItems.map((item: Item) => {
         const isSelected = isSelectedItem(item, selectedItem);
         const icon = getEntityPickerIcon(item, isSelected && isCurrentLevel);
 
         return (
-          <div data-testid="picker-item" key={`${item.model}-${item.id}`}>
+          <Box
+            data-testid="picker-item"
+            key={`${item.model}-${item.id}`}
+            {...containerProps}
+          >
             <NavLink
               w={"auto"}
               disabled={shouldDisableItem?.(item)}
               rightSection={
                 isFolder(item) ? <Icon name="chevronright" size={10} /> : null
               }
+              mb={0}
               label={
                 <Flex align="center">
                   {item.name}{" "}
@@ -116,10 +128,9 @@ export const ItemList = <
                 onClick(item);
               }}
               variant={isCurrentLevel ? "default" : "mb-light"}
-              mb="xs"
               {...navLinkProps?.(isSelected)}
             />
-          </div>
+          </Box>
         );
       })}
     </VirtualizedList>

--- a/frontend/src/metabase/common/components/Pickers/DataPicker/components/DatabaseList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/DataPicker/components/DatabaseList.tsx
@@ -52,10 +52,12 @@ export const DatabaseList = ({
         selectedItem={selectedItem}
         onClick={onClick}
         shouldDisableItem={(item) => shouldDisableItem?.(item) || false}
+        containerProps={{
+          pb: "1rem",
+        }}
         navLinkProps={(isSelected) => ({
           px: "1.5rem",
           py: "1.25rem",
-          mb: "1rem",
           rightSection: null,
           style: {
             border: isSelected ? undefined : "1px solid var(--mb-color-border)",


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #44966
### Description
Using margin to space the items in entity picker lists was causing the height calculation to be incorrect for the virtualized list. This change uses padding in the container element instead

### How to verify

1. Open the entity picker, and go to a collection with many items (or a database with many tables)
2. grab the scroll bar of the large list, and drag it up and down, the scrollbar should stay attached to the mouse without drifting

### Demo

https://github.com/user-attachments/assets/5ceeb088-2f11-4236-8b31-b19e6cdce228

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
