### PR TITLE
Ignore some test vars

### DIFF
--- a/ci-test-config.json
+++ b/ci-test-config.json
@@ -1,11 +1,14 @@
 {
   "version": "1.0.0",
   "ignored": {
-    "vars": []
+    "vars": [
+      "metabase.session.models.session-test/send-email-on-first-login-from-new-device-test",
+      "metabase-enterprise.impersonation.driver-test/nested-do-with-connection-with-options-test"
+    ]
   },
   "metadata": {
     "last_updated": "2025-08-02",
-    "updated_by": "engineering-team",
-      "reason": "Initial, and empty, ci test config"
+    "updated_by": "dpsutton",
+    "reason": "Two flakes: send-email-on-first-login-from-new-device-test has schema error if emails from another thread are present; nested-do-with-connection-with-options-test is causing deadlocks i believe."
   }
 }


### PR DESCRIPTION
metabase.session.models.session-test/send-email-on-first-login-from-new-device-test test is failing because sometimes there's an extra email in there.

metabase-enterprise.impersonation.driver-test/nested-do-with-connection-with-options-test is failing because it deadlocks all the app-db connections
