### PR TITLE
Fix model sidebar for joined tables

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionRelationshipsTab.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/QuestionRelationshipsTab.tsx
@@ -22,7 +22,7 @@ export const QuestionRelationshipsTab = ({
         </SidesheetCard>
       )}
       <SidesheetCard title={t`Linked tables`}>
-        <TablesLinkedToQuestion question={question} />
+        <TablesLinkedToQuestion />
       </SidesheetCard>
     </Stack>
   );

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/TablesLinkedToQuestion.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/components/TablesLinkedToQuestion.tsx
@@ -2,8 +2,9 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import Link from "metabase/common/components/Link";
+import { useSelector } from "metabase/lib/redux";
+import { getQuestionWithoutComposing } from "metabase/query_builder/selectors";
 import { Flex, Icon, Stack, Text } from "metabase/ui";
-import type Question from "metabase-lib/v1/Question";
 
 import { ToggleFullList } from "./ToggleFullList";
 import { useExpandableList } from "./hooks";
@@ -11,13 +12,10 @@ import type { QuestionSource } from "./types";
 import { getJoinedTablesWithIcons } from "./utils";
 
 /** Displays tables linked to the question via a foreign-key relationship */
-export const TablesLinkedToQuestion = ({
-  question,
-}: {
-  question: Question;
-}) => {
+export const TablesLinkedToQuestion = () => {
+  const question = useSelector(getQuestionWithoutComposing);
   const joinedTablesWithIcons: QuestionSource[] = useMemo(
-    () => getJoinedTablesWithIcons(question),
+    () => (question ? getJoinedTablesWithIcons(question) : []),
     [question],
   );
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/setup.tsx
@@ -13,7 +13,7 @@ import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, waitForLoaderToBeRemoved } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
-import { getMetadata } from "metabase/selectors/metadata";
+import { getQuestion } from "metabase/query_builder/selectors";
 import type { Card, Settings, User } from "metabase-types/api";
 import {
   createMockCard,
@@ -57,8 +57,7 @@ export const setup = async ({
       questions: [card],
     }),
   });
-  const metadata = getMetadata(state);
-  const question = checkNotNull(metadata.question(card.id));
+  const question = checkNotNull(getQuestion(state));
   const onSave = jest.fn();
 
   if (hasEnterprisePlugins) {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/57469

How to verify:
- Models -> New -> Orders -> Join Products -> Save
- Info icon -> Relationships -> You should see the Products table now

<img width="1726" height="457" alt="Screenshot 2025-08-29 at 12 41 39" src="https://github.com/user-attachments/assets/2532b49e-5959-4b0b-ab4c-41a9f3925236" />
