### PR TITLE
WRK-865 Flaky Test: detail view value rendering respects datamodel remapping and viz settings

### DIFF
--- a/e2e/test/scenarios/detail-view/detail-view.cy.spec.ts
+++ b/e2e/test/scenarios/detail-view/detail-view.cy.spec.ts
@@ -318,7 +318,7 @@ describe("detail view", () => {
       cy.log("image should be rendered in a frame with a link");
       DetailView.getDetailsRowValue({ index: 8, rowsCount: 15 }).within(() => {
         cy.findByRole("img")
-          .should("be.visible")
+          .should("exist") // do not wait for image to load
           .and("have.attr", "src", "https://example.com/product/14.jpg");
 
         cy.findByRole("link")


### PR DESCRIPTION
Fixes [WRK-865](https://linear.app/metabase/issue/WRK-865/flaky-test-detail-view-value-rendering-respects-datamodel-remapping)

### Description

I could not reproduce the issue (neither locally nor [in CI](https://github.com/metabase/metabase/actions/runs/17397147423))

Stress test: https://github.com/metabase/metabase/actions/runs/17397153012

