### PR TITLE
Fix conversion of grouped pivot values to consistent types (2nd attempt)

### DIFF
--- a/src/metabase/pivot/core.cljc
+++ b/src/metabase/pivot/core.cljc
@@ -109,7 +109,7 @@
               (persistent!
                (reduce
                 (fn [acc row]
-                  (let [grouping-key (ensure-consistent-type (perf/mapv #(nth row %) column-indexes))
+                  (let [grouping-key (perf/mapv #(ensure-consistent-type (nth row %)) column-indexes)
                         values (perf/mapv #(nth row %) val-indexes)]
                     (assoc! acc grouping-key values)))
                 (transient {})


### PR DESCRIPTION
Hopefully this fully fixes #62879. This bug has been a leftover after #62762 fixes another issue with `ensure-consistent-type`.

I haven't added new tests but I modified existing test to actually match how the pivoted table looks on the UI (the test was missing one value).