### PR TITLE
When navigating with browser back/forward buttons, re-run the query only when the existing query results are dirty

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.ts
@@ -1217,7 +1217,7 @@ describe("issue 34514", () => {
     assertBackToEmptyState();
   });
 
-  it("should allow browser history navigation between tabs (metabase#34514)", () => {
+  it("should allow browser history navigation between tabs (metabase#34514, metabase#45787)", () => {
     H.entityPickerModal().within(() => {
       H.entityPickerModalTab("Tables").click();
       cy.wait("@fetchTables");
@@ -1230,13 +1230,15 @@ describe("issue 34514", () => {
 
     cy.findByTestId("editor-tabs-columns-name").click();
     assertMetadataTabState();
+    cy.get("@dataset.all").should("have.length", 1);
 
     cy.go("back");
-    cy.wait(["@dataset", "@fetchDatabase"]); // This should be removed when (metabase#45787) is fixed
     assertQueryTabState();
+    cy.get("@dataset.all").should("have.length", 1);
 
     cy.go("back");
     assertBackToEmptyState();
+    cy.get("@dataset.all").should("have.length", 1);
   });
 
   function assertQueryTabState() {

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -43,7 +43,11 @@ import {
   getSubmittableQuestion,
   isBasedOnExistingQuestion,
 } from "../../selectors";
-import { clearQueryResult, runQuestionQuery } from "../querying";
+import {
+  clearQueryResult,
+  runDirtyQuestionQuery,
+  runQuestionQuery,
+} from "../querying";
 import { onCloseSidebars } from "../ui";
 import { updateUrl } from "../url";
 import { zoomInRow } from "../zoom";
@@ -120,7 +124,7 @@ export const setCardAndRun = (
 
     // Update the card and originalCard before running the actual query
     dispatch({ type: SET_CARD_AND_RUN, payload: { card, originalCard } });
-    dispatch(runQuestionQuery({ shouldUpdateUrl }));
+    dispatch(runDirtyQuestionQuery({ shouldUpdateUrl }));
 
     // Load table & database metadata for the current question
     dispatch(loadMetadataForCard(card));

--- a/frontend/src/metabase/query_builder/actions/querying.ts
+++ b/frontend/src/metabase/query_builder/actions/querying.ts
@@ -85,8 +85,13 @@ const loadErrorUIControls = createThunkAction(
   },
 );
 
+type RunDirtyQuestionQueryOpts = {
+  shouldUpdateUrl?: boolean;
+};
+
 export const runDirtyQuestionQuery =
-  () => async (dispatch: Dispatch, getState: GetState) => {
+  ({ shouldUpdateUrl }: RunDirtyQuestionQueryOpts = {}) =>
+  async (dispatch: Dispatch, getState: GetState) => {
     const areResultsDirty = getIsResultDirty(getState());
     const queryResults = getQueryResults(getState());
 
@@ -100,7 +105,7 @@ export const runDirtyQuestionQuery =
       return dispatch(queryCompleted(question, queryResults));
     }
 
-    return dispatch(runQuestionQuery());
+    return dispatch(runQuestionQuery({ shouldUpdateUrl }));
   };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/45787

The title says it all. 

How to verify:
- Models -> New -> Notebook -> Orders -> Run the query
- Go to the "Columns" tab
- Now click "Back". There should be no additional `/api/dataset` request.