### PR TITLE
[perf] Suggest drop-in replacements for clojure.core functions from metabase.util.performance

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -832,7 +832,16 @@
   performance-sensitive
   {:linters
    {:discouraged-var
-    {clojure.core/update-keys {:message "Use metabase.util.performance/update-keys"}}}}
+    {clojure.core/every?          {:message "Use metabase.util.performance/every?"}
+     clojure.core/mapv            {:message "Use metabase.util.performance/mapv"}
+     clojure.core/run!            {:message "Use metabase.util.performance/run!"}
+     clojure.core/select-keys     {:message "Use metabase.util.performance/select-keys"}
+     clojure.core/some            {:message "Use metabase.util.performance/some"}
+     clojure.core/update-keys     {:message "Use metabase.util.performance/update-keys"}
+     clojure.walk/keywordize-keys {:message "Use metabase.util.performance/keywordize-keys"}
+     clojure.walk/postwalk        {:message "Use metabase.util.performance/postwalk"}
+     clojure.walk/prewalk         {:message "Use metabase.util.performance/prewalk"}
+     clojure.walk/walk            {:message "Use metabase.util.performance/walk"}}}}
 
   qp-and-driver-source-namespaces
   {:linters

--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -1,5 +1,5 @@
 (ns metabase.driver.athena
-  (:refer-clojure :exclude [second])
+  (:refer-clojure :exclude [some select-keys mapv])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -18,7 +18,8 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.performance :refer [some select-keys mapv]])
   (:import
    (java.sql
     Connection

--- a/modules/drivers/athena/src/metabase/driver/athena/hive_parser.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena/hive_parser.clj
@@ -1,8 +1,8 @@
 (ns metabase.driver.athena.hive-parser
   (:require
    [clojure.string :as str]
-   [clojure.walk :as walk]
-   [metabase.util.json :as json]))
+   [metabase.util.json :as json]
+   [metabase.util.performance :as perf]))
 
 (set! *warn-on-reflection* true)
 
@@ -59,4 +59,4 @@
   (-> schema
       parse-to-json-string
       json/decode
-      walk/keywordize-keys))
+      perf/keywordize-keys))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.bigquery-cloud-sdk
+  (:refer-clojure :exclude [mapv some])
   (:require
    [clojure.core.async :as a]
    [clojure.set :as set]
@@ -20,6 +21,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv some]]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
   (:import

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.bigquery-cloud-sdk.query-processor
+  (:refer-clojure :exclude [select-keys some])
   (:require
    [clojure.string :as str]
    [honey.sql :as sql]
@@ -17,7 +18,8 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys some]])
   (:import
    (com.google.cloud.bigquery
     Field

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.clickhouse-qp
   "CLickHouse driver: QueryProcessor-related definition"
+  (:refer-clojure :exclude [some])
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
@@ -12,7 +13,8 @@
    [metabase.driver.sql.util :as sql.u]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.honey-sql-2 :as h2x])
+   [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.performance :refer [some]])
   (:import
    [java.net Inet4Address Inet6Address]
    [java.sql ResultSet ResultSetMetaData Types]

--- a/modules/drivers/druid-jdbc/src/metabase/driver/druid_jdbc.clj
+++ b/modules/drivers/druid-jdbc/src/metabase/driver/druid_jdbc.clj
@@ -1,8 +1,8 @@
 (ns metabase.driver.druid-jdbc
+  (:refer-clojure :exclude [mapv])
   (:require
    [clj-http.client :as http]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [java-time.api :as t]
    [metabase.driver :as driver]
    [metabase.driver-api.core :as driver-api]
@@ -14,7 +14,8 @@
    [metabase.driver.sql.query-processor.util :as sql.qp.u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.json :as json]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.performance :as perf :refer [mapv]])
   (:import
    (java.sql ResultSet Types)
    (java.time LocalDate LocalDateTime ZonedDateTime)))
@@ -164,7 +165,7 @@
       (if (or (::sql.qp/forced-alias opts)
               (= driver-api/qp.add.source (driver-api/qp.add.source-table opts)))
         (keyword (driver-api/qp.add.source-alias opts))
-        (walk/postwalk #(if (h2x/identifier? %)
+        (perf/postwalk #(if (h2x/identifier? %)
                           (sql.qp/json-query :druid-jdbc % stored-field)
                           %)
                        identifier)))))

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.druid.query-processor
+  (:refer-clojure :exclude [every? mapv some])
   (:require
    [clojure.core.match :refer [match]]
    [clojure.string :as str]
@@ -9,7 +10,8 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every? mapv some]]))
 
 (set! *warn-on-reflection* true)
 

--- a/modules/drivers/druid/src/metabase/driver/druid/sync.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/sync.clj
@@ -1,9 +1,11 @@
 (ns metabase.driver.druid.sync
+  (:refer-clojure :exclude [select-keys])
   (:require
    [medley.core :as m]
    [metabase.driver-api.core :as driver-api]
    [metabase.driver.druid.client :as druid.client]
-   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]))
+   [metabase.driver.sql-jdbc.connection.ssh-tunnel :as ssh]
+   [metabase.util.performance :refer [select-keys]]))
 
 (defn- do-segment-metadata-query [details datasource]
   {:pre [(map? details) (string? datasource)]}

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.mongo
   "MongoDB Driver."
+  (:refer-clojure :exclude [some])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -19,6 +20,7 @@
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
+   [metabase.util.performance :refer [some]]
    [taoensso.nippy :as nippy])
   (:import
    (com.mongodb.client MongoClient MongoDatabase)

--- a/modules/drivers/mongo/src/metabase/driver/mongo/conversion.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/conversion.clj
@@ -16,11 +16,13 @@
    TODO: Names of protocol functions and protocols are bit misleading as were in monger.
 
    TODOs should be addressed during follow-up of monger removal."
+  (:refer-clojure :exclude [mapv])
   (:require
    [flatland.ordered.map :as ordered-map]
    [java-time.api :as t]
    [metabase.driver-api.core :as driver-api]
-   [metabase.driver.mongo.query-processor :as mongo.qp])
+   [metabase.driver.mongo.query-processor :as mongo.qp]
+   [metabase.util.performance :refer [mapv]])
   (:import
    (java.nio ByteBuffer)
    (java.util UUID)

--- a/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/execute.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.mongo.execute
+  (:refer-clojure :exclude [every? mapv])
   (:require
    [clojure.core.async :as a]
    [clojure.set :as set]
@@ -12,7 +13,8 @@
    [metabase.driver.settings :as driver.settings]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every? mapv]])
   (:import
    (com.mongodb.client
     AggregateIterable

--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -1,7 +1,6 @@
 (ns metabase.driver.mongo.parameters
   (:require
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [java-time.api :as t]
    [metabase.driver-api.core :as driver-api]
    [metabase.driver.common.parameters :as params]
@@ -15,7 +14,8 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :as perf])
   (:import
    (java.time ZoneOffset)
    (java.time.temporal Temporal)
@@ -212,4 +212,4 @@
   "Implementation of [[metabase.driver/substitute-native-parameters]] for MongoDB."
   [_driver inner-query]
   (let [param->value (params.values/query->params-map inner-query)]
-    (update inner-query :query (partial walk/postwalk (partial parse-and-substitute param->value)))))
+    (update inner-query :query (partial perf/postwalk (partial parse-and-substitute param->value)))))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1,10 +1,10 @@
 (ns metabase.driver.mongo.query-processor
   "Logic for translating MBQL queries into Mongo Aggregation Pipeline queries. See
   https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/ for more details."
+  (:refer-clojure :exclude [some mapv select-keys])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [flatland.ordered.map :as ordered-map]
    [java-time.api :as t]
    [medley.core :as m]
@@ -27,7 +27,8 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :as perf :refer [some mapv select-keys]])
   (:import
    (org.bson BsonBinarySubType)
    (org.bson.types Binary ObjectId)))
@@ -1307,7 +1308,7 @@ function(bin) {
                                   ;; are used match against `aggr-expr` where identifiers have the prefix.
                                   (map #(str \$ %)))
                             distinct-keys)]
