### PR TITLE
feat(embed-js): throws when setting invalid metabaseConfig keys

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/constants.ts
@@ -57,7 +57,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "withNewQuestion",
     "withNewDashboard",
   ] satisfies (keyof BrowserEmbedOptions)[],
-};
+} as const;
 
 // This file is used by embed.js, so we shouldn't import external dependencies.
 const uniq = <T>(list: T[]): T[] => Array.from(new Set(list));

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -9,7 +9,10 @@ import {
   MetabaseError,
 } from "embedding-sdk-bundle/errors";
 
-import { DISABLE_UPDATE_FOR_KEYS } from "./constants";
+import {
+  ALLOWED_EMBED_SETTING_KEYS_MAP,
+  DISABLE_UPDATE_FOR_KEYS,
+} from "./constants";
 import type {
   SdkIframeEmbedEvent,
   SdkIframeEmbedEventHandler,
@@ -50,6 +53,7 @@ const setupConfigWatcher = () => {
     },
     set(newVal: Record<string, unknown>) {
       assertFieldCanBeUpdated(newVal);
+      assertValidMetabaseConfigField(newVal);
 
       currentConfig = { ...currentConfig, ...newVal };
       proxyConfig = createProxy(currentConfig);
@@ -96,6 +100,23 @@ function assertFieldCanBeUpdated(newValues: Partial<SdkIframeEmbedSettings>) {
       currentConfig[field] !== newValues[field]
     ) {
       raiseError(`${field} cannot be updated after the embed is created`);
+    }
+  }
+}
+
+type AllowedMetabaseConfigKey =
+  (typeof ALLOWED_EMBED_SETTING_KEYS_MAP.base)[number];
+
+function assertValidMetabaseConfigField(
+  newValues: Partial<SdkIframeEmbedSettings>,
+) {
+  for (const field in newValues) {
+    if (
+      !ALLOWED_EMBED_SETTING_KEYS_MAP.base.includes(
+        field as AllowedMetabaseConfigKey,
+      )
+    ) {
+      raiseError(`${field} is not a valid configuration name`);
     }
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
@@ -173,4 +173,20 @@ describe("embed.js script tag for sdk iframe embedding", () => {
       expect(consoleErrorSpy).not.toHaveBeenCalled();
     },
   );
+
+  it("should throw for multiple invalid keys and report the first one", () => {
+    expect(() => {
+      defineMetabaseConfig({
+        invalidKey1: "value1",
+        invalidKey2: "value2",
+      } as any);
+    }).toThrow("invalidKey1 is not a valid configuration name");
+  });
+
+  it("should not throw for valid config", () => {
+    expect(() => {
+      defineMetabaseConfig({ instanceUrl: "https://example.com" });
+      defineMetabaseConfig({});
+    }).not.toThrow();
+  });
 });


### PR DESCRIPTION
Closes EMB-683

Throws an error when the user sets an invalid `metabaseConfig` key.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
