### PR TITLE
Closes EMB-716 publicly shared maps in dashboards

### DIFF
--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -1,3 +1,4 @@
+import { isUuid } from "metabase/lib/uuid";
 import type { Dataset, JsonQuery } from "metabase-types/api";
 
 interface TileCoordinate {
@@ -44,8 +45,8 @@ export function getTileUrl(params: TileUrlParams): string {
       return adhocQueryTileUrl(zoom, coord, latField, lonField, datasetQuery);
     }
 
-    if (typeof dashboardId === "string") {
-      throw Error("dashboardId must be an int");
+    if (typeof dashboardId === "string" && !isUuid(dashboardId)) {
+      throw Error("dashboardId must be an int or a uuid");
     }
     const isPublicDashboard = uuid;
 
@@ -159,7 +160,7 @@ function savedQuestionTileUrl(
 }
 
 function dashboardTileUrl(
-  dashboardId: number,
+  dashboardId: number | string,
   dashcardId: number,
   cardId: number,
   zoom: string | number,

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -1,5 +1,5 @@
 import { isUuid } from "metabase/lib/uuid";
-import type { Dataset, JsonQuery } from "metabase-types/api";
+import type { DashboardId, Dataset, JsonQuery } from "metabase-types/api";
 
 interface TileCoordinate {
   x: number | string;
@@ -8,7 +8,7 @@ interface TileCoordinate {
 
 interface TileUrlParams {
   cardId?: number;
-  dashboardId?: number | string;
+  dashboardId?: DashboardId;
   dashcardId?: number;
   zoom: string | number;
   coord: TileCoordinate;
@@ -160,7 +160,7 @@ function savedQuestionTileUrl(
 }
 
 function dashboardTileUrl(
-  dashboardId: number | string,
+  dashboardId: DashboardId,
   dashcardId: number,
   cardId: number,
   zoom: string | number,

--- a/frontend/src/metabase/visualizations/lib/map.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/map.unit.spec.ts
@@ -179,7 +179,8 @@ describe("map", () => {
     describe("public dashboard", () => {
       it("should generate url for public dashboard without parameters", () => {
         const url = getTileUrl({
-          dashboardId: 10,
+          // public dashboards have a uuid instead of an id
+          dashboardId: "621efc8c-9fd9-42db-a39a-1abdbfe23937",
           dashcardId: 20,
           cardId: 30,
           zoom,
@@ -202,7 +203,8 @@ describe("map", () => {
         });
 
         const url = getTileUrl({
-          dashboardId: 10,
+          // public dashboards have a uuid instead of an id
+          dashboardId: "621efc8c-9fd9-42db-a39a-1abdbfe23937",
           dashcardId: 20,
           cardId: 30,
           zoom,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62066
Closes [EMB-716: dashboardId must be an int - error displayed for embedded maps with more than 1000 pins](https://linear.app/metabase/issue/EMB-716/dashboardid-must-be-an-int-error-displayed-for-embedded-maps-with-more)

### Description

In #61634 we added an extra check on dashboards ids to ensure tile map URLs were sanitized. However public dashboards have a uuid as their id, and that made the check fail and the code throw.

### How to verify

 1. Make a new question (People > visualize > change to Map > save)
 2. Make a new dashboard (Add the new question to it > make public)
 3. Open the public link in a new tab

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
