### PR TITLE
Update default map type based on docs

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
@@ -18,6 +18,7 @@ import {
   getDefaultSize,
   getMinSize,
 } from "metabase/visualizations/shared/utils/sizes";
+import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 import {
   hasLatitudeAndLongitudeColumns,
   isCountry,
@@ -152,7 +153,7 @@ export class Map extends Component {
           ? "heat"
           : vizSettings["map.type"] === "grid"
             ? "grid"
-            : data.rows.length >= 1000
+            : data.rows.length > HARD_ROW_LIMIT
               ? "tiles"
               : "markers",
       getHidden: (series, vizSettings) =>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61296

### Description

Sets default map viz pins type to be aligned with docs. 

<= 2000 items - pins
'> 2000 - tiles

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
