### PR TITLE
Stop pushing useless version info highlights

### DIFF
--- a/release/src/version-info.ts
+++ b/release/src/version-info.ts
@@ -1,14 +1,14 @@
 import fetch from "node-fetch";
 
-import { getMilestoneIssues } from "./github";
 import type {
-  Issue,
   ReleaseChannel,
   ReleaseProps,
   VersionInfo,
   VersionInfoFile,
 } from "./types";
 import {
+  getMajorVersion,
+  getMinorVersion,
   getVersionType,
   isEnterpriseVersion,
   isPatchVersion,
@@ -16,26 +16,25 @@ import {
 
 const generateVersionInfo = ({
   version,
-  milestoneIssues,
 }: {
   version: string;
-  milestoneIssues: Issue[];
 }): VersionInfo => {
+  const majorVersion = getMajorVersion(version);
+  const minorVersion = getMinorVersion(version);
+
   return {
     version,
     released: new Date().toISOString().slice(0, 10),
     patch: ["patch", "minor"].includes(getVersionType(version)),
-    highlights: milestoneIssues.map?.(issue => issue.title) ?? [],
+    highlights: [ `see https://www.metabase.com/changelog/${majorVersion}#metabase${majorVersion}${minorVersion}}` ],
   };
 };
 
 export const generateVersionInfoJson = ({
   version,
   existingVersionInfo,
-  milestoneIssues,
 }: {
   version: string;
-  milestoneIssues: Issue[];
   existingVersionInfo: VersionInfoFile;
 }) => {
   const isAlreadyReleased =
@@ -49,7 +48,7 @@ export const generateVersionInfoJson = ({
     return existingVersionInfo;
   }
 
-  const newVersionInfo = generateVersionInfo({ version, milestoneIssues });
+  const newVersionInfo = generateVersionInfo({ version });
 
   return {
     ...existingVersionInfo,
@@ -119,25 +118,14 @@ export const getVersionInfoUrl = (version: string) => {
 // for adding a new release to version info
 export async function getVersionInfo({
   version,
-  github,
-  owner,
-  repo,
 }: ReleaseProps) {
   const url = getVersionInfoUrl(version);
   const existingFile = (await fetch(url).then(r =>
     r.json(),
   )) as VersionInfoFile;
 
-  const milestoneIssues = await getMilestoneIssues({
-    version,
-    github,
-    owner,
-    repo,
-  });
-
   const newVersionJson = generateVersionInfoJson({
     version,
-    milestoneIssues,
     existingVersionInfo: existingFile,
   });
 

--- a/release/src/version-info.ts
+++ b/release/src/version-info.ts
@@ -26,7 +26,7 @@ const generateVersionInfo = ({
     version,
     released: new Date().toISOString().slice(0, 10),
     patch: ["patch", "minor"].includes(getVersionType(version)),
-    highlights: [ `see https://www.metabase.com/changelog/${majorVersion}#metabase${majorVersion}${minorVersion}}` ],
+    highlights: [ `see https://www.metabase.com/changelog/${majorVersion}#metabase-${majorVersion}${minorVersion}}` ],
   };
 };
 

--- a/release/src/version-info.unit.spec.ts
+++ b/release/src/version-info.unit.spec.ts
@@ -8,7 +8,7 @@ describe("version-info", () => {
         version: "v0.2.3",
         released: "2021-01-01",
         patch: true,
-        highlights: ["see https://www.metabase.com/changelog/2#metabase23}"],
+        highlights: ["see https://www.metabase.com/changelog/2#metabase-23}"],
       },
       older: [],
     } as VersionInfoFile;
@@ -23,7 +23,7 @@ describe("version-info", () => {
         version: "v0.3.0",
         released: expect.any(String),
         patch: false,
-        highlights: ["see https://www.metabase.com/changelog/3#metabase30}"],
+        highlights: ["see https://www.metabase.com/changelog/3#metabase-30}"],
       }]);
     });
 
@@ -64,7 +64,7 @@ describe("version-info", () => {
         version: "v0.1.9",
         released: expect.any(String),
         patch: true,
-        highlights: ["see https://www.metabase.com/changelog/1#metabase19}"],
+        highlights: ["see https://www.metabase.com/changelog/1#metabase-19}"],
       });
     });
 

--- a/release/src/version-info.unit.spec.ts
+++ b/release/src/version-info.unit.spec.ts
@@ -1,47 +1,20 @@
-import type { Issue, VersionInfoFile } from "./types";
+import type { VersionInfoFile } from "./types";
 import { generateVersionInfoJson, getVersionInfoUrl, updateVersionInfoChannelJson, updateVersionInfoLatestJson } from "./version-info";
 
 describe("version-info", () => {
   describe("generateVersionInfoJson", () => {
-    const issues = [
-      {
-        number: 1,
-        title: "New Issue 1",
-        labels: [{ name: "Type:Bug" }],
-      },
-      {
-        number: 2,
-        title: "New Issue 2",
-        labels: [{ name: "Type:Enhancement" }],
-      },
-    ] as Issue[];
-
-    const moreIssues = [
-      {
-        number: 3,
-        title: "New Issue 3",
-        labels: [{ name: "Type:Bug" }],
-      },
-      {
-        number: 4,
-        title: "New Issue 4",
-        labels: [{ name: "Type:Enhancement" }],
-      },
-    ] as Issue[];
-
     const oldJson = {
       latest: {
         version: "v0.2.3",
         released: "2021-01-01",
         patch: true,
-        highlights: ["Old Issue 1", "Old Issue 2"],
+        highlights: ["see https://www.metabase.com/changelog/2#metabase23}"],
       },
       older: [],
     } as VersionInfoFile;
 
     it("should add new version to version info json", () => {
       const generatedJson = generateVersionInfoJson({
-        milestoneIssues: issues,
         version: "v0.3.0",
         existingVersionInfo: oldJson,
       });
@@ -50,13 +23,12 @@ describe("version-info", () => {
         version: "v0.3.0",
         released: expect.any(String),
         patch: false,
-        highlights: ["New Issue 1", "New Issue 2"],
+        highlights: ["see https://www.metabase.com/changelog/3#metabase30}"],
       }]);
     });
 
     it("should leave old latest version intact", () => {
       const generatedJson = generateVersionInfoJson({
-        milestoneIssues: issues,
         version: "v0.3.0",
         existingVersionInfo: oldJson,
       });
@@ -66,7 +38,6 @@ describe("version-info", () => {
 
     it("properly records patch releases", () => {
       const generatedJson = generateVersionInfoJson({
-        milestoneIssues: moreIssues,
         version: "v0.45.1",
         existingVersionInfo: oldJson,
       });
@@ -76,7 +47,6 @@ describe("version-info", () => {
 
     it("properly recognizes major releases", () => {
       const generatedJson = generateVersionInfoJson({
-        milestoneIssues: moreIssues,
         version: "v0.45.0",
         existingVersionInfo: oldJson,
       });
@@ -86,7 +56,6 @@ describe("version-info", () => {
 
     it("should always record releases in older array", () => {
       const generatedJson = generateVersionInfoJson({
-        milestoneIssues: issues,
         version: "v0.1.9",
         existingVersionInfo: oldJson,
       });
@@ -95,13 +64,12 @@ describe("version-info", () => {
         version: "v0.1.9",
         released: expect.any(String),
         patch: true,
-        highlights: ["New Issue 1", "New Issue 2"],
+        highlights: ["see https://www.metabase.com/changelog/1#metabase19}"],
       });
     });
 
     it("should ignore an already released version", () => {
       const generatedJson = generateVersionInfoJson({
-        milestoneIssues: moreIssues,
         version: "v0.2.3",
         existingVersionInfo: oldJson,
       });


### PR DESCRIPTION
Closes DEV-97

### Description

With every update we push a list of highlights to our `version-info.json` that are meant to give people an idea of what updating metabase will get them, and we show them in-product on the updates tab.

However, these are just auto-generated from PR titles. Here is a sample of the "highlights" from version 56.3
```
"docs - embed js edits",
"update bouncycastle versions for snowflake to shutdown complains",
"update jakarta.mail to 1.6.8",
"update athena to 3.5.1",
"Auto-update documentation for release-x.56.x",
"Disable vertica tests until new image is published",
"Add `background-hover` to custom colors list",
"docs - prefer https links",
"Update Snowplow Micro image",
"Add the metabase-browser experience to embed flow",
"fix actions tests",
"fix: handle whitespaces in the connection string, decode username and password",
"comment embedding codeowners in release branch",
"Add embedded analytics JS documentation to admin panel",
"docs - update filter doc",
"wait up to 10 seconds for worker to stop",
"Log propagation for notifications",
"Better error messages for actions that violate custom constraints",
"docs: remove examples for R/CLS docs",
```

Absolute 💩  as far as informing users what's going on.

This PR replaces all this with 
```
see https://www.metabase.com/changelog/56#metabase-563
``` 
Short, sweet, and actually helpful.

Longer term, we're updating this page to pull in our website "what's new" and "changelog" pages to be nicely formatted, and always up-to-date (https://github.com/metabase/metabase/pull/62943). But this will only help users on new versions. To maintain backwards compatibility, we should continue pushing these link strings in. It may also shave a few seconds off the release process 🤷 .

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
