### PR TITLE
fix(sdk): drills and go to dashcard does not work in dashboard with entity ids

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -209,6 +209,46 @@ describe("scenarios > embedding-sdk > interactive-dashboard", () => {
     });
   });
 
+  const idTypes = [
+    { idType: "numeric id", dashboardIdAlias: "@dashboardId" },
+    { idType: "entity id", dashboardIdAlias: "@dashboardEntityId" },
+  ];
+
+  idTypes.forEach(({ idType, dashboardIdAlias }) => {
+    it(`can go to dashcard and go back using a ${idType} dashboard (EMB-773)`, () => {
+      cy.get(dashboardIdAlias).then((dashboardId) => {
+        mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+      });
+
+      getSdkRoot().within(() => {
+        H.getDashboardCard().findByText("Orders").click();
+
+        cy.findByTestId("interactive-question-result-toolbar").should(
+          "be.visible",
+        );
+
+        cy.findByLabelText("Back to Orders in a dashboard").click();
+        cy.findByText("Orders in a dashboard").should("be.visible");
+        cy.findByText("Back to Orders in a dashboard").should("not.exist");
+      });
+    });
+
+    it(`can drill a question and go back using a ${idType} dashboard (EMB-773)`, () => {
+      cy.get(dashboardIdAlias).then((dashboardId) => {
+        mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+      });
+
+      getSdkRoot().within(() => {
+        cy.findByText("123").first().click();
+        H.popover().findByText("View this Product's Orders").click();
+
+        cy.findByLabelText("Back to Orders in a dashboard").click();
+        cy.findByText("Orders in a dashboard").should("be.visible");
+        cy.findByText("Back to Orders in a dashboard").should("not.exist");
+      });
+    });
+  });
+
   it("should only call POST /dataset once when parent component re-renders (EMB-288)", () => {
     cy.intercept("POST", "/api/dataset").as("datasetQuery");
 


### PR DESCRIPTION
Closes EMB-773

### Description

Drills and navigating to dashboard cards does not work in dashboards with Entity IDs.

### How to verify

1. Open the SDK's **InteractiveDashboard** storybook.
2. Set the dashboardId to **Entity ID** in the Controls section of the bottom bar.
3. Do drill-down on a question. Or, click on a dashboard card.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
