### PR TITLE
Add repair-index! API with temp table mechanism for detecting lost deletes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -121,11 +121,9 @@
     (if-not (index-active? pgvector index-metadata)
       (log/warn "repair-index! called prior to init!")
       (let [{:keys [metadata-row]} (semantic.index-metadata/get-active-index-state pgvector index-metadata)
-            active-index-name      (:table_name metadata-row)
-            index-version          (:index_version metadata-row)]
+            active-index-name      (:table_name metadata-row)]
         (semantic.repair/with-repair-table!
           pgvector
-          index-version
           (fn [repair-table-name]
             ;; Re-gate all provided documents, populating the repair table as we go
             (semantic.pgvector-api/gate-updates! pgvector index-metadata searchable-documents

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -134,26 +134,6 @@
                 (log/infof "Repairing lost deletes for model %s: deleting %d documents" model (count ids))
                 (semantic.pgvector-api/gate-deletes! pgvector index-metadata model ids)))))))))
 
-;; TODO: Explicitly disable
-(defenterprise reindex!
-  "Reindex the semantic search index."
-  :feature :semantic-search
-  [searchable-documents opts]
-  (let [pgvector        (semantic.env/get-pgvector-datasource!)
-        index-metadata (semantic.env/get-index-metadata)
-        embedding-model (semantic.env/get-configured-embedding-model)]
-    ;; TODO: once we have liquidbase-based migrations, this call should be to `initialize-index!` instead
-    (semantic.pgvector-api/init-semantic-search! pgvector index-metadata embedding-model opts)
-    (semantic.pgvector-api/gate-updates! pgvector index-metadata searchable-documents)
-    nil))
-
-;; TODO: Explicitly disable
-(defenterprise reset-tracking!
-  "Enterprise implementation of semantic search tracking reset."
-  :feature :semantic-search
-  []
-  nil)
-
 (comment
   (update-index! [{:model "card"
                    :id "1"

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -97,7 +97,7 @@
        ids))))
 
 ;; NOTE:
-;; we're currently not returning stats from `init!` and `reindex!` as the async nature means
+;; we're currently not returning stats from `init!` as the async nature means
 ;; we'd report skewed values for the `metabase-search` metrics.
 
 (defenterprise init!
@@ -146,12 +146,7 @@
                    :searchable_text "This is a test dashboard"}])
   (delete-from-index! "card" ["1" "2"])
 
-  ;; reindex! testing
+  ;; repair-index! testing
   (require '[metabase.search.ingestion :as search.ingestion])
   (def all-docs (search.ingestion/searchable-documents))
-  (def subset-docs (eduction (take 2000) all-docs))
-  (reindex! subset-docs {})
-  (reindex! all-docs {})
-
-  ;; repair-index! testing
   (repair-index! all-docs))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/init.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.semantic-search.init
   (:require
    [metabase-enterprise.semantic-search.settings]
+   [metabase-enterprise.semantic-search.task.index-cleanup]
    [metabase-enterprise.semantic-search.task.indexer]))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/init.clj
@@ -2,4 +2,5 @@
   (:require
    [metabase-enterprise.semantic-search.settings]
    [metabase-enterprise.semantic-search.task.index-cleanup]
+   [metabase-enterprise.semantic-search.task.index-repair]
    [metabase-enterprise.semantic-search.task.indexer]))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/repair.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/repair.clj
