### PR TITLE
Better test isolation for semantic search and related refactor

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
@@ -12,16 +12,10 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]))
 
-(defmacro with-mock-index-metadata!
-  [& body]
-  `(with-redefs [semantic.embedding/get-configured-model (constantly semantic.tu/mock-embedding-model)
-                 semantic.env/get-index-metadata (constantly semantic.tu/mock-index-metadata)]
-     ~@body))
-
 (deftest status-endpoint-test
   (testing "GET /api/ee/semantic-search/status"
     (mt/with-premium-features #{:semantic-search}
-      (with-mock-index-metadata!
+      (semantic.tu/with-test-db! {:mode :mock-initialized}
         (with-open [index-ref (semantic.tu/open-temp-index!)]
           (with-redefs [semantic.index-metadata/get-active-index-state (fn [_ _]
                                                                          {:index @index-ref

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.core.memoize :as memoize]
    [clojure.test :refer :all]
    [metabase-enterprise.semantic-search.api :as semantic.api]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
@@ -10,14 +10,7 @@
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.search.ingestion :as search.ingestion]
-   [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]))
-
-;; TODO: This ns' test seem not to run from cli. Figure out why!
-
-(use-fixtures :once (compose-fixtures
-                     (fixtures/initialize :db)
-                     #'semantic.tu/once-fixture))
+   [metabase.test :as mt]))
 
 (defmacro with-mock-index-metadata!
   [& body]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
@@ -65,7 +65,7 @@
 (deftest re-init-endpoint-test
   (testing "POST /api/search/re-init with semantic search support"
     (mt/with-premium-features #{:semantic-search}
-      (semantic.tu/with-index!
+      (semantic.tu/with-test-db! {:mode :mock-indexed}
         (let [original-index      semantic.tu/mock-index
               original-table-name (:table-name original-index)
               new-index           (with-redefs [semantic.index/model-table-suffix (constantly 345)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/api_test.clj
@@ -3,14 +3,14 @@
    [clojure.core.memoize :as memoize]
    [clojure.test :refer :all]
    [metabase-enterprise.semantic-search.api :as semantic.api]
-   [metabase-enterprise.semantic-search.embedding :as semantic.embedding]
-   [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]))
+
+(use-fixtures :once #'semantic.tu/once-fixture)
 
 (deftest status-endpoint-test
   (testing "GET /api/ee/semantic-search/status"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.semantic-search.core :as semantic.core]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.app-db.core :as mdb]
@@ -21,7 +22,8 @@
   (mt/with-premium-features #{:semantic-search}
     (mt/with-temporary-setting-values [search.settings/search-engine "semantic"]
       (with-open [_ (semantic.tu/open-temp-index!)]
-        (semantic.tu/cleanup-index-metadata! semantic.tu/db semantic.tu/mock-index-metadata)
+        (semantic.tu/cleanup-index-metadata! (semantic.env/get-pgvector-datasource!)
+                                             semantic.tu/mock-index-metadata)
         (semantic.tu/with-index!
           (is (search.engine/supported-engine? (if (= :mysql (mdb/db-type))
                                                  ;; appdb is not supported on :mysql, should fallback to in-place

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -11,12 +11,7 @@
    [metabase.search.in-place.legacy :as in-place.legacy]
    [metabase.search.in-place.scoring :as in-place.scoring]
    [metabase.search.settings :as search.settings]
-   [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]))
-
-(use-fixtures :once (compose-fixtures
-                     (fixtures/initialize :db)
-                     #'semantic.tu/once-fixture))
+   [metabase.test :as mt]))
 
 (deftest fallback-engine-available-with-semantic-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -13,6 +13,8 @@
    [metabase.search.settings :as search.settings]
    [metabase.test :as mt]))
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 (deftest fallback-engine-available-with-semantic-test
   (mt/with-premium-features #{:semantic-search}
     (mt/with-temporary-setting-values [search.settings/search-engine "semantic"]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/core_test.clj
@@ -19,7 +19,7 @@
       (with-open [_ (semantic.tu/open-temp-index!)]
         (semantic.tu/cleanup-index-metadata! (semantic.env/get-pgvector-datasource!)
                                              semantic.tu/mock-index-metadata)
-        (semantic.tu/with-index!
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
           (is (search.engine/supported-engine? (if (= :mysql (mdb/db-type))
                                                  ;; appdb is not supported on :mysql, should fallback to in-place
                                                  :search.engine/in-place

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/dlq_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/dlq_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [honey.sql :as sql]
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.gate :as semantic.gate]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
@@ -46,7 +47,7 @@
 
 (deftest dlq-table-creation-test
   (testing "DLQ table creation and existence checks"
-    (let [pgvector       semantic.tu/db
+    (let [pgvector       (semantic.env/get-pgvector-datasource!)
           index-metadata (semantic.tu/unique-index-metadata)
           index-id       42]
       (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)]
@@ -58,7 +59,7 @@
 
 (deftest dlq-entry-management-test
   (testing "DLQ entry add, query, and delete operations"
-    (let [pgvector       semantic.tu/db
+    (let [pgvector       (semantic.env/get-pgvector-datasource!)
           index-metadata (semantic.tu/unique-index-metadata)
           index-id       42]
       (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)
@@ -97,7 +98,7 @@
 
 (deftest dlq-entry-upsert-test
   (testing "DLQ entry upsert behavior on conflict"
-    (let [pgvector       semantic.tu/db
+    (let [pgvector       (semantic.env/get-pgvector-datasource!)
           index-metadata (semantic.tu/unique-index-metadata)
           index-id       42]
       (with-open [_ (semantic.tu/open-metadata! pgvector index-metadata)
@@ -129,7 +130,7 @@
             (is (= t2 (:error_gated_at (first results))))))))))
 
 (deftest dlq-poll-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         model          semantic.tu/mock-embedding-model
         index          (semantic.index-metadata/qualify-index (semantic.index/default-index model) index-metadata)
@@ -194,7 +195,7 @@
           (is (= 3 (count (semantic.dlq/poll pgvector index-metadata @index-id-ref 10)))))))))
 
 (deftest dlq-retry-loop-test
-  (let [pgvector         semantic.tu/db
+  (let [pgvector         (semantic.env/get-pgvector-datasource!)
         index-metadata   (semantic.tu/unique-index-metadata)
         model            semantic.tu/mock-embedding-model
         index            (semantic.index-metadata/qualify-index (semantic.index/default-index model) index-metadata)
@@ -296,7 +297,7 @@
                 (is (pos? (:failure-count result)))))))))))
 
 (deftest try-batch-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         model          semantic.tu/mock-embedding-model
         index          (semantic.index-metadata/qualify-index (semantic.index/default-index model) index-metadata)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/dlq_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/dlq_test.clj
@@ -19,8 +19,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :once #'semantic.tu/once-fixture)
-
 (defn- open-dlq! ^Closeable [pgvector index-metadata index-id]
   (semantic.tu/closeable
    (semantic.dlq/create-dlq-table-if-not-exists! pgvector index-metadata index-id)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/dlq_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/dlq_test.clj
@@ -19,6 +19,8 @@
 
 (set! *warn-on-reflection* true)
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 (defn- open-dlq! ^Closeable [pgvector index-metadata index-id]
   (semantic.tu/closeable
    (semantic.dlq/create-dlq-table-if-not-exists! pgvector index-metadata index-id)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/gate_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/gate_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [honey.sql :as sql]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.gate :as semantic.gate]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
@@ -89,7 +90,7 @@
   (:ts (jdbc/execute-one! pgvector ["select clock_timestamp() ts"])))
 
 (deftest gate-documents!-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         t0             (ts "2025-01-01T00:00:00Z")
         t1             (ts "2025-01-01T00:01:00Z")
@@ -168,7 +169,7 @@
                (comparable-gate-row (dissoc (get-gate-row! pgvector index-metadata (:id (version c3 t3))) :gated_at))))))))
 
 (deftest poll-test
-  (let [pgvector        semantic.tu/db
+  (let [pgvector        (semantic.env/get-pgvector-datasource!)
         index-metadata  (semantic.tu/unique-index-metadata)
         epoch-watermark {:last-poll Instant/EPOCH :last-seen Instant/EPOCH}
         c1              {:model "card" :id "123" :searchable_text "a"}
@@ -275,7 +276,7 @@
              (:last-seen watermark))))))
 
 (deftest flush-watermark!-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         model1         {:provider "foo" :model-name "m1" :vector-dimensions 42}
         model2         {:provider "foo" :model-name "m2" :vector-dimensions 42}
@@ -330,7 +331,7 @@
 
 (deftest gate-documents-metrics-test
   (mt/with-prometheus-system! [_ system]
-    (let [pgvector       semantic.tu/db
+    (let [pgvector       (semantic.env/get-pgvector-datasource!)
           index-metadata (semantic.tu/unique-index-metadata)
           t1             (ts "2025-01-01T00:01:00Z")
           c1             {:model "card" :id "123" :searchable_text "Dog Training Guide"}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/gate_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/gate_test.clj
@@ -21,6 +21,8 @@
 
 (set! *warn-on-reflection* true)
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 (defn- open-tables! ^Closeable [pgvector index-metadata]
   (semantic.tu/closeable
    (semantic.index-metadata/create-tables-if-not-exists! pgvector index-metadata)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/gate_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/gate_test.clj
@@ -21,8 +21,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :once #'semantic.tu/once-fixture)
-
 (defn- open-tables! ^Closeable [pgvector index-metadata]
   (semantic.tu/closeable
    (semantic.index-metadata/create-tables-if-not-exists! pgvector index-metadata)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.semantic-search.index-metadata-test
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
@@ -23,7 +24,7 @@
                                             semantic.index/hnsw-index-name)))))))
 
 (deftest create-tables-if-not-exists!-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         ;; could use open-tables here but I chose to be explicit
         sut            #(semantic.tu/closeable
@@ -46,7 +47,7 @@
    (fn [_] (semantic.tu/cleanup-index-metadata! pgvector index-metadata))))
 
 (deftest drop-tables-if-exists!-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         sut            semantic.index-metadata/drop-tables-if-exists!]
     (with-open [_ (open-tables! pgvector index-metadata)]
@@ -59,7 +60,7 @@
         (is (= now-expected (semantic.tu/get-table-names pgvector)))))))
 
 (deftest ensure-control-row-exists!-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         sut            semantic.index-metadata/ensure-control-row-exists!]
     (with-open [_ (open-tables! pgvector index-metadata)]
@@ -74,7 +75,7 @@
           (is (= control-snap (semantic.tu/get-control-rows pgvector index-metadata))))))))
 
 (deftest activate-index!-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         un-index       (semantic.index/default-index semantic.tu/mock-embedding-model)
         index1         (semantic.index-metadata/qualify-index (assoc un-index :table-name "i1") index-metadata)
@@ -98,7 +99,7 @@
             (is (=? [{:active_id index-id2}] (semantic.tu/get-control-rows pgvector index-metadata)))))))))
 
 (deftest get-active-index-state-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         un-index       (semantic.index/default-index semantic.tu/mock-embedding-model)
         index          (semantic.index-metadata/qualify-index un-index index-metadata)
@@ -134,7 +135,7 @@
   (run! #(add-index! pgvector index-metadata %) inactive))
 
 (deftest find-compatible-index!-test
-  (let [pgvector         semantic.tu/db
+  (let [pgvector         (semantic.env/get-pgvector-datasource!)
         embedding-model1 semantic.tu/mock-embedding-model
         embedding-model2 (assoc semantic.tu/mock-embedding-model
                                 :model-name "mock2")
@@ -190,7 +191,7 @@
                   (is (nil? (sut' model))))))))))))
 
 (deftest create-new-index-spec-test
-  (let [pgvector         semantic.tu/db
+  (let [pgvector         (semantic.env/get-pgvector-datasource!)
         index-metadata   (semantic.tu/unique-index-metadata)
         embedding-model  semantic.tu/mock-embedding-model
         sut              semantic.index-metadata/create-new-index-spec]
@@ -202,7 +203,7 @@
                 result))))))
 
 (deftest record-new-index-table!-test
-  (let [pgvector        semantic.tu/db
+  (let [pgvector        (semantic.env/get-pgvector-datasource!)
         index-metadata  (semantic.tu/unique-index-metadata)
         embedding-model semantic.tu/mock-embedding-model
         index           (default-index embedding-model index-metadata)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
@@ -8,8 +8,6 @@
    [metabase.test :as mt]
    [metabase.util :as u]))
 
-(use-fixtures :once #'semantic.tu/once-fixture)
-
 ;; NOTE: isolation tests are absent, in prod there is only one index-metadata
 
 (deftest qualify-index-test

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
@@ -8,6 +8,8 @@
    [metabase.test :as mt]
    [metabase.util :as u]))
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 ;; NOTE: isolation tests are absent, in prod there is only one index-metadata
 
 (deftest qualify-index-test

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -13,6 +13,8 @@
    [metabase.test :as mt]
    [metabase.util :as u]))
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 (deftest create-index-table!-test
   (mt/with-premium-features #{:semantic-search}
     (with-open [index-ref (semantic.tu/open-temp-index!)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -13,8 +13,6 @@
    [metabase.test :as mt]
    [metabase.util :as u]))
 
-(use-fixtures :once #'semantic.tu/once-fixture)
-
 (deftest create-index-table!-test
   (mt/with-premium-features #{:semantic-search}
     (with-open [index-ref (semantic.tu/open-temp-index!)]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/indexer_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/indexer_test.clj
@@ -20,8 +20,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :once #'semantic.tu/once-fixture)
-
 (defn- get-metadata-row! [pgvector index-metadata index]
   (jdbc/execute-one! pgvector
                      (sql/format {:select [:*]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/indexer_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/indexer_test.clj
@@ -20,6 +20,8 @@
 
 (set! *warn-on-reflection* true)
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 (defn- get-metadata-row! [pgvector index-metadata index]
   (jdbc/execute-one! pgvector
                      (sql/format {:select [:*]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
@@ -21,7 +21,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :once #'semantic.tu/once-fixture)
 (use-fixtures :each #'semantic.tu/ensure-no-migration-table-fixture)
 
 (deftest migration-table-versions-test

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
@@ -25,7 +25,7 @@
 
 (deftest migration-table-versions-test
   (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-test-db! semantic.tu/default-test-db
+    (semantic.tu/with-test-db-defaults!
       (letfn [(migrate-and-get-db-version
                 [attempted-version]
                 (with-redefs [semantic.db.migration.impl/schema-version attempted-version
@@ -56,7 +56,7 @@
 
 (deftest migration-lock-coordination-test
   (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-test-db! semantic.tu/default-test-db
+    (semantic.tu/with-test-db-defaults!
       (testing "Migration of simultaneous init attempt is blocked"
         (let [original-write-fn @#'semantic.db.migration/write-successful-migration!
               original-migrate-fn @#'semantic.db.connection/do-with-migrate-tx
@@ -121,7 +121,7 @@
 (deftest expected-db-schema-after-migration-test
   (try
     (mt/with-premium-features #{:semantic-search}
-      (semantic.tu/with-test-db! semantic.tu/default-test-db
+      (semantic.tu/with-test-db-defaults!
         (with-redefs [semantic.pgvector-api/index-documents! (constantly nil)]
           (semantic.core/init! (semantic.tu/mock-documents) nil)
           (testing "migration table has expected columns"
@@ -219,7 +219,7 @@
 
 (deftest dynamic-schema-migration-test
   (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-test-db! semantic.tu/default-test-db
+    (semantic.tu/with-test-db-defaults!
       (with-redefs [semantic.pgvector-api/index-documents! (constantly nil)]
         (semantic.core/init! (semantic.tu/mock-documents) nil)
              ;; add column to index table

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
@@ -9,6 +9,7 @@
    [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
    [metabase-enterprise.semantic-search.db.migration :as semantic.db.migration]
    [metabase-enterprise.semantic-search.db.migration.impl :as semantic.db.migration.impl]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.pgvector-api :as semantic.pgvector-api]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
@@ -126,7 +127,7 @@
           (semantic.core/init! (semantic.tu/mock-documents) nil)
           (testing "migration table has expected columns"
             (is (map-contains-keys?
-                 (jdbc/execute-one! (semantic.db.datasource/ensure-initialized-data-source!)
+                 (jdbc/execute-one! (semantic.env/get-pgvector-datasource!)
                                     (sql/format {:select [:*]
                                                  :from [:migration]}))
                  (qualify :migration [:migrated_at
@@ -134,7 +135,7 @@
                                       :version]))))
           (testing "control table has expected columns"
             (is (map-contains-keys?
-                 (jdbc/execute-one! (semantic.db.datasource/ensure-initialized-data-source!)
+                 (jdbc/execute-one! (semantic.env/get-pgvector-datasource!)
                                     (sql/format {:select [:*]
                                                  :from [:index_control]}))
                  (qualify :index_control [:active_id
@@ -143,7 +144,7 @@
                                           :version]))))
           (testing "metadata table has expected columns"
             (is  (map-contains-keys?
-                  (jdbc/execute-one! semantic.tu/db
+                  (jdbc/execute-one! (semantic.env/get-pgvector-datasource!)
                                      (sql/format {:select [:*]
                                                   :from [:index_metadata]}))
                   (qualify :index_metadata [:id
@@ -190,7 +191,7 @@
                         "text_search_with_native_query_vector"
                         "verified"
                         "view_count"}
-                      (->>  (jdbc/execute! semantic.tu/db
+                      (->>  (jdbc/execute! (semantic.env/get-pgvector-datasource!)
                                            (sql/format {:select [:column_name]
                                                         :from [:information_schema.columns]
                                                         :where [[:= :table_name [:inline index-table]]]}))
@@ -198,7 +199,7 @@
                             set)))))
           (testing "index table has expected columns"
             (is (= ["document" "document_hash" "gated_at" "id" "model" "model_id" "updated_at"]
-                   (->> (jdbc/execute! semantic.tu/db
+                   (->> (jdbc/execute! (semantic.env/get-pgvector-datasource!)
                                        (sql/format {:select [:column_name]
                                                     :from [:information_schema.columns]
                                                     :where [[:= :table_name [:inline "index_gate"]]]}))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
@@ -1,6 +1,6 @@
 (ns metabase-enterprise.semantic-search.migration-test
   (:require
-   [clojure.test :refer [deftest is testing use-fixtures]]
+   [clojure.test :refer [deftest is testing]]
    [honey.sql :as sql]
    [java-time.api :as t]
    [medley.core :as m]
@@ -20,8 +20,6 @@
    [next.jdbc :as jdbc]))
 
 (set! *warn-on-reflection* true)
-
-(use-fixtures :each #'semantic.tu/ensure-no-migration-table-fixture)
 
 (deftest migration-table-versions-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
@@ -1,6 +1,6 @@
 (ns metabase-enterprise.semantic-search.migration-test
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [honey.sql :as sql]
    [java-time.api :as t]
    [medley.core :as m]
@@ -20,6 +20,8 @@
    [next.jdbc :as jdbc]))
 
 (set! *warn-on-reflection* true)
+
+(use-fixtures :once #'semantic.tu/once-fixture)
 
 (deftest migration-table-versions-test
   (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/migration_test.clj
@@ -61,8 +61,7 @@
               original-maybe-migrate @#'semantic.db.migration/maybe-migrate!
               results (atom {:executed-migrations 0
                              :log []})]
-          (with-redefs-fn {;; TODO: why in ci init index won't succeed -- http on embedding
-                           #'semantic.pgvector-api/index-documents! (constantly nil)
+          (with-redefs-fn {#'semantic.pgvector-api/index-documents! (constantly nil)
                            #'semantic.db.connection/do-with-migrate-tx
                            (fn [& args]
                              (let [tid (.getId (Thread/currentThread))]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
@@ -21,8 +21,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :each #'semantic.tu/ensure-no-migration-table-fixture)
-
 ;; NOTE: isolation tests are absent, in prod there is only one index-metadata
 
 (deftest init-semantic-search!-test

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
@@ -21,7 +21,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :once #'semantic.tu/once-fixture)
 (use-fixtures :each #'semantic.tu/ensure-no-migration-table-fixture)
 
 ;; NOTE: isolation tests are absent, in prod there is only one index-metadata

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [honey.sql :as sql]
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.indexer :as semantic.indexer]
@@ -26,7 +27,7 @@
 ;; NOTE: isolation tests are absent, in prod there is only one index-metadata
 
 (deftest init-semantic-search!-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         model1         semantic.tu/mock-embedding-model
         model2         (assoc semantic.tu/mock-embedding-model :model-name "embed-harder")
@@ -69,7 +70,7 @@
                       (semantic.index-metadata/find-compatible-index! pgvector index-metadata model2))))))))))
 
 (deftest init-recreates-missing-index-table-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         model1         semantic.tu/mock-embedding-model
         sut*           semantic.pgvector-api/init-semantic-search!
@@ -98,7 +99,7 @@
     (is (thrown? Exception (apply sut args)))))
 
 (deftest index-documents!-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         model1         semantic.tu/mock-embedding-model
         model2         (assoc semantic.tu/mock-embedding-model :model-name "embedagain")
@@ -125,7 +126,7 @@
                        @calls))))))))))
 
 (deftest delete-documents!-test
-  (let [pgvector       semantic.tu/db
+  (let [pgvector       (semantic.env/get-pgvector-datasource!)
         index-metadata (semantic.tu/unique-index-metadata)
         dash           "dashboard"
         card           "card"
@@ -166,7 +167,7 @@
 (deftest query-test
   (semantic.tu/with-indexable-documents!
     (mt/with-dynamic-fn-redefs [semantic.index/model-table-suffix semantic.tu/mock-table-suffix]
-      (let [pgvector       semantic.tu/db
+      (let [pgvector       (semantic.env/get-pgvector-datasource!)
             index-metadata (semantic.tu/unique-index-metadata)
             model1         semantic.tu/mock-embedding-model
             model2         (assoc semantic.tu/mock-embedding-model :model-name "judge-embedd")
@@ -218,7 +219,7 @@
 
 (deftest e2e-index-a-sample-db-with-gate-test
   (let [docs            (mt/dataset test-data (vec (search.ingestion/searchable-documents)))
-        pgvector        semantic.tu/db
+        pgvector        (semantic.env/get-pgvector-datasource!)
         index-metadata  (semantic.tu/unique-index-metadata)
         embedding-model semantic.tu/mock-embedding-model
         open-job-thread (fn [& args]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/pgvector_api_test.clj
@@ -21,6 +21,8 @@
 
 (set! *warn-on-reflection* true)
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 ;; NOTE: isolation tests are absent, in prod there is only one index-metadata
 
 (deftest init-semantic-search!-test

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -9,6 +9,8 @@
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 (deftest basic-query-test
   (testing "Simple queries with no filters"
     (mt/with-premium-features #{:semantic-search}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.semantic-search.query-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.permissions.models.data-permissions :as data-perms]
@@ -9,10 +8,6 @@
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
-
-(deftest database-initialised-test
-  (is (some? @semantic.db.datasource/data-source))
-  (is (= {:test 1} (semantic.db.datasource/test-connection!))))
 
 (deftest basic-query-test
   (testing "Simple queries with no filters"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -20,7 +20,7 @@
   (testing "Simple queries with no filters"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-index!
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
           (semantic.tu/with-only-semantic-weights
             (testing "Dog-related query finds dog content"
               (let [results (-> (semantic.tu/query-index {:search-string "puppy"})

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -42,7 +42,7 @@
   (testing "Tests for :search-native-query"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-index!
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
           (semantic.tu/with-only-semantic-weights
             (let [not-top-10? #(or (nil? %) (< 10 %))]
               (doseq [{:keys [name desc search-string search-native-query? expected-index?]}
@@ -111,7 +111,7 @@
   (testing "Filter results by model type"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-index!
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
           (testing "Filter for cards only"
             (let [card-results (semantic.tu/query-index {:search-string "avian" :models ["card"]})
                   filtered-results (semantic.tu/filter-for-mock-embeddings card-results)]
@@ -134,7 +134,7 @@
   (testing "Filter results by archived status"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-index!
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
           (testing "Include only non-archived items"
             (let [active-results (semantic.tu/query-index {:search-string "feline" :archived? false})]
               (is (every? #(not (:archived %)) active-results))))
@@ -154,7 +154,7 @@
   (testing "Filter results by creator"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-index!
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
           (testing "Filter by single creator"
             (let [crowberto-results (semantic.tu/query-index {:search-string "aquatic" :created-by [(mt/user->id :crowberto)]})
                   filtered-results (semantic.tu/filter-for-mock-embeddings crowberto-results)]
@@ -171,7 +171,7 @@
   (testing "Filter results by verified status"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-index!
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
           (testing "Include only verified items"
             (let [verified-results (semantic.tu/query-index {:search-string "puppy" :verified true})
                   filtered-results (semantic.tu/filter-for-mock-embeddings verified-results)]
@@ -187,7 +187,7 @@
   (testing "Complex filters with multiple criteria"
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
-        (semantic.tu/with-index!
+        (semantic.tu/with-test-db! {:mode :mock-indexed}
           (testing "Non-archived cards by specific creator"
             (let [results (semantic.tu/query-index {:search-string "equine"
                                                     :models ["card"]
@@ -221,7 +221,7 @@
 
 (deftest permissions-test
   (mt/with-premium-features #{:semantic-search}
-    (semantic.tu/with-index!
+    (semantic.tu/with-test-db! {:mode :mock-indexed}
       (let [monsters-table (t2/select-one-pk :model/Table :name "Monsters Table")
             q (fn [model s] (map :name (semantic.tu/query-index {:search-string s, :models [model]})))
             all-users (perms-group/all-users)
@@ -257,7 +257,7 @@
     (mt/with-premium-features #{:semantic-search}
       (mt/as-admin
         (binding [semantic.index/*batch-size* 1]
-          (semantic.tu/with-index!
+          (semantic.tu/with-test-db! {:mode :mock-indexed}
             (semantic.tu/with-only-semantic-weights
               (testing "Horse-related query finds horse content"
                 (let [results (-> (semantic.tu/query-index {:search-string "marine mammal"})

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/query_test.clj
@@ -10,8 +10,6 @@
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
-(use-fixtures :once #'semantic.tu/once-fixture)
-
 (deftest database-initialised-test
   (is (some? @semantic.db.datasource/data-source))
   (is (= {:test 1} (semantic.db.datasource/test-connection!))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
@@ -15,6 +15,8 @@
 
 (set! *warn-on-reflection* true)
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 (defn- gate-table-contents
   "Query all documents in the gate table, returning them as maps"
   [pgvector gate-table-name]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
@@ -56,7 +56,7 @@
 (deftest repair-index-integration-test
   (testing "repair-index! properly handles document additions and deletions via gate table"
     (mt/with-premium-features #{:semantic-search}
-      (semantic.tu/with-index!
+      (semantic.tu/with-test-db! {:mode :mock-indexed}
         (let [pgvector       (semantic.env/get-pgvector-datasource!)
               index-metadata (semantic.env/get-index-metadata)
               gate-table     (:gate-table-name index-metadata)
@@ -90,7 +90,7 @@
 (deftest repair-table-cleanup-test
   (testing "The repair table gets cleaned up properly at the end of a repair-index! job"
     (mt/with-premium-features #{:semantic-search}
-      (semantic.tu/with-index!
+      (semantic.tu/with-test-db! {:mode :mock-indexed}
         (let [pgvector       (semantic.env/get-pgvector-datasource!)
               index-metadata semantic.tu/mock-index-metadata
               gate-table     (:gate-table-name index-metadata)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
@@ -60,9 +60,7 @@
     (mt/with-premium-features #{:semantic-search}
       (semantic.tu/with-index!
         (let [pgvector       (semantic.env/get-pgvector-datasource!)
-              #_#_pgvector semantic.tu/db
               index-metadata (semantic.env/get-index-metadata)
-              #_#_index-metadata semantic.tu/mock-index-metadata
               gate-table     (:gate-table-name index-metadata)
               _              (clear-gate-table! pgvector gate-table)
               initial-docs   [(create-test-document "card" 1 "Dog Training Guide")
@@ -95,7 +93,7 @@
   (testing "The repair table gets cleaned up properly at the end of a repair-index! job"
     (mt/with-premium-features #{:semantic-search}
       (semantic.tu/with-index!
-        (let [pgvector       semantic.tu/db
+        (let [pgvector       (semantic.env/get-pgvector-datasource!)
               index-metadata semantic.tu/mock-index-metadata
               gate-table     (:gate-table-name index-metadata)
               initial-docs   [(create-test-document "card" 6 "Dog Training Guide")]]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
@@ -15,8 +15,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :once #'semantic.tu/once-fixture)
-
 (defn- gate-table-contents
   "Query all documents in the gate table, returning them as maps"
   [pgvector gate-table-name]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/repair_test.clj
@@ -5,6 +5,7 @@
    [honey.sql :as sql]
    [java-time.api :as t]
    [metabase-enterprise.semantic-search.core :as semantic.core]
+   [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.repair :as semantic.repair]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase-enterprise.semantic-search.util :as semantic.util]
@@ -58,8 +59,10 @@
   (testing "repair-index! properly handles document additions and deletions via gate table"
     (mt/with-premium-features #{:semantic-search}
       (semantic.tu/with-index!
-        (let [pgvector       semantic.tu/db
-              index-metadata semantic.tu/mock-index-metadata
+        (let [pgvector       (semantic.env/get-pgvector-datasource!)
+              #_#_pgvector semantic.tu/db
+              index-metadata (semantic.env/get-index-metadata)
+              #_#_index-metadata semantic.tu/mock-index-metadata
               gate-table     (:gate-table-name index-metadata)
               _              (clear-gate-table! pgvector gate-table)
               initial-docs   [(create-test-document "card" 1 "Dog Training Guide")

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -14,6 +14,8 @@
 
 (set! *warn-on-reflection* true)
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 (defn- add-doc-defaults
   [doc]
   (merge {:id 123

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -14,8 +14,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :once #'semantic.tu/once-fixture)
-
 (defn- add-doc-defaults
   [doc]
   (merge {:id 123

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -31,7 +31,7 @@
   "Populate the index with the given documents."
   {:style/indent :defn}
   [documents & body]
-  `(with-open [_# (semantic.tu/open-temp-index!)]
+  `(semantic.tu/with-test-db! {:mode :mock-initialized}
      (semantic.tu/upsert-index! (map add-doc-defaults ~documents))
      ~@body))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -69,7 +69,7 @@
 
 (deftest stale-index-cleanup-test
   (mt/with-premium-features #{:semantic-search}
-    (let [pgvector semantic.tu/db
+    (let [pgvector (semantic.env/get-pgvector-datasource!)
           index-metadata (semantic.tu/unique-index-metadata)
           retention-hours 24
           old-time (t/minus (t/offset-date-time) (t/hours (inc retention-hours)))
@@ -133,7 +133,7 @@
 
 (deftest tombstone-cleanup-test
   (mt/with-premium-features #{:semantic-search}
-    (let [pgvector semantic.tu/db
+    (let [pgvector (semantic.env/get-pgvector-datasource!)
           index-metadata (semantic.tu/unique-index-metadata)
           retention-hours (semantic.settings/tombstone-retention-hours)
           old-time (t/minus (t/offset-date-time) (t/hours (inc retention-hours)))
@@ -228,7 +228,7 @@
 
 (deftest repair-table-cleanup-test
   (mt/with-premium-features #{:semantic-search}
-    (let [pgvector semantic.tu/db
+    (let [pgvector (semantic.env/get-pgvector-datasource!)
           retention-hours 2
           old-time (t/minus (t/instant) (t/hours (inc retention-hours))) ; 3 hours ago
           recent-time (t/minus (t/instant) (t/hours 1))]                 ; 1 hour ago

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -19,8 +19,6 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :once #'semantic.tu/once-fixture)
-
 (defn- create-test-index
   "Create a test index object with the given table name and embedding model."
   [table-name {:keys [provider model-name vector-dimensions]}]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/index_cleanup_test.clj
@@ -19,6 +19,8 @@
 
 (set! *warn-on-reflection* true)
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 (defn- create-test-index
   "Create a test index object with the given table name and embedding model."
   [table-name {:keys [provider model-name vector-dimensions]}]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
@@ -100,7 +100,3 @@
               (is (== 0 (mt/metric-value system :metabase-search/semantic-dlq-size))))
             (finally
               (drop-test-tables! pgvector index-metadata))))))))
-
-(deftest test-test
-  (semantic.tu/with-index!
-    (is true)))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
@@ -1,6 +1,6 @@
 (ns metabase-enterprise.semantic-search.task.metric-collector-test
   (:require
-   [clojure.test :refer [deftest is testing use-fixtures]]
+   [clojure.test :refer [deftest is testing]]
    [honey.sql :as sql]
    [java-time.api :as t]
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]
@@ -12,8 +12,6 @@
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.test :as mt]
    [next.jdbc :as jdbc]))
-
-(use-fixtures :once #'semantic.tu/once-fixture)
 
 (defn- create-test-tables!
   [pgvector index-metadata model]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
@@ -1,6 +1,6 @@
 (ns metabase-enterprise.semantic-search.task.metric-collector-test
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [honey.sql :as sql]
    [java-time.api :as t]
    [metabase-enterprise.semantic-search.dlq :as semantic.dlq]
@@ -12,6 +12,8 @@
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.test :as mt]
    [next.jdbc :as jdbc]))
+
+(use-fixtures :once #'semantic.tu/once-fixture)
 
 (defn- create-test-tables!
   [pgvector index-metadata model]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/metric_collector_test.clj
@@ -67,11 +67,10 @@
 (deftest metric-collector-test
   (mt/with-premium-features #{:semantic-search}
     (mt/with-prometheus-system! [_ system]
-      (let [pgvector       semantic.tu/db
+      (let [pgvector       (semantic.env/get-pgvector-datasource!)
             index-metadata (semantic.tu/unique-index-metadata)
             model semantic.tu/mock-embedding-model]
-        (with-redefs [semantic.env/get-pgvector-datasource! (fn [] pgvector)
-                      semantic.env/get-index-metadata (fn [] index-metadata)
+        (with-redefs [semantic.env/get-index-metadata (fn [] index-metadata)
                       semantic.env/get-configured-embedding-model (fn [] model)]
           (testing "Missing tables are handled gracefully"
             (let [result (try
@@ -103,3 +102,7 @@
               (is (== 0 (mt/metric-value system :metabase-search/semantic-dlq-size))))
             (finally
               (drop-test-tables! pgvector index-metadata))))))))
+
+(deftest test-test
+  (semantic.tu/with-index!
+    (is true)))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -31,6 +31,12 @@
 
 (set! *warn-on-reflection* true)
 
+;; Purpose of this fixure is to block running tests if db-url is not set. That's true for enterprise app-db tests in CI.
+(defn once-fixture
+  [f]
+  (when semantic.db.datasource/db-url
+    (f)))
+
 (def default-test-db "my_test_db")
 
 (defn- alt-db-name-url
@@ -247,6 +253,7 @@
 (defn query-index [search-context]
   (:results (semantic.index/query-index (semantic.env/get-pgvector-datasource!) mock-index search-context)))
 
+;; TODO: this should go!!!
 (defn upsert-index! [documents & {:keys [index] :or {index mock-index} :as opts}]
   (semantic.index/upsert-index! (semantic.env/get-pgvector-datasource!) index documents opts))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -82,6 +82,7 @@
       (semantic.pgvector-api/init-semantic-search! pgvector index-metadata embedding-model)
       (thunk))))
 
+;; TODO: declare with macro (the do- less version) throws weird errors -- investigate!
 (declare do-with-indexable-documents!)
 
 (defmethod do-with-setup-test-db! :mock-gated

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -150,7 +150,7 @@
           (log/debugf "Test pgvector database teardown %s failed" dbname)
           (throw e))))))
 
-;; TODO: When we are parallelizing tests, we'd have to make 
+;; TODO: When we are parallelizing tests, we'd have to make
 ;;       - `with-test-db!` use thread-safe version of with-redefs or similar,
 ;;       - instead of `default-test-db` we could make unique database per test by means of eg. some counter.
 (defmacro with-test-db!

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -172,18 +172,6 @@
   `(with-weights {:rrf 1}
      ~@body))
 
-;; TODO: remove
-(defn once-fixture [f]
-  (when semantic.db.datasource/db-url
-    (f)))
-
-;; TODO: remove
-#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
-(defn ensure-no-migration-table-fixture [f]
-  (semantic.db.migration/drop-migration-table! (semantic.env/get-pgvector-datasource!))
-  (f)
-  (semantic.db.migration/drop-migration-table! (semantic.env/get-pgvector-datasource!)))
-
 (def mock-embeddings
   "Static mapping from strings to (made-up) 4-dimensional embedding vectors for testing. Each pair of strings represents a
   document and a search query that should be most semantically similar to it, according to the embeddings."

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -133,6 +133,9 @@
           (log/debugf "Test pgvector database teardown %s failed" dbname)
           (throw e))))))
 
