### PR TITLE
Return explicit errors when trying to edit a table without a PK

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/action_v2/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/data_editing.clj
@@ -108,7 +108,8 @@
   [table-id input-rows]
   (let [input-keys  (into #{} (mapcat keys) input-rows)
         field-names (map name input-keys)
-        fields      (t2/select :model/Field :table_id table-id :name [:in field-names])
+        fields      (when (seq field-names)
+                      (t2/select :model/Field :table_id table-id :name [:in field-names]))
         coerce-fn   (->> (for [{field-name :name, :keys [coercion_strategy, semantic_type]} fields
                                :when (not (isa? semantic_type :type/PK))]
                            [(keyword field-name)

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -304,6 +304,8 @@
   (log/tracef "Deleting %s" query)
   (let [db-id      (u/the-id database)
         table-id   (-> query :query :source-table)
+        ;; We'd error anyway, about not having a filter, but this fails earlier with a more explicit error
+        _           (assert-pk! db-id table-id)
         row-before (atom nil)
         driver               (:engine database)
         {:keys [from where]} (mbql-query->raw-hsql driver query)
@@ -353,16 +355,19 @@
 
 (defn- row-update!* [action database {:keys [update-row] :as query}]
   (log/tracef "updating %s" query)
-  (let [driver               (:engine database)
-        source-table         (get-in query [:query :source-table])
+  (let [driver      (:engine database)
+        db-id       (u/the-id database)
+        table-id    (get-in query [:query :source-table])
+        ;; We'd error anyway, about not having a filter, but this fails earlier with a more explicit error
+        _           (assert-pk! db-id table-id)
         {:keys [from where]} (mbql-query->raw-hsql driver query)
-        update-hsql          (-> {:update (first from)
-                                  :set    (cast-values driver update-row (u/the-id database) source-table)
-                                  :where  where}
-                                 (prepare-query driver action))
-        sql-args             (sql.qp/format-honeysql driver update-hsql)]
+        update-hsql (-> {:update (first from)
+                         :set    (cast-values driver update-row db-id table-id)
+                         :where  where}
+                        (prepare-query driver action))
+        sql-args    (sql.qp/format-honeysql driver update-hsql)]
     (log/tracef "hsql: %s" (u/pprint-to-str update-hsql))
-    (with-jdbc-transaction [conn (u/the-id database)]
+    (with-jdbc-transaction [conn db-id]
       (let [table-id     (-> query :query :source-table)
             row-before   (->> (prepare-query {:select [:*] :from from :where where} driver action)
                               (query-rows-correct-name driver conn table-id)
@@ -379,7 +384,7 @@
                               (query-rows-correct-name driver conn table-id)
                               first)]
         {:table-id (-> query :query :source-table)
-         :db-id    (u/the-id database)
+         :db-id    db-id
          :before   row-before
          :after    row-after}))))
 
@@ -425,15 +430,33 @@
     (log/tracef ":model.row/create SELECT HoneySQL:\n\n%s" (u/pprint-to-str select-hsql))
     (first (jdbc/query {:connection conn} select-sql-args {:identifiers identity, :transaction? false, :keywordize? false}))))
 
+(defn- assert-pk! [db-id table-id]
+  (when (empty? (table-id->pk-field-name->id db-id table-id))
+    (throw (ex-info (tru "Cannot edit a table without it having at least one entity key configured.")
+                    {:type        :data-editing/no-pk
+                     :status-code 400
+                     :table-id    table-id}))))
+
+(mu/defn- table-id->pk-field-name->id :- [:map-of driver-api/schema.common.non-blank-string driver-api/schema.id.field]
+  "Given a `table-id` return a map of string Field name -> Field ID for the primary key columns for that Table."
+  [database-id :- driver-api/schema.id.database
+   table-id :- driver-api/schema.id.table]
+  (driver-api/cached-value
+   [::table-id->pk-field-name->id table-id]
+   #(pk-field-name->id* database-id table-id)))
+
 (defn- row-create!* [action database {:keys [create-row] :as query}]
   (log/tracef "creating %s" query)
   (let [db-id       (u/the-id database)
         driver      (:engine database)
+        table-id    (get-in query [:query :source-table])
+        ;; Check that we have a PK before we insert thte data, because we'd need this to query the return data.
+        _           (assert-pk! db-id table-id)
         {:keys [from]} (mbql-query->raw-hsql driver query)
         create-hsql (-> {:insert-into (first from)
                          :values      (if-not (seq create-row)
                                         :default
-                                        [(cast-values driver create-row db-id (get-in query [:query :source-table]))])}
+                                        [(cast-values driver create-row db-id table-id)])}
                         (prepare-query driver action))
         sql-args    (sql.qp/format-honeysql driver create-hsql)]
     (log/tracef "hsql: %s" (u/pprint-to-str create-hsql))
@@ -559,20 +582,15 @@
   [action context inputs]
   (table-row-create! action context inputs))
 
-(mu/defn- table-id->pk-field-name->id :- [:map-of driver-api/schema.common.non-blank-string driver-api/schema.id.field]
-  "Given a `table-id` return a map of string Field name -> Field ID for the primary key columns for that Table."
-  [database-id :- driver-api/schema.id.database
-   table-id :- driver-api/schema.id.table]
-  (driver-api/cached-value
-   [::table-id->pk-field-name->id table-id]
-   #(into {}
-          (comp (filter (fn [{:keys [semantic-type], :as _field}]
-                          (isa? semantic-type :type/PK)))
-                (map (juxt :name :id)))
-          (driver-api/with-metadata-provider database-id
-            (driver-api/fields
-             (driver-api/metadata-provider)
-             table-id)))))
+(defn- pk-field-name->id* [database-id table-id]
+  (into {}
+        (comp (filter (fn [{:keys [semantic-type], :as _field}]
+                        (isa? semantic-type :type/PK)))
+              (map (juxt :name :id)))
+        (driver-api/with-metadata-provider database-id
+          (driver-api/fields
+           (driver-api/metadata-provider)
+           table-id))))
 
 (mu/defn- row->mbql-filter-clause
   "Given [[field-name->id]] as returned by [[table-id->pk-field-name->id]] or similar and a `row` of column name to
@@ -581,7 +599,10 @@
    row :- driver-api/schema.actions.args.row]
   (when (empty? row)
     (throw (ex-info (tru "Cannot build filter clause: row cannot be empty.")
-                    {:field-name->id field-name->id, :row row, :status-code 400})))
+                    {:type           :data-editing/no-filter
+                     :status-code    400
+                     :field-name->id field-name->id
+                     :row            row})))
   (into [:and] (for [[field-name value] row
                      :let               [field-id (get field-name->id field-name)
                                         ;; if the field isn't in `field-name->id` then it's an error in our code. Not
@@ -654,7 +675,11 @@
                             :row-action   :model.row/delete
                             :row-fn       row-delete!*
                             :validate-fn  (fn [database table-id rows]
-                                            (let [pk-name->id (table-id->pk-field-name->id (:id database) table-id)]
+                                            (let [db-id        (u/the-id database)
+                                                  ;; We'd error anyway, about not having a filter, but this fails
+                                                  ;; earlier with a more explicit error
+                                                  _            (assert-pk! db-id table-id)
+                                                  pk-name->id  (table-id->pk-field-name->id db-id table-id)]
                                               (check-consistent-row-keys rows)
                                               (check-rows-have-expected-columns-and-no-other-keys rows (keys pk-name->id))
                                               (check-unique-rows rows)))
@@ -728,6 +753,7 @@
           :row-fn     row-update!*
           :validate-fn (fn [database table-id rows]
                          (let [db-id            (:id database)
+                               _                (assert-pk! db-id table-id)
                                pk-name->id      (table-id->pk-field-name->id db-id table-id)
                                pk-names         (set (keys pk-name->id))]
                            (doseq [row rows]

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -288,6 +288,41 @@
           (is (= 77
                  (categories-row-count))))))))
 
+(defn- unset-entity-key! [table-id]
+  (t2/update! :model/Field
+              {:table_id      table-id
+               :semantic_type :type/PK}
+              {:semantic_type nil}))
+
+(deftest table-row-create-no-pk
+  (testing "table.row/create"
+    (mt/test-drivers (mt/normal-drivers-with-feature :actions)
+      (with-actions-test-data-and-actions-permissively-enabled!
+        (let [db-id    (mt/id)
+              table-id (mt/id :categories)
+              name-col (format-field-name :name)]
+          (unset-entity-key! table-id)
+          (is (= 75
+                 (categories-row-count)))
+          (is (= {:status-code               400
+                  :errors                    [{:index 0, :error "Cannot edit a table without it having at least one entity key configured.", :type :data-editing/no-pk, :status-code 400, :table-id table-id}
+                                              {:index 1, :error "Cannot edit a table without it having at least one entity key configured.", :type :data-editing/no-pk, :status-code 400, :table-id table-id}]
+                  :results                   []
+                  :metabase.util.log/context {:action :table.row/create, :db-id db-id}}
+                 (try
+                   (actions/perform-action-v2! :table.row/create
+                                               test-scope
+                                               [{:database db-id, :table-id table-id, :row {name-col "NEW_A"}}
+                                                {:database db-id, :table-id table-id, :row {name-col "NEW_B"}}])
+                   ::did-not-throw
+                   (catch Exception e
+                     (or (ex-data e) ::did-not-throw-ex-info)))))
+          (is (= []
+                 (mt/rows (mt/run-mbql-query categories {:filter   [:starts-with $name "NEW"]
+                                                         :order-by [[:asc $id]]}))))
+          (is (= 75
+                 (categories-row-count))))))))
+
 (deftest table-row-create-failure-test
   (testing "table.row/create"
     (mt/test-drivers (mt/normal-drivers-with-feature :actions)
@@ -350,6 +385,32 @@
                                                  :table-id table-id
                                                  :row      {(format-field-name :id) 74}}])))))
           (is (= 73 (categories-row-count))))))))
