### PR TITLE
Fix: Translation issue in filters and graphical display #34942

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.ts
@@ -12,8 +12,11 @@ import type {
   ColumnSettings,
 } from "metabase/visualizations/types";
 import { COMPARISON_TYPES } from "metabase/visualizations/visualizations/SmartScalar/constants";
-import { formatChange } from "metabase/visualizations/visualizations/SmartScalar/utils";
-import * as Lib from "metabase-lib";
+import {
+  formatChange,
+  formatPreviousPeriodOptionName,
+} from "metabase/visualizations/visualizations/SmartScalar/utils";
+import type { ClickObject } from "metabase-lib";
 import { isDate } from "metabase-lib/v1/types/utils/isa";
 import type {
   DatasetColumn,
@@ -53,7 +56,7 @@ interface DateUnitSettings {
 }
 
 interface MetricData {
-  clicked: Lib.ClickObject;
+  clicked: ClickObject;
   date: string;
   dateUnitSettings: DateUnitSettings;
   formatOptions: ColumnSettings;
@@ -287,7 +290,7 @@ function getCurrentMetricData({
     compact: settings["scalar.compact_primary_number"],
   };
 
-  const clicked: Lib.ClickObject = {
+  const clicked: ClickObject = {
     value,
     column: cols[metricColIndex],
     dimensions: [
@@ -502,10 +505,6 @@ function computeComparisonPeriodsAgo({
   dateUnitSettings: DateUnitSettings;
   dateUnitsAgo: number;
 }) {
-  const dateUnitDisplay = Lib.describeTemporalUnit(
-    dateUnitSettings.dateUnit,
-  ).toLowerCase();
-
   const computedPrevDate = dayjs
     .parseZone(nextDate)
     .subtract(dateUnitsAgo, dateUnitSettings.dateUnit)
@@ -521,12 +520,19 @@ function computeComparisonPeriodsAgo({
     rows,
   });
 
+  const getPreviousPeriodStr = () => {
+    const { dateUnit } = dateUnitSettings;
+    const previousPeriodStr =
+      dateUnit && formatPreviousPeriodOptionName(dateUnit);
+    return (previousPeriodStr || t`Previous`).toLocaleLowerCase();
+  };
+
   const prevDate = !isEmpty(rowPeriodsAgo)
     ? (rowPeriodsAgo?.[dimensionColIndex] as string)
     : computedPrevDate;
   const comparisonDescStr =
     dateUnitsAgo === 1
-      ? t`vs. previous ${dateUnitDisplay}`
+      ? t`vs. ${getPreviousPeriodStr()}`
       : computeComparisonStrPreviousValue({
           dateUnitSettings,
           nextDate,

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -378,7 +378,7 @@ function createComparisonMenuOption(
   return COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE;
 }
 
-function formatPreviousPeriodOptionName(dateUnit: DateTimeAbsoluteUnit) {
+export function formatPreviousPeriodOptionName(dateUnit: DateTimeAbsoluteUnit) {
   switch (dateUnit) {
     case "minute":
       return t`Previous minute`;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34942
Closes [UXW-57](https://linear.app/metabase/issue/UXW-57)

### Description

Updates SmartScalar comparison text so it reuses existing, localizable strings.

<img width="1312" height="744" alt="Screenshot 2025-08-28 at 3 53 46 PM" src="https://github.com/user-attachments/assets/44fe495b-4f52-4202-9e49-f998f1bb78c5" />

### How to verify

1. Create a Trend visualization grouped by time (e.g. Orders > Summarize: Count by Created At)
2. Change your language to French
3. Verify "vs. previous year" is translated as "vs. année précédente"
4. Change the period (e.g. "Mois" (month))
5. Verify "vs. previous month" is translated as "vs. mois précédent"*

\* - In general, the visualization "vs." text should match what's selected in the sidebar

### Demo

<img width="1312" height="744" alt="Screenshot 2025-08-28 at 3 49 57 PM" src="https://github.com/user-attachments/assets/918a83d9-b8ad-4591-9a94-0cc2cab1762c" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