-    [(walk/postwalk (fn [x]
+    [(perf/postwalk (fn [x]
                       (if (and (string? x)
                                (distinct-vals x))
                         {$size x}
@@ -1669,7 +1670,7 @@ function(bin) {
 (defn- log-aggregation-pipeline [form]
   (when-not driver-api/*disable-qp-logging*
     (log/tracef "\nMongo aggregation pipeline:\n%s\n"
-                (u/pprint-to-str 'green (walk/postwalk #(if (symbol? %) (symbol (name %)) %) form)))))
+                (u/pprint-to-str 'green (perf/postwalk #(if (symbol? %) (symbol (name %)) %) form)))))
 
 (defn simple-mbql->native
   "Compile a simple (non-nested) MBQL query."

--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.oracle
+  (:refer-clojure :exclude [mapv])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -24,7 +25,8 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr])
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [mapv]])
   (:import
    (com.mchange.v2.c3p0 C3P0ProxyConnection)
    (java.security KeyStore)

--- a/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
+++ b/modules/drivers/presto-jdbc/src/metabase/driver/presto_jdbc.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.presto-jdbc
   "Presto JDBC driver. See https://prestodb.io/docs/current/ for complete dox."
+  (:refer-clojure :exclude [select-keys])
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.java.jdbc :as jdbc]
@@ -23,7 +24,8 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [trs]]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.performance :refer [select-keys]])
   (:import
    (com.facebook.presto.jdbc PrestoConnection)
    (com.mchange.v2.c3p0 C3P0ProxyConnection)

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.snowflake
   "Snowflake Driver."
+  (:refer-clojure :exclude [select-keys])
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.java.jdbc :as jdbc]
@@ -29,6 +30,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
+   [metabase.util.performance :refer [select-keys]]
    [ring.util.codec :as codec])
   (:import
    (java.io File)

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.sparksql
+  (:refer-clojure :exclude [select-keys every?])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -16,7 +17,8 @@
    [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.util :as sql.u]
-   [metabase.util.honey-sql-2 :as h2x])
+   [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.performance :refer [select-keys every?]])
   (:import
    (java.sql Connection ResultSet Types)))
 

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.sqlite
+  (:refer-clojure :exclude [mapv])
   (:require
    [clojure.java.io :as io]
    [clojure.set :as set]
@@ -17,7 +18,8 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv]])
   (:import
    (java.sql Connection ResultSet Types)
    (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1,10 +1,10 @@
 (ns metabase.driver.sqlserver
   "Driver for SQLServer databases. Uses the official Microsoft JDBC driver under the hood (pre-0.25.0, used jTDS)."
+  (:refer-clojure :exclude [mapv])
   (:require
    [clojure.data.xml :as xml]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [honey.sql :as sql]
    [honey.sql.helpers :as sql.helpers]
    [java-time.api :as t]
@@ -24,7 +24,8 @@
    [metabase.driver.sql.util :as sql.u]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.performance :as perf :refer [mapv]])
   (:import
    (java.sql
     Connection
@@ -336,7 +337,7 @@
   "Parsed xml may contain whitespace elements as `\"\n\n\t\t\"` in its contents. Leave only maps in content for
   purposes of [[zone-id->windows-zone]]."
   [parsed]
-  (walk/postwalk
+  (perf/postwalk
    (fn [x]
      (if (and (map? x)
               (contains? x :content)

--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.starburst
   "starburst driver."
+  (:refer-clojure :exclude [select-keys])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -22,7 +23,8 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [trs]]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.performance :refer [select-keys]])
   (:import
    (com.mchange.v2.c3p0 C3P0ProxyConnection)
    (io.trino.jdbc TrinoConnection)

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.common.parameters.dates
   "Shared code for handling datetime parameters, used by both MBQL and native params implementations."
+  (:refer-clojure :exclude [every? some])
   #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.string :as str]
@@ -15,6 +16,7 @@
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every? some]]
    [metabase.util.time :as u.time])
   (:import
    (java.time.temporal Temporal)))

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -8,6 +8,7 @@
                              :param {:type   \"date/range\"
                                      :target [\"dimension\" [\"template-tag\" \"checkin_date\"]]
                                      :value  \"2015-01-01~2016-09-01\"}}}"
+  (:refer-clojure :exclude [every? some mapv])
   #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.string :as str]
@@ -28,7 +29,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every? some mapv]])
   (:import
    (clojure.lang ExceptionInfo)
    (java.util UUID)))

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.h2
+  (:refer-clojure :exclude [some every?])
   (:require
    [clojure.math.combinatorics :as math.combo]
    [clojure.string :as str]
@@ -18,7 +19,8 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some every?]])
   (:import
    (java.sql
     Clob

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1,11 +1,11 @@
 (ns metabase.driver.mysql
   "MySQL driver. Builds off of the SQL-JDBC driver."
+  (:refer-clojure :exclude [some])
   (:require
    [clojure.java.io :as jio]
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [honey.sql :as sql]
    [java-time.api :as t]
    [medley.core :as m]
@@ -27,7 +27,8 @@
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru]]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.performance :as perf :refer [some]])
   (:import
    (java.io File)
    (java.sql
@@ -455,7 +456,7 @@
       (keyword (driver-api/qp.add.source-alias opts))
 
       :else
-      (walk/postwalk #(if (h2x/identifier? %)
+      (perf/postwalk #(if (h2x/identifier? %)
                         (sql.qp/json-query :mysql % stored-field)
                         %)
                      honeysql-expr))))

--- a/src/metabase/driver/mysql/ddl.clj
+++ b/src/metabase/driver/mysql/ddl.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.mysql.ddl
+  (:refer-clojure :exclude [some])
   (:require
    [clojure.core.async :as a]
    [clojure.string :as str]
@@ -10,7 +11,8 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.ddl :as sql.ddl]
    [metabase.util.i18n :refer [trs]]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.performance :refer [some]])
   (:import
    (java.sql SQLNonTransientConnectionException)))
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1,11 +1,11 @@
 (ns metabase.driver.postgres
   "Database driver for PostgreSQL databases. Builds on top of the SQL JDBC driver, which implements most functionality
   for JDBC-based drivers."
+  (:refer-clojure :exclude [some select-keys mapv])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [honey.sql :as sql]
    [honey.sql.helpers :as sql.helpers]
    [honey.sql.pg-ops :as sql.pg-ops]
@@ -33,7 +33,8 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :as perf :refer [some select-keys mapv]])
   (:import
    (java.io StringReader)
    (java.sql
@@ -757,7 +758,7 @@
       (if (or (::sql.qp/forced-alias opts)
               (= (driver-api/qp.add.source-table opts) driver-api/qp.add.source))
         (keyword (driver-api/qp.add.source-alias opts))
-        (walk/postwalk #(if (h2x/identifier? %)
+        (perf/postwalk #(if (h2x/identifier? %)
                           (sql.qp/json-query :postgres % stored-field)
                           %)
                        identifier))

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.sql
   "Shared code for all drivers that use SQL under the hood."
+  (:refer-clojure :exclude [some])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -14,6 +15,7 @@
    [metabase.driver.sql.util :as sql.u]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some]]
    [potemkin :as p]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.sql.query-processor
   "The Query Processor is responsible for translating the Metabase Query Language into HoneySQL SQL forms."
+  (:refer-clojure :exclude [some mapv every? select-keys])
   (:require
    [clojure.core.match :refer [match]]
    [clojure.string :as str]
@@ -18,7 +19,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf]
+   [metabase.util.performance :as perf :refer [some mapv every? select-keys]]
    [toucan2.pipeline :as t2.pipeline])
   (:import
    (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)

--- a/src/metabase/driver/sql/query_processor/boolean_to_comparison.clj
+++ b/src/metabase/driver/sql/query_processor/boolean_to_comparison.clj
@@ -5,10 +5,11 @@
 
   Drivers can call boolean->comparison to convert boolean literals and refs into comparison expressions. See the
   sqlserver or oracle drivers for examples."
+  (:refer-clojure :exclude [some mapv update-keys])
   (:require
    [metabase.driver-api.core :as driver-api]
    [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.util.performance :as perf]))
+   [metabase.util.performance :refer [some mapv update-keys]]))
 
 ;; Oracle and SQLServer (and maybe others) use 0 and 1 for boolean constants, but, for example, none of the following
 ;; queries are valid in such databases:
@@ -47,7 +48,7 @@
         (some-isa? ((some-fn :base-type :effective-type)
                     ;; :value clauses have snake keys like :base_type, but field metadata is a snake-hating-map and
                     ;; will throw if you try to access snake keys, so normalize them first.
-                    (perf/update-keys m driver-api/normalize-token))
+                    (update-keys m driver-api/normalize-token))
                    boolean-types))))
 
 (defn- boolean-typed-clause? [[_tag _x options]]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.sql-jdbc
   "Shared code for drivers for SQL databases using their respective JDBC drivers under the hood."
+  (:refer-clojure :exclude [mapv])
   (:require
    [clojure.core.memoize :as memoize]
    [clojure.java.jdbc :as jdbc]
@@ -19,7 +20,8 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sync :as driver.s]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv]])
   (:import
    (java.sql Connection SQLException SQLTimeoutException)))
 

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -1,4 +1,5 @@
 (ns metabase.driver.sql-jdbc.actions
+  (:refer-clojure :exclude [some mapv select-keys])
   #_{:clj-kondo/ignore [:discouraged-namespace]} ;; for using toucan2 in this ns
   (:require
    [clojure.java.jdbc :as jdbc]
@@ -17,7 +18,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf]
+   [metabase.util.performance :as perf :refer [some mapv select-keys]]
    [methodical.core :as methodical]
    [toucan2.core :as t2])
   (:import

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.sql-jdbc.connection
   "Logic for creating and managing connection pools for SQL JDBC drivers. Implementations for connection-related driver
   multimethods for SQL JDBC drivers."
+  (:refer-clojure :exclude [some select-keys])
   (:require
    [clojure.java.jdbc :as jdbc]
    [metabase.driver :as driver]
@@ -12,6 +13,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some select-keys]]
    [potemkin :as p]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -4,6 +4,7 @@
   `metabase.driver.sql-jdbc.execute.old-impl`, which will be removed in a future release; implementations of methods
   for JDBC drivers that do not support `java.time` classes can be found in
   `metabase.driver.sql-jdbc.execute.legacy-impl`. "
+  (:refer-clojure :exclude [mapv])
   #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.core.async :as a]
@@ -24,7 +25,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf]
+   [metabase.util.performance :as perf :refer [mapv]]
    [potemkin :as p])
   (:import
    (java.sql

--- a/src/metabase/driver/sql_jdbc/metadata.clj
+++ b/src/metabase/driver/sql_jdbc/metadata.clj
@@ -1,10 +1,12 @@
 (ns metabase.driver.sql-jdbc.metadata
   "SQL JDBC implementation of [[metabase.driver/query-result-metadata]]."
+  (:refer-clojure :exclude [mapv])
   (:require
    [metabase.driver-api.core :as driver-api]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.sql-jdbc.sync.describe-table
   "SQL JDBC impl for `describe-fields`, `describe-table`, `describe-fks`, `describe-table-fks`, and `describe-nested-field-columns`.
   `describe-table-fks` is deprecated and will be replaced by `describe-fks` in the future."
+  (:refer-clojure :exclude [some select-keys every? mapv])
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.set :as set]
@@ -20,6 +21,7 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some select-keys every? mapv]]
    [potemkin :as p]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.util
   "Utility functions for common operations on drivers."
+  (:refer-clojure :exclude [mapv])
   #_{:clj-kondo/ignore [:metabase/modules]}
   (:require
    [clojure.core.memoize :as memoize]
@@ -21,7 +22,7 @@
    [metabase.util.i18n :refer [deferred-tru trs]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf]
+   [metabase.util.performance :as perf :refer [mapv]]
    [metabase.util.snake-hating-map :refer [snake-hating-map?]])
   (:import
    (java.io ByteArrayInputStream)

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -28,6 +28,7 @@
   Removing empty clauses like `{:aggregation nil}` or `{:breakout []}`.
 
   Token normalization occurs first, followed by canonicalization, followed by removing empty clauses."
+  (:refer-clojure :exclude [mapv every? some select-keys])
   (:require
    [clojure.set :as set]
    [medley.core :as m]
@@ -42,7 +43,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf]
+   [metabase.util.performance :as perf :refer [mapv every? some select-keys]]
    [metabase.util.time :as u.time]))
 
 (defn- mbql-clause?

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1,6 +1,7 @@
 (ns metabase.legacy-mbql.schema
   "Schema for validating a *normalized* MBQL query. This is also the definitive grammar for MBQL, wow!"
-  (:refer-clojure :exclude [count distinct min max + - / * and or not not-empty = < > <= >= time case concat replace abs float])
+  (:refer-clojure :exclude [count distinct min max + - / * and or not not-empty = < > <= >= time case concat replace
+                            abs float every? select-keys])
   (:require
    [clojure.core :as core]
    [clojure.set :as set]
@@ -26,7 +27,8 @@
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [every? select-keys]]))
 
 ;; A NOTE ABOUT METADATA:
 ;;

--- a/src/metabase/legacy_mbql/schema/macros.clj
+++ b/src/metabase/legacy_mbql/schema/macros.clj
@@ -1,7 +1,9 @@
 (ns metabase.legacy-mbql.schema.macros
+  (:refer-clojure :exclude [run!])
   (:require
    [metabase.legacy-mbql.schema.helpers]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [run!]]))
 
 (defn- stringify-names [arg-names-and-schemas]
   (into []

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -1,6 +1,6 @@
 (ns metabase.legacy-mbql.util
   "Utilitiy functions for working with MBQL queries."
-  (:refer-clojure :exclude [replace])
+  (:refer-clojure :exclude [replace some mapv every?])
   (:require
    #?@(:clj
        [[metabase.legacy-mbql.jvm-util :as mbql.jvm-u]
@@ -17,6 +17,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.namespaces :as shared.ns]
+   [metabase.util.performance :refer [some mapv every?]]
    [metabase.util.time :as u.time]))
 
 (shared.ns/import-fns

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.aggregation
-  (:refer-clojure :exclude [count distinct max min var])
+  (:refer-clojure :exclude [count distinct max min var select-keys mapv])
   (:require
    [medley.core :as m]
    [metabase.lib.common :as lib.common]
@@ -20,7 +20,8 @@
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys mapv]]))
 
 (mu/defn column-metadata->aggregation-ref :- :mbql.clause/aggregation
   "Given `:metadata/column` column metadata for an aggregation, construct an `:aggregation` reference."

--- a/src/metabase/lib/binning.cljc
+++ b/src/metabase/lib/binning.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.binning
+  (:refer-clojure :exclude [mapv select-keys])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -14,7 +15,8 @@
    [metabase.util :as u]
    [metabase.util.formatting.numbers :as fmt.num]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv select-keys]]))
 
 (defmulti with-binning-method
   "Implementation for [[with-binning]]. Implement this to tell [[with-binning]] how to add binning to a particular MBQL

--- a/src/metabase/lib/binning/util.cljc
+++ b/src/metabase/lib/binning/util.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.binning.util
+  (:refer-clojure :exclude [some])
   (:require
    [clojure.math :as math]
    [metabase.lib.metadata :as lib.metadata]
@@ -6,7 +7,8 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util :as u]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some]]))
 
 (mu/defn- calculate-bin-width :- ::lib.schema.binning/bin-width
   "Calculate bin width required to cover interval [`min-value`, `max-value`] with `num-bins`."

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.breakout
+  (:refer-clojure :exclude [mapv])
   (:require
    [clojure.string :as str]
    [metabase.lib.binning :as lib.binning]
@@ -14,7 +15,8 @@
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv]]))
 
 (defmethod lib.metadata.calculation/describe-top-level-key-method :breakout
   [query stage-number _k]

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.card
+  (:refer-clojure :exclude [mapv select-keys])
   (:require
    [medley.core :as m]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
@@ -21,7 +22,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf]))
+   [metabase.util.performance :as perf :refer [mapv select-keys]]))
 
 (defmethod lib.metadata.calculation/display-name-method :metadata/card
   [_query _stage-number card-metadata _style]

--- a/src/metabase/lib/column_group.cljc
+++ b/src/metabase/lib/column_group.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.column-group
+  (:refer-clojure :exclude [select-keys])
   (:require
    [medley.core :as m]
    [metabase.lib.card :as lib.card]
@@ -12,7 +13,8 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (def ^:private GroupType
   [:enum

--- a/src/metabase/lib/common.cljc
+++ b/src/metabase/lib/common.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.common
+  (:refer-clojure :exclude [mapv every?])
   (:require
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
@@ -6,7 +7,8 @@
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema.common :as schema.common]
    [metabase.util :as u]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv #?@(:clj [every?])]])
   #?(:cljs (:require-macros [metabase.lib.common])))
 
 (comment lib.options/keep-me

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.convert
+  (:refer-clojure :exclude [mapv some select-keys])
   (:require
    [clojure.data :as data]
    [clojure.set :as set]
@@ -20,7 +21,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf])
+   [metabase.util.performance :as perf :refer [mapv some select-keys]])
   #?@(:cljs [(:require-macros [metabase.lib.convert :refer [with-aggregation-list]])]))
 
 (def ^:private ^:dynamic *pMBQL-uuid->legacy-index*

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.drill-thru
+  (:refer-clojure :exclude [select-keys])
   (:require
    [metabase.lib.drill-thru.automatic-insights :as lib.drill-thru.automatic-insights]
    [metabase.lib.drill-thru.column-extract :as lib.drill-thru.column-extract]
@@ -30,7 +31,8 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.util :as u]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (comment
   lib.drill-thru.fk-details/keep-me

--- a/src/metabase/lib/drill_thru/column_extract.cljc
+++ b/src/metabase/lib/drill_thru/column_extract.cljc
@@ -13,6 +13,7 @@
 
   - MBQL stages only
   - Database must support `:regex` feature for the URL and Email extractions to work."
+  (:refer-clojure :exclude [select-keys])
   (:require
    [medley.core :as m]
    [metabase.lib.drill-thru.column-filter :as lib.drill-thru.column-filter]
@@ -24,7 +25,8 @@
    [metabase.lib.schema.extraction :as lib.schema.extraction]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (defn- column-extract-drill-for-column [query column]
   (when-let [extractions (not-empty (lib.extraction/column-extractions query column))]

--- a/src/metabase/lib/drill_thru/common.cljc
+++ b/src/metabase/lib/drill_thru/common.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.drill-thru.common
+  (:refer-clojure :exclude [select-keys])
   (:require
    [medley.core :as m]
    [metabase.lib.card :as lib.card]
@@ -14,7 +15,8 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (defn mbql-stage?
   "Is this query stage an MBQL stage?"

--- a/src/metabase/lib/drill_thru/fk_details.cljc
+++ b/src/metabase/lib/drill_thru/fk_details.cljc
@@ -31,6 +31,7 @@
   drills ([[metabase.lib.drill-thru.pk]], [[metabase.lib.drill-thru.fk-details]],
   or [[metabase.lib.drill-thru.zoom]]); see [[metabase.lib.drill-thru.object-details]] for the high-level logic that
   calls out to the individual implementations."
+  (:refer-clojure :exclude [select-keys])
   (:require
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.filter :as lib.filter]
@@ -39,7 +40,8 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.types.isa :as lib.types.isa]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (mu/defn fk-details-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.fk-details]
   "Return an `:fk-details` 'View details' drill when clicking on the value of a FK column."

--- a/src/metabase/lib/drill_thru/fk_filter.cljc
+++ b/src/metabase/lib/drill_thru/fk_filter.cljc
@@ -20,6 +20,7 @@
 
   Question transformation:
   - None"
+  (:refer-clojure :exclude [select-keys])
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
@@ -32,7 +33,8 @@
    [metabase.lib.stage :as lib.stage]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (mu/defn fk-filter-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.fk-filter]
   "When clicking on a foreign key value, filter this query by that column.

--- a/src/metabase/lib/drill_thru/object_details.cljc
+++ b/src/metabase/lib/drill_thru/object_details.cljc
@@ -1,11 +1,13 @@
 (ns metabase.lib.drill-thru.object-details
+  (:refer-clojure :exclude [some])
   (:require
    [metabase.lib.drill-thru.fk-details :as lib.drill-thru.fk-details]
    [metabase.lib.drill-thru.pk :as lib.drill-thru.pk]
    [metabase.lib.drill-thru.zoom :as lib.drill-thru.zoom]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some]]))
 
 (mu/defn object-detail-drill :- [:maybe [:or
                                          ::lib.schema.drill-thru/drill-thru.pk

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -41,6 +41,7 @@
   - `pivotTypes` function that return available column types for the drill - \"category\" | \"location\" | \"time\"
 
   - `pivotColumnsForType` returns the list of available columns for the drill and the selected type"
+  (:refer-clojure :exclude [select-keys])
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
@@ -52,7 +53,8 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (mu/defn- pivot-drill-pred :- [:sequential ::lib.schema.metadata/column]
   "Implementation for pivoting on various kinds of fields.

--- a/src/metabase/lib/drill_thru/pk.cljc
+++ b/src/metabase/lib/drill_thru/pk.cljc
@@ -33,6 +33,7 @@
   drills ([[metabase.lib.drill-thru.pk]], [[metabase.lib.drill-thru.fk-details]],
   or [[metabase.lib.drill-thru.zoom]]); see [[metabase.lib.drill-thru.object-details]] for the high-level logic that
   calls out to the individual implementations."
+  (:refer-clojure :exclude [select-keys])
   (:require
    [medley.core :as m]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
@@ -41,7 +42,8 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.types.isa :as lib.types.isa]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (mu/defn pk-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.pk]
   "'View details' drill when you click on a value in a table that has MULTIPLE PKs. There are two subtypes of PK

--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -38,6 +38,7 @@
   There is a separate function `filterDrillDetails` which returns `query` and `column` used for the `FilterPicker`. It
   should automatically append a query stage and find the corresponding _filterable_ column in this stage. It is used
   for `contains` and `does-not-contain` operators."
+  (:refer-clojure :exclude [select-keys mapv])
   (:require
    [medley.core :as m]
    [metabase.lib.drill-thru.column-filter :as lib.drill-thru.column-filter]
@@ -55,7 +56,8 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]
-   [metabase.util.number :as u.number]))
+   [metabase.util.number :as u.number]
+   [metabase.util.performance :refer [select-keys mapv]]))
 
 (defn- maybe-bigint->value-clause
   [value]

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -28,6 +28,7 @@
   Question transformation:
 
   - Set display \"table\""
+  (:refer-clojure :exclude [mapv])
   (:require
    [medley.core :as m]
    [metabase.lib.aggregation :as lib.aggregation]
@@ -46,7 +47,8 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv]]))
 
 (mu/defn underlying-records-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.underlying-records]
   "When clicking on a particular broken-out group, offer a look at the details of all the rows that went into this

--- a/src/metabase/lib/drill_thru/zoom.cljc
+++ b/src/metabase/lib/drill_thru/zoom.cljc
@@ -33,13 +33,15 @@
   drills ([[metabase.lib.drill-thru.pk]], [[metabase.lib.drill-thru.fk-details]],
   or [[metabase.lib.drill-thru.zoom]]); see [[metabase.lib.drill-thru.object-details]] for the high-level logic that
   calls out to the individual implementations."
+  (:refer-clojure :exclude [select-keys])
   (:require
    [medley.core :as m]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (defn- zoom-drill* [column value]
   {:lib/type  :metabase.lib.drill-thru/drill-thru

--- a/src/metabase/lib/drill_thru/zoom_in_bins.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_bins.cljc
@@ -82,7 +82,8 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some every?]]))
 
 ;;;
 ;;; available-drill-thrus

--- a/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
@@ -74,6 +74,7 @@
 
      2b. Otherwise if `:bin-width` is < 20°, replace them with the current `:bin-width` divided by 10, and add
          `:>=`/`:<` filters for the clicked latitude/longitude values."
+  (:refer-clojure :exclude [some])
   (:require
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
@@ -89,7 +90,8 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some]]))
 
 (def ^:private ContextWithLatLon
   [:merge

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.equality
   "Logic for determining whether two pMBQL queries are equal."
-  (:refer-clojure :exclude [=])
+  (:refer-clojure :exclude [= every? some mapv])
   (:require
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
@@ -20,7 +20,8 @@
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.util :as lib.util]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every? some mapv]]))
 
 (defmulti =
   "Determine whether two already-normalized pMBQL maps, clauses, or other sorts of expressions are equal. The basic rule

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.expression
-  (:refer-clojure :exclude [+ - * / case coalesce abs time concat replace float])
+  (:refer-clojure :exclude [+ - * / case coalesce abs time concat replace float mapv some select-keys])
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -26,7 +26,8 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.number :as u.number]))
+   [metabase.util.number :as u.number]
+   [metabase.util.performance :refer [mapv some select-keys]]))
 
 (mu/defn column-metadata->expression-ref :- :mbql.clause/expression
   "Given `:metadata/column` column metadata for an expression, construct an `:expression` reference."

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.fe-util
+  (:refer-clojure :exclude [every? mapv select-keys some])
   (:require
    [inflections.core :as inflections]
    [medley.core :as m]
@@ -34,6 +35,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.number :as u.number]
+   [metabase.util.performance :refer [every? mapv select-keys some]]
    [metabase.util.time :as u.time]))
 
 (def ^:private ExpressionArg

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.field
+  (:refer-clojure :exclude [every? select-keys mapv])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -31,6 +32,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [every? select-keys mapv]]
    [metabase.util.time :as u.time]))
 
 (defn- column-metadata-effective-type

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.field.resolution
   "Code for resolving field metadata from a field ref. There's a lot of code here, isn't there? This is probably more
   complicated than it needs to be!"
+  (:refer-clojure :exclude [some select-keys])
   (:require
    #?@(:clj
        ([metabase.config.core :as config]))
@@ -24,7 +25,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some select-keys]]))
 
 (mr/def ::id-or-name
   [:or :string ::lib.schema.id/field])

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.filter
-  (:refer-clojure :exclude [filter and or not = < <= > >= not-empty case])
+  (:refer-clojure :exclude [filter and or not = < <= > >= not-empty case every? some mapv])
   (:require
    [inflections.core :as inflections]
    [medley.core :as m]
@@ -27,6 +27,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.number :as u.number]
+   [metabase.util.performance :refer [every? some mapv]]
    [metabase.util.time :as u.time]))
 
 (doseq [tag [:and :or]]

--- a/src/metabase/lib/filter/desugar.cljc
+++ b/src/metabase/lib/filter/desugar.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.filter.desugar
+  (:refer-clojure :exclude [some mapv])
   (:require
    #?@(:clj ([metabase.lib.filter.desugar.jvm :as lib.filter.desugar.jvm]
              [metabase.util.i18n :as i18n])
@@ -15,6 +16,7 @@
    [metabase.lib.util.match :as lib.util.match]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some mapv]]
    [metabase.util.time :as u.time]))
 
 (mr/def ::clause

--- a/src/metabase/lib/filter/simplify_compound.cljc
+++ b/src/metabase/lib/filter/simplify_compound.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.filter.simplify-compound
+  (:refer-clojure :exclude [some])
   (:require
    [medley.core :as m]
    [metabase.lib.filter :as lib.filter]
@@ -8,7 +9,8 @@
    [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some]]))
 
 (mr/def ::mbql-clause
   "An MBQL clause that may not be well-formed, e.g. an `:and` clause with only one arg."

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.join
   "Functions related to manipulating EXPLICIT joins in MBQL."
+  (:refer-clojure :exclude [mapv run! some])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -33,7 +34,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv run! some]]))
 
 (defn- join? [x]
   (= (lib.dispatch/dispatch-value x) :mbql/join))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -57,7 +57,6 @@
    [filter])
   (:require
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [goog.object :as gobject]
    [medley.core :as m]
    [metabase.legacy-mbql.js :as mbql.js]
@@ -1002,7 +1001,7 @@
   [x]
   (as-> x parts
     (js->clj parts :keywordize-keys true)
-    (walk/postwalk
+    (perf/postwalk
      #(cond-> %
         (expression-parts-like? %) (assoc :lib/type :mbql/expression-parts))
      parts)))
@@ -1038,7 +1037,7 @@
   > **Code health:** Healthy"
   [a-query stage-number an-expression-clause]
   (let [parts (lib.core/expression-parts a-query stage-number an-expression-clause)]
-    (walk/postwalk
+    (perf/postwalk
      (fn [node]
        (if (and (map? node) (= :mbql/expression-parts (:lib/type node)))
          (let [{:keys [operator options args]} node]

--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -1,8 +1,8 @@
 (ns metabase.lib.js.metadata
+  (:refer-clojure :exclude [keywordize-keys])
   (:require
    [clojure.core.protocols]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [goog]
    [goog.object :as gobject]
    [medley.core :as m]
@@ -11,7 +11,8 @@
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.performance :as perf]))
 
 ;;; metabase-lib/metadata/Metadata comes in an object like
 ;;;
@@ -282,7 +283,7 @@
       :coercion-strategy                (keyword v)
       :effective-type                   (keyword v)
       :fingerprint                      (if (map? v)
-                                          (walk/keywordize-keys v)
+                                          (perf/keywordize-keys v)
                                           (js->clj v :keywordize-keys true))
       :has-field-values                 (keyword v)
 
@@ -555,7 +556,7 @@
       ;; thing at once.
       clojure.core.protocols/Datafiable
       (datafy [_this]
-        (walk/postwalk
+        (perf/postwalk
          (fn [form]
            (if (delay? form)
              (deref form)

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.metadata
+  (:refer-clojure :exclude [every?])
   (:require
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema :as lib.schema]
@@ -8,7 +9,8 @@
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every?]]))
 
 ;;; TODO -- deprecate all the schemas below, and just use the versions in [[lib.schema.metadata]] instead.
 

--- a/src/metabase/lib/metadata/cached_provider.cljc
+++ b/src/metabase/lib/metadata/cached_provider.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.metadata.cached-provider
+  (:refer-clojure :exclude [update-keys])
   (:require
    #?@(:clj ([metabase.util.json :as json]
              [pretty.core :as pretty]))
@@ -8,7 +9,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf]))
+   [metabase.util.performance :refer [update-keys]]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -36,7 +37,7 @@
                      [:metadata/metric        ::lib.schema.metadata/metric]
                      [:metadata/segment       ::lib.schema.metadata/segment]]]
   (let [metadata (-> metadata
-                     (perf/update-keys u/->kebab-case-en)
+                     (update-keys u/->kebab-case-en)
                      (assoc :lib/type metadata-type))]
     (store-in-cache! cache [metadata-type id] metadata))
   true)

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.metadata.calculation
+  (:refer-clojure :exclude [select-keys mapv])
   (:require
    #?(:clj  [metabase.config.core :as config]
       :cljs [metabase.lib.cache :as lib.cache])
@@ -22,7 +23,8 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [select-keys mapv]]))
 
 (mr/def ::display-name-style
   "Schema for valid values of `display-name-style` as passed to [[display-name-method]].

--- a/src/metabase/lib/metadata/composed_provider.cljc
+++ b/src/metabase/lib/metadata/composed_provider.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.metadata.composed-provider
+  (:refer-clojure :exclude [some])
   (:require
    #?(:clj [pretty.core :as pretty])
    [better-cond.core :as b]
@@ -7,7 +8,8 @@
    [clojure.set :as set]
    [medley.core :as m]
    [metabase.lib.metadata.protocols :as metadata.protocols]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some]]))
 
 (mu/defn- cached-providers :- [:sequential ::metadata.protocols/cached-metadata-provider]
   [providers :- [:maybe [:sequential ::metadata.protocols/metadata-provider]]]

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -6,6 +6,7 @@
 
   Traditionally this code lived in the [[metabase.query-processor.middleware.annotate]] namespace, where it is still
   used today."
+  (:refer-clojure :exclude [mapv select-keys some update-keys every?])
   (:require
    #?@(:clj
        ([metabase.config.core :as config]))
@@ -32,7 +33,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf]))
+   [metabase.util.performance :refer [mapv select-keys some update-keys every?]]))
 
 (mr/def ::col
   ;; TODO (Cam 6/19/25) -- I think we should actually namespace all the keys added here (to make it clear where they
@@ -62,7 +63,7 @@
   from the driver to values calculated by Lib."
   [driver-col :- [:maybe ::col]
    lib-col    :- [:maybe ::col]]
-  (let [driver-col (perf/update-keys driver-col u/->kebab-case-en)]
+  (let [driver-col (update-keys driver-col u/->kebab-case-en)]
     (merge lib-col
            (m/filter-vals some? driver-col)
            ;; Prefer our inferred base type if the driver returned `:type/*` and ours is more specific
@@ -387,7 +388,7 @@
                      lib-cols)]
       (->> initial-cols
            (map (fn [col]
-                  (perf/update-keys col u/->kebab-case-en)))
+                  (update-keys col u/->kebab-case-en)))
            ((fn [cols]
               (cond-> cols
                 (seq lib-cols) (merge-cols lib-cols))))

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.metric
   "A Metric is a special type of Card that you can do special metric stuff with. (Not sure exactly what said special
   stuff is TBH.)"
+  (:refer-clojure :exclude [select-keys])
   (:require
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.aggregation :as lib.aggregation]
@@ -16,7 +17,8 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (defn- resolve-metric [query card-id]
   (when (pos-int? card-id)

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.native
   "Functions for working with native queries."
+  (:refer-clojure :exclude [some select-keys mapv every?])
   (:require
    [clojure.core.match :refer [match]]
    [clojure.set :as set]
@@ -18,7 +19,8 @@
    [metabase.util.humanization :as u.humanization]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some select-keys mapv every?]]))
 
 (def ^:private variable-tag-regex
   #"\{\{\s*([A-Za-z0-9_\.]+)\s*\}\}")

--- a/src/metabase/lib/normalize.cljc
+++ b/src/metabase/lib/normalize.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.normalize
+  (:refer-clojure :exclude [some])
   (:require
    [malli.core :as mc]
    [malli.error :as me]
@@ -9,7 +10,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some]]))
 
 (defn- lib-type [x]
   (when (map? x)

--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.order-by
+  (:refer-clojure :exclude [some mapv])
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
@@ -15,7 +16,8 @@
    [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some mapv]]))
 
 (lib.hierarchy/derive :asc  ::order-by-clause)
 (lib.hierarchy/derive :desc ::order-by-clause)

--- a/src/metabase/lib/parse.cljc
+++ b/src/metabase/lib/parse.cljc
@@ -1,9 +1,11 @@
 (ns metabase.lib.parse
+  (:refer-clojure :exclude [some])
   (:require
    [clojure.string :as str]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [metabase.util.performance :refer [some]]))
 
 (defn- combine-adjacent-strings
   "Returns any adjacent strings in coll combined together"

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.query
-  (:refer-clojure :exclude [remove])
+  (:refer-clojure :exclude [remove some select-keys mapv])
   (:require
    [medley.core :as m]
    ;; allowed since this is needed to convert legacy queries to MBQL 5
@@ -29,6 +29,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some select-keys mapv]]
    [weavejester.dependency :as dep]))
 
 (defmethod lib.metadata.calculation/metadata-method :mbql/query

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.remove-replace
+  (:refer-clojure :exclude [every? mapv run! some])
   (:require
    [clojure.set :as set]
-   [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.lib.common :as lib.common]
    [metabase.lib.equality :as lib.equality]
@@ -21,7 +21,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :as perf :refer [every? mapv run! some]]))
 
 (defn- stage-paths
   [query stage-number]
@@ -333,8 +334,8 @@
   [stage target replacement]
   (->> (if (lib.util/expression-name target)
          (local-replace-expression stage target replacement)
-         (walk/postwalk #(if (= % target) replacement %) stage))
-       (walk/postwalk #(if (= % (lib.options/uuid target)) (lib.options/uuid replacement) %))))
+         (perf/postwalk #(if (= % target) replacement %) stage))
+       (perf/postwalk #(if (= % (lib.options/uuid target)) (lib.options/uuid replacement) %))))
 
 (defn- returned-columns-at-stage
   [query stage-number]

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -6,7 +6,7 @@
   Some primitives below are duplicated from [[metabase.util.malli.schema]] since that's not `.cljc`. Other stuff is
   copied from [[metabase.legacy-mbql.schema]] so this can exist completely independently; hopefully at some point in the
   future we can deprecate that namespace and eventually do away with it entirely."
-  (:refer-clojure :exclude [ref])
+  (:refer-clojure :exclude [ref every? some])
   (:require
    [medley.core :as m]
    [metabase.legacy-mbql.util :as mbql.u]
@@ -34,7 +34,8 @@
    [metabase.lib.schema.template-tag :as template-tag]
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.util.match :as lib.util.match]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [every? some]]))
 
 (comment metabase.lib.schema.expression.arithmetic/keep-me
          metabase.lib.schema.expression.conditional/keep-me

--- a/src/metabase/lib/schema/aggregation.cljc
+++ b/src/metabase/lib/schema/aggregation.cljc
@@ -1,10 +1,12 @@
 (ns metabase.lib.schema.aggregation
+  (:refer-clojure :exclude [some])
   (:require
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.mbql-clause :as mbql-clause]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some]]))
 
 ;; count has an optional expression arg. This is the number of non-NULL values -- corresponds to count(<expr>) in SQL
 (mbql-clause/define-catn-mbql-clause :count :- :type/Integer

--- a/src/metabase/lib/schema/binning.cljc
+++ b/src/metabase/lib/schema/binning.cljc
@@ -4,9 +4,11 @@
   There are two approaches to binning, selected by `:strategy`:
   - `{:strategy :bin-width :bin-width 10}` makes 1 or more bins that are 10 wide;
   - `{:strategy :num-bins  :num-bins  12}` splits the column into 12 bins."
+  (:refer-clojure :exclude [some])
   (:require
    [metabase.lib.schema.common :as lib.schema.common]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some]]))
 
 (mr/def ::strategy
   [:enum

--- a/src/metabase/lib/schema/common.cljc
+++ b/src/metabase/lib/schema/common.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.schema.common
+  (:refer-clojure :exclude [update-keys #?@(:clj [some])])
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -7,7 +8,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.memoize :as u.memo]
-   [metabase.util.performance :as perf]))
+   [metabase.util.performance :refer [update-keys #?@(:clj [some])]]))
 
 (comment metabase.types.core/keep-me)
 
@@ -33,7 +34,7 @@
   "Part of [[normalize-map]]; converts keys to keywords but DOES NOT convert to `kebab-case`."
   [m]
   (when (map? m)
-    (let [m (perf/update-keys m keyword)]
+    (let [m (update-keys m keyword)]
       (cond-> m
         (string? (:lib/type m)) (update :lib/type keyword)))))
 
@@ -53,7 +54,7 @@
   "Convert a map to kebab case, for use with `:decode/normalize`."
   [m]
   (when (map? m)
-    (perf/update-keys m memoized-kebab-key)))
+    (update-keys m memoized-kebab-key)))
 
 (defn normalize-map
   "Base normalization behavior for a pMBQL map: keywordize keys and keywordize `:lib/type`; convert map to

--- a/src/metabase/lib/schema/drill_thru.cljc
+++ b/src/metabase/lib/schema/drill_thru.cljc
@@ -3,6 +3,7 @@
 
   Drill-thrus are not part of MBQL; they are a set of actions one can take to transform a query.
   For example, adding a filter like `created_at < 2022-01-01`, or following a foreign key."
+  (:refer-clojure :exclude [some])
   (:require
    [metabase.lib.schema :as-alias lib.schema]
    [metabase.lib.schema.binning :as lib.schema.binning]
@@ -16,7 +17,8 @@
    [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.lib.schema.temporal-bucketing
     :as lib.schema.temporal-bucketing]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some]]))
 
 (mr/def ::pivot-types
   [:enum :category :location :time])

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.schema.expression
+  (:refer-clojure :exclude [some])
   (:require
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
@@ -8,7 +9,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some]]))
 
 (defmulti type-of-method
   "Impl for [[type-of]]. Use [[type-of]], but implement [[type-of-method]].

--- a/src/metabase/lib/schema/expression/arithmetic.cljc
+++ b/src/metabase/lib/schema/expression/arithmetic.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.schema.expression.arithmetic
   "Arithmetic expressions like `:+`."
+  (:refer-clojure :exclude [every? some])
   (:require
    [medley.core :as m]
    [metabase.lib.hierarchy :as lib.hierarchy]
@@ -8,7 +9,8 @@
    [metabase.lib.schema.mbql-clause :as mbql-clause]
    [metabase.lib.schema.temporal-bucketing :as temporal-bucketing]
    [metabase.types.core :as types]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [every? some]]))
 
 (defn- valid-interval-for-type? [[_tag _opts _n unit :as _interval] expr-type]
   (let [unit-schema (cond

--- a/src/metabase/lib/schema/expression/temporal.cljc
+++ b/src/metabase/lib/schema/expression/temporal.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.schema.expression.temporal
+  (:refer-clojure :exclude [some])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -10,6 +11,7 @@
    [metabase.lib.schema.temporal-bucketing :as temporal-bucketing]
    [metabase.util :as u]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [some]]
    [metabase.util.time.impl-common :as u.time.impl-common])
   #?@
    (:clj

--- a/src/metabase/lib/schema/filter.cljc
+++ b/src/metabase/lib/schema/filter.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.schema.filter
   "Schemas for the various types of filter clauses that you'd pass to `:filters` or use inside something else that takes
   a boolean expression."
+  (:refer-clojure :exclude [every?])
   (:require
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
@@ -8,7 +9,8 @@
    [metabase.lib.schema.literal :as literal]
    [metabase.lib.schema.mbql-clause :as mbql-clause]
    [metabase.lib.schema.temporal-bucketing :as temporal-bucketing]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [every?]]))
 
 (defn- tuple-clause-of-comparables-schema
   "Helper intended for use with [[define-mbql-clause]]. Create a clause schema with `:tuple` and ensure that

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -1,11 +1,13 @@
 (ns metabase.lib.schema.join
   "Schemas for things related to joins."
+  (:refer-clojure :exclude [mapv every?])
   (:require
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [mapv every?]]))
 
 (mr/def ::fields
   "The Fields to include in the results *if* a top-level `:fields` clause *is not* specified. This can be either

--- a/src/metabase/lib/schema/mbql_clause.cljc
+++ b/src/metabase/lib/schema/mbql_clause.cljc
@@ -1,11 +1,13 @@
 (ns metabase.lib.schema.mbql-clause
+  (:refer-clojure :exclude [every?])
   (:require
    [malli.core :as mc]
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.types.core]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [every?]]))
 
 (comment metabase.types.core/keep-me)
 

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -1,4 +1,5 @@
 (ns metabase.lib.schema.metadata
+  (:refer-clojure :exclude [every?])
   (:require
    #?@(:clj
        ([metabase.util.regex :as u.regex]))
@@ -10,7 +11,8 @@
    [metabase.lib.schema.join :as lib.schema.join]
    [metabase.lib.schema.metadata.fingerprint :as lib.schema.metadata.fingerprint]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [every?]]))
 
 (defn- kebab-cased-key? [k]
   (and (keyword? k)

--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -1,10 +1,12 @@
 (ns metabase.lib.schema.template-tag
+  (:refer-clojure :exclude [every?])
   (:require
    [malli.core :as mc]
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.id :as id]
    [metabase.lib.schema.parameter :as lib.schema.parameter]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [every?]]))
 
 ;; Schema for valid values of `:widget-type` for a [[TemplateTag:FieldFilter]].
 (mr/def ::widget-type

--- a/src/metabase/lib/schema/util.cljc
+++ b/src/metabase/lib/schema/util.cljc
@@ -1,12 +1,11 @@
 (ns metabase.lib.schema.util
-  (:refer-clojure :exclude [ref])
+  (:refer-clojure :exclude [ref run! every? mapv])
   (:require
-   #?(:clj [metabase.util.performance :refer [postwalk]]
-      :default [clojure.walk :refer [postwalk]])
    [medley.core :as m]
    [metabase.lib.options :as lib.options]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :as perf :refer [run! every? mapv]]))
 
 (declare collect-uuids*)
 
@@ -120,7 +119,7 @@
 (defn remove-lib-uuids
   "Recursively remove all uuids from `x`."
   [x]
-  (postwalk
+  (perf/postwalk
    (fn [x]
      (cond-> x
        (map? x) (dissoc :lib/uuid)))

--- a/src/metabase/lib/segment.cljc
+++ b/src/metabase/lib/segment.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.segment
   "A Segment is a saved MBQL query stage snippet with `:filter`. Segments are always boolean expressions."
+  (:refer-clojure :exclude [mapv])
   (:require
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata :as lib.metadata]
@@ -11,7 +12,8 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv]]))
 
 (defn- resolve-segment [query segment-id]
   (when (integer? segment-id)

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.stage
   "Method implementations for a stage of a query."
+  (:refer-clojure :exclude [mapv some])
   (:require
    [clojure.string :as str]
    [metabase.lib.aggregation :as lib.aggregation]
@@ -22,7 +23,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.namespaces :as shared.ns]))
+   [metabase.util.namespaces :as shared.ns]
+   [metabase.util.performance :refer [mapv some]]))
 
 (comment metabase.lib.stage.util/keep-me)
 

--- a/src/metabase/lib/temporal_bucket.cljc
+++ b/src/metabase/lib/temporal_bucket.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.temporal-bucket
   "TODO (Cam 6/13/25) -- decide whether things are `unit` or `bucket` and rename functions and args for consistency.
   Confusing to use both as synonyms."
+  (:refer-clojure :exclude [mapv select-keys some])
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -14,6 +15,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv select-keys some]]
    [metabase.util.time :as u.time]))
 
 (mu/defn describe-temporal-unit :- :string

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -1,9 +1,10 @@
 (ns metabase.lib.types.isa
   "Ported from frontend/src/metabase-lib/types/utils/isa.js"
-  (:refer-clojure :exclude [isa? any? boolean? number? string? integer?])
+  (:refer-clojure :exclude [isa? any? boolean? number? string? integer? some])
   (:require
    [metabase.lib.types.constants :as lib.types.constants]
-   [metabase.types.core]))
+   [metabase.types.core]
+   [metabase.util.performance :refer [some]]))
 
 (comment metabase.types.core/keep-me)
 

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.util
-  (:refer-clojure :exclude [format])
+  (:refer-clojure :exclude [format every? mapv select-keys update-keys some])
   (:require
    #?@(:clj
        ([potemkin :as p])
@@ -26,7 +26,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf]))
+   [metabase.util.performance :refer [every? mapv select-keys update-keys some]]))
 
 #?(:clj
    (set! *warn-on-reflection* true))
@@ -229,7 +229,7 @@
           (update :columns (fn [columns]
                              (mapv (fn [column]
                                      (-> column
-                                         (perf/update-keys u/->kebab-case-en)
+                                         (update-keys u/->kebab-case-en)
                                          (assoc :lib/type :metadata/column)))
                                    columns)))
           (assoc :lib/type :metadata/results)))))

--- a/src/metabase/lib/util/match.clj
+++ b/src/metabase/lib/util/match.clj
@@ -1,10 +1,10 @@
 (ns metabase.lib.util.match
   "Internal implementation of the MBQL `match` and `replace` macros. Don't use these directly."
-  (:refer-clojure :exclude [replace])
+  (:refer-clojure :exclude [every? run! some mapv replace])
   (:require
    [clojure.core.match]
-   [clojure.walk :as walk]
    [metabase.lib.util.match.impl]
+   [metabase.util.performance :as perf :refer [every? run! some mapv]]
    [net.cgrand.macrovich :as macros]))
 
 (defn- generate-pattern
@@ -35,7 +35,7 @@
 (defn- rewrite-recurs
   "Replace any `recur` forms with ones that include the implicit `&parents` arg."
   [fn-name result-form]
-  (walk/postwalk
+  (perf/postwalk
    (fn [form]
      (if (recur-form? form)
        ;; we *could* use plain `recur` here, but `core.match` cannot apply code size optimizations if a `recur` form

--- a/src/metabase/lib/util/match/impl.cljc
+++ b/src/metabase/lib/util/match/impl.cljc
@@ -1,5 +1,8 @@
 (ns metabase.lib.util.match.impl
-  "Internal implementation of the MBQL `match` and `replace` macros. Don't use these directly.")
+  "Internal implementation of the MBQL `match` and `replace` macros. Don't use these directly."
+  (:refer-clojure :exclude [mapv])
+  (:require
+   [metabase.util.performance :refer [mapv]]))
 
 ;; have to do this at runtime because we don't know if a symbol is a class or pred or whatever when we compile the macro
 (defn match-with-pred-or-class

--- a/src/metabase/lib/walk.cljc
+++ b/src/metabase/lib/walk.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.walk
   "Tools for walking and transforming a query."
+  (:refer-clojure :exclude [mapv])
   (:require
    [medley.core :as m]
    [metabase.lib.dispatch :as lib.dispatch]
@@ -12,7 +13,8 @@
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [mapv]]))
 
 (declare walk-stages*)
 

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.card
   "Code for running a query in the context of a specific Card."
+  (:refer-clojure :exclude [mapv select-keys])
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -32,6 +33,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv select-keys]]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.dashboard
   "Code for running a query in the context of a specific DashboardCard."
+  (:refer-clojure :exclude [some select-keys])
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -19,6 +20,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some select-keys]]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))

--- a/src/metabase/query_processor/metadata.clj
+++ b/src/metabase/query_processor/metadata.clj
@@ -3,6 +3,7 @@
   MBQL queries; for native queries we use the driver implementation of
   [[metabase.driver/query-result-metadata]], which hopefully can calculate metadata without running the query. If
   that's not possible, our fallback `:default` implementation adds the equivalent of `LIMIT 1` to query and runs it."
+  (:refer-clojure :exclude [mapv])
   (:require
    [metabase.analyze.core :as analyze]
    [metabase.driver :as driver]
@@ -24,7 +25,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf]))
+   [metabase.util.performance :as perf :refer [mapv]]))
 
 (mu/defn- metadata-from-preprocessing :- [:maybe [:sequential :map]]
   "For MBQL queries or native queries with result metadata attached to them already we can infer the columns just by

--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.add-implicit-clauses
   "Middlware for adding an implicit `:fields` and `:order-by` clauses to certain queries."
+  (:refer-clojure :exclude [every?])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -8,7 +9,8 @@
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every?]]))
 
 (mu/defn- should-add-implicit-fields?
   "Whether we should add implicit Fields to a `stage`. True if all of the following are true:

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.add-implicit-joins
   "Middleware that creates corresponding `:joins` for Tables referred to by `:field` clauses with `:source-field` info
   in the options and adds `:join-alias` info to those `:field` clauses."
-  (:refer-clojure :exclude [alias])
+  (:refer-clojure :exclude [alias mapv some])
   (:require
    [better-cond.core :as b]
    [clojure.set :as set]
@@ -22,7 +22,8 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [mapv some]]))
 
 (defn- implicitly-joined-fields
   "Find fields that come from implicit join in form `x`, presumably a query.

--- a/src/metabase/query_processor/middleware/add_remaps.clj
+++ b/src/metabase/query_processor/middleware/add_remaps.clj
@@ -25,6 +25,7 @@
   `name` is `:remapped_from` `:category_id`.
 
   See also [[metabase.parameters.chain-filter]] for another explanation of remapping."
+  (:refer-clojure :exclude [mapv select-keys some])
   (:require
    [clojure.data :as data]
    [medley.core :as m]
@@ -46,7 +47,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [mapv select-keys some]]))
 
 (mr/def ::simplified-ref
   [:tuple

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.annotate
   "Middleware for annotating (adding type information to) the results of a query, under the `:cols` column."
+  (:refer-clojure :exclude [every? mapv])
   (:require
    [metabase.analyze.core :as analyze]
    [metabase.driver.common :as driver.common]
@@ -16,6 +17,7 @@
    [metabase.query-processor.schema :as qp.schema]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [every? mapv]]
    [potemkin :as p]))
 
 (comment metabase.query-processor.middleware.annotate.legacy-helper-fns/keep-me)

--- a/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
+++ b/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
@@ -2,6 +2,7 @@
   "Middleware for automatically bucketing unbucketed `:type/Temporal` (but not `:type/Time`) Fields with `:day`
   bucketing. Applies to any unbucketed Field in a breakout, or fields in a filter clause being compared against
   `yyyy-MM-dd` format datetime strings."
+  (:refer-clojure :exclude [select-keys every? some])
   (:require
    [medley.core :as m]
    [metabase.lib.core :as lib]
@@ -14,7 +15,8 @@
    [metabase.lib.walk :as lib.walk]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [select-keys every? some]]))
 
 (mr/def ::column-type-info
   [:map

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.catch-exceptions
   "Middleware for catching exceptions thrown by the query processor and returning them in a friendlier format."
+  (:refer-clojure :exclude [some])
   (:require
    [clojure.string :as str]
    [metabase.analytics.core :as analytics]
@@ -12,7 +13,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some]])
   (:import
    (clojure.lang ExceptionInfo)
    (java.sql SQLException)))

--- a/src/metabase/query_processor/middleware/desugar.clj
+++ b/src/metabase/query_processor/middleware/desugar.clj
@@ -1,11 +1,13 @@
 (ns metabase.query-processor.middleware.desugar
+  (:refer-clojure :exclude [select-keys])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (defn- desugar*
   [stage-or-join]

--- a/src/metabase/query_processor/middleware/expand_aggregations.clj
+++ b/src/metabase/query_processor/middleware/expand_aggregations.clj
@@ -1,9 +1,11 @@
 (ns metabase.query-processor.middleware.expand-aggregations
+  (:refer-clojure :exclude [select-keys])
   (:require
    [medley.core :as m]
    [metabase.lib.options :as lib.options]
    [metabase.lib.util :as lib.util]
-   [metabase.lib.walk :as lib.walk]))
+   [metabase.lib.walk :as lib.walk]
+   [metabase.util.performance :refer [select-keys]]))
 
 (defn- expand-aggregation-ref
   [aggregation-ref aggregation]

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -2,6 +2,7 @@
   "Middleware for expanding LEGACY `:segment` 'macros' in *unexpanded* MBQL queries.
 
   (`:segment` forms are expanded into filter clauses.)"
+  (:refer-clojure :exclude [mapv])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.filter :as lib.filter]
@@ -17,7 +18,8 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [mapv]]))
 
 ;;; "legacy macro" as used below means legacy Segment.
 (mr/def ::legacy-macro

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.middleware.fetch-source-query
+  (:refer-clojure :exclude [some])
   (:require
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
@@ -18,6 +19,7 @@
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some]]
    [weavejester.dependency :as dep]))
 
 ;;; TODO -- consider whether [[normalize-card-query]] should be moved into [[metabase.lib.card]], seems like it would

--- a/src/metabase/query_processor/middleware/large_int.clj
+++ b/src/metabase/query_processor/middleware/large_int.clj
@@ -1,8 +1,9 @@
 (ns metabase.query-processor.middleware.large-int
   "Middleware for handling conversion of integers to strings for proper display of large numbers"
+  (:refer-clojure :exclude [mapv])
   (:require
    [metabase.query-processor.store :as qp.store]
-   [metabase.util.performance :as perf])
+   [metabase.util.performance :as perf :refer [mapv]])
   (:import
    (clojure.lang BigInt)
    (java.math BigDecimal BigInteger)))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.middleware.metrics
+  (:refer-clojure :exclude [select-keys some])
   (:require
-   [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.analytics.core :as analytics]
    [metabase.lib.core :as lib]
@@ -10,7 +10,8 @@
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.util :as u]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :as perf :refer [select-keys some]]))
 
 (defn- filters->condition
   [filters]
@@ -95,7 +96,7 @@
   [aggregation condition]
   (cond->> aggregation
     (seq condition)
-    (walk/postwalk
+    (perf/postwalk
      (fn [form]
        (if-not (and (vector? form)
                     (not (map-entry? form)))

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.parameters.mbql
   "Code for handling parameter substitution in MBQL queries."
+  (:refer-clojure :exclude [every?])
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -18,7 +19,8 @@
    [metabase.query-processor.parameters.operators :as params.ops]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every?]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/query_processor/middleware/parameters/native.clj
+++ b/src/metabase/query_processor/middleware/parameters/native.clj
@@ -25,6 +25,7 @@
 
   3.  `substitute` (and the related namespace `substitution`) replace optional and param objects with appropriate SQL
       snippets and prepared statement args, and combine the sequence of fragments back into a single SQL string."
+  (:refer-clojure :exclude [mapv])
   (:require
    [clojure.set :as set]
    [medley.core :as m]
@@ -35,7 +36,8 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.query-processor.store :as qp.store]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv]]))
 
 (defn- substitute-native-parameters* [stage]
   (-> stage

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -5,6 +5,7 @@
 
   ViewLog recording is triggered indirectly by the call to [[events/publish-event!]] with the `:event/card-query`
   event -- see [[metabase.view-log.events.view-log]]."
+  (:refer-clojure :exclude [every?])
   (:require
    [java-time.api :as t]
    [metabase.analytics.core :as analytics]
@@ -15,6 +16,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every?]]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor.middleware.resolve-joins
   "Middleware that fetches tables that will need to be joined, referred to by `:field` clauses with `:source-field`
   options, and adds information to the query about what joins should be done and how they should be performed."
-  (:refer-clojure :exclude [alias])
+  (:refer-clojure :exclude [alias every? mapv])
   (:require
    [clojure.string :as str]
    [medley.core :as m]
@@ -10,7 +10,8 @@
    [metabase.lib.schema.join :as lib.schema.join]
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.walk :as lib.walk]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every? mapv]]))
 
 (mu/defn- merge-defaults :- ::lib.schema.join/join
   [join]

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -2,6 +2,7 @@
   "Middleware that stores metadata about results column types after running a query for a Card,
    and returns that metadata (which can be passed *back* to the backend when saving a Card) as well
    as a checksum in the API response."
+  (:refer-clojure :exclude [mapv select-keys])
   (:require
    [clojure.string :as str]
    [malli.error :as me]
@@ -18,6 +19,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [mapv select-keys]]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.middleware.wrap-value-literals
   "Middleware that wraps value literals in `value`/`absolute-datetime`/etc. clauses containing relevant type
   information; parses datetime string literals when appropriate."
+  (:refer-clojure :exclude [select-keys])
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
@@ -17,7 +18,8 @@
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]])
   (:import
    (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)))
 

--- a/src/metabase/query_processor/parameters/dates.clj
+++ b/src/metabase/query_processor/parameters/dates.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.parameters.dates
   "Shared code for handling datetime parameters, used by both MBQL and native params implementations."
+  (:refer-clojure :exclude [every? some])
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
@@ -15,6 +16,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [every? some]]
    [metabase.util.time :as u.time])
   (:import
    (java.time.temporal Temporal)))

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -3,6 +3,7 @@
   warehouse and concatenates the result rows together, sort of like the way [[clojure.core/lazy-cat]] works. This is
   dumb, right? It's not just me? Why don't we just generate a big ol' UNION query so we can run one single query
   instead of running like 10 separate queries? -- Cam"
+  (:refer-clojure :exclude [every? mapv some select-keys update-keys])
   (:require
    [medley.core :as m]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
@@ -30,7 +31,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf]))
+   [metabase.util.performance :as perf :refer [mapv some every? select-keys update-keys]]))
 
 (set! *warn-on-reflection* true)
 
@@ -423,10 +424,10 @@
                                  (lib/returned-columns query))]
     (-> (or (:column_settings viz-settings)
             (::mb.viz/column-settings viz-settings))
-        (perf/update-keys (fn [k]
-                            (if (string? k)
-                              (-> k json/decode last index-in-breakouts)
-                              (->> k ::mb.viz/column-name index-in-breakouts))))
+        (update-keys (fn [k]
+                       (if (string? k)
+                         (-> k json/decode last index-in-breakouts)
+                         (->> k ::mb.viz/column-name index-in-breakouts))))
         (update-vals (comp keyword :pivot_table.column_sort_order)))))
 
 (mu/defn- field-ref-pivot-options :- ::pivot-opts

--- a/src/metabase/query_processor/pivot/postprocess.clj
+++ b/src/metabase/query_processor/pivot/postprocess.clj
@@ -4,14 +4,14 @@
   The shape returned by the pivot qp is not the same visually as what a pivot table looks like in the app.
   It's all of the same data, but some post-processing logic needs to run on the rows to be able to present them
   visually in the same way as in the app."
-  (:refer-clojure :exclude [run!])
+  (:refer-clojure :exclude [mapv])
   (:require
    [clojure.set :as set]
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.pivot.core :as pivot]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf]))
+   [metabase.util.performance :as perf :refer [mapv]]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.streaming
+  (:refer-clojure :exclude [every? some])
   (:require
    [clojure.string :as str]
    [metabase.analytics.core :as analytics]
@@ -18,7 +19,8 @@
    [metabase.server.streaming-response :as streaming-response]
    [metabase.util :as u]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [every? some]])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)
    (java.io OutputStream)

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.streaming.common
   "Shared util fns for various export (download) streaming formats."
+  (:refer-clojure :exclude [mapv select-keys])
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
@@ -10,7 +11,7 @@
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util.currency :as currency]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.performance :as perf])
+   [metabase.util.performance :as perf :refer [mapv select-keys]])
   (:import
    (clojure.lang ISeq)
    (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.streaming.csv
+  (:refer-clojure :exclude [mapv])
   (:require
    [clojure.data.csv]
    [medley.core :as m]
@@ -8,7 +9,7 @@
    [metabase.query-processor.settings :as qp.settings]
    [metabase.query-processor.streaming.common :as streaming.common]
    [metabase.query-processor.streaming.interface :as qp.si]
-   [metabase.util.performance :as perf])
+   [metabase.util.performance :as perf :refer [mapv]])
   (:import
    (java.io BufferedWriter OutputStream OutputStreamWriter)
    (java.nio.charset StandardCharsets)))

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -1,13 +1,15 @@
 (ns metabase.query-processor.streaming.json
   "Impls for JSON-based QP streaming response types. `:json` streams a simple array of maps as opposed to the full
   response with all the metadata for `:api`."
+  (:refer-clojure :exclude [mapv])
   (:require
    [medley.core :as m]
    [metabase.formatter.core :as formatter]
    [metabase.query-processor.pivot.postprocess :as qp.pivot.postprocess]
    [metabase.query-processor.streaming.common :as streaming.common]
    [metabase.query-processor.streaming.interface :as qp.si]
-   [metabase.util.json :as json])
+   [metabase.util.json :as json]
+   [metabase.util.performance :refer [mapv]])
   (:import
    (com.fasterxml.jackson.core JsonGenerator)
    (java.io BufferedWriter OutputStream OutputStreamWriter)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.streaming.xlsx
+  (:refer-clojure :exclude [mapv some])
   (:require
    [clojure.string :as str]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
@@ -16,7 +17,8 @@
    [metabase.util.currency :as currency]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.json :as json])
+   [metabase.util.json :as json]
+   [metabase.util.performance :refer [mapv some]])
   (:import
    (java.io OutputStream)
    (java.time

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -1,10 +1,10 @@
 (ns metabase.query-processor.util
   "Utility functions used by the global query processor and middleware functions."
+  (:refer-clojure :exclude [select-keys])
   (:require
    [buddy.core.codecs :as codecs]
    [buddy.core.hash :as buddy-hash]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.driver :as driver]
    ;; legacy usage -- don't use Legacy MBQL utils in QP code going forward, prefer Lib. This will be updated to use
@@ -19,7 +19,8 @@
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.json :as json]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :as perf :refer [select-keys]]))
 
 (set! *warn-on-reflection* true)
 
@@ -82,7 +83,7 @@
   "We don't want two queries to have different hashes because their map keys are in different orders, now do we? Convert
   all the maps to sorted maps so queries are serialized to JSON in an identical order."
   [x]
-  (walk/postwalk
+  (perf/postwalk
    (fn [x]
      (if (and (map? x)
               (not (sorted? x)))

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -40,7 +40,7 @@
 
   If this clause is 'selected' (i.e., appears in `:fields`, `:aggregation`, or `:breakout`), select the clause `AS`
   this alias. This alias is guaranteed to be unique."
-  (:refer-clojure :exclude [ref])
+  (:refer-clojure :exclude [mapv ref select-keys some])
   (:require
    [medley.core :as m]
    [metabase.config.core :as config]
@@ -60,7 +60,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :refer [mapv select-keys some]]))
 
 (mu/defn- ^:dynamic *escape-alias-fn* :- :string
   [driver :- :keyword

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -5,8 +5,8 @@
 
    (This namespace is here rather than in the shared MBQL lib because it relies on other QP-land utils like the QP
   refs stuff.)"
+  (:refer-clojure :exclude [mapv select-keys some])
   (:require
-   [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.api.common :as api]
    ;; legacy usage -- don't use Legacy MBQL utils in QP code going forward, prefer Lib. This will be updated to use
@@ -24,7 +24,8 @@
    [metabase.query-processor.util.add-alias-info :as add]
    [metabase.util :as u]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :as perf :refer [mapv select-keys some]]))
 
 (defn- all-fields-for-table [table-id]
   (->> (lib.metadata/fields (qp.store/metadata-provider) table-id)
@@ -98,7 +99,7 @@
 (defn- joined-fields [inner-query]
   (m/distinct-by
    normalize-clause
-   (lib.util.match/match (walk/prewalk (fn [x]
+   (lib.util.match/match (perf/prewalk (fn [x]
                                          (if (map? x)
                                            (dissoc x :source-query :source-metadata :temporal-unit)
                                            x))

--- a/src/metabase/query_processor/util/transformations/nest_breakouts.clj
+++ b/src/metabase/query_processor/util/transformations/nest_breakouts.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.util.transformations.nest-breakouts
   "TODO (Cam 8/7/25) -- this is a pure-MBQL-5 high-level query transformation, and almost certainly belongs in Lib
   rather than in QP -- we should move it there."
+  (:refer-clojure :exclude [mapv select-keys some])
   (:require
    [flatland.ordered.set :as ordered-set]
    [medley.core :as m]
@@ -12,7 +13,8 @@
    [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [mapv select-keys some]]))
 
 (defn- stage-has-window-aggregation? [stage]
   (lib.util.match/match (:aggregation stage)

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -38,6 +38,10 @@
   (cond-> coll
     (transient? coll) persistent!))
 
+(defn- add-original-meta [coll og-form]
+  (when-not (nil? coll)
+    (with-meta coll (meta og-form))))
+
 ;; Collection functions
 
 #?(:clj
@@ -288,7 +292,7 @@
                                        (assoc+ k' v)))))
                              m m)
                   maybe-persistent!
-                  (with-meta (meta m)))))
+                  (add-original-meta m))))
 
 ;; clojure.walk reimplementation. Partially adapted from https://github.com/tonsky/clojure-plus.
 
@@ -313,7 +317,7 @@
                                  (-> m (dissoc+ k) (assoc+ k' v')))))))
                      form form)
           maybe-persistent!
-          (with-meta (meta form))
+          (add-original-meta form)
           outer))
 
     (vector? form)
@@ -324,12 +328,12 @@
                          (assoc+ v idx el'))))
                    form form)
         maybe-persistent!
-        (with-meta (meta form))
+        (add-original-meta form)
         outer)
 
     ;; Don't care much about optimizing seq and generic coll cases. When efficiency is required, use vectors.
-    (seq? form) (outer (with-meta (seq (mapv inner form)) (meta form))) ;;
-    (coll? form) (outer (with-meta (into (empty form) (map inner) form) (meta form)))
+    (seq? form) (outer (add-original-meta (seq (mapv inner form)) form)) ;;
+    (coll? form) (outer (add-original-meta (into (empty form) (map inner) form) form))
     :else (outer form)))
 
 (defn prewalk
@@ -355,7 +359,7 @@
                           m))
                       form form)
            maybe-persistent!
-           (with-meta (meta form)))
+           (add-original-meta form))
        form))
    m))
 

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -157,8 +157,9 @@
      (^long [c1 c2 c3 c4] (min (count c1) (count c2) (count c3) (count c4)))))
 
 (defn mapv
-  "Like `clojure.core/mapv`, but iterates multiple collections more efficiently and uses Java iterators under the
-  hood (the CLJ version). CLJS version is only optimized for a single collection arity."
+  "Drop-in replacement for `clojure.core/mapv`.
+  Iterates multiple collections more efficiently and uses Java iterators under the hood (the CLJ version). CLJS
+  version is only optimized for a single collection arity."
   ([f coll1]
    (let [n (count coll1)]
      (cond (= n 0) []
@@ -190,7 +191,8 @@
       (core/mapv f coll1 coll2 coll3 coll4))))
 
 (defn run!
-  "Like `clojure.core/run!`, but iterates collections more efficiently and uses Java iterators under the hood."
+  "Drop-in replacement for `clojure.core/run!`.
+  Iterates collections more efficiently and uses Java iterators under the hood."
   ([f coll1]
    (reduce (fn [_ x] (f x)) nil coll1)))
 
@@ -206,17 +208,19 @@
       ([x y z & args] (mapv #(apply % x y z args) fns)))))
 
 (defn some
-  "Like `clojure.core/some` but uses our custom `reduce` which in turn uses iterators."
+  "Drop-in replacement for `clojure.core/some`.
+  Uses our custom `reduce` which in turn uses iterators."
   [f coll]
   (unreduced (reduce #(when-let [match (f %2)] (reduced match)) nil coll)))
 
 (defn every?
-  "Like `clojure.core/every?` but uses our custom `reduce` which in turn uses iterators."
+  "Drop-in replacement for `clojure.core/every?`.
+  Uses our custom `reduce` which in turn uses iterators."
   [f coll]
   (unreduced (reduce #(if (f %2) true (reduced false)) true coll)))
 
 (defn concat
-  "Like `clojure.core/concat` but accumulates the result into a vector."
+  "Like `clojure.core/concat` but accumulates the result into a vector. NOT a drop-in replacement."
   ([a b]
    (into (vec a) b))
   ([a b c]
@@ -264,7 +268,7 @@
              (first coll-of-colls)))))
 
 (defn select-keys
-  "Like `clojure.walk/select-keys`, but much more efficient."
+  "Drop-in replacement for `clojure.walk/select-keys`, but much more efficient."
   [m keyseq]
   (let [absent #?(:clj (Object.) :cljs #js{})]
     (persistent! (reduce (fn [acc k]
@@ -275,7 +279,8 @@
                          (transient {}) keyseq))))
 
 (defn update-keys
-  "Like `clojure.core/update-keys`, but doesn't recreate the collection if no keys are changed after applying `f`."
+  "Drop-in replacement for `clojure.core/update-keys`.
+  Doesn't recreate the collection if no keys are changed after applying `f`."
   [m f]
   (cond (nil? m) {}
         ;; Fallback for non-editable collections where transients aren't supported.
@@ -297,7 +302,7 @@
 ;; clojure.walk reimplementation. Partially adapted from https://github.com/tonsky/clojure-plus.
 
 (defn walk
-  "Like `clojure.walk/walk`, but optimized for efficiency and has the following behavior differences:
+  "Drop-in replacement for `clojure.walk/walk`. Optimized for efficiency and has the following behavior differences:
   - Doesn't walk over map entries. When descending into a map, walks keys and values separately.
   - Uses transients and reduce where possible and tries to return the same input `form` if no changes were made."
   [inner outer form]
@@ -337,18 +342,20 @@
     :else (outer form)))
 
 (defn prewalk
-  "Like `clojure.walk/prewalk`, but uses a more efficient `metabase.util.performance/walk` underneath."
+  "Drop-in replacement for `clojure.walk/prewalk`.
+  Uses a more efficient `metabase.util.performance/walk` underneath."
   [f form]
   (walk (fn prewalker [form] (walk prewalker identity (f form))) identity (f form)))
 
 (defn postwalk
-  "Like `clojure.walk/postwalk`, but uses a more efficient `metabase.util.performance/walk` underneath."
+  "Drop-in replacement for `clojure.walk/postwalk`.
+  Uses a more efficient `metabase.util.performance/walk` underneath."
   [f form]
   (walk (fn postwalker [form] (walk postwalker f form)) f form))
 
 (defn keywordize-keys
-  "Like `clojure.walk/keywordize-keys`, but uses a more efficient `metabase.util.performance/walk` underneath and
-  preserves original metadata on the transformed maps."
+  "Drop-in replacement for `clojure.walk/keywordize-keys`.
+  Uses `metabase.util.performance/walk` underneath and preserves original metadata on the transformed maps."
   [m]
   (postwalk
    (fn [form]

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -52,7 +52,7 @@
      ([f init coll1]
       (if (nil? coll1)
         init
-        (let [it1 (.iterator ^Iterable coll1)]
+        (let [it1 (RT/iter coll1)]
           (loop [res init]
             (if (.hasNext it1)
               (let [res (f res (.next it1))]
@@ -63,8 +63,8 @@
      ([f init coll1 coll2]
       (if (or (nil? coll1) (nil? coll2))
         init
-        (let [it1 (.iterator ^Iterable coll1)
-              it2 (.iterator ^Iterable coll2)]
+        (let [it1 (RT/iter coll1)
+              it2 (RT/iter coll2)]
           (loop [res init]
             (if (and (.hasNext it1) (.hasNext it2))
               (let [res (f res (.next it1) (.next it2))]
@@ -75,9 +75,9 @@
      ([f init coll1 coll2 coll3]
       (if (or (nil? coll1) (nil? coll2) (nil? coll3))
         init
-        (let [it1 (.iterator ^Iterable coll1)
-              it2 (.iterator ^Iterable coll2)
-              it3 (.iterator ^Iterable coll3)]
+        (let [it1 (RT/iter coll1)
+              it2 (RT/iter coll2)
+              it3 (RT/iter coll3)]
           (loop [res init]
             (if (and (.hasNext it1) (.hasNext it2) (.hasNext it3))
               (let [res (f res (.next it1) (.next it2) (.next it3))]
@@ -88,10 +88,10 @@
      ([f init coll1 coll2 coll3 coll4]
       (if (or (nil? coll1) (nil? coll2) (nil? coll3) (nil? coll4))
         init
-        (let [it1 (.iterator ^Iterable coll1)
-              it2 (.iterator ^Iterable coll2)
-              it3 (.iterator ^Iterable coll3)
-              it4 (.iterator ^Iterable coll4)]
+        (let [it1 (RT/iter coll1)
+              it2 (RT/iter coll2)
+              it3 (RT/iter coll3)
+              it4 (RT/iter coll4)]
           (loop [res init]
             (if (and (.hasNext it1) (.hasNext it2) (.hasNext it3) (.hasNext it4))
               (let [res (f res (.next it1) (.next it2) (.next it3) (.next it4))]

--- a/test/metabase/util/performance_test.cljc
+++ b/test/metabase/util/performance_test.cljc
@@ -5,6 +5,14 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
+#?(:clj
+   (deftest ^:parallel reduce-test
+     (is (= 10 (perf/reduce + 0 [1 2 3 4])))
+     (is (= 20 (perf/reduce + 0 [1 2 3 4] [1 2 3 4])))
+     (is (= 30 (perf/reduce + 0 [1 2 3 4] [1 2 3 4] [1 2 3 4])))
+     (is (= 40 (perf/reduce + 0 [1 2 3 4] [1 2 3 4] [1 2 3 4] [1 2 3 4])))
+     (is (= "hello" (perf/reduce str "" "hello")))))
+
 (deftest ^:parallel concat-test
   (is (= [1 2 3 4 5] (perf/concat [1] [] [2] [3 4] nil '(5))))
   (is (= [] (perf/concat [] [])))


### PR DESCRIPTION
As discussed with @camsaul, many functions in `metabase.util.performance` are obscure and poorly discoverable. While it is not reasonable to enforce their usage everywhere, nudging the developers to reach for them at least in the "performance-sensitive" parts of the system should increase familiarity.

- I've updated the docstrings to explicitly state which functions are drop-in replacements (to the best of my knowledge).
- Updated Kondo rules to suggest using drop-in replacements for core functions in lib, qp, drivers, etc.
- Walked through impacted namespaces and referred those drop-in replacements and unreferred the respective core functions. I think this approach is cleaner than adding an alias everywhere.