### PR TITLE
remove missing key warning from embed hub

### DIFF
--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -42,7 +42,7 @@ export const EmbeddingHub = () => {
 
         <Text mb="xl" c="text-medium">
           {c("{0} is the link to the selected embedding type.")
-            .jt`Get started with ${(<EmbeddingTypeDropdown />)}`}
+            .jt`Get started with ${(<EmbeddingTypeDropdown key="embedding-type-dropdown" />)}`}
         </Text>
 
         <EmbeddingHubChecklist


### PR DESCRIPTION
Fixes:
<img width="922" height="111" alt="image" src="https://github.com/user-attachments/assets/0abcfcd6-6312-4e5f-ac45-f3be0d1b714b" />
