### PR TITLE
Fix semantic search tests when running on mysql and enable all appdbs in CI

### DIFF
--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  semantic-search-tests-pgvector:
+  semantic-search-tests-h2:
     if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
@@ -20,11 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - name: pgvector pg16
-            junit-name: semantic-search-tests-pgvector-16
-            image: pgvector/pgvector:pg16
-            env:
-              enable-ssl-tests: 'false'
+          - name: H2 with pgvector pg16
+            junit-name: semantic-search-tests-h2-pgvector-16
+            pgvector-image: pgvector/pgvector:pg16
         job:
           - name: Semantic Search Tests
             build-static-viz: false
@@ -34,7 +32,7 @@ jobs:
 
     services:
       pgvector:
-        image: ${{ matrix.version.image }}
+        image: ${{ matrix.version.pgvector-image }}
         ports:
           - "5432:5432"
         env:
@@ -42,21 +40,6 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref == 'master' ||
-              startsWith(github.ref, 'release-')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
       MB_PGVECTOR_DB_URL: 'jdbc:postgres://localhost:5432/mb_semantic_search?user=postgres&password=postgres'
       CI: 'true'
     name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
@@ -69,7 +52,236 @@ jobs:
           junit-name: ${{ matrix.version.junit-name }}
           test-args: >-
             ${{ matrix.job.test-args }}
