### PR TITLE
Faster sync when adding new table

### DIFF
--- a/src/metabase/sync/api/notify.clj
+++ b/src/metabase/sync/api/notify.clj
@@ -50,12 +50,9 @@
 (defn- find-and-sync-new-table
   [database table-name schema-name]
   (let [driver (driver.u/database->driver database)
-        {db-tables :tables} (driver/describe-database driver database)]
-    (if-let [table (some (fn [table-in-db]
-                           (when (and (= schema-name (:schema table-in-db))
-                                      (= table-name (:name table-in-db)))
-                             table-in-db))
-                         db-tables)]
+        table  {:name   table-name
+                :schema schema-name}]
+    (if (driver/table-exists? driver database table)
       (let [created (sync-tables/create-or-reactivate-table! database table)]
         (doto created
           sync/sync-table!


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/63266

want to check that the new table exists before adding it into the app-db. The old way worked for all databases but is pretty dumb: it enumerates all tables in the db (as it would for regular sync) and then checks if the new table is in there.

We can be better with the `driver/table-exists?` function.

The shape of data coming back from describe-data is the following:

```clojure
notify=> (let [database (toucan2.core/select-one :model/Database :id 1)]
           (driver/describe-database :h2 database))
{:tables #{{:name "ORDERS",
            :schema "PUBLIC",
            :description nil,
            :is_writable true}
           {:name "PEOPLE",
            :schema "PUBLIC",
            :description nil,
            :is_writable true}
           {:name "FEEDBACK",
            :schema "PUBLIC",
            :description nil,
            :is_writable true}
            ...
```

So we can create the same shape (i omit description and is_writable to seemingly no deleterious effect).

And from the cli:
```sql
testing=# create table new_table_demo(id int);
CREATE TABLE
```

```shell
❯ http post :3000/api/notify/db/89/new-table x-metabase-apikey:notify_key schema_name=public table_name=new_table_demo -pb
{
    "active": true,
    "archived_at": null,
    "caveats": null,
    "created_at": "2025-09-08T20:55:23.62874Z",
    "data_authority": "unconfigured",
    "database_require_filter": null,
    "db_id": 89,
    "deactivated_at": null,
    "description": null,
    "display_name": "New Table Demo",
    "entity_type": null,
    "estimated_row_count": null,
    "field_order": "database",
    "id": 5271,
    "initial_sync_status": "incomplete",
    "is_upload": false,
    "is_writable": null,
    "name": "new_table_demo",
    "points_of_interest": null,
    "schema": "public",
    "show_in_getting_started": false,
    "updated_at": "2025-09-08T20:55:23.62874Z",
    "view_count": 0,
    "visibility_type": null
}
```