+;; TODO: When we are parallelizing tests, we'd have to make 
+;;       - `with-test-db!` use thread-safe version of with-redefs or similar,
+;;       - instead of `default-test-db` we could make unique database per test by means of eg. some counter.
 (defmacro with-test-db!
   "Drop, create database dbname on pgvector and redefine datasource accordingly. Not thread safe."
   [opts & body]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -73,16 +73,12 @@
 
 (defmethod do-with-setup-test-db! :mock-initialized
   [_mode thunk]
-  ;; why redefinition does not work as expected?
-  (with-redefs [;; yes
-                semantic.embedding/get-configured-model        (fn [] mock-embedding-model)
-                ;; no
+  (with-redefs [semantic.embedding/get-configured-model        (fn [] mock-embedding-model)
                 semantic.index-metadata/default-index-metadata mock-index-metadata
-                ;; probably no
                 semantic.index/model-table-suffix              mock-table-suffix]
-    (let [pgvector @(def pgv (semantic.env/get-pgvector-datasource!))
-          index-metadata @(def yy (semantic.env/get-index-metadata))
-          embedding-model @(def xix (semantic.env/get-configured-embedding-model))]
+    (let [pgvector (semantic.env/get-pgvector-datasource!)
+          index-metadata (semantic.env/get-index-metadata)
+          embedding-model (semantic.env/get-configured-embedding-model)]
       (semantic.pgvector-api/init-semantic-search! pgvector index-metadata embedding-model)
       (thunk))))
 

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -450,9 +450,6 @@
           (index-all!)
           (thunk))))))
 
