### PR TITLE
Closes EMB-780 selected cell color in embedding dark mode

### DIFF
--- a/frontend/src/metabase/data-grid/components/BaseCell/BaseCell.tsx
+++ b/frontend/src/metabase/data-grid/components/BaseCell/BaseCell.tsx
@@ -28,9 +28,9 @@ export const BaseCell = memo(function BaseCell({
   const cellStyle = useMemo(() => {
     if (isSelected) {
       return {
-        "--cell-bg-color": `color-mix(in srgb, var(--mb-color-brand), white 90%)`,
+        "--cell-bg-color": `color-mix(in srgb, var(--mb-color-brand), transparent 80%)`,
         "--cell-hover-bg-color": hasHover
-          ? `color-mix(in srgb, var(--mb-color-brand), white 80%)`
+          ? `color-mix(in srgb, var(--mb-color-brand), transparent 80%)`
           : undefined,
       } as React.CSSProperties;
     }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63108
Closes [EMB-780: Selected Table Cell unreadable in dark mode](https://linear.app/metabase/issue/EMB-780/selected-table-cell-unreadable-in-dark-mode)

### Description

Updates the hovered/selected color for table cell so it looks good in dark mode too. Thanks @yeeharn!

### How to verify

 1. Make a new dashboard with a table
 2. Publish it as static, and set "dark mode" on in the Look and Feel tab
 3. Open the embedded dashboard
 4. Hover/select a cell

### Demo

Light mode:
<img width="1712" height="746" alt="SCR-20250905-lxgl-2" src="https://github.com/user-attachments/assets/00ee6845-8001-4950-9923-d459131e2095" />


Dark mode:
<img width="1712" height="746" alt="SCR-20250905-lxly-2" src="https://github.com/user-attachments/assets/b0bd970a-a868-4963-892d-c9ecd4979845" />
