### PR TITLE
Quick ci test disabling

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -1,4 +1,7 @@
 name: Prepare back-end environment
+description: |
+  Prepare the backend. Installs jdk, Clojure, and fetches the cache for m2. The CI config fetchs `ci-test-config.json`
+  from master and lets us ignore tests at the var level if they are flaking.
 inputs:
   java-version:
     required: true
@@ -21,6 +24,7 @@ runs:
         distribution: 'temurin'
     - name: Install Clojure CLI
       shell: bash
+      continue-on-error: true
       run: |
         curl -O https://download.clojure.org/install/linux-install-${{ inputs.clojure-version }}.sh &&
         sudo bash ./linux-install-${{ inputs.clojure-version }}.sh

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -24,6 +24,10 @@ runs:
       run: |
         curl -O https://download.clojure.org/install/linux-install-${{ inputs.clojure-version }}.sh &&
         sudo bash ./linux-install-${{ inputs.clojure-version }}.sh
+    - name: Fetch CI config
+      shell: bash
+      run: |
+        curl -o ci-test-config.json https://raw.githubusercontent.com/metabase/metabase/refs/heads/master/ci-test-config.json
     - name: Check to see if dependencies should be cached
       if: ${{ contains(github.event.head_commit.message, '[ci nocache]') }}
       run: echo "Commit message includes [ci nocache]; dependencies will NOT be cached"

--- a/ci-test-config.json
+++ b/ci-test-config.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.0.0",
+  "ignored": {
+    "vars": []
+  },
+  "metadata": {
+    "last_updated": "2025-08-02",
+    "updated_by": "engineering-team",
+      "reason": "Initial, and empty, ci test config"
+  }
+}

--- a/deps.edn
+++ b/deps.edn
@@ -255,7 +255,7 @@
     criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
     djblue/portal                {:mvn/version "0.60.2"}                    ; ui for inspecting values
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}                     ; cleaner test output
-    io.github.metabase/hawk      {:sha "1fe839cfa48549e21b89c6418c747895eda7e7bc"} ; test runner
+    io.github.metabase/hawk      {:sha "8813c2b0969e9f78025c267af0488c96792b35d1"} ; test runner
     jonase/eastwood              {:mvn/version "1.4.3"                      ; inspects namespaces and reports possible problems using tools.analyzer
                                   :exclusions
                                   [org.ow2.asm/asm-all]}

--- a/deps.edn
+++ b/deps.edn
@@ -255,7 +255,7 @@
     criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
     djblue/portal                {:mvn/version "0.60.2"}                    ; ui for inspecting values
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}                     ; cleaner test output
-    io.github.metabase/hawk      {:sha "8813c2b0969e9f78025c267af0488c96792b35d1"} ; test runner
+    io.github.metabase/hawk      {:mvn/version "1.0.11"}                    ; test runner
     jonase/eastwood              {:mvn/version "1.4.3"                      ; inspects namespaces and reports possible problems using tools.analyzer
                                   :exclusions
                                   [org.ow2.asm/asm-all]}
@@ -409,7 +409,7 @@
     cider/piggieback                   {:mvn/version "0.6.0"}
     cljs-bean/cljs-bean                {:mvn/version "1.9.0"}
     com.lambdaisland/glogi             {:mvn/version "1.3.169"}
