### PR TITLE
fix(qb): do not show view detail button in step preview

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -1309,6 +1309,26 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       );
     });
   });
+
+  it("should not render detail view column in preview (metabase#63070)", () => {
+    function openPreview() {
+      cy.findByTestId("step-preview-button").click();
+    }
+
+    function verifyPreviewIsRendered() {
+      cy.findByTestId("table-scroll-container").should("contain", "37.65");
+    }
+
+    function verifyIndexColumnsNotRendered() {
+      cy.findAllByTestId("row-id-cell").should("have.length", 0);
+    }
+
+    H.openOrdersTable({ mode: "notebook" });
+
+    openPreview();
+    verifyPreviewIsRendered();
+    verifyIndexColumnsNotRendered();
+  });
 });
 
 function assertTableRowCount(expectedCount) {

--- a/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookStep/NotebookStepPreview/NotebookStepPreview.jsx
@@ -97,6 +97,7 @@ export const VisualizationPreview = ({ rawSeries, result, error }) => {
     <Visualization
       rawSeries={rawSeries}
       error={err}
+      queryBuilderMode="notebook"
       className={cx(CS.bordered, CS.shadowed, CS.rounded, CS.bgWhite, {
         [CS.p2]: err,
       })}


### PR DESCRIPTION
closes UXW-612

hides view detail button and column in preview (we used to show it left to ID column, but it didn't work at least in 56,55 and 54)

<img width="1048" height="683" alt="Screenshot 2025-09-03 at 16 32 52" src="https://github.com/user-attachments/assets/781d33af-03e5-4ec3-aeae-2c94c8a8a401" />