+
+(deftest table-row-delete-no-pk
+  (testing "table.row/delete"
+    (mt/test-drivers (mt/normal-drivers-with-feature :actions)
+      (with-actions-test-data-and-actions-permissively-enabled!
+        (let [db-id    (mt/id)
+              table-id (mt/id :categories)]
+          (unset-entity-key! table-id)
+
+          (is (= 75 (categories-row-count)))
+          (is (= {:type                      :data-editing/no-pk
+                  :status-code               400
+                  :table-id                  table-id
+                  :metabase.util.log/context {:action :table.row/delete
+                                              :db-id  db-id}}
+                 (try
+                   (actions/perform-action-v2! :table.row/delete
+                                               test-scope
+                                               [{:database db-id
+                                                 :table-id table-id
+                                                 :row      {}}])
+                   ::did-not-throw
+                   (catch Exception e
+                     (or (ex-data e) ::did-not-throw-ex-info)))))
+          (testing "nothing was deleted"
+            (is (= 75 (categories-row-count)))))))))
 
 (deftest table-row-delete-failure-test
   (testing "table.row/delete"
@@ -442,6 +503,43 @@
           (testing "rows should be updated in the DB"
             (is (= [[1 "Seed Bowl"]
                     [2 "Millet Treat"]
+                    [3 "Artisan"]]
+                   (first-three-categories)))))))))
+
+(deftest table-row-update-no-pk
+  (testing "table.row/update"
+    (mt/test-drivers (mt/normal-drivers-with-feature :actions)
+      (with-actions-test-data-and-actions-permissively-enabled!
+        (let [db-id    (mt/id)
+              table-id (mt/id :categories)]
+          (unset-entity-key! table-id)
+          (is (= [[1 "African"]
+                  [2 "American"]
+                  [3 "Artisan"]]
+                 (first-three-categories)))
+
+          (is (= {:type                      :data-editing/no-pk
+                  :status-code               400
+                  :table-id                  table-id
+                  :metabase.util.log/context {:action :table.row/update
+                                              :db-id  db-id}}
+                 (try
+                   (let [id   (format-field-name :id)
+                         name (format-field-name :name)]
+                     (actions/perform-action-v2! :table.row/update
+                                                 test-scope
+                                                 (for [row [{id 1, name "Seed Bowl"}
+                                                            {id 2, name "Millet Treat"}]]
+                                                   {:database db-id
+                                                    :table-id table-id
+                                                    :row      row})))
+                   ::did-not-throw
+                   (catch Exception e
+                     (or (ex-data e) ::did-not-throw-ex-info)))))
+
+          (testing "rows should NOT be updated in the DB"
+            (is (= [[1 "African"]
+                    [2 "American"]
                     [3 "Artisan"]]
                    (first-three-categories)))))))))
 


### PR DESCRIPTION
Closes WRK-842

Without a PK, there is no way for the BE to understand which row we are trying to update or delete.

For insertion, we will be able to insert it, but our current implementation fails to coerce the data back into the display format, and the request fails.

It's possible to fix the creation request with a little bit more sophistication, but we are not tackling that in this PR.

With this change, all 3 requests will return the same error message along with an unambiguous "type" value which can be used to enhance the error with a settings link to fix the issue.

Unfortunately, due to the complex control flow within these routes, the precise shape of the error response bodies is not quite identical, although the FE already seems to handle that.

Making the shape consistent is not tackled in this PR either.
