### PR TITLE
Set initial timestamp in create event modal

### DIFF
--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -121,9 +121,11 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.findByLabelText("Event name").type("RC1");
 
       cy.findByTestId("event-form").within(() => {
-        cy.findByLabelText("Date").clear().type("10/20/2026");
+        // adding the time first reproduces metabase#62999
         cy.button("Add time").click();
         cy.findByLabelText("Time").type("10:20");
+
+        cy.findByLabelText("Date").clear().type("10/20/2026");
         cy.findByText("Create").click();
         cy.wait("@createEvent");
       });

--- a/frontend/src/metabase/forms/components/FormDateInput/FormDateInput.tsx
+++ b/frontend/src/metabase/forms/components/FormDateInput/FormDateInput.tsx
@@ -50,6 +50,7 @@ export const FormDateInput = forwardRef(function FormDateInput(
   return (
     <DateInput
       fw="bold"
+      onChange={handleChange}
       {...props}
       id={id}
       ref={ref}
@@ -57,7 +58,6 @@ export const FormDateInput = forwardRef(function FormDateInput(
       name={name}
       value={dayjs(date).toDate()}
       error={touched && error != null}
-      onChange={handleChange}
       onBlur={onBlur}
     />
   );

--- a/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
@@ -80,7 +80,10 @@ const EventForm = ({
 
   return (
     <FormProvider
-      initialValues={initialValues}
+      initialValues={{
+        ...initialValues,
+        timestamp: initialValues.timestamp || dayjs().utc(true).toISOString(),
+      }}
       validationSchema={EVENT_SCHEMA}
       onSubmit={onSubmit}
     >
@@ -99,6 +102,19 @@ const EventForm = ({
                 title={t`Date`}
                 flex={1}
                 valueFormat={dateSettings?.date_style}
+                onChange={(date) => {
+                  if (values.time_matters) {
+                    // if time matters, preserve the time part of the timestamp
+                    // when changing the date part
+                    const timePart = dayjs.tz(values.timestamp);
+                    const newDate = parseTimestamp(date)
+                      .set("hour", timePart.hour())
+                      .set("minute", timePart.minute());
+                    setFieldValue("timestamp", newDate.toISOString());
+                  } else {
+                    setFieldValue("timestamp", dayjs(date).toISOString());
+                  }
+                }}
               />
               {values.time_matters ? (
                 <Flex gap="xs" align="end">


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62999
closes UXW-607

### Description

The timeline event form didn't have logic to set a default timestamp. Things worked fine if you selected a date first, because it would populate a timestamp, but if you selected "add time" before picking a date (even if it looked like there was one populated) it would throw an error trying to parse an empty timestamp.

The fix is easy: default to the form value to the current timestamp.

This exposed another issue: if you set a time before setting the date, and then selected a date, it would reset the time to midnight UTC. This is fixed as well.

Before | After
---|---
![CleanShot 2025-09-02 at 16 00 56](https://github.com/user-attachments/assets/c9065b2c-5ee3-43ec-a303-8a81f2e7485f) | ![CleanShot 2025-09-02 at 16 00 19](https://github.com/user-attachments/assets/dc6106e4-3003-42ba-b2fb-1f188f423f60)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
