### PR TITLE
feat: render link to table metadata editing in the error message

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/toasts/ErrorUpdateToast.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/toasts/ErrorUpdateToast.tsx
@@ -1,9 +1,15 @@
 import { useState } from "react";
-import { t } from "ttag";
+import { Link } from "react-router";
+import { jt, t } from "ttag";
 
-import { Button, Group, Icon, Stack, Text } from "metabase/ui";
+import { useGetTableQuery } from "metabase/api";
+import { Anchor, Box, Button, Group, Icon, Stack, Text } from "metabase/ui";
 
-import { getUpdateApiErrorMessage } from "./getUpdateErrorMessage";
+import {
+  getUpdateApiErrorMessage,
+  getUpdateApiErrorType,
+  getUpdateApiTableId,
+} from "./getUpdateErrorMessage";
 
 type ErrorUpdateToastProps = {
   error: unknown;
@@ -13,7 +19,36 @@ export const ErrorUpdateToast = ({ error }: ErrorUpdateToastProps) => {
   const [showDetails, setShowDetails] = useState(false);
 
   const errorMessage = getUpdateApiErrorMessage(error);
+  const errorType = getUpdateApiErrorType(error);
+  const tableId = getUpdateApiTableId(error);
 
+  const showPkError = errorType === "data-editing/no-pk" && tableId;
+  const { data: table } = useGetTableQuery(
+    { id: tableId ?? 0 },
+    { skip: !showPkError },
+  );
+
+  if (showPkError) {
+    return (
+      <Box w="18rem">
+        <Text
+          c="text-white"
+          fw={700}
+        >{t`Editing unavailable: no PK defined`}</Text>
+        <Text c="text-white">{jt`Add a primary key in your database or set an ${(
+          <Anchor
+            component={Link}
+            to={`/admin/datamodel/database/${table?.db_id}/schema/${table?.schema}/table/${table?.id}`}
+            disabled={!table}
+            key="entity-key-link"
+            target="_blank"
+          >
+            {t`Entity Key`}
+          </Anchor>
+        )} to enable editing`}</Text>
+      </Box>
+    );
+  }
   if (showDetails) {
     return (
       <Stack gap="0.5rem" w="30rem" maw="100%">

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/toasts/getUpdateErrorMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/toasts/getUpdateErrorMessage.tsx
@@ -32,3 +32,33 @@ export const getUpdateApiErrorMessage = (
 
   return t`Unknown error`;
 };
+
+export function getUpdateApiErrorType(error: unknown): string {
+  if (
+    isRecord(error) &&
+    isRecord(error.data) &&
+    isRecord(error.data.data) &&
+    typeof error.data.data.type === "string"
+  ) {
+    return error.data.data.type;
+  }
+
+  return "";
+}
+
+export function getUpdateApiTableId(error: unknown): number | undefined {
+  if (
+    isRecord(error) &&
+    isRecord(error.data) &&
+    isRecord(error.data.data) &&
+    typeof error.data.data["table-id"] === "number"
+  ) {
+    return error.data.data["table-id"];
+  }
+
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
See [WRK-841](https://linear.app/metabase/issue/WRK-841/add-missing-pk-errors-when-a-table-has-no-pk-or-entity-key)
<img width="942" height="356" alt="image" src="https://github.com/user-attachments/assets/42816126-aa91-4b52-91fe-be3f86f54b7d" />
