### PR TITLE
Avoid losing work when closing custom expression from shortut

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-reproductions.cy.spec.js
@@ -2495,3 +2495,67 @@ describe("issue 62987", () => {
     });
   });
 });
+
+describe("issue 63180", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          expressions: {
+            Foo: ["+", 1, 2],
+          },
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    H.openNotebook();
+  });
+
+  it("should not be possible to close the custom expression editor when creating a new expression from a combine or extract shortcut (metabase#63180)", () => {
+    function testCombineColumns() {
+      H.getNotebookStep("expression").icon("add").click();
+      H.expressionEditorWidget().within(() => {
+        cy.findByText("Combine columns").click();
+        cy.button("Done").scrollIntoView().click();
+      });
+
+      cy.log("clicking outside the editor should not close it");
+      H.getNotebookStep("data").click();
+      H.expressionEditorWidget().should("be.visible");
+      H.modal().should("not.exist");
+
+      cy.log("clearing the expression should allow clicking outside to work");
+      H.CustomExpressionEditor.clear();
+      H.getNotebookStep("data").click();
+      H.expressionEditorWidget().should("not.exist");
+      H.modal().should("not.exist");
+    }
+
+    function testExtractColumns() {
+      H.getNotebookStep("expression").icon("add").click();
+      H.expressionEditorWidget().within(() => {
+        cy.findByText("Extract columns").click();
+        cy.findByText("Email").click();
+        cy.findByText("Domain").click();
+      });
+
+      cy.log("clicking outside the editor should not close it");
+      H.getNotebookStep("data").click();
+      H.expressionEditorWidget().should("be.visible");
+      H.modal().should("not.exist");
+
+      cy.log("clearing the expression should allow clicking outside to work");
+      H.CustomExpressionEditor.clear();
+      H.getNotebookStep("data").click();
+      H.expressionEditorWidget().should("not.exist");
+      H.modal().should("not.exist");
+    }
+
+    testCombineColumns();
+    testExtractColumns();
+  });
+});

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -255,6 +255,7 @@ function useExpression({
   availableColumns,
   metadata,
   onChange,
+  initialClause,
 }: EditorProps & {
   metadata: Metadata;
 }) {
@@ -347,7 +348,7 @@ function useExpression({
   useMount(() => {
     // format the source when the component mounts
     formatExpression({
-      initial: true,
+      initial: clause === initialClause,
     });
   });
 

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/Editor.tsx
@@ -43,6 +43,7 @@ import { hasActiveSnippet, useInitialClause } from "./utils";
 type EditorProps = {
   id?: string;
   clause?: Lib.Expressionable | null;
+  initialClause?: Lib.Expressionable | null;
   query: Lib.Query;
   stageIndex: number;
   expressionMode: Lib.ExpressionMode;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget/ExpressionWidget.tsx
@@ -193,6 +193,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps) => {
         id="expression-content"
         expressionMode={expressionMode}
         clause={clause}
+        initialClause={initialClause}
         onChange={handleExpressionChange}
         query={query}
         stageIndex={stageIndex}


### PR DESCRIPTION
Closes #63180

#### To verify
1. New question → Orders
2. Add custom column
3. Use `Combine columns` or `Extract columns` to generate an expression
4. While the expression editor is still open, click outside of it: it should not close
6. Click an active element on the page: a modal should warn you for losing work