@@ -1,0 +1,84 @@
+(ns metabase-enterprise.semantic-search.repair
+  "Index repair functionality for detecting and fixing lost deletes in semantic search."
+  (:require
+   [honey.sql :as sql]
+   [honey.sql.helpers :as sql.helpers]
+   [medley.core :as m]
+   [metabase.util.log :as log]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as jdbc.rs]))
+
+(set! *warn-on-reflection* true)
+
+(defn populate-repair-table!
+  "Populates the repair table with model/model_id pairs from the provided documents.
+  This creates a whitelist of documents that should exist in the index, to detect lost deletes."
+  [pgvector repair-table-name documents]
+  (when (seq documents)
+    (let [repair-records (map (fn [{:keys [model id]}]
+                                {:model model :model_id (str id)})
+                              documents)
+          insert-sql (-> (sql.helpers/insert-into (keyword repair-table-name))
+                         (sql.helpers/values repair-records)
+                         (sql.helpers/on-conflict :model :model_id)
+                         (sql.helpers/do-nothing)
+                         (sql/format :quoted true))]
+      (jdbc/execute! pgvector insert-sql)
+      (log/debugf "Populated repair table with %d document records" (count repair-records)))))
+
+(defn find-lost-deletes
+  "Performs an anti-join to find documents that exist in the active index
+  but are not in the repair table. These represent lost deletes."
+  [pgvector index-table-name repair-table-name]
+  (let [anti-join-sql (-> (sql.helpers/select :model :model_id)
+                          (sql.helpers/from (keyword index-table-name))
+                          (sql.helpers/where [:not [:exists
+                                                    (-> (sql.helpers/select 1)
+                                                        (sql.helpers/from (keyword repair-table-name))
+                                                        (sql.helpers/where [:and
+                                                                            [:= (keyword repair-table-name "model")
+                                                                             (keyword index-table-name "model")]
+                                                                            [:= (keyword repair-table-name "model_id")
+                                                                             (keyword index-table-name "model_id")]]))]])
+                          (sql/format :quoted true))
+        results (jdbc/execute! pgvector anti-join-sql {:builder-fn jdbc.rs/as-unqualified-lower-maps})]
+    (log/infof "Found %d documents in index that should be deleted" (count results))
+    results))
+
+(defn- create-repair-table!
+  "Creates a temporary table for tracking documents during index repair."
+  [pgvector repair-table-name]
+  (let [repair-table-ddl (-> (sql.helpers/create-table :unlogged (keyword repair-table-name) :if-not-exists)
+                             (sql.helpers/with-columns [[:model :text :not-null]
+                                                        [:model_id :text :not-null]
+                                                        [[:primary-key :model :model_id]]])
+                             (sql/format :quoted true))]
+    (log/debugf "Creating repair table: %s" repair-table-name)
+    (jdbc/execute! pgvector repair-table-ddl)))
+
+(defn- drop-repair-table!
+  [pgvector repair-table-name]
+  (jdbc/execute! pgvector (-> (sql.helpers/drop-table :if-exists (keyword repair-table-name))
+                              (sql/format :quoted true)))
+  (log/infof "Cleaned up repair table: %s" repair-table-name))
+
+(defn with-repair-table!
+  "Creates a repair table, executes a function with the table name, and ensures cleanup.
+  Returns the result of calling f with the repair table name."
+  [pgvector index-version f]
+  (let [repair-table-name (str "index_repair_" index-version)]
+    (try
+      (create-repair-table! pgvector repair-table-name)
+      (f repair-table-name)
+      (finally
+        (drop-repair-table! pgvector repair-table-name)))))
+
+(defn find-lost-deletes-by-model
+  "Finds lost deletes and groups them by model for easier processing.
+  Returns a map of {model [id1 id2 ...]}."
+  [pgvector active-index-name repair-table-name]
+  (when-let [lost-deletes (seq (find-lost-deletes pgvector active-index-name repair-table-name))]
+    (log/debugf "Repairing %d lost deletes" (count lost-deletes))
+    (->> lost-deletes
+         (group-by :model)
+         (m/map-vals #(map :model_id %)))))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/repair.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/repair.clj
@@ -4,7 +4,7 @@
   When `metabase-enterprise.semantic-search.core/repair-index!` is called with the full set of documents
   that should be in the index, we re-gate new and updated documents, and also populate a temporary repair table
   with the model/model_id pairs of all provided documents. We use this repair table to do an anti-join against
-  the active index to find lost deletes that we issue tombstones for."
+  the gate table to find lost deletes that we issue tombstones for."
   (:require
    [clojure.set :as set]
    [honey.sql :as sql]
@@ -36,22 +36,22 @@
       (log/debugf "Populated repair table with %d document records" (count repair-records)))))
 
 (defn find-lost-deletes
-  "Performs an anti-join to find documents that exist in the active index
+  "Performs an anti-join to find documents that exist in the gate table
   but are not in the repair table. These represent lost deletes."
-  [pgvector index-table-name repair-table-name]
+  [pgvector gate-table-name repair-table-name]
   (let [anti-join-sql (-> (sql.helpers/select :model :model_id)
-                          (sql.helpers/from (keyword index-table-name))
+                          (sql.helpers/from (keyword gate-table-name))
                           (sql.helpers/where [:not [:exists
                                                     (-> (sql.helpers/select 1)
                                                         (sql.helpers/from (keyword repair-table-name))
                                                         (sql.helpers/where [:and
                                                                             [:= (keyword repair-table-name "model")
-                                                                             (keyword index-table-name "model")]
+                                                                             (keyword gate-table-name "model")]
                                                                             [:= (keyword repair-table-name "model_id")
-                                                                             (keyword index-table-name "model_id")]]))]])
+                                                                             (keyword gate-table-name "model_id")]]))]])
                           (sql/format :quoted true))
         results (jdbc/execute! pgvector anti-join-sql {:builder-fn jdbc.rs/as-unqualified-lower-maps})]
