### PR TITLE
Apply the new upsell flow to interactive and embed js upsells

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -107,12 +107,66 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
       cy.findByRole("article", { name: /Interactive embedding/ }).within(() => {
         cy.findByText("Interactive embedding");
 
-        cy.findByRole("link", { name: "Try for free" })
-          .should("have.attr", "href")
-          .and(
-            "eq",
-            "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=upsell&utm_campaign=embedding-interactive&utm_content=embedding-page&source_plan=oss",
-          );
+        cy.findByRole("button", { name: "Try for free" });
+      });
+    });
+
+    it("should show the sdk settings page with upsell button", () => {
+      cy.on("window:before:load", (win) => {
+        // prevent Cypress opening in a new window/tab and spy on this method
+        cy.stub(win, "open").as("open");
+      });
+
+      cy.visit("/admin/settings/embedding-in-other-applications/sdk");
+
+      mainPage().within(() => {
+        cy.contains("SDK for React").should("be.visible");
+        cy.contains("Embedded Analytics JS").should("be.visible");
+      });
+
+      cy.findByRole("button", { name: "Try for free" }).click();
+
+      cy.get("@open").should((spy) => {
+        const url = spy.getCall(0).args[0];
+
+        expect(url).to.include(
+          "https://test-store.metabase.com/checkout/upgrade/self-hosted",
+        );
+
+        expect(url).to.match(/utm_source=product/);
+        expect(url).to.match(/utm_medium=upsell/);
+        expect(url).to.match(/utm_campaign=embedded-analytics-js/);
+        expect(url).to.match(/utm_content=embedding-page/);
+        expect(url).to.match(/source_plan=oss/);
+      });
+    });
+
+    it("should show the interactive embed card with upsell button", () => {
+      cy.on("window:before:load", (win) => {
+        // prevent Cypress opening in a new window/tab and spy on this method
+        cy.stub(win, "open").as("open");
+      });
+
+      cy.visit("/admin/settings/embedding-in-other-applications");
+
+      mainPage().within(() => {
+        cy.contains("Interactive embedding").should("be.visible");
+      });
+
+      cy.findByRole("button", { name: "Try for free" }).click();
+
+      cy.get("@open").should((spy) => {
+        const url = spy.getCall(0).args[0];
+
+        expect(url).to.include(
+          "https://test-store.metabase.com/checkout/upgrade/self-hosted",
+        );
+
+        expect(url).to.match(/utm_source=product/);
+        expect(url).to.match(/utm_medium=upsell/);
+        expect(url).to.match(/utm_campaign=embedding-interactive/);
+        expect(url).to.match(/utm_content=embedding-page/);
+        expect(url).to.match(/source_plan=oss/);
       });
     });
 

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -107,66 +107,25 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
       cy.findByRole("article", { name: /Interactive embedding/ }).within(() => {
         cy.findByText("Interactive embedding");
 
-        cy.findByRole("button", { name: "Try for free" });
+        cy.findByRole("link", { name: "Try for free" })
+          .should("have.attr", "href")
+          .and(
+            "eq",
+            "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=upsell&utm_campaign=embedding-interactive&utm_content=embedding-page&source_plan=oss",
+          );
       });
     });
 