-    io.github.metabase/hawk            {:mvn/version "1.0.7"}
+    io.github.metabase/hawk            {:mvn/version "1.0.11"}
     org.clojars.mmb90/cljs-cache       {:mvn/version "0.1.4"}
     refactor-nrepl/refactor-nrepl      {:mvn/version "3.11.0"}
     ;; keep it in sync with package.json

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -104,7 +104,10 @@
   ```"
   [json-config]
   (try
-    (let [{:keys [ignored] :as _config} (json/parse-string (slurp json-config) true)]
+    (let [{:keys [ignored] :as config} (json/parse-string (slurp json-config) true)]
+      (when (seq ignored)
+        #_{:clj-kondo/ignore [:discouraged-var]}
+        (println (format "using config file: \n%s\n" config)))
       (cond-> {}
         (seq (:vars ignored))
         (assoc :vars (-> ignored :vars set))))

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -94,7 +94,7 @@
   will extend to namespaces, drivers. Ideally e2e tests as well. Example config:
   ```javascript
      {
-       \"ignore\": {
+       \"ignored\": {
          \"vars\": [
            \"metabase.util.queue-test/bounded-transfer-queue-test\",
            \"metabase.util.queue-test/take-batch-test\"


### PR DESCRIPTION
Quickly disable tests globally for backend tests (both driver and app-db).

Pulls `"ci-test-config.json"` from master branch and consults this for any vars to ignore.

Example run:

```
❯ clj -X:dev:test :only metabase.util.queue-test
Running tests with options {:mode :cli/local, :namespace-pattern #"^(?:(?:metabase.*)|(?:hooks\..*))", :exclude-directories [".clj-kondo/src" "classes" "dev" "enterprise/backend/src" "local" "resources" "resources-ee" "src" "target" "test_config" "test_resources"], :test-warn-time 3000, :ignored {}, :exclude-tags [:metabot-v3/e2e], :only metabase.util.queue-test}
Running tests in metabase.util.queue-test
Finding tests took 7.5 s.
Running 6 tests
Running before-run hooks...

LONG TEST in metabase.util.queue-test/take-batch-test
Test took 4.720 seconds seconds to run

LONG TEST in metabase.util.queue-test/bounded-transfer-queue-test
Test took 7.518 seconds seconds to run

6/6   100% [==================================================]  ETA: 00:00

Ran 6 tests in 12.421 seconds
53 assertions, 0 failures, 0 errors.
{:test 6, :pass 53, :fail 0, :error 0, :type :summary, :duration 12421.435583, :single-threaded 6}
Ran 0 tests in parallel, 6 single-threaded.
Finding and running tests took 20.0 s.
All tests passed.
Running after-run hooks...
Running QP tests against these drivers: #{:h2}

```

versus with a config:
```
❯ clj -X:dev:test :only metabase.util.queue-test :ci-config-file '"/tmp/config.json"'
Loading CI config file from /tmp/config.json
Running tests with options {:mode :cli/local, :namespace-pattern #"^(?:(?:metabase.*)|(?:hooks\..*))", :exclude-directories [".clj-kondo/src" "classes" "dev" "enterprise/backend/src" "local" "resources" "resources-ee" "src" "target" "test_config" "test_resources"], :test-warn-time 3000, :ignored {:vars #{"metabase.util.queue-test/bounded-transfer-queue-test" "metabase.util.queue-test/take-batch-test"}}, :exclude-tags [:metabot-v3/e2e], :only metabase.util.queue-test, :ci-config-file "/tmp/config.json"}
Running tests in metabase.util.queue-test
Finding tests took 6.9 s.
Running 4 tests
Running before-run hooks...

4/4   100% [==================================================]  ETA: 00:00

Ran 4 tests in 0.133 seconds
42 assertions, 0 failures, 0 errors.
{:test 4, :pass 42, :fail 0, :error 0, :type :summary, :duration 133.16525, :single-threaded 4}
Ran 0 tests in parallel, 4 single-threaded.
Finding and running tests took 7.1 s.
All tests passed.
Running after-run hooks...
Running QP tests against these drivers: #{:h2}
```

4 tests  vs 6 with a file of:

```
❯ cat /tmp/config.json
{
  "version": "1.0.0",
  "ignored": {
    "vars": [
      "metabase.util.queue-test/bounded-transfer-queue-test",
      "metabase.util.queue-test/take-batch-test"
    ]
  },
  "metadata": {
    "last_updated": "2025-08-22T10:00:00Z",
    "updated_by": "engineering-team",
    "reason": "Testing CI config implementation"
  }
}
```

In order to suppress tests, just commit to master the vars (namespace/var) into the json file. Use [ci skip] to get it quickly in, and then all branches with this PR will skip those jobs.

Todo:
- turn off drivers
- turn off e2e tests (using https://www.npmjs.com/package/@cypress/grep)