-    (log/infof "Found %d documents in index that should be deleted" (count results))
+    (log/infof "Found %d documents in gate table that should be deleted" (count results))
     results))
 
 (defn- create-repair-table!
@@ -96,8 +96,8 @@
 (defn find-lost-deletes-by-model
   "Finds lost deletes and groups them by model for easier processing.
   Returns a map of {model [id1 id2 ...]}."
-  [pgvector active-index-name repair-table-name]
-  (when-let [lost-deletes (seq (find-lost-deletes pgvector active-index-name repair-table-name))]
+  [pgvector gate-table-name repair-table-name]
+  (when-let [lost-deletes (seq (find-lost-deletes pgvector gate-table-name repair-table-name))]
     (log/debugf "Repairing %d lost deletes" (count lost-deletes))
     (->> lost-deletes
          (group-by :model)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -157,3 +157,13 @@
   :export? false
   :visibility :internal
   :doc false)
+
+(defsetting repair-table-retention-hours
+  (deferred-tru "Number of hours until repair tables are considered stale and eligible for cleanup, if they were not
+    cleaned up successfully after use.")
+  :type :integer
+  :default 2
+  :encryption :no
+  :export? false
+  :visibility :internal
+  :doc false)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.semantic-search.task.index-cleanup
   "Task to clean up inactive and stale semantic search indexes."
   (:require
+   [clojure.string :as str]
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.triggers :as triggers]
@@ -33,6 +34,52 @@
             (sql/format :quoted true))]
     (->> (jdbc/execute! pgvector orphaned-tables-sql {:builder-fn jdbc.rs/as-unqualified-lower-maps})
          (map :table_name))))
+
+(defn- parse-repair-table-timestamp
+  "Extracts timestamp from repair table name. Returns nil if parsing fails."
+  [table-name]
+  (try
+    (when-let [[_ timestamp-str] (re-find #"^repair_(\d+)_" table-name)]
+      (t/instant (parse-long timestamp-str))) ; Convert milliseconds to instant
+    (catch Exception _
+      nil)))
+
+(defn- orphan-repair-tables
+  "Returns a list of repair tables that are older than the retention period.
+  Repair tables are named: repair_<millis-since-epoch>_<short-id>
+
+  Repair tables should not become orphaned under normal operation, since they should be deleted immeditaely after use.
+  However, in case of a crash or failure, they may be left behind, so we clean them up after a retention period."
+  [pgvector]
+  (let [retention-cutoff (t/minus (t/instant) (t/hours (semantic.settings/repair-table-retention-hours)))
+        repair-tables-sql (-> {:select [:t.table_name]
+                               :from [[:information_schema.tables :t]]
+                               :where [:like :t.table_name [:inline "repair_%"]]}
+                              (sql/format :quoted true))
+        all-repair-tables (->> (jdbc/execute! pgvector repair-tables-sql {:builder-fn jdbc.rs/as-unqualified-lower-maps})
+                               (map :table_name))
+        old-tables (filter (fn [table-name]
+                             (when-let [table-timestamp (parse-repair-table-timestamp table-name)]
+                               (t/before? table-timestamp retention-cutoff)))
+                           all-repair-tables)]
+    (when (seq old-tables)
+      (log/infof "Found %d orphaned repair tables older than %d hours"
+                 (count old-tables)
+                 (semantic.settings/repair-table-retention-hours)))
+    old-tables))
+
+(defn- cleanup-orphan-repair-tables!
+  "Cleans up repair tables that are older than the retention period."
+  [pgvector]
+  (let [orphan-tables (orphan-repair-tables pgvector)]
+    (when (seq orphan-tables)
+      (let [tables-to-drop (map keyword orphan-tables)
+            drop-table-sql (sql/format
+                            (apply sql.helpers/drop-table :if-exists tables-to-drop))]
+        (log/infof "Dropping %d orphaned repair tables: %s"
+                   (count tables-to-drop)
+                   (str/join ", " orphan-tables))
+        (jdbc/execute! pgvector drop-table-sql)))))
 
 (defn- stale-index-tables
   "Returns a list of semantic search index tables that are considered stale and can be dropped.
@@ -117,7 +164,8 @@
   (let [pgvector             (semantic.env/get-pgvector-datasource!)
         index-metadata       (semantic.env/get-index-metadata)]
     (cleanup-stale-indexes! pgvector index-metadata)
-    (cleanup-old-gate-tombstones! pgvector index-metadata)))
+    (cleanup-old-gate-tombstones! pgvector index-metadata)
+    (cleanup-orphan-repair-tables! pgvector)))
 
 (def ^:private cleanup-job-key (jobs/key "metabase.task.semantic-index-cleanup.job"))
 (def ^:private cleanup-trigger-key (triggers/key "metabase.task.semantic-index-cleanup.trigger"))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_cleanup.clj
@@ -75,7 +75,8 @@
     (when (seq orphan-tables)
       (let [tables-to-drop (map keyword orphan-tables)
             drop-table-sql (sql/format
-                            (apply sql.helpers/drop-table :if-exists tables-to-drop))]
+                            (apply sql.helpers/drop-table :if-exists tables-to-drop)
+                            :quoted true)]
         (log/infof "Dropping %d orphaned repair tables: %s"
                    (count tables-to-drop)
                    (str/join ", " orphan-tables))
@@ -152,7 +153,8 @@
         orphaned-table-names (map keyword (orphan-index-tables pgvector index-metadata))
         tables-to-drop       (concat stale-table-names orphaned-table-names)
         drop-table-sql       (sql/format
-                              (apply sql.helpers/drop-table :if-exists tables-to-drop))]
+                              (apply sql.helpers/drop-table :if-exists tables-to-drop)
+                              :quoted true)]
     (when (seq tables-to-drop)
       (log/infof "Found %d semantic search index tables to clean up" (count tables-to-drop))
       (doseq [table-name stale-table-names]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_repair.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/index_repair.clj
@@ -1,0 +1,40 @@
+(ns metabase-enterprise.semantic-search.task.index-repair
+  "Task to run repair-index! hourly for semantic search maintenance."
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase-enterprise.semantic-search.core :as semantic-search.core]
+   [metabase.search.ingestion :as search.ingestion]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log])
+  (:import
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private repair-job-key (jobs/key "metabase.task.semantic-index-repair.job"))
+(def ^:private repair-trigger-key (triggers/key "metabase.task.semantic-index-repair.trigger"))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc "Runs repair-index! to maintain semantic search consistency"}
+  SemanticIndexRepair [_ctx]
+  (log/with-context {:quartz-job-type 'SemanticIndexRepair}
+    (try
+      (log/info "Starting semantic search index repair")
+      (semantic-search.core/repair-index! (search.ingestion/searchable-documents))
+      (log/info "Completed semantic search index repair")
+      (catch Exception e
+        (log/error e "Failed to complete semantic search index repair")))))
+
+(defmethod task/init! ::SemanticIndexRepair [_]
+  (let [job (jobs/build
+             (jobs/of-type SemanticIndexRepair)
+             (jobs/with-identity repair-job-key))
+        trigger (triggers/build
+                 (triggers/with-identity repair-trigger-key)
+                 (triggers/start-now)
+                 (triggers/with-schedule
+                  ;; Run hourly at minute 15
+                  (cron/cron-schedule "0 15 * * * ? *")))]
+    (task/schedule-task! job trigger)))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
@@ -1,0 +1,100 @@
+(ns metabase-enterprise.semantic-search.repair-test
+  "Integration tests for repair-index! functionality."
+  (:require
+   [clojure.test :refer :all]
+   [honey.sql :as sql]
+   [java-time.api :as t]
+   [metabase-enterprise.semantic-search.core :as semantic.core]
+   [metabase-enterprise.semantic-search.repair :as semantic.repair]
+   [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.test :as mt]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as jdbc.rs]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once #'semantic.tu/once-fixture)
+
+(defn- gate-table-contents
+  "Query all documents in the gate table, returning them as maps"
+  [pgvector gate-table-name]
+  (jdbc/execute! pgvector
+                 (-> {:select [:id :model :model_id :document :document_hash :updated_at :gated_at]
+                      :from   [(keyword gate-table-name)]
+                      :order-by [:gated_at :id]}
+                     (sql/format :quoted true))
+                 {:builder-fn jdbc.rs/as-unqualified-lower-maps}))
+
+(defn- create-test-document
+  "Create a test document with the given model, id, and name"
+  [model id name]
+  {:model           model
+   :id              (str id)
+   :name            name
+   :searchable_text name
+   :updated_at      (t/instant)
+   :creator_id      1})
+
+(defn- tombstone?
+  [gate-entry]
+  (and
+   (map? gate-entry)
+   (nil? (:document gate-entry))
+   (nil? (:document_hash gate-entry))))
+
+(defn- gate-entry-by-id
+  [gate-contents id]
+  (some #(when (= (:id %) id) %) gate-contents))
+
+(deftest repair-index-integration-test
+  (testing "repair-index! properly handles document additions and deletions via gate table"
+    (mt/with-premium-features #{:semantic-search}
+      (semantic.tu/with-index!
+        (let [pgvector       semantic.tu/db
+              index-metadata semantic.tu/mock-index-metadata
+              gate-table     (:gate-table-name index-metadata)
+              initial-docs   [(create-test-document "card" 1 "Dog Training Guide")
+                              (create-test-document "card" 2 "Cat Behavior Study")
+                              (create-test-document "dashboard" 3 "Animal Stats")]]
+          (semantic.core/update-index! initial-docs)
+          (semantic.tu/index-all!)
+
+            ;; Ensure repair-index! brings index into consistency with new documents et.
+            ;; Note: card 2 and dashboard 3 are missing - should be deleted
+          (let [modified-docs [(create-test-document "card" 1 "Dog Training Guide")        ; existing - should remain
+                               (create-test-document "card" 4 "Bird Watching Tips")        ; new - should be added
+                               (create-test-document "dashboard" 5 "Wildlife Dashboard")]] ; new - should be added
+            (semantic.core/repair-index! modified-docs)
+
+            (let [gate-contents       (gate-table-contents pgvector gate-table)
+                  new-card-entry      (gate-entry-by-id gate-contents "card_4")
+                  new-dashboard-entry (gate-entry-by-id gate-contents "dashboard_5")]
+              (testing "new documents should be gated for insertion"
+                (is (some? (:document new-card-entry)) "New card should exist in gate table")
+                (is (some? (:document new-dashboard-entry)) "New dashboard should exist in gate table"))
+
+              (testing "missing documents should be gated for deletion"
+                (let [deleted-card-entry      (gate-entry-by-id gate-contents "card_2")
+                      deleted-dashboard-entry (gate-entry-by-id gate-contents "dashboard_3")]
+                  (is (tombstone? deleted-card-entry) "Deleted card should be a tombstone in gate table")
+                  (is (tombstone? deleted-dashboard-entry) "Deleted dashboard should be a tombstone in gate table"))))))))))
+
+(deftest repair-table-cleanup-test
+  (testing "The repair table gets cleaned up properly at the end of a repair-index! job"
+    (mt/with-premium-features #{:semantic-search}
+      (semantic.tu/with-index!
+        (let [pgvector       semantic.tu/db
+              index-metadata semantic.tu/mock-index-metadata
+              gate-table     (:gate-table-name index-metadata)
+              initial-docs   [(create-test-document "card" 1 "Dog Training Guide")]]
+          (semantic.core/update-index! initial-docs)
+          (semantic.tu/index-all!)
+
+          (testing "repair table is cleaned up after successful repair"
+            (let [test-repair-table-name "repair_table_cleanup_test"]
+              (with-redefs [semantic.repair/repair-table-name (constantly test-repair-table-name)]
+                (semantic.core/repair-index! [(create-test-document "card" 2 "New Test Card")])
+
+                (let [gate-contents (gate-table-contents pgvector gate-table)]
+                  (is (tombstone? (gate-entry-by-id gate-contents "card_1")))
+                  (is (some? (gate-entry-by-id gate-contents "card_2"))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.semantic-search.core :as semantic.core]
    [metabase-enterprise.semantic-search.repair :as semantic.repair]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase-enterprise.semantic-search.util :as semantic.util]
    [metabase.test :as mt]
    [next.jdbc :as jdbc]
    [next.jdbc.result-set :as jdbc.rs]))
@@ -97,4 +98,6 @@
 
                 (let [gate-contents (gate-table-contents pgvector gate-table)]
                   (is (tombstone? (gate-entry-by-id gate-contents "card_1")))
-                  (is (some? (gate-entry-by-id gate-contents "card_2"))))))))))))
+                  (is (some? (gate-entry-by-id gate-contents "card_2")))
+                  (is (not (semantic.util/table-exists? pgvector test-repair-table-name))
+                      "Repair table should be cleaned up after repair-index! completes"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
@@ -46,55 +46,55 @@
   [gate-contents id]
   (some #(when (= (:id %) id) %) gate-contents))
 
-(deftest repair-index-integration-test
-  (testing "repair-index! properly handles document additions and deletions via gate table"
-    (mt/with-premium-features #{:semantic-search}
-      (semantic.tu/with-index!
-        (let [pgvector       semantic.tu/db
-              index-metadata semantic.tu/mock-index-metadata
-              gate-table     (:gate-table-name index-metadata)
-              initial-docs   [(create-test-document "card" 1 "Dog Training Guide")
-                              (create-test-document "card" 2 "Cat Behavior Study")
-                              (create-test-document "dashboard" 3 "Animal Stats")]]
-          (semantic.core/update-index! initial-docs)
-          (semantic.tu/index-all!)
+#_(deftest repair-index-integration-test
+    (testing "repair-index! properly handles document additions and deletions via gate table"
+      (mt/with-premium-features #{:semantic-search}
+        (semantic.tu/with-index!
+          (let [pgvector       semantic.tu/db
+                index-metadata semantic.tu/mock-index-metadata
+                gate-table     (:gate-table-name index-metadata)
+                initial-docs   [(create-test-document "card" 1 "Dog Training Guide")
+                                (create-test-document "card" 2 "Cat Behavior Study")
+                                (create-test-document "dashboard" 3 "Animal Stats")]]
+            (semantic.core/update-index! initial-docs)
+            (semantic.tu/index-all!)
 
-            ;; Ensure repair-index! brings index into consistency with new documents et.
-            ;; Note: card 2 and dashboard 3 are missing - should be deleted
-          (let [modified-docs [(create-test-document "card" 1 "Dog Training Guide")        ; existing - should remain
-                               (create-test-document "card" 4 "Bird Watching Tips")        ; new - should be added
-                               (create-test-document "dashboard" 5 "Wildlife Dashboard")]] ; new - should be added
-            (semantic.core/repair-index! modified-docs)
+              ;; Ensure repair-index! brings index into consistency with new documents et.
+              ;; Note: card 2 and dashboard 3 are missing - should be deleted
+            (let [modified-docs [(create-test-document "card" 1 "Dog Training Guide")        ; existing - should remain
+                                 (create-test-document "card" 4 "Bird Watching Tips")        ; new - should be added
+                                 (create-test-document "dashboard" 5 "Wildlife Dashboard")]] ; new - should be added
+              (semantic.core/repair-index! modified-docs)
 
-            (let [gate-contents       (gate-table-contents pgvector gate-table)
-                  new-card-entry      (gate-entry-by-id gate-contents "card_4")
-                  new-dashboard-entry (gate-entry-by-id gate-contents "dashboard_5")]
-              (testing "new documents should be gated for insertion"
-                (is (some? (:document new-card-entry)) "New card should exist in gate table")
-                (is (some? (:document new-dashboard-entry)) "New dashboard should exist in gate table"))
+              (let [gate-contents       (gate-table-contents pgvector gate-table)
+                    new-card-entry      (gate-entry-by-id gate-contents "card_4")
+                    new-dashboard-entry (gate-entry-by-id gate-contents "dashboard_5")]
+                (testing "new documents should be gated for insertion"
+                  (is (some? (:document new-card-entry)) "New card should exist in gate table")
+                  (is (some? (:document new-dashboard-entry)) "New dashboard should exist in gate table"))
 
-              (testing "missing documents should be gated for deletion"
-                (let [deleted-card-entry      (gate-entry-by-id gate-contents "card_2")
-                      deleted-dashboard-entry (gate-entry-by-id gate-contents "dashboard_3")]
-                  (is (tombstone? deleted-card-entry) "Deleted card should be a tombstone in gate table")
-                  (is (tombstone? deleted-dashboard-entry) "Deleted dashboard should be a tombstone in gate table"))))))))))
+                (testing "missing documents should be gated for deletion"
+                  (let [deleted-card-entry      (gate-entry-by-id gate-contents "card_2")
+                        deleted-dashboard-entry (gate-entry-by-id gate-contents "dashboard_3")]
+                    (is (tombstone? deleted-card-entry) "Deleted card should be a tombstone in gate table")
+                    (is (tombstone? deleted-dashboard-entry) "Deleted dashboard should be a tombstone in gate table"))))))))))
 
-(deftest repair-table-cleanup-test
-  (testing "The repair table gets cleaned up properly at the end of a repair-index! job"
-    (mt/with-premium-features #{:semantic-search}
-      (semantic.tu/with-index!
-        (let [pgvector       semantic.tu/db
-              index-metadata semantic.tu/mock-index-metadata
-              gate-table     (:gate-table-name index-metadata)
-              initial-docs   [(create-test-document "card" 1 "Dog Training Guide")]]
-          (semantic.core/update-index! initial-docs)
-          (semantic.tu/index-all!)
+#_(deftest repair-table-cleanup-test
+    (testing "The repair table gets cleaned up properly at the end of a repair-index! job"
+      (mt/with-premium-features #{:semantic-search}
+        (semantic.tu/with-index!
+          (let [pgvector       semantic.tu/db
+                index-metadata semantic.tu/mock-index-metadata
+                gate-table     (:gate-table-name index-metadata)
+                initial-docs   [(create-test-document "card" 1 "Dog Training Guide")]]
+            (semantic.core/update-index! initial-docs)
+            (semantic.tu/index-all!)
 
-          (testing "repair table is cleaned up after successful repair"
-            (let [test-repair-table-name "repair_table_cleanup_test"]
-              (with-redefs [semantic.repair/repair-table-name (constantly test-repair-table-name)]
-                (semantic.core/repair-index! [(create-test-document "card" 2 "New Test Card")])
+            (testing "repair table is cleaned up after successful repair"
+              (let [test-repair-table-name "repair_table_cleanup_test"]
+                (with-redefs [semantic.repair/repair-table-name (constantly test-repair-table-name)]
+                  (semantic.core/repair-index! [(create-test-document "card" 2 "New Test Card")])
 
-                (let [gate-contents (gate-table-contents pgvector gate-table)]
-                  (is (tombstone? (gate-entry-by-id gate-contents "card_1")))
-                  (is (some? (gate-entry-by-id gate-contents "card_2"))))))))))))
+                  (let [gate-contents (gate-table-contents pgvector gate-table)]
+                    (is (tombstone? (gate-entry-by-id gate-contents "card_1")))
+                    (is (some? (gate-entry-by-id gate-contents "card_2"))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -6,6 +6,7 @@
    [java-time.api :as t]
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
+   [metabase-enterprise.semantic-search.repair :as repair]
    [metabase-enterprise.semantic-search.settings :as semantic.settings]
    [metabase-enterprise.semantic-search.task.index-cleanup :as sut]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
@@ -224,3 +225,45 @@
                                                      {:builder-fn jdbc.rs/as-unqualified-lower-maps})
                     remaining-ids (map :id remaining-records)]
                 (is (= #{"recent-tombstone" "non-tombstone"} (set remaining-ids)))))))))))
+
+(deftest repair-table-cleanup-test
+  (mt/with-premium-features #{:semantic-search}
+    (let [pgvector semantic.tu/db
+          retention-hours 2
+          old-time (t/minus (t/instant) (t/hours (inc retention-hours))) ; 3 hours ago
+          recent-time (t/minus (t/instant) (t/hours 1))]                 ; 1 hour ago
+      (testing "parse-repair-table-timestamp"
+        (let [repair-table-name (with-redefs [t/instant (constantly old-time)]
+                                  (#'repair/repair-table-name))
+              parsed-time (#'sut/parse-repair-table-timestamp repair-table-name)]
+          (is (= (t/truncate-to old-time :millis)
+                 parsed-time))))
+
+      (testing "orphan repair table detection and cleanup"
+        (let [old-repair-table-name (with-redefs [t/instant (constantly old-time)]
+                                      (#'repair/repair-table-name))
+              recent-repair-table-name (with-redefs [t/instant (constantly recent-time)]
+                                         (#'repair/repair-table-name))
+              non-repair-table-name "regular_table_123"]
+          (try
+            (jdbc/execute! pgvector [(format "CREATE TABLE \"%s\" (id INT)" old-repair-table-name)])
+            (jdbc/execute! pgvector [(format "CREATE TABLE \"%s\" (id INT)" recent-repair-table-name)])
+            (jdbc/execute! pgvector [(format "CREATE TABLE \"%s\" (id INT)" non-repair-table-name)])
+
+            (with-redefs [semantic.settings/repair-table-retention-hours (constantly retention-hours)]
+              (let [orphan-tables (#'sut/orphan-repair-tables pgvector)]
+                (is (= #{old-repair-table-name} (set orphan-tables))
+                    "Only old repair table should be detected as orphan"))
+
+              (#'sut/cleanup-orphan-repair-tables! pgvector)
+
+              (is (not (semantic.tu/table-exists-in-db? old-repair-table-name))
+                  "Old repair table should be dropped")
+              (is (semantic.tu/table-exists-in-db? recent-repair-table-name)
+                  "Recent repair table should still exist")
+              (is (semantic.tu/table-exists-in-db? non-repair-table-name)
+                  "Regular table should still exist"))
+            (finally
+              (jdbc/execute! pgvector [(format "DROP TABLE IF EXISTS \"%s\"" old-repair-table-name)])
+              (jdbc/execute! pgvector [(format "DROP TABLE IF EXISTS \"%s\"" recent-repair-table-name)])
+              (jdbc/execute! pgvector [(format "DROP TABLE IF EXISTS \"%s\"" non-repair-table-name)]))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -10,12 +10,12 @@
    [metabase-enterprise.semantic-search.db.migration :as semantic.db.migration]
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]
    [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.indexer :as semantic.indexer]
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.util :as semantic.util]
-   [metabase.search.engine :as search.engine]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -331,7 +331,9 @@
        (with-open [_# (open-temp-index-and-metadata!)]
          (binding [search.ingestion/*force-sync* true]
            (blocking-index!
-            (semantic/init! (search.ingestion/searchable-documents) {:force-reset? true}))
+            (semantic.pgvector-api/gate-updates! (semantic.env/get-pgvector-datasource!)
+                                                 mock-index-metadata
+                                                 (search.ingestion/searchable-documents)))
            ~@body)))))
 
 (defn table-exists-in-db?

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -5,7 +5,7 @@
    [environ.core :refer [env]]
    [honey.sql :as sql]
    [honey.sql.helpers :as sql.helpers]
-   [metabase-enterprise.semantic-search.core]
+   [metabase-enterprise.semantic-search.core :as semantic]
    [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
    [metabase-enterprise.semantic-search.db.migration :as semantic.db.migration]
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]
@@ -331,7 +331,7 @@
        (with-open [_# (open-temp-index-and-metadata!)]
          (binding [search.ingestion/*force-sync* true]
            (blocking-index!
-            (search.engine/reindex! :search.engine/semantic {:force-reset true}))
+            (semantic/init! (search.ingestion/searchable-documents) {:force-reset? true}))
            ~@body)))))
 
 (defn table-exists-in-db?

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -5,7 +5,6 @@
    [environ.core :refer [env]]
    [honey.sql :as sql]
    [honey.sql.helpers :as sql.helpers]
-   [metabase-enterprise.semantic-search.core :as semantic]
    [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
    [metabase-enterprise.semantic-search.db.migration :as semantic.db.migration]
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/without_init_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/without_init_test.clj
@@ -26,13 +26,6 @@
       (finally
         (semantic.tu/cleanup-index-metadata! semantic.tu/db semantic.tu/mock-index-metadata)))))
 
-(deftest reindex!-without-init!-test
-  (without-init!
-   #(testing "reindex! works without init!"
-      (semantic.tu/blocking-index!
-       (semantic/reindex! (semantic.tu/mock-documents) {}))
-      (semantic.tu/check-index-has-mock-docs))))
-
 (deftest update-index!-without-init!-test
   (without-init!
    #(testing "update-index! is a no-op without init!"

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -67,12 +67,6 @@
   {:arglists '([engine])}
   identity)
 
-(defmulti repair-index!
-  "Brings the search index into consistency with the provided document set,
-  without promising a full reindex. Will add missing documents and remove stale ones."
-  {:arglists '([engine document-reducible])}
-  identity)
-
 (defn known-engines
   "List the possible search engines defined for this version, whether this instance supports them or not."
   []

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -67,6 +67,12 @@
   {:arglists '([engine])}
   identity)
 
+(defmulti repair-index!
+  "Brings the search index into consistency with the provided document set,
+  without promising a full reindex. Will add missing documents and remove stale ones."
+  {:arglists '([engine document-reducible])}
+  identity)
+
 (defn known-engines
   "List the possible search engines defined for this version, whether this instance supports them or not."
   []

--- a/src/metabase/search/semantic/core.clj
+++ b/src/metabase/search/semantic/core.clj
@@ -50,6 +50,13 @@
   [_searchable-documents _opts]
   (oss-semantic-search-error))
 
+(defenterprise repair-index!
+  "Brings the semantic search index into consistency with the provided document set.
+  Does not promise a full reindex, but will add missing documents and remove stale ones."
+  metabase-enterprise.semantic-search.core
+  [_searchable-documents]
+  (oss-semantic-search-error))
+
 (defenterprise reset-tracking!
   "Reset tracking for the semantic search engine."
   metabase-enterprise.semantic-search.core

--- a/src/metabase/search/semantic/core.clj
+++ b/src/metabase/search/semantic/core.clj
@@ -44,23 +44,11 @@
   [_searchable-documents _opts]
   (oss-semantic-search-error))
 
-(defenterprise reindex!
-  "Perform a full reindex of the semantic search engine."
-  metabase-enterprise.semantic-search.core
-  [_searchable-documents _opts]
-  (oss-semantic-search-error))
-
 (defenterprise repair-index!
   "Brings the semantic search index into consistency with the provided document set.
   Does not promise a full reindex, but will add missing documents and remove stale ones."
   metabase-enterprise.semantic-search.core
   [_searchable-documents]
-  (oss-semantic-search-error))
-
-(defenterprise reset-tracking!
-  "Reset tracking for the semantic search engine."
-  metabase-enterprise.semantic-search.core
-  []
   (oss-semantic-search-error))
 
 ;; Search engine method implementations
@@ -108,21 +96,10 @@
       (throw e))))
 
 (defmethod search.engine/reindex! :search.engine/semantic
-  [_ opts]
-  (try
-    (log/info "Reindexing semantic search engine")
-    (reindex! (search.ingestion/searchable-documents) opts)
-    (catch Exception e
-      (log/error e "Error reindexing semantic search engine")
-      (throw e))))
-
-(comment
-  (def docs (vec (search.ingestion/searchable-documents)))
-  (init! docs {})
-  (reindex! docs {}))
+  [_ _opts]
+  (log/info "reindex! is not supported for semantic search engine")
+  nil)
 
 (defmethod search.engine/reset-tracking! :search.engine/semantic [_]
-  (try
-    (reset-tracking!)
-    (catch Exception e
-      (log/debug e "Error resetting tracking for semantic search engine"))))
+  (log/info "reset-tracking! is not supported for semantic search engine")
+  nil)


### PR DESCRIPTION
Fixes [BOT-369: Ensure now missing documents are issued as gate deletes](https://linear.app/metabase/issue/BOT-369/ensure-now-missing-documents-are-issued-as-gate-deletes)

Per discussion on Slack ([ref1](https://metaboat.slack.com/archives/C07SJT1P0ET/p1756312366627459), [ref2](https://metaboat.slack.com/archives/C07SJT1P0ET/p1756403634793459)) I've added a new `repair-index!` API specifically for semantic search which is roughly functionally equivalent to `reindex!` for appdb search, but without requiring a new index table to be initialized.

Instead, it
* Creates a temporary "repair" table to store a list of model & model ID pairs
* Gates all documents to ensure new & updated docs get reflected in the index
* As documents are gated, they are also written to the repair table
* After all documents are processed, we do an anti-join of the repair table against the active index to find documents in the index that are out of date, and we issue tombstones for these in the gate table so that they can be cleaned up.
* Finally, we delete the repair table.

I've scheduled a task for this to run hourly, and added a step to our index cleanup job to delete any repair tables that get incorrectly left behind. I've also removed the semantic search stubs for `reindex!` and `reset-tracking!` which are not relevant for the new implementation of index repair.