### PR TITLE
[ClickHouse] Fix SQL for equality filters on UUID columns

### DIFF
--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -1,6 +1,8 @@
 (ns ^:mb/driver-tests metabase.driver.clickhouse-data-types-test
   (:require
    [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
    [metabase.test.data.clickhouse :as ctd]))
 
@@ -334,6 +336,23 @@
                   (mt/run-mbql-query
                     array_of_tuples_test
                     {})))))))))
+
+(deftest ^:parallel uuid-literals-test
+  (mt/test-driver :clickhouse
+    (mt/dataset
+      (mt/dataset-definition
+       "metabase_tests_uuids_nullable"
+       [["uuids_nullable"
+         [{:field-name "uuid1", :base-type {:native "Nullable(UUID)"}}]
+         [[#uuid "550e8400-e29b-41d4-a716-446655440000"]
+          [nil]]]])
+      (let [mp (mt/metadata-provider)]
+        (is (= [[1 #uuid "550e8400-e29b-41d4-a716-446655440000"]]
+               (-> (lib/query mp (lib.metadata/table mp (mt/id :uuids_nullable)))
+                   (lib/filter (lib/= (lib.metadata/field mp (mt/id :uuids_nullable :uuid1))
+                                      "550e8400-e29b-41d4-a716-446655440000"))
+                   mt/process-query
+                   mt/rows)))))))
 
 #_(deftest ^:parallel clickhouse-array-of-uuids
     (mt/test-driver :clickhouse

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1558,16 +1558,14 @@
 (defn- uuid-field?
   [x]
   (and (driver-api/mbql-clause? x)
-       (let [[_kind id-or-value opts] x
-             field-type (or (:effective-type opts)
-                            (:effective_type opts)
-                            (when (pos-int? id-or-value)
-                              (let [{:keys [base-type effective-type]}
-                                    (driver-api/field (driver-api/metadata-provider) id-or-value)]
-                                (or effective-type base-type)))
-                            (:base-type opts)
-                            (:base_type opts))]
-         (isa? field-type :type/UUID))))
+       (isa? (or (:effective-type (get x 2))
+                 (let [field-id (second x)]
+                   (when (pos-int? field-id)
+                     (let [{:keys [base-type effective-type]}
+                           (driver-api/field (driver-api/metadata-provider) field-id)]
+                       (or effective-type base-type))))
+                 (:base-type (get x 2)))
+             :type/UUID)))
 
 (mu/defn- maybe-cast-uuid-for-equality
   "For := and :!=. Comparing UUID fields against non-uuid values requires casting."

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1558,14 +1558,16 @@
 (defn- uuid-field?
   [x]
   (and (driver-api/mbql-clause? x)
-       (isa? (or (:effective-type (get x 2))
-                 (let [field-id (second x)]
-                   (when (pos-int? field-id)
-                     (let [{:keys [base-type effective-type]}
-                           (driver-api/field (driver-api/metadata-provider) field-id)]
-                       (or effective-type base-type))))
-                 (:base-type (get x 2)))
-             :type/UUID)))
+       (let [[_kind id-or-value opts] x
+             field-type (or (:effective-type opts)
+                            (:effective_type opts)
+                            (when (pos-int? id-or-value)
+                              (let [{:keys [base-type effective-type]}
+                                    (driver-api/field (driver-api/metadata-provider) id-or-value)]
+                                (or effective-type base-type)))
+                            (:base-type opts)
+                            (:base_type opts))]
+         (isa? field-type :type/UUID))))
 
 (mu/defn- maybe-cast-uuid-for-equality
   "For := and :!=. Comparing UUID fields against non-uuid values requires casting."


### PR DESCRIPTION
Closes #62492.

### Description

A literal UUID was reaching the driver as
`[:value "uuid-string" {:base_type :type/UUID}]`
but this was not recognized as a UUID-valued field because `:value`
clauses have `:base_type` and not `:base-type` like `:field` clauses.

Therefore the `:sql` core driver was rewriting this clause to cast the
UUID field to a string and compare that against the literal string.
With that logic now correctly recognizing such a `:value` clause, the
UUID fields are compared directly. This is much better for indexing,
but also works with *nullable* UUID columns, where the
`CAST(my_uuid AS text)` would cause SQL compilation errors.

### How to verify

Follow the repro in #62492 - connect a ClickHouse DB, create a table with a
`Nullable(UUID)` column, add NULL and non-NULL data to it, and try to filter for a specific UUID.

Before this PR, you get SQL compilation errors. With this PR, you correct SQL.
And *that's not all!* If you review within the next 90 minutes you get more indexable queries too!

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
