### PR TITLE
BOT-310 lower the weight on the :rrf score for semantic search results

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -15,6 +15,7 @@
    [metabase-enterprise.semantic-search.indexer :as semantic.indexer]
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.util :as semantic.util]
+   [metabase.search.config :as search.config]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -81,6 +82,18 @@
   "Drop, create database dbname on pgvector and redefine datasource accordingly. Not thread safe."
   [db-name & body]
   `(do-with-test-db! ~db-name (fn [] ~@body)))
+
+(defmacro with-weights
+  "Execute `body` overriding search weights with `weight-map`."
+  [weight-map & body]
+  `(mt/with-dynamic-fn-redefs [search.config/weights (constantly ~weight-map)]
+     ~@body))
+
+(defmacro with-only-semantic-weights
+  "Execute `body` with only the semantic search hybrid scorer weights active."
+  [& body]
+  `(with-weights {:rrf 1}
+     ~@body))
 
 (def ^:private init-delay
   (delay

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -94,8 +94,8 @@
     :mine                1
     :exact               5
     :prefix              0
-    ;; TODO figure out a better way to blend these scorers with wildly different scale.
-    :rrf                 5000}
+    ;; RRF is the "Reciprocal Rank Fusion" score used by the semantic search backend to blend semantic and keyword scores
+    :rrf                 500}
    :command-palette
    {:prefix               5
     :model/collection     1


### PR DESCRIPTION
Closes BOT-310

### Description

* Lower the weight on the `:rrf` score for semantic search results

Stats has been running with these weights via an env var override for ~ a week, and this seems to give a better blend between the `:rrf` score coming from the semantic search hybrid query and the other post-search metadata scorers.

* Add `with-weights` and `with-only-semantic-weights` test util macros

* Use `semantic.tu/with-weights` in scoring tests

* Update query tests to use `semantic.tu/with-only-semantic-weights`

This prevents other metadata scorers from overriding the expected rankings for these tests. The query tests are
largely focused on making sure the basic machinery of semantic queries and text and embedding vectors are working. Tests exercising individual scorers are in scoring_test.clj

* Add tests for `:official_collection` and `:verified` "premium" scorers

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
