### PR TITLE
Add CurrencyPicker to places where you can change the semantic type

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.ts
@@ -434,6 +434,30 @@ describe("issue 55619", () => {
       cy.button(/Save/).click();
       cy.button(/Edit/).should("be.visible");
     });
+
+    cy.log("model metadata");
+    H.navigationSidebar().findByText("Models").click();
+    H.main().within(() => {
+      cy.findByLabelText("Create a new model").click();
+      cy.findByText("Use the notebook editor").click();
+    });
+    H.entityPickerModal().within(() => {
+      H.entityPickerModalTab("Tables").click();
+      cy.findByText("Orders").click();
+    });
+    H.runButtonOverlay().click();
+    cy.findByTestId("editor-tabs-columns-name").click();
+    H.openColumnOptions("Discount");
+    cy.findByTestId("sidebar-content")
+      .findByDisplayValue("Australian Dollar")
+      .click();
+    H.popover().findByText("Euro").click();
+    cy.findByTestId("sidebar-content")
+      .findByDisplayValue("Euro")
+      .should("be.visible");
+    H.datasetEditBar().button("Save").click();
+    H.modal().button("Save").click();
+    H.tableHeaderColumn("Discount (€)").should("be.visible");
   });
 });
 

--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.ts
@@ -373,12 +373,12 @@ describe("issues 55617, 55618", () => {
     cy.findByPlaceholderText("Select a target")
       .should("have.value", "People → ID")
       .click();
-    cy.get("main").scrollTo("top"); // scroll to top so the popover drops up
+    H.main().scrollTo("bottom"); // scroll to bottom so the popover drops up
     H.popover().within(() => {
-      cy.findByText("Orders → ID").should("be.visible");
-      cy.findByText("People → ID").should("be.visible");
-      cy.findByText("Products → ID").should("be.visible");
-      cy.findByText("Reviews → ID").should("be.visible").click();
+      cy.findByText("Orders → ID").should("exist");
+      cy.findByText("People → ID").should("exist");
+      cy.findByText("Products → ID").should("exist");
+      cy.findByText("Reviews → ID").should("exist").click();
     });
     cy.findByPlaceholderText("Select a target").should(
       "have.value",

--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.ts
@@ -397,6 +397,46 @@ describe("issues 55617, 55618", () => {
   });
 });
 
+describe("issue 55619", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow you to change the currency where you can set a semantic type (metabase#55619)", () => {
+    cy.log("set a non-default value");
+    cy.request("PUT", `/api/field/${ORDERS.DISCOUNT}`, {
+      settings: { currency: "CAD" },
+    });
+
+    cy.log("data reference - field list");
+    cy.visit(`/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}/fields`);
+    H.main().within(() => {
+      cy.button(/Edit/).click();
+      cy.findByDisplayValue("Canadian Dollar").click();
+    });
+    H.popover().findByText("Euro").click();
+    H.main().within(() => {
+      cy.findByDisplayValue("Euro").should("be.visible");
+      cy.button(/Save/).click();
+      cy.button(/Edit/).should("be.visible");
+    });
+
+    cy.log("data reference - field details");
+    H.main().within(() => {
+      cy.findByRole("link", { name: /Discount/ }).click();
+      cy.button(/Edit/).click();
+      cy.findByDisplayValue("Euro").click();
+    });
+    H.popover().findByText("Australian Dollar").click();
+    H.main().within(() => {
+      cy.findByDisplayValue("Australian Dollar").should("be.visible");
+      cy.button(/Save/).click();
+      cy.button(/Edit/).should("be.visible");
+    });
+  });
+});
+
 function waitForFieldSyncToFinish(iteration = 0) {
   // 100 x 100ms should be plenty of time for the sync to finish.
   // If it doesn't, we have a much bigger problem than this issue.

--- a/frontend/src/metabase-lib/v1/types/utils/isa.js
+++ b/frontend/src/metabase-lib/v1/types/utils/isa.js
@@ -40,6 +40,10 @@ export function isTypeFK(type) {
   return isa(type, TYPE.FK);
 }
 
+export function isTypeCurrency(type) {
+  return isa(type, TYPE.Currency);
+}
+
 export function isFieldType(type, field) {
   if (!field) {
     return false;

--- a/frontend/src/metabase/metadata/components/SemanticTypeAndTargetPicker/SemanticTypeAndTargetPicker.tsx
+++ b/frontend/src/metabase/metadata/components/SemanticTypeAndTargetPicker/SemanticTypeAndTargetPicker.tsx
@@ -83,7 +83,7 @@ export const SemanticTypeAndTargetPicker = ({
 
           <CurrencyPicker
             {...selectProps}
-            value={getFieldCurrency(field)}
+            value={getFieldCurrency(field.settings)}
             onChange={handleChangeCurrency}
           />
         </>

--- a/frontend/src/metabase/metadata/utils/field.ts
+++ b/frontend/src/metabase/metadata/utils/field.ts
@@ -41,15 +41,16 @@ export function getRawTableFieldId(field: Field): FieldId {
   return field.id;
 }
 
-export function getFieldCurrency(field: Field): string {
-  if (field.settings?.currency) {
-    return field.settings.currency;
+export function getFieldCurrency(
+  fieldSettings?: FieldFormattingSettings,
+): string {
+  if (fieldSettings?.currency) {
+    return fieldSettings.currency;
   }
 
-  const settings: FieldFormattingSettings = getGlobalSettingsForColumn();
-
-  if (settings.currency) {
-    return settings.currency;
+  const globalSettings: FieldFormattingSettings = getGlobalSettingsForColumn();
+  if (globalSettings.currency) {
+    return globalSettings.currency;
   }
 
   return "USD";

--- a/frontend/src/metabase/metadata/utils/field.unit.spec.ts
+++ b/frontend/src/metabase/metadata/utils/field.unit.spec.ts
@@ -87,7 +87,7 @@ describe("getFieldCurrency", () => {
       },
     });
 
-    expect(getFieldCurrency(field)).toBe("EUR");
+    expect(getFieldCurrency(field.settings)).toBe("EUR");
   });
 
   it("returns currency from global settings when field settings are not available", () => {
@@ -99,7 +99,7 @@ describe("getFieldCurrency", () => {
 
     const field = createMockField();
 
-    expect(getFieldCurrency(field)).toBe("GBP");
+    expect(getFieldCurrency(field.settings)).toBe("GBP");
   });
 
   it("returns USD as default when no currency is specified", () => {
@@ -107,7 +107,7 @@ describe("getFieldCurrency", () => {
 
     const field = createMockField();
 
-    expect(getFieldCurrency(field)).toBe("USD");
+    expect(getFieldCurrency(field.settings)).toBe("USD");
   });
 
   it("prioritizes field settings over global settings", () => {
@@ -123,7 +123,7 @@ describe("getFieldCurrency", () => {
       },
     });
 
-    expect(getFieldCurrency(field)).toBe("JPY");
+    expect(getFieldCurrency(field.settings)).toBe("JPY");
   });
 });
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataCurrencyPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataCurrencyPicker.tsx
@@ -1,0 +1,34 @@
+import { useField } from "formik";
+
+import { CurrencyPicker } from "metabase/metadata/components";
+import { getFieldCurrency } from "metabase/metadata/utils/field";
+import type { FieldFormattingSettings } from "metabase-types/api";
+
+type DatasetFieldMetadataCurrencyPickerProps = {
+  onChange: (value: FieldFormattingSettings) => void;
+};
+
+export const DatasetFieldMetadataCurrencyPicker = ({
+  onChange,
+}: DatasetFieldMetadataCurrencyPickerProps) => {
+  const [formField, _meta, { setValue }] = useField("settings");
+  const { value: settings } = formField;
+  const currency = getFieldCurrency(settings);
+
+  const handleChange = (newCurrency: string) => {
+    const newSettings = { ...settings, currency: newCurrency };
+    setValue(newSettings);
+    onChange(newSettings);
+  };
+
+  return (
+    <CurrencyPicker
+      value={currency}
+      fw="bold"
+      comboboxProps={{
+        width: 300,
+      }}
+      onChange={handleChange}
+    />
+  );
+};

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -18,7 +18,7 @@ import {
 import { color } from "metabase/lib/colors";
 import { FIELD_VISIBILITY_TYPES } from "metabase/lib/core";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
-import { Box, Radio, Tabs } from "metabase/ui";
+import { Box, Radio, Stack, Tabs } from "metabase/ui";
 import ColumnSettings, {
   hasColumnSettingsWidgets,
 } from "metabase/visualizations/components/ColumnSettings";
@@ -276,7 +276,7 @@ function DatasetFieldMetadataSidebar({
                     />
                   </Box>
                 )}
-                <Box mb="1.5rem">
+                <Stack gap="sm" mb="1.5rem">
                   <DatasetFieldMetadataSemanticTypePicker
                     className={DatasetFieldMetadataSidebarS.SelectButton}
                     field={field}
@@ -284,23 +284,19 @@ function DatasetFieldMetadataSidebar({
                     onChange={handleSemanticTypeChange}
                     onKeyDown={onLastEssentialFieldKeyDown}
                   />
-                </Box>
-                {isCurrency(formFieldValues) && (
-                  <Box mb="1.5rem">
+                  {isCurrency(formFieldValues) && (
                     <DatasetFieldMetadataCurrencyPicker
                       onChange={handleFormattingSettingsChange}
                     />
-                  </Box>
-                )}
-                {isFK(formFieldValues) && (
-                  <Box mb="1.5rem">
+                  )}
+                  {isFK(formFieldValues) && (
                     <DatasetFieldMetadataFkTargetPicker
                       databaseId={dataset.databaseId()}
                       field={field}
                       onChange={handleFkTargetChange}
                     />
-                  </Box>
-                )}
+                  )}
+                </Stack>
               </div>
 
               <Tabs value={tab} onChange={setTab}>

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -24,10 +24,11 @@ import ColumnSettings, {
 } from "metabase/visualizations/components/ColumnSettings";
 import { getGlobalSettingsForColumn } from "metabase/visualizations/lib/settings/column";
 import * as Lib from "metabase-lib";
-import { isFK } from "metabase-lib/v1/types/utils/isa";
+import { isCurrency, isFK } from "metabase-lib/v1/types/utils/isa";
 
 import { EDITOR_TAB_INDEXES } from "../constants";
 
+import { DatasetFieldMetadataCurrencyPicker } from "./DatasetFieldMetadataCurrencyPicker";
 import { DatasetFieldMetadataFkTargetPicker } from "./DatasetFieldMetadataFkTargetPicker";
 import { DatasetFieldMetadataSemanticTypePicker } from "./DatasetFieldMetadataSemanticTypePicker";
 import DatasetFieldMetadataSidebarS from "./DatasetFieldMetadataSidebar.module.css";
@@ -110,6 +111,7 @@ function DatasetFieldMetadataSidebar({
       fk_target_field_id: field.fk_target_field_id || null,
       visibility_type: field.visibility_type || "normal",
       should_index: field.should_index ?? fieldHasIndex(modelIndexes, field),
+      settings: field.settings,
     };
     const { isNative } = Lib.queryDisplayInfo(dataset.query());
 
@@ -283,6 +285,13 @@ function DatasetFieldMetadataSidebar({
                     onKeyDown={onLastEssentialFieldKeyDown}
                   />
                 </Box>
+                {isCurrency(formFieldValues) && (
+                  <Box mb="1.5rem">
+                    <DatasetFieldMetadataCurrencyPicker
+                      onChange={handleFormattingSettingsChange}
+                    />
+                  </Box>
+                )}
                 {isFK(formFieldValues) && (
                   <Box mb="1.5rem">
                     <DatasetFieldMetadataFkTargetPicker

--- a/frontend/src/metabase/redux/downloads.unit.spec.ts
+++ b/frontend/src/metabase/redux/downloads.unit.spec.ts
@@ -56,6 +56,11 @@ describe("getDatasetResponse", () => {
 });
 
 describe("getChartFileName", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2024-12-15"));
+  });
+
   const createMockQuestion = (name?: string) => {
     return new Question(createMockCard({ name }), undefined);
   };

--- a/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
@@ -84,7 +84,12 @@ const EditableReferenceHeader = ({
           ]
         )}
         {user && user.is_superuser && !isEditing && (
-          <Button icon="pencil" style={{ fontSize: 14 }} onClick={startEditing}>
+          <Button
+            icon="pencil"
+            style={{ fontSize: 14 }}
+            type="button"
+            onClick={startEditing}
+          >
             {t`Edit`}
           </Button>
         )}

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -17,15 +17,7 @@ import { isTypeFK } from "metabase-lib/v1/types/utils/isa";
 import F from "./Field.module.css";
 import { FieldFkTargetPicker } from "./FieldFkTargetPicker";
 
-const Field = ({
-  databaseId,
-  field,
-  foreignKeys,
-  url,
-  icon,
-  isEditing,
-  formField,
-}) => {
+const Field = ({ databaseId, field, url, icon, isEditing, formField }) => {
   const semanticType =
     typeof formField.semantic_type.value !== "undefined"
       ? formField.semantic_type.value
@@ -105,31 +97,24 @@ const Field = ({
         </div>
         <div className={S.itemSubtitle}>
           <div className={F.fieldForeignKey}>
-            {isEditing
-              ? isTypeFK(semanticType) && (
-                  <FieldFkTargetPicker
-                    className={CS.mt1}
-                    databaseId={databaseId}
-                    field={field}
-                    value={
-                      formField.fk_target_field_id.value ||
-                      field.fk_target_field_id
-                    }
-                    onChange={(value) => {
-                      formField.fk_target_field_id.onChange({
-                        target: {
-                          name: formField.fk_target_field_id.name,
-                          value,
-                        },
-                      });
-                    }}
-                  />
-                )
-              : isTypeFK(field.semantic_type) && (
-                  <span className={CS.mt1}>
-                    {getIn(foreignKeys, [field.fk_target_field_id, "name"])}
-                  </span>
-                )}
+            {isEditing && isTypeFK(semanticType) && (
+              <FieldFkTargetPicker
+                className={CS.mt1}
+                databaseId={databaseId}
+                field={field}
+                value={
+                  formField.fk_target_field_id.value || field.fk_target_field_id
+                }
+                onChange={(value) => {
+                  formField.fk_target_field_id.onChange({
+                    target: {
+                      name: formField.fk_target_field_id.name,
+                      value,
+                    },
+                  });
+                }}
+              />
+            )}
           </div>
 
           {match({ description: field.description, isEditing })
@@ -159,7 +144,6 @@ const Field = ({
 Field.propTypes = {
   databaseId: PropTypes.number.isRequired,
   field: PropTypes.object.isRequired,
-  foreignKeys: PropTypes.object.isRequired,
   url: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   icon: PropTypes.string,

--- a/frontend/src/metabase/reference/components/Field.jsx
+++ b/frontend/src/metabase/reference/components/Field.jsx
@@ -10,9 +10,13 @@ import { t } from "ttag";
 import S from "metabase/common/components/List/List.module.css";
 import CS from "metabase/css/core/index.css";
 import { FIELD_SEMANTIC_TYPES_MAP } from "metabase/lib/core";
-import { SemanticTypePicker } from "metabase/metadata/components";
-import { Icon } from "metabase/ui";
-import { isTypeFK } from "metabase-lib/v1/types/utils/isa";
+import {
+  CurrencyPicker,
+  SemanticTypePicker,
+} from "metabase/metadata/components";
+import { getFieldCurrency } from "metabase/metadata/utils/field";
+import { Box, Icon } from "metabase/ui";
+import { isTypeCurrency, isTypeFK } from "metabase-lib/v1/types/utils/isa";
 
 import F from "./Field.module.css";
 import { FieldFkTargetPicker } from "./FieldFkTargetPicker";
@@ -96,10 +100,9 @@ const Field = ({ databaseId, field, url, icon, isEditing, formField }) => {
           <div className={F.fieldDataType}>{field.database_type}</div>
         </div>
         <div className={S.itemSubtitle}>
-          <div className={F.fieldForeignKey}>
-            {isEditing && isTypeFK(semanticType) && (
+          {isEditing && isTypeFK(semanticType) && (
+            <Box mt="sm">
               <FieldFkTargetPicker
-                className={CS.mt1}
                 databaseId={databaseId}
                 field={field}
                 value={
@@ -114,8 +117,27 @@ const Field = ({ databaseId, field, url, icon, isEditing, formField }) => {
                   });
                 }}
               />
-            )}
-          </div>
+            </Box>
+          )}
+
+          {isEditing && isTypeCurrency(semanticType) && (
+            <Box Box mt="sm">
+              <CurrencyPicker
+                value={getFieldCurrency(
+                  formField.settings.value ?? field.settings,
+                )}
+                fw="bold"
+                onChange={(currency) => {
+                  formField.settings.onChange({
+                    target: {
+                      name: formField.settings.name,
+                      value: { ...field.settings, currency },
+                    },
+                  });
+                }}
+              />
+            </Box>
+          )}
 
           {match({ description: field.description, isEditing })
             .with({ isEditing: true }, () => {

--- a/frontend/src/metabase/reference/components/Field.module.css
+++ b/frontend/src/metabase/reference/components/Field.module.css
@@ -47,13 +47,6 @@
   letter-spacing: 1px;
 }
 
-.fieldForeignKey {
-  composes: textMedium from "style";
-  flex: 0.25;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
 .fieldOther {
   composes: fieldDataType;
 }

--- a/frontend/src/metabase/reference/components/FieldTypeDetail.jsx
+++ b/frontend/src/metabase/reference/components/FieldTypeDetail.jsx
@@ -31,7 +31,7 @@ const FieldTypeDetail = ({
   const settings =
     typeof fieldSettingsFormField.value !== "undefined"
       ? fieldSettingsFormField.value
-      : field.settings?.currency;
+      : field.settings;
   const currency = getFieldCurrency(settings);
 
   return (

--- a/frontend/src/metabase/reference/components/FieldTypeDetail.jsx
+++ b/frontend/src/metabase/reference/components/FieldTypeDetail.jsx
@@ -4,26 +4,35 @@ import PropTypes from "prop-types";
 import { memo } from "react";
 import { t } from "ttag";
 
-import CS from "metabase/css/core/index.css";
 import { FIELD_SEMANTIC_TYPES_MAP } from "metabase/lib/core";
-import { SemanticTypePicker } from "metabase/metadata/components";
+import {
+  CurrencyPicker,
+  SemanticTypePicker,
+} from "metabase/metadata/components";
+import { getFieldCurrency } from "metabase/metadata/utils/field";
 import D from "metabase/reference/components/Detail.module.css";
-import { isTypeFK } from "metabase-lib/v1/types/utils/isa";
+import { Box } from "metabase/ui";
+import { isTypeCurrency, isTypeFK } from "metabase-lib/v1/types/utils/isa";
 
 import { FieldFkTargetPicker } from "./FieldFkTargetPicker";
 
 const FieldTypeDetail = ({
   databaseId,
   field,
-  foreignKeys,
   fieldTypeFormField,
   foreignKeyFormField,
+  fieldSettingsFormField,
   isEditing,
 }) => {
   const semanticType =
     typeof fieldTypeFormField.value !== "undefined"
       ? fieldTypeFormField.value
       : field.semantic_type;
+  const settings =
+    typeof fieldSettingsFormField.value !== "undefined"
+      ? fieldSettingsFormField.value
+      : field.settings?.currency;
+  const currency = getFieldCurrency(settings);
 
   return (
     <div className={cx(D.detail)}>
@@ -59,31 +68,39 @@ const FieldTypeDetail = ({
               </span>
             )}
           </span>
-          <span className={CS.ml4}>
-            {isEditing
-              ? isTypeFK(semanticType) && (
-                  <FieldFkTargetPicker
-                    databaseId={databaseId}
-                    field={field}
-                    value={
-                      foreignKeyFormField.value || field.fk_target_field_id
-                    }
-                    onChange={(value) => {
-                      foreignKeyFormField.onChange({
-                        target: {
-                          name: foreignKeyFormField.name,
-                          value,
-                        },
-                      });
-                    }}
-                  />
-                )
-              : isTypeFK(field.semantic_type) && (
-                  <span>
-                    {getIn(foreignKeys, [field.fk_target_field_id, "name"])}
-                  </span>
-                )}
-          </span>
+          {isEditing && isTypeCurrency(semanticType) && (
+            <Box mt="sm">
+              <CurrencyPicker
+                value={currency}
+                fw="bold"
+                onChange={(currency) => {
+                  fieldSettingsFormField.onChange({
+                    target: {
+                      name: fieldSettingsFormField.name,
+                      value: { ...field.settings, currency },
+                    },
+                  });
+                }}
+              />
+            </Box>
+          )}
+          {isEditing && isTypeFK(semanticType) && (
+            <Box mt="sm">
+              <FieldFkTargetPicker
+                databaseId={databaseId}
+                field={field}
+                value={foreignKeyFormField.value || field.fk_target_field_id}
+                onChange={(value) => {
+                  foreignKeyFormField.onChange({
+                    target: {
+                      name: foreignKeyFormField.name,
+                      value,
+                    },
+                  });
+                }}
+              />
+            </Box>
+          )}
         </div>
       </div>
     </div>
@@ -93,9 +110,9 @@ const FieldTypeDetail = ({
 FieldTypeDetail.propTypes = {
   databaseId: PropTypes.number.isRequired,
   field: PropTypes.object.isRequired,
-  foreignKeys: PropTypes.object.isRequired,
   fieldTypeFormField: PropTypes.object.isRequired,
   foreignKeyFormField: PropTypes.object.isRequired,
+  fieldSettingsFormField: PropTypes.object.isRequired,
   isEditing: PropTypes.bool.isRequired,
 };
 

--- a/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
@@ -18,7 +18,6 @@ import {
   getDatabase,
   getError,
   getFields,
-  getForeignKeys,
   getIsEditing,
   getIsFormulaExpanded,
   getLoading,
@@ -38,7 +37,6 @@ const mapStateToProps = (state, props) => {
     // naming this 'error' will conflict with redux form
     loadingError: getError(state, props),
     user: getUser(state, props),
-    foreignKeys: getForeignKeys(state, props),
     isEditing: getIsEditing(state, props),
     isFormulaExpanded: getIsFormulaExpanded(state, props),
   };

--- a/frontend/src/metabase/reference/databases/FieldDetail.jsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.jsx
@@ -21,7 +21,6 @@ import {
   getDatabase,
   getError,
   getField,
-  getForeignKeys,
   getIsEditing,
   getIsFormulaExpanded,
   getLoading,
@@ -81,7 +80,6 @@ const mapStateToProps = (state, props) => {
     // naming this 'error' will conflict with redux form
     loadingError: getError(state, props),
     user: getUser(state, props),
-    foreignKeys: getForeignKeys(state, props),
     isEditing: getIsEditing(state, props),
     isFormulaExpanded: getIsFormulaExpanded(state, props),
   };
@@ -101,7 +99,6 @@ const propTypes = {
   table: PropTypes.object,
   user: PropTypes.object.isRequired,
   database: PropTypes.object.isRequired,
-  foreignKeys: PropTypes.object,
   isEditing: PropTypes.bool,
   startEditing: PropTypes.func.isRequired,
   endEditing: PropTypes.func.isRequired,
@@ -123,7 +120,6 @@ const FieldDetail = (props) => {
     loadingError,
     loading,
     user,
-    foreignKeys,
     isEditing,
     startEditing,
     endEditing,
@@ -247,9 +243,9 @@ const FieldDetail = (props) => {
                   <FieldTypeDetail
                     databaseId={table.db_id}
                     field={entity}
-                    foreignKeys={foreignKeys}
                     fieldTypeFormField={getFormField("semantic_type")}
                     foreignKeyFormField={getFormField("fk_target_field_id")}
+                    fieldSettingsFormField={getFormField("settings")}
                     isEditing={isEditing}
                   />
                 </li>

--- a/frontend/src/metabase/reference/databases/FieldList.jsx
+++ b/frontend/src/metabase/reference/databases/FieldList.jsx
@@ -107,6 +107,7 @@ const FieldList = (props) => {
     description: getFormField(`${id}.description`),
     semantic_type: getFormField(`${id}.semantic_type`),
     fk_target_field_id: getFormField(`${id}.fk_target_field_id`),
+    settings: getFormField(`${id}.settings`),
   });
 
   return (

--- a/frontend/src/metabase/reference/databases/FieldList.jsx
+++ b/frontend/src/metabase/reference/databases/FieldList.jsx
@@ -22,7 +22,6 @@ import { getIconForField } from "metabase-lib/v1/metadata/utils/fields";
 import {
   getError,
   getFieldsByTable,
-  getForeignKeys,
   getIsEditing,
   getLoading,
   getTable,
@@ -41,7 +40,6 @@ const mapStateToProps = (state, props) => {
   return {
     table: getTable(state, props),
     entities: data,
-    foreignKeys: getForeignKeys(state, props),
     loading: getLoading(state, props),
     loadingError: getError(state, props),
     user: getUser(state, props),
@@ -58,7 +56,6 @@ const mapDispatchToProps = {
 const propTypes = {
   style: PropTypes.object.isRequired,
   entities: PropTypes.object.isRequired,
-  foreignKeys: PropTypes.object.isRequired,
   isEditing: PropTypes.bool,
   startEditing: PropTypes.func.isRequired,
   endEditing: PropTypes.func.isRequired,
@@ -78,7 +75,6 @@ const FieldList = (props) => {
   const {
     style,
     entities,
-    foreignKeys,
     table,
     loadingError,
     loading,
@@ -178,7 +174,6 @@ const FieldList = (props) => {
                             <Field
                               databaseId={table.db_id}
                               field={entity}
-                              foreignKeys={foreignKeys}
                               url={`/reference/databases/${table.db_id}/tables/${table.id}/fields/${entity.id}`}
                               icon={getIconForField(entity)}
                               isEditing={isEditing}

--- a/frontend/src/metabase/reference/databases/TableDetail.jsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.jsx
@@ -20,7 +20,6 @@ import { getMetadata } from "metabase/selectors/metadata";
 import {
   getError,
   getFields,
-  getForeignKeys,
   getHasSingleSchema,
   getIsEditing,
   getIsFormulaExpanded,
@@ -66,7 +65,6 @@ const mapStateToProps = (state, props) => {
     // naming this 'error' will conflict with redux form
     loadingError: getError(state, props),
     user: getUser(state, props),
-    foreignKeys: getForeignKeys(state, props),
     isEditing: getIsEditing(state, props),
     hasSingleSchema: getHasSingleSchema(state, props),
     isFormulaExpanded: getIsFormulaExpanded(state, props),

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx
@@ -21,7 +21,6 @@ import { getMetadata } from "metabase/selectors/metadata";
 import {
   getError,
   getFieldBySegment,
-  getForeignKeys,
   getIsEditing,
   getIsFormulaExpanded,
   getLoading,
@@ -68,7 +67,6 @@ const mapStateToProps = (state, props) => {
     // naming this 'error' will conflict with redux form
     loadingError: getError(state, props),
     user: getUser(state, props),
-    foreignKeys: getForeignKeys(state, props),
     isEditing: getIsEditing(state, props),
     isFormulaExpanded: getIsFormulaExpanded(state, props),
     metadata: getMetadata(state),
@@ -86,7 +84,6 @@ const propTypes = {
   entity: PropTypes.object.isRequired,
   table: PropTypes.object,
   user: PropTypes.object.isRequired,
-  foreignKeys: PropTypes.object,
   isEditing: PropTypes.bool,
   startEditing: PropTypes.func.isRequired,
   endEditing: PropTypes.func.isRequired,
@@ -109,7 +106,6 @@ const SegmentFieldDetail = (props) => {
     loadingError,
     loading,
     user,
-    foreignKeys,
     isEditing,
     startEditing,
     endEditing,
@@ -223,9 +219,9 @@ const SegmentFieldDetail = (props) => {
                   <FieldTypeDetail
                     databaseId={table.db_id}
                     field={entity}
-                    foreignKeys={foreignKeys}
                     fieldTypeFormField={getFormField("semantic_type")}
                     foreignKeyFormField={getFormField("fk_target_field_id")}
+                    fieldSettingsFormField={getFormField("settings")}
                     isEditing={isEditing}
                   />
                 </li>

--- a/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
@@ -22,7 +22,6 @@ import { getIconForField } from "metabase-lib/v1/metadata/utils/fields";
 import {
   getError,
   getFieldsBySegment,
-  getForeignKeys,
   getIsEditing,
   getLoading,
   getSegment,
@@ -41,7 +40,6 @@ const mapStateToProps = (state, props) => {
   return {
     segment: getSegment(state, props),
     entities: data,
-    foreignKeys: getForeignKeys(state, props),
     loading: getLoading(state, props),
     loadingError: getError(state, props),
     user: getUser(state, props),
@@ -59,7 +57,6 @@ const propTypes = {
   segment: PropTypes.object.isRequired,
   style: PropTypes.object.isRequired,
   entities: PropTypes.object.isRequired,
-  foreignKeys: PropTypes.object.isRequired,
   isEditing: PropTypes.bool,
   startEditing: PropTypes.func.isRequired,
   endEditing: PropTypes.func.isRequired,
@@ -79,7 +76,6 @@ const SegmentFieldList = (props) => {
     segment,
     style,
     entities,
-    foreignKeys,
     loadingError,
     loading,
     user,
@@ -171,7 +167,6 @@ const SegmentFieldList = (props) => {
                           <Field
                             databaseId={table.db_id}
                             field={entity}
-                            foreignKeys={foreignKeys}
                             url={`/reference/segments/${segment.id}/fields/${entity.id}`}
                             icon={getIconForField(entity)}
                             isEditing={isEditing}

--- a/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
@@ -107,6 +107,7 @@ const SegmentFieldList = (props) => {
     display_name: getFormField(`${id}.display_name`),
     semantic_type: getFormField(`${id}.semantic_type`),
     fk_target_field_id: getFormField(`${id}.fk_target_field_id`),
+    settings: getFormField(`${id}.settings`),
   });
 
   return (

--- a/frontend/src/metabase/reference/selectors.js
+++ b/frontend/src/metabase/reference/selectors.js
@@ -10,7 +10,7 @@ import {
   getShallowTables as getTables,
 } from "metabase/selectors/metadata";
 
-import { databaseToForeignKeys, idsToObjectMap } from "./utils";
+import { idsToObjectMap } from "./utils";
 
 // import { getDatabases, getTables, getFields, getSegments } from "metabase/selectors/metadata";
 
@@ -100,32 +100,6 @@ export const getTableQuestions = createSelector(
     Object.values(questions).filter(
       (question) => question.table_id === table.id,
     ),
-);
-
-const getDatabaseBySegment = createSelector(
-  [getSegment, getTables, getDatabases],
-  (segment, tables, databases) =>
-    (segment &&
-      segment.table_id &&
-      tables[segment.table_id] &&
-      databases[tables[segment.table_id].db_id]) ||
-    {},
-);
-
-const getForeignKeysBySegment = createSelector(
-  [getDatabaseBySegment],
-  databaseToForeignKeys,
-);
-
-const getForeignKeysByDatabase = createSelector(
-  [getDatabase],
-  databaseToForeignKeys,
-);
-
-export const getForeignKeys = createSelector(
-  [getSegmentId, getForeignKeysBySegment, getForeignKeysByDatabase],
-  (segmentId, foreignKeysBySegment, foreignKeysByDatabase) =>
-    segmentId ? foreignKeysBySegment : foreignKeysByDatabase,
 );
 
 export const getLoading = (state, props) => state.reference.isLoading;

--- a/frontend/src/metabase/reference/utils.js
+++ b/frontend/src/metabase/reference/utils.js
@@ -1,12 +1,9 @@
 import dayjs from "dayjs";
-import { assoc } from "icepick";
 import { t } from "ttag";
 
-import { humanize, titleize } from "metabase/lib/formatting";
 import * as Urls from "metabase/lib/urls";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
-import { isTypePK } from "metabase-lib/v1/types/utils/isa";
 
 export const idsToObjectMap = (ids, objects) =>
   ids
@@ -22,34 +19,6 @@ export const filterUntouchedFields = (fields, entity = {}) =>
     .reduce((map, key) => ({ ...map, [key]: fields[key] }), {});
 
 export const isEmptyObject = (object) => Object.keys(object).length === 0;
-
-export const databaseToForeignKeys = (database) =>
-  database && database.tables_lookup
-    ? Object.values(database.tables_lookup)
-        // ignore tables without primary key
-        .filter(
-          (table) =>
-            table &&
-            table.fields.find((field) => isTypePK(field.semantic_type)),
-        )
-        .map((table) => ({
-          table: table,
-          field:
-            table &&
-            table.fields.find((field) => isTypePK(field.semantic_type)),
-        }))
-        .map(({ table, field }) => ({
-          id: field.id,
-          name:
-            table.schema_name && table.schema_name !== "public"
-              ? `${titleize(humanize(table.schema_name))}.${
-                  table.display_name
-                } → ${field.display_name}`
-              : `${table.display_name} → ${field.display_name}`,
-          description: field.description,
-        }))
-        .reduce((map, foreignKey) => assoc(map, foreignKey.id, foreignKey), {})
-    : {};
 
 export const getQuestion = ({
   dbId: databaseId,

--- a/frontend/src/metabase/reference/utils.unit.spec.js
+++ b/frontend/src/metabase/reference/utils.unit.spec.js
@@ -1,7 +1,6 @@
 import { createMockMetadata } from "__support__/metadata";
 import { separateTablesBySchema } from "metabase/reference/databases/TableList";
-import { databaseToForeignKeys, getQuestion } from "metabase/reference/utils";
-import { TYPE } from "metabase-lib/v1/types/constants";
+import { getQuestion } from "metabase/reference/utils";
 import {
   createMockDatabase,
   createMockField,
@@ -10,60 +9,6 @@ import {
 } from "metabase-types/api/mocks";
 
 describe("Reference utils.js", () => {
-  describe("databaseToForeignKeys()", () => {
-    it("should build foreignKey viewmodels from database", () => {
-      const database = {
-        tables_lookup: {
-          1: {
-            id: 1,
-            display_name: "foo",
-            schema_name: "PUBLIC",
-            fields: [
-              {
-                id: 1,
-                semantic_type: TYPE.PK,
-                display_name: "bar",
-                description: "foobar",
-              },
-            ],
-          },
-          2: {
-            id: 2,
-            display_name: "bar",
-            schema_name: "public",
-            fields: [
-              {
-                id: 2,
-                semantic_type: TYPE.PK,
-                display_name: "foo",
-                description: "barfoo",
-              },
-            ],
-          },
-          3: {
-            id: 3,
-            display_name: "boo",
-            schema_name: "TEST",
-            fields: [
-              {
-                id: 3,
-                display_name: "boo",
-                description: "booboo",
-              },
-            ],
-          },
-        },
-      };
-
-      const foreignKeys = databaseToForeignKeys(database);
-
-      expect(foreignKeys).toEqual({
-        1: { id: 1, name: "Public.foo → bar", description: "foobar" },
-        2: { id: 2, name: "bar → foo", description: "barfoo" },
-      });
-    });
-  });
-
   describe("tablesToSchemaSeparatedTables()", () => {
     it("should add schema separator to appropriate locations and sort tables by name", () => {
       const tables = {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/55619

Allows the user to set the currency for certain semantic types in Data Reference and Model Metadata.

<img width="1402" height="653" alt="Screenshot 2025-09-02 at 15 05 03" src="https://github.com/user-attachments/assets/89b27aa9-c845-488e-a43d-4b9d23531a10" />
<img width="957" height="173" alt="Screenshot 2025-09-02 at 15 05 08" src="https://github.com/user-attachments/assets/3b889b99-c8d5-4f22-a8ba-3fe56941c22b" />
<img width="404" height="664" alt="Screenshot 2025-09-02 at 15 08 15" src="https://github.com/user-attachments/assets/98c6eeb8-6c16-4b17-bfe8-799faf758bcd" />
