### PR TITLE
[Search] Fix schema version number for search snowplow event

### DIFF
--- a/frontend/src/metabase/lib/analytics.ts
+++ b/frontend/src/metabase/lib/analytics.ts
@@ -28,7 +28,7 @@ const VERSIONS: Record<SchemaType, SchemaVersion> = {
   invite: "1-0-1",
   model: "1-0-0",
   question: "1-0-6",
-  search: "1-2-0",
+  search: "1-1-1",
   serialization: "1-0-1",
   settings: "1-0-2",
   setup: "1-0-3",

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-1
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "search",
     "format": "jsonschema",
-    "version": "1-2-0"
+    "version": "1-1-1"
   },
   "type": "object",
   "properties": {


### PR DESCRIPTION
### Description

Fix the version for `search` event, the version for recent schema changes should have been a patch change, not a minor version change.