### PR TITLE
Cache Store OpenAPI description only for 5min

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/harbormaster/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/harbormaster/client.clj
@@ -2,6 +2,7 @@
   "API client for interfacing with Harbormaster on store-api-url."
   (:require
    [clj-http.client :as http]
+   [clojure.core.memoize :as memoize]
    [clojure.string :as str]
    [martian.clj-http :as martian-http]
    [martian.core :as martian]
@@ -135,7 +136,8 @@
    {:headers {"Authorization" (str "Bearer " api-key)}}))
 
 (def ^:private create-client-memo
-  (memoize create-client))
+  (memoize/ttl create-client
+               :ttl/threshold (m.util/minutes->ms 5)))
 
 (defn- client []
   (let [store-api-url (store-api/store-api-url)


### PR DESCRIPTION
The Store API's OpenAPI description (OAD) can change over time, but
Metabase's Store client would not notice.  For example, the client
would fail a HTTP request, not because the server rejected it, but
because the client "believes" it needs to send a field that the server
no longer requires.

Instead of caching the client, and thus OAD, for the whole lifetime of
the Metabase instance, cache it only for 5min.

Fixes: 1dd56e5f148db1730726df2c720b417abd40219f
References: https://metaboat.slack.com/archives/C010ZSXQY87/p1757002462314229
