### PR TITLE
Ensure results are realized when falling back to in-place results in semantic search

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -60,6 +60,8 @@
           (analytics/observe! :metabase-search/semantic-results-before-fallback final-count)
           (let [fallback-results (try
                                    (cond->> (search.engine/results (assoc search-ctx :search-engine fallback))
+                                     ;; The in-place engine returns a reducible (but not seqable) result that needs to
+                                     ;; be realized before we concat and dedup with the semantic engine results.
                                      (= :search.engine/in-place fallback)
                                      (into [] (comp (map t2.realize/realize)
                                                     (take (- (semantic.settings/semantic-search-results-limit) final-count)))))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -12,7 +12,8 @@
    [metabase.analytics.core :as analytics]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.search.engine :as search.engine]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [toucan2.realize :as t2.realize]))
 
 (defn- fallback-engine
   "Find the highest priority search engine available for fallback."
@@ -58,7 +59,10 @@
           (analytics/inc! :metabase-search/semantic-fallback-triggered {:fallback-engine fallback})
           (analytics/observe! :metabase-search/semantic-results-before-fallback final-count)
           (let [fallback-results (try
-                                   (search.engine/results (assoc search-ctx :search-engine fallback))
+                                   (cond->> (search.engine/results (assoc search-ctx :search-engine fallback))
+                                     (= :search.engine/in-place fallback)
+                                     (into [] (comp (map t2.realize/realize)
+                                                    (take (- (semantic.settings/semantic-search-results-limit) final-count)))))
                                    (catch Throwable t
                                      (log/warn t "Semantic search fallback errored, ignoring")
                                      []))


### PR DESCRIPTION
Closes BOT-399

### Description

Unlike the semantic and appdb backends, the in-place backend returns a reducible result set from
search.engine/results. Make sure we realize the results before attempting to pass them to `m/indexed-by` to dedup
them. This avoids a `Don't know how to create ISeq from: toucan2.pipeline$reducible_fn$reify__48497` exception when falling back to in-place results.

### How to verify

1. Setup MySQL appdb
2. Search for something that triggers fallback or else browse the Models or Metrics page in the sidebar which also uses search and triggers this error

### Demo

**before**

<img width="1448" height="606" alt="Screenshot 2025-09-08 at 9 17 43 AM" src="https://github.com/user-attachments/assets/f2e5d79a-3556-4c54-a4fc-236477a1cf14" />


**after**

<img width="1453" height="577" alt="Screenshot 2025-09-08 at 9 16 28 AM" src="https://github.com/user-attachments/assets/48a51588-10f7-4bae-996a-725692bd6995" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
