### PR TITLE
small fix for the bar chart being resized when props are passed and t…

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -10,6 +10,7 @@ import {
   StaticDashboard,
 } from "embedding-sdk-bundle/components/public/dashboard";
 import type { MetabaseAuthConfig } from "embedding-sdk-package";
+import { useMemoizedValue } from "metabase/common/hooks/use-memoized-value";
 import { EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG } from "metabase/embedding-sdk/config";
 import { PLUGIN_EMBEDDING_IFRAME_SDK } from "metabase/plugins";
 import { Box } from "metabase/ui";
@@ -33,6 +34,9 @@ const onSettingsChanged = (settings: SdkIframeEmbedSettings) => {
 
 export const SdkIframeEmbedRoute = () => {
   const { embedSettings } = useSdkIframeEmbedEventBus({ onSettingsChanged });
+
+  // we memoize the theme to not retrigger changes when they pass the same theme
+  const memoizedTheme = useMemoizedValue(embedSettings?.theme);
 
   // The embed settings won't be available until the parent sends it via postMessage.
   // The SDK will show its own loading indicator, so we don't need to show it twice.
@@ -68,7 +72,11 @@ export const SdkIframeEmbedRoute = () => {
   };
 
   return (
-    <ComponentProvider authConfig={authConfig} theme={theme} locale={locale}>
+    <ComponentProvider
+      authConfig={authConfig}
+      theme={memoizedTheme}
+      locale={locale}
+    >
       <Box h="100vh" bg={theme?.colors?.background}>
         <SdkIframeEmbedView settings={embedSettings} />
       </Box>

--- a/frontend/src/metabase/common/hooks/use-memoized-value.ts
+++ b/frontend/src/metabase/common/hooks/use-memoized-value.ts
@@ -1,0 +1,17 @@
+import { useRef } from "react";
+import { isEqual } from "underscore";
+
+/**
+ * Use `_.isEqual` to deep compare the passed value and return the old value if it
+ * hasn't changed, used to return a stable reference needed in dependencies of
+ * other hooks.
+ */
+export function useMemoizedValue<T>(value: T): T {
+  const ref = useRef<T>(value);
+
+  if (!isEqual(ref.current, value)) {
+    ref.current = value;
+  }
+
+  return ref.current;
+}


### PR DESCRIPTION
…heme is passed
Temporary fix for https://metaboat.slack.com/archives/C063Q3F1HPF/p1756920813412649
This doesn't fix the whole issue, as it still happens when we change the theme colors, but it's a small bandaid until we figure a better fix


How to reproduce:
- in the embed flow, select the browser component
- from the browser, open a bar chart
- check that toggling the read only checkbox on the last step doesn't move the charts