### PR TITLE
Mark tests as flaky

### DIFF
--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -224,7 +224,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     H.modal().button("Save").should("be.disabled");
   });
 
-  it("should allow clicking on the title", () => {
+  it("should allow clicking on the title", { tags: "@flaky" }, () => {
     createDashboardWithVisualizerDashcards();
 
     // Click on both series of the first chart

--- a/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
@@ -66,7 +66,7 @@ describe("scenarios > dashboard > visualizer > drillthrough", () => {
     });
   });
 
-  it("should work", () => {
+  it("should work", { tags: "@flaky" }, () => {
     createDashboardWithVisualizerDashcards();
 
     const ORDERS_SERIES_COLOR = "#88BF4D";

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -396,15 +396,19 @@ describe("issue 52806", () => {
     cy.signInAsNormalUser();
   });
 
-  it("should remove parameter values from the URL when leaving the query builder and discarding changes (metabase#52806)", () => {
-    cy.visit("/");
-    H.newButton("SQL query").click();
-    H.NativeEditor.focus().type("select {{x}}");
-    cy.findByTestId("main-logo-link").click();
-    H.modal().button("Discard changes").click();
-    cy.findByTestId("home-page");
-    cy.location().should((location) => expect(location.search).to.eq(""));
-  });
+  it(
+    "should remove parameter values from the URL when leaving the query builder and discarding changes (metabase#52806)",
+    { tags: "@flaky" },
+    () => {
+      cy.visit("/");
+      H.newButton("SQL query").click();
+      H.NativeEditor.focus().type("select {{x}}");
+      cy.findByTestId("main-logo-link").click();
+      H.modal().button("Discard changes").click();
+      cy.findByTestId("home-page");
+      cy.location().should((location) => expect(location.search).to.eq(""));
+    },
+  );
 });
 
 describe("issue 55951", () => {


### PR DESCRIPTION
These are some of the flakiest tests currently

 - [e2e-tests] scenarios > dashboard > visualizer > basics should allow clicking on the title: **5% failure rate**
- should remove parameter values from the URL when leaving the query builder and discarding changes (metabase#52806): **4% failure rate** (I thought I'd fixed this, but there's still flakes apparently)
- [e2e-tests] scenarios > dashboard > visualizer > drillthrough should work : **4% failure rate**