### PR TITLE
Update pgvector to pg17 in semantic search docker-compose.yml and CI workflow

### DIFF
--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -77,14 +77,10 @@ jobs:
             junit-name: semantic-search-tests-mariadb-10-2
             mariadb-image: circleci/mariadb:10.2.23
             pgvector-image: pgvector/pgvector:pg17
-            env:
-              enable-ssl-tests: 'false'
           - name: MariaDB Latest with pgvector pg17
             junit-name: semantic-search-tests-mariadb-latest
             mariadb-image: circleci/mariadb:latest
             pgvector-image: pgvector/pgvector:pg17
-            env:
-              enable-ssl-tests: 'false'
         job:
           - name: Semantic Search Tests
             build-static-viz: false
@@ -153,14 +149,10 @@ jobs:
             junit-name: semantic-search-tests-mysql-8-0
             mysql-image: cimg/mysql:8.0
             pgvector-image: pgvector/pgvector:pg17
-            env:
-              enable-ssl-tests: 'false'
           - name: MySQL Latest with pgvector pg17
             junit-name: semantic-search-tests-mysql-latest
             mysql-image: mysql:latest
             pgvector-image: pgvector/pgvector:pg17
-            env:
-              enable-ssl-tests: 'true'
         job:
           - name: Semantic Search Tests
             build-static-viz: false
@@ -229,14 +221,10 @@ jobs:
             junit-name: semantic-search-tests-postgres-12
             postgres-image: postgres:12-alpine
             pgvector-image: pgvector/pgvector:pg17
-            env:
-              enable-ssl-tests: 'false'
           - name: Postgres Latest with pgvector pg17
             junit-name: semantic-search-tests-postgres-latest
             postgres-image: postgres:latest
             pgvector-image: pgvector/pgvector:pg17
-            env:
-              enable-ssl-tests: 'true'
         job:
           - name: Semantic Search Tests
             build-static-viz: false

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - name: H2 with pgvector pg16
-            junit-name: semantic-search-tests-h2-pgvector-16
-            pgvector-image: pgvector/pgvector:pg16
+          - name: H2 with pgvector pg17
+            junit-name: semantic-search-tests-h2-pgvector-17
+            pgvector-image: pgvector/pgvector:pg17
         job:
           - name: Semantic Search Tests
             build-static-viz: false
@@ -73,16 +73,16 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - name: MariaDB 10.2 with pgvector pg16
+          - name: MariaDB 10.2 with pgvector pg17
             junit-name: semantic-search-tests-mariadb-10-2
             mariadb-image: circleci/mariadb:10.2.23
-            pgvector-image: pgvector/pgvector:pg16
+            pgvector-image: pgvector/pgvector:pg17
             env:
               enable-ssl-tests: 'false'
-          - name: MariaDB Latest with pgvector pg16
+          - name: MariaDB Latest with pgvector pg17
             junit-name: semantic-search-tests-mariadb-latest
             mariadb-image: circleci/mariadb:latest
-            pgvector-image: pgvector/pgvector:pg16
+            pgvector-image: pgvector/pgvector:pg17
             env:
               enable-ssl-tests: 'false'
         job:
@@ -149,16 +149,16 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - name: MySQL 8.0 with pgvector pg16
+          - name: MySQL 8.0 with pgvector pg17
             junit-name: semantic-search-tests-mysql-8-0
             mysql-image: cimg/mysql:8.0
-            pgvector-image: pgvector/pgvector:pg16
+            pgvector-image: pgvector/pgvector:pg17
             env:
               enable-ssl-tests: 'false'
-          - name: MySQL Latest with pgvector pg16
+          - name: MySQL Latest with pgvector pg17
             junit-name: semantic-search-tests-mysql-latest
             mysql-image: mysql:latest
-            pgvector-image: pgvector/pgvector:pg16
+            pgvector-image: pgvector/pgvector:pg17
             env:
               enable-ssl-tests: 'true'
         job:
@@ -225,16 +225,16 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - name: Postgres 12.x with pgvector pg16
+          - name: Postgres 12.x with pgvector pg17
             junit-name: semantic-search-tests-postgres-12
             postgres-image: postgres:12-alpine
-            pgvector-image: pgvector/pgvector:pg16
+            pgvector-image: pgvector/pgvector:pg17
             env:
               enable-ssl-tests: 'false'
-          - name: Postgres Latest with pgvector pg16
+          - name: Postgres Latest with pgvector pg17
             junit-name: semantic-search-tests-postgres-latest
             postgres-image: postgres:latest
-            pgvector-image: pgvector/pgvector:pg16
+            pgvector-image: pgvector/pgvector:pg17
             env:
               enable-ssl-tests: 'true'
         job:

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/docker-compose.yml
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   postgres:
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg17
     environment:
       POSTGRES_DB: mb_semantic_search
       POSTGRES_USER: postgres
@@ -10,7 +10,7 @@ services:
     ports:
       - "55432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - pgvector17_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -30,5 +30,5 @@ services:
       retries: 3
 
 volumes:
-  postgres_data:
+  pgvector17_data:
   ollama_data:


### PR DESCRIPTION
### Description

This matches the version that will be used in prod and staging deployments.

https://metaboat.slack.com/archives/C07SJT1P0ET/p1756480696913319?thread_ts=1756478308.210429&cid=C07SJT1P0ET

I changed volume name to be version-specific; otherwise pg17 tries to start and complain about the version mismatch with database files in the existing volume.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
