### PR TITLE
Fix buttons focus state

### DIFF
--- a/frontend/src/metabase/css/components/buttons.module.css
+++ b/frontend/src/metabase/css/components/buttons.module.css
@@ -24,13 +24,9 @@
   background: var(--mb-color-bg-light);
 }
 
-.Button:focus {
-  border: 2px solid var(--mb-color-background);
+.Button:focus-visible {
+  border-color: var(--mb-color-background);
   outline: 2px solid var(--mb-color-brand);
-}
-
-.Button:focus:not(:focus-visible) {
-  outline: none;
 }
 
 @media screen and (--breakpoint-min-lg) {
@@ -64,7 +60,7 @@
 .ButtonPrimary {
   color: var(--mb-color-text-white);
   background: var(--mb-color-brand);
-  border: 2px solid var(--mb-color-brand);
+  border-color: var(--mb-color-brand);
 }
 
 .ButtonPrimary:hover {
@@ -73,7 +69,7 @@
   background-color: var(--mb-color-brand-alpha-88);
 }
 
-.ButtonPrimary:focus {
+.ButtonPrimary:focus-visible {
   border-color: var(--mb-color-background);
   outline-color: var(--mb-color-brand);
 }
@@ -81,7 +77,7 @@
 .ButtonWarning {
   color: var(--mb-color-text-white);
   background: var(--mb-color-error);
-  border: 2px solid var(--mb-color-error);
+  border-color: var(--mb-color-error);
 }
 
 .ButtonWarning:hover {
@@ -90,7 +86,7 @@
   background-color: var(--mb-color-error);
 }
 
-.ButtonWarning:focus {
+.ButtonWarning:focus-visible {
   border-color: var(--mb-color-background);
   outline-color: var(--mb-color-error);
 }
@@ -116,7 +112,7 @@
   color: var(--mb-color-text-medium);
 }
 
-.ButtonBorderless:focus {
+.ButtonBorderless:focus-visible {
   border-color: var(--mb-color-background);
   outline-color: var(--mb-color-brand);
 }
@@ -128,7 +124,7 @@
   padding: 0;
 }
 
-.ButtonOnlyIcon:focus {
+.ButtonOnlyIcon:focus-visible {
   border: none;
   outline-color: var(--mb-color-brand);
 }
@@ -192,7 +188,7 @@
   border-color: var(--mb-color-error);
 }
 
-.ButtonDanger:focus {
+.ButtonDanger:focus-visible {
   border-color: var(--mb-color-background);
   outline-color: var(--mb-color-error);
 }
@@ -209,7 +205,7 @@
   color: var(--mb-color-text-white);
 }
 
-.ButtonSuccess:focus {
+.ButtonSuccess:focus-visible {
   border-color: var(--mb-color-background);
   outline-color: var(--mb-color-success);
 }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/63037

There is an edge case with legacy `Button`s that have `:focus` but not `:focus-visible`. In this case the border will be hidden. This PR fixes the issue in styles; hopefully the change is minimal. 

How to verify:
- Open any table, click on a numeric cell value
- Force the "focused" state for the `<` button. 