### PR TITLE
feat: audit for cloud add on purchase

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1605,6 +1605,7 @@
   {:team "Cloud"
    :api  #{metabase-enterprise.cloud-add-ons.api}
    :uses #{api
+           events
            premium-features
            util
            enterprise/harbormaster}}

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -35,7 +35,7 @@
                                       {:terms_of_service true})))))
     (testing "when all conditions are met"
       (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting :offer-metabase-ai}
+        (mt/with-premium-features #{:hosting :offer-metabase-ai :audit-app}
           ;; FIXME: With `(mt/with-temporary-setting-values [token-status {:store-users [{:email (:email user)}]}])`,
           ;;  `(premium-features/token-status)` still returns `nil`; thus resort to `with-redefs`:
           (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})]
@@ -64,4 +64,8 @@
                   (is (not-empty @store-api-calls)
                       "Store API was called")
                   (is (not-empty @clear-token-cache-calls)
-                      "Token cache was cleared"))))))))))
+                      "Token cache was cleared")
+                  (testing "audit log entry generated"
+                    (let [{:keys [details user_id]} (mt/latest-audit-log-entry "cloud-add-on-purchase")]
+                      (is (= (:id user) user_id))
+                      (is (= {:add-on {:product-type "metabase-ai"}} details)))))))))))))

--- a/src/metabase/audit_app/events/audit_log.clj
+++ b/src/metabase/audit_app/events/audit_log.clj
@@ -267,3 +267,10 @@
 (methodical/defmethod events/publish-event! ::permissions-group-membership-event
   [topic event]
   (audit-log/record-event! topic event))
+
+(derive ::cloud-add-on-event ::event)
+(derive :event/cloud-add-on-purchase ::cloud-add-on-event)
+
+(methodical/defmethod events/publish-event! ::cloud-add-on-event
+  [topic event]
+  (audit-log/record-event! topic event))


### PR DESCRIPTION
Fix https://linear.app/metabase/issue/CLO-4380/pass-metabase-user-information-to-store-api-using-a-http-header
