### PR TITLE
two fixes, compaction and when to run

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -40,7 +40,7 @@ runs:
         list-tests: failed
         fail-on-error: false
     - name: Upload Logs on Failure
-      if: failure()
+      if: always() && !success()
       uses: actions/upload-artifact@v4
       with:
         name: test-logs-${{ github.job }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -154,7 +154,7 @@ jobs:
           fail-on-error: false
 
       - name: Upload Logs on Failure
-        if: failure()
+        if: always() && !success()
         uses: actions/upload-artifact@v4
         with:
           name: test-logs-${{ matrix.java-version }}-${{ matrix.job.edition }}-${{ github.job }}

--- a/resources/c3p0.properties
+++ b/resources/c3p0.properties
@@ -1,3 +1,5 @@
 c3p0.initialPoolSize=1
 c3p0.minPoolSize=1
 com.mchange.v2.c3p0.impl.DefaultConnectionTester.isValidTimeout=6
+c3p0.unreturnedConnectionTimeout=300
+c3p0.debugUnreturnedConnectionStackTraces=true

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -14,7 +14,7 @@
       </Filters>
     </Console>
     <File name="File" fileName="logs/test-log.json" append="false">
-      <JsonLayout locationInfo="false" properties="true" compact="true" />
+      <JsonLayout locationInfo="false" properties="true" compact="true" eventEol="true"/>
       <Filters>
         <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
       </Filters>


### PR DESCRIPTION
Test logs are super, duper awesome. We upload them on failure since we don't presumably need to see healthy logs.

There are two issues:
1. We upload them on `failure()`, but timeouts don't seem to trigger this condition. So now upload on `always() && !success()` Why not just `!success()`? An LLM suggests that timeouts are a bit special and go into another mode. The always() will run and then we qualify it. Let's see.

2. The logs are all on a single line.

We have a few axes here: compact and eventEol.
I have three files with these. If you want to grep for logs during a particular test, here's what you get:

Compact: (current behavior)
```
❯ ag "metabase.util.queue-test/result-listener-test" logs/test-log.json.compact
<not reproducing here, because it's the whole file>
```

compact false
```
❯ ag "metabase.util.queue-test/result-listener-test" logs/test-log.json.not-compact
251:    "mb-test" : "metabase.util.queue-test/result-listener-test"
268:    "mb-test" : "metabase.util.queue-test/result-listener-test"
414:    "mb-test" : "metabase.util.queue-test/result-listener-test"
```

It's _too_ expanded.

```
{
  "instant" : {
    "epochSecond" : 1756844736,
    "nanoOfSecond" : 357005000
  },
  "thread" : "main",
  "level" : "INFO",
  "loggerName" : "metabase.util",
  "message" : "Maximum memory available to JVM: 8.0 GB",
  "contextMap" : { },
  "endOfBatch" : false,
  "loggerFqcn" : "org.apache.logging.log4j.spi.AbstractLogger",
  "threadId" : 1,
  "threadPriority" : 5
}
{
  "instant" : {
    "epochSecond" : 1756844739,
    "nanoOfSecond" : 802772000
  },
```

Compact true, eventEol (this PR sets this)
```
❯ ag "metabase.util.queue-test/result-listener-test" logs/test-log.json
17:{"instant":{"epochSecond":1756844991,"nanoOfSecond":537601000},"thread":"main","level":"INFO","loggerName":"metabase.util.queue","message":"Starting listener \u001B[32mtest-result-listener\u001B[0m with 1 threads 🎧","contextMap":{"mb-test":"metabase.util.queue-test/result-listener-test"},"endOfBatch":false,"loggerFqcn":"org.apache.logging.log4j.spi.AbstractLogger","threadId":1,"threadPriority":5}
18:{"instant":{"epochSecond":1756844991,"nanoOfSecond":572361000},"thread":"main","level":"INFO","loggerName":"metabase.util.queue","message":"Stopping listener test-result-listener...","contextMap":{"mb-test":"metabase.util.queue-test/result-listener-test"},"endOfBatch":false,"loggerFqcn":"org.apache.logging.log4j.spi.AbstractLogger","threadId":1,"threadPriority":5}
20:{"instant":{"epochSecond":1756844991,"nanoOfSecond":585407000},"thread":"main","level":"INFO","loggerName":"metabase.util.queue","message":"Stopping listener test-result-listener...done","contextMap":{"mb-test":"metabase.util.queue-test/result-listener-test"},"endOfBatch":false,"loggerFqcn":"org.apache.logging.log4j.spi.AbstractLogger","threadId":1,"threadPriority":5}
```

You get the whole log lines. super helpful. pipe these through a processing pipeline, use jq, etc.

Also, these files are ~817MB when running in a test suite. I'm doing these with a single namespace

```
❯ clj -X:dev:test :only metabase.util.queue-test

❯ ls -lh logs
13K Sep  2 15:29 test-log.json
13K Sep  2 15:24 test-log.json.compact
16K Sep  2 15:26 test-log.json.not-compact
```
