### PR TITLE
fix: selected table cell background color

### DIFF
--- a/frontend/src/metabase/data-grid/components/BaseCell/BaseCell.tsx
+++ b/frontend/src/metabase/data-grid/components/BaseCell/BaseCell.tsx
@@ -28,9 +28,9 @@ export const BaseCell = memo(function BaseCell({
   const cellStyle = useMemo(() => {
     if (isSelected) {
       return {
-        "--cell-bg-color": `color-mix(in srgb, var(--mb-color-brand), white 90%)`,
+        "--cell-bg-color": `color-mix(in srgb, var(--mb-color-brand), transparent 90%)`,
         "--cell-hover-bg-color": hasHover
-          ? `color-mix(in srgb, var(--mb-color-brand), white 80%)`
+          ? `color-mix(in srgb, var(--mb-color-brand), transparent 80%)`
           : undefined,
       } as React.CSSProperties;
     }


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

Closes https://github.com/metabase/metabase/issues/63108

### Description

Use `transparent` instead of `white` for the `color-mix()` of selected cell background, so that the white don't interfere with the text color when the cell is selected in dark mode.

### How to verify

Click on any table cell in a night theme static embed, the cell is now highlighted with light brand color as its background.
