### PR TITLE
Update :bookmarked and :user_recency scorer to work with mysql and mariadb

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -78,9 +78,11 @@
     {:rrf        rrf-rank-exp
      :view-count (view-count-expr index-table search.config/view-count-scaling-percentile)
      :pinned     (search.scoring/truthy :pinned)
-     :recency    (search.scoring/inverse-duration [:coalesce :last_viewed_at :model_updated_at]
-                                                  [:now]
-                                                  search.config/stale-time-in-days)
+     :recency    (search.scoring/inverse-duration
+                  :postgres
+                  [:coalesce :last_viewed_at :model_updated_at]
+                  [:now]
+                  search.config/stale-time-in-days)
      :dashboard  (search.scoring/size :dashboardcard_count search.config/dashboard-count-ceiling)
      :model      (search.scoring/model-rank-expr search-ctx)
      :mine       (search.scoring/equal :creator_id (:current-user-id search-ctx))
@@ -185,11 +187,9 @@
   "The appdb-based scorers for search ranking results. Like `base-scorers`, but for scorers that need to query the appdb."
   [{:keys [limit-int] :as search-ctx}]
   (when-not (and limit-int (zero? limit-int))
-    (merge {:bookmarked search.scoring/bookmark-score-expr}
-           (when-not (= :mysql (mdb/db-type))
-             ;; The appdb scorers need to be modified to work with mysql / mariadb (BOT-360)
-             {:user-recency (search.scoring/inverse-duration
-                             (search.scoring/user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)}))))
+    {:bookmarked search.scoring/bookmark-score-expr
+     :user-recency (search.scoring/inverse-duration
+                    (search.scoring/user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)}))
 
 (defn with-appdb-scores
   "Add appdb-based scores to `search-results` and re-sort the results based on the new combined scores.

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -134,15 +134,21 @@
 ;; appdb-based scorers: these scorers rely on tables in the appdb
 ;;
 
-(defn- search-doc->values
+(defn- search-doc->select
   [{:keys [id model]}]
-  [[:cast [:inline id] :text] [:inline model]])
+  {:select [[[:inline (str id)]] [[:inline model]]]})
 
 (defn- search-index-query
   [search-results]
   {:with     [[[:search_index {:columns [:model_id :model]}]
-               {:values (map search-doc->values search-results)}]]
-   :select   [[[:cast :search_index.model_id :int] :id]
+               ;; We could use :values here, except MySQL uses a slightly different syntax and I can't seem to get
+               ;; honeysql to generate a valid WITH ... VALUES statement for MySQL, so fallback to UNION + SELECT
+               ;; which works with all supported appdbs. https://dev.mysql.com/doc/refman/8.4/en/values.html
+               {:union (map search-doc->select search-results)}]]
+   :select   [[[:cast :search_index.model_id (if (= :mysql (mdb/db-type))
+                                               :unsigned
+                                               :int)]
+               :id]
               [:search_index.model :model]]
    :from     [:search_index]})
 
