### PR TITLE
chore(sdk): limit what branch we can release when using the workflow

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -5,18 +5,12 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch we want to release the SDK from"
+        description: "Branch we want to release the SDK from (to release from other branches use the workflow from those branches)"
         type: choice
         required: true
         default: "master"
         options:
           - master
-          - release-x.51.x
-          - release-x.52.x
-          - release-x.53.x
-          - release-x.54.x
-          - release-x.55.x
-          - release-x.56.x
 
 concurrency:
   # We want to ensure only one job is running at a time per branch because


### PR DESCRIPTION
from master
See https://metaboat.slack.com/archives/C063Q3F1HPF/p1756461005115329
<img width="443" height="333" alt="image" src="https://github.com/user-attachments/assets/b2f820b9-fecd-4af5-8df6-fee34ee2d9cd" />
