### PR TITLE
Create standalone add DB page

### DIFF
--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -655,7 +655,7 @@ describe("scenarios > admin > databases > sample database", () => {
   it("allows to save the default schedule (metabase#57198)", () => {
     visitDatabase(SAMPLE_DB_ID);
     editDatabase();
-    H.modal().findByText("Show advanced options").click();
+    cy.findByRole("button", { name: /Show advanced options/ }).click();
     cy.findByLabelText(/Choose when syncs and scans happen/).click({
       force: true,
     });

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -229,12 +229,13 @@ describe("admin > database > add", () => {
           "contain.text",
           "QA Postgres12",
         );
-        editDatabase();
 
         cy.findAllByTestId("database-connection-info-section").should(
           "contain.text",
           "Connected",
         );
+
+        editDatabase();
 
         cy.findByLabelText(/Choose when syncs and scans happen/).should(
           "have.attr",

--- a/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/datamodel.cy.spec.ts
@@ -175,7 +175,9 @@ describe("scenarios > admin > datamodel", () => {
           .click();
 
         cy.location("pathname").should("eq", "/admin/databases/create");
-        H.modal().should("be.visible").and("contain.text", "Add a database");
+        cy.findByRole("heading", { name: "Add a database" }).should(
+          "be.visible",
+        );
       });
     });
 

--- a/e2e/test/scenarios/onboarding/add-initial-data.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/add-initial-data.cy.spec.ts
@@ -208,10 +208,8 @@ describe("Add data modal", () => {
         cy.location("search").should("eq", "?engine=snowflake");
       });
 
-      H.modal().within(() => {
-        cy.findByText("Add a database").should("be.visible");
-        cy.findByLabelText("Database type").should("have.value", "Snowflake");
-      });
+      cy.findByRole("heading", { name: "Add a database" }).should("be.visible");
+      cy.findByLabelText("Database type").should("have.value", "Snowflake");
     });
 
     it("should not offer to add data when in full app embedding", () => {

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DestinationDatabaseConnectionModal/DestinationDatabaseConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DestinationDatabaseConnectionModal/DestinationDatabaseConnectionModal.tsx
@@ -144,6 +144,7 @@ export const DestinationDatabaseConnectionModalInner = ({
             engine: { fieldState: "hidden" },
           }}
           autofocusFieldName="name"
+          formLocation="admin"
         />
       </LoadingAndErrorWrapper>
     </Modal>

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -1,3 +1,4 @@
+import type { FormLocation } from "metabase/databases/types";
 import type {
   ChecklistItemCTA,
   ChecklistItemValue,
@@ -270,12 +271,12 @@ export type TableEditingRecordModifiedEvent = ValidateEvent<{
 
 export type ConnectionStringParsedSuccessEvent = ValidateEvent<{
   event: "connection_string_parsed_success";
-  triggered_from: "admin" | "setup" | "embedding_setup";
+  triggered_from: FormLocation;
 }>;
 
 export type ConnectionStringParsedFailedEvent = ValidateEvent<{
   event: "connection_string_parsed_failed";
-  triggered_from: "admin" | "setup" | "embedding_setup";
+  triggered_from: FormLocation;
 }>;
 
 export type TransformTriggerManualRunEvent = ValidateEvent<{

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
@@ -96,7 +96,7 @@ export const DatabaseEditConnectionForm = withRouter(
               onCancel={onCancel}
               onSubmit={handleSubmit}
               setIsDirty={setIsDirty}
-              location={formLocation ?? "admin"}
+              location={formLocation}
             />
           ) : (
             <Text my="md">{t`This database is managed by Metabase Cloud and cannot be modified.`}</Text>

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
@@ -14,6 +14,7 @@ import {
   DatabaseForm,
   type DatabaseFormConfig,
 } from "metabase/databases/components/DatabaseForm";
+import type { FormLocation } from "metabase/databases/types";
 import { useDispatch } from "metabase/lib/redux";
 import { Text } from "metabase/ui";
 import type {
@@ -55,7 +56,7 @@ export const DatabaseEditConnectionForm = withRouter(
     location: LocationDescriptorObject;
     autofocusFieldName?: string;
     config?: Omit<DatabaseFormConfig, "isAdvanced">;
-    formLocation: "admin" | "full-page";
+    formLocation: Extract<FormLocation, "admin" | "full-page">;
   }) => {
     const dispatch = useDispatch();
 

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
@@ -42,6 +42,7 @@ export const DatabaseEditConnectionForm = withRouter(
     route,
     location,
     config,
+    formLocation,
     ...props
   }: {
     database?: Partial<DatabaseData>;
@@ -54,6 +55,7 @@ export const DatabaseEditConnectionForm = withRouter(
     location: LocationDescriptorObject;
     autofocusFieldName?: string;
     config?: Omit<DatabaseFormConfig, "isAdvanced">;
+    formLocation: "admin" | "full-page";
   }) => {
     const dispatch = useDispatch();
 
@@ -94,7 +96,7 @@ export const DatabaseEditConnectionForm = withRouter(
               onCancel={onCancel}
               onSubmit={handleSubmit}
               setIsDirty={setIsDirty}
-              location="admin"
+              location={formLocation ?? "admin"}
             />
           ) : (
             <Text my="md">{t`This database is managed by Metabase Cloud and cannot be modified.`}</Text>

--- a/frontend/src/metabase/admin/databases/containers/DatabaseConnectionModal.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseConnectionModal.tsx
@@ -1,20 +1,12 @@
 import type { LocationDescriptor } from "history";
 import type { Route } from "react-router";
-import { push } from "react-router-redux";
-import { t } from "ttag";
 
-import { skipToken, useGetDatabaseQuery } from "metabase/api";
 import title from "metabase/hoc/Title";
-import { useDispatch } from "metabase/lib/redux";
-import { PLUGIN_DB_ROUTING } from "metabase/plugins";
 import { Modal } from "metabase/ui";
-import type {
-  DatabaseData,
-  DatabaseEditErrorType,
-  DatabaseId,
-} from "metabase-types/api";
+import type { DatabaseData, DatabaseEditErrorType } from "metabase-types/api";
 
 import { DatabaseEditConnectionForm } from "../components/DatabaseEditConnectionForm";
+import { useDatabaseConnection } from "../hooks/use-database-connection";
 
 import S from "./DatabaseConnectionModal.module.css";
 
@@ -27,42 +19,18 @@ export const DatabaseConnectionModalInner = ({
   location: LocationDescriptor;
   params: { databaseId: string };
 }) => {
-  const dispatch = useDispatch();
-
-  const queryParams = new URLSearchParams(location.search);
-  const preselectedEngine = queryParams.get("engine") ?? undefined;
-
-  const addingNewDatabase = params.databaseId === undefined;
-
-  const databaseReq = useGetDatabaseQuery(
-    addingNewDatabase ? skipToken : { id: parseInt(params.databaseId, 10) },
-  );
-  const database = databaseReq.currentData ?? {
-    id: undefined,
-    is_attached_dwh: false,
-    router_user_attribute: undefined,
-    engine: preselectedEngine,
-  };
-
-  const handleCloseModal = () => {
-    dispatch(
-      database?.id
-        ? push(`/admin/databases/${database.id}`)
-        : push(`/admin/databases`),
-    );
-  };
-
-  const handleOnSubmit = (savedDB: { id: DatabaseId }) => {
-    if (addingNewDatabase) {
-      dispatch(push(`/admin/databases/${savedDB.id}`));
-    } else {
-      handleCloseModal();
-    }
-  };
+  const {
+    database,
+    databaseReq,
+    handleCancel: handleCloseModal,
+    handleOnSubmit,
+    title,
+    config,
+  } = useDatabaseConnection({ databaseId: params.databaseId });
 
   return (
     <Modal
-      title={addingNewDatabase ? t`Add a database` : t`Edit connection details`}
+      title={title}
       opened
       onClose={handleCloseModal}
       padding="xl"
@@ -79,13 +47,7 @@ export const DatabaseConnectionModalInner = ({
         onSubmitted={handleOnSubmit}
         onCancel={handleCloseModal}
         route={route}
-        config={{
-          engine: {
-            fieldState: database
-              ? PLUGIN_DB_ROUTING.getPrimaryDBEngineFieldState(database)
-              : "disabled",
-          },
-        }}
+        config={config}
         formLocation="admin"
       />
     </Modal>

--- a/frontend/src/metabase/admin/databases/containers/DatabaseConnectionModal.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseConnectionModal.tsx
@@ -86,6 +86,7 @@ export const DatabaseConnectionModalInner = ({
               : "disabled",
           },
         }}
+        formLocation="admin"
       />
     </Modal>
   );

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
@@ -14,8 +14,10 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
   const { database, databaseReq, handleCancel, handleOnSubmit, title, config } =
     useDatabaseConnection({ databaseId: params.databaseId });
 
+  const pageMaxWidth = `calc(28.5rem + 4rem)`;
+
   return (
-    <Box w="100%" maw="54rem" mx="auto" p="xl">
+    <Box w="100%" maw={pageMaxWidth} mx="auto" p="xl">
       <Title order={1} mb="lg">
         {title}
       </Title>

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
@@ -30,7 +30,7 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
     engine: preselectedEngine,
   };
 
-  const handleCloseModal = () => {
+  const handleCancel = () => {
     dispatch(
       database?.id
         ? push(`/admin/databases/${database.id}`)
@@ -42,7 +42,7 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
     if (addingNewDatabase) {
       dispatch(push(`/admin/databases/${savedDB.id}`));
     } else {
-      handleCloseModal();
+      handleCancel();
     }
   };
 
@@ -55,7 +55,7 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
         initializeError={databaseReq.error}
         onSubmitted={handleOnSubmit}
         route={route}
-        onCancel={handleCloseModal}
+        onCancel={handleCancel}
         config={{
           engine: {
             fieldState: database

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
@@ -1,0 +1,70 @@
+import type { Route } from "react-router";
+import { push } from "react-router-redux";
+import { t } from "ttag";
+
+import { skipToken, useGetDatabaseQuery } from "metabase/api";
+import { useDispatch } from "metabase/lib/redux";
+import { PLUGIN_DB_ROUTING } from "metabase/plugins";
+import { Box, Title } from "metabase/ui";
+import type { DatabaseId } from "metabase-types/api";
+
+import { DatabaseEditConnectionForm } from "../components/DatabaseEditConnectionForm";
+
+interface DatabasePageProps {
+  params: { databaseId: string };
+  route: Route;
+}
+
+export function DatabasePage({ params, route }: DatabasePageProps) {
+  const dispatch = useDispatch();
+  const queryParams = new URLSearchParams(location.search);
+  const preselectedEngine = queryParams.get("engine") ?? undefined;
+  const addingNewDatabase = params.databaseId === undefined;
+  const databaseReq = useGetDatabaseQuery(
+    addingNewDatabase ? skipToken : { id: parseInt(params.databaseId, 10) },
+  );
+  const database = databaseReq.currentData ?? {
+    id: undefined,
+    is_attached_dwh: false,
+    router_user_attribute: undefined,
+    engine: preselectedEngine,
+  };
+
+  const handleCloseModal = () => {
+    dispatch(
+      database?.id
+        ? push(`/admin/databases/${database.id}`)
+        : push(`/admin/databases`),
+    );
+  };
+
+  const handleOnSubmit = (savedDB: { id: DatabaseId }) => {
+    if (addingNewDatabase) {
+      dispatch(push(`/admin/databases/${savedDB.id}`));
+    } else {
+      handleCloseModal();
+    }
+  };
+
+  return (
+    <Box w="100%" maw="54rem" mx="auto" p="xl">
+      <Title order={1} mb="lg">{t`Add database`}</Title>
+      <DatabaseEditConnectionForm
+        database={database}
+        isAttachedDWH={database?.is_attached_dwh ?? false}
+        initializeError={databaseReq.error}
+        onSubmitted={handleOnSubmit}
+        route={route}
+        onCancel={handleCloseModal}
+        config={{
+          engine: {
+            fieldState: database
+              ? PLUGIN_DB_ROUTING.getPrimaryDBEngineFieldState(database)
+              : "disabled",
+          },
+        }}
+        formLocation="full-page"
+      />
+    </Box>
+  );
+}

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
@@ -46,9 +46,15 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
     }
   };
 
+  const title = addingNewDatabase
+    ? t`Add a database`
+    : t`Edit connection details`;
+
   return (
     <Box w="100%" maw="54rem" mx="auto" p="xl">
-      <Title order={1} mb="lg">{t`Add database`}</Title>
+      <Title order={1} mb="lg">
+        {title}
+      </Title>
       <DatabaseEditConnectionForm
         database={database}
         isAttachedDWH={database?.is_attached_dwh ?? false}

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
@@ -14,10 +14,19 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
   const { database, databaseReq, handleCancel, handleOnSubmit, title, config } =
     useDatabaseConnection({ databaseId: params.databaseId });
 
-  const pageMaxWidth = `calc(28.5rem + 4rem)`;
-
   return (
-    <Box w="100%" maw={pageMaxWidth} mx="auto" p="xl">
+    <Box
+      w="100%"
+      maw={{
+        base: `calc(28.5rem + 2rem)`,
+        md: `calc(28.5rem + 4rem)`,
+      }}
+      mx="auto"
+      p={{
+        base: `md`,
+        md: `xl`,
+      }}
+    >
       <Title order={1} mb="lg">
         {title}
       </Title>

--- a/frontend/src/metabase/admin/databases/hooks/use-database-connection.ts
+++ b/frontend/src/metabase/admin/databases/hooks/use-database-connection.ts
@@ -1,0 +1,69 @@
+import { push } from "react-router-redux";
+import { t } from "ttag";
+
+import { skipToken, useGetDatabaseQuery } from "metabase/api";
+import { useDispatch } from "metabase/lib/redux";
+import { PLUGIN_DB_ROUTING } from "metabase/plugins";
+import type { DatabaseId } from "metabase-types/api";
+
+interface UseDatabaseConnectionProps {
+  databaseId?: string;
+}
+
+export const useDatabaseConnection = ({
+  databaseId,
+}: UseDatabaseConnectionProps) => {
+  const dispatch = useDispatch();
+  const queryParams = new URLSearchParams(location.search);
+  const preselectedEngine = queryParams.get("engine") ?? undefined;
+  const addingNewDatabase = databaseId === undefined;
+
+  const databaseReq = useGetDatabaseQuery(
+    addingNewDatabase ? skipToken : { id: parseInt(databaseId, 10) },
+  );
+
+  const database = databaseReq.currentData ?? {
+    id: undefined,
+    is_attached_dwh: false,
+    router_user_attribute: undefined,
+    engine: preselectedEngine,
+  };
+
+  const handleCancel = () => {
+    dispatch(
+      database?.id
+        ? push(`/admin/databases/${database.id}`)
+        : push(`/admin/databases`),
+    );
+  };
+
+  const handleOnSubmit = (savedDB: { id: DatabaseId }) => {
+    if (addingNewDatabase) {
+      dispatch(push(`/admin/databases/${savedDB.id}`));
+    } else {
+      handleCancel();
+    }
+  };
+
+  const title = addingNewDatabase
+    ? t`Add a database`
+    : t`Edit connection details`;
+
+  const config = {
+    engine: {
+      fieldState: database
+        ? PLUGIN_DB_ROUTING.getPrimaryDBEngineFieldState(database)
+        : "disabled",
+    },
+  };
+
+  return {
+    database,
+    databaseReq,
+    addingNewDatabase,
+    handleCancel,
+    handleOnSubmit,
+    title,
+    config,
+  };
+};

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -3,7 +3,6 @@ import { IndexRedirect, IndexRoute, Redirect } from "react-router";
 import { t } from "ttag";
 
 import AdminApp from "metabase/admin/app/components/AdminApp";
-import { DatabaseConnectionModal } from "metabase/admin/databases/containers/DatabaseConnectionModal";
 import { DatabaseEditApp } from "metabase/admin/databases/containers/DatabaseEditApp";
 import { DatabaseListApp } from "metabase/admin/databases/containers/DatabaseListApp";
 import { DatabasePage } from "metabase/admin/databases/containers/DatabasePage";
@@ -66,8 +65,8 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
         <Route component={IsAdmin}>
           <Route path="create" component={DatabasePage} />
         </Route>
+        <Route path=":databaseId/edit" component={DatabasePage} />
         <Route path=":databaseId" component={DatabaseEditApp}>
-          <ModalRoute path="edit" modal={DatabaseConnectionModal} noWrap />
           {PLUGIN_DB_ROUTING.getDestinationDatabaseRoutes(IsAdmin)}
         </Route>
       </Route>

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -61,7 +61,6 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
         component={createAdminRouteGuard("databases")}
       >
         <IndexRoute component={DatabaseListApp} />
-        <Route component={DatabaseListApp} />
         <Route component={IsAdmin}>
           <Route path="create" component={DatabasePage} />
         </Route>

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -6,6 +6,7 @@ import AdminApp from "metabase/admin/app/components/AdminApp";
 import { DatabaseConnectionModal } from "metabase/admin/databases/containers/DatabaseConnectionModal";
 import { DatabaseEditApp } from "metabase/admin/databases/containers/DatabaseEditApp";
 import { DatabaseListApp } from "metabase/admin/databases/containers/DatabaseListApp";
+import { DatabasePage } from "metabase/admin/databases/containers/DatabasePage";
 import RevisionHistoryApp from "metabase/admin/datamodel/containers/RevisionHistoryApp";
 import SegmentApp from "metabase/admin/datamodel/containers/SegmentApp";
 import SegmentListApp from "metabase/admin/datamodel/containers/SegmentListApp";
@@ -61,10 +62,9 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
         component={createAdminRouteGuard("databases")}
       >
         <IndexRoute component={DatabaseListApp} />
-        <Route component={DatabaseListApp}>
-          <Route component={IsAdmin}>
-            <ModalRoute path="create" modal={DatabaseConnectionModal} noWrap />
-          </Route>
+        <Route component={DatabaseListApp} />
+        <Route component={IsAdmin}>
+          <Route path="create" component={DatabasePage} />
         </Route>
         <Route path=":databaseId" component={DatabaseEditApp}>
           <ModalRoute path="edit" modal={DatabaseConnectionModal} noWrap />

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
@@ -8,6 +8,7 @@ import { Group, Icon, Text, Textarea, Transition } from "metabase/ui";
 import type { DatabaseData } from "metabase-types/api";
 import { isEngineKey } from "metabase-types/guards";
 
+import type { FormLocation } from "../../types";
 import { setDatabaseFormValues } from "../../utils/schema";
 
 import {
@@ -31,7 +32,7 @@ export function DatabaseConnectionStringField({
     shouldValidate?: boolean,
   ) => Promise<void | FormikErrors<DatabaseData>>;
   engineKey: string | undefined;
-  location: "admin" | "setup" | "embedding_setup";
+  location: FormLocation;
 }) {
   const [status, setStatus] = useState<"success" | "failure" | null>(null);
   const { start: delayedClearStatus, clear: clearTimeout } = useTimeout(

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/analytics.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/analytics.ts
@@ -1,17 +1,14 @@
 import { trackSimpleEvent } from "metabase/lib/analytics";
 
-export function connectionStringParsedSuccess(
-  location: "admin" | "setup" | "embedding_setup",
-) {
+import type { FormLocation } from "../../types";
+export function connectionStringParsedSuccess(location: FormLocation) {
   trackSimpleEvent({
     event: "connection_string_parsed_success",
     triggered_from: location,
   });
 }
 
-export function connectionStringParsedFailed(
-  location: "admin" | "setup" | "embedding_setup",
-) {
+export function connectionStringParsedFailed(location: FormLocation) {
   trackSimpleEvent({
     event: "connection_string_parsed_failed",
     triggered_from: location,

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -1,5 +1,6 @@
 import { useFormikContext } from "formik";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { match } from "ts-pattern";
 import { c, t } from "ttag";
 
 import ExternalLink from "metabase/common/components/ExternalLink";
@@ -13,6 +14,7 @@ import { Box, Button, Flex, Text } from "metabase/ui";
 import type { DatabaseData, Engine, EngineKey } from "metabase-types/api";
 
 import { getEngines } from "../../selectors";
+import type { FormLocation } from "../../types";
 import { getDefaultEngineKey } from "../../utils/engine";
 import {
   getSubmitValues,
@@ -52,7 +54,7 @@ interface DatabaseFormProps {
   onCancel?: () => void;
   setIsDirty?: (isDirty: boolean) => void;
   config?: DatabaseFormConfig;
-  location: "admin" | "setup" | "embedding_setup";
+  location: FormLocation;
   /**
    * Whether to show the sample database indicator in the engine list and change the "I'll add my data later" button to "Continue with sample data"
    */
@@ -147,7 +149,7 @@ interface DatabaseFormBodyProps {
   config: DatabaseFormConfig;
   showSampleDatabase?: boolean;
   ContinueWithoutDataSlot?: ContinueWithoutDataComponent;
-  location: "admin" | "setup" | "embedding_setup";
+  location: FormLocation;
 }
 
 const DatabaseFormBody = ({
@@ -175,14 +177,20 @@ const DatabaseFormBody = ({
     return engine ? getVisibleFields(engine, values, isAdvanced) : [];
   }, [engine, values, isAdvanced]);
 
+  const px = match(location)
+    .with("setup", () => "sm")
+    .with("embedding_setup", () => "xl")
+    .with("admin", () => "xl")
+    .with("full-page", () => undefined)
+    .exhaustive();
+  const mah = location === "full-page" ? "100%" : "calc(100vh - 20rem)";
+
   return (
-    <Form data-testid="database-form" pt="md">
-      <Box
-        mah="calc(100vh - 20rem)"
-        style={{ overflowY: "auto" }}
-        px={location === "setup" ? "sm" : "xl"}
-        mb="md"
-      >
+    <Form
+      data-testid="database-form"
+      pt={location === "full-page" ? undefined : "md"}
+    >
+      <Box mah={mah} style={{ overflowY: "auto" }} px={px} mb="md">
         {engineFieldState !== "hidden" && (
           <>
             <DatabaseEngineField
@@ -229,6 +237,7 @@ const DatabaseFormBody = ({
         onCancel={onCancel}
         showSampleDatabase={showSampleDatabase}
         ContinueWithoutDataSlot={ContinueWithoutDataSlot}
+        location={location}
       />
     </Form>
   );
@@ -240,6 +249,7 @@ interface DatabaseFormFooterProps {
   onCancel?: () => void;
   showSampleDatabase?: boolean;
   ContinueWithoutDataSlot?: ContinueWithoutDataComponent;
+  location: FormLocation;
 }
 
 const DatabaseFormFooter = ({
@@ -248,6 +258,7 @@ const DatabaseFormFooter = ({
   onCancel,
   showSampleDatabase,
   ContinueWithoutDataSlot,
+  location,
 }: DatabaseFormFooterProps) => {
   const { values } = useFormikContext<DatabaseData>();
   const isNew = values.id == null;
@@ -259,7 +270,10 @@ const DatabaseFormFooter = ({
 
   if (isAdvanced) {
     return (
-      <FormFooter data-testid="form-footer" px="xl">
+      <FormFooter
+        data-testid="form-footer"
+        px={location === "full-page" ? undefined : "xl"}
+      >
         <FormErrorMessage />
         <Flex justify="space-between" align="center" w="100%">
           {isNew ? (

--- a/frontend/src/metabase/databases/types.ts
+++ b/frontend/src/metabase/databases/types.ts
@@ -23,3 +23,5 @@ export interface EngineFieldProps {
   description?: ReactNode;
   placeholder?: string;
 }
+
+export type FormLocation = "admin" | "setup" | "embedding_setup" | "full-page";


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-112/admin-settings-make-add-database-a-full-page-keeping-the-ability-to

### Description

- Updated routing in `routes.jsx` so Add and Edit Database can be loaded without loading the DB details page
- Introduced Full Page specific styles.

### How to verify

- Verify how Add and Edit Database form looks like and if it's possible to add and edit DB.
- DB routing Database form should be still in a modal
- Onboarding DB forms should looks as before.

### Demo

https://www.loom.com/share/d10b85f5319240ada460ff6542a3d397

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
