### PR TITLE
Hiros document desires

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -56,7 +56,7 @@ export function entityPickerModalLevel(level) {
 /**
  *
  * @param {number} level
- * @param {string} name
+ * @param {string | RegExp} name
  */
 export function entityPickerModalItem(level, name) {
   return entityPickerModalLevel(level).findByText(name).parents("a");

--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -95,9 +95,36 @@ H.describeWithSnowplowEE("documents", () => {
 
     H.openCollectionItemMenu("Test Document");
 
-    H.popover().findByText("Move to trash").click();
+    H.popover().findByText("Duplicate").click();
+    cy.findByRole("heading", { name: 'Duplicate "Test Document"' }).should(
+      "exist",
+    );
+
+    cy.findByTestId("collection-picker-button").click();
+    H.entityPickerModalTab("Collections").click();
+    H.entityPickerModalItem(0, /Personal Collection/).click();
+    H.entityPickerModal().findByRole("button", { name: "Select" }).click();
+    H.modal().findByRole("button", { name: "Copy" }).click();
+    H.openNavigationSidebar();
+    H.navigationSidebar().findByText("Your personal collection").click();
+
+    cy.findByTestId("collection-table")
+      .findByText("Test Document - Duplicate")
+      .click();
+
+    cy.findByRole("textbox", { name: "Document Title" }).should(
+      "have.value",
+      "Test Document - Duplicate",
+    );
+
+    H.documentContent().should("contain.text", "This is a paragraph");
 
     H.openNavigationSidebar();
+    H.navigationSidebar().findByText("Our analytics").click();
+
+    H.openCollectionItemMenu("Test Document");
+
+    H.popover().findByText("Move to trash").click();
 
     // Force the click since this is hidden behind a toast notification
     H.navigationSidebar().findByText("Trash").click({ force: true });

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentCopyForm/DocumentCopyForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentCopyForm/DocumentCopyForm.tsx
@@ -1,0 +1,51 @@
+import { t } from "ttag";
+
+import {
+  Form,
+  FormProvider,
+  FormSubmitButton,
+  FormTextInput,
+} from "metabase/forms";
+import { Button, Stack } from "metabase/ui";
+import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker";
+import { FormFooter } from "metabase/common/components/FormFooter";
+
+export const DocumentCopyForm = ({
+  initialValues,
+  onCancel,
+  onSubmit,
+  onSaved,
+}) => {
+  return (
+    <FormProvider
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      enableReinitialize
+    >
+      {({ dirty }) => (
+        <Form>
+          <Stack gap="md" mb="md">
+            <FormTextInput
+              name="name"
+              label={t`Name`}
+              placeholder={t`What is the name of your dashboard?`}
+              autoFocus
+            />
+            <div>
+              <FormCollectionPicker
+                name="collection_id"
+                title={t`Folder this document should be copied to`}
+              />
+            </div>
+          </Stack>
+          <FormFooter>
+            {!!onCancel && (
+              <Button type="button" onClick={onCancel}>{t`Cancel`}</Button>
+            )}
+            <FormSubmitButton label={t`Copy`} variant="primary" />
+          </FormFooter>
+        </Form>
+      )}
+    </FormProvider>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/documents/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/index.ts
@@ -6,6 +6,7 @@ import {
 import Documents from "metabase-enterprise/entities/document";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
+import { DocumentCopyForm } from "./components/DocumentCopyForm/DocumentCopyForm";
 import { documentsReducer } from "./documents.slice";
 import { getRoutes } from "./routes";
 import {
@@ -20,6 +21,7 @@ if (hasPremiumFeature("documents")) {
   PLUGIN_DOCUMENTS.getCurrentDocument = getCurrentDocument;
   PLUGIN_DOCUMENTS.getSidebarOpen = getSidebarOpen;
   PLUGIN_DOCUMENTS.getCommentSidebarOpen = getCommentSidebarOpen;
+  PLUGIN_DOCUMENTS.DocumentCopyForm = DocumentCopyForm;
 
   PLUGIN_REDUCERS.documents = documentsReducer;
 

--- a/enterprise/frontend/src/metabase-enterprise/entities/document.ts
+++ b/enterprise/frontend/src/metabase-enterprise/entities/document.ts
@@ -15,6 +15,7 @@ import { DocumentSchema } from "metabase/schema";
 import { documentApi, useGetDocumentQuery } from "metabase-enterprise/api";
 import type {
   Collection,
+  CollectionId,
   CreateDocumentRequest,
   DeleteDocumentRequest,
   Document,
@@ -104,9 +105,21 @@ const Documents = createEntity({
         },
       ),
     copy:
-      ({ id }: Document) =>
+      (
+        { id }: Document,
+        overrides: { name: string; collection_id: CollectionId },
+      ) =>
       async (dispatch: Dispatch) => {
-        console.log("derp");
+        const data = (await dispatch(
+          documentApi.endpoints.getDocument.initiate({ id }),
+        )) as { data: Document };
+
+        await dispatch(
+          documentApi.endpoints.createDocument.initiate({
+            document: data.data.document,
+            ...overrides,
+          }),
+        );
       },
   },
 

--- a/enterprise/frontend/src/metabase-enterprise/entities/document.ts
+++ b/enterprise/frontend/src/metabase-enterprise/entities/document.ts
@@ -103,6 +103,11 @@ const Documents = createEntity({
             typeof pinned === "number" ? pinned : pinned ? 1 : null,
         },
       ),
+    copy:
+      ({ id }: Document) =>
+      async (dispatch: Dispatch) => {
+        console.log("derp");
+      },
   },
 
   objectSelectors: {

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedNode.tsx
@@ -136,7 +136,14 @@ export const CardEmbed: Node<{
 });
 
 export const CardEmbedComponent = memo(
-  ({ node, updateAttributes, selected, editor, getPos }: NodeViewProps) => {
+  ({
+    node,
+    updateAttributes,
+    selected,
+    editor,
+    getPos,
+    deleteNode,
+  }: NodeViewProps) => {
     const childTargetId = useSelector(getChildTargetId);
     const hoveredChildTargetId = useSelector(getHoveredChildTargetId);
     const document = useSelector(getCurrentDocument);
@@ -270,6 +277,11 @@ export const CardEmbedComponent = memo(
       },
       [updateAttributes, document],
     );
+
+    const handleRemoveNode = useCallback(() => {
+      deleteNode();
+      editor.chain().focus();
+    }, [deleteNode, editor]);
 
     // Handle drill-through navigation
     const handleChangeCardAndRun = useCallback(
@@ -490,6 +502,13 @@ export const CardEmbedComponent = memo(
                           leftSection={<Icon name="refresh" size={14} />}
                         >
                           {t`Replace`}
+                        </Menu.Item>
+                        <Menu.Item
+                          onClick={handleRemoveNode}
+                          disabled={!canWrite}
+                          leftSection={<Icon name="trash" size={14} />}
+                        >
+                          {t`Remove Chart`}
                         </Menu.Item>
                       </Menu.Dropdown>
                     </Menu>

--- a/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
+++ b/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
@@ -7,8 +7,8 @@ import {
   CopyDashboardFormConnected,
   type CopyDashboardFormProperties,
 } from "metabase/dashboard/containers/CopyDashboardForm";
-import { CopyQuestionForm } from "metabase/questions/components/CopyQuestionForm";
 import { PLUGIN_DOCUMENTS } from "metabase/plugins";
+import { CopyQuestionForm } from "metabase/questions/components/CopyQuestionForm";
 
 interface EntityCopyModalProps {
   entityType: string;
@@ -47,8 +47,6 @@ const EntityCopyModal = ({
     ...dissoc(resolvedObject, "id"),
     name: resolvedObject.name + " - " + t`Duplicate`,
   };
-
-  console.log({ entityType });
 
   return (
     <ModalContent

--- a/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
+++ b/frontend/src/metabase/entities/containers/EntityCopyModal.tsx
@@ -8,6 +8,7 @@ import {
   type CopyDashboardFormProperties,
 } from "metabase/dashboard/containers/CopyDashboardForm";
 import { CopyQuestionForm } from "metabase/questions/components/CopyQuestionForm";
+import { PLUGIN_DOCUMENTS } from "metabase/plugins";
 
 interface EntityCopyModalProps {
   entityType: string;
@@ -47,6 +48,8 @@ const EntityCopyModal = ({
     name: resolvedObject.name + " - " + t`Duplicate`,
   };
 
+  console.log({ entityType });
+
   return (
     <ModalContent
       title={title || t`Duplicate "${resolvedObject.name}"`}
@@ -64,6 +67,16 @@ const EntityCopyModal = ({
       )}
       {entityType === "questions" && (
         <CopyQuestionForm
+          onSubmit={copy}
+          onCancel={onClose}
+          onSaved={onSaved}
+          initialValues={initialValues}
+          model={entityObject?.type}
+          {...props}
+        />
+      )}
+      {entityType === "documents" && (
+        <PLUGIN_DOCUMENTS.DocumentCopyForm
           onSubmit={copy}
           onCancel={onClose}
           onSaved={onSaved}

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -818,6 +818,7 @@ export const PLUGIN_DOCUMENTS = {
   getCurrentDocument: (_state: any) => null as Document | null,
   getSidebarOpen: (_state: any) => false,
   getCommentSidebarOpen: (_state: any) => false,
+  DocumentCopyForm: (_props: any) => null as React.ReactElement | null,
 };
 
 export const PLUGIN_ENTITIES = {


### PR DESCRIPTION
Closes UXW-593
Closes UXW-595

### Description
Adds the ability to copy Documents from the collection item menu. Solution is purely frontend, so this could be updated with a BE endpoint that allows us to not fetch the source document beforehand. Also adds a menu item in card embeds to remove the chart from a document

### How to verify
1. Open a collection with a document
2. Click the action menu and select Duplicate
3. choose a collection to save it in and hit Copy
4. New document should be available. Any charts in the document should also have their own unique IDs as well
5. Open a document with a chart, and there should be an option to remove the chart

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
