### PR TITLE
Upgrade c3p0 to 0.11.2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -58,7 +58,7 @@
                                             {:mvn/version "2.1.214"}            ; embedded SQL database
   com.ibm.icu/icu4j                         {:mvn/version "77.1"}               ; Used to transliterate Unicode characters into Latin characters
   com.knuddels/jtokkit                      {:mvn/version "1.1.0"}              ; Java tokenizer library for OpenAI models, used for token counting in semantic search
-  com.mchange/c3p0                          {:mvn/version "0.10.1"}             ; DB connection pool
+  com.mchange/c3p0                          {:mvn/version "0.11.2"}             ; DB connection pool
   com.snowplowanalytics/snowplow-java-tracker ^:antq/exclude                    ; 2+ depend on apache httpclient 5.x, but saml and clj-http depend on 4.x
                                             {:mvn/version "1.0.1"}              ; Snowplow analytics
   com.sun.mail/jakarta.mail                 ^:antq/exclude                      ; 2+ changes imports from javax.mail to jakarta.mail
@@ -85,7 +85,7 @@
   hiccup/hiccup                             {:mvn/version "2.0.0"}              ; HTML templating
   inflections/inflections                   {:mvn/version "0.15.0"}             ; Clojure/Script library used for prularizing words
   instaparse/instaparse                     {:mvn/version "1.5.0"}              ; Make your own parser
-  io.github.camsaul/toucan2                 {:mvn/version "1.0.566"}
+  io.github.camsaul/toucan2                 {:mvn/version "1.0.567"}
   io.github.eerohele/pp                     {#_#_:git/tag "2024-11-13.77"       ; super fast pretty-printing library
                                              :git/sha "4998a1fdd9d3713d7034d04509e9212204773bf2"
                                              :git/url "https://github.com/eerohele/pp"}

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -172,7 +172,8 @@
   ^Parser [h2-db-id]
   (with-open [conn (.getConnection (sql-jdbc.execute/datasource-with-diagnostic-info! :h2 h2-db-id))]
     ;; The H2 Parser class is created from the H2 JDBC session, but these fields are not public
-    (let [session (-> conn (get-field "inner") (get-field "session"))]
+    (let [inner (.unwrap conn java.sql.Connection) ;; May be a wrapper, get the innermost object that has session field
+          session (get-field inner "session")]
       ;; Only SessionLocal represents a connection we can create a parser with. Remote sessions and other
       ;; session types are ignored.
       (when (instance? SessionLocal session)


### PR DESCRIPTION
The reason why the 0.10 -> 0.11 upgrade breaks is because, apparently, c3p0 now wraps the connections in its own branded wrapper (`com.mchange.v2.c3p0.impl.NewProxyConnectionJdbc43Full`). Maybe it used to do it before but the wrapper was different, not sure, but anyway – if the new wrapper is not peeled off, then various multimethod overrides that Toucan2 has for Postgres and MySQL don't work.

@camsaul – I need your advice here. 

- On one hand, it probably is better fixed on Toucan2 side, but that would make toucan be aware about c3p0 at least in some capacity which is a change I'm not sure you want to make. 
- Another options is to leave it in Metabase proper and solve it with `:around` multimethods like I did here. Maybe you want it in some other place, not `metabase.driver`. 
- Finally, I've discovered that `.unwrap` functionality is not unique to c3p0, so perhaps it is possible to move this to Toucan but not hardcode it against c3p0, just try to unwrap anything to the barebones java.sql.Connection.