@@ -179,11 +185,11 @@
   "The appdb-based scorers for search ranking results. Like `base-scorers`, but for scorers that need to query the appdb."
   [{:keys [limit-int] :as search-ctx}]
   (when-not (and limit-int (zero? limit-int))
-    (when-not (= :mysql (mdb/db-type))
-      ;; The appdb scorers need to be modified to work with mysql / mariadb (BOT-360)
-      {:bookmarked search.scoring/bookmark-score-expr
-       :user-recency (search.scoring/inverse-duration
-                      (search.scoring/user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)})))
+    (merge {:bookmarked search.scoring/bookmark-score-expr}
+           (when-not (= :mysql (mdb/db-type))
+             ;; The appdb scorers need to be modified to work with mysql / mariadb (BOT-360)
+             {:user-recency (search.scoring/inverse-duration
+                             (search.scoring/user-recency-expr search-ctx) [:now] search.config/stale-time-in-days)}))))
 
 (defn with-appdb-scores
   "Add appdb-based scores to `search-results` and re-sort the results based on the new combined scores.

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/scoring_test.clj
@@ -256,45 +256,43 @@
 
 (deftest bookmark-test
   (mt/with-premium-features #{:semantic-search}
-    ;; TODO (BOT-360) enable for :mysql
-    (when-not (= :mysql (mdb/db-type))
-      (let [crowberto (mt/user->id :crowberto)
-            rasta     (mt/user->id :rasta)]
-        (mt/with-temp [:model/Card {c1 :id} {}
-                       :model/Card {c2 :id} {}]
-          (testing "bookmarked items are ranker higher"
-            (with-index-contents!
-              [{:model "card" :id c1 :name "card normal"}
-               {:model "card" :id c2 :name "card crowberto loved"}]
-              (mt/with-temp [:model/CardBookmark _ {:card_id c2 :user_id crowberto}
-                             :model/CardBookmark _ {:card_id c1 :user_id rasta}]
-                (is (= [["card" c2 "card crowberto loved"]
-                        ["card" c1 "card normal"]]
-                       (search-results :bookmarked "card" {:current-user-id crowberto})))))))
+    (let [crowberto (mt/user->id :crowberto)
+          rasta     (mt/user->id :rasta)]
+      (mt/with-temp [:model/Card {c1 :id} {}
+                     :model/Card {c2 :id} {}]
+        (testing "bookmarked items are ranker higher"
+          (with-index-contents!
+            [{:model "card" :id c1 :name "card normal"}
+             {:model "card" :id c2 :name "card crowberto loved"}]
+            (mt/with-temp [:model/CardBookmark _ {:card_id c2 :user_id crowberto}
+                           :model/CardBookmark _ {:card_id c1 :user_id rasta}]
+              (is (= [["card" c2 "card crowberto loved"]
+                      ["card" c1 "card normal"]]
+                     (search-results :bookmarked "card" {:current-user-id crowberto})))))))
 
-        (mt/with-temp [:model/Dashboard {d1 :id} {}
-                       :model/Dashboard {d2 :id} {}]
-          (testing "bookmarked dashboard"
-            (with-index-contents!
-              [{:model "dashboard" :id d1 :name "dashboard normal"}
-               {:model "dashboard" :id d2 :name "dashboard crowberto loved"}]
-              (mt/with-temp [:model/DashboardBookmark _ {:dashboard_id d2 :user_id crowberto}
-                             :model/DashboardBookmark _ {:dashboard_id d1 :user_id rasta}]
-                (is (= [["dashboard" d2 "dashboard crowberto loved"]
-                        ["dashboard" d1 "dashboard normal"]]
-                       (search-results :bookmarked "dashboard" {:current-user-id crowberto})))))))
+      (mt/with-temp [:model/Dashboard {d1 :id} {}
+                     :model/Dashboard {d2 :id} {}]
+        (testing "bookmarked dashboard"
+          (with-index-contents!
+            [{:model "dashboard" :id d1 :name "dashboard normal"}
+             {:model "dashboard" :id d2 :name "dashboard crowberto loved"}]
+            (mt/with-temp [:model/DashboardBookmark _ {:dashboard_id d2 :user_id crowberto}
+                           :model/DashboardBookmark _ {:dashboard_id d1 :user_id rasta}]
+              (is (= [["dashboard" d2 "dashboard crowberto loved"]
+                      ["dashboard" d1 "dashboard normal"]]
+                     (search-results :bookmarked "dashboard" {:current-user-id crowberto})))))))
 
-        (mt/with-temp [:model/Collection {c1 :id} {}
-                       :model/Collection {c2 :id} {}]
-          (testing "bookmarked collection"
-            (with-index-contents!
-              [{:model "collection" :id c1 :name "collection normal"}
-               {:model "collection" :id c2 :name "collection crowberto loved"}]
-              (mt/with-temp [:model/CollectionBookmark _ {:collection_id c2 :user_id crowberto}
-                             :model/CollectionBookmark _ {:collection_id c1 :user_id rasta}]
-                (is (= [["collection" c2 "collection crowberto loved"]
-                        ["collection" c1 "collection normal"]]
-                       (search-results :bookmarked "collection" {:current-user-id crowberto})))))))))))
+      (mt/with-temp [:model/Collection {c1 :id} {}
+                     :model/Collection {c2 :id} {}]
+        (testing "bookmarked collection"
+          (with-index-contents!
+            [{:model "collection" :id c1 :name "collection normal"}
+             {:model "collection" :id c2 :name "collection crowberto loved"}]
+            (mt/with-temp [:model/CollectionBookmark _ {:collection_id c2 :user_id crowberto}
+                           :model/CollectionBookmark _ {:collection_id c1 :user_id rasta}]
+              (is (= [["collection" c2 "collection crowberto loved"]
+                      ["collection" c1 "collection normal"]]
+                     (search-results :bookmarked "collection" {:current-user-id crowberto}))))))))))
 
 (deftest user-recency-test
   (mt/with-premium-features #{:semantic-search}

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -2,9 +2,16 @@
   (:require
    [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
+   [metabase.app-db.core :as mdb]
    [metabase.search.config :as search.config]))
 
 (def ^:private seconds-in-a-day 86400)
+
+(defn- cast-to-text
+  [column]
+  [:cast column (if (= :mysql (mdb/db-type))
+                  :char
+                  :text)])
 
 (defn truthy
   "Prefer it when a (potentially nullable) boolean is true."
@@ -106,7 +113,7 @@
         [:in :search_index.model (mapv (fn [m] [:inline (name m)]) sms)]
         [:= :search_index.model [:inline model-name]])
       [:= (keyword (str table-name ".user_id")) user-id]
-      [:= :search_index.model_id [:cast (keyword (str table-name "." model-name "_id")) :text]]]]))
+      [:= :search_index.model_id (cast-to-text (keyword (str table-name "." model-name "_id")))]]]))
 
 (defn join-bookmarks
   "Add join clause to bookmark tables for :bookmarked scorer."

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -7,12 +7,6 @@
 
 (def ^:private seconds-in-a-day 86400)
 
-(defn- cast-to-text
-  [column]
-  [:cast column (if (= :mysql (mdb/db-type))
-                  :char
-                  :text)])
-
 (defn truthy
   "Prefer it when a (potentially nullable) boolean is true."
   [column]
@@ -44,18 +38,29 @@
 
 (defn inverse-duration
   "Score an item based on the duration between two dates, where less is better."
-  [from-column to-column ceiling-in-days]
-  (let [ceiling [:inline ceiling-in-days]]
-    [:/
-     [:greatest
-      [:- ceiling
-       [:/
-        ;; Use seconds for granularity in the fraction.
-        ;; TODO will probably need to specialize this based on (mdb/db-type)
-        [[:raw "EXTRACT(epoch FROM (" [:- to-column from-column] [:raw "))"]]]
-        [:inline (double seconds-in-a-day)]]]
-      [:inline 0]]
-     ceiling]))
+  ([from-column to-column ceiling-in-days]
+   (inverse-duration (mdb/db-type) from-column to-column ceiling-in-days))
+  ([db-type from-column to-column ceiling-in-days]
+   (let [ceiling [:inline ceiling-in-days]]
+     [:/
+      [:greatest
+       [:- ceiling
+        [:/
+         ;; Use seconds for granularity in the fraction.
+         (if (= :mysql db-type)
+           [:coalesce
+            [[:timestampdiff [:raw "SECOND"] from-column to-column]]
+            [:* ceiling (double seconds-in-a-day)]]
+           [[:raw "EXTRACT(epoch FROM (" [:- to-column from-column] [:raw "))"]]])
+         [:inline (double seconds-in-a-day)]]]
+       [:inline 0]]
+      ceiling])))
+
+(defn- cast-to-text
+  [column]
+  [:cast column (if (= :mysql (mdb/db-type))
+                  :char
+                  :text)])
 
 (defn user-recency-expr
   "Expression to select the `:user-recency` timestamp for the `current-user-id`."
@@ -64,7 +69,7 @@
    :from   [:recent_views]
    :where  [:and
             [:= :recent_views.user_id current-user-id]
-            [:= [:cast :recent_views.model_id :text] :search_index.model_id]
+            [:= (cast-to-text :recent_views.model_id) :search_index.model_id]
             [:= :recent_views.model
              [:case
               [:= :search_index.model [:inline "dataset"]] [:inline "card"]


### PR DESCRIPTION
Closes BOT-360

### Description

Update `:bookmarked` and `:user_recency` scorer to work with mysql and mariadb

* Switch from `VALUES` to more portable `SELECT` + `UNION` for generating `search_index` CTE.
* Fix cast to text for MySQL
* Fix `inverse-duration` expression for MySQL to use `TIMESTAMPDIFF` rather than `EXTACT(epoch FROM ...)`


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
