### PR TITLE
Adjust clj-kondo linter to allow keyword flags in `require`

### DIFF
--- a/.clj-kondo/src/hooks/clojure/core/require.clj
+++ b/.clj-kondo/src/hooks/clojure/core/require.clj
@@ -52,7 +52,9 @@
 
 (defn- lint-require* [node current-ns config]
   (let [[_require & args]   (:children node)
-        required-namespaces (keep unwrap-require args)]
+        required-namespaces (->> (keep unwrap-require args)
+                                 ;; :reload, :reload-all
+                                 (remove keyword?))]
     (lint* node current-ns config required-namespaces)))
 
 (defn- lint-requiring-resolve* [node current-ns config]

--- a/.clj-kondo/src/hooks/clojure/core/require.clj
+++ b/.clj-kondo/src/hooks/clojure/core/require.clj
@@ -53,7 +53,11 @@
 (defn- lint-require* [node current-ns config]
   (let [[_require & args]   (:children node)
         required-namespaces (->> (keep unwrap-require args)
-                                 ;; :reload, :reload-all
+                                 ;; `require` runs through `cc/load-libs` which allows
+                                 ;; #{:as :reload :reload-all :require :use :verbose :refer :as-alias}
+                                 ;; as args. If you use a REPL tool that applies clj-kondo linting (e.g., Clojure MCP)
+                                 ;; you may wish to `:reload` or `:reload-all` a namespace. So we shouldn't assume all
+                                 ;; args are keywords:
                                  (remove keyword?))]
     (lint* node current-ns config required-namespaces)))
 


### PR DESCRIPTION
### Description

Clojure MCP runs clj-kondo linting on all of its REPL code, picking up all of our project hooks. It adds warnings to the output for the LLM to see, but if there are any errors it simply won't execute the code at all. This does seem useful to the LLM.

The issue is that if Claude is editing files and using the REPL, it knows to `(require '[the.namespace] :reload)` to pick up changes. And the linter throws an exception when it sees `:reload` because, well, it's not a proper namespace.

This removes all keywords from the linting logic.
