### PR TITLE
Enable ts incremental builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,13 @@ xcuserdata
 dev/src/dev/nocommit/
 dev/serialization_deltas/
 *~
+
+# TypeScript compilation artifacts
+/build/
+*.tsbuildinfo
+/trace-output/
+/temp-types/
+
 **/cypress_sample_database.json
 **/cypress_sample_instance_data.json
 /frontend/src/cljs

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": ".tsbuildinfo",
     "outDir": "build",
     "paths": {
       "*": [


### PR DESCRIPTION
Uses incremental builds to speed up type-checking and reduce memory usage

For `yarn type-check-pure `:

First run: 67s → 37s
Subsequent runs: 67s → 8s

For `yarn type-check`

First run:  90s → 45
Subsequent runs: 90s → 45

It's expected that `yarn type-check `doesn't get as much benefit because it rebuilds all the cljs which needs to be type-checked again