### PR TITLE
Fix multiple datasource viz settings in visualizer

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/reproductions.cy.spec.ts
@@ -1,0 +1,167 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type { StructuredQuestionDetails } from "e2e/support/helpers";
+
+const { H } = cy;
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("issue 61521", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+  });
+
+  it("should preserve column settings when use visualizer (metabase#61521)", () => {
+    const questionADetails = {
+      name: "Question A for 61521",
+      display: "line" as const,
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [
+          [
+            "aggregation-options",
+            [
+              "/",
+              [
+                "sum",
+                [
+                  "field" as const,
+                  ORDERS.TAX,
+                  {
+                    "base-type": "type/Float",
+                  },
+                ],
+              ],
+              [
+                "sum",
+                [
+                  "field" as const,
+                  ORDERS.SUBTOTAL,
+                  {
+                    "base-type": "type/Float",
+                  },
+                ],
+              ],
+            ],
+            {
+              name: "Tax over Sub",
+              "display-name": "Tax over Sub",
+            },
+          ],
+        ],
+        breakout: [
+          [
+            "field",
+            ORDERS.CREATED_AT,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "month",
+            },
+          ],
+        ],
+      },
+      visualization_settings: {
+        "graph.dimensions": ["CREATED_AT"],
+        "graph.metrics": ["Tax over Sub"],
+        column_settings: {
+          '["name","Tax over Sub"]': { number_style: "percent" },
+        },
+      },
+    };
+
+    const questionBDetails = {
+      name: "Question B for 61521",
+      display: "line" as const,
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [
+          [
+            "aggregation-options",
+            [
+              "/",
+              [
+                "sum",
+                [
+                  "field",
+                  ORDERS.TAX,
+                  {
+                    "base-type": "type/Float",
+                  },
+                ],
+              ],
+              [
+                "sum",
+                [
+                  "field",
+                  ORDERS.TOTAL,
+                  {
+                    "base-type": "type/Float",
+                  },
+                ],
+              ],
+            ],
+            {
+              name: "Tax over Total",
+              "display-name": "Tax over Total",
+            },
+          ],
+        ],
+        breakout: [
+          [
+            "field",
+            ORDERS.CREATED_AT,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "month",
+            },
+          ],
+        ],
+      },
+      visualization_settings: {
+        "graph.dimensions": ["CREATED_AT"],
+        "graph.metrics": ["Tax over Total"],
+        column_settings: {
+          '["name","Tax over Total"]': { number_style: "percent" },
+        },
+      },
+    };
+
+    H.createQuestion(questionBDetails as unknown as StructuredQuestionDetails);
+
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      H.createQuestionAndAddToDashboard(
+        questionADetails as unknown as StructuredQuestionDetails,
+        dashboardId,
+      );
+
+      cy.visit(`/dashboard/${dashboardId}`);
+    });
+
+    H.editDashboard();
+    H.findDashCardAction(
+      H.getDashboardCard(0),
+      "Visualize another way",
+    ).click();
+
+    H.modal().within(() => {
+      H.switchToAddMoreData();
+
+      cy.findByText("Question B for 61521")
+        .closest("[data-testid='swap-dataset-button']")
+        .should("not.have.attr", "aria-pressed", "true")
+        .click({ force: true });
+
+      cy.wait("@cardQuery");
+
+      cy.findByLabelText("Legend")
+        .findByText("Question B for 61521")
+        .should("exist");
+
+      // ensure there is no additional unformatted axis
+      cy.findByText("0.06").should("not.exist");
+      cy.findByText("0.05").should("not.exist");
+      cy.findByText("0.04").should("not.exist");
+    });
+  });
+});

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -185,7 +185,7 @@ export function getInitialStateForCardDataSource(
       }
 
       if (Array.isArray(originalValue)) {
-        // When there're no sensible metrics/dimensions,
+        // When there are no sensible metrics/dimensions,
         // "graph.dimensions" and "graph.metrics" are `[null]`
         if (originalValue.filter(Boolean).length === 0) {
           return;

--- a/frontend/src/metabase/visualizer/utils/index.ts
+++ b/frontend/src/metabase/visualizer/utils/index.ts
@@ -11,3 +11,4 @@ export * from "./is-visualizer-dashboard-card";
 export * from "./merge-data";
 export * from "./split-series";
 export * from "./get-visualization-columns";
+export * from "./update-viz-settings-with-refs";

--- a/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/cartesian.unit.spec.ts
@@ -879,7 +879,6 @@ describe("cartesian", () => {
       combineWithCartesianChart(
         nextState,
         settings,
-        {},
         createMockDataset({
           data: { cols: [newMetricColumn, newDimensionColumn] },
         }),
@@ -969,7 +968,6 @@ describe("cartesian", () => {
       combineWithCartesianChart(
         nextState,
         settings,
-        {},
         createMockDataset({
           data: {
             cols: [
@@ -1065,7 +1063,6 @@ describe("cartesian", () => {
         combineWithCartesianChart(
           nextState,
           settings,
-          {},
           createMockDataset({
             data: {
               cols: [stringDimension, anotherStringDimension, dateDimension],
@@ -1135,7 +1132,6 @@ describe("cartesian", () => {
         combineWithCartesianChart(
           nextState,
           settings,
-          {},
           createMockDataset({
             data: {
               cols: [stringDimension, dateDimension, numericDimension],
@@ -1203,7 +1199,6 @@ describe("cartesian", () => {
         combineWithCartesianChart(
           nextState,
           settings,
-          {},
           createMockDataset({
             data: {
               cols: [dateDimension, anotherDateDimension, stringDimension],
@@ -1270,7 +1265,6 @@ describe("cartesian", () => {
         combineWithCartesianChart(
           nextState,
           settings,
-          {},
           createMockDataset({
             data: {
               cols: [stringDimension, dateDimension, anotherStringDimension],

--- a/frontend/src/metabase/visualizer/visualizations/pie.ts
+++ b/frontend/src/metabase/visualizer/visualizations/pie.ts
@@ -105,7 +105,6 @@ export function findColumnSlotForPieChart(parameters: {
 export function addColumnToPieChart(
   state: VisualizerVizDefinitionWithColumns,
   settings: ComputedVisualizationSettings,
-  datasets: Record<string, Dataset>,
   dataSourceColumns: DatasetColumn[],
   column: DatasetColumn,
   columnRef: VisualizerColumnReference,
@@ -154,7 +153,6 @@ export function removeColumnFromPieChart(
 export function combineWithPieChart(
   state: VisualizerVizDefinitionWithColumns,
   settings: ComputedVisualizationSettings,
-  datasets: Record<string, Dataset>,
   { data }: Dataset,
   dataSource: VisualizerDataSource,
 ) {
@@ -176,14 +174,7 @@ export function combineWithPieChart(
       dataSource.name,
       state.columns,
     );
-    addColumnToPieChart(
-      state,
-      settings,
-      datasets,
-      data.cols,
-      column,
-      columnRef,
-    );
+    addColumnToPieChart(state, settings, data.cols, column, columnRef);
   }
 
   if (_.isEmpty(settings["pie.dimension"]) && dimensions.length === 1) {
@@ -199,13 +190,6 @@ export function combineWithPieChart(
       dataSource.name,
       state.columns,
     );
-    addColumnToPieChart(
-      state,
-      settings,
-      datasets,
-      data.cols,
-      column,
-      columnRef,
-    );
+    addColumnToPieChart(state, settings, data.cols, column, columnRef);
   }
 }

--- a/frontend/src/metabase/visualizer/visualizations/pie.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/visualizations/pie.unit.spec.ts
@@ -62,7 +62,6 @@ describe("pie", () => {
       addColumnToPieChart(
         state,
         {},
-        {},
         [metricColumn],
         { ...metricColumn, name: "COLUMN_1" },
         metricColumnRef,
@@ -98,7 +97,6 @@ describe("pie", () => {
       addColumnToPieChart(
         state,
         settings,
-        {},
         [metricColumn2],
         { ...metricColumn2, name: "COLUMN_2" },
         metricColumn2Ref,
@@ -119,7 +117,6 @@ describe("pie", () => {
 
       addColumnToPieChart(
         state,
-        {},
         {},
         [dimensionColumn],
         { ...dimensionColumn, name: "COLUMN_1" },
@@ -155,7 +152,6 @@ describe("pie", () => {
 
       addColumnToPieChart(
         state,
-        {},
         {},
         [dimensionColumn2],
         { ...dimensionColumn2, name: "COLUMN_2" },
@@ -288,7 +284,6 @@ describe("pie", () => {
       combineWithPieChart(
         state,
         settings,
-        {},
         createMockDataset({
           data: { cols: [metricColumn2] },
         }),
@@ -329,7 +324,6 @@ describe("pie", () => {
       combineWithPieChart(
         state,
         settings,
-        {},
         createMockDataset({
           data: { cols: [metricColumn2] },
         }),
@@ -357,7 +351,6 @@ describe("pie", () => {
       combineWithPieChart(
         state,
         settings,
-        {},
         createMockDataset({
           data: { cols: [metricColumn2, metricColumn3] },
         }),
@@ -385,7 +378,6 @@ describe("pie", () => {
       combineWithPieChart(
         state,
         settings,
-        {},
         createMockDataset({
           data: { cols: [dimensionColumn] },
         }),
@@ -422,7 +414,6 @@ describe("pie", () => {
       combineWithPieChart(
         state,
         settings,
-        {},
         createMockDataset({
           data: { cols: [dimensionColumn2, dimensionColumn3] },
         }),
@@ -450,7 +441,6 @@ describe("pie", () => {
       combineWithPieChart(
         state,
         settings,
-        {},
         createMockDataset({
           data: { cols: [dimensionColumn2] },
         }),

--- a/frontend/src/metabase/visualizer/visualizer.slice.ts
+++ b/frontend/src/metabase/visualizer/visualizer.slice.ts
@@ -176,6 +176,7 @@ export const addDataSource = createAsyncThunk(
 
     let dataSource: VisualizerDataSource | null = null;
     let dataset: Dataset | null = null;
+    let vizSettings: VisualizationSettings | null = null;
 
     if (type === "card") {
       // TODO handle rejected requests
@@ -186,6 +187,7 @@ export const addDataSource = createAsyncThunk(
 
       const card = cardAction.payload as Card;
       dataset = cardQueryAction.payload as Dataset;
+      vizSettings = card.visualization_settings || null;
 
       if (
         !state.display ||
@@ -224,9 +226,9 @@ export const addDataSource = createAsyncThunk(
         settings,
       },
       settings,
-      state.datasets,
       dataSource,
       dataset,
+      vizSettings,
     );
   },
 );
@@ -427,7 +429,6 @@ const visualizerSlice = createSlice({
         addColumnToPieChart(
           state,
           settings,
-          state.datasets as Record<string, Dataset>,
           dataset.data.cols,
           column,
           columnRef,
@@ -643,20 +644,26 @@ const visualizerSlice = createSlice({
 function maybeCombineDataset(
   state: VisualizerVizDefinitionWithColumns,
   settings: ComputedVisualizationSettings,
-  datasets: Record<string, Dataset>,
   dataSource: VisualizerDataSource,
   dataset: Dataset,
+  vizSettings: VisualizationSettings | null,
 ) {
   if (!state.display) {
     return;
   }
 
   if (isCartesianChart(state.display)) {
-    combineWithCartesianChart(state, settings, datasets, dataset, dataSource);
+    combineWithCartesianChart(
+      state,
+      settings,
+      dataset,
+      dataSource,
+      vizSettings,
+    );
   }
 
   if (state.display === "pie") {
-    combineWithPieChart(state, settings, datasets, dataset, dataSource);
+    combineWithPieChart(state, settings, dataset, dataSource);
   }
 
   if (state.display === "funnel") {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61521 / UXW-385

### Description

Adds "column_settings" visualization settings initial state when adding a new data source using visualizer

### How to verify

Check steps from https://github.com/metabase/metabase/issues/61521

### Demo

https://github.com/user-attachments/assets/ed67ecab-7266-49ab-b02d-cc1514886a03



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