-            :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
+            :exclude-tags '[${{ matrix.job.exclude-tag }}]'
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+
+  semantic-search-tests-mariadb:
+    if: ${{ !inputs.skip }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - name: MariaDB 10.2 with pgvector pg16
+            junit-name: semantic-search-tests-mariadb-10-2
+            mariadb-image: circleci/mariadb:10.2.23
+            pgvector-image: pgvector/pgvector:pg16
+            env:
+              enable-ssl-tests: 'false'
+          - name: MariaDB Latest with pgvector pg16
+            junit-name: semantic-search-tests-mariadb-latest
+            mariadb-image: circleci/mariadb:latest
+            pgvector-image: pgvector/pgvector:pg16
+            env:
+              enable-ssl-tests: 'false'
+        job:
+          - name: Semantic Search Tests
+            build-static-viz: false
+            test-args: >-
+              :only '"enterprise/backend/test/metabase_enterprise/semantic_search"'
+            exclude-tag: ':mb/driver-tests'
+
+    services:
+      pgvector:
+        image: ${{ matrix.version.pgvector-image }}
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: mb_semantic_search
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+      mysql:
+        image: ${{ matrix.version.mariadb-image }}
+        ports:
+          - "3306:3306"
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: circle_test
+    env:
+      CI: 'true'
+      DRIVERS: mysql
+      MB_DB_TYPE: mysql
+      MB_DB_HOST: localhost
+      MB_DB_PORT: 3306
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: root
+      MB_MYSQL_TEST_USER: root
+      MB_PGVECTOR_DB_URL: 'jdbc:postgres://localhost:5432/mb_semantic_search?user=postgres&password=postgres'
+    name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test ${{ matrix.version.name }}
+        uses: ./.github/actions/test-driver
+        with:
+          build-static-viz: ${{ matrix.job.build-static-viz }}
+          junit-name: ${{ matrix.version.junit-name }}
+          test-args: >-
+            ${{ matrix.job.test-args }}
+            :exclude-tags '[${{ matrix.job.exclude-tag }}]'
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+
+  semantic-search-tests-mysql:
+    if: ${{ !inputs.skip }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - name: MySQL 8.0 with pgvector pg16
+            junit-name: semantic-search-tests-mysql-8-0
+            mysql-image: cimg/mysql:8.0
+            pgvector-image: pgvector/pgvector:pg16
+            env:
+              enable-ssl-tests: 'false'
+          - name: MySQL Latest with pgvector pg16
+            junit-name: semantic-search-tests-mysql-latest
+            mysql-image: mysql:latest
+            pgvector-image: pgvector/pgvector:pg16
+            env:
+              enable-ssl-tests: 'true'
+        job:
+          - name: Semantic Search Tests
+            build-static-viz: false
+            test-args: >-
+              :only '"enterprise/backend/test/metabase_enterprise/semantic_search"'
+            exclude-tag: ':mb/driver-tests'
+
+    services:
+      pgvector:
+        image: ${{ matrix.version.pgvector-image }}
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: mb_semantic_search
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+      mysql:
+        image: ${{ matrix.version.mysql-image }}
+        ports:
+          - "3306:3306"
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: circle_test
+    env:
+      CI: 'true'
+      DRIVERS: mysql
+      MB_DB_TYPE: mysql
+      MB_DB_HOST: localhost
+      MB_DB_PORT: 3306
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: root
+      MB_MYSQL_TEST_USER: root
+      MB_PGVECTOR_DB_URL: 'jdbc:postgres://localhost:5432/mb_semantic_search?user=postgres&password=postgres'
+    name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test ${{ matrix.version.name }}
+        uses: ./.github/actions/test-driver
+        with:
+          build-static-viz: ${{ matrix.job.build-static-viz }}
+          junit-name: ${{ matrix.version.junit-name }}
+          test-args: >-
+            ${{ matrix.job.test-args }}
+            :exclude-tags '[${{ matrix.job.exclude-tag }}]'
+      - name: Upload Test Results
+        uses: ./.github/actions/upload-test-results
+        if: always()
+        with:
+          input-path: ./target/junit/
+          output-name: ${{ github.job }}
+          bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+          aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+
+  semantic-search-tests-postgres:
+    if: ${{ !inputs.skip }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - name: Postgres 12.x with pgvector pg16
+            junit-name: semantic-search-tests-postgres-12
+            postgres-image: postgres:12-alpine
+            pgvector-image: pgvector/pgvector:pg16
+            env:
+              enable-ssl-tests: 'false'
+          - name: Postgres Latest with pgvector pg16
+            junit-name: semantic-search-tests-postgres-latest
+            postgres-image: postgres:latest
+            pgvector-image: pgvector/pgvector:pg16
+            env:
+              enable-ssl-tests: 'true'
+        job:
+          - name: Semantic Search Tests
+            build-static-viz: false
+            test-args: >-
+              :only '"enterprise/backend/test/metabase_enterprise/semantic_search"'
+            exclude-tag: ':mb/driver-tests'
+
+    services:
+      pgvector:
+        image: ${{ matrix.version.pgvector-image }}
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: mb_semantic_search
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+      postgres:
+        image: ${{ matrix.version.postgres-image }}
+        ports:
+          - "5433:5432"
+        env:
+          POSTGRES_USER: mb_test
+          POSTGRES_DB: mb_test
+          POSTGRES_HOST_AUTH_METHOD: trust
+    env:
+      CI: 'true'
+      DRIVERS: postgres
+      MB_DB_TYPE: postgres
+      MB_DB_PORT: 5433
+      MB_DB_HOST: localhost
+      MB_DB_DBNAME: mb_test
+      MB_DB_USER: mb_test
+      MB_POSTGRESQL_TEST_USER: mb_test
+      MB_PGVECTOR_DB_URL: 'jdbc:postgres://localhost:5432/mb_semantic_search?user=postgres&password=postgres'
+    name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test ${{ matrix.version.name }}
+        uses: ./.github/actions/test-driver
+        with:
+          build-static-viz: ${{ matrix.job.build-static-viz }}
+          junit-name: ${{ matrix.version.junit-name }}
+          test-args: >-
+            ${{ matrix.job.test-args }}
+            :exclude-tags '[${{ matrix.job.exclude-tag }}]'
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -84,7 +296,10 @@ jobs:
 
   semantic-search-tests-result:
     needs:
-      - semantic-search-tests-pgvector
+      - semantic-search-tests-h2
+      - semantic-search-tests-mariadb
+      - semantic-search-tests-mysql
+      - semantic-search-tests-postgres
     runs-on: ubuntu-latest
     timeout-minutes: 5
     name: semantic-search-tests-result

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -179,11 +179,11 @@
   "The appdb-based scorers for search ranking results. Like `base-scorers`, but for scorers that need to query the appdb."
   [{:keys [limit-int] :as search-ctx}]
   (when-not (and limit-int (zero? limit-int))
-    (merge {:bookmarked search.scoring/bookmark-score-expr}
-           (when-not (= :mysql (mdb/db-type))
-             ;; The :user-recency scorer needs to be modified to work with mysql / mariadb (BOT-360)
-             {:user-recency (search.scoring/inverse-duration
-                             (search.scoring/user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)}))))
+    (when-not (= :mysql (mdb/db-type))
+      ;; The appdb scorers need to be modified to work with mysql / mariadb (BOT-360)
+      {:bookmarked search.scoring/bookmark-score-expr
+       :user-recency (search.scoring/inverse-duration
+                      (search.scoring/user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)})))
 
 (defn with-appdb-scores
   "Add appdb-based scores to `search-results` and re-sort the results based on the new combined scores.

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.semantic-search.core :as semantic.core]
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.app-db.core :as mdb]
    [metabase.search.appdb.core :as appdb]
    [metabase.search.engine :as search.engine]
    [metabase.search.settings :as search.settings]
@@ -14,13 +15,16 @@
                      (fixtures/initialize :db)
                      #'semantic.tu/once-fixture))
 
-(deftest appdb-available-with-semantic
+(deftest fallback-engine-available-with-semantic-test
   (mt/with-premium-features #{:semantic-search}
     (mt/with-temporary-setting-values [search.settings/search-engine "semantic"]
       (with-open [_ (semantic.tu/open-temp-index!)]
         (semantic.tu/cleanup-index-metadata! semantic.tu/db semantic.tu/mock-index-metadata)
         (semantic.tu/with-index!
-          (is (search.engine/supported-engine? :search.engine/appdb)))))))
+          (is (search.engine/supported-engine? (if (= :mysql (mdb/db-type))
+                                                 ;; appdb is not supported on :mysql, should fallback to in-place
+                                                 :search.engine/in-place
+                                                 :search.engine/appdb))))))))
 
 (deftest api-engine-switching-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -5,6 +5,7 @@
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.scoring :as semantic.scoring]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.app-db.core :as mdb]
    [metabase.search.appdb.scoring-test :refer [with-weights]]
    [metabase.search.config :as search.config]
    [metabase.test :as mt])
