### PR TITLE
Protect against nil search_vector

### DIFF
--- a/src/metabase/search/appdb/specialization/postgres.clj
+++ b/src/metabase/search/appdb/specialization/postgres.clj
@@ -55,8 +55,8 @@
 (defmethod specialization/extra-entry-fields :postgres [entity]
   {:search_vector
    [:||
-    (search.util/weighted-tsvector "A" (:name entity))
-    (search.util/weighted-tsvector "B" (:searchable_text entity ""))]
+    (search.util/weighted-tsvector "A" (or (:name entity) ""))
+    (search.util/weighted-tsvector "B" (or (:searchable_text entity) ""))]
 
    :with_native_query_vector
    [:||

--- a/src/metabase/search/appdb/specialization/postgres.clj
+++ b/src/metabase/search/appdb/specialization/postgres.clj
@@ -60,7 +60,7 @@
 
    :with_native_query_vector
    [:||
-    (search.util/weighted-tsvector "A" (:name entity))
+    (search.util/weighted-tsvector "A" (or (:name entity) ""))
     (search.util/weighted-tsvector "B" (str/join " " (keep entity [:searchable_text :native_query])))]})
 
 ;; See https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-RANKING


### PR DESCRIPTION
Best guess solution for https://metaboat.slack.com/archives/C05MPF0TM3L/p1757080030680069

I'm not sure which search model(s) would allow a nil name, so didn't reproduce the issue first. 

Don't have any other theories though.