-    it("should show the sdk settings page with upsell button", () => {
-      cy.on("window:before:load", (win) => {
-        // prevent Cypress opening in a new window/tab and spy on this method
-        cy.stub(win, "open").as("open");
-      });
-
+    it("should show the sdk upsell link in oss", () => {
       cy.visit("/admin/settings/embedding-in-other-applications/sdk");
 
       mainPage().within(() => {
-        cy.contains("SDK for React").should("be.visible");
-        cy.contains("Embedded Analytics JS").should("be.visible");
-      });
-
-      cy.findByRole("button", { name: "Try for free" }).click();
-
-      cy.get("@open").should((spy) => {
-        const url = spy.getCall(0).args[0];
-
-        expect(url).to.include(
-          "https://test-store.metabase.com/checkout/upgrade/self-hosted",
-        );
-
-        expect(url).to.match(/utm_source=product/);
-        expect(url).to.match(/utm_medium=upsell/);
-        expect(url).to.match(/utm_campaign=embedded-analytics-js/);
-        expect(url).to.match(/utm_content=embedding-page/);
-        expect(url).to.match(/source_plan=oss/);
-      });
-    });
-
-    it("should show the interactive embed card with upsell button", () => {
-      cy.on("window:before:load", (win) => {
-        // prevent Cypress opening in a new window/tab and spy on this method
-        cy.stub(win, "open").as("open");
-      });
-
-      cy.visit("/admin/settings/embedding-in-other-applications");
-
-      mainPage().within(() => {
-        cy.contains("Interactive embedding").should("be.visible");
-      });
-
-      cy.findByRole("button", { name: "Try for free" }).click();
-
-      cy.get("@open").should((spy) => {
-        const url = spy.getCall(0).args[0];
-
-        expect(url).to.include(
-          "https://test-store.metabase.com/checkout/upgrade/self-hosted",
-        );
-
-        expect(url).to.match(/utm_source=product/);
-        expect(url).to.match(/utm_medium=upsell/);
-        expect(url).to.match(/utm_campaign=embedding-interactive/);
-        expect(url).to.match(/utm_content=embedding-page/);
-        expect(url).to.match(/source_plan=oss/);
+        cy.findByRole("link", { name: "Try for free" })
+          .should("have.attr", "href")
+          .and(
+            "eq",
+            "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=upsell&utm_campaign=embedded-analytics-js&utm_content=embedding-page&source_plan=oss",
+          );
       });
     });
 

--- a/e2e/test/scenarios/embedding/embedding-upsells.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-upsells.cy.spec.ts
@@ -1,0 +1,72 @@
+const { H } = cy;
+
+describe("scenarios > embedding > upsells", { tags: "@EE" }, () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.updateSetting("show-sdk-embed-terms", false);
+  });
+
+  it("should show the sdk settings page with upsell button", () => {
+    cy.on("window:before:load", (win) => {
+      // prevent Cypress opening in a new window/tab and spy on this method
+      cy.stub(win, "open").as("open");
+    });
+
+    cy.visit("/admin/settings/embedding-in-other-applications/sdk");
+
+    mainPage().within(() => {
+      cy.contains("SDK for React").should("be.visible");
+      cy.contains("Embedded Analytics JS").should("be.visible");
+    });
+
+    cy.findByRole("button", { name: "Try for free" }).click();
+
+    cy.get<sinon.SinonSpy>("@open").should((spy) => {
+      const url = spy.getCall(0).args[0];
+
+      expect(url).to.include(
+        "https://test-store.metabase.com/checkout/upgrade/self-hosted",
+      );
+
+      expect(url).to.match(/utm_source=product/);
+      expect(url).to.match(/utm_medium=upsell/);
+      expect(url).to.match(/utm_campaign=embedded-analytics-js/);
+      expect(url).to.match(/utm_content=embedding-page/);
+      expect(url).to.match(/source_plan=oss/);
+    });
+  });
+
+  it("should show the interactive embed card with upsell button", () => {
+    cy.on("window:before:load", (win) => {
+      // prevent Cypress opening in a new window/tab and spy on this method
+      cy.stub(win, "open").as("open");
+    });
+
+    cy.visit("/admin/settings/embedding-in-other-applications");
+
+    mainPage().within(() => {
+      cy.contains("Interactive embedding").should("be.visible");
+    });
+
+    cy.findByRole("button", { name: "Try for free" }).click();
+
+    cy.get<sinon.SinonSpy>("@open").should((spy) => {
+      const url = spy.getCall(0).args[0];
+
+      expect(url).to.include(
+        "https://test-store.metabase.com/checkout/upgrade/self-hosted",
+      );
+
+      expect(url).to.match(/utm_source=product/);
+      expect(url).to.match(/utm_medium=upsell/);
+      expect(url).to.match(/utm_campaign=embedding-interactive/);
+      expect(url).to.match(/utm_content=embedding-page/);
+      expect(url).to.match(/source_plan=oss/);
+    });
+  });
+});
+
+function mainPage() {
+  return cy.findByTestId("admin-layout-content");
+}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/InteractiveEmbeddingOptionCard/InteractiveEmbeddingOptionCard.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingOption/InteractiveEmbeddingOptionCard/InteractiveEmbeddingOptionCard.tsx
@@ -85,7 +85,7 @@ export const InteractiveEmbeddingOptionCard = () => {
             url="https://www.metabase.com/product/embedded-analytics"
             campaign="embedding-interactive"
             location="embedding-page"
-            large
+            size="large"
           />
         )}
         <EmbeddingToggle

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -218,6 +218,7 @@ export function EmbeddingSdkSettings() {
                 url="https://www.metabase.com/product/embedded-analytics"
                 campaign="embedded-analytics-js"
                 location="embedding-page"
+                size="default"
               />
             )}
           </Group>

--- a/frontend/src/metabase/admin/upsells/UpsellEmbeddingButton.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellEmbeddingButton.tsx
@@ -1,21 +1,20 @@
-import cx from "classnames";
 import { t } from "ttag";
 
-import ExternalLink from "metabase/common/components/ExternalLink";
+import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 
-import S from "./components/UpsellCta.module.css";
+import { UpsellCta } from "./components/UpsellCta";
 import { useUpsellLink } from "./components/use-upsell-link";
 
 export const UpsellEmbeddingButton = ({
   url,
   campaign,
   location,
-  large = false,
+  size = "default",
 }: {
   url: string;
   campaign: string;
   location: string;
-  large?: boolean;
+  size?: "default" | "large";
 }) => {
   const upsellLink = useUpsellLink({
     url,
@@ -23,12 +22,19 @@ export const UpsellEmbeddingButton = ({
     location,
   });
 
+  const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
+    campaign,
+    location,
+  });
+
   return (
-    <ExternalLink
-      href={upsellLink}
-      className={cx(S.UpsellCTALink, large && S.Large)}
-    >
-      {t`Try for free`}
-    </ExternalLink>
+    <UpsellCta
+      onClick={triggerUpsellFlow}
+      buttonText={t`Try for free`}
+      url={upsellLink}
+      internalLink={undefined}
+      onClickCapture={() => {}}
+      size={size}
+    />
   );
 };


### PR DESCRIPTION
Closes EMB-700

### Description

Uses the new `PLUGIN_ADMIN_SETTINGS.useUpsellFlow` hook to trigger the new upsell flow. Should apply to both Interactive Embedding and Embedded Analytics JS upsells.

### How to verify

Interactive Embedding

- Run EE locally
- Go to interactive embedding card
- Click on the upsell button
- It should open a new window to Metabase Store

Embedded Analytics JS

- Run EE locally
- Go to Modular Embedding settings page
- Click on the upsell button
- It should open a new window to Metabase Store

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
