### PR TITLE
Update broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Take a [tour of Metabase](https://www.metabase.com/learn/getting-started/tour-of
 ## Supported databases
 
 - [Officially supported databases](./docs/databases/connecting.md#connecting-to-supported-databases)
-- [Community drivers](./docs/developers-guide/partner-and-community-drivers.md)
+- [Community drivers](./docs/developers-guide/community-drivers.md)
 
 ## Installation
 


### PR DESCRIPTION
The README currently links to https://github.com/metabase/metabase/blob/master/docs/developers-guide/partner-and-community-drivers.md, which 404's.

It was renamed in https://github.com/metabase/metabase/pull/56184.