### PR TITLE
Embed JS should show "Try it out" before docs in admin panel

### DIFF
--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -193,6 +193,15 @@ export function EmbeddingSdkSettings() {
 
             {isSimpleEmbedFeatureEnabled ? (
               <Group gap="md">
+                <LinkButton
+                  size="compact-xs"
+                  variant="outline"
+                  to="/embed-js"
+                  fz="sm"
+                >
+                  {t`Try it out`}
+                </LinkButton>
+
                 <Button
                   size="compact-xs"
                   variant="outline"
@@ -203,15 +212,6 @@ export function EmbeddingSdkSettings() {
                 >
                   {t`Documentation`}
                 </Button>
-
-                <LinkButton
-                  size="compact-xs"
-                  variant="outline"
-                  to="/embed-js"
-                  fz="sm"
-                >
-                  {t`Try it out`}
-                </LinkButton>
               </Group>
             ) : (
               <UpsellEmbeddingButton


### PR DESCRIPTION
Moves the "Try it out" button to be before the docs button, so people can try out the embed flow first before deep-diving into the docs. Suggestions by Roman.