-;; TODO: When we are parallelizing tests, we'd have to make 
-;;       - `with-test-db!` use thread-safe version of with-redefs or similar,
-;;       - instead of `default-test-db` we could make unique database per test by means of eg. some counter.
 (defmacro with-index!
   "Wrapper for [[do-with-index!]]."
   [& body]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/without_init_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/without_init_test.clj
@@ -17,14 +17,15 @@
 (defn- without-init! [test-func]
   (mt/with-premium-features #{:semantic-search}
     (try
-      (semantic.tu/cleanup-index-metadata! semantic.tu/db semantic.tu/mock-index-metadata)
+      (semantic.tu/cleanup-index-metadata! (semantic.env/get-pgvector-datasource!)
+                                           semantic.tu/mock-index-metadata)
       (with-redefs [semantic.db.datasource/data-source          (atom nil)
                     semantic.env/get-index-metadata             (constantly semantic.tu/mock-index-metadata)
                     semantic.env/get-configured-embedding-model (constantly semantic.tu/mock-embedding-model)
                     semantic.index/model-table-suffix           semantic.tu/mock-table-suffix]
         (test-func))
       (finally
-        (semantic.tu/cleanup-index-metadata! semantic.tu/db semantic.tu/mock-index-metadata)))))
+        (semantic.tu/cleanup-index-metadata! (semantic.env/get-pgvector-datasource!) semantic.tu/mock-index-metadata)))))
 
 (deftest update-index!-without-init!-test
   (without-init!

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/without_init_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/without_init_test.clj
@@ -8,8 +8,6 @@
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.test :as mt]))
 
