### PR TITLE
feat(sdk): native questions should hide filter and summarize from toolbar

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
@@ -115,4 +115,22 @@ describe("scenarios > embedding-sdk > interactive-question > native", () => {
       });
     });
   });
+
+  it("should not show filter/summarize/breakout buttons for native questions", () => {
+    mountInteractiveQuestion({});
+
+    getSdkRoot().within(() => {
+      cy.log("should show native question data");
+      cy.findByText("test question").should("be.visible");
+
+      cy.log("should not show Filter button");
+      cy.findByText("Filter").should("not.exist");
+
+      cy.log("should not show Summarize button");
+      cy.findByText("Summarize").should("not.exist");
+
+      cy.log("should not show Group button");
+      cy.findByText("Group").should("not.exist");
+    });
+  });
 });

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -1,7 +1,7 @@
 import { useDisclosure } from "@mantine/hooks";
 import cx from "classnames";
 import type { ReactElement } from "react";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { t } from "ttag";
 
 import {
@@ -23,6 +23,7 @@ import {
   PopoverBackButton,
   Stack,
 } from "metabase/ui";
+import * as Lib from "metabase-lib";
 
 import {
   FlexibleSizeComponent,
@@ -97,6 +98,16 @@ export const SdkQuestionDefaultView = ({
 
   const [isSaveModalOpen, { open: openSaveModal, close: closeSaveModal }] =
     useDisclosure(false);
+
+  const isNativeQuestion = useMemo(() => {
+    if (!question) {
+      return false;
+    }
+
+    const { isNative } = Lib.queryDisplayInfo(question.query());
+
+    return isNative;
+  }, [question]);
 
   useEffect(() => {
     if (isNewQuestion && !isQuestionSaved) {
@@ -205,17 +216,25 @@ export const SdkQuestionDefaultView = ({
                         <ChartTypeDropdown />
                         <QuestionSettingsDropdown />
                       </Button.Group>
-                      <Divider
-                        mx="xs"
-                        orientation="vertical"
-                        // we have to do this for now because Mantine's divider overrides this color no matter what
-                        color="var(--mb-color-border) !important"
-                      />
+
+                      {!isNativeQuestion && (
+                        <Divider
+                          mx="xs"
+                          orientation="vertical"
+                          // we have to do this for now because Mantine's divider overrides this color no matter what
+                          color="var(--mb-color-border) !important"
+                        />
+                      )}
                     </>
                   )}
-                  <FilterDropdown />
-                  <SummarizeDropdown />
-                  <BreakoutDropdown />
+
+                  {!isNativeQuestion && (
+                    <>
+                      <FilterDropdown />
+                      <SummarizeDropdown />
+                      <BreakoutDropdown />
+                    </>
+                  )}
                 </>
               )}
             </Group>


### PR DESCRIPTION
Closes EMB-715

When embedding a native SQL question, the filter/summarize/group actions are very confusing as it does nothing. This hides those actions when viewing a native SQL question via SdkQuestion.

### How to verify

- Create a native question in your instance
- Go to Storybook
- Change the Number ID in storybook to that of your native question in `storybook-id-args.ts`
- It should not show the action buttons anymore.

### Demo

Before

<img width="1254" height="522" alt="image" src="https://github.com/user-attachments/assets/a048c3d4-eb10-4334-8e1c-32c6900bfcae" />

After

<img width="1848" height="482" alt="CleanShot 2568-09-03 at 23 20 47@2x" src="https://github.com/user-attachments/assets/84af1e03-cc87-48b2-aea4-76b36d17c438" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
