### PR TITLE
fix(sdk): prevent double scrollbars in sdk dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -66,7 +66,9 @@ const DashboardDefaultView = ({ className }: { className?: string }) => {
   }
 
   const isEmpty = !dashboardHasCards || (dashboardHasCards && !tabHasCards);
-  const isFullHeight = isEditing || isSharing;
+
+  // Embedding SDK has parent containers that requires dashboard to be full height to avoid double scrollbars.
+  const isFullHeight = isEditing || isSharing || isEmbeddingSdk();
 
   return (
     <Flex


### PR DESCRIPTION
Closes EMB-774

### Description

Dashboard pages in https://embedded-analytics-sdk-demo.metabase.com/admin/analytics/i5s-lcGYLc1GyFdIy4TxH is showing double scrollbars on Shoppy.

This is because `.DashboardLoadingAndErrorWrapper` has the following styles:

```css
.DashboardLoadingAndErrorWrapper {
  min-height: 100%;
  height: 1px;
  /* prevents header from scrolling so we can have a fixed sidebar */

  &.isFullHeight {
    height: 100%;
  }
}
```

In the SDK, our parent already has `min-height: 100vh` setup as a sane default so we can safely use the full height (100%), rather than the 1px height workaround. This fully removes the scrollbar.

### How to verify

- Run Shoppy locally (see `README.md` on Shoppy, especially the section on using `local-dist`).
- Go to `Inventory Performance` dashboard. You should see a scrollbar.
- Build this branch with `yarn build-embedding-sdk` and copy it to the local-dist.
- You should no longer get the double scrollbar.

### Demo

Before: double scrollbar

<img width="2567" height="1806" alt="image" src="https://github.com/user-attachments/assets/6c8e4691-b43b-4729-ae3a-6d694a899cc2" />

After: no more secondary scrollbar

<img width="2542" height="1762" alt="CleanShot 2568-08-30 at 04 54 01@2x" src="https://github.com/user-attachments/assets/bff0a1c7-6fbb-4279-9e32-823a5f239b4e" />