### PR TITLE
semantic search: fallback to backup engine when search-string is nil

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.semantic-search.core
   "Enterprise implementations of semantic search core functions using defenterprise."
   (:require
+   [clojure.string :as str]
    [medley.core :as m]
    [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
    [metabase-enterprise.semantic-search.env :as semantic.env]
@@ -43,7 +44,10 @@
           final-count (count results)
           threshold (semantic.settings/semantic-search-min-results-threshold)]
       (if (or (>= final-count threshold)
-              (zero? raw-count))
+              (and (zero? raw-count)
+                   ;; :search-string is nil when using search to populate the list of tables for a given database in
+                   ;; the native query editor. Semantic search doesn't support this, so fallback in this case.
+                   (not (str/blank? (:search-string search-ctx)))))
         results
         ;; Fallback: semantic search found results but some were filtered out (e.g. due to permission checks), so try to
         ;; supplement with appdb search.


### PR DESCRIPTION
Closes BOT-376

### Description

Semantic search currently returns no results when search is called from the FE to populate the list of tables and models in the native query editor sidebar, because in this case the frontend calls the search api with `:search-string nil`, and semantic search returns an empty result set.

This is a quick workaround to get stats working. Follow up issue in case we want to handle these queries directly from the semantic index: [BOT-377 Handle :search-string nil queries in semantic search index](https://linear.app/metabase/issue/BOT-377/handle-search-string-nil-queries-in-semantic-search-index)

### How to verify

1. New **SQL query** -> Sample Dataset
2. Should see list of tables and model in sidebar to the right of the native query editor

### Demo

**before**
<img width="903" height="628" alt="Screenshot 2025-08-29 at 12 27 00 PM" src="https://github.com/user-attachments/assets/0d747f8c-bdee-430b-9bda-a36764aa54f2" />


**after**
<img width="893" height="625" alt="Screenshot 2025-08-29 at 12 26 25 PM" src="https://github.com/user-attachments/assets/7bdb2a7f-0ffc-41c7-a042-f484f7eb7312" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
