### PR TITLE
Closes EMB-756 translations for static embedded visualizer cards

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_translation/tests/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/tests/utils.unit.spec.ts
@@ -2,6 +2,7 @@ import type { HoveredObject } from "metabase/visualizations/types";
 import type { DatasetColumn, DictionaryArray } from "metabase-types/api";
 import { createMockColumn, createMockSeries } from "metabase-types/api/mocks";
 
+import { leaveUntranslated } from "../use-translate-content";
 import {
   translateCardNames,
   translateContentString,
@@ -400,9 +401,8 @@ describe("content translation utils", () => {
 
     it("should return the original series if no translations are available", () => {
       const series = createMockSeries();
-      const result = translateFieldValuesInSeries(series, mockTC);
+      const result = translateFieldValuesInSeries(series, leaveUntranslated);
       expect(result).toEqual(series);
-      expect(mockTC).not.toHaveBeenCalled();
     });
 
     it("should translate all columns in the series", () => {

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -124,12 +124,18 @@ export const translateFieldValuesInSeries = (
     if (!singleSeries.data) {
       return singleSeries;
     }
+    const untranslatedRows = singleSeries.data.rows.concat();
+
     const translatedRows = singleSeries.data.rows.map((row) =>
       row.map((value) => tc(value)),
     );
     return {
       ...singleSeries,
-      data: { ...singleSeries.data, rows: translatedRows },
+      data: {
+        ...singleSeries.data,
+        untranslatedRows,
+        rows: translatedRows,
+      },
     };
   });
 };

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -6,8 +6,8 @@ import type { ContentTranslationFunction } from "metabase/i18n/types";
 import type { HoveredObject } from "metabase/visualizations/types";
 import type {
   DictionaryArray,
+  MaybeTranslatedSeries,
   Series,
-  TranslatedSeries,
 } from "metabase-types/api";
 
 import { hasTranslations, useTranslateContent } from "./use-translate-content";
@@ -120,7 +120,7 @@ export const useTranslateFieldValuesInHoveredObject = (
 export const translateFieldValuesInSeries = (
   series: Series,
   tc: ContentTranslationFunction,
-): TranslatedSeries => {
+): MaybeTranslatedSeries => {
   if (!hasTranslations(tc)) {
     return series;
   }

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -4,7 +4,11 @@ import _ from "underscore";
 
 import type { ContentTranslationFunction } from "metabase/i18n/types";
 import type { HoveredObject } from "metabase/visualizations/types";
-import type { DictionaryArray, Series } from "metabase-types/api";
+import type {
+  DictionaryArray,
+  Series,
+  TranslatedSeries,
+} from "metabase-types/api";
 
 import { hasTranslations, useTranslateContent } from "./use-translate-content";
 
@@ -116,7 +120,7 @@ export const useTranslateFieldValuesInHoveredObject = (
 export const translateFieldValuesInSeries = (
   series: Series,
   tc: ContentTranslationFunction,
-) => {
+): TranslatedSeries => {
   if (!hasTranslations(tc)) {
     return series;
   }

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -177,7 +177,9 @@ export type SingleSeries = {
    * COLUMN_2, etc.) to their original values (count, avg, etc.).
    */
   columnValuesMapping?: Record<string, VisualizerColumnValueSource[]>;
+} & Pick<Dataset, "error" | "started_at" | "data">;
 
+export type SingleSeriesWithTranslation = SingleSeries & {
   data: Dataset["data"] & {
     /**
      * The original, untranslated rows for this series (if any).
@@ -185,10 +187,11 @@ export type SingleSeries = {
      */
     untranslatedRows?: RowValues[];
   };
-} & Pick<Dataset, "error" | "started_at">;
+};
 
 export type RawSeries = SingleSeries[];
 export type TransformedSeries = RawSeries & { _raw: Series };
+export type TranslatedSeries = SingleSeriesWithTranslation[];
 export type Series = RawSeries | TransformedSeries;
 
 export type TemplateTagId = string;

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -191,7 +191,7 @@ export type SingleSeriesWithTranslation = SingleSeries & {
 
 export type RawSeries = SingleSeries[];
 export type TransformedSeries = RawSeries & { _raw: Series };
-export type TranslatedSeries = SingleSeriesWithTranslation[];
+export type MaybeTranslatedSeries = SingleSeriesWithTranslation[];
 export type Series = RawSeries | TransformedSeries;
 
 export type TemplateTagId = string;

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -177,7 +177,15 @@ export type SingleSeries = {
    * COLUMN_2, etc.) to their original values (count, avg, etc.).
    */
   columnValuesMapping?: Record<string, VisualizerColumnValueSource[]>;
-} & Pick<Dataset, "data" | "error" | "started_at">;
+
+  data: Dataset["data"] & {
+    /**
+     * The original, untranslated rows for this series (if any).
+     * Undefined if no translation occured.
+     */
+    untranslatedRows?: RowValues[];
+  };
+} & Pick<Dataset, "error" | "started_at">;
 
 export type RawSeries = SingleSeries[];
 export type TransformedSeries = RawSeries & { _raw: Series };

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -207,7 +207,7 @@ interface DashCardVisualizationProps {
 
 export function DashCardVisualization({
   dashcard,
-  series: untranslatedRawSeries,
+  series: rawSeries,
   question,
   metadata,
   getHref,
@@ -247,10 +247,6 @@ export function DashCardVisualization({
 
   const inlineParameters = useSelector((state) =>
     getDashCardInlineValuePopulatedParameters(state, dashcard.id),
-  );
-
-  const rawSeries = PLUGIN_CONTENT_TRANSLATION.useTranslateSeries(
-    untranslatedRawSeries,
   );
 
   const visualizerErrMsg = useMemo(() => {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -273,7 +273,7 @@ export function DashCardVisualization({
     }
   }, [dashcard, rawSeries]);
 
-  const series = useMemo(() => {
+  const untranslatedSeries = useMemo(() => {
     if (
       !dashcard ||
       !rawSeries ||
@@ -324,8 +324,9 @@ export function DashCardVisualization({
     ) as Card;
 
     if (!didEveryDatasetLoad) {
-      return [{ card }];
+      return [{ card }] as RawSeries;
     }
+
     const series: RawSeries = [
       {
         card: extendCardWithDashcardSettings(
@@ -369,6 +370,9 @@ export function DashCardVisualization({
 
     return series;
   }, [rawSeries, dashcard, datasets]);
+
+  const series =
+    PLUGIN_CONTENT_TRANSLATION.useTranslateSeries(untranslatedSeries);
 
   const handleOnUpdateVisualizationSettings = useCallback(
     (settings: VisualizationSettings) => {

--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -193,14 +193,25 @@ export function getPieRows(
   const untranslatedKeysToTranslatedKeys = new Map<string, string>();
   if (untranslatedRows) {
     untranslatedRows.forEach((row, i) => {
-      untranslatedKeysToTranslatedKeys.set(
-        row[0] as string,
-        dataRows[i][0] as string,
-      );
+      const untranslatedValue = row[0];
+      const translatedValue = dataRows[i][0];
+
+      if (
+        typeof untranslatedValue === "string" &&
+        typeof translatedValue === "string"
+      ) {
+        untranslatedKeysToTranslatedKeys.set(
+          untranslatedValue,
+          translatedValue,
+        );
+      }
     });
   } else {
     dataRows.forEach((row) => {
-      untranslatedKeysToTranslatedKeys.set(row[0] as string, row[0] as string);
+      if (typeof row[0] !== "string") {
+        return;
+      }
+      untranslatedKeysToTranslatedKeys.set(row[0], row[0]);
     });
   }
 

--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -185,9 +185,23 @@ export function getPieRows(
 ) {
   const [
     {
-      data: { rows: dataRows },
+      data: { rows: dataRows, untranslatedRows },
     },
   ] = rawSeries;
+
+  const untranslatedKeysToTranslatedKeys = new Map<string, string>();
+  if (untranslatedRows) {
+    untranslatedRows.forEach((row, i) => {
+      untranslatedKeysToTranslatedKeys.set(
+        row[0] as string,
+        dataRows[i][0] as string,
+      );
+    });
+  } else {
+    dataRows.forEach((row) => {
+      untranslatedKeysToTranslatedKeys.set(row[0] as string, row[0] as string);
+    });
+  }
 
   if (!settings["pie.metric"] || !settings["pie.dimension"]) {
     return [];
@@ -239,6 +253,13 @@ export function getPieRows(
   const savedPieRows = hasSortDimensionChanged
     ? []
     : (settings["pie.rows"] ?? []);
+  const savedColors = new Map<string, string>();
+  savedPieRows.forEach((pieRow) => {
+    savedColors.set(
+      untranslatedKeysToTranslatedKeys.get(pieRow.key) ?? pieRow.key,
+      pieRow.color,
+    );
+  });
 
   const savedPieKeys = savedPieRows.map((pieRow) => pieRow.key);
 
@@ -280,7 +301,7 @@ export function getPieRows(
         key,
         name,
         originalName: name,
-        color,
+        color: savedColors.get(key) ?? color,
         defaultColor: true,
         enabled: true,
         hidden: false,
@@ -326,7 +347,7 @@ export function getPieRows(
           key,
           name,
           originalName: name,
-          color,
+          color: savedColors.get(key) ?? color,
           defaultColor: true,
           enabled: true,
           hidden: false,

--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -21,6 +21,7 @@ import type {
   RawSeries,
   RowValue,
   RowValues,
+  TranslatedSeries,
 } from "metabase-types/api";
 
 export function getPieDimensions(settings: ComputedVisualizationSettings) {
@@ -179,7 +180,7 @@ export function getColors(
 }
 
 export function getPieRows(
-  rawSeries: RawSeries,
+  rawSeries: TranslatedSeries,
   settings: ComputedVisualizationSettings,
   formatter: Formatter,
 ) {

--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -18,10 +18,10 @@ import type {
 } from "metabase/visualizations/types";
 import type {
   DatasetColumn,
+  MaybeTranslatedSeries,
   RawSeries,
   RowValue,
   RowValues,
-  TranslatedSeries,
 } from "metabase-types/api";
 
 export function getPieDimensions(settings: ComputedVisualizationSettings) {
@@ -180,7 +180,7 @@ export function getColors(
 }
 
 export function getPieRows(
-  rawSeries: TranslatedSeries,
+  rawSeries: MaybeTranslatedSeries,
   settings: ComputedVisualizationSettings,
   formatter: Formatter,
 ) {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62382
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62373
Closes [EMB-756: Translations not working for different plot styles](https://linear.app/metabase/issue/EMB-756/translations-not-working-for-different-plot-styles)
Closes [EMB-757: Content-translated charts lose custom colors](https://linear.app/metabase/issue/EMB-757/content-translated-charts-lose-custom-colors)

### Description

EMB-756: The series we use to populate visualizer cards weren't translated in a static embedding context.
EMB-757: Pie charts with custom colors and translation would lose their custom colors


### How to verify

EMB-756:
 1. Add a translation dictionnary in the admin settings (under "Static Embedding")
 2. Make a new question
 3. In a dashboard, add this question by clicking on "Visualize another way"
 4. Publish the dashboard as a static one, and open it
 
EMB-757:
1. Add a translation dictionnary in the admin settings (under "Static Embedding")
2. Make a new pie chart and set custom colors
3. In a dashboard, add this question
4. Publish the dashboard as a static one, and open it

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
