### PR TITLE
feat(embed-js): append entity-types=model to embed flow code snippet if the instance has over 2 models

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -183,6 +183,13 @@ H.describeWithSnowplow(suiteTitle, () => {
     getEmbedSidebar().within(() => {
       codeBlock().should("not.contain", "entity-types");
     });
+
+    H.waitForSimpleEmbedIframesToLoad();
+
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByText("Orders", { timeout: 20_000 }).should("be.visible");
+      cy.findByText("Orders Model").should("be.visible");
+    });
   });
 
   it("should include entity-types when model count is 3", () => {
@@ -197,6 +204,13 @@ H.describeWithSnowplow(suiteTitle, () => {
 
     getEmbedSidebar().within(() => {
       codeBlock().should("contain", "entity-types='[\"model\"]'");
+    });
+
+    H.waitForSimpleEmbedIframesToLoad();
+
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByText("Orders Model", { timeout: 20_000 }).should("be.visible");
+      cy.findByText("Orders").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -169,4 +169,34 @@ H.describeWithSnowplow(suiteTitle, () => {
       codeBlock().should("contain", "metabase-question");
     });
   });
+
+  it("should not include entity-types when model count is 1", () => {
+    cy.intercept("GET", "/api/search?limit=0&models=dataset", {
+      data: [],
+      total: 1,
+    }).as("searchModels");
+
+    navigateToGetCodeStep({ experience: "exploration" });
+
+    cy.wait("@searchModels");
+
+    getEmbedSidebar().within(() => {
+      codeBlock().should("not.contain", "entity-types");
+    });
+  });
+
+  it("should include entity-types when model count is 3", () => {
+    cy.intercept("GET", "/api/search?limit=0&models=dataset", {
+      data: [],
+      total: 3,
+    }).as("searchModels");
+
+    navigateToGetCodeStep({ experience: "exploration" });
+
+    cy.wait("@searchModels");
+
+    getEmbedSidebar().within(() => {
+      codeBlock().should("contain", "entity-types='[\"model\"]'");
+    });
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/constants.ts
@@ -39,6 +39,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "withDownloads",
     "initialSqlParameters",
     "drills",
+    "entityTypes",
   ] satisfies (keyof QuestionEmbedOptions)[],
   exploration: [
     "template",

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -8,6 +8,7 @@ import {
 import { match } from "ts-pattern";
 import _ from "underscore";
 
+import { useSearchQuery } from "metabase/api";
 import { useUserSetting } from "metabase/common/hooks";
 
 import { trackEmbedWizardSettingsUpdated } from "../analytics";
@@ -50,6 +51,13 @@ export const SdkIframeEmbedSetupProvider = ({
     isRecentsLoading,
   } = useRecentItems();
 
+  const { data: searchData } = useSearchQuery({
+    limit: 0,
+    models: ["dataset"],
+  });
+
+  const modelCount = searchData?.total ?? 0;
+
   const defaultSettings = useMemo(() => {
     return getDefaultSdkIframeEmbedSettings(
       "dashboard",
@@ -61,7 +69,25 @@ export const SdkIframeEmbedSetupProvider = ({
     "select-embed-experience",
   );
 
-  const settings = rawSettings ?? defaultSettings;
+  const settings = useMemo(() => {
+    const mergedSettings = rawSettings ?? defaultSettings;
+
+    // Append entity-types=model if there are more than 2 models in the instance.
+    if (modelCount > 2) {
+      return match(mergedSettings)
+        .with({ componentName: "metabase-question" }, (settings) => ({
+          ...settings,
+          entityTypes: ["model" as const],
+        }))
+        .with({ componentName: "metabase-browser" }, (settings) => ({
+          ...settings,
+          dataPickerEntityTypes: ["model" as const],
+        }))
+        .otherwise((settings) => settings);
+    }
+
+    return mergedSettings;
+  }, [defaultSettings, modelCount, rawSettings]);
 
   // Which embed experience are we setting up?
   const experience = useMemo(

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -70,11 +70,11 @@ export const SdkIframeEmbedSetupProvider = ({
   );
 
   const settings = useMemo(() => {
-    const mergedSettings = rawSettings ?? defaultSettings;
+    const latestSettings = rawSettings ?? defaultSettings;
 
     // Append entity-types=model if there are more than 2 models in the instance.
     if (modelCount > 2) {
-      return match(mergedSettings)
+      return match(latestSettings)
         .with({ componentName: "metabase-question" }, (settings) => ({
           ...settings,
           entityTypes: ["model" as const],
@@ -86,7 +86,7 @@ export const SdkIframeEmbedSetupProvider = ({
         .otherwise((settings) => settings);
     }
 
-    return mergedSettings;
+    return latestSettings;
   }, [defaultSettings, modelCount, rawSettings]);
 
   // Which embed experience are we setting up?


### PR DESCRIPTION
Closes EMB-703

The embed flow now checks if the number of models on the instance is more than 2 models. If so, it appends `entity-types=['model']` to the "Get Code" snippet page as well as the embed preview. This only applies to the embed flow.

The rationale is that if the user's instance has 3 or more models, the tables are more likely to be distractions.

### How to verify

Case 1: less than 3 models

- Go to Embed Flow (+ New > Embed)
- Make sure your instance has 2 or less models
- Go to the "Get Code" step of the embed flow (keep clicking "Next")
- The snippet will not include `entity-types`
- The embed preview will include all entity types

Case 2: 3 or more models on the instance

- The snippet will include `entity-types`
- The embed preview will only include models.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
