### PR TITLE
don't document metabot env vars

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/llm/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/settings.clj
@@ -9,7 +9,7 @@
   :visibility :settings-manager
   :default "gpt-4-turbo-preview"
   :export? false
-  :doc "This feature is experimental.")
+  :doc false)
 
 (defsetting ee-openai-api-base-url
   (deferred-tru "The OpenAI embeddings base URL used in Metabase Enterprise.")
@@ -17,14 +17,14 @@
   :visibility :settings-manager
   :default "https://api.openai.com"
   :export? false
-  :doc "This feature is experimental.")
+  :doc false)
 
 (defsetting ee-openai-api-key
   (deferred-tru "The OpenAI API Key used in Metabase Enterprise.")
   :encryption :no
   :visibility :settings-manager
   :export? false
-  :doc "This feature is experimental.")
+  :doc false)
 
 (defsetting ee-ai-features-enabled
   (deferred-tru "Enable AI features.")
@@ -35,4 +35,4 @@
   :setter (fn [new-value]
             (when (some? (ee-openai-api-key))
               (setting/set-value-of-type! :boolean :ee-ai-features-enabled new-value)))
-  :doc "This feature is experimental.")
+  :doc false)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
@@ -9,7 +9,8 @@
   :encryption :no
   :default    "http://localhost:8000"
   :visibility :internal
-  :export?    false)
+  :export?    false
+  :doc        false)
 
 (defsetting site-uuid-for-metabot-tools
   "UUID that we use for encrypting JWT tokens given to the AI service to make callbacks with."
@@ -37,7 +38,8 @@
   :visibility :internal
   :feature    :metabot-v3
   :encryption :no
-  :export?    false)
+  :export?    false
+  :doc        false)
 
 (defsetting ai-service-profile-id
   (deferred-tru "Override Metabot profile ID for agent streaming requests.")
@@ -45,4 +47,5 @@
   :visibility :internal
   :feature    :metabot-v3
   :encryption :no
-  :export?    false)
+  :export?    false
+  :doc        false)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -12,7 +12,7 @@
   :default "ai-service"
   :type :string
   :export? false
-  :doc "This feature is experimental.")
+  :doc false)
 
 (defsetting ee-embedding-model
   (deferred-tru "Set the embedding model for the selected provider")
@@ -20,7 +20,7 @@
   :visibility :settings-manager
   :default "Snowflake/snowflake-arctic-embed-l-v2.0"
   :export? false
-  :doc "This feature is experimental.")
+  :doc false)
 
 (defsetting ee-embedding-model-dimensions
   (deferred-tru "Set the dimension size for the selected embedding model")
@@ -29,7 +29,7 @@
   :default 1024
   :type :positive-integer
   :export? false
-  :doc "This feature is experimental.")
+  :doc false)
 
 (defn openai-api-base-url
   "Get the OpenAI API base url from the existing LLM settings."
@@ -50,7 +50,8 @@
   :getter     (fn []
                 (and (setting/get-value-of-type :boolean :semantic-search-enabled)
                      (premium-features/enable-semantic-search?)))
-  :type       :boolean)
+  :type       :boolean
+  :doc        false)
 
 (defsetting openai-max-tokens-per-batch
   (deferred-tru "The maximum number of tokens sent in a single embedding API call.")
@@ -68,7 +69,7 @@
   :encryption :no
   :export? false
   :visibility :internal
-  :doc "Maximum number of results to return from a single semantic search query.")
+  :doc false)
 
 (defsetting semantic-search-min-results-threshold
   (deferred-tru "Minimum number of semantic search results required before falling back to other engines.")
@@ -77,7 +78,7 @@
   :encryption :no
   :export? false
   :visibility :internal
-  :doc "Minimum number of semantic search results required before falling back to other engines.")
+  :doc false)
 
 (defsetting index-update-thread-count
   (deferred-tru "Number of threads to use for batched index updates, including embedding requests")
@@ -95,35 +96,40 @@
   :type :integer
   :default 5
   :export? false
-  :visibility :internal)
+  :visibility :internal
+  :doc false)
 
 (defsetting ee-search-gate-max-batch-size
   "The maximum number of documents that can be sent to `gate-documents!` without causing an error."
   :type :integer
   :default 512
   :export? false
-  :visibility :internal)
+  :visibility :internal
+  :doc false)
 
 (defsetting ee-search-indexer-poll-limit
   "Indexer poll limit."
   :type :integer
   :default 1000
   :export? false
-  :visibility :internal)
+  :visibility :internal
+  :doc false)
 
 (defsetting ee-search-indexer-exit-early-cold-duration
   "Number of seconds indexer should wait to see new data before yielding back to quartz."
   :type :integer
   :default 30
   :export? false
-  :visibility :internal)
+  :visibility :internal
+  :doc false)
 
 (defsetting ee-search-indexer-max-run-duration
   "Number of minutes we expect to run the indexer loop for before yielding to quartz."
   :type :integer
   :default 60
   :export? false
-  :visibility :internal)
+  :visibility :internal
+  :doc false)
 
 (defsetting ee-search-indexer-lag-tolerance-multiplier
   (str "Multiplier for computation of [[metabase-enterprise.semantic-search.indexer/lag-tolerance]]. The formula "
@@ -131,7 +137,8 @@
   :type :integer
   :default 2
   :export? false
-  :visibility :internal)
+  :visibility :internal
+  :doc false)
 
 (defsetting stale-index-retention-hours
   (deferred-tru "Number of hours to retain stale semantic search indexes before cleanup.")
@@ -140,7 +147,7 @@
   :encryption :no
   :export? false
   :visibility :internal
-  :doc "Number of hours to retain stale semantic search indexes before cleanup.")
+  :doc false)
 
 (defsetting tombstone-retention-hours
   (deferred-tru "Number of hours to retain tombstone records in the gate table before cleanup.")
@@ -148,4 +155,5 @@
   :default 24
   :encryption :no
   :export? false
-  :visibility :internal)
+  :visibility :internal
+  :doc false)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -59,7 +59,7 @@
   :encryption :no
   :export? false
   :visibility :internal
-  :doc "The maximum number of tokens sent in a single embedding API call.")
+  :doc false)
 
 (defsetting semantic-search-results-limit
   (deferred-tru "Maximum number of results to return from a single semantic search query.")

--- a/src/metabase/appearance/settings.clj
+++ b/src/metabase/appearance/settings.clj
@@ -208,7 +208,8 @@ See [fonts](../configuring-metabase/fonts.md).")
   :type       :boolean
   :audit      :getter
   :feature    :whitelabel
-  :default    true)
+  :default    true
+  :doc        false)
 
 (defsetting login-page-illustration
   (deferred-tru "Options for displaying the illustration on the login page.")


### PR DESCRIPTION
These env vars are only relevant for internal/cloud use. Marking these `defsetting`s as `:doc false` will tell the docs script to skip them when generating env var and config template docs.

https://metaboat.slack.com/archives/C07SJT1P0ET/p1756472617689509