### PR TITLE
Fix sync after foreign key dropped

### DIFF
--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -322,7 +322,8 @@
           ;; 2. drop the FK relationship in the database with SQL
           (jdbc/execute! db-spec "ALTER TABLE country DROP CONSTRAINT country_continent_id_fkey;")
           (sync/sync-database! db {:scan :schema})
-
-          (qp/process-query (mt/query continent_1))
-          (qp/process-query (mt/query continent_2))
-          (qp/process-query (mt/query country)))))))
+          (testing "after dropping the FK relationship, country's continent_id is targeting nothing"
+            (is (nil? (get-fk-target))))
+          #_(qp/process-query (mt/query continent_1))
+          #_(qp/process-query (mt/query continent_2))
+          #_(qp/process-query (mt/query country)))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #39687
Closes QUE-313


### Describe the bug

Currently if a foreign key relationship is dropped in the customer database, we don't pick it up on syncs after the initial sync.

The original foreign key relationship persists.

### Verification

The test creates a table with a foreign key, performs a sync, then it drops the fk constraint, then syncs again.
