### PR TITLE
Fix time-interval filters

### DIFF
--- a/src/metabase/query_processor/parameters/dates.clj
+++ b/src/metabase/query_processor/parameters/dates.clj
@@ -253,7 +253,7 @@
               (let [last-unit (t/minus (maybe-reduce-resolution unit dt) (to-period 1))]
                 (unit-range last-unit last-unit)))
     :filter (fn [{:keys [unit]} field-clause]
-              [:time-interval field-clause :last (keyword unit)])}
+              (lib/time-interval field-clause :last (keyword unit)))}
 
    {:parser (regex->parser (re-pattern (str #"this" temporal-units-regex))
                            [:unit])
@@ -261,7 +261,7 @@
               (let [dt-adj (maybe-reduce-resolution unit dt)]
                 (unit-range dt-adj dt-adj)))
     :filter (fn [{:keys [unit]} field-clause]
-              [:time-interval field-clause :current (keyword unit)])}])
+              (lib/time-interval field-clause :current (keyword unit)))}])
 
 (defn- ->iso-8601-date [t]
   (t/format :iso-local-date t))

--- a/test/metabase/query_processor/parameters/dates_test.clj
+++ b/test/metabase/query_processor/parameters/dates_test.clj
@@ -104,6 +104,32 @@
              "past3days~"
              [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"])))))
 
+(deftest ^:parallel date-string->filter-test-9a
+  ;; metabase.lib.schema.temporal-bucketing/datetime-interval-units
+  (doseq [unit #{:day :hour :millisecond :minute :month :quarter :second :week :year}]
+    (testing "relative (last)"
+      (is (=? [:time-interval
+               {}
+               [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"]
+               :last
+               unit]
+              (params.dates/date-string->filter
+               (str "last" (name unit))
+               [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"]))))))
+
+(deftest ^:parallel date-string->filter-test-9b
+  ;; metabase.lib.schema.temporal-bucketing/datetime-interval-units
+  (doseq [unit #{:day :hour :millisecond :minute :month :quarter :second :week :year}]
+    (testing "relative (current)"
+      (is (=? [:time-interval
+               {}
+               [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"]
+               :current
+               unit]
+              (params.dates/date-string->filter
+               (str "this" (name unit))
+               [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"]))))))
+
 (deftest ^:parallel date-string->filter-test-10
   (testing "relative (next) exclusive"
     (is (=? [:time-interval


### PR DESCRIPTION
Reported on stats that the examples dashboard was breaking when you used some relative timestamps. There it was a bit cryptic with

```
class java.lang.Integer cannot be cast to class
clojure.lang.IPersistentMap (java.lang.Integer is in module java.base of
loader 'bootstrap'; clojure.lang.IPersistentMap is in unnamed module of
loader 'app')
```

Locally in dev, we get:

```
 Error processing query: Invalid output: ["invalid tuple size 4, expected 5, got: [:time-interval [:field {:base-type :type/DateTime, :lib/uuid \"69655229-95a0-4bfb-9d3a-7675b1111ec4\"} 13] :current :day]"]
```

And it's a failure to have the time-interval options

before:
`[:time-interval field-clause :last (keyword unit)]` after:
`[:time-interval interval-options field-clause :last (keyword unit)]`

spec:

```
(mbql-clause/define-mbql-clause :time-interval :- :type/Boolean
  ;; TODO -- we should probably further constrain this so you can't do weird stuff like
  ;;
  ;;    [:time-interval {} <time> :current :year]
  ;;
  ;; using units that don't agree with the expr type
  [:tuple
   [:= {:decode/normalize common/normalize-keyword} :time-interval]
   [:merge ::common/options ::time-interval-options]  ;; <---- missing bits
   #_expr [:ref ::expression/temporal]
   #_n    [:multi
           {:dispatch (some-fn keyword? string?)}
           [true  [:enum {:decode/normalize common/normalize-keyword} :current :last :next]]
           ;; I guess there's no reason you shouldn't be able to do something like 1 + 2 in here
           [false [:ref ::expression/integer]]]
   #_unit [:ref ::temporal-bucketing/unit.date-time.interval]])
```

Switching them to lib calls and then i noticed there were no tests.

With fix:

```clojure
dates=> (date-string->filter
          "lastmonth"
          [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"])
[:time-interval
 {:lib/uuid "bbca7a83-feb9-4259-a4db-bbb79687eb4e"}  ;; <------- missing on master, not required on 56
 [:field
  {:lib/uuid "00000000-0000-0000-0000-000000000000",
   :base-type :type/DateTime}
  "field"]
 :last
 :month]
```

In a 56.3.4 repl:
```
user=> (metabase.driver.common.parameters.dates/date-string->filter "lastmonth" [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"])
[:time-interval [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"] :last :month]
user=> (pp)
[:time-interval
 [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"]
 :last
 :month]
nil
```

Note the missing options in the second position

#### Before (master)
<img width="1507" height="967" alt="image" src="https://github.com/user-attachments/assets/fb541e63-4948-43b6-bf65-7d3c2b3188aa" />

#### After (this PR)
<img width="1509" height="969" alt="image" src="https://github.com/user-attachments/assets/53fd57db-5260-4e22-80c8-20e1463d526d" />

#### 56.4.3 (unaffected by bug)
<img width="1240" height="1121" alt="image" src="https://github.com/user-attachments/assets/5e92be83-5076-45ae-8c91-a7cc68537a15" />
