### PR TITLE
Closes EMB-779 content translation is now case insensitive

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_translation/tests/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/tests/utils.unit.spec.ts
@@ -101,13 +101,13 @@ describe("content translation utils", () => {
       ).toBe("Whitespace Translation");
     });
 
-    it("should handle case sensitivity", () => {
+    it("should be case insensitive for msgid (metabase#61795)", () => {
       expect(translateContentString(mockDictionary, "es", "hello")).toBe(
-        "hello",
-      ); // no match
-      expect(translateContentString(mockDictionary, "ES", "Hello")).toBe(
-        "Hello",
-      ); // no match
+        "Hola",
+      );
+      expect(translateContentString(mockDictionary, "es", "WORLD")).toBe(
+        "Mundo",
+      );
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -43,8 +43,11 @@ export const translateContentString: TranslateContentStringFunction = (
     return msgid;
   }
 
+  const lowerCaseMsgId = msgid.toLowerCase();
+
   const msgstr = dictionary?.find(
-    (row) => row.locale === locale && row.msgid === msgid,
+    (row) =>
+      row.locale === locale && row.msgid.toLowerCase() === lowerCaseMsgId,
   )?.msgstr;
 
   if (!msgstr || !msgstr.trim()) {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61795
Closes [EMB-779: Make Content Translations Case Insensitive](https://linear.app/metabase/issue/EMB-779/make-content-translations-case-insensitive)

### Description

Make content translation case insensitive.

### How to verify

1. Make a new dashboard, with a new question (Products > count per category)
2. Add a translation dictionnary (in Admin Settings > Static Embedding) that contains lower case msgids ("gizmo" instead of "Gizmo", for instance)
3. Open the new dashboard in a static embedding context, with a locale explicitly set (see https://www.metabase.com/docs/latest/embedding/static-embedding-parameters#setting-the-language-for-a-static-embed)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
