### PR TITLE
fix(embed-js): disable the next button when embedded js is disabled

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetup.tsx
@@ -63,7 +63,11 @@ const SdkIframeEmbedSetupContent = () => {
       </Button>
     ))
     .otherwise(() => (
-      <Button variant="filled" onClick={handleNext}>
+      <Button
+        variant="filled"
+        onClick={handleNext}
+        disabled={!isSimpleEmbeddingEnabled}
+      >
         {t`Next`}
       </Button>
     ));

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/tests/SdkIframeEmbedSetup-embedding-hub.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/tests/SdkIframeEmbedSetup-embedding-hub.unit.spec.tsx
@@ -21,7 +21,10 @@ describe("Embed flow > embedding hub step completion tracking", () => {
     "updates setting on $trigger with $authMethod",
     async ({ authMethod, trigger }) => {
       mockLocation(`auth_method=${authMethod}`);
-      setup({ jwtReady: authMethod === "sso" });
+      setup({
+        jwtReady: authMethod === "sso",
+        simpleEmbeddingEnabled: true,
+      });
 
       await userEvent.click(screen.getByRole("button", { name: "Next" }));
       await userEvent.click(screen.getByRole("button", { name: "Next" }));

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -87,4 +87,11 @@ describe("Embed flow > forward and backward navigation", () => {
       screen.queryByText("Select a dashboard to embed"),
     ).not.toBeInTheDocument();
   });
+
+  it("disables next and back buttons when simple embedding is disabled", () => {
+    setup({ simpleEmbeddingEnabled: false });
+
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/tests/test-setup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/tests/test-setup.tsx
@@ -41,3 +41,15 @@ export async function waitForPutRequests() {
     return puts;
   });
 }
+
+export async function waitForUpdateSetting(settingKey: string, value: any) {
+  return waitFor(async () => {
+    const puts = await findRequests("PUT");
+
+    return puts.find(
+      (request) =>
+        request.url.includes("/api/setting") &&
+        request.body[settingKey] === value,
+    );
+  });
+}

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubAccordion.module.css
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubAccordion.module.css
@@ -21,7 +21,7 @@
 .control:not([data-css-specificity-hack="🪗"]) {
   background: linear-gradient(
     to right,
-    var(--mb-base-color-blue-10) 3rem,
+    var(--mb-color-brand-lighter) 3rem,
     transparent 3rem
   );
   border: 1px solid var(--mb-color-border);
@@ -33,8 +33,8 @@
   &:hover {
     background: linear-gradient(
       to right,
-      var(--mb-base-color-brand-20) 3rem,
-      var(--mb-base-color-brand-10) 3rem
+      var(--mb-color-brand-light) 3rem,
+      var(--mb-color-brand-lighter) 3rem
     );
     color: var(--mb-color-brand);
   }
@@ -50,7 +50,7 @@
       background: linear-gradient(
         to right,
         var(--mb-color-brand) 3rem,
-        var(--mb-base-color-brand-10) 3rem
+        var(--mb-color-brand-lighter) 3rem
       );
 
       .label,
@@ -80,7 +80,7 @@
   width: 3rem;
 
   [data-active="true"] & {
-    color: var(--mb-base-color-white);
+    color: var(--mb-color-text-white);
   }
 }
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubChecklist.module.css
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubChecklist/EmbeddingHubChecklist.module.css
@@ -2,7 +2,7 @@
 .completedControl:not([data-css-specificity-hack="🪗"]) {
   background: linear-gradient(
     to right,
-    var(--mb-base-color-palm-10) 3rem,
+    color-mix(in srgb, var(--mb-color-success) 15%, white) 3rem,
     transparent 3rem
   ) !important;
 }


### PR DESCRIPTION
Disables the Next button when Embedded Analytics JS is disabled. Otherwise, you can bypass the first step.

## How to verify

- Disable Embedded Analytics JS in admin panel
- Go to Embed Flow (+ New > Embed)
- The "Next" button should be disabled