### PR TITLE
inline dashcard parameter can only be mapped to the card

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -2397,7 +2397,7 @@ describe("scenarios > dashboard > parameters", () => {
       });
     });
 
-    it("should allow connecting inline parameters only to cards on the same tab", () => {
+    it("should not allow connecting inline parameters to cards on a different tab", () => {
       H.createQuestionAndDashboard({
         questionDetails: ordersCountByCategory,
       }).then(({ body: dashcard }) => {
@@ -2420,9 +2420,6 @@ describe("scenarios > dashboard > parameters", () => {
         // Add a filter to the first card
         H.setDashCardFilter(0, "Text or Category", null, "Category");
         H.selectDashboardFilter(H.getDashboardCard(0), "Category");
-
-        // Connect it to the second card
-        H.selectDashboardFilter(H.getDashboardCard(1), "Category");
 
         H.goToTab("Tab 2");
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
@@ -8,6 +8,7 @@ import CS from "metabase/css/core/index.css";
 import { setParameterMapping } from "metabase/dashboard/actions/parameters";
 import {
   getVirtualCardType,
+  isQuestionDashCard,
   isVirtualDashCard,
   showVirtualDashCardInfoText,
 } from "metabase/dashboard/utils";
@@ -86,6 +87,14 @@ export const DashCardCardParameterMapperContent = ({
         dashcard.dashboard_tab_id
     );
   }, [editingParameterInlineDashcard, dashcard.dashboard_tab_id]);
+
+  const isInlineParameterOfAnotherQuestionCard = useMemo(() => {
+    return (
+      editingParameterInlineDashcard != null &&
+      isQuestionDashCard(editingParameterInlineDashcard) &&
+      editingParameterInlineDashcard.id !== dashcard.id
+    );
+  }, [editingParameterInlineDashcard, dashcard.id]);
 
   const headerContent = useMemo(() => {
     if (layoutHeight <= 2) {
@@ -175,9 +184,18 @@ export const DashCardCardParameterMapperContent = ({
 
   if (isInlineParameterFromAnotherTab) {
     return (
-      <Flex className={S.TextCardDefault} gap="sm" ta="center">
+      <Flex className={S.TextCardDefault} gap="sm" align="center" ta="center">
         <Icon name="info" size={12} className={S.InfoIcon} />
         {t`The selected filter is on another tab.`}
+      </Flex>
+    );
+  }
+
+  if (isInlineParameterOfAnotherQuestionCard) {
+    return (
+      <Flex className={S.TextCardDefault} gap="sm" align="center" ta="center">
+        <Icon name="info" size={12} className={S.InfoIcon} />
+        {t`This filter can only connect to its own card.`}
       </Flex>
     );
   }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapperContent.tsx
@@ -96,6 +96,10 @@ export const DashCardCardParameterMapperContent = ({
     );
   }, [editingParameterInlineDashcard, dashcard.id]);
 
+  const hasExistingConnection = useMemo(() => {
+    return target != null;
+  }, [target]);
+
   const headerContent = useMemo(() => {
     if (layoutHeight <= 2) {
       return null;
@@ -191,7 +195,7 @@ export const DashCardCardParameterMapperContent = ({
     );
   }
 
-  if (isInlineParameterOfAnotherQuestionCard) {
+  if (isInlineParameterOfAnotherQuestionCard && !hasExistingConnection) {
     return (
       <Flex className={S.TextCardDefault} gap="sm" align="center" ta="center">
         <Icon name="info" size={12} className={S.InfoIcon} />

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -234,7 +234,6 @@ export function DashCardVisualization({
     cardTitled,
     dashboard,
     dashcardMenu,
-    editingParameter,
     getClickActionMode,
     isEditing = false,
     shouldRenderAsNightMode,
@@ -512,17 +511,13 @@ export function DashCardVisualization({
       return null;
     }
 
-    const effectiveParameters = editingParameter
-      ? inlineParameters.filter((param) => param.id === editingParameter.id)
-      : inlineParameters;
-
     return (
       <Group>
-        {effectiveParameters.length > 0 && (
+        {inlineParameters.length > 0 && (
           <CollapsibleDashboardParameterList
             className={S.InlineParametersList}
             triggerClassName={S.InlineParametersMenuTrigger}
-            parameters={effectiveParameters}
+            parameters={inlineParameters}
             isCollapsed={shouldCollapseList}
             isSortable={false}
             widgetsPopoverPosition="bottom-end"
@@ -549,7 +544,6 @@ export function DashCardVisualization({
     dashcard,
     dashcardMenu,
     isEditing,
-    editingParameter,
     inlineParameters,
     onChangeCardAndRun,
     onEditVisualization,

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -3,7 +3,11 @@ import _ from "underscore";
 
 import { tag_names } from "cljs/metabase.parameters.shared";
 import { getColumnIcon } from "metabase/common/utils/columns";
-import { isActionDashCard, isVirtualDashCard } from "metabase/dashboard/utils";
+import {
+  isActionDashCard,
+  isQuestionDashCard,
+  isVirtualDashCard,
+} from "metabase/dashboard/utils";
 import { getGroupName } from "metabase/querying/filters/utils/groups";
 import { getAllowedIframeAttributes } from "metabase/visualizations/visualizations/IFrameViz/utils";
 import * as Lib from "metabase-lib";
@@ -138,6 +142,14 @@ export function getParameterMappingOptions(
     parameterDashcard != null &&
     parameterDashcard.dashboard_tab_id !== dashcard?.dashboard_tab_id;
   if (isInlineParameterOnCardFromOtherTab) {
+    return [];
+  }
+
+  const isInlineParameterOfAnotherQuestionCard =
+    parameterDashcard != null &&
+    isQuestionDashCard(parameterDashcard) &&
+    parameterDashcard.id !== dashcard?.id;
+  if (isInlineParameterOfAnotherQuestionCard) {
     return [];
   }
 

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -149,7 +149,21 @@ export function getParameterMappingOptions(
     parameterDashcard != null &&
     isQuestionDashCard(parameterDashcard) &&
     parameterDashcard.id !== dashcard?.id;
-  if (isInlineParameterOfAnotherQuestionCard) {
+
+  // Check if there's an existing connection between this parameter and this specific dashcard/card combo
+  const hasExistingConnection =
+    parameter != null &&
+    dashcard != null &&
+    isQuestionDashCard(dashcard) &&
+    "id" in card &&
+    dashcard.parameter_mappings?.some(
+      (mapping) =>
+        mapping.parameter_id === parameter.id && mapping.card_id === card.id,
+    );
+
+  // Only block if it's an inline parameter of another card AND there's no existing connection
+  // to allow users to see and potentially disconnect existing connections
+  if (isInlineParameterOfAnotherQuestionCard && !hasExistingConnection) {
     return [];
   }
 

--- a/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
@@ -520,6 +520,56 @@ describe("parameters/utils/mapping-options", () => {
 
       expect(options.length).toBeGreaterThan(0);
     });
+
+    it("should return empty array when inline parameter on question card tries to map to different card", () => {
+      const card = structured({ "source-table": ORDERS_ID });
+      const question = new Question(card, metadata);
+      const dashcard = createMockDashboardCard({
+        id: 1,
+        dashboard_tab_id: 1,
+        card_id: 123,
+      });
+      const parameterDashcard = createMockDashboardCard({
+        id: 2,
+        dashboard_tab_id: 1,
+        card_id: 456,
+      });
+
+      const options = getParameterMappingOptions(
+        question,
+        { type: "date/single" },
+        card,
+        dashcard,
+        parameterDashcard,
+      );
+
+      expect(options).toEqual([]);
+    });
+
+    it("should return normal options when inline parameter on question card maps to its own card", () => {
+      const card = structured({ "source-table": ORDERS_ID });
+      const question = new Question(card, metadata);
+      const dashcard = createMockDashboardCard({
+        id: 1,
+        dashboard_tab_id: 1,
+        card_id: 123,
+      });
+      const parameterDashcard = createMockDashboardCard({
+        id: 1,
+        dashboard_tab_id: 1,
+        card_id: 123,
+      });
+
+      const options = getParameterMappingOptions(
+        question,
+        { type: "date/single" },
+        card,
+        dashcard,
+        parameterDashcard,
+      );
+
+      expect(options.length).toBeGreaterThan(0);
+    });
   });
 });
 

--- a/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.unit.spec.js
@@ -570,6 +570,41 @@ describe("parameters/utils/mapping-options", () => {
 
       expect(options.length).toBeGreaterThan(0);
     });
+
+    it("should return options when inline parameter on question card has existing connection to different card", () => {
+      const card = { ...structured({ "source-table": ORDERS_ID }), id: 123 };
+      const question = new Question(card, metadata);
+      const parameterId = "param123";
+      const parameter = { id: parameterId, type: "date/single" };
+      const dashcard = createMockDashboardCard({
+        id: 1,
+        dashboard_tab_id: 1,
+        card_id: 123,
+        parameter_mappings: [
+          {
+            parameter_id: parameterId,
+            card_id: 123,
+            target: ["dimension", ["field", ORDERS.CREATED_AT, null]],
+          },
+        ],
+      });
+      const parameterDashcard = createMockDashboardCard({
+        id: 2,
+        dashboard_tab_id: 1,
+        card_id: 456,
+      });
+
+      const options = getParameterMappingOptions(
+        question,
+        parameter,
+        card,
+        dashcard,
+        parameterDashcard,
+      );
+
+      // Should return options to allow users to see and potentially disconnect existing connections
+      expect(options.length).toBeGreaterThan(0);
+    });
   });
 });
 


### PR DESCRIPTION
Closes [VIZ-1138: Prevent question card filters usage by other dashcards](https://linear.app/metabase/issue/VIZ-1138/prevent-question-card-filters-usage-by-other-dashcards)
Closes [UXW-477: Feedback on filter editing experience in product demo](https://linear.app/metabase/issue/UXW-477/feedback-on-filter-editing-experience-in-product-demo)

### Description

This PR limits the ability to connect inline dashcard filter only to its own card:
<img width="1127" height="692" alt="Screenshot 2025-09-02 at 6 56 01 PM" src="https://github.com/user-attachments/assets/6ae0d1f9-f60d-4fd5-84d5-044a2f8ac7f1" />

Also fixes unnecessary hidden other inline dashcard filters when one is in the mapping mode:
<img width="1351" height="766" alt="Screenshot 2025-09-02 at 6 56 57 PM" src="https://github.com/user-attachments/assets/b7a0eb99-f339-42a0-b921-6cfb667fdb33" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
