### PR TITLE
Fix: Command palette layout shift on open

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -23,7 +23,9 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     cy.intercept("GET", "/api/dashboard/*").as("dashboard");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-    cy.intercept("GET", "/api/activity/recents?*").as("recentActivity");
+    cy.intercept("GET", "/api/activity/recents?context=selections*").as(
+      "recentActivity",
+    );
   });
 
   afterEach(() => {

--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -9,11 +9,21 @@ import { useSelector } from "metabase/lib/redux";
 import { getUser } from "metabase/selectors/user";
 import { Box, Card, Center, Overlay, type OverlayProps } from "metabase/ui";
 
+import { useCommandPalette } from "../hooks/useCommandPalette";
 import { useCommandPaletteBasicActions } from "../hooks/useCommandPaletteBasicActions";
 
 import { PaletteInput } from "./Palette.styled";
 import { PaletteFooter } from "./PaletteFooter";
 import { PaletteResults } from "./PaletteResults";
+
+/**
+ * Thin wrapper for useCommandPalette.
+ * Limits re-render scope and provides an easy way to enable/disable entire hook.
+ */
+const AdvancedPaletteActions = withRouter((props) => {
+  useCommandPalette({ locationQuery: props.location.query });
+  return null;
+});
 
 /** Command palette */
 export const Palette = withRouter((props) => {
@@ -26,18 +36,20 @@ export const Palette = withRouter((props) => {
 
   useCommandPaletteBasicActions({ ...props, isLoggedIn });
 
-  //Disable when iframed in
   const { query } = useKBar();
+  const disabled =
+    isWithinIframe() || !isLoggedIn || disableCommandPaletteForRoute;
   useEffect(() => {
-    query.disable(
-      isWithinIframe() || !isLoggedIn || disableCommandPaletteForRoute,
-    );
-  }, [isLoggedIn, query, disableCommandPaletteForRoute]);
+    query.disable(disabled);
+  }, [disabled, query]);
 
   return (
-    <KBarPortal>
-      <PaletteContainer />
-    </KBarPortal>
+    <>
+      <KBarPortal>
+        <PaletteContainer />
+      </KBarPortal>
+      {!disabled && <AdvancedPaletteActions />}
+    </>
   );
 });
 

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -1,13 +1,10 @@
-import type { Location } from "history";
 import { useKBar, useMatches } from "kbar";
 import { useEffect, useMemo } from "react";
-import { withRouter } from "react-router";
 import { useKeyPressEvent } from "react-use";
 import { t } from "ttag";
 
 import { Box, Flex } from "metabase/ui";
 
-import { useCommandPalette } from "../hooks/useCommandPalette";
 import type { PaletteActionImpl } from "../types";
 import { navigateActionIndex, processResults } from "../utils";
 
@@ -16,90 +13,86 @@ import { PaletteResultList } from "./PaletteResultsList";
 
 const PAGE_SIZE = 4;
 
-export const PaletteResults = withRouter(
-  ({ location }: { location: Location }) => {
-    // Used for finding actions within the list
-    const { query } = useKBar();
+export const PaletteResults = () => {
+  // Used for finding actions within the list
+  const { query } = useKBar();
 
-    useCommandPalette({ locationQuery: location.query });
+  const { results } = useMatches();
 
-    const { results } = useMatches();
+  const processedResults = useMemo(
+    () => processResults(results as (PaletteActionImpl | string)[]),
+    [results],
+  );
 
-    const processedResults = useMemo(
-      () => processResults(results as (PaletteActionImpl | string)[]),
-      [results],
+  useEffect(() => {
+    if (processedResults[0] === t`Search results`) {
+      query.setActiveIndex(2);
+    }
+  }, [processedResults, query]);
+
+  useKeyPressEvent("End", () => {
+    query.setActiveIndex(
+      navigateActionIndex(processedResults, processedResults.length, -1),
     );
+  });
 
-    useEffect(() => {
-      if (processedResults[0] === t`Search results`) {
-        query.setActiveIndex(2);
-      }
-    }, [processedResults, query]);
+  useKeyPressEvent("Home", () => {
+    query.setActiveIndex(navigateActionIndex(processedResults, -1, 1));
+  });
 
-    useKeyPressEvent("End", () => {
-      query.setActiveIndex(
-        navigateActionIndex(processedResults, processedResults.length, -1),
-      );
-    });
-
-    useKeyPressEvent("Home", () => {
-      query.setActiveIndex(navigateActionIndex(processedResults, -1, 1));
-    });
-
-    useKeyPressEvent("PageDown", () => {
-      query.setActiveIndex((i) =>
-        navigateActionIndex(processedResults, i, PAGE_SIZE),
-      );
-    });
-
-    useKeyPressEvent("PageUp", () => {
-      query.setActiveIndex((i) =>
-        navigateActionIndex(processedResults, i, -PAGE_SIZE),
-      );
-    });
-
-    return (
-      <Flex align="stretch" direction="column" p="0.75rem 0">
-        <PaletteResultList
-          items={processedResults} // items needs to be a stable reference, otherwise the activeIndex will constantly be hijacked
-          maxHeight={530}
-          onRender={({
-            item,
-            active,
-          }: {
-            item: string | PaletteActionImpl;
-            active: boolean;
-          }) => {
-            const isFirst = processedResults[0] === item;
-
-            return (
-              <Flex lh="1rem" pb="2px">
-                {typeof item === "string" ? (
-                  <Box
-                    px="1.5rem"
-                    fz="14px"
-                    pt="1rem"
-                    pb="0.5rem"
-                    style={
-                      isFirst
-                        ? undefined
-                        : {
-                            borderTop: "1px solid var(--mb-color-border)",
-                            marginTop: "1rem",
-                          }
-                    }
-                    w="100%"
-                  >
-                    {item}
-                  </Box>
-                ) : (
-                  <PaletteResultItem item={item} active={active} />
-                )}
-              </Flex>
-            );
-          }}
-        />
-      </Flex>
+  useKeyPressEvent("PageDown", () => {
+    query.setActiveIndex((i) =>
+      navigateActionIndex(processedResults, i, PAGE_SIZE),
     );
-  },
-);
+  });
+
+  useKeyPressEvent("PageUp", () => {
+    query.setActiveIndex((i) =>
+      navigateActionIndex(processedResults, i, -PAGE_SIZE),
+    );
+  });
+
+  return (
+    <Flex align="stretch" direction="column" p="0.75rem 0">
+      <PaletteResultList
+        items={processedResults} // items needs to be a stable reference, otherwise the activeIndex will constantly be hijacked
+        maxHeight={530}
+        onRender={({
+          item,
+          active,
+        }: {
+          item: string | PaletteActionImpl;
+          active: boolean;
+        }) => {
+          const isFirst = processedResults[0] === item;
+
+          return (
+            <Flex lh="1rem" pb="2px">
+              {typeof item === "string" ? (
+                <Box
+                  px="1.5rem"
+                  fz="14px"
+                  pt="1rem"
+                  pb="0.5rem"
+                  style={
+                    isFirst
+                      ? undefined
+                      : {
+                          borderTop: "1px solid var(--mb-color-border)",
+                          marginTop: "1rem",
+                        }
+                  }
+                  w="100%"
+                >
+                  {item}
+                </Box>
+              ) : (
+                <PaletteResultItem item={item} active={active} />
+              )}
+            </Flex>
+          );
+        }}
+      />
+    </Flex>
+  );
+};

--- a/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
+++ b/frontend/src/metabase/palette/components/test/PaletteResults/setup.tsx
@@ -1,4 +1,4 @@
-import { useKBar } from "kbar";
+import { VisualState, useKBar } from "kbar";
 import { useEffect } from "react";
 import { Route, type WithRouterProps, withRouter } from "react-router";
 import _ from "underscore";
@@ -12,6 +12,7 @@ import {
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
 import { getAdminPaths } from "metabase/admin/app/reducers";
+import { useCommandPalette } from "metabase/palette/hooks/useCommandPalette";
 import { useCommandPaletteBasicActions } from "metabase/palette/hooks/useCommandPaletteBasicActions";
 import type { RecentItem, Settings } from "metabase-types/api";
 import {
@@ -33,10 +34,12 @@ import { PaletteResults } from "../../PaletteResults";
 const TestComponent = withRouter(
   ({ q, ...props }: WithRouterProps & { q?: string; isLoggedIn: boolean }) => {
     useCommandPaletteBasicActions(props);
+    useCommandPalette({ locationQuery: props.location.query });
 
     const { query } = useKBar();
 
     useEffect(() => {
+      query.setVisualState(VisualState.showing);
       if (q) {
         query.setSearch(q);
       }

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -63,10 +63,10 @@ export const useCommandPalette = ({
 
   useDebounce(
     () => {
-      setDebouncedSearchText(trimmedQuery);
+      setDebouncedSearchText(isVisible ? trimmedQuery : "");
     },
-    SEARCH_DEBOUNCE_DURATION,
-    [trimmedQuery],
+    isVisible ? SEARCH_DEBOUNCE_DURATION : 0,
+    [trimmedQuery, isVisible],
   );
 
   const hasQuery = searchQuery.length > 0;

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -1,6 +1,6 @@
 import type { Query } from "history";
-import { Priority, useKBar, useRegisterActions } from "kbar";
-import { useMemo, useState } from "react";
+import { Priority, VisualState, useKBar, useRegisterActions } from "kbar";
+import { useEffect, useMemo, useState } from "react";
 import { useDebounce } from "react-use";
 import { jt, t } from "ttag";
 
@@ -43,6 +43,9 @@ export const useCommandPalette = ({
   const dispatch = useDispatch();
   const docsUrl = useSelector((state) => getDocsUrl(state, {}));
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+  const { isVisible } = useKBar((s) => ({
+    isVisible: s.visualState !== VisualState.hidden,
+  }));
 
   const isAdmin = useSelector(getUserIsAdmin);
   const canUserAccessSettings = useSelector(canAccessSettings);
@@ -86,9 +89,12 @@ export const useCommandPalette = ({
     },
   );
 
-  const { data: recentItems } = useListRecentsQuery(undefined, {
-    refetchOnMountOrArgChange: true,
-  });
+  const { data: recentItems, refetch: refetchRecents } = useListRecentsQuery();
+  useEffect(() => {
+    if (isVisible) {
+      refetchRecents();
+    }
+  }, [isVisible, refetchRecents]);
 
   const adminPaths = useSelector(getAdminPaths);
   const settingValues = useSelector(getSettings);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/59112
Closes [UXW-295](https://linear.app/metabase/issue/UXW-295)

### Description

Fixes command palette layout shift by moving `useCommandPalette` to the always-mounted Palette component

### How to verify

1. Open the command palette (cmd+k)
2. Verify there's no layout shift
3. Verify no regressions, e.g.
  a. Recents refresh on open
  b. Search is debounced, doesn't use cached responses for previous search terms, and isn't called more than it needs to be
  c. Filters are retained in "View and filter ..." option when kbar-ing from /search
  d. Command palette is disabled in iframe/when logged out/when setting up
  e. Anything else you can think of

### Demo

https://github.com/user-attachments/assets/f11adda8-726b-45f6-8292-001373f15a7e

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
