### PR TITLE
Add section about new connection string at top of db settings

### DIFF
--- a/docs/databases/connections/athena.md
+++ b/docs/databases/connections/athena.md
@@ -16,6 +16,10 @@ Here you can [sync the database schema and rescan field values](../sync-scan.md)
 
 You can edit these settings at any time (and remember to save your changes).
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/bigquery.md
+++ b/docs/databases/connections/bigquery.md
@@ -44,6 +44,10 @@ Here you can [sync the database schema and rescan field values](../sync-scan.md)
 
 You can edit these settings at any time. Just remember to save your changes.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/clickhouse.md
+++ b/docs/databases/connections/clickhouse.md
@@ -19,6 +19,10 @@ Here you can [sync the database schema and rescan field values](../sync-scan.md)
 
 To access or modify your database connection settings, click the **Edit connection details** button.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/databricks.md
+++ b/docs/databases/connections/databricks.md
@@ -10,6 +10,10 @@ You can edit these settings at any time. Just remember to save your changes.
 
 ## Edit connection details
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/druid.md
+++ b/docs/databases/connections/druid.md
@@ -12,6 +12,10 @@ To add a database connection, click on the **gear** icon in the top right, and n
 
 Fill out the fields for that database, and click **Save changes** at the bottom. You can edit these settings at any time. Just remember to save your changes.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/mariadb.md
+++ b/docs/databases/connections/mariadb.md
@@ -18,6 +18,10 @@ Metabase supports the oldest supported version of Maria DB through the latest st
 
 You can edit these settings at any time. Just remember to save your changes.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/mysql.md
+++ b/docs/databases/connections/mysql.md
@@ -18,6 +18,10 @@ Metabase supports the oldest supported version through the latest stable version
 
 You can edit these settings at any time. Just remember to save your changes.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/oracle.md
+++ b/docs/databases/connections/oracle.md
@@ -16,6 +16,10 @@ Metabase supports the oldest supported version through the latest stable version
 
 You can edit these settings at any time. Just remember to save your changes.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/postgresql.md
+++ b/docs/databases/connections/postgresql.md
@@ -30,6 +30,10 @@ Here you can [sync the database schema and rescan field values](../sync-scan.md)
 
 You can edit these settings at any time. Just remember to save your changes.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/presto.md
+++ b/docs/databases/connections/presto.md
@@ -12,6 +12,10 @@ Fill out the fields for that database, and click **Save changes** at the bottom.
 
 You can edit these settings at any time. Just remember to save your changes.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/redshift.md
+++ b/docs/databases/connections/redshift.md
@@ -19,6 +19,10 @@ Here you can [sync the database schema and rescan field values](../sync-scan.md)
 
 To access or modify your database connection settings, click the **Edit connection details** button.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/snowflake.md
+++ b/docs/databases/connections/snowflake.md
@@ -10,6 +10,10 @@ To add a database connection, click on the **gear** icon in the top right, and n
 
 You can edit these settings at any time. Just remember to save your changes.
 
+## Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ## Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/sparksql.md
+++ b/docs/databases/connections/sparksql.md
@@ -10,6 +10,10 @@ To add a database connection, click on the **gear** icon in the top right, and n
 
 You can edit these settings at any time. Just remember to save your changes.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/sql-server.md
+++ b/docs/databases/connections/sql-server.md
@@ -14,6 +14,10 @@ Metabase supports the oldest supported version of SQL Server through the latest 
 
 You can edit these settings at any time. Just remember to save your changes.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/sqlite.md
+++ b/docs/databases/connections/sqlite.md
@@ -14,6 +14,10 @@ Fill out the fields for that database, and click **Save changes** at the bottom.
 
 You can edit these settings at any time. Just remember to save your changes.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.

--- a/docs/databases/connections/starburst.md
+++ b/docs/databases/connections/starburst.md
@@ -21,6 +21,10 @@ Here you can [sync the database schema and rescan field values](../sync-scan.md)
 
 To access or modify your database connection settings, click the **Edit connection details** button.
 
+### Connection string
+
+Paste a connection string here to pre-fill the remaining fields below.
+
 ### Display name
 
 The display name for the database in the Metabase interface.


### PR DESCRIPTION
Adds a section explaining the new connection string at the top of DB settings to all DBs (except MongoDB, which already had it).