-(use-fixtures :once #'semantic.tu/once-fixture)
-
 ;; When booting a new install from a fresh app db, we can wind up getting calls into the search backend from things
 ;; like loading the sample or audit db content before search has been initialized, and therefore before receiving an
 ;; init! call. These tests ensure that we can handle such calls and don't throw if it does happen.

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/without_init_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/without_init_test.clj
@@ -8,6 +8,8 @@
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.test :as mt]))
 
+(use-fixtures :once #'semantic.tu/once-fixture)
+
 ;; When booting a new install from a fresh app db, we can wind up getting calls into the search backend from things
 ;; like loading the sample or audit db content before search has been initialized, and therefore before receiving an
 ;; init! call. These tests ensure that we can handle such calls and don't throw if it does happen.


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-405/better-isolation-for-semantic-search-tests

This PR adds tools for better test isolation of semantic search tests and factors out now redundant code. For more context see [this thread](https://metaboat.slack.com/archives/C07SJT1P0ET/p1757006913717929?thread_ts=1755713600.787409&cid=C07SJT1P0ET).

Specifically, it:
- Adds `with-test-db!` macro and its internals. It is responsible for creating separate pg database for a test.
  - As per linked thread, `with-test-db!` uses notion of `:mode`s for specific test startup configurations. New modes can be added by implementing `semantic.tu/do-with-setup-test-db!`.
  - Only the `default-test-db` is used currently. Shall we parallelize those tests, we can randomize the databases and would have address `with-redefs` not being thread safe, as mentioned in the linked thread in more detail.
  - As the result of former:
    - `with-index!` was removed completely in favor of this new approach.

With regards to refactorings:
- I believe we no longer need `semantic.tu/db`. I was removed in favor of `semantic.env/get-pgvector-datasource!`.
- Fixtures, which I believe we don't need anymore were also removed.
- Other minor helpers were either adjusted are removed as those are redundant now.

Follow-ups:
- When we get a chance for another round of test suite gardening, we could:
  - Make the rest of the suite use `with-test-db!` so we have not 2 but single approach for setup and tear down.
  - Enable parallel test execution by means discussed in the linked thread.

Finally, I'll be rebasing this branch on https://github.com/metabase/metabase/pull/63319 when merged.