### PR TITLE
change mr/cache shape to be flat [k schema-key] -> fn

### DIFF
--- a/src/metabase/util/malli/registry.cljc
+++ b/src/metabase/util/malli/registry.cljc
@@ -11,7 +11,9 @@
    [malli.util :as mut])
   #?(:cljs (:require-macros [metabase.util.malli.registry])))
 
-(defonce ^:private cache (atom {}))
+(defonce ^{:private true
+           :doc "The entries are {[k schema-key] function}. Where `k` is one of :validator or :explainer."}
+  cache (atom {}))
 
 (defn- schema-cache-key
   "Make schemas that aren't `=` to identical ones e.g.
@@ -43,11 +45,11 @@
   you used namespaced keys if you are using it elsewhere."
   [k schema value-thunk]
   (let [schema-key (schema-cache-key schema)]
-    (or (get (get @cache k) schema-key)     ; get-in is terribly inefficient
+    (or (get @cache [k schema-key])     ; get-in is terribly inefficient
         (let [v (value-thunk)]
           (when *cache-miss-hook*
             (*cache-miss-hook* k schema v))
-          (swap! cache assoc-in [k schema-key] v)
+          (swap! cache assoc [k schema-key] v)
           v))))
 
 (defn validator

--- a/test/metabase/util/malli/registry_test.cljc
+++ b/test/metabase/util/malli/registry_test.cljc
@@ -25,7 +25,7 @@
     (let [unique-id (rand)]
       (is (= 1 (with-returning-cache-miss-count
                  (mr/validate [:and {:id unique-id} :string [:re #"\d{4}"]] "1234"))))
-      (let [validator-key-set (set (keys (:validator @@#'mr/cache)))]
+      (let [validator-key-set (set (keep (fn [[[k s] _]] (when (= k :validator) s)) @@#'mr/cache))]
         (is (contains? validator-key-set
                        (#'mr/schema-cache-key [:and {:id unique-id} :string [:re #"\d{4}"]])))
         (is (not (contains? validator-key-set


### PR DESCRIPTION
`(get (get @cache k) schema-key)` becomes `(get @cache [k schema-key])`.

This opens the door to using more advanced caches than an atom.