### PR TITLE
Search Indexing Improvements

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
@@ -85,7 +85,7 @@
                             (-> (qp/process-query query) (dissoc :data))))))))))))))
 
 (deftest e2e-advanced-caching
-  (binding [search.ingestion/*force-sync* true]
+  (binding [search.ingestion/*disable-updates* true]
     (mt/with-empty-h2-app-db!
       (mt/with-premium-features #{:cache-granular-controls}
         (mt/dataset (mt/dataset-definition "caching1"

--- a/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
@@ -7,6 +7,7 @@
    [metabase.queries.models.query :as query]
    [metabase.query-processor :as qp]
    [metabase.query-processor.card :as qp.card]
+   [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]))
 
 (comment
@@ -84,97 +85,98 @@
                             (-> (qp/process-query query) (dissoc :data))))))))))))))
 
 (deftest e2e-advanced-caching
-  (mt/with-empty-h2-app-db!
-    (mt/with-premium-features #{:cache-granular-controls}
-      (mt/dataset (mt/dataset-definition "caching1"
-                                         [["table"
-                                           [{:field-name "value" :indexed? true :base-type :type/Text}]
-                                           [["a"] ["b"] ["c"]]]])
-        (mt/with-temp [:model/Card       card1 {:dataset_query (mt/mbql-query table)}
-                       :model/Card       card2 {:dataset_query (mt/mbql-query table)}
-                       :model/Card       card3 {:dataset_query (mt/mbql-query table)}
-                       :model/Card       card4 {:dataset_query (mt/mbql-query table)}
+  (binding [search.ingestion/*force-sync* true]
+    (mt/with-empty-h2-app-db!
+      (mt/with-premium-features #{:cache-granular-controls}
+        (mt/dataset (mt/dataset-definition "caching1"
+                                           [["table"
+                                             [{:field-name "value" :indexed? true :base-type :type/Text}]
+                                             [["a"] ["b"] ["c"]]]])
+          (mt/with-temp [:model/Card       card1 {:dataset_query (mt/mbql-query table)}
+                         :model/Card       card2 {:dataset_query (mt/mbql-query table)}
+                         :model/Card       card3 {:dataset_query (mt/mbql-query table)}
+                         :model/Card       card4 {:dataset_query (mt/mbql-query table)}
 
-                       :model/CacheConfig _cr {:model    "root"
-                                               :model_id 0
-                                               :strategy :ttl
-                                               :config   {:multiplier      200
-                                                          :min_duration_ms 10}}
-                       :model/CacheConfig _c1 {:model    "question"
-                                               :model_id (:id card1)
-                                               :strategy :ttl
-                                               :config   {:multiplier      100
-                                                          :min_duration_ms 0}}
-                       :model/CacheConfig _c2 {:model    "question"
-                                               :model_id (:id card2)
-                                               :strategy :duration
-                                               :config   {:duration 1
-                                                          :unit     "minutes"}}
-                       :model/CacheConfig _c3 {:model    "question"
-                                               :model_id (:id card3)
-                                               :strategy :schedule
-                                               :config   {:schedule "0 0/2 * * * ? *"}}]
-          (let [t     (fn [seconds]
-                        (t/plus #t "2024-02-13T10:00:00Z" (t/duration seconds :seconds)))
-                mkres (fn [input]
-                        {:cache/details (if input
-                                          {:cached true, :updated_at input, :hash some?}
-                                          {:stored true, :hash some?})
-                         :row_count     3
-                         :status        :completed})]
-            (testing "strategy = ttl"
-              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                (mt/with-clock (t 0)
-                  (let [q (with-redefs [query/average-execution-time-ms (constantly 1000)]
-                            (#'qp.card/query-for-card card1 [] {} {} {}))]
-                    (is (=? {:type :ttl :multiplier 100}
-                            (:cache-strategy q)))
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query q) (dissoc :data))))
-                    (testing "There is cache on second call"
-                      (is (=? (mkres (t 0))
-                              (-> (qp/process-query q) (dissoc :data)))))
-                    (testing "No cache after expiration"
-                      (mt/with-clock (t 101) ;; avg execution time 1s * multiplier 100 + 1
-                        (is (=? (mkres nil)
-                                (-> (qp/process-query q) (dissoc :data))))))))))
-
-            (testing "strategy = duration"
-              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                (mt/with-clock (t 0)
-                  (let [q (#'qp.card/query-for-card card2 [] {} {} {})]
-                    (is (=? {:type :duration}
-                            (:cache-strategy q)))
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query q) (dissoc :data))))
-                    (testing "There is cache on the next call"
-                      (is (=? (mkres (t 0))
-                              (-> (qp/process-query q) (dissoc :data)))))
-                    (testing "No cache after expiration"
-                      (mt/with-clock (t 61)
-                        (is (=? (mkres nil)
-                                (-> (qp/process-query q) (dissoc :data))))))))))
-
-            (testing "strategy = schedule"
-              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                (mt/with-clock (t 0)
-                  (is (pos? (:schedule-invalidated (#'task.cache/refresh-cache-configs!))))
-                  (let [q (#'qp.card/query-for-card card3 [] {} {} {})]
-                    (is (=? {:type :schedule}
-                            (:cache-strategy q)))
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query q) (dissoc :data))))
-                    (testing "There is cache on second call"
-                      (is (=? (mkres (t 0))
-                              (-> (qp/process-query q) (dissoc :data)))))))
-                (testing "No cache after job ran again"
-                  (mt/with-clock (t 121)
-                    (is (pos? (:schedule-invalidated (#'task.cache/refresh-cache-configs!))))
-                    (let [q (#'qp.card/query-for-card card3 {} {} {} {})]
+                         :model/CacheConfig _cr {:model    "root"
+                                                 :model_id 0
+                                                 :strategy :ttl
+                                                 :config   {:multiplier      200
+                                                            :min_duration_ms 10}}
+                         :model/CacheConfig _c1 {:model    "question"
+                                                 :model_id (:id card1)
+                                                 :strategy :ttl
+                                                 :config   {:multiplier      100
+                                                            :min_duration_ms 0}}
+                         :model/CacheConfig _c2 {:model    "question"
+                                                 :model_id (:id card2)
+                                                 :strategy :duration
+                                                 :config   {:duration 1
+                                                            :unit     "minutes"}}
+                         :model/CacheConfig _c3 {:model    "question"
+                                                 :model_id (:id card3)
+                                                 :strategy :schedule
+                                                 :config   {:schedule "0 0/2 * * * ? *"}}]
+            (let [t     (fn [seconds]
+                          (t/plus #t "2024-02-13T10:00:00Z" (t/duration seconds :seconds)))
+                  mkres (fn [input]
+                          {:cache/details (if input
+                                            {:cached true, :updated_at input, :hash some?}
+                                            {:stored true, :hash some?})
+                           :row_count     3
+                           :status        :completed})]
+              (testing "strategy = ttl"
+                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                  (mt/with-clock (t 0)
+                    (let [q (with-redefs [query/average-execution-time-ms (constantly 1000)]
+                              (#'qp.card/query-for-card card1 [] {} {} {}))]
+                      (is (=? {:type :ttl :multiplier 100}
+                              (:cache-strategy q)))
                       (is (=? (mkres nil)
-                              (-> (qp/process-query q) (dissoc :data)))))))))
+                              (-> (qp/process-query q) (dissoc :data))))
+                      (testing "There is cache on second call"
+                        (is (=? (mkres (t 0))
+                                (-> (qp/process-query q) (dissoc :data)))))
+                      (testing "No cache after expiration"
+                        (mt/with-clock (t 101) ;; avg execution time 1s * multiplier 100 + 1
+                          (is (=? (mkres nil)
+                                  (-> (qp/process-query q) (dissoc :data))))))))))
 
-            (testing "default strategy = ttl"
-              (let [q (#'qp.card/query-for-card card4 [] {} {} {})]
-                (is (=? {:type :ttl :multiplier 200}
-                        (:cache-strategy q)))))))))))
+              (testing "strategy = duration"
+                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                  (mt/with-clock (t 0)
+                    (let [q (#'qp.card/query-for-card card2 [] {} {} {})]
+                      (is (=? {:type :duration}
+                              (:cache-strategy q)))
+                      (is (=? (mkres nil)
+                              (-> (qp/process-query q) (dissoc :data))))
+                      (testing "There is cache on the next call"
+                        (is (=? (mkres (t 0))
+                                (-> (qp/process-query q) (dissoc :data)))))
+                      (testing "No cache after expiration"
+                        (mt/with-clock (t 61)
+                          (is (=? (mkres nil)
+                                  (-> (qp/process-query q) (dissoc :data))))))))))
+
+              (testing "strategy = schedule"
+                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                  (mt/with-clock (t 0)
+                    (is (pos? (:schedule-invalidated (#'task.cache/refresh-cache-configs!))))
+                    (let [q (#'qp.card/query-for-card card3 [] {} {} {})]
+                      (is (=? {:type :schedule}
+                              (:cache-strategy q)))
+                      (is (=? (mkres nil)
+                              (-> (qp/process-query q) (dissoc :data))))
+                      (testing "There is cache on second call"
+                        (is (=? (mkres (t 0))
+                                (-> (qp/process-query q) (dissoc :data)))))))
+                  (testing "No cache after job ran again"
+                    (mt/with-clock (t 121)
+                      (is (pos? (:schedule-invalidated (#'task.cache/refresh-cache-configs!))))
+                      (let [q (#'qp.card/query-for-card card3 {} {} {} {})]
+                        (is (=? (mkres nil)
+                                (-> (qp/process-query q) (dissoc :data)))))))))
+
+              (testing "default strategy = ttl"
+                (let [q (#'qp.card/query-for-card card4 [] {} {} {})]
+                  (is (=? {:type :ttl :multiplier 200}
+                          (:cache-strategy q))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
@@ -85,7 +85,7 @@
                             (-> (qp/process-query query) (dissoc :data))))))))))))))
 
 (deftest e2e-advanced-caching
-  (binding [search.ingestion/*disable-updates* true]
+  (binding [search.ingestion/*force-sync* true]
     (mt/with-empty-h2-app-db!
       (mt/with-premium-features #{:cache-granular-controls}
         (mt/dataset (mt/dataset-definition "caching1"

--- a/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
@@ -85,7 +85,8 @@
                             (-> (qp/process-query query) (dissoc :data))))))))))))))
 
 (deftest e2e-advanced-caching
-  (binding [search.ingestion/*force-sync* true]
+  (binding [search.ingestion/*force-sync* true
+            search.ingestion/*disable-updates* true]
     (mt/with-empty-h2-app-db!
       (mt/with-premium-features #{:cache-granular-controls}
         (mt/dataset (mt/dataset-definition "caching1"

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -168,12 +168,12 @@
   (let [index-created (search.index/when-index-created)]
     (if (and index-created (< 3 (t/time-between (t/instant index-created) (t/instant) :days)))
       (do
-        (log/debug "Forcing early reindex because existing index is old")
+        (log/info "Forcing early reindex because existing index is old")
         (search.engine/reindex! :search.engine/appdb {}))
 
       (let [created? (search.index/ensure-ready! opts)]
         (when (or created? re-populate?)
-          (log/debug "Populating index")
+          (log/info "Populating index")
           (populate-index! :search/updating))))))
 
 (defmethod search.engine/reindex! :search.engine/appdb

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -174,7 +174,7 @@
       (let [created? (search.index/ensure-ready! opts)]
         (when (or created? re-populate?)
           (log/info "Populating index")
-          (populate-index! :search/updating))))))
+          (populate-index! (if created? :search/reindexing :search/updating)))))))
 
 (defmethod search.engine/reindex! :search.engine/appdb
   [_ {:keys [in-place?]}]

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -276,7 +276,7 @@
   (let [active-table (active-table)
         entries (map document->entry documents)
         ;; No need to update the active index if we are doing a full index and it will be swapped out soon. Most updates are no-ops anyway.
-        active-updated? (when-not (and active-table (= context :search/reindexing)) (safe-batch-upsert! active-table entries))
+        active-updated? (when-not (and active-table (pending-table) (= context :search/reindexing)) (safe-batch-upsert! active-table entries))
         pending-updated? (safe-batch-upsert! (pending-table) entries)]
     (when (or active-updated? pending-updated?)
       (u/prog1 (->> entries (map :model) frequencies)

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -290,11 +290,14 @@
    Context should be :search/updating or :search/reindexing to help control how to manage the updates"
   [context document-reducible]
   ;; New connection used for performing the updates which commit periodically without impacting any outer transactions.
-  (t2/with-connection [_conn (if search.ingestion/*force-sync* nil (mdb/data-source))]
-    (transduce (comp (partition-all insert-batch-size)
-                     (map (partial batch-update! context)))
-               (partial merge-with +)
-               document-reducible)))
+  (letfn [(do-index []
+            (transduce (comp (partition-all insert-batch-size)
+                             (map (partial batch-update! context)))
+                       (partial merge-with +)
+                       document-reducible))]
+    (if search.ingestion/*force-sync*
+      (do-index)
+      (t2/with-connection [_conn (mdb/data-source)] (do-index)))))
 
 (defmethod search.engine/update! :search.engine/appdb [_engine document-reducible]
   (index-docs! :search/updating document-reducible))

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -296,7 +296,7 @@
                              (map (partial batch-update! context)))
                        (partial merge-with +)
                        document-reducible))]
-    (if (or true search.ingestion/*force-sync*)
+    (if search.ingestion/*force-sync*
       (do-index)
       (t2/with-connection [_conn (mdb/data-source)] (do-index)))))
 

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -289,11 +289,11 @@
    Context should be :search/updating or :search/reindexing to help control how to manage the updates"
   [context document-reducible]
   ;; New connection used for performing the updates which commit periodically without impacting any outer transactions.
-  (t2/with-connection [_conn (.getConnection (mdb/data-source))]
-    (transduce (comp (partition-all insert-batch-size)
-                     (map (partial batch-update! context)))
-               (partial merge-with +)
-               document-reducible)))
+  ;(t2/with-connection [_conn (.getConnection (mdb/data-source))]
+  (transduce (comp (partition-all insert-batch-size)
+                   (map (partial batch-update! context)))
+             (partial merge-with +)
+             document-reducible));)
 
 (defmethod search.engine/update! :search.engine/appdb [_engine document-reducible]
   (index-docs! :search/updating document-reducible))

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -280,7 +280,7 @@
         pending-updated? (safe-batch-upsert! (pending-table) entries)]
     (when (or active-updated? pending-updated?)
       (u/prog1 (->> entries (map :model) frequencies)
-        (when (and false (not search.ingestion/*force-sync*))
+        (when (not search.ingestion/*force-sync*)
           (t2/query ["commit"]))
         (log/trace "indexed documents for " <>)
         (when active-updated?

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -11,6 +11,7 @@
    [metabase.search.appdb.specialization.postgres :as postgres]
    [metabase.search.config :as search.config]
    [metabase.search.engine :as search.engine]
+   [metabase.search.ingestion :as search.ingestion]
    [metabase.search.models.search-index-metadata :as search-index-metadata]
    [metabase.search.spec :as search.spec]
    [metabase.util :as u]
@@ -289,11 +290,11 @@
    Context should be :search/updating or :search/reindexing to help control how to manage the updates"
   [context document-reducible]
   ;; New connection used for performing the updates which commit periodically without impacting any outer transactions.
-  ;(t2/with-connection [_conn (.getConnection (mdb/data-source))]
-  (transduce (comp (partition-all insert-batch-size)
-                   (map (partial batch-update! context)))
-             (partial merge-with +)
-             document-reducible));)
+  (t2/with-connection [_conn (if search.ingestion/*force-sync* nil (mdb/data-source))]
+    (transduce (comp (partition-all insert-batch-size)
+                     (map (partial batch-update! context)))
+               (partial merge-with +)
+               document-reducible)))
 
 (defmethod search.engine/update! :search.engine/appdb [_engine document-reducible]
   (index-docs! :search/updating document-reducible))

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -280,7 +280,7 @@
         pending-updated? (safe-batch-upsert! (pending-table) entries)]
     (when (or active-updated? pending-updated?)
       (u/prog1 (->> entries (map :model) frequencies)
-        (when (or false (not search.ingestion/*force-sync*))
+        (when (and false (not search.ingestion/*force-sync*))
           (t2/query ["commit"]))
         (log/trace "indexed documents for " <>)
         (when active-updated?

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -295,7 +295,7 @@
                              (map (partial batch-update! context)))
                        (partial merge-with +)
                        document-reducible))]
-    (if search.ingestion/*force-sync*
+    (if (or true search.ingestion/*force-sync*)
       (do-index)
       (t2/with-connection [_conn (mdb/data-source)] (do-index)))))
 

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -261,7 +261,7 @@
 
 (defn- batch-update!
   "Create the given search index entries in bulk. Commits after each batch"
-  [context separate-connection? documents]
+  [context documents]
   ;; Protect against tests that nuke the appdb
   (when config/is-test?
     (when-let [table (active-table)]

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -12,9 +12,12 @@
    [toucan2.tools.transformed :as t2.transformed]))
 
 (def search-models
-  "Set of search model string names."
-  (cond->  #{"dashboard" "table" "dataset" "segment" "collection" "database" "action" "indexed-entity" "metric" "card"}
-    config/ee-available? (conj "document")))
+  "Set of search model string names. Sorted by order to index based on importance and amount of time to index"
+  (cond->  ["collection" "dashboard" "segment" "database" "action"]
+    config/ee-available? (conj "document")
+    ;; metric/card/dataset moved to the end because they take a long time due to computing has_temporal_dim etc.
+    ;; table and indexed-entity moved to the end because there can be a large number of them
+    true (conj "table" "indexed-entity" "metric" "card" "dataset")))
 
 (def ^:private search-model->toucan-model
   (into {}

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -493,7 +493,7 @@
                                                          :state      "initial"
                                                          :creator_id (mt/user->id :rasta)}]
       (model-index/add-values! model-index)
-      (is (= "indexed-entity" (last (into [] (map :model) (search.ingestion/searchable-documents))))))))
+      (is (= "dataset" (last (into [] (map :model) (search.ingestion/searchable-documents))))))))
 
 (deftest ^:synchronized table-cleanup-test
   (when (search/supports-index?)

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -26,7 +26,6 @@
    [metabase.premium-features.test-util :as premium-features.test-util]
    [metabase.query-processor.util :as qp.util]
    [metabase.search.core :as search]
-   [metabase.search.ingestion :as search.ingestion]
    [metabase.settings.core :as setting]
    [metabase.settings.models.setting]
    [metabase.settings.models.setting.cache :as setting.cache]
@@ -835,8 +834,7 @@
            {:delete-from (t2/table-name model)
             :where [:and max-id-condition additional-conditions]}))
         ;; TODO we don't (currently) have index update hooks on deletes, so we need this to ensure rollback happens.
-        (when-not search.ingestion/*disable-updates*
-          (search/reindex! {:in-place? true :async? false}))))))
+        (search/reindex! {:in-place? true :async? false})))))
 
 (defmacro with-model-cleanup
   "Execute `body`, then delete any *new* rows created for each model in `models`. Calls `delete!`, so if the model has

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -26,6 +26,7 @@
    [metabase.premium-features.test-util :as premium-features.test-util]
    [metabase.query-processor.util :as qp.util]
    [metabase.search.core :as search]
+   [metabase.search.ingestion :as search.ingestion]
    [metabase.settings.core :as setting]
    [metabase.settings.models.setting]
    [metabase.settings.models.setting.cache :as setting.cache]
@@ -834,7 +835,8 @@
            {:delete-from (t2/table-name model)
             :where [:and max-id-condition additional-conditions]}))
         ;; TODO we don't (currently) have index update hooks on deletes, so we need this to ensure rollback happens.
-        (search/reindex! {:in-place? true :async? false})))))
+        (when-not search.ingestion/*disable-updates*
+          (search/reindex! {:in-place? true :async? false}))))))
 
 (defmacro with-model-cleanup
   "Execute `body`, then delete any *new* rows created for each model in `models`. Calls `delete!`, so if the model has


### PR DESCRIPTION
### Description

For large instances, the initial indexing can take enough time that it's noticeable to users when search results are not yet available.

This PR improves it in 3 ways:
1. Use an independent "search index version" that is independent of the metabase version, which avoids a full rebuild with on startup each time a new metabase version is deployed
2. When a new index version is required, make what has been indexed so far available for search. It's better to have a subset of search results than no search results
3. Sort the types of values to index so most important types are indexed first, and the least important and/or longest to index items are last

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
