### PR TITLE
Handle mongo dbrefs properly

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -1131,3 +1131,20 @@
     (with-describe-table-for-sample
       []
       (is (=? #{} @nested-fields)))))
+
+(deftest dbref-field-test
+  (mt/test-driver :mongo
+    (let [id-1 (ObjectId. "68bee671b76da7388a01e6c1")
+          id-2 (ObjectId. "68bee676e7c18921ff7dcf04")
+          ref-1 (com.mongodb.DBRef. "some_collection" id-1)
+          ref-2 (com.mongodb.DBRef. "some_db" "some_collection" id-2)]
+      (mt/dataset (mt/dataset-definition
+                   "dbref_db"
+                   [["dbref_coll"
+                     [{:field-name "name", :base-type :type/Text}
+                      {:field-name "dbref", :base-type :type/*}]
+                     [["ref1" ref-1]
+                      ["ref2" ref-2]]]])
+        (is (= [[1 "ref1" ref-1 "some_collection" id-1 nil]
+                [2 "ref2" ref-2 "some_collection" id-2 "some_db"]]
+               (mt/rows (mt/run-mbql-query dbref_coll))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63231

### Description

We were trying to call `.get` on `com.mongodb.DBRef` which doesn't exist. Instead we need separate handling for `com.mongodb.DBRef` to get the database, collection and ID. 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a mongo collection with a dbref object
2. You should be able to query this collection in metabase

### Demo

https://github.com/user-attachments/assets/a5d1a220-005c-41e7-8875-e06afa89ef8a

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