@@ -213,71 +214,77 @@
         (is (indifferent? :dashboard "card"))))))
 
 (deftest bookmark-test
-  (let [crowberto (mt/user->id :crowberto)
-        rasta     (mt/user->id :rasta)]
-    (mt/with-temp [:model/Card {c1 :id} {}
-                   :model/Card {c2 :id} {}]
-      (testing "bookmarked items are ranker higher"
-        (with-index-contents!
-          [{:model "card" :id c1 :name "card normal"}
-           {:model "card" :id c2 :name "card crowberto loved"}]
-          (mt/with-temp [:model/CardBookmark _ {:card_id c2 :user_id crowberto}
-                         :model/CardBookmark _ {:card_id c1 :user_id rasta}]
-            (is (= [["card" c2 "card crowberto loved"]
-                    ["card" c1 "card normal"]]
-                   (search-results :bookmarked "card" {:current-user-id crowberto})))))))
+  (mt/with-premium-features #{:semantic-search}
+    ;; TODO (BOT-360) enable for :mysql
+    (when-not (= :mysql (mdb/db-type))
+      (let [crowberto (mt/user->id :crowberto)
+            rasta     (mt/user->id :rasta)]
+        (mt/with-temp [:model/Card {c1 :id} {}
+                       :model/Card {c2 :id} {}]
+          (testing "bookmarked items are ranker higher"
+            (with-index-contents!
+              [{:model "card" :id c1 :name "card normal"}
+               {:model "card" :id c2 :name "card crowberto loved"}]
+              (mt/with-temp [:model/CardBookmark _ {:card_id c2 :user_id crowberto}
+                             :model/CardBookmark _ {:card_id c1 :user_id rasta}]
+                (is (= [["card" c2 "card crowberto loved"]
+                        ["card" c1 "card normal"]]
+                       (search-results :bookmarked "card" {:current-user-id crowberto})))))))
 
-    (mt/with-temp [:model/Dashboard {d1 :id} {}
-                   :model/Dashboard {d2 :id} {}]
-      (testing "bookmarked dashboard"
-        (with-index-contents!
-          [{:model "dashboard" :id d1 :name "dashboard normal"}
-           {:model "dashboard" :id d2 :name "dashboard crowberto loved"}]
-          (mt/with-temp [:model/DashboardBookmark _ {:dashboard_id d2 :user_id crowberto}
-                         :model/DashboardBookmark _ {:dashboard_id d1 :user_id rasta}]
-            (is (= [["dashboard" d2 "dashboard crowberto loved"]
-                    ["dashboard" d1 "dashboard normal"]]
-                   (search-results :bookmarked "dashboard" {:current-user-id crowberto})))))))
+        (mt/with-temp [:model/Dashboard {d1 :id} {}
+                       :model/Dashboard {d2 :id} {}]
+          (testing "bookmarked dashboard"
+            (with-index-contents!
+              [{:model "dashboard" :id d1 :name "dashboard normal"}
+               {:model "dashboard" :id d2 :name "dashboard crowberto loved"}]
+              (mt/with-temp [:model/DashboardBookmark _ {:dashboard_id d2 :user_id crowberto}
+                             :model/DashboardBookmark _ {:dashboard_id d1 :user_id rasta}]
+                (is (= [["dashboard" d2 "dashboard crowberto loved"]
+                        ["dashboard" d1 "dashboard normal"]]
+                       (search-results :bookmarked "dashboard" {:current-user-id crowberto})))))))
 
-    (mt/with-temp [:model/Collection {c1 :id} {}
-                   :model/Collection {c2 :id} {}]
-      (testing "bookmarked collection"
-        (with-index-contents!
-          [{:model "collection" :id c1 :name "collection normal"}
-           {:model "collection" :id c2 :name "collection crowberto loved"}]
-          (mt/with-temp [:model/CollectionBookmark _ {:collection_id c2 :user_id crowberto}
-                         :model/CollectionBookmark _ {:collection_id c1 :user_id rasta}]
-            (is (= [["collection" c2 "collection crowberto loved"]
-                    ["collection" c1 "collection normal"]]
-                   (search-results :bookmarked "collection" {:current-user-id crowberto})))))))))
+        (mt/with-temp [:model/Collection {c1 :id} {}
+                       :model/Collection {c2 :id} {}]
+          (testing "bookmarked collection"
+            (with-index-contents!
+              [{:model "collection" :id c1 :name "collection normal"}
+               {:model "collection" :id c2 :name "collection crowberto loved"}]
+              (mt/with-temp [:model/CollectionBookmark _ {:collection_id c2 :user_id crowberto}
+                             :model/CollectionBookmark _ {:collection_id c1 :user_id rasta}]
+                (is (= [["collection" c2 "collection crowberto loved"]
+                        ["collection" c1 "collection normal"]]
+                       (search-results :bookmarked "collection" {:current-user-id crowberto})))))))))))
 
 (deftest user-recency-test
-  (let [user-id     (mt/user->id :crowberto)
-        right-now   (Instant/now)
-        long-ago    (.minus right-now 10 ChronoUnit/DAYS)
-        forever-ago (.minus right-now 30 ChronoUnit/DAYS)
-        recent-view (fn [model-id timestamp]
-                      {:model     "card"
-                       :model_id  model-id
-                       :user_id   user-id
-                       :timestamp timestamp})]
-    (mt/with-temp [:model/Card        {c1 :id} {}
-                   :model/Card        {c2 :id} {}
-                   :model/Card        {c3 :id} {}
-                   :model/Card        {c4 :id} {}
-                   :model/RecentViews _ (recent-view c1 forever-ago)
-                   :model/RecentViews _ (recent-view c2 right-now)
-                   :model/RecentViews _ (recent-view c2 forever-ago)
-                   :model/RecentViews _ (recent-view c4 forever-ago)
-                   :model/RecentViews _ (recent-view c4 long-ago)]
-      (with-index-contents!
-        [{:model "card"    :id c1 :name "card ancient"}
-         {:model "metric"  :id c2 :name "card recent"}
-         {:model "dataset" :id c3 :name "card unseen"}
-         {:model "dataset" :id c4 :name "card old"}]
-        (testing "We prefer results more recently viewed by the current user"
-          (is (= [["metric"  c2 "card recent"]
-                  ["dataset" c4 "card old"]
-                  ["card"    c1 "card ancient"]
-                  ["dataset" c3 "card unseen"]]
-                 (search-results :user-recency "card" {:current-user-id user-id}))))))))
+  (mt/with-premium-features #{:semantic-search}
+    ;; TODO (BOT-360) enable for :mysql
+    (when-not (= :mysql (mdb/db-type))
+      (let [user-id     (mt/user->id :crowberto)
+            right-now   (Instant/now)
+            long-ago    (.minus right-now 10 ChronoUnit/DAYS)
+            forever-ago (.minus right-now 30 ChronoUnit/DAYS)
+            recent-view (fn [model-id timestamp]
+                          {:model     "card"
+                           :model_id  model-id
+                           :user_id   user-id
+                           :timestamp timestamp})]
+        (mt/with-temp [:model/Card        {c1 :id} {}
+                       :model/Card        {c2 :id} {}
+                       :model/Card        {c3 :id} {}
+                       :model/Card        {c4 :id} {}
+                       :model/RecentViews _ (recent-view c1 forever-ago)
+                       :model/RecentViews _ (recent-view c2 right-now)
+                       :model/RecentViews _ (recent-view c2 forever-ago)
+                       :model/RecentViews _ (recent-view c4 forever-ago)
+                       :model/RecentViews _ (recent-view c4 long-ago)]
+          (with-index-contents!
+            [{:model "card"    :id c1 :name "card ancient"}
+             {:model "metric"  :id c2 :name "card recent"}
+             {:model "dataset" :id c3 :name "card unseen"}
+             {:model "dataset" :id c4 :name "card old"}]
+            (testing "We prefer results more recently viewed by the current user"
+              (is (= [["metric"  c2 "card recent"]
+                      ["dataset" c4 "card old"]
+                      ["card"    c1 "card ancient"]
+                      ["dataset" c3 "card unseen"]]
+                     (search-results :user-recency "card" {:current-user-id user-id}))))))))))

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -608,14 +608,18 @@
        :limit    search.config/*db-max-results*})))
 
 ;; Return a reducible-query corresponding to searching the entities without an index.
-(defmethod search.engine/results
-  :search.engine/in-place
+(defn- results
   [search-ctx]
   (let [search-query (full-search-query search-ctx)]
     (log/tracef "Searching with query:\n%s\n%s"
                 (u/pprint-to-str search-query)
                 (mdb/format-sql (first (mdb/compile search-query))))
     (t2/reducible-query search-query)))
+
+(defmethod search.engine/results
+  :search.engine/in-place
+  [search-ctx]
+  (results search-ctx))
 
 (defmethod search.engine/score :search.engine/in-place [search-ctx result]
   (scoring/score-and-result result search-ctx))


### PR DESCRIPTION
Closes BOT-358
Closes BOT-359
 
### Description

Fix a handful of tests that were failing when run with a mysql appdb, and modify the github workflow for the semantic-search tests to run them against all the same appdb versions that we run the normal backend tests against, namely:

* H2
* MariaDB 10.2 & Latest
* MySQL 8.0 & Latest
* Postgres 12.x & Latest

This feels a bit like overkill since most of the semantic search tests don't really care about the appdb, but there were 10 or so failing on mysql, and running them in CI is realistically the only way to ensure they keep working.

Possibly these tests should just be included in the normal app-db / backend test runs, but seems better to keep the semantic search tests in a separate set of jobs for now, at least until we can rework them to be a bit faster and use `^:parallel` where possible.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
