### PR TITLE
App DB should always return same type of Card queries (Lib)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -298,16 +298,22 @@
    toucan2.tools.debug/debug                          {:message "Don't commit code using t2/debug"}}
 
   :discouraged-namespace
-  {camel-snake-kebab.core {:message "CSK is not Turkish-safe, use the versions in metabase.util instead."}
-   cheshire.core          {:message "Use metabase.util.json instead of cheshire.core directly."}
-   clj-time.core          {:message "Use java-time.api or metabase.util.date-2 instead of clj-time"}
-   clojure.tools.logging  {:message "Use metabase.util.log instead of clojure.tools.logging directly"}
-   grouper.core           {:message "Use metabase.util.grouper instead of grouper.core"}
-   honeysql.core          {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
-   honeysql.format        {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
-   honeysql.helpers       {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
-   honeysql.types         {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
-   honeysql.util          {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}}
+  {camel-snake-kebab.core              {:message "CSK is not Turkish-safe, use the versions in metabase.util instead."}
+   cheshire.core                       {:message "Use metabase.util.json instead of cheshire.core directly."}
+   clj-time.core                       {:message "Use java-time.api or metabase.util.date-2 instead of clj-time"}
+   clojure.tools.logging               {:message "Use metabase.util.log instead of clojure.tools.logging directly"}
+   grouper.core                        {:message "Use metabase.util.grouper instead of grouper.core"}
+   honeysql.core                       {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
+   honeysql.format                     {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
+   honeysql.helpers                    {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
+   honeysql.types                      {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
+   honeysql.util                       {:message "Use Honey SQL 2. Honey SQL 1 is removed as a dependency in Metabase 49+."}
+   metabase.legacy-mbql.normalize      {:message "Use Lib instead of the legacy MBQL utils"}
+   metabase.legacy-mbql.predicates     {:message "Use Lib instead of the legacy MBQL utils"}
+   metabase.legacy-mbql.schema         {:message "Use Lib instead of the legacy MBQL utils"}
+   metabase.legacy-mbql.schema.helpers {:message "Use Lib instead of the legacy MBQL utils"}
+   metabase.legacy-mbql.schema.macros  {:message "Use Lib instead of the legacy MBQL utils"}
+   metabase.legacy-mbql.util           {:message "Use Lib instead of the legacy MBQL utils"}}
 
   :discouraged-tag {p {:message "You can use it, but don't commit it."}}
 
@@ -712,6 +718,8 @@
    :name    metabase-lib}
   {:pattern "^metabase\\.lib\\..*"
    :name    metabase-lib-excluding-legacy-mbql}
+  {:pattern "^metabase\\.legacy-mbql\\..*"
+   :name    legacy-mbql-namespaces}
   ;;
   ;; QP and driver source namespaces: `metabase.query-processor.*`, `metabase-enterprise.sandbox.query-processor.*`,
   ;; and `metabase.driver.*`, excluding `-test` namespaces.
@@ -816,13 +824,18 @@
   metabase-lib-excluding-legacy-mbql
   {:linters
    {:discouraged-var
-    {metabase.legacy-mbql.util/unique-name-generator {:message "Use metabase.lib.util/unique-name-generator or non-truncating-unique-name-generator"}}}
+    {metabase.legacy-mbql.util/unique-name-generator {:message "Use metabase.lib.util/unique-name-generator or non-truncating-unique-name-generator"}}}}
 
-   :discouraged-namespace
-   {metabase.legacy-mbql.js         {:message "Avoid legacy MBQL utils in Lib; move things into Lib if needded."}
-    metabase.legacy-mbql.jvm-util   {:message "Avoid legacy MBQL utils in Lib; move things into Lib if needded."}
-    metabase.legacy-mbql.predicates {:message "Avoid legacy MBQL utils in Lib; move things into Lib if needded."}
-    metabase.legacy-mbql.util       {:message "Avoid legacy MBQL utils in Lib; move things into Lib if needded."}}}
+  legacy-mbql-namespaces
+  {:linters
+   {:discouraged-namespace
+    ;; it's ok to use legacy-mbql namespaces within the legacy MBQL module.
+    {metabase.legacy-mbql.normalize      {:level :off}
+     metabase.legacy-mbql.predicates     {:level :off}
+     metabase.legacy-mbql.schema         {:level :off}
+     metabase.legacy-mbql.schema.helpers {:level :off}
+     metabase.legacy-mbql.schema.macros  {:level :off}
+     metabase.legacy-mbql.util           {:level :off}}}}
 
   driver-namespaces
   {:linters

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -764,6 +764,7 @@
   parameters
   {:team "Querying"
    :api  #{metabase.parameters.chain-filter
+           metabase.parameters.core
            metabase.parameters.custom-values
            metabase.parameters.dashboard
            metabase.parameters.field
@@ -898,8 +899,7 @@
    :api  #{metabase.queries.api
            metabase.queries.core
            metabase.queries.init
-           metabase.queries.models.query ; TODO FIXME
-           metabase.queries.schema} ; TODO FIXME
+           metabase.queries.models.query} ; TODO FIXME
    :uses #{analytics
            analyze
            api

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
@@ -51,7 +51,7 @@
   [query :- ::lib.schema/query]
   (cond-> query
     (and (is-download? query)
-         (= (:lib/type (lib/query-stage query -1)) :mbql.stage/mbql)
+         (lib/mbql-stage? query -1)
          (= (current-user-download-perms-level query) :ten-thousand-rows))
     (lib/limit ((fnil min Integer/MAX_VALUE) (lib/current-limit query -1) max-rows-in-limited-downloads))))
 

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -319,7 +319,7 @@
   (lib.walk/walk-stages
    query
    (fn [query _path stage]
-     (when (and (= (:lib/type stage) :mbql.stage/mbql)
+     (when (and (lib/mbql-stage? stage)
                 (:source-table stage)
                 (not (::sandbox? stage)))
        (when-let [sandbox (get table-id->sandbox (:source-table stage))]

--- a/src/metabase/analyze/query_results.clj
+++ b/src/metabase/analyze/query_results.clj
@@ -7,6 +7,8 @@
    [metabase.analyze.classifiers.name :as classifiers.name]
    [metabase.analyze.fingerprint.fingerprinters :as fingerprinters]
    [metabase.analyze.fingerprint.insights :as insights]
+   ;; allowed for now since this hasn't been updated to work with Lib-style metadata yet
+   ^{:clj-kondo/ignore [:discouraged-namespace]}
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
@@ -14,20 +16,16 @@
    [metabase.util.malli.registry :as mr]
    [redux.core :as redux]))
 
-(def ^:private ResultColumnMetadata
-  "Result metadata for a single column"
-  [:ref ::mbql.s/legacy-column-metadata])
-
 (mr/def ::ResultsMetadata
   (mu/with-api-error-message
-   [:maybe [:sequential ResultColumnMetadata]]
+   [:maybe [:sequential ::mbql.s/legacy-column-metadata]]
    (i18n/deferred-tru "value must be an array of valid results column metadata maps.")))
 
 (def ResultsMetadata
   "Schema for valid values of the `result_metadata` column."
   [:ref ::ResultsMetadata])
 
-(mu/defn- maybe-infer-semantic-type :- ResultColumnMetadata
+(mu/defn- maybe-infer-semantic-type :- ::mbql.s/legacy-column-metadata
   "Infer the semantic type and add it to the result metadata. If the inferred semantic type is nil, don't override the
   semantic type with a nil semantic type"
   [col]
@@ -41,7 +39,7 @@
        (nil :type/Number) (classifiers.name/infer-semantic-type-by-name col)
        original-value))))
 
-(mu/defn- col->ResultColumnMetadata :- ResultColumnMetadata
+(mu/defn- col->ResultColumnMetadata :- ::mbql.s/legacy-column-metadata
   "Make sure a `column` as it comes back from a driver's initial results metadata matches the schema for valid results
   column metadata, adding placeholder values and removing nil keys."
   [column]

--- a/src/metabase/analyze/schema.clj
+++ b/src/metabase/analyze/schema.clj
@@ -5,12 +5,10 @@
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]))
 
-(mr/def ::no-kebab-case-keys (ms/MapWithNoKebabKeys))
-
 (mr/def ::Table
   [:and
    (ms/InstanceOf :model/Table)
-   ::no-kebab-case-keys])
+   [:ref ::ms/snake_case_map]])
 
 ;; TODO: fix memory issues with `mu/defn` and `ms/InstanceOf` so we don't need to do this
 (def Table

--- a/src/metabase/api/open_api.clj
+++ b/src/metabase/api/open_api.clj
@@ -87,18 +87,17 @@
   [:merge
    ::parameter.schema.common
    [:map
-
     [:type ::parameter.type]
     ;; TODO -- I don't think `:null` can have `:enum`
     [:enum {:optional true} [:sequential :any]]]])
 
 (mr/def ::parameter.schema.string
+  "https://swagger.io/docs/specification/v3_0/data-models/data-types/#strings"
   [:merge
    ::parameter.schema.typed.common
    [:map
-
     [:type [:= :string]]
-    [:format    {:optional true} [:enum :binary "binary" :byte "byte"]]
+    [:format    {:optional true} [:or :keyword [:string {:min 1}]]] ; format is open and can be anything.
     [:minLength {:optional true} integer?]
     [:maxLength {:optional true} integer?]
     [:pattern   {:optional true} (ms/InstanceOfClass java.util.regex.Pattern)]]])
@@ -107,7 +106,6 @@
   [:merge
    ::parameter.schema.typed.common
    [:map
-
     [:type [:= :number]]
     [:minimum {:optional true} number?]
     [:maximum {:optional true} number?]]])
@@ -116,7 +114,6 @@
   [:merge
    ::parameter.schema.typed.common
    [:map
-
     [:type [:= :integer]]
     [:minimum {:optional true} integer?]
     [:maximum {:optional true} integer?]]])
@@ -125,14 +122,12 @@
   [:merge
    ::parameter.schema.typed.common
    [:map
-
     [:type [:= :boolean]]]])
 
 (mr/def ::parameter.schema.null
   [:merge
    ::parameter.schema.typed.common
    [:map
-
     [:type [:= :null]]]])
 
 (mr/def ::parameter.schema.object
@@ -152,7 +147,6 @@
   [:merge
    ::parameter.schema.typed.common
    [:map
-
     [:type        [:= :array]]
     [:items           {:optional true} [:multi
                                         {:dispatch map?}
@@ -183,7 +177,6 @@
   [:merge
    ::parameter.schema.common
    [:map
-
     [:$ref [:re
             {:description "string starting with '#/components/schemas/'"}
             #"^#/components/schemas/[^/]+$"]]
@@ -200,34 +193,29 @@
     [:merge
      ::parameter.schema.common
      [:map
-
       [:anyOf [:sequential [:ref ::parameter.schema]]]]]]
    [:oneOf
     [:merge
      ::parameter.schema.common
      [:map
-
       [:oneOf [:sequential [:ref ::parameter.schema]]]]]]])
 
 (mr/def ::parameter.schema.and
   [:merge
    ::parameter.schema.common
    [:map
-
     [:allOf [:sequential [:ref ::parameter.schema]]]]])
 
 (mr/def ::parameter.schema.const
   [:merge
    ::parameter.schema.common
    [:map
-
     [:const :any]]])
 
 (mr/def ::parameter.schema.untyped-enum
   [:merge
    ::parameter.schema.common
    [:map
-
     [:enum [:sequential :any]]]])
 
 (mr/def ::parameter.schema.empty

--- a/src/metabase/bookmarks/models/bookmark.clj
+++ b/src/metabase/bookmarks/models/bookmark.clj
@@ -3,8 +3,8 @@
    [clojure.string :as str]
    [metabase.app-db.core :as mdb]
    [metabase.config.core :as config]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.premium-features.core :as premium-features]
-   [metabase.queries.schema :as queries.schema]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -35,7 +35,7 @@
    [:item_id                          ms/PositiveInt]
    [:name                             ms/NonBlankString]
    [:authority_level {:optional true} [:maybe :string]]
-   [:card_type       {:optional true} [:maybe ::queries.schema/card-type]]
+   [:card_type       {:optional true} [:maybe ::lib.schema.metadata/card.type]]
    [:description     {:optional true} [:maybe :string]]
    [:display         {:optional true} [:maybe :string]]])
 

--- a/src/metabase/collections/api.clj
+++ b/src/metabase/collections/api.clj
@@ -18,6 +18,7 @@
    [metabase.driver.common.parameters.parse :as params.parse]
    [metabase.eid-translation.core :as eid-translation]
    [metabase.events.core :as events]
+   [metabase.lib-be.core :as lib-be]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.models.interface :as mi]
    [metabase.notification.core :as notification]
@@ -544,7 +545,7 @@
 
 (defn- post-process-card-row [row]
   (-> (t2/instance :model/Card row)
-      (update :dataset_query (:out mi/transform-metabase-query))
+      (update :dataset_query (:out lib-be/transform-query))
       (update :collection_preview api/bit->boolean)
       (update :archived api/bit->boolean)
       (update :archived_directly api/bit->boolean)))

--- a/src/metabase/dashboards/schema.clj
+++ b/src/metabase/dashboards/schema.clj
@@ -1,0 +1,104 @@
+(ns metabase.dashboards.schema
+  (:require
+   [metabase.lib.core :as lib]
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.parameters.schema :as parameters.schema]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms]))
+
+(mr/def ::dashcard.base
+  [:map
+   ;;
+   [:id                 {:optional true} int?]
+   [:size_x             {:optional true} ms/PositiveInt]
+   [:size_y             {:optional true} ms/PositiveInt]
+   [:row                {:optional true} ms/IntGreaterThanOrEqualToZero]
+   [:col                {:optional true} ms/IntGreaterThanOrEqualToZero]
+   [:parameter_mappings {:optional true} [:maybe [:sequential [:ref :metabase.parameters.schema/parameter-mapping]]]]
+   [:inline_parameters  {:optional true} [:maybe [:sequential ms/NonBlankString]]]])
+
+(mr/def ::dashcard
+  "Schema for a (possibly hydrated) Dashboard Card."
+  [:merge
+   [:ref ::dashcard.base]
+   [:map
+    ;; these keys can be added by hydration
+    [:card   {:optional true} [:maybe [:ref :metabase.queries.schema/card]]]
+    ;; TODO -- not sure what the schema for series is supposed to be. Same as a Card?
+    [:series {:optional true} [:maybe [:sequential :map]]]]])
+
+(mr/def ::dashcard.update
+  "Schema for updates to a DashboardCard.
+
+  `:id` can be negative, it indicates a new card and BE should create them."
+  [:merge
+   [:ref ::dashcard.base]
+   [:map
+    [:id {:optional true} int?]]])
+
+(mu/defn normalize-dashcard :- ::dashcard
+  "Normalize a DashboardCard."
+  [dashcard :- :map]
+  (lib/normalize ::dashcard dashcard))
+
+(mr/def ::dashcards
+  (ms/maps-with-unique-key [:sequential ::dashcard] :id))
+
+(mr/def ::dashcards.update
+  "Schema for a sequence of DashboardCard updates (when updating a Dashboard)."
+  (ms/maps-with-unique-key [:sequential ::dashcard.update] :id))
+
+(mr/def ::dashboard-tab
+  [:map
+   [:id   {:optional true} pos-int?]
+   [:name {:optional true} ms/NonBlankString]])
+
+(mr/def ::dashboard-tab.update
+  "id can be negative, it indicates a new card and BE should create them."
+  [:merge
+   [:ref ::dashboard-tab]
+   [:map
+    [:id {:optional true} int?]]])
+
+(mr/def ::dashboard-tabs
+  (ms/maps-with-unique-key [:sequential ::dashboard-tab] :id))
+
+(mr/def ::dashboard-tabs.update
+  (ms/maps-with-unique-key [:sequential ::dashboard-tab.update] :id))
+
+(mr/def ::dashboard
+  [:map
+   [:archived                {:optional true} [:maybe :boolean]]
+   [:cache_ttl               {:optional true} [:maybe ms/PositiveInt]]
+   [:caveats                 {:optional true} [:maybe :string]]
+   [:collection_id           {:optional true} [:maybe ::lib.schema.id/collection]]
+   [:collection_position     {:optional true} [:maybe ms/PositiveInt]]
+   [:dashcards               {:optional true} [:maybe ::dashcards]]
+   [:description             {:optional true} [:maybe :string]]
+   [:embedding_params        {:optional true} [:maybe ms/EmbeddingParams]]
+   [:enable_embedding        {:optional true} [:maybe :boolean]]
+   [:id                      {:optional true} [:maybe ::lib.schema.id/dashboard]]
+   [:name                    {:optional true} [:maybe ms/NonBlankString]]
+   [:parameters              {:optional true} [:maybe [:sequential ::parameters.schema/parameter]]]
+   [:points_of_interest      {:optional true} [:maybe :string]]
+   [:position                {:optional true} [:maybe ms/PositiveInt]]
+   [:show_in_getting_started {:optional true} [:maybe :boolean]]
+   [:tabs                    {:optional true} [:maybe [:ref ::dashboard-tabs]]]
+   [:width                   {:optional true} [:enum {:decode/normalize lib.schema.common/normalize-keyword} :fixed :full]]])
+
+(mr/def ::dashboard.update
+  [:merge
+   [:ref ::dashboard]
+   [:map
+    [:tabs {:optional true} [:ref ::dashboard-tabs.update]]]])
+
+(mu/defn normalize-dashboard :- :map
+  "Normalize a Dashboard using `schema`, default `::dashboard`."
+  ([dashboard]
+   (normalize-dashboard dashboard ::dashboard))
+
+  ([dashboard :- :map
+    schema]
+   (lib/normalize schema dashboard)))

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -564,7 +564,7 @@
   "Takes a string description of a *date* (not datetime) range such as 'lastmonth' or '2016-07-15~2016-08-6', or
   an absolute date *or datetime* string, and returns a corresponding MBQL filter clause for a given field reference."
   [date-string :- :string
-   field       :- [:or ::lib.schema.id/field mbql.s/Field]]
+   field       :- [:or ::lib.schema.id/field mbql.s/FieldOrExpressionRef]]
   (or (execute-decoders all-date-string-decoders :filter (mbql.u/wrap-field-id-if-needed field) date-string)
       (throw (ex-info (tru "Don''t know how to parse date string {0}" (pr-str date-string))
                       {:type        qp.error-type/invalid-parameter

--- a/src/metabase/driver_api/core.clj
+++ b/src/metabase/driver_api/core.clj
@@ -1,7 +1,10 @@
 (ns metabase.driver-api.core
   {:clj-kondo/config '{:linters
-                       ;; this is actually ok here since this is a drivers namespace
-                       {:discouraged-namespace {metabase.query-processor.store {:level :off}}
+                       {:discouraged-namespace {;; allowed for now until we update drivers to use Lib
+                                                metabase.legacy-mbql.schema    {:level :off}
+                                                metabase.legacy-mbql.util      {:level :off}
+                                                ;; this is actually ok here since this is a drivers namespace
+                                                metabase.query-processor.store {:level :off}}
                         ;; this is also ok here since this is a drivers namespace
                         :discouraged-var       {metabase.lib.core/->legacy-MBQL {:level :off}}}}}
   (:refer-clojure :exclude [replace compile require])
@@ -119,7 +122,6 @@
  limit/determine-query-max-rows
  logger/level-enabled?
  mbql.s/Join
- mbql.s/MBQLQuery
  mbql.u/aggregation-at-index
  mbql.u/assoc-field-options
  mbql.u/desugar-filter-clause
@@ -311,3 +313,7 @@
 (def qp.util.transformations.nest-breakouts.externally-remapped-field
   ":metabase.query-processor.util.transformations.nest-breakouts/externally-remapped-field"
   ::qp.util.transformations.nest-breakouts/externally-remapped-field)
+
+(def MBQLQuery
+  "Schema for a legacy MBQL inner query."
+  [:ref ::mbql.s/MBQLInnerQuery])

--- a/src/metabase/indexed_entities/models/model_index.clj
+++ b/src/metabase/indexed_entities/models/model_index.clj
@@ -48,13 +48,13 @@
   "Filter function for valid tuples for indexing: an id and a value."
   [[id v]] (and id v))
 
-(mu/defn- fix-expression-refs :- mbql.s/Field
+(mu/defn- fix-expression-refs :- mbql.s/FieldOrExpressionRef
   "Convert expression ref into a field ref.
 
   Expression refs (`[:expression \"full-name\"]`) are how the _query_ refers to a custom column. But nested queries
   don't, (and shouldn't) care that those are expressions. They are just another field. The field type is always
   `:type/Text` enforced by the endpoint to create model indexes."
-  [field-ref :- mbql.s/Field
+  [field-ref :- mbql.s/FieldOrExpressionRef
    base-type :- ::lib.schema.common/base-type]
   (case (first field-ref)
     :field field-ref

--- a/src/metabase/legacy_mbql/schema/helpers.cljc
+++ b/src/metabase/legacy_mbql/schema/helpers.cljc
@@ -1,4 +1,5 @@
 (ns metabase.legacy-mbql.schema.helpers
+  {:clj-kondo/config '{:linters {:deprecated-var {:level :off}}}}
   (:refer-clojure :exclude [distinct])
   (:require
    [clojure.string :as str]
@@ -8,7 +9,10 @@
 (comment metabase.types.core/keep-me)
 
 (defn mbql-clause?
-  "True if `x` is an MBQL clause (a sequence with a keyword as its first arg)."
+  "True if `x` is an MBQL clause (a sequence with a keyword as its first arg).
+
+  DEPRECATED: use [[metabase.lib.core/clause?]] instead."
+  {:deprecated "0.57.0"}
   [x]
   (and (sequential? x)
        (not (map-entry? x))
@@ -18,7 +22,10 @@
   "If `x` is an MBQL clause, and an instance of clauses defined by keyword(s) `k-or-ks`?
 
     (is-clause? :count [:count 10])        ; -> true
-    (is-clause? #{:+ :- :* :/} [:+ 10 20]) ; -> true"
+    (is-clause? #{:+ :- :* :/} [:+ 10 20]) ; -> true
+
+  DEPRECATED: use [[metabase.lib.core/clause-of-type?]] instead."
+  {:deprecated "0.57.0"}
   [k-or-ks x]
   (and
    (mbql-clause? x)
@@ -31,7 +38,10 @@
 
     (check-clause :count [:count 10]) ; => [:count 10]
     (check-clause? #{:+ :- :* :/} [:+ 10 20]) ; -> [:+ 10 20]
-    (check-clause :sum [:count 10]) ; => nil"
+    (check-clause :sum [:count 10]) ; => nil
+
+  DEPRECATED: use [[metabase.lib.core/clause-of-type?]] instead."
+  {:deprecated "0.57.0"}
   [k-or-ks x]
   (when (is-clause? k-or-ks x)
     x))

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -1,5 +1,6 @@
 (ns metabase.legacy-mbql.util
   "Utilitiy functions for working with MBQL queries."
+  {:clj-kondo/config '{:linters {:deprecated-var {:level :off}}}}
   (:refer-clojure :exclude [replace])
   (:require
    #?@(:clj
@@ -59,7 +60,6 @@
 (defn- simplify-and-or-filter
   {:deprecated "0.57.0"}
   [op args]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (let [args (distinct (filter some? args))]
     (case (count args)
       ;; an empty filter, toss it
@@ -86,7 +86,6 @@
   Use [[metabase.lib.filter.simplify-compound/simplify-compound-filter]] going forward."
   {:deprecated "0.57.0"}
   [x]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (cond
     ;; look for filters in the values
     (map? x) (update-vals x simplify-compound-filter)
@@ -118,7 +117,6 @@
   DEPRECATED: This will be removed in the near future. Use lib utils going forward."
   {:deprecated "0.57.0"}
   [filter-clause & more-filter-clauses]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (simplify-compound-filter (cons :and (cons filter-clause more-filter-clauses))))
 
 ;;; TODO (Cam 7/16/25) -- why does the LEGACY MBQL UTILS have STAGE STUFF IN IT!
@@ -169,7 +167,6 @@
    non-`emptyable` types act as `:is-null`. If field has nil base type it is considered not emptyable expansion wise."
   {:deprecated "0.57.0"}
   [m]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace m
     [:is-empty clause]
     (if (emptyable? clause)
@@ -185,7 +182,6 @@
   "Replace a field or expression inside :time-interval"
   {:deprecated "0.57.0"}
   [m unit]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace m
     [:field id-or-name opts]
     [:field id-or-name (assoc opts :temporal-unit unit)]
@@ -198,7 +194,6 @@
   "Rewrite `:time-interval` filter clauses as simpler ones like `:=` or `:between`."
   {:deprecated "0.57.0"}
   [m]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace m
     [:time-interval field-or-expression n unit] (recur [:time-interval field-or-expression n unit nil])
 
@@ -250,7 +245,6 @@
   "Transform `:relative-time-interval` to `:and` expression."
   {:deprecated "0.57.0"}
   [m]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace
     m
     [:relative-time-interval col value bucket offset-value offset-bucket]
@@ -273,7 +267,6 @@
   "Transform a `:during` expression to an `:and` expression."
   {:deprecated "0.57.0"}
   [m]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace
     m
     [:during col value unit]
@@ -290,7 +283,6 @@
   "Transform a `:if` expression to an `:case` expression."
   {:deprecated "0.57.0"}
   [m]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace
     m
     [:if & args]
@@ -300,7 +292,6 @@
   "Transform `:in` and `:not-in` expressions to `:=` and `:!=` expressions."
   {:deprecated "0.57.0"}
   [m]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace m
     [:in & args]
     (into [:=] args)
@@ -316,7 +307,6 @@
   `[:and [:not [:contains ...]] [:not [:contains ...]]]`."
   {:deprecated "0.57.0"}
   [m]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace m
     [:does-not-contain & args]
     [:not (into [:contains] args)]))
@@ -335,7 +325,6 @@
   `[:contains {} field x y z]`."
   {:deprecated "0.57.0"}
   [m]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace m
     [:= field x y & more]
     (apply vector :or (for [x (concat [x y] more)]
@@ -359,7 +348,6 @@
   `<unit>` is inferred from the `:field` the clause is being compared to (if any), otherwise falls back to `default.`"
   {:deprecated "0.57.0"}
   [m]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace m
     [clause field & (args :guard (partial some (partial = [:relative-datetime :current])))]
     (let [temporal-unit (or (lib.util.match/match-lite-recursive field
@@ -387,7 +375,6 @@
    [:get-second      nil]       :second-of-minute})
 
 (def ^:private ^{:deprecated "0.57.0"} temporal-extract-ops
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (->> (keys temporal-extract-ops->unit)
        (map first)
        set))
@@ -396,7 +383,6 @@
   "Replace datetime extractions clauses like `[:get-year field]` with `[:temporal-extract field :year]`."
   {:deprecated "0.57.0"}
   [m]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace m
     [(op :guard temporal-extract-ops) field & args]
     [:temporal-extract field (temporal-extract-ops->unit [op (first args)])]))
@@ -427,7 +413,6 @@
   the query itself. Filtering should be done based on the number, rather than the name."
   {:deprecated "0.57.0"}
   [expression]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace expression
     [:month-name column]
     (recur (temporal-case-expression column :month-of-year 12))
@@ -441,7 +426,6 @@
   to compile."
   {:deprecated "0.57.0"}
   [expression :- ::mbql.s/FieldOrExpressionDef]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   ;; The `mbql.jvm-u/desugar-host-and-domain` is implemented only for jvm because regexes are not compatible with
   ;; Safari.
   (let [desugar-host-and-domain* #?(:clj  mbql.jvm-u/desugar-host-and-domain
@@ -456,7 +440,6 @@
 (defn- maybe-desugar-expression
   {:deprecated "0.57.0"}
   [clause]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (cond-> clause
     (mbql.preds/FieldOrExpressionDef? clause) desugar-expression))
 
@@ -470,7 +453,6 @@
   forward."
   {:deprecated "0.57.0"}
   [filter-clause :- mbql.s/Filter]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (-> filter-clause
       desugar-current-relative-datetime
       desugar-in
@@ -514,7 +496,6 @@
   filter clause types). Useful for generating highly optimized filter clauses and for drivers that do not support
   top-level `:not` filter clauses."
   [filter-clause :- mbql.s/Filter]
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (-> filter-clause desugar-filter-clause negate* simplify-compound-filter))
 
 (mu/defn query->source-table-id :- [:maybe ::lib.schema.id/table]
@@ -867,14 +848,16 @@
   Also handles unwrapped integers for legacy compatibility.
 
     (unwrap-field-clause [:field 100 nil]) ; -> [:field 100 nil]"
+  {:deprecated "0.57.0"}
   [field-form]
   (if (integer? field-form)
     [:field field-form nil]
     (lib.util.match/match-lite-recursive field-form :field field-form)))
 
-(mu/defn unwrap-field-or-expression-clause :- mbql.s/Field
+(mu/defn unwrap-field-or-expression-clause :- mbql.s/FieldOrExpressionRef
   "Unwrap a `:field` clause or expression clause, such as a template tag. Also handles unwrapped integers for
   legacy compatibility."
+  {:deprecated "0.57.0"}
   [field-or-ref-form]
   (or (unwrap-field-clause field-or-ref-form)
       (lib.util.match/match-lite-recursive field-or-ref-form :expression field-or-ref-form)))

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -55,8 +55,8 @@
 
 (mu/defn- infer-returned-columns :- [:maybe [:sequential ::lib.schema.metadata/column]]
   [metadata-providerable                 :- ::lib.schema.metadata/metadata-providerable
-   {card-query :dataset-query :as _card} :- :map]
-  (when (some? card-query)
+   {card-query :dataset-query :as _card} :- ::lib.schema.metadata/card]
+  (when (seq card-query)
     (lib.metadata.calculation/returned-columns (lib.query/query metadata-providerable card-query))))
 
 (mu/defn- ->card-metadata-column :- ::lib.schema.metadata/column
@@ -170,7 +170,7 @@
   "If `card` itself has a source card that is a Model, return that Model's columns."
   [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
    card                  :- ::lib.schema.metadata/card]
-  (when-let [card-query (some->> (:dataset-query card) (lib.query/query metadata-providerable))]
+  (when-let [card-query (some->> (:dataset-query card) not-empty (lib.query/query metadata-providerable))]
     (when-let [source-card-id (lib.util/source-card-id card-query)]
       (when-not (= source-card-id (:id card))
         (let [source-card (lib.metadata/card metadata-providerable source-card-id)]

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -44,6 +44,7 @@
    [metabase.lib.query :as lib.query]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.remove-replace :as lib.remove-replace]
+   [metabase.lib.schema]
    [metabase.lib.schema.util]
    [metabase.lib.segment :as lib.segment]
    [metabase.lib.serialize]
@@ -95,6 +96,7 @@
          lib.query/keep-me
          lib.ref/keep-me
          lib.remove-replace/keep-me
+         metabase.lib.schema/keep-me
          metabase.lib.schema.util/keep-me
          lib.segment/keep-me
          metabase.lib.serialize/keep-me
@@ -408,6 +410,8 @@
   rename-join
   replace-clause
   replace-join]
+ [metabase.lib.schema
+  native-only-query?]
  [metabase.lib.schema.util]
  [lib.segment
   available-segments]
@@ -437,16 +441,23 @@
   clause?
   clause-of-type?
   fresh-uuids
+  mbql-stage?
   native-stage?
   normalized-query-type
+  normalized-mbql-version
   previous-stage
   previous-stage-number
   query-stage
   source-table-id
+  source-card-id
   update-query-stage]
  [metabase.lib.walk.util
   all-field-ids
   all-source-card-ids
   all-source-table-ids
+  all-template-tag-field-ids
+  all-template-tag-snippet-ids
   all-template-tags
+  all-template-tags-map
+  all-template-tags-id->field-ids
   any-native-stage?])

--- a/src/metabase/lib/metadata/cached_provider.cljc
+++ b/src/metabase/lib/metadata/cached_provider.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.metadata.cached-provider
   (:require
-   #?@(:clj ([pretty.core :as pretty]))
+   #?@(:clj ([metabase.util.json :as json]
+             [pretty.core :as pretty]))
    [clojure.set :as set]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -158,3 +159,10 @@
   ^CachedProxyMetadataProvider [metadata-provider]
   (log/debugf "Wrapping %s in CachedProxyMetadataProvider" (pr-str metadata-provider))
   (->CachedProxyMetadataProvider (atom {}) metadata-provider))
+
+#?(:clj
+   ;; do not encode MetadataProviders to JSON, just generate `nil` instead.
+   (json/add-encoder
+    CachedProxyMetadataProvider
+    (fn [_mp json-generator]
+      (json/generate-nil nil json-generator))))

--- a/src/metabase/lib/metadata/invocation_tracker.cljc
+++ b/src/metabase/lib/metadata/invocation_tracker.cljc
@@ -1,6 +1,8 @@
 (ns metabase.lib.metadata.invocation-tracker
   (:require
-   #?(:clj [pretty.core :as pretty])
+   #?@(:clj
+       ([metabase.util.json :as json]
+        [pretty.core :as pretty]))
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]))
 
 (def ^:private ^:dynamic *to-track-metadata-types*
@@ -89,3 +91,10 @@
   "Wraps `metadata-provider` with a provider that records all invoked ids of [[lib.metadata.protocols/MetadataProvider]] methods."
   [metadata-provider]
   (->InvocationTracker (atom {}) metadata-provider))
+
+#?(:clj
+   ;; do not encode MetadataProviders to JSON, just generate `nil` instead.
+   (json/add-encoder
+    InvocationTracker
+    (fn [_mp json-generator]
+      (json/generate-nil nil json-generator))))

--- a/src/metabase/lib/metadata/protocols.cljc
+++ b/src/metabase/lib/metadata/protocols.cljc
@@ -150,7 +150,12 @@
   "Whether `x` is a [[metadata-provider?]], or has one attached at `:lib/metadata` (i.e., a query)."
   [x]
   (or (metadata-provider? x)
-      (some-> x :lib/metadata metadata-providerable?)))
+      (some-> x :lib/metadata metadata-providerable?)
+      ;; function with the signature
+      ;;
+      ;;    (f database-id) => metadata-provider
+      (fn? x)
+      (var? x)))
 
 (mr/def ::metadata-providerable
   "Something that can be used to get a MetadataProvider. Either a MetadataProvider, or a map with a MetadataProvider in

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -2,6 +2,8 @@
   (:refer-clojure :exclude [remove])
   (:require
    [medley.core :as m]
+   ;; allowed since this is needed to convert legacy queries to MBQL 5
+   ^{:clj-kondo/ignore [:discouraged-namespace]}
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.dispatch :as lib.dispatch]
@@ -120,10 +122,10 @@
   [query :- ::lib.schema/query]
   (can-run query "question"))
 
-(defn add-types-to-fields
+(mu/defn add-types-to-fields
   "Add `:base-type` and `:effective-type` to options of fields in `x` using `metadata-provider`. Works on pmbql fields.
   `:effective-type` is required for coerced fields to pass schema checks."
-  [x metadata-provider]
+  [x metadata-provider :- ::lib.schema.metadata/metadata-provider]
   (if-let [field-ids (lib.util.match/match x
                        [:field
                         (_options :guard (every-pred map? (complement (every-pred :base-type :effective-type))))
@@ -170,12 +172,13 @@
 (defn- query-from-legacy-query
   [metadata-providerable legacy-query]
   (try
-    (let [pmbql-query (-> (binding [lib.schema.expression/*suppress-expression-type-check?* true]
-                            (lib.convert/->pMBQL (mbql.normalize/normalize-or-throw legacy-query)))
-                          (add-types-to-fields metadata-providerable))]
+    (let [mbql5-query (binding [lib.schema.expression/*suppress-expression-type-check?* true]
+                        (lib.convert/->pMBQL (mbql.normalize/normalize-or-throw legacy-query)))
+          mp          (lib.metadata/->metadata-provider metadata-providerable (:database mbql5-query))
+          mbql5-query (add-types-to-fields mbql5-query mp)]
       (merge
-       pmbql-query
-       (query-with-stages metadata-providerable (:stages pmbql-query))))
+       mbql5-query
+       (query-with-stages mp (:stages mbql5-query))))
     (catch #?(:clj Throwable :cljs :default) e
       (throw (ex-info (i18n/tru "Error creating query from legacy query: {0}" (ex-message e))
                       {:legacy-query legacy-query}
@@ -207,12 +210,12 @@
 ;; - fill in top expression refs with metadata
 (defmethod query-method :mbql/query
   [metadata-providerable {converted? :lib.convert/converted? :as query}]
-  (let [metadata-provider (lib.metadata/->metadata-provider metadata-providerable)
-        query (-> query
-                  (assoc :lib/metadata metadata-provider)
-                  (dissoc :lib.convert/converted?)
-
-                  lib.normalize/normalize)
+  (let [database-id       (some #(get query %) [:database "database"])
+        metadata-provider (lib.metadata/->metadata-provider metadata-providerable database-id)
+        query             (-> query
+                              (assoc :lib/metadata metadata-provider)
+                              (dissoc :lib.convert/converted?)
+                              lib.normalize/normalize)
         stages (:stages query)]
     (cond-> query
       converted?
@@ -232,9 +235,9 @@
                                             second
                                             (select-keys [:base-type :effective-type])))
                                        (catch #?(:clj Exception :cljs :default) _
-                                        ;; This currently does not find expressions defined in join stages
+                                         ;; This currently does not find expressions defined in join stages
                                          nil))]
-                      ;; Fallback if metadata is missing
+                       ;; Fallback if metadata is missing
                        [:expression (merge found-ref opts) expression-name]))))
              (m/indexed stages))))))
 

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -393,7 +393,8 @@
 (mr/def ::query
   [:and
    [:map
-    {:decode/normalize common/normalize-map
+    {:description      "Valid MBQL 5 query."
+     :decode/normalize common/normalize-map
      :encode/serialize serialize-query}
     [:lib/type [:=
                 {:decode/normalize common/normalize-keyword, :default :mbql/query}
@@ -437,3 +438,17 @@
      :expressions  ":expressions is not allowed in the top level of a query, only in MBQL stages"
      :filters      ":filters is not allowed in the top level of a query, only in MBQL stages"
      :source-table ":source-table is not allowed in the top level of a query, only in MBQL stages"})])
+
+(defn native-only-query?
+  "Whether MBQL 5 `query` only has a single native stage (and is thus pure-native). This is the equivalent of the old
+  `:type :native` queries in MBQL <= 4."
+  [query]
+  (and (map? query)
+       (= (count (:stages query)) 1)
+       (= (get-in query [:stages 0 :lib/type]) :mbql.stage/native)))
+
+(mr/def ::native-only-query
+  "Schema for a pure-native query with one single native stage."
+  [:and
+   [:ref ::query]
+   [:fn {:error/message "native-only query"} native-only-query?]])

--- a/src/metabase/lib/schema/binning.cljc
+++ b/src/metabase/lib/schema/binning.cljc
@@ -25,7 +25,6 @@
 (mr/def ::binning
   "Schema for `:binning` options passed to a `:field` clause."
   [:and
-   {:doc/title "`:binning` options"}
    [:map
     {:decode/normalize lib.schema.common/normalize-map}
     [:strategy [:ref ::strategy]]]

--- a/src/metabase/lib/schema/common.cljc
+++ b/src/metabase/lib/schema/common.cljc
@@ -154,7 +154,7 @@
 ;;; only support fixing really broken types like `:type/creationtime` to `:type/CreationTime` in prod... Malli checks
 ;;; will throw in dev. See [[metabase.lib.schema.common-test/normalize-base-type-test]] for more info
 
-(mu/defn- normalize-base-type* :- [:ref ::base-type]
+(mu/defn- normalize-base-type* :- [:maybe [:ref ::base-type]]
   [x]
   (normalize-keyword x))
 

--- a/src/metabase/lib/schema/id.cljc
+++ b/src/metabase/lib/schema/id.cljc
@@ -6,7 +6,8 @@
 ;;; them, e.g. when we start working on the generative stuff
 
 (mr/def ::database
-  [:schema {:doc/title "Valid Database ID"} pos-int?])
+  "Valid Database ID"
+  pos-int?)
 
 (def saved-questions-virtual-database-id
   "The ID used to signify that a database is 'virtual' rather than physical.
@@ -27,45 +28,57 @@
 ;;; with that Card. The QP will resolve this to the correct Database later.
 (mr/def ::saved-questions-virtual-database
   [:=
-   {:doc/title   "Saved Questions Virtual Database ID"
-    :description (:doc (meta #'saved-questions-virtual-database-id))}
+   {:description (:doc (meta #'saved-questions-virtual-database-id))}
    saved-questions-virtual-database-id])
 
 (mr/def ::table
-  [:schema {:doc/title "Valid Table ID"} pos-int?])
+  "Valid Table ID"
+  pos-int?)
 
 (mr/def ::field
-  [:schema {:doc/title "Valid Field ID"} pos-int?])
+  "Valid Field ID"
+  pos-int?)
 
 (mr/def ::card
-  [:schema {:doc/title "Valid Card ID"} pos-int?])
+  "Valid Card ID"
+  pos-int?)
 
 (mr/def ::segment
-  [:schema {:doc/title "Valid legacy Segment ID"} pos-int?])
+  "Valid legacy Segment ID"
+  pos-int?)
 
 (mr/def ::snippet
-  [:schema {:doc/title "Valid Snippet ID"} pos-int?])
+  "Valid Snippet ID"
+  pos-int?)
 
 (mr/def ::dimension
-  [:schema {:doc/title "Valid Dimension ID"} pos-int?])
+  "Valid Dimension ID"
+  pos-int?)
 
 (mr/def ::action
-  [:schema {:doc/title "Valid Action ID"} pos-int?])
+  "Valid Action ID"
+  pos-int?)
 
 (mr/def ::dashboard
-  [:schema {:doc/title "Valid Dashboard ID"} pos-int?])
+  "Valid Dashboard ID"
+  pos-int?)
 
 (mr/def ::dashcard
-  [:schema {:doc/title "Valid DashboardCard ID"} pos-int?])
+  "Valid DashboardCard ID"
+  pos-int?)
 
 (mr/def ::user
-  [:schema {:doc/title "Valid User ID"} pos-int?])
+  "Valid User ID"
+  pos-int?)
 
 (mr/def ::pulse
-  [:schema {:doc/title "Valid Pulse ID"} pos-int?])
+  "Valid Pulse ID"
+  pos-int?)
 
 (mr/def ::native-query-snippet
-  [:schema {:doc/title "Valid Native Query Snippet ID"} pos-int?])
+  "Valid Native Query Snippet ID"
+  pos-int?)
 
 (mr/def ::collection
-  [:schema {:doc/title "Valid Collection ID"} pos-int?])
+  "Valid Collection ID"
+  pos-int?)

--- a/src/metabase/lib/schema/literal.cljc
+++ b/src/metabase/lib/schema/literal.cljc
@@ -91,8 +91,8 @@
      :cljs ::string.date))
 
 (mr/def ::time
+  "time literal"
   #?(:clj [:or
-           {:doc/title "time literal"}
            ::string.time
            [:time/local-time
             {:error/message    "instance of java.time.LocalTime"

--- a/src/metabase/lib/schema/parameter.cljc
+++ b/src/metabase/lib/schema/parameter.cljc
@@ -24,6 +24,7 @@
   (:require
    #?@(:clj
        ([flatland.ordered.map :as ordered-map]))
+   [malli.core :as mc]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.util.malli.registry :as mr]))
 
@@ -143,6 +144,7 @@
    :boolean/=               {:type :boolean, :operator :variadic, :allowed-for #{:boolean :boolean/=}}))
 
 (mr/def ::type
+  "Valid parameter :type"
   (into [:enum {:error/message    "valid parameter type"
                 :decode/normalize lib.schema.common/normalize-keyword}]
         (keys types)))
@@ -183,12 +185,12 @@
 (defn- normalize-legacy-ref [legacy-ref]
   ((#?(:clj requiring-resolve :cljs resolve) 'metabase.legacy-mbql.normalize/normalize-field-ref) legacy-ref))
 
-(mr/def ::legacy-field-ref
+(mr/def ::target.legacy-field-ref
   [:ref
    {:decode/normalize normalize-legacy-ref}
    :metabase.legacy-mbql.schema/field])
 
-(mr/def ::legacy-expression-ref
+(mr/def ::target.legacy-expression-ref
   [:ref
    {:decode/normalize normalize-legacy-ref}
    :metabase.legacy-mbql.schema/expression])
@@ -198,9 +200,10 @@
            :error/fn (fn [{:keys [value]} _]
                        (str "Invalid :dimension target: must be a :field, :template-tag, or :expression, got: "
                             (pr-str value)))}
-   [:field        [:ref ::legacy-field-ref]]
-   [:expression   [:ref ::legacy-expression-ref]]
-   [:template-tag [:ref ::template-tag]]])
+   [:expression   [:ref ::target.legacy-expression-ref]]
+   [:template-tag [:ref ::template-tag]]
+   ;; other stuff like MBQL 3 `:fk->` and `:field-id` need to get converted to MBQL 4 `:field`
+   [::mc/default  [:ref ::target.legacy-field-ref]]])
 
 ;;; TODO (Cam 8/8/25) -- is options supposed to be non-empty? It it supposed to be removed from `:dimension` if it's
 ;;; empty? Unclear. I don't think it matters tho.
@@ -213,6 +216,24 @@
 ;;; real MBQL clause tho.
 (mr/def ::dimension
   [:catn
+   ;; this `:decode/normalize` function seems unnecessary but it improves the errors a lot: without it we won't
+   ;; normalize the tag if the target or options are invalid:
+   ;;
+   ;; without:
+   ;;
+   ;;    (metabase.lib.core/normalize ::target ["dimension" ["template-tags" "category"]])
+   ;;    ;; WARN lib.normalize :: Error normalizing MBQL 5: [["should be :dimension"]]
+   ;;    {:value ["dimension" ["template-tags" "category"]], :schema :metabase.lib.schema.parameter/target}
+   ;;
+   ;; with:
+   ;;
+   ;;    ;; WARN lib.normalize :: Error normalizing MBQL 5: [nil ["Invalid :dimension target: must be a :field, :template-tag, or :expression, got: [\"template-tags\" \"category\"]"]]
+   ;;    {:value [:dimension ["template-tags" "category"]], :schema :metabase.lib.schema.parameter/target}
+   {:decode/normalize (fn [dimension]
+                        (if (and (sequential? dimension)
+                                 (string? (first dimension)))
+                          (update (vec dimension) 0 keyword)
+                          dimension))}
    [:tag     [:= {:decode/normalize lib.schema.common/normalize-keyword} :dimension]]
    [:target  ::dimension.target]
    [:options [:? [:maybe ::dimension.options]]]])
@@ -232,7 +253,7 @@
            :error/message "A :variable target must be a (legacy) :field or :template-tag"
            :error/fn      (fn [{:keys [value]} _]
                             (str "Invalid :variable target: must be a :field or :template-tag, got: " (pr-str value)))}
-   [:field        [:ref ::legacy-field-ref]]
+   [:field        [:ref ::target.legacy-field-ref]]
    [:template-tag [:ref ::template-tag]]])
 
 (mr/def ::variable
@@ -247,9 +268,10 @@
                             (pr-str value)))}
    ;; TODO (Cam 9/12/25) -- the old legacy MBQL schema also said `:expression` refs where allowed here, but I don't
    ;; know if we actually did allow that in practice.
-   [:field     [:ref ::legacy-field-ref]]
-   [:dimension [:ref ::dimension]]
-   [:variable  [:ref ::variable]]])
+   [:dimension    [:ref ::dimension]]
+   [:variable     [:ref ::variable]]
+   ;; MBQL 3 refs like `:field-id` should get normalized to `:field`
+   [::mc/default  [:ref ::target.legacy-field-ref]]])
 
 (defn- normalize-parameter
   [param]
@@ -263,6 +285,9 @@
             (nil? l) (assoc :type :number/<=, :value [u])))
         param))))
 
+(mr/def ::id
+  [:ref ::lib.schema.common/non-blank-string])
+
 (mr/def ::parameter
   "Schema for the *value* of a parameter (e.g. a Dashboard parameter or a native query template tag) as passed in as
   part of the `:parameters` list in a query."
@@ -272,7 +297,7 @@
     [:type [:ref ::type]]
     ;; TODO -- these definitely SHOULD NOT be optional but a ton of tests aren't passing them in like they should be.
     ;; At some point we need to go fix those tests and then make these keys required
-    [:id       {:optional true} ::lib.schema.common/non-blank-string]
+    [:id       {:optional true} [:ref ::id]]
     [:target   {:optional true} [:ref ::target]]
     ;; not specified if the param has no value. TODO - make this stricter; type of `:value` should be validated based
     ;; on the [[ParameterType]]

--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -17,8 +17,8 @@
    ;; TODO -- move this stuff into `metabase.lib`
    (keys lib.schema.parameter/types)))
 
-;; Schema for valid values of template tag `:type`.
 (mr/def ::type
+  "Schema for valid values of template tag `:type`."
   [:enum
    {:decode/normalize common/normalize-keyword}
    :snippet :card :dimension :number :text :date :boolean :temporal-unit])
@@ -28,6 +28,11 @@
    {:decode/normalize common/normalize-string-key}
    ::common/non-blank-string])
 
+(mr/def ::id
+  [:multi {:dispatch uuid?}
+   [true  :uuid]
+   [false ::common/non-blank-string]])
+
 ;;; Things required by all template tag types.
 (mr/def ::common
   [:map
@@ -35,9 +40,7 @@
    [:display-name ::common/non-blank-string]
    ;; TODO -- `:id` is actually 100% required but we have a lot of tests that don't specify it because this constraint
    ;; wasn't previously enforced; we need to go in and fix those tests and make this non-optional
-   [:id {:optional true} [:multi {:dispatch uuid?}
-                          [true  :uuid]
-                          [false ::common/non-blank-string]]]])
+   [:id {:optional true} [:ref ::id]]])
 
 ;;; Stuff shared between the Field filter and raw value template tag schemas.
 (mr/def ::value.common

--- a/src/metabase/lib/stage/util.cljc
+++ b/src/metabase/lib/stage/util.cljc
@@ -3,6 +3,7 @@
   high-level ones like `lib.schema` and `lib.util`. This namespace was spun out from [[metabase.lib.stage]] to avoid
   circular dependencies between it and other Lib namespaces."
   (:require
+   [medley.core :as m]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]))
@@ -11,7 +12,11 @@
   "Does given query stage have any clauses?"
   [query        :- ::lib.schema/query
    stage-number :- :int]
-  (boolean (seq (dissoc (lib.util/query-stage query stage-number) :lib/type :source-table :source-card))))
+  (-> (lib.util/query-stage query stage-number)
+      (dissoc :source-table :source-card)
+      (->> (m/filter-keys simple-keyword?))
+      not-empty
+      boolean))
 
 (mu/defn append-stage :- ::lib.schema/query
   "Adds a new blank stage to the end of the pipeline."

--- a/src/metabase/lib/walk.cljc
+++ b/src/metabase/lib/walk.cljc
@@ -394,7 +394,7 @@
                                             (walk-clauses* f)))))
 
          :lib.walk/stage
-         (when (= (:lib/type stage-or-join) :mbql.stage/mbql)
+         (when (lib.util/mbql-stage? stage-or-join)
            (reduce
             (fn [stage k]
               (m/update-existing stage k walk-clauses* f))

--- a/src/metabase/lib/walk/util.cljc
+++ b/src/metabase/lib/walk/util.cljc
@@ -2,6 +2,7 @@
   "Utility functions built on top of [[metabase.lib.walk]]."
   (:require
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
    [metabase.lib.util.match :as lib.util.match]
@@ -9,45 +10,65 @@
    [metabase.util.malli :as mu]))
 
 (defn- transduce-stages
-  ([query rf]
-   (transduce-stages query (rf) rf))
+  ([rf query]
+   (transduce-stages rf (rf) query))
 
-  ([query init rf]
+  ([rf init query]
    (let [acc (volatile! init)]
      (lib.walk/walk-stages
       query
       (fn [_query _path stage]
         (vswap! acc rf stage)
         nil))
-     (rf @acc))))
+     (rf @acc)))
+
+  ([xform rf init query]
+   (transduce-stages (xform rf) init query)))
 
 (defn- stage-values-set [query xform]
   (not-empty
-   (transduce-stages query (transient #{}) (-> conj!
-                                               xform
-                                               (completing persistent!)))))
+   (transduce-stages
+    xform
+    (completing conj! persistent!)
+    (transient #{})
+    query)))
 
 (mu/defn all-source-table-ids :- [:maybe [:set {:min 1} ::lib.schema.id/table]]
   "Return a set of all `:source-table` Table IDs referenced anywhere in the query."
   [query :- ::lib.schema/query]
   (stage-values-set query (keep :source-table)))
 
-(mu/defn all-source-card-ids :- [:maybe [:set {:min 1} ::lib.schema.id/card]]
-  "Return a set of all `:source-card` Card IDs referenced anywhere in the query."
+(mu/defn all-template-tags-map :- [:maybe ::lib.schema.template-tag/template-tag-map]
+  "Return a combined template tags map for all native stages of a `query`."
   [query :- ::lib.schema/query]
-  (stage-values-set query (keep :source-card)))
+  (transduce-stages
+   (comp (filter (fn [stage]
+                   (= (:lib/type stage) :mbql.stage/native)))
+         (mapcat :template-tags))
+   (fn rf
+     ([m]
+      (not-empty (persistent! m)))
+     ([m [template-tag-name template-tag]]
+      (assoc! m template-tag-name template-tag)))
+   (transient {})
+   query))
 
 (mu/defn all-template-tags :- [:maybe [:set {:min 1} ::lib.schema.template-tag/template-tag]]
-  "Return a map of Param IDs to sets of Field IDs referenced by each template tag parameter in this `card`.
-
-  Mostly used for determining Fields referenced by Cards for purposes other than processing queries. Filters out
-  `:field` clauses which use names."
+  "Return a set of all template tags in native stages of a `query`."
   [query :- ::lib.schema/query]
-  (stage-values-set query (comp (filter (fn [stage]
-                                          (= (:lib/type stage) :mbql.stage/native)))
-                                (mapcat :template-tags)
-                                (map (fn [[template-tag-name template-tag]]
-                                       (assoc template-tag :lib.walk/template-tag-name template-tag-name))))))
+  (not-empty
+   (into #{}
+         (map (fn [[template-tag-name template-tag]]
+                (assoc template-tag :lib.walk/template-tag-name template-tag-name)))
+         (all-template-tags-map query))))
+
+(mu/defn all-source-card-ids :- [:maybe [:set {:min 1} ::lib.schema.id/card]]
+  "Return a set of all `:source-card` Card IDs anywhere in the query, as well as all `:card-id`s in template tags."
+  [query :- ::lib.schema/query]
+  (not-empty
+   (into (set (stage-values-set query (keep :source-card)))
+         (keep :card-id)
+         (all-template-tags query))))
 
 (mu/defn any-native-stage?
   "Returns true if any stage of this query is native."
@@ -63,14 +84,51 @@
     @has-native-stage?))
 
 (mu/defn all-field-ids :- [:set ::lib.schema.id/field]
-  "Set of all Field IDs referenced in `:field` refs in `query`."
-  [query :- ::lib.schema/query]
-  (let [field-ids (volatile! (transient #{}))]
-    (lib.walk/walk-clauses
-     query
-     (fn [_query _path-type _stage-or-join-path clause]
-       (lib.util.match/match-lite clause
-         [:field _opts (id :guard pos-int?)]
-         (vswap! field-ids conj! id))
-       nil))
+  "Set of all Field IDs referenced in `:field` refs in a query or MBQL clause."
+  [query-or-clause :- [:or
+                       ::lib.schema/query
+                       vector?]]
+  (let [field-ids   (volatile! (transient #{}))
+        walk-clause (fn [clause]
+                      (lib.util.match/match-lite clause
+                        [:field _opts (id :guard pos-int?)]
+                        (vswap! field-ids conj! id))
+                      nil)]
+    (if (map? query-or-clause)
+      (lib.walk/walk-clauses query-or-clause (fn [_query _path-type _stage-or-join-path clause]
+                                               (walk-clause clause)))
+      (lib.walk/walk-clause query-or-clause walk-clause))
     (persistent! @field-ids)))
+
+(mu/defn all-template-tags-id->field-ids :- [:maybe
+                                             [:map-of
+                                              ::lib.schema.template-tag/id
+                                              [:set ::lib.schema.id/field]]]
+  "Return a map of
+
+    template-tag-id -> template-tag-field-ids-set
+
+  For all template tags in `query`."
+  [query :- ::lib.schema/query]
+  (not-empty
+   (into {}
+         (comp (filter :dimension)
+               (map (fn [template-tag]
+                      [(:id template-tag) (all-field-ids (:dimension template-tag))])))
+         (all-template-tags query))))
+
+(mu/defn all-template-tag-field-ids :- [:set ::lib.schema.id/field]
+  "Set of all `:field` IDs used in template tags."
+  [query]
+  (into #{}
+        (comp (keep :dimension)
+              (mapcat all-field-ids))
+        (all-template-tags query)))
+
+(mu/defn all-template-tag-snippet-ids :- [:set ::lib.schema.id/snippet]
+  "Set of all Native Query Snippet IDs used in template tags."
+  [query]
+  (into #{}
+        (comp (filter #(= (:type %) :snippet))
+              (keep :snippet-id))
+        (all-template-tags query)))

--- a/src/metabase/lib_be/core.clj
+++ b/src/metabase/lib_be/core.clj
@@ -1,13 +1,23 @@
 (ns metabase.lib-be.core
   (:require
+   [metabase.lib-be.metadata.jvm]
+   [metabase.lib-be.models.transforms]
    [metabase.lib-be.settings]
    [potemkin :as p]))
 
-(comment metabase.lib-be.settings/keep-me)
+(comment
+  metabase.lib-be.metadata.jvm/keep-me
+  metabase.lib-be.models.transforms/keep-me
+  metabase.lib-be.settings/keep-me)
 
 (p/import-vars
- [metabase.lib-be.settings
-  breakout-bin-width
-  breakout-bins-num
-  enable-nested-queries
-  start-of-week])
+  [metabase.lib-be.metadata.jvm
+   application-database-metadata-provider]
+  [metabase.lib-be.models.transforms
+   normalize-query
+   transform-query]
+  [metabase.lib-be.settings
+   breakout-bin-width
+   breakout-bins-num
+   enable-nested-queries
+   start-of-week])

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -14,6 +14,7 @@
    [metabase.models.interface :as mi]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.malli :as mu]
    [metabase.util.memoize :as u.memo]
    [metabase.util.performance :as perf]
@@ -518,3 +519,9 @@
   (if-let [cache-atom *metadata-provider-cache*]
     (cache.wrapped/lookup-or-miss cache-atom database-id application-database-metadata-provider-factory)
     (application-database-metadata-provider-factory database-id)))
+
+;;; do not encode MetadataProviders to JSON, just generate `nil` instead.
+(json/add-encoder
+ UncachedApplicationDatabaseMetadataProvider
+ (fn [_mp json-generator]
+   (json/generate-nil nil json-generator)))

--- a/src/metabase/lib_be/models/transforms.clj
+++ b/src/metabase/lib_be/models/transforms.clj
@@ -1,0 +1,19 @@
+(ns metabase.lib-be.models.transforms
+  (:require
+   [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
+   [metabase.lib.core :as lib]
+   [metabase.models.interface :as mi]
+   [metabase.util.malli :as mu]))
+
+(mu/defn normalize-query
+  "Normalize an MBQL `query` to MBQL 5 and attach a metadata provider."
+  [query :- [:maybe :map]]
+  (cond
+    (empty? query)        {}
+    (:lib/metadata query) query
+    :else                 (lib/query lib.metadata.jvm/application-database-metadata-provider query)))
+
+(def transform-query
+  "Toucan 2 transform spec for Card `dataset_query` and other columns that store MBQL."
+  {:in  (comp mi/json-in lib/prepare-for-serialization normalize-query)
+   :out (comp (mi/catch-normalization-exceptions normalize-query) mi/json-out-without-keywordization)})

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1355,7 +1355,7 @@
   [parameters]
   (reduce set/union #{}
           (for [parameter parameters
-                :when (= "card" (:values_source_type parameter))
+                :when (= (keyword (:values_source_type parameter)) :card)
                 :let  [config (:values_source_config parameter)]]
             (set/union #{[{:model "Card" :id (:card_id config)}]}
                        (mbql-deps-vector (:value_field config))))))

--- a/src/metabase/parameters/core.clj
+++ b/src/metabase/parameters/core.clj
@@ -1,0 +1,18 @@
+(ns metabase.parameters.core
+  (:require
+   [metabase.parameters.models.transforms]
+   [metabase.parameters.schema]
+   [potemkin :as p]))
+
+(comment metabase.parameters.schema/keep-me
+         metabase.parameters.models.transforms/keep-me)
+
+(p/import-vars
+  [metabase.parameters.schema
+   normalize-parameter
+   normalize-parameters
+   normalize-parameter-mapping
+   normalize-parameter-mappings]
+  [metabase.parameters.models.transforms
+   transform-parameters
+   transform-parameter-mappings])

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -8,6 +8,7 @@
    [metabase.parameters.chain-filter :as chain-filter]
    [metabase.parameters.custom-values :as custom-values]
    [metabase.parameters.params :as params]
+   [metabase.parameters.schema :as parameters.schema]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
@@ -40,7 +41,11 @@
        :options  options})))
 
 (mu/defn ^:private chain-filter-constraints :- chain-filter/Constraints
-  [dashboard                   :- :map
+  [dashboard                   :- [:map
+                                   [:resolved-params
+                                    [:map-of
+                                     ::lib.schema.parameter/id
+                                     ::parameters.schema/parameter]]]
    constraint-param-key->value :- [:map-of string? any?]]
   (vec (for [[param-key value] constraint-param-key->value
              :let              [param (get-in dashboard [:resolved-params param-key])]
@@ -82,7 +87,7 @@
                  2 second
                  1 first)))))
 
-(mu/defn chain-filter :- ms/FieldValuesResult
+(mu/defn chain-filter :- ::parameters.schema/field-values-result
   "C H A I N filters!
 
   Used to query for values that populate chained filter dropdowns and text search boxes."

--- a/src/metabase/parameters/models/transforms.clj
+++ b/src/metabase/parameters/models/transforms.clj
@@ -1,0 +1,14 @@
+(ns metabase.parameters.models.transforms
+  (:require
+   [metabase.models.interface :as mi]
+   [metabase.parameters.schema :as parameters.schema]))
+
+(def transform-parameters
+  "Transform for parameters list."
+  {:in  (comp mi/json-in #'parameters.schema/normalize-parameters)
+   :out (comp (mi/catch-normalization-exceptions #'parameters.schema/normalize-parameters) mi/json-out-with-keywordization)})
+
+(def transform-parameter-mappings
+  "Transform for parameter mappings."
+  {:in  (comp mi/json-in #'parameters.schema/normalize-parameter-mappings)
+   :out (comp (mi/catch-normalization-exceptions #'parameters.schema/normalize-parameter-mappings) mi/json-out-with-keywordization)})

--- a/src/metabase/parameters/schema.clj
+++ b/src/metabase/parameters/schema.clj
@@ -1,22 +1,16 @@
 (ns metabase.parameters.schema
   (:require
-   [metabase.legacy-mbql.normalize :as mbql.normalize]
-   [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.lib.core :as lib]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli :as mu]))
 
 (mr/def ::human-readable-remapping-map
   "Schema for the map of actual value -> human-readable value. Cannot be empty."
   [:map-of {:min 1} :any [:maybe :string]])
-
-(mr/def ::legacy-field-or-expression-reference
-  "Schema for a valid legacy `:field` or `:expression` reference (possibly not yet normalized)."
-  [:fn
-   (fn [k]
-     ((comp (mr/validator mbql.s/Field)
-            mbql.normalize/normalize-tokens) k))])
 
 (mr/def ::values-source-config
   "Schema for valid source_options within a Parameter"
@@ -24,24 +18,24 @@
   [:map
    [:values      {:optional true} [:* :any]]
    [:card_id     {:optional true} ::lib.schema.id/card]
-   [:value_field {:optional true} ::legacy-field-or-expression-reference]
-   [:label_field {:optional true} ::legacy-field-or-expression-reference]])
+   [:value_field {:optional true} ::lib.schema.parameter/dimension.target]
+   [:label_field {:optional true} ::lib.schema.parameter/dimension.target]])
 
 #_(def ParameterSource
     (mc/schema
      [:multi {:dispatch :values_source_type}
-      ["card"        [:map
-                      [:values_source_type :string]
-                      [:values_source_config
-                       [:map {:closed true}
-                        [:card_id {:optional true} IntGreaterThanZero]
-                        [:value_field {:optional true} Field]
-                        [:label_field {:optional true} Field]]]]]
-      ["static-list" [:map
-                      [:values_source_type :string]
-                      [:values_source_config
-                       [:map {:closed true}
-                        [:values {:optional true} [:* :any]]]]]]]))
+      [:card        [:map
+                     [:values_source_type :string]
+                     [:values_source_config
+                      [:map {:closed true}
+                       [:card_id {:optional true} IntGreaterThanZero]
+                       [:value_field {:optional true} Field]
+                       [:label_field {:optional true} Field]]]]]
+      [:static-list [:map
+                     [:values_source_type :string]
+                     [:values_source_config
+                      [:map {:closed true}
+                       [:values {:optional true} [:* :any]]]]]]]))
 
 (mr/def ::keyword-or-non-blank-string
   [:or
@@ -49,30 +43,99 @@
    :keyword
    ::lib.schema.common/non-blank-string])
 
+(mr/def ::card
+  [:ref :metabase.queries.schema/card])
+
+(mr/def ::dashcard
+  [:ref :metabase.dashboards.schema/dashcard])
+
+(mr/def ::id
+  [:ref ::lib.schema.parameter/id])
+
+(mr/def ::parameter-mapping
+  "Valid parameter mapping for a Card or DashboardCard `parameter_mappings`."
+  [:map
+   {:description "parameter_mapping must be a map with :parameter_id and :target keys"}
+   [:parameter_id ::id]
+   [:target       [:ref ::lib.schema.parameter/target]]
+   [:card_id      {:optional true} ::lib.schema.id/card]
+   [:dashcard     {:optional true} [:ref ::dashcard]]])
+
+(mu/defn normalize-parameter-mapping :- ::parameter-mapping
+  "Normalize `parameter-mappings` when coming out of the application database or in via an API request."
+  [parameter-mapping]
+  (lib/normalize ::parameter-mapping parameter-mapping))
+
+(mr/def ::parameter-mappings
+  [:sequential [:ref ::parameter-mapping]])
+
+(mu/defn normalize-parameter-mappings :- [:maybe ::parameter-mappings]
+  "Normalize `parameter-mappings` when coming out of the application database or in via an API request."
+  [parameter-mappings :- [:maybe [:sequential :map]]]
+  (when parameter-mappings
+    (lib/normalize ::parameter-mappings parameter-mappings)))
+
+(mr/def ::values-source-type
+  [:enum {:decode/normalize lib.schema.common/normalize-keyword} :static-list :card])
+
+(mr/def ::values-query-type
+  [:enum {:decode/normalize lib.schema.common/normalize-keyword} :none :list :search])
+
 (mr/def ::parameter
   "Schema for a valid Parameter. We're not using [[metabase.legacy-mbql.schema/Parameter]] here because this Parameter
   is meant to be used for Parameters we store on dashboard/card, and it has some difference with Parameter in MBQL."
   ;; TODO we could use :multi to dispatch values_source_type to the correct values_source_config
   [:map
    {:description "parameter must be a map with :id and :type keys"}
-   [:id   ::lib.schema.common/non-blank-string]
-   [:type ::keyword-or-non-blank-string]
-   ;; TODO how to merge this with ParameterSource above?
-   [:values_source_type   {:optional true} [:enum "static-list" "card" nil]]
-   [:values_source_config {:optional true} ::values-source-config]
-   [:slug                 {:optional true} :string]
-   [:name                 {:optional true} :string]
+   [:id                   ::id]
    [:default              {:optional true} :any]
+   [:mappings             {:optional true} [:maybe [:or
+                                                    [:ref ::parameter-mappings]
+                                                    [:set [:ref ::parameter-mapping]]]]]
+   [:name                 {:optional true} :string]
+   ;; TODO (Cam 9/18/25) -- why are we mixing `camelCase` and `snake_case` here? Is this to make me sad?
    [:sectionId            {:optional true} ::lib.schema.common/non-blank-string]
-   [:temporal_units       {:optional true} [:sequential ::lib.schema.temporal-bucketing/unit]]
-   ;; TODO FIXME -- I've seen this key used in [[metabase.parameters.params/dashboard-param->field-ids]] but no idea
-   ;; what the expected shape is supposed to be. Please fixx
-   [:mappings             {:optional true} :any]])
+   [:slug                 {:optional true} :string]
+   [:target               {:optional true} [:ref ::lib.schema.parameter/target]]
+   [:temporal_units       {:optional true} [:maybe [:sequential ::lib.schema.temporal-bucketing/unit]]]
+   [:type                 [:ref ::lib.schema.parameter/type]]
+   [:values_query_type    {:optional true} ::values-query-type]
+   [:values_source_config {:optional true} ::values-source-config]
+   [:values_source_type   {:optional true} [:maybe ::values-source-type]]])
 
-(mr/def ::parameter-mapping
-  "Schema for a valid Parameter Mapping"
+(defn normalize-parameter
+  "Normalize `parameter` when coming out of the application database or in via an API request."
+  [parameter]
+  (lib/normalize ::parameter parameter))
+
+(mr/def ::parameters
+  [:sequential [:ref ::parameter]])
+
+(defn normalize-parameters
+  "Normalize `parameters` when coming out of the application database or in via an API request."
+  [parameters]
+  (lib/normalize ::parameters parameters))
+
+(mr/def ::remapped-field-value
+  "Has two components:
+    1. <value-of-field>          (can be anything)
+    2. <value-of-remapped-field> (must be a string)"
+  [:tuple :any :string])
+
+(mr/def ::non-remapped-field-value
+  "Has one component: <value-of-field>"
+  [:tuple :any])
+
+(mr/def ::field-values-list
+  "Schema for a valid list of values for a field, in contexts where the field can have a remapped field."
+  [:sequential
+   [:or
+    [:ref ::remapped-field-value]
+    [:ref ::non-remapped-field-value]]])
+
+(mr/def ::field-values-result
+  "Schema for a value result of fetching the values for a field, in contexts where the field can have a remapped field."
   [:map
-   {:description "parameter_mapping must be a map with :parameter_id and :target keys"}
-   [:parameter_id ::lib.schema.common/non-blank-string]
-   [:target       :any]
-   [:card_id      {:optional true} ::lib.schema.id/card]])
+   [:has_more_values :boolean]
+   [:values          [:ref ::field-values-list]]
+   [:field_id        {:optional true} ::lib.schema.id/field]])

--- a/src/metabase/pulse/core.clj
+++ b/src/metabase/pulse/core.clj
@@ -1,4 +1,4 @@
-(ns ^:deprecated metabase.pulse.core
+(ns metabase.pulse.core
   "API namespace for the `metabase.pulse` module.
 
   This namespace is deprecated, soon everything will be migrated to notifications."

--- a/src/metabase/pulse/update_alerts.clj
+++ b/src/metabase/pulse/update_alerts.clj
@@ -2,6 +2,7 @@
   ;; TODO this should be moved to notification
   (:require
    [metabase.events.core :as events]
+   [metabase.lib.core :as lib]
    [metabase.notification.models :as models.notification]
    [toucan2.core :as t2]))
 
@@ -46,11 +47,12 @@
 (defn- multiple-breakouts?
   "If there are multiple breakouts and a goal, we don't know which breakout to compare to the goal, so it invalidates
   the alert"
-  [{:keys [display] :as new-card}]
+  [{:keys [display], query :dataset_query, :as new-card}]
   (and (get-in new-card [:visualization_settings :graph.goal_value])
        (or (line-area-bar? display)
            (progress? display))
-       (< 1 (count (get-in new-card [:dataset_query :query :breakout])))))
+       (when (seq query)
+         (> (count (lib/breakouts query)) 1))))
 
 (defn delete-alert-and-notify!
   "Removes all of the alerts and notifies all of the email recipients of the alerts change."

--- a/src/metabase/queries/api/cards.clj
+++ b/src/metabase/queries/api/cards.clj
@@ -42,6 +42,7 @@
                                     [:collection_id {:optional true} [:maybe ms/PositiveInt]]
                                     [:dashboard_id  {:optional true} [:maybe ms/PositiveInt]]]]
   (t2/with-transaction [_conn]
+    ;; TODO (Cam 9/18/25) -- N+1 endpoint
     (doseq [card-id card_ids]
-      (api.card/update-card! card-id (select-keys body [:collection_id :dashboard_id]) true)))
+      (api.card/update-card! card-id (select-keys body [:collection_id :dashboard_id]) {:delete-old-dashcards? true})))
   {:status :success})

--- a/src/metabase/queries/card.clj
+++ b/src/metabase/queries/card.clj
@@ -1,14 +1,17 @@
 (ns metabase.queries.card
   (:require
    [medley.core :as m]
-   [metabase.lib.util.match :as lib.util.match]
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.id :as lib.schema.id]
    [metabase.parameters.chain-filter :as chain-filter]
    [metabase.parameters.custom-values :as custom-values]
    [metabase.parameters.field :as parameters.field]
    [metabase.parameters.params :as params]
+   [metabase.parameters.schema :as parameters.schema]
    [metabase.queries.models.card :as card]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]))
 
@@ -22,19 +25,21 @@
       (throw (ex-info (tru "Card does not have a parameter with the ID {0}" (pr-str param-key))
                       {:status-code 400})))))
 
-(defn- param->field-id
-  [card param]
-  (when-let [field-clause (params/param-target->field-clause (:target param) card)]
-    (lib.util.match/match-one field-clause [:field (id :guard integer?) _] id)))
+(mu/defn- param->field-id :- [:maybe ::lib.schema.id/field]
+  [card  :- ::parameters.schema/card
+   param :- ::parameters.schema/parameter]
+  (params/param-target->field-id (:target param) (:dataset_query card)))
 
-(defn mapping->field-values
+(mu/defn- mapping->field-values :- [:maybe ::parameters.schema/field-values-result]
   "Get param values for the \"old style\" parameters. This mimic's the api/dashboard version except we don't have
   chain-filter issues or dashcards to worry about."
-  [card param query]
+  [card  :- ::parameters.schema/card
+   param :- ::parameters.schema/parameter
+   query :- [:maybe ::lib.schema.common/non-blank-string]]
   (when-let [field-id (param->field-id card param)]
     (parameters.field/search-values-from-field-id field-id query)))
 
-(mu/defn card-param-values
+(mu/defn card-param-values :- ::parameters.schema/field-values-result
   "Fetch values for a parameter that contain `query`. If `query` is nil or not provided, return all values.
 
   The source of values could be:
@@ -43,21 +48,31 @@
   ([card param-key]
    (card-param-values card param-key nil))
 
-  ([card      :- ms/Map
-    param-key :- ms/NonBlankString
-    query     :- [:maybe ms/NonBlankString]]
+  ([card         :- ::parameters.schema/card
+    param-key    :- ms/NonBlankString
+    query-string :- [:maybe ms/NonBlankString]]
    (let [param (get-param-or-throw card param-key)]
-     (custom-values/parameter->values param query (fn [] (mapping->field-values card param query))))))
+     (custom-values/parameter->values
+      param query-string
+      (fn default-case-thunk []
+        (or
+         (mapping->field-values card param query-string)
+         (do (log/error "mapping->field-values unexpectedly returned nil (maybe this shouldn't have been called?)"
+                        (pr-str {:card card, :param param, :query-string query-string}))
+             nil)))))))
 
-(defn card-param-remapped-value
+(mu/defn card-param-remapped-value
   "Fetch the remapped value for the given `value` of parameter with ID `:param-key` of `card`."
-  [card param-key value]
+  [card      :- ::parameters.schema/card
+   param-key :- ms/NonBlankString
+   value]
   (or (let [param (get-param-or-throw card param-key)]
         (custom-values/parameter-remapped-value
          param
          value
-         #(when-let [field-id (param->field-id card param)]
-            (-> (chain-filter/chain-filter field-id [{:field-id field-id, :op :=, :value value}] :limit 1)
-                :values
-                first))))
+         (fn default-case-thunk []
+           (when-let [field-id (param->field-id card param)]
+             (-> (chain-filter/chain-filter field-id [{:field-id field-id, :op :=, :value value}] :limit 1)
+                 :values
+                 first)))))
       [value]))

--- a/src/metabase/queries/core.clj
+++ b/src/metabase/queries/core.clj
@@ -6,6 +6,7 @@
    [metabase.queries.models.card.metadata]
    [metabase.queries.models.parameter-card]
    [metabase.queries.models.query]
+   [metabase.queries.schema]
    [potemkin :as p]))
 
 (comment metabase.queries.card/keep-me
@@ -13,7 +14,8 @@
          metabase.queries.models.card/keep-me
          metabase.queries.models.card.metadata/keep-me
          metabase.queries.models.parameter-card/keep-me
-         metabase.queries.models.query/keep-me)
+         metabase.queries.models.query/keep-me
+         metabase.queries.schema/keep-me)
 
 (p/import-vars
  [metabase.queries.card
@@ -38,11 +40,10 @@
  [metabase.queries.models.parameter-card]
  [metabase.queries.models.query
   average-execution-time-ms
-  query->database-and-table-ids
-  save-query-and-update-average-execution-time!])
-
-#_{:clj-kondo/ignore [:missing-docstring]}
-(p/import-def metabase.queries.models.card/lib-query card->lib-query)
+  query->database-and-table-id
+  save-query-and-update-average-execution-time!]
+ [metabase.queries.schema
+  normalize-card])
 
 #_{:clj-kondo/ignore [:missing-docstring]}
 (p/import-def metabase.queries.models.card/populate-query-fields populate-card-query-fields)

--- a/src/metabase/queries/init.clj
+++ b/src/metabase/queries/init.clj
@@ -2,5 +2,4 @@
   (:require
    [metabase.queries.events.cards-notification-deleted-on-card-save]
    [metabase.queries.events.schema]
-   ;; for Malli-registered schemas
    [metabase.queries.schema]))

--- a/src/metabase/queries/models/card/metadata.clj
+++ b/src/metabase/queries/models/card/metadata.clj
@@ -80,7 +80,11 @@ saved later when it is ready."
 
 (defn normalize-dataset-query
   "Normalize the query `dataset-query` received via an HTTP call.
-  Handles both (legacy) MBQL and pMBQL queries."
+  Handles both (legacy) MBQL and pMBQL queries.
+
+  DEPRECATED: this should no longer be needed since [[metabase.lib.core/query]] will normalize the query
+  automatically as needed. Delete this."
+  {:deprecated "0.57.0"}
   [dataset-query]
   (if (= (lib/normalized-query-type dataset-query) :mbql/query)
     (lib/normalize dataset-query)

--- a/src/metabase/queries/models/query.clj
+++ b/src/metabase/queries/models/query.clj
@@ -1,15 +1,13 @@
 (ns metabase.queries.models.query
   "Functions related to the 'Query' model, which records stuff such as average query execution time."
   (:require
-   [clojure.walk :as walk]
    [metabase.app-db.core :as mdb]
-   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.util :as lib.util]
    [metabase.models.interface :as mi]
-   ;; legacy usage -- don't do things like this going forward
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.query-processor.store :as qp.store]
+   [metabase.queries.schema :as queries.schema]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
@@ -34,7 +32,7 @@
   "Fetch the average execution time (in milliseconds) for query with QUERY-HASH if available.
    Returns `nil` if no information is available."
   ^Integer [^bytes query-hash]
-  {:pre [(instance? (Class/forName "[B") query-hash)]}
+  {:pre [(bytes? query-hash)]}
   (t2/select-one-fn :average_execution_time :model/Query :query_hash query-hash))
 
 (defn- int-casting-type
@@ -91,91 +89,27 @@
               ;; rethrow e if updating an existing average execution time failed
               (throw e))))))
 
-(mr/def ::database-and-table-ids
+(mr/def ::database-and-table-id
   [:map
    [:database-id ::lib.schema.id/database]
    [:table-id    [:maybe ::lib.schema.id/table]]])
 
-(mu/defn- pmbql-query->database-and-table-ids :- ::database-and-table-ids
-  [{database-id :database, :as query} :- [:map
-                                          [:lib/type [:= :mbql/query]]]]
-  (if-let [source-card-id (lib.util/source-card-id query)]
-    (let [card (lib.metadata/card query source-card-id)]
-      (merge {:table-id nil} (select-keys card [:database-id :table-id])))
-    (let [table-id (lib.util/source-table-id query)]
-      {:database-id database-id
-       :table-id    table-id})))
-
-(mu/defn- legacy-query->database-and-table-ids :- ::database-and-table-ids
-  [{database-id :database, query-type :type, {:keys [source-table source-query]} :query} :- [:map
-                                                                                             [:type [:enum :query :native]]]]
-  (cond
-    (= :native query-type)  {:database-id database-id, :table-id nil}
-    (integer? source-table) {:database-id database-id, :table-id source-table}
-    (string? source-table)  (let [card-id (lib.util/legacy-string-table-id->card-id source-table)]
-                              (if (qp.store/initialized?)
-                                (lib.metadata/card (qp.store/metadata-provider) card-id)
-                                (-> (t2/select-one [:model/Card
-                                                    ;; `card_schema` is only needed for post-processing.
-                                                    :card_schema
-                                                    [:table_id :table-id]
-                                                    [:database_id :database-id]]
-                                                   :id card-id)
-                                    ;; remove `card_schema` so people don't try to use a key that would be `kebab-case`
-                                    ;; if we got it from the metadata provider.
-                                    (dissoc :card_schema))))
-    (map? source-query)     (legacy-query->database-and-table-ids {:database database-id
-                                                                   :type     query-type
-                                                                   :query    source-query})))
-
-(mu/defn query->database-and-table-ids :- [:maybe ::database-and-table-ids]
-  "Return a map with `:database-id` and source `:table-id` that should be saved for a Card.
-
- Handles either pMBQL (MLv2) queries or legacy MBQL queries. Handles source Cards by fetching them as needed."
-  [query :- [:maybe :map]]
-  (when query
-    (when-let [f (case (lib/normalized-query-type query)
-                   :mbql/query      pmbql-query->database-and-table-ids
-                   (:native :query) legacy-query->database-and-table-ids
-                   nil)]
-      (f (mi/maybe-normalize-query :out query)))))
-
-(defn- parse-source-query-id
-  "Return the ID of the card used as source table, if applicable; otherwise return `nil`."
-  [source-table]
-  (when (string? source-table)
-    (when-let [[_ card-id-str] (re-matches #"card__(\d+)" source-table)]
-      (parse-long card-id-str))))
-
-(defn collect-card-ids
-  "Return a sequence of model ids referenced in the MBQL `query`."
-  [query]
-  (let [ids (java.util.HashSet.)
-        walker (fn [form]
-                 (when (map? form)
-                   ;; model references in native queries
-                   (when-let [card-id (:card-id form)]
-                     (when (int? card-id)
-                       (.add ids card-id)))
-                   ;; source tables (possibly in joins)
-                   ;;
-                   ;; MLv2 `:source-card`
-                   (when-let [card-id (:source-card form)]
-                     (.add ids card-id))
-                   ;; legacy MBQL card__<id> `:source-table`
-                   (when-let [card-id (parse-source-query-id (:source-table form))]
-                     (.add ids card-id)))
-                 form)]
-    (walk/prewalk walker query)
-    (seq ids)))
+(mu/defn query->database-and-table-id :- [:maybe ::database-and-table-id]
+  "Return a map with `:database-id` and source `:table-id` that should be saved for a Card."
+  [{database-id :database, :as query} :- [:maybe ::queries.schema/query]]
+  (when (seq query)
+    (if-let [source-card-id (lib.util/source-card-id query)]
+      (when-let [card (lib.metadata/card query source-card-id)]
+        (merge {:table-id nil}
+               (select-keys card [:database-id :table-id])))
+      (let [table-id (lib.util/source-table-id query)]
+        {:database-id database-id
+         :table-id    table-id}))))
 
 (mu/defn query-is-native? :- :boolean
   "Whether this query (pMBQL or legacy) has a `:native` first stage. Queries with source Cards are considered to be MBQL
   regardless of whether the Card has a native query or not."
-  [query :- :map]
-  (case (lib/normalized-query-type query)
-    :query      false
-    :native     true
-    :mbql/query (let [query (mi/maybe-normalize-query :out query)]
-                  (lib.util/first-stage-is-native? query))
-    false))
+  [query :- [:maybe ::queries.schema/query]]
+  (boolean
+   (when (seq query)
+     (lib.util/first-stage-is-native? query))))

--- a/src/metabase/queries/schema.clj
+++ b/src/metabase/queries/schema.clj
@@ -1,20 +1,96 @@
 (ns metabase.queries.schema
   (:require
+   [metabase.analyze.core :as analyze]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.parameters.schema :as parameters.schema]
+   [metabase.util.i18n :as i18n]
+   [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.regex :as u.regex]))
+   [metabase.util.malli.schema :as ms]
+   [toucan2.core :as t2]))
 
-(def card-types
-  "All acceptable card types.
+(mr/def ::query.non-empty
+  [:and
+   [:map
+    {:decode/normalize #'lib-be/normalize-query}]
+   [:ref ::lib.schema/query]])
 
-  Previously (< 49), we only had 2 card types: question and model, which were differentiated using the boolean
-  `dataset` column. Soon we'll have more card types (e.g: metric) and we will longer be able to use a boolean column
-  to differentiate between all types. So we've added a new `type` column for this purpose.
+(mr/def ::query
+  "Schema for a valid Card `dataset_query`."
+  ;; apparently a Card is allowed to be saved with an empty query map, whether or not this makes sense... we have
+  ;; hundreds of tests that do it tho so I guess we'll just have to allow it for now.
+  [:and
+   :map
+   [:multi {:dispatch (comp boolean empty?)}
+    [true  [:= {:description "empty map"} {}]]
+    [false [:ref ::query.non-empty]]]])
 
-  Migrating all the code to use `report_card.type` will be quite an effort, we decided that we'll migrate it
-  gradually."
-  #{:model :question :metric})
+(mr/def ::card.result-metadata
+  "Cards still expect legacy-style metadata... for now."
+  analyze/ResultsMetadata)
 
-(mr/def ::card-type
-  (into [:enum {:decode/json keyword
-                :api/regex   (u.regex/re-or (map name card-types))}]
-        card-types))
+;;; TODO (Cam 9/17/25) -- fill this out a bit more. We can use a lot of stuff from
+;;; `:metabase.lib.schema.metadata/card`
+(mr/def ::card
+  "General schema for a `:model/Card` when it comes out of the app DB for CRU operations. Mostly everything is marked
+  `:optional` here to facilitate use in partial updates (patching)."
+  [:and
+   [:map
+    [:archived               {:optional true} [:maybe :boolean]]
+    [:cache_ttl              {:optional true} [:maybe ms/PositiveInt]]
+    [:collection_id          {:optional true} [:maybe ::lib.schema.id/collection]]
+    [:collection_position    {:optional true} [:maybe [:or
+                                                       ms/PositiveInt
+                                                       ;; Honey SQL to increment collection position.
+                                                       [:= [:+ :collection_position 1]]
+                                                       [:= [:- :collection_position 1]]]]]
+    [:collection_preview     {:optional true} [:maybe :boolean]]
+    [:dashboard_id           {:optional true} [:maybe ::lib.schema.id/dashboard]]
+    [:dashboard_tab_id       {:optional true} [:maybe ms/PositiveInt]]
+    [:dataset_query          {:optional true} [:maybe ::query]]
+    [:description            {:optional true} [:maybe :string]]
+    [:display                {:optional true} [:maybe [:keyword {:decode/normalize lib.schema.common/normalize-keyword}]]]
+    [:embedding_params       {:optional true} [:maybe ms/EmbeddingParams]]
+    [:enable_embedding       {:optional true} [:maybe :boolean]]
+    [:id                     {:optional true} [:maybe ::lib.schema.id/card]]
+    [:name                   {:optional true} [:maybe ms/NonBlankString]]
+    [:parameter_mappings     {:optional true} [:maybe [:sequential ::parameters.schema/parameter-mapping]]]
+    [:parameters             {:optional true} [:maybe [:sequential ::parameters.schema/parameter]]]
+    [:result_metadata        {:optional true} [:maybe ::card.result-metadata]]
+    [:type                   {:optional true} [:maybe ::lib.schema.metadata/card.type]]
+    [:visualization_settings {:optional true} [:maybe ms/Map]]]
+   [:fn
+    {:error/message    "Card database_id must match dataset_query.database"
+     :decode/normalize (fn [{{query-database-id :database} :dataset_query, :as card}]
+                         (cond-> card
+                           (pos-int? query-database-id)
+                           (assoc :database_id query-database-id)))}
+    (fn [{database-id :database_id, {query-database-id :database} :dataset_query, :as _card}]
+      (if (and database-id query-database-id)
+        (= database-id query-database-id)
+        true))]])
+
+(mr/def ::card.updates
+  "Version of `::card` for updates. The same as `::card` but if you're going to update `:dataset_query` it has to be
+  something valid."
+  [:merge
+   [:ref ::card]
+   [:map
+    [:dataset_query {:optional true} [:ref ::query.non-empty]]]])
+
+(mu/defn normalize-card :- ::card
+  ([card]
+   (normalize-card card ::card))
+  ([card :- :map
+    schema]
+   (try
+     (lib/normalize schema card)
+     (catch Throwable e
+       (throw (ex-info (i18n/tru "Invalid Card: {0}" (ex-message e))
+                       {:card card}
+                       e))))))

--- a/src/metabase/query_processor/compile.clj
+++ b/src/metabase/query_processor/compile.clj
@@ -43,7 +43,7 @@
   stages can only be the first stage, so if the last stage is native it means we have only one stage and this query is
   native-only."
   [query]
-  (= (:lib/type (lib/query-stage query -1)) :mbql.stage/native))
+  (lib/native-stage? query -1))
 
 (mu/defn- compile* :- ::compiled
   [query :- ::lib.schema/query]

--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -20,7 +20,7 @@
   [{:keys        [fields]
     breakouts    :breakout
     aggregations :aggregation, :as stage} :- ::lib.schema/stage]
-  (and (= (:lib/type stage) :mbql.stage/mbql)
+  (and (lib/mbql-stage? stage)
        (every? empty? [aggregations breakouts fields])))
 
 (mu/defn- add-implicit-fields :- [:maybe ::lib.schema/stage]

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -396,7 +396,7 @@
   [query :- ::lib.schema/query
    path  :- ::lib.walk/path
    stage :- ::lib.schema/stage]
-  (when (and (= (:lib/type stage) :mbql.stage/mbql)
+  (when (and (lib/mbql-stage? stage)
              (lib.util.match/match-one stage
                [:field (_opts :guard (every-pred :source-field (complement :join-alias))) _id-or-name]))
     (when (and driver/*driver*
@@ -412,7 +412,7 @@
   [query :- ::lib.schema/query
    path  :- ::lib.walk/path
    stage :- ::lib.schema/stage]
-  (when (= (:lib/type stage) :mbql.stage/mbql)
+  (when (lib/mbql-stage? stage)
     (add-fields-from-next-stage query path stage)))
 
 (mu/defn add-implicit-joins :- ::lib.schema/query

--- a/src/metabase/query_processor/middleware/add_remaps.clj
+++ b/src/metabase/query_processor/middleware/add_remaps.clj
@@ -341,7 +341,7 @@
   [{{:keys [disable-remaps?]} :middleware, :as query} :- ::lib.schema/query]
   (if (or disable-remaps?
           ;; last stage (only stage) is native
-          (= (:lib/type (lib/query-stage query -1)) :mbql.stage/native))
+          (lib/native-stage? query -1))
     query
     (let [{:keys [remaps query]} (add-fk-remaps query)]
       (cond-> query

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -4,6 +4,7 @@
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.card :as lib.card]
+   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.query :as lib.query]
    [metabase.lib.schema :as lib.schema]
@@ -97,7 +98,7 @@
   [query     :- ::lib.schema/query
    stage     :- ::lib.schema/stage
    dep-graph :- (lib.schema.common/instance-of-class clojure.lang.Volatile)]
-  (when (and (= (:lib/type stage) :mbql.stage/mbql)
+  (when (and (lib/mbql-stage? stage)
              (:source-card stage))
     ;; make sure nested queries are enabled before resolving them.
     (when-not (lib-be/enable-nested-queries)

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -355,8 +355,8 @@
       (let [new-stages (update-metric-transition-stages query path expanded-stages idx metric-metadata)]
         (recur (assoc-in query (conj path :stages) new-stages) path new-stages))
 
-      (or (= (:lib/type first-stage) :mbql.stage/mbql)
-          (and (= (:lib/type first-stage) :mbql.stage/native)
+      (or (lib/mbql-stage? first-stage)
+          (and (lib/native-stage? first-stage)
                (:qp/stage-is-from-source-card first-stage)))
       (splice-compatible-metrics query path expanded-stages)
 

--- a/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
+++ b/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
@@ -96,5 +96,5 @@
   (lib.walk/walk-stages
    query
    (fn [query stage-path stage]
-     (when (= (:lib/type stage) :mbql.stage/mbql)
+     (when (lib/mbql-stage? stage)
        (reconcile-bucketing-in-stage query stage-path stage)))))

--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -33,8 +33,6 @@
     ;; bucketed in different ways in previous stages; joins thus ought to be using field name refs; but this ends up
     ;; breaking a ton of stuff, especially `lib.equality`... #63109 was my attempt to make this stuff work when using
     ;; field name refs for joins but it's a long way off from landing.
-    ;;
-    ;; NOCOMMIT
     (for [{field-id :id, :as col} cols
           :let                    [[_tag opts id-or-name, :as field-ref] (lib/ref col)
                                    force-id-ref?         (and (string? id-or-name)

--- a/src/metabase/query_processor/middleware/visualization_settings.clj
+++ b/src/metabase/query_processor/middleware/visualization_settings.clj
@@ -74,7 +74,7 @@
                                            (when (lib/previous-stage query -1)
                                              (lib/fields query -2)))
           field-ids                    (filter pos-int? (map last fields))
-          updated-column-viz-settings  (if (= (:lib/type (lib/query-stage query -1)) :mbql.stage/mbql)
+          updated-column-viz-settings  (if (lib/mbql-stage? query -1)
                                          (update-card-viz-settings query column-viz-settings field-ids)
                                          column-viz-settings)
           global-settings              (update-vals (appearance/custom-formatting)

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -143,18 +143,16 @@
                                   e))))]
     (buddy-hash/sha3-256 (json/encode (select-keys-for-hashing query)))))
 
-;;; --------------------------------------------- Query Source Card IDs ----------------------------------------------
-
 (defn query->source-card-id
-  "Return the ID of the Card used as the \"source\" query of this query, if applicable; otherwise return `nil`."
+  "Return the ID of the Card used as the \"source\" query of this query, if applicable; otherwise return `nil`.
+
+  DEPRECATED: use [[metabase.lib.core/source-card-id]] going forward."
   {:deprecated "0.57.0"}
-  ^Integer [outer-query]
+  ^Long [outer-query]
   (let [source-table (get-in outer-query [:query :source-table])]
     (when (string? source-table)
       (when-let [[_ card-id-str] (re-matches #"^card__(\d+$)" source-table)]
-        (Integer/parseInt card-id-str)))))
-
-;;; ------------------------------------------- Metadata Combination Utils --------------------------------------------
+        (parse-long card-id-str)))))
 
 (defn field-ref->key
   "A standard and repeatable way to address a column. Names can collide and sometimes are not unique. Field refs should

--- a/src/metabase/query_processor/writeback.clj
+++ b/src/metabase/query_processor/writeback.clj
@@ -3,6 +3,7 @@
   (:require
    [metabase.driver :as driver]
    [metabase.lib.core :as lib]
+   [metabase.lib.schema :as lib.schema]
    [metabase.query-processor :as qp]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.enterprise :as qp.enterprise]
@@ -14,8 +15,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli :as mu]))
 
 (def ^:private execution-middleware
   "Middleware that happens after compilation, AROUND query execution itself. Has the form
@@ -33,38 +33,23 @@
    qp
    middleware-fns))
 
-(mr/def ::native-mbql-4-query
-  [:map
-   [:type   [:= :native]]
-   [:native [:map
-             [:query :string]]]])
-
-(mu/defn- substitute-params :- ::native-mbql-4-query
-  [query :- ::native-mbql-4-query]
-  (->> query
-       (lib/query (qp.store/metadata-provider))
-       parameters/substitute-parameters
-       lib/->legacy-MBQL))
-
 (defn- writeback-qp []
   ;; `rff` and `context` are not currently used by the writeback QP stuff, so these parameters can be ignored; we pass
   ;; in `nil` for these below.
   (letfn [(qp* [query _rff]
-            (let [query (substitute-params query)]
+            (let [query (parameters/substitute-parameters query)]
               ;; ok, now execute the query.
               (log/debugf "Executing query\n\n%s" (u/pprint-to-str query))
-              (driver/execute-write-query! driver/*driver* query)))]
+              (driver/execute-write-query! driver/*driver* (lib/->legacy-MBQL query))))]
     (apply-middleware qp* (concat execution-middleware qp/around-middleware))))
 
 (mu/defn execute-write-query!
   "Execute an writeback query (which currently has to be an MBQL 4 native query) from an action."
-  [query :- ::native-mbql-4-query]
+  [query :- ::lib.schema/native-only-query]
   (qp.setup/with-qp-setup [query query]
-    (let [{query-type :type, :as query} (-> (qp.preprocess/preprocess query)
-                                            ;; TODO (Cam 8/19/25) -- update this code to use MBQL 5 / Lib
-                                            lib/->legacy-MBQL)]
+    (let [query (qp.preprocess/preprocess query)]
       ;; make sure this is a native query.
-      (when-not (= query-type :native)
+      (when-not (lib/native-only-query? query)
         (throw (ex-info (tru "Only native queries can be executed as write queries.")
                         {:type qp.error-type/invalid-query, :status-code 400, :query query})))
       ((writeback-qp) query (constantly conj)))))

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -6,10 +6,8 @@
    [medley.core :as m]
    [metabase.app-db.core :as mdb]
    [metabase.collections.models.collection :as collection]
-   [metabase.queries.schema :as queries.schema]
-   [metabase.search.config
-    :as search.config
-    :refer [SearchContext SearchableModel]]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.search.config :as search.config :refer [SearchableModel SearchContext]]
    [metabase.search.engine :as search.engine]
    [metabase.search.filter :as search.filter]
    [metabase.search.in-place.filter :as search.in-place.filter]
@@ -458,7 +456,7 @@
       (search.in-place.filter/build-filters model context)))
 
 (mu/defn- shared-card-impl
-  [model :- ::queries.schema/card-type
+  [model :- ::lib.schema.metadata/card.type
    search-ctx :- SearchContext]
   (-> (base-query-for-model "card" search-ctx)
       (sql.helpers/where [:= :card.type (name model)])

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -113,12 +113,12 @@
 
 (mr/def ::FKMetadataEntry
   [:map
-   [:fk-table-name    ::lib.schema.common/non-blank-string]
-   [:fk-table-schema  [:maybe ::lib.schema.common/non-blank-string]]
-   [:fk-column-name   ::lib.schema.common/non-blank-string]
-   [:pk-table-name    ::lib.schema.common/non-blank-string]
-   [:pk-table-schema  [:maybe ::lib.schema.common/non-blank-string]]
-   [:pk-column-name   ::lib.schema.common/non-blank-string]])
+   [:fk-table-name   ::lib.schema.common/non-blank-string]
+   [:fk-table-schema [:maybe ::lib.schema.common/non-blank-string]]
+   [:fk-column-name  ::lib.schema.common/non-blank-string]
+   [:pk-table-name   ::lib.schema.common/non-blank-string]
+   [:pk-table-schema [:maybe ::lib.schema.common/non-blank-string]]
+   [:pk-column-name  ::lib.schema.common/non-blank-string]])
 
 (def FKMetadataEntry
   "Schema for an entry in the expected output of [[metabase.driver/describe-fks]]."
@@ -129,12 +129,10 @@
 ;; out from the ns declaration when running `cljr-clean-ns`. Plus as a bonus in the future we could add additional
 ;; validations to these, e.g. requiring that a Field have a base_type
 
-(mr/def ::no-kebab-case-keys (ms/MapWithNoKebabKeys))
-
 (mr/def ::DatabaseInstance
   [:and
    (ms/InstanceOf :model/Database)
-   ::no-kebab-case-keys])
+   [:ref ::ms/snake_case_map]])
 
 (def DatabaseInstance
   "Schema for a valid instance of a Metabase Database."
@@ -143,7 +141,7 @@
 (mr/def ::TableInstance
   [:and
    (ms/InstanceOf :model/Table)
-   ::no-kebab-case-keys])
+   [:ref ::ms/snake_case_map]])
 
 (def TableInstance
   "Schema for a valid instance of a Metabase Table."
@@ -153,7 +151,7 @@
   [:and
    [:and
     (ms/InstanceOf :model/Field)
-    ::no-kebab-case-keys]])
+    [:ref ::ms/snake_case_map]]])
 
 (def FieldInstance
   "Schema for a valid instance of a Metabase Field."

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -746,7 +746,7 @@
   "For models that depend on only one table, return its id, otherwise return nil. Doesn't support native queries."
   [model]
   ; dataset_query can be empty in tests
-  (when-let [query (queries/card->lib-query model)]
+  (when-let [query (:dataset_query model)]
     (when (and (mbql? model) (no-joins? query))
       (lib/source-table-id query))))
 

--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -241,7 +241,7 @@
   [field-or-field-id]
   (if-not (map? field-or-field-id)
     (let [field-id (u/the-id field-or-field-id)]
-      (recur (or (t2/select-one ['Field :base_type :visibility_type :has_field_values] :id field-id)
+      (recur (or (t2/select-one [:model/Field :base_type :visibility_type :has_field_values] :id field-id)
                  (throw (ex-info (tru "Field {0} does not exist." field-id)
                                  {:field-id field-id, :status-code 404})))))
     (let [{base-type        :base_type

--- a/src/metabase/warehouses/api.clj
+++ b/src/metabase/warehouses/api.clj
@@ -17,11 +17,11 @@
    [metabase.events.core :as events]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
-   [metabase.queries.schema :as queries.schema]
    [metabase.request.core :as request]
    [metabase.sample-data.core :as sample-data]
    [metabase.secrets.core :as secret]
@@ -143,7 +143,7 @@
 
 (mu/defn- source-query-cards
   "Fetch the Cards that can be used as source queries (e.g. presented as virtual tables)."
-  [card-type :- ::queries.schema/card-type
+  [card-type :- ::lib.schema.metadata/card.type
    & {:keys [additional-constraints xform], :or {xform identity}}]
   (when-let [ids-of-dbs-that-support-source-queries (not-empty (ids-of-dbs-that-support-source-queries))]
     (transduce
@@ -176,20 +176,20 @@
 
 (mu/defn- source-query-cards-exist?
   "Truthy if a single Card that can be used as a source query exists."
-  [card-type :- ::queries.schema/card-type]
+  [card-type :- ::lib.schema.metadata/card.type]
   (seq (source-query-cards card-type :xform (take 1))))
 
 (mu/defn- cards-virtual-tables
   "Return a sequence of 'virtual' Table metadata for eligible Cards.
    (This takes the Cards from `source-query-cards` and returns them in a format suitable for consumption by the Query
    Builder.)"
-  [card-type :- ::queries.schema/card-type
+  [card-type :- ::lib.schema.metadata/card.type
    & {:keys [include-fields?]}]
   (for [card (source-query-cards card-type)]
     (schema.table/card->virtual-table card :include-fields? include-fields?)))
 
 (mu/defn- saved-cards-virtual-db-metadata
-  [card-type :- ::queries.schema/card-type
+  [card-type :- ::lib.schema.metadata/card.type
    & {:keys [include-tables? include-fields?]}]
   (when (lib-be/enable-nested-queries)
     (cond-> {:name               (trs "Saved Questions")

--- a/src/metabase/xrays/api/automagic_dashboards.clj
+++ b/src/metabase/xrays/api/automagic_dashboards.clj
@@ -17,7 +17,8 @@
    [metabase.xrays.transforms.dashboard :as transforms.dashboard]
    [metabase.xrays.transforms.materialize :as transforms.materialize]
    [ring.util.codec :as codec]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2]
+   [metabase.lib-be.core :as lib-be]))
 
 (set! *warn-on-reflection* true)
 
@@ -114,8 +115,8 @@
   "Wrap query map into a Query object (mostly to facilitate type dispatch)."
   [query :- :map]
   (mi/instance :model/Query
-               (merge (queries/query->database-and-table-ids query)
-                      {:dataset_query (mi/maybe-normalize-query :out query)})))
+               (merge (queries/query->database-and-table-id query)
+                      {:dataset_query (lib-be/normalize-query query)})))
 
 (defmethod ->entity :adhoc
   [_entity-type encoded-query]

--- a/test/metabase/app_db/custom_migrations/metrics_v2_test.clj
+++ b/test/metabase/app_db/custom_migrations/metrics_v2_test.clj
@@ -147,11 +147,11 @@
                                                             2 (:id metric2-card)})
                json/decode+kw)))))
 
-(def query-validator
-  (mr/validator mbql.s/MBQLQuery))
+(defn query-validator [inner-query]
+  (mr/validate ::mbql.s/MBQLInnerQuery inner-query))
 
-(def query-explainer
-  (mr/explainer mbql.s/MBQLQuery))
+(defn query-explainer [inner-query]
+  (mr/explain ::mbql.s/MBQLInnerQuery inner-query))
 
 (deftest migrate-metrics-to-v2-test
   (impl/test-migrations ["v51.2024-05-13T15:30:57" "v51.2024-05-13T16:00:00"] [migrate!]

--- a/test/metabase/embedding/api/embed_test.clj
+++ b/test/metabase/embedding/api/embed_test.clj
@@ -251,7 +251,7 @@
                                     ;; order importance: the default from template-tag is in the final result
                  :default "C TAG"
                  :required false
-                 :values_source_type    "static-list"
+                 :values_source_type    :static-list
                  :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}
                                     ;; the parameter id = "d" is in template-tags, but not card.parameters,
                                     ;; when fetching card we should get it returned
@@ -1788,13 +1788,13 @@
                                             :slug                 "static_category"
                                             :id                   param-static-list
                                             :type                 "category"
-                                            :values_source_type   "static-list"
+                                            :values_source_type   :static-list
                                             :values_source_config {:values ["African" "American" "Asian"]}}
                                            {:name                 "Static Category label"
                                             :slug                 "static_category_label"
                                             :id                   param-static-list-label
                                             :type                 "category"
-                                            :values_source_type   "static-list"
+                                            :values_source_type   :static-list
                                             :values_source_config {:values [["Af rican" "Af"] ["American" "Am"] ["Asian" "As"]]}}
                                            {:name                 "Card as source"
                                             :slug                 "card"

--- a/test/metabase/legacy_mbql/schema_test.cljc
+++ b/test/metabase/legacy_mbql/schema_test.cljc
@@ -158,7 +158,7 @@
       [:or mbql.s/absolute-datetime mbql.s/value])))
 
 (deftest ^:parallel expression-value-wrapped-literals-test
-  (are [value] (not (me/humanize (mr/explain mbql.s/MBQLQuery
+  (are [value] (not (me/humanize (mr/explain ::mbql.s/MBQLInnerQuery
                                              {:source-table 1, :expressions {"expr" [:value value nil]}})))
     ""
     "192.168.1.1"
@@ -172,7 +172,7 @@
 
 (deftest ^:parallel expression-unwrapped-literals-test
   (are [value] (= {:expressions {"expr" ["valid instance of one of these MBQL clauses: :expression, :field"]}}
-                  (me/humanize (mr/explain mbql.s/MBQLQuery
+                  (me/humanize (mr/explain ::mbql.s/MBQLInnerQuery
                                            {:source-table 1, :expressions {"expr" value}})))
     ""
     "192.168.1.1"

--- a/test/metabase/legacy_mbql/util_test.cljc
+++ b/test/metabase/legacy_mbql/util_test.cljc
@@ -893,3 +893,11 @@
   (t/testing "If this gets called incorrectly with a base type keyword then handle it gracefully"
     (t/is (= :type/Text
              (mbql.u/normalize-token "type/Text")))))
+
+(t/deftest ^:parallel wrap-field-id-if-needed-test
+  (doseq [[x expected] {10                                      [:field 10 nil]
+                        [:field 10 nil]                         [:field 10 nil]
+                        [:field "name" {:base-type :type/Text}] [:field "name" {:base-type :type/Text}]}]
+    (t/testing x
+      (t/is (= expected
+               (mbql.u/wrap-field-id-if-needed x))))))

--- a/test/metabase/lib/schema/parameter_test.cljc
+++ b/test/metabase/lib/schema/parameter_test.cljc
@@ -1,7 +1,7 @@
 (ns metabase.lib.schema.parameter-test
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
-   [clojure.test :refer [are deftest is]]
+   [clojure.test :refer [are deftest is testing]]
    [malli.error :as me]
    [metabase.lib.core :as lib]
    [metabase.lib.normalize :as lib.normalize]
@@ -46,3 +46,18 @@
     (is (=? {:stages [{:parameters [{:target [:dimension [:expression "my_stringExpr" {:base-type :type/Text}] {:stage-number 0}]}]}]}
             query))
     (is (not (me/humanize (mr/explain ::lib.schema/query query))))))
+
+(deftest ^:parallel dimension-target-test
+  (testing "Failures"
+    (are [v] (not (mr/validate ::lib.schema.parameter/dimension.target v))
+      [:aggregation 0]
+      [:field "name" {}]))
+  (testing "Successes"
+    (are [v] (mr/validate ::lib.schema.parameter/dimension.target v)
+      [:field 3 nil])))
+
+(deftest ^:parallel normalize-mbql-3-refs-test
+  (are [clause expected] (= expected
+                            (lib/normalize ::lib.schema.parameter/dimension clause))
+    [:dimension ["field-id" 76331]] [:dimension [:field 76331 nil]]
+    ["dimension" ["fk->" 23 30]]    [:dimension [:field 30 {:source-field 23}]]))

--- a/test/metabase/lib_be/models/transforms_test.clj
+++ b/test/metabase/lib_be/models/transforms_test.clj
@@ -1,0 +1,29 @@
+(ns metabase.lib-be.models.transforms-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.util.json :as json]))
+
+(deftest ^:parallel handle-bad-template-tags-test
+  (testing (str "an malformed template tags map like the one below is invalid. Rather than potentially destroy an entire API "
+                "response because of one malformed Card, dump the error to the logs and return nil.")
+    (is (= nil
+           ((:out lib-be/transform-query)
+            (json/encode
+             {:database 1
+              :type     :native
+              :native   {:template-tags 1000}}))))))
+
+(deftest ^:parallel template-tag-validate-saves-test
+  (testing "on the other hand we should be a little more strict on the way and disallow you from saving the invalid stuff"
+    ;; TODO -- we should make sure this returns a good error message so we don't have to dig thru the exception chain.
+    (is (thrown?
+         Exception
+         ((:in lib-be/transform-query)
+          {:database 1
+           :type     :native
+           :native   {:template-tags {100 [:field-id "WOW"]}}})))))
+
+(deftest ^:parallel normalize-empty-query-test
+  (is (= {}
+         ((:out lib-be/transform-query) "{}"))))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -10,53 +9,10 @@
    [metabase.util.encryption-test :as encryption-test]
    [metabase.util.json :as json]
    [toucan2.core :as t2])
-  (:import (com.fasterxml.jackson.core JsonParseException)))
+  (:import
+   (com.fasterxml.jackson.core JsonParseException)))
 
-;; let's make sure the `transform-metabase-query`/`transform-metric-segment-definition`/`transform-parameters-list`
-;; normalization functions respond gracefully to invalid stuff when pulling them out of the Database. See #8914
-
-(deftest ^:parallel handle-bad-template-tags-test
-  (testing (str "an malformed template tags map like the one below is invalid. Rather than potentially destroy an entire API "
-                "response because of one malformed Card, dump the error to the logs and return nil.")
-    (is (= nil
-           ((:out mi/transform-metabase-query)
-            (json/encode
-             {:database 1
-              :type     :native
-              :native   {:template-tags 1000}}))))))
-
-(deftest ^:parallel template-tag-validate-saves-test
-  (testing "on the other hand we should be a little more strict on the way and disallow you from saving the invalid stuff"
-    ;; TODO -- we should make sure this returns a good error message so we don't have to dig thru the exception chain.
-    (is (thrown?
-         Exception
-         ((:in mi/transform-metabase-query)
-          {:database 1
-           :type     :native
-           :native   {:template-tags {100 [:field-id "WOW"]}}})))))
-
-(deftest ^:parallel normalize-empty-query-test
-  (is (= {}
-         ((:out mi/transform-metabase-query) "{}"))))
-
-(deftest handle-errors-gracefully-test
-  (testing (str "Cheat and override the `normalization-tokens` function to always throw an Exception so we can make "
-                "sure the Toucan type fn handles the error gracefully")
-    (with-redefs [mbql.normalize/normalize-tokens (fn [& _] (throw (Exception. "BARF")))]
-      (is (= nil
-             ((:out mi/transform-parameters-list)
-              (json/encode
-               [{:target [:dimension [:field "ABC" nil]]}])))))))
-
-(deftest do-not-eat-exceptions-test
-  (testing "should not eat Exceptions if normalization barfs when saving"
-    (is (thrown?
-         Exception
-         (with-redefs [mbql.normalize/normalize-tokens (fn [& _] (throw (Exception. "BARF")))]
-           ((:in mi/transform-parameters-list)
-            [{:target [:dimension [:field "ABC" nil]]}]))))))
-
-(deftest timestamped-property-test
+(deftest ^:parallel timestamped-property-test
   (testing "Make sure updated_at gets updated for timestamped models"
     (mt/with-temp [:model/Table table {:updated_at #t "2023-02-02T01:00:00"}]
       (let [updated-at (:updated_at table)
@@ -68,7 +24,7 @@
                  :updated_at (partial not= updated-at)}
                 (t2/select-one [:model/Table :id :name :updated_at] (u/the-id table))))))))
 
-(deftest timestamped-property-do-not-stomp-on-explicit-values-test
+(deftest ^:parallel timestamped-property-do-not-stomp-on-explicit-values-test
   (testing "The :timestamped property should not stomp on :created_at/:updated_at if they are explicitly specified"
     (mt/with-temp [:model/Field field]
       (testing "Nothing specified: use now() for both"
@@ -91,7 +47,7 @@
 (defmethod mi/non-timestamped-fields :test-model/updated-at-tester [_]
   #{:non_timestamped :other})
 
-(deftest timestamped-property-skips-non-timestamped-fields-test
+(deftest ^:parallel timestamped-property-skips-non-timestamped-fields-test
   (testing "Does not add a timestamp if it only includes non-timestamped fields"
     (let [instance (-> (t2/instance :test-model/updated-at-tester {:non_timestamped nil})
                        (assoc :non_timestamped 1))]
@@ -104,7 +60,7 @@
       (is (= {:non_timestamped 1 :included 2 :updated_at (mi/now)}
              (#'mi/add-updated-at-timestamp instance))))))
 
-(deftest ^:parallel upgrade-to-v2-viz-settings-test
+(deftest ^:parallel ^:parallel upgrade-to-v2-viz-settings-test
   (let [migrate #(select-keys (#'mi/migrate-viz-settings %)
                               [:version :pie.percent_visibility])]
     (testing "show_legend -> inside"

--- a/test/metabase/parameters/custom_values_test.clj
+++ b/test/metabase/parameters/custom_values_test.clj
@@ -174,7 +174,7 @@
                   :has_more_values true}
                  (custom-values/values-from-card
                   card
-                  [:field "Categories__NAME" {:base_type :type/Text}]
+                  [:field "Categories__NAME" {:base-type :type/Text}]
                   {:stage-number 1}))))))))
 
 (deftest ^:parallel with-mbql-card-test-6-expressions
@@ -270,8 +270,8 @@
                 {:name                 "Card as source"
                  :slug                 "card"
                  :id                   "_CARD_"
-                 :type                 "category"
-                 :values_source_type   "card"
+                 :type                 :category
+                 :values_source_type   :card
                  :values_source_config {:card_id     (:id card)
                                         :value_field (mt/$ids $venues.name)}}
                 nil
@@ -290,8 +290,8 @@
                     {:name                 "Card as source"
                      :slug                 "card"
                      :id                   "_CARD_"
-                     :type                 "category"
-                     :values_source_type   "card"
+                     :type                 :category
+                     :values_source_type   :card
                      :values_source_config {:card_id     (:id card)
                                             :value_field (mt/$ids $venues.name)}}
                     nil
@@ -310,10 +310,10 @@
                     {:name                 "Card as source"
                      :slug                 "card"
                      :id                   "_CARD_"
-                     :type                 "category"
-                     :values_source_type   "card"
+                     :type                 :category
+                     :values_source_type   :card
                      :values_source_config {:card_id     (:id card)
-                                            :value_field [:field 0 nil]}}
+                                            :value_field [:field Integer/MAX_VALUE nil]}}
                     nil
                     (constantly mock-default-result))))))))))
 
@@ -337,77 +337,79 @@
                   card
                   (mt/$ids $products.category)))))))))
 
-(deftest pk-of-fk-pk-field-ids-test
+(deftest ^:parallel pk-of-fk-pk-field-ids-test-1
   (testing "single group"
     (testing "with PK"
-      (is (= (mt/id :products :id)
-             (custom-values/pk-of-fk-pk-field-ids [(mt/id :orders :product_id)
-                                                   (mt/id :products :id)])))
-      (is (= (mt/id :products :id)
-             (custom-values/pk-of-fk-pk-field-ids [(mt/id :orders :product_id)
-                                                   (mt/id :reviews :product_id)
-                                                   (mt/id :products :id)]))))
+      (are [input] (= (mt/id :products :id)
+                      (custom-values/pk-of-fk-pk-field-ids input))
+        [(mt/id :orders :product_id) (mt/id :products :id)]
+        [(mt/id :orders :product_id) (mt/id :reviews :product_id) (mt/id :products :id)]))))
+
+(deftest ^:parallel pk-of-fk-pk-field-ids-test-1b
+  (testing "single group"
     (testing "without PK"
-      (is (= (mt/id :products :id)
-             (custom-values/pk-of-fk-pk-field-ids #{(mt/id :orders :product_id)})))
-      (is (= (mt/id :products :id)
-             (custom-values/pk-of-fk-pk-field-ids [(mt/id :orders :product_id)
-                                                   (mt/id :reviews :product_id)]))))
+      (are [input] (= (mt/id :products :id)
+                      (custom-values/pk-of-fk-pk-field-ids input))
+        #{(mt/id :orders :product_id)}
+        [(mt/id :orders :product_id) (mt/id :reviews :product_id)]))))
+
+(deftest ^:parallel pk-of-fk-pk-field-ids-test-1c
+  (testing "single group"
     (testing "duplicates are OK "
-      (is (= (mt/id :products :id)
-             (custom-values/pk-of-fk-pk-field-ids [(mt/id :orders :product_id)
-                                                   (mt/id :orders :product_id)
-                                                   (mt/id :reviews :product_id)
-                                                   (mt/id :reviews :product_id)])))
-      (is (= (mt/id :products :id)
-             (custom-values/pk-of-fk-pk-field-ids [(mt/id :orders :product_id)
-                                                   (mt/id :orders :product_id)
-                                                   (mt/id :orders :product_id)
-                                                   (mt/id :reviews :product_id)])))
-      (is (= (mt/id :products :id)
-             (custom-values/pk-of-fk-pk-field-ids [(mt/id :orders :product_id)
-                                                   (mt/id :orders :product_id)
-                                                   (mt/id :orders :product_id)])))))
+      (are [input] (= (mt/id :products :id)
+                      (custom-values/pk-of-fk-pk-field-ids input))
+        [(mt/id :orders :product_id)
+         (mt/id :orders :product_id)
+         (mt/id :reviews :product_id)
+         (mt/id :reviews :product_id)]
+
+        [(mt/id :orders :product_id)
+         (mt/id :orders :product_id)
+         (mt/id :orders :product_id)
+         (mt/id :reviews :product_id)]
+
+        [(mt/id :orders :product_id) (mt/id :orders :product_id) (mt/id :orders :product_id)]))))
+
+(deftest ^:parallel pk-of-fk-pk-field-ids-test-2
   (testing "two groups"
     (testing "both with PKs"
-      (is (nil? (custom-values/pk-of-fk-pk-field-ids [(mt/id :orders :product_id)
-                                                      (mt/id :reviews :product_id)
-                                                      (mt/id :products :id)
-                                                      (mt/id :orders :user_id)
-                                                      (mt/id :people :id)]))))
+      (is (nil? (custom-values/pk-of-fk-pk-field-ids
+                 [(mt/id :orders :product_id)
+                  (mt/id :reviews :product_id)
+                  (mt/id :products :id)
+                  (mt/id :orders :user_id)
+                  (mt/id :people :id)]))))))
+
+(deftest ^:parallel pk-of-fk-pk-field-ids-test-2b
+  (testing "two groups"
     (testing "one with PK"
-      (is (nil? (custom-values/pk-of-fk-pk-field-ids [(mt/id :orders :product_id)
-                                                      (mt/id :reviews :product_id)
-                                                      (mt/id :orders :user_id)
-                                                      (mt/id :people :id)]))))
+      (is (nil? (custom-values/pk-of-fk-pk-field-ids
+                 [(mt/id :orders :product_id) (mt/id :reviews :product_id) (mt/id :orders :user_id) (mt/id :people :id)]))))))
+
+(deftest ^:parallel pk-of-fk-pk-field-ids-test-2c
+  (testing "two groups"
     (testing "none with PK"
-      (is (nil? (custom-values/pk-of-fk-pk-field-ids [(mt/id :orders :product_id)
-                                                      (mt/id :reviews :product_id)
-                                                      (mt/id :orders :user_id)])))))
+      (is (nil? (custom-values/pk-of-fk-pk-field-ids
+                 [(mt/id :orders :product_id) (mt/id :reviews :product_id) (mt/id :orders :user_id)]))))))
+
+(deftest ^:parallel pk-of-fk-pk-field-ids-test-3
   (testing "single group with PK plus other field"
-    (is (nil? (custom-values/pk-of-fk-pk-field-ids #{(mt/id :orders :product_id)
-                                                     (mt/id :reviews :product_id)
-                                                     (mt/id :products :id)
-                                                     (mt/id :people :name)})))
-    (is (nil? (custom-values/pk-of-fk-pk-field-ids #{(mt/id :orders :product_id)
-                                                     (mt/id :reviews :product_id)
-                                                     (mt/id :products :id)
-                                                     Integer/MAX_VALUE})))
-    (is (nil? (custom-values/pk-of-fk-pk-field-ids #{(mt/id :orders :product_id)
-                                                     (mt/id :reviews :product_id)
-                                                     (mt/id :products :id)
-                                                     -1}))))
+    (are [input] (nil? (custom-values/pk-of-fk-pk-field-ids input))
+      #{(mt/id :products :id) (mt/id :orders :product_id) (mt/id :reviews :product_id) (mt/id :people :name)}
+      #{(mt/id :products :id) (mt/id :orders :product_id) (mt/id :reviews :product_id) Integer/MAX_VALUE}
+      #{-1 (mt/id :products :id) (mt/id :orders :product_id) (mt/id :reviews :product_id)})))
+
+(deftest ^:parallel pk-of-fk-pk-field-ids-test-4
   (testing "single group without PK plus other field"
-    (is (nil? (custom-values/pk-of-fk-pk-field-ids [(mt/id :orders :product_id)
-                                                    (mt/id :reviews :product_id)
-                                                    (mt/id :people :name)])))
-    (is (nil? (custom-values/pk-of-fk-pk-field-ids #{(mt/id :orders :product_id)
-                                                     (mt/id :reviews :product_id)
-                                                     Integer/MAX_VALUE})))
-    (is (nil? (custom-values/pk-of-fk-pk-field-ids #{(mt/id :orders :product_id)
-                                                     (mt/id :reviews :product_id)
-                                                     -1}))))
+    (are [input] (nil? (custom-values/pk-of-fk-pk-field-ids input))
+      [(mt/id :orders :product_id) (mt/id :reviews :product_id) (mt/id :people :name)]
+      #{(mt/id :orders :product_id) (mt/id :reviews :product_id) Integer/MAX_VALUE}
+      #{-1 (mt/id :orders :product_id) (mt/id :reviews :product_id)})))
+
+(deftest ^:parallel pk-of-fk-pk-field-ids-test-5
   (testing "just a PK"
-    (is (nil? (custom-values/pk-of-fk-pk-field-ids [(mt/id :products :id)]))))
+    (is (nil? (custom-values/pk-of-fk-pk-field-ids [(mt/id :products :id)])))))
+
+(deftest ^:parallel pk-of-fk-pk-field-ids-test-6
   (testing "just a non-key"
     (is (nil? (custom-values/pk-of-fk-pk-field-ids [(mt/id :people :name)])))))

--- a/test/metabase/parameters/models/transforms_test.clj
+++ b/test/metabase/parameters/models/transforms_test.clj
@@ -1,0 +1,72 @@
+(ns metabase.parameters.models.transforms-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.legacy-mbql.normalize :as mbql.normalize]
+   [metabase.parameters.core :as parameters]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.parameter :as lib.schema.parameter]
+   [metabase.parameters.schema :as parameters.schema]))
+
+(deftest handle-errors-gracefully-test
+  (testing (str "Cheat and override the `normalization-tokens` function to always throw an Exception so we can make "
+                "sure the Toucan type fn handles the error gracefully")
+    (with-redefs [parameters.schema/normalize-parameters (fn [& _] (throw (Exception. "BARF")))]
+      (is (= nil
+             ((:out parameters/transform-parameters)
+              (json/encode
+               [{:target [:dimension [:field "ABC" nil]]}])))))))
+
+(deftest do-not-eat-exceptions-test
+  (testing "should not eat Exceptions if normalization barfs when saving"
+    (is (thrown?
+         Exception
+         (with-redefs [parameters.schema/normalize-parameters (fn [& _] (throw (Exception. "BARF")))]
+           ((:in parameters/transform-parameters)
+            [{:target [:dimension [:field "ABC" nil]]}]))))))
+
+(deftest ^:parallel normalize-parameter-mappings-test
+  (testing "DashboardCard parameter mappings should get normalized when coming out of the DB"
+    (mt/with-temp [:model/Dashboard     dashboard {:parameters [{:name "Venue ID"
+                                                                 :slug "venue_id"
+                                                                 :id   "22486e00"
+                                                                 :type "id"}]}
+                   :model/Card          card      {}
+                   :model/DashboardCard dashcard  {:dashboard_id       (u/the-id dashboard)
+                                                   :card_id            (u/the-id card)
+                                                   :parameter_mappings [{:parameter_id "22486e00"
+                                                                         :card_id      (u/the-id card)
+                                                                         :target       [:dimension [:field-id (mt/id :venues :id)]]}]}]
+      (is (= [{:parameter_id "22486e00"
+               :card_id      (u/the-id card)
+               :target       [:dimension [:field (mt/id :venues :id) nil]]}]
+             (t2/select-one-fn :parameter_mappings :model/DashboardCard :id (u/the-id dashcard)))))))
+
+(deftest ^:parallel normalize-parameter-mappings-test-2
+  (testing "make sure parameter mappings correctly normalize things like legacy MBQL clauses"
+    (is (=? [{:target [:dimension [:field 30 {:source-field 23}]]}]
+            ((:out parameters/transform-parameter-mappings)
+             (json/encode
+              [{:parameter_id "a", :target [:dimension [:fk-> 23 30]]}]))))))
+
+(deftest ^:parallel keep-empty-parameter-mappings-empty-test
+  (testing (str "we should keep empty parameter mappings as empty instead of making them nil (if `normalize` removes "
+                "them because they are empty) (I think this is to prevent NPEs on the FE? Not sure why we do this)")
+    (is (= []
+           ((:out parameters/transform-parameters)
+            (json/encode []))))))
+
+(deftest ^:parallel normalize-card-parameter-mappings-test
+  (doseq [parameters [[]
+                      [{:name "Time grouping"
+                        :slug "time_grouping"
+                        :id "8e366c15"
+                        :type :temporal-unit
+                        :sectionId "temporal-unit"
+                        :temporal_units [:minute :quarter-of-year]}]]]
+    (is (= parameters
+           ((:out parameters/transform-parameters)
+            (json/encode parameters))))))

--- a/test/metabase/parameters/params_test.clj
+++ b/test/metabase/parameters/params_test.clj
@@ -2,22 +2,14 @@
   "Tests for the utility functions for dealing with parameters in `metabase.parameters.params`."
   (:require
    [clojure.test :refer :all]
-   [metabase.legacy-mbql.util :as mbql.u]
+   [metabase.lib.core :as lib]
+   [metabase.lib.test-metadata :as meta]
    [metabase.parameters.params :as params]
    [metabase.public-sharing.api-test :as public-test]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.util.malli :as mu]
    [toucan2.core :as t2]))
-
-(deftest ^:parallel wrap-field-id-if-needed-test
-  (doseq [[x expected] {10                                      [:field 10 nil]
-                        [:field 10 nil]                         [:field 10 nil]
-                        [:field "name" {:base-type :type/Text}] [:field "name" {:base-type :type/Text}]}]
-    (testing x
-      (is (= expected
-             (mbql.u/wrap-field-id-if-needed x))))))
-
-;;; ---------------------------------------------- name_field hydration ----------------------------------------------
 
 (deftest ^:parallel hydrate-name-field-test
   (testing "make sure that we can hydrate the `name_field` property for PK Fields"
@@ -34,15 +26,17 @@
                             :fk_target_field_id nil}}
            (-> (t2/select-one [:model/Field :name :table_id :semantic_type], :id (mt/id :venues :id))
                (t2/hydrate :name_field)
-               mt/derecordize))))
+               mt/derecordize)))))
 
+(deftest ^:parallel hydrate-name-field-test-2
   (testing "make sure it works for multiple fields efficiently. Should only require one DB call to hydrate many Fields"
     (let [venues-fields (t2/select :model/Field :table_id (mt/id :venues))]
       (t2/with-call-count [call-count]
         (t2/hydrate venues-fields :name_field)
         (is (= 1
-               (call-count))))))
+               (call-count)))))))
 
+(deftest ^:parallel hydrate-name-field-test-3
   (testing "It shouldn't hydrate for Fields that aren't PKs"
     (is (= {:name          "PRICE"
             :table_id      (mt/id :venues)
@@ -50,8 +44,9 @@
             :name_field    nil}
            (-> (t2/select-one [:model/Field :name :table_id :semantic_type], :id (mt/id :venues :price))
                (t2/hydrate :name_field)
-               mt/derecordize))))
+               mt/derecordize)))))
 
+(deftest ^:parallel hydrate-name-field-test-4
   (testing "Or if it *is* a PK, but no name Field is available for that Table, it shouldn't hydrate"
     (is (= {:name          "ID"
             :table_id      (mt/id :checkins)
@@ -60,8 +55,6 @@
            (-> (t2/select-one [:model/Field :name :table_id :semantic_type], :id (mt/id :checkins :id))
                (t2/hydrate :name_field)
                mt/derecordize)))))
-
-;;; -------------------------------------------------- param_fields --------------------------------------------------
 
 (deftest ^:parallel hydrate-param-fields-for-card-test
   (testing "check that we can hydrate param_fields for a Card"
@@ -119,7 +112,9 @@
                                           :dimensions         []}]}
               (-> (t2/hydrate dashboard :param_fields)
                   :param_fields
-                  mt/derecordize)))))
+                  mt/derecordize))))))
+
+(deftest hydrate-param-fields-for-dashboard-test-2
   (testing "should ignore invalid parameter mappings"
     (mt/with-temporary-setting-values [enable-public-sharing true]
       (mt/with-temp [:model/Dashboard    dashboard  {:parameters [{:id "p1" :type :number/=}
@@ -180,89 +175,93 @@
           (is (not (contains? param-fields "p7"))))))))
 
 (deftest ^:parallel card->template-tag-test
-  (let [card {:dataset_query (mt/native-query {:query "SELECT *"
-                                               :template-tags {"id"   {:name         "id"
-                                                                       :display_name "ID"
-                                                                       :id           "11111111"
-                                                                       :type         :dimension
-                                                                       :dimension    [:field (mt/id :venues :id) nil]}
-                                                               "name" {:name         "name"
-                                                                       :display_name "Name"
-                                                                       :id           "aaaaaaaa"
-                                                                       :type         :dimension
-                                                                       :dimension    [:field "name" {:base-type :type/Text}]}}})}]
-    (testing "card->template-tag-param-id->field-clauses"
-      (is (= {"11111111" #{[:field (mt/id :venues :id) nil]}
-              "aaaaaaaa" #{[:field "name" {:base-type :type/Text}]}}
-             (#'params/card->template-tag-param-id->field-clauses card))))
-
+  (let [card {:dataset_query (lib/query
+                              meta/metadata-provider
+                              (mt/native-query {:query         "SELECT *"
+                                                :template-tags {"id"   {:name         "id"
+                                                                        :display_name "ID"
+                                                                        :id           "11111111"
+                                                                        :type         :dimension
+                                                                        :dimension    [:field (meta/id :venues :id) nil]}
+                                                                "name" {:name         "name"
+                                                                        :display_name "Name"
+                                                                        :id           "aaaaaaaa"
+                                                                        :type         :dimension
+                                                                        :dimension    [:field "name" {:base-type :type/Text}]}}}))}]
     (testing "card->template-tag-param-id->field-ids"
-      (is (= {"11111111" #{(mt/id :venues :id)}
+      (is (= {"11111111" #{(meta/id :venues :id)}
               "aaaaaaaa" #{}}
              (#'params/card->template-tag-param-id->field-ids card))))
-
     (testing "card->template-tag-field-ids"
-      (is (= #{(mt/id :venues :id)}
+      (is (= #{(meta/id :venues :id)}
              (params/card->template-tag-field-ids card))))))
 
 (deftest ^:parallel get-linked-field-ids-test
   (testing "get-linked-field-ids basic test"
     (is (= {"foo" #{256}
             "bar" #{267}}
-           (params/get-linked-field-ids
-            [{:parameter_mappings
-              [{:parameter_id "foo" :target [:dimension [:field 256 nil]]}
-               {:parameter_id "bar" :target [:dimension [:field 267 nil]]}]}]))))
+           (mu/disable-enforcement
+             (params/get-linked-field-ids
+              [{:parameter_mappings
+                [{:parameter_id "foo"
+                  :target       [:dimension [:field 256 nil]]}
+                 {:parameter_id "bar"
+                  :target       [:dimension [:field 267 nil]]}]}]))))))
+
+(deftest ^:parallel get-linked-field-ids-test-2
   (testing "get-linked-field-ids multiple fields to one param test"
     (is (= {"foo" #{256 10}
             "bar" #{267}}
-           (params/get-linked-field-ids
-            [{:parameter_mappings
-              [{:parameter_id "foo" :target [:dimension [:field 256 nil]]}
-               {:parameter_id "bar" :target [:dimension [:field 267 nil]]}]}
-             {:parameter_mappings
-              [{:parameter_id "foo" :target [:dimension [:field 10 nil]]}]}]))))
+           (mu/disable-enforcement
+             (params/get-linked-field-ids
+              [{:parameter_mappings
+                [{:parameter_id "foo" :target [:dimension [:field 256 nil]]}
+                 {:parameter_id "bar" :target [:dimension [:field 267 nil]]}]}
+               {:parameter_mappings
+                [{:parameter_id "foo" :target [:dimension [:field 10 nil]]}]}]))))))
+
+(deftest ^:parallel get-linked-field-ids-test-3
   (testing "get-linked-field-ids-test misc fields"
     (is (= {"1" #{1} "2" #{2} "3" #{3} "4" #{4} "5" #{5}}
-           (params/get-linked-field-ids
-            [{:parameter_mappings
-              [{:parameter_id "1" :target [:dimension [:field 1 {}]]}
-               {:parameter_id "2" :target [:dimension [:field 2 {:x true}]]}
-               {:parameter_id "wow" :target [:dimension [:field "wow" {:base-type :type/Integer}]]}
-               {:parameter_id "3" :target [:dimension [:field 3 {:source-field 1}]]}
-               {:parameter_id "4" :target [:dimension [:field 4 {:binning {:strategy :num-bins, :num-bins 1}}]]}
-               {:parameter_id "5" :target [:dimension [:field 5]]}]}]))))
+           (mu/disable-enforcement
+             (params/get-linked-field-ids
+              [{:parameter_mappings
+                [{:parameter_id "1" :target [:dimension [:field 1 {}]]}
+                 {:parameter_id "2" :target [:dimension [:field 2 {:x true}]]}
+                 {:parameter_id "wow" :target [:dimension [:field "wow" {:base-type :type/Integer}]]}
+                 {:parameter_id "3" :target [:dimension [:field 3 {:source-field 1}]]}
+                 {:parameter_id "4" :target [:dimension [:field 4 {:binning {:strategy :num-bins, :num-bins 1}}]]}
+                 {:parameter_id "5" :target [:dimension [:field 5]]}]}]))))))
+
+(deftest ^:parallel get-linked-field-ids-test-4
   (testing "get-linked-field-ids-test no fields"
     (is (= {}
-           (params/get-linked-field-ids
-            [{:parameter_mappings []}])))))
+           (mu/disable-enforcement
+             (params/get-linked-field-ids
+              [{:parameter_mappings []}]))))))
 
 (deftest ^:parallel duplicate-column-names-test
   (testing "columns with duplicated names get mapped correctly to parameters"
     (testing "native queries"
-      (let [card {:dataset_query (mt/native-query {:query "SELECT *"
-                                                   :template-tags
-                                                   {"tag1" {:name         "tag1"
-                                                            :display_name "Tag 1"
-                                                            :id           "11111111"
-                                                            :type         :dimension
-                                                            :dimension    [:field (mt/id :orders :id) nil]}
-                                                    "tag2" {:name         "tag2"
-                                                            :display_name "Tag 2"
-                                                            :id           "aaaaaaaa"
-                                                            :type         :dimension
-                                                            :dimension    [:field (mt/id :products :id) nil]}}})}]
-        (testing "card->template-tag-param-id->field-clauses"
-          (is (= {"11111111" #{[:field (mt/id :orders :id) nil]}
-                  "aaaaaaaa" #{[:field (mt/id :products :id) nil]}}
-                 (#'params/card->template-tag-param-id->field-clauses card))))
-
+      (let [card {:dataset_query (lib/query
+                                  meta/metadata-provider
+                                  (mt/native-query {:query "SELECT *"
+                                                    :template-tags
+                                                    {"tag1" {:name         "tag1"
+                                                             :display_name "Tag 1"
+                                                             :id           "11111111"
+                                                             :type         :dimension
+                                                             :dimension    [:field (meta/id :orders :id) nil]}
+                                                     "tag2" {:name         "tag2"
+                                                             :display_name "Tag 2"
+                                                             :id           "aaaaaaaa"
+                                                             :type         :dimension
+                                                             :dimension    [:field (meta/id :products :id) nil]}}}))}]
         (testing "card->template-tag-param-id->field-ids"
-          (is (= {"11111111" #{(mt/id :orders :id)}
-                  "aaaaaaaa" #{(mt/id :products :id)}}
+          (is (= {"11111111" #{(meta/id :orders :id)}
+                  "aaaaaaaa" #{(meta/id :products :id)}}
                  (#'params/card->template-tag-param-id->field-ids card))))
-
         (testing "card->template-tag-field-ids"
-          (is (= #{(mt/id :orders :id)
-                   (mt/id :products :id)}
+          (is (= #{(meta/id :orders :id)
+                   (meta/id :products :id)}
                  (params/card->template-tag-field-ids card))))))))

--- a/test/metabase/public_sharing/api_test.clj
+++ b/test/metabase/public_sharing/api_test.clj
@@ -47,7 +47,7 @@
                                   :slug                 "static_category"
                                   :id                   "_STATIC_CATEGORY_",
                                   :type                 "category",
-                                  :values_source_type   "static-list"
+                                  :values_source_type   :static-list
                                   :values_source_config {:values ["African" "American" "Asian"]}}]})
                  (shared-obj)
                  m)]
@@ -195,7 +195,7 @@
    :parameters       [{:type "date", :name "a", :display_name "a" :id "a" :default "A param"}
                       {:type "date", :name "b", :display_name "b" :id "b" :default "B param"}
                       {:type "date", :name "c", :display_name "c" :id "c" :default "C param"
-                       :values_source_type "static-list" :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}]
+                       :values_source_type :static-list :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}]
    :embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}})
 
 (deftest get-card-parameters-should-work-with-legacy-template-tags
@@ -231,7 +231,7 @@
                  ;; order importance: the default from template-tag is in the final result
                  :default              "C TAG",
                  :required             false
-                 :values_source_type   "static-list",
+                 :values_source_type   :static-list,
                  :id                   "c",
                  :target               ["variable" ["template-tag" "c"]],
                  :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}
@@ -1248,7 +1248,7 @@
                                                                      {:name                 "Static Category label"
                                                                       :id                   list-param-id
                                                                       :type                 "category"
-                                                                      :values_source_type   "static-list"
+                                                                      :values_source_type   :static-list
                                                                       :values_source_config {:values [["A frican" "Af"]
                                                                                                       ["American" "Am"]
                                                                                                       ["A   sian" "As"]]}}]}
@@ -1329,13 +1329,13 @@
                                                  :slug                 "static_category"
                                                  :id                   param-static-list
                                                  :type                 "category"
-                                                 :values_source_type   "static-list"
+                                                 :values_source_type   :static-list
                                                  :values_source_config {:values ["African" "American" "Asian"]}}
                                                 {:name                 "Static Category label"
                                                  :slug                 "static_category_label"
                                                  :id                   param-static-list-label
                                                  :type                 "category"
-                                                 :values_source_type   "static-list"
+                                                 :values_source_type   :static-list
                                                  :values_source_config {:values [["Af rican" "Af"] ["American" "Am"] ["Asian" "As"]]}}
                                                 {:name                 "Card as source"
                                                  :slug                 "card"

--- a/test/metabase/queries/models/parameter_card_test.clj
+++ b/test/metabase/queries/models/parameter_card_test.clj
@@ -35,29 +35,26 @@
                                                     :card_id                   card-id}]
 
     (testing "deletes all ParameterCards for given object when no exclusions"
-      (parameter-card/delete-all-for-parameterized-object! "dashboard" 1)
+      (parameter-card/delete-all-for-parameterized-object! :model/Dashboard 1)
       (is (nil? (t2/select-one :model/ParameterCard :id pc1-id)))
       (is (nil? (t2/select-one :model/ParameterCard :id pc2-id)))
       (is (some? (t2/select-one :model/ParameterCard :id pc3-id))))
-
     (testing "preserves ParameterCards with parameter IDs still in use"
-      (parameter-card/delete-all-for-parameterized-object! "dashboard" 2 ["param3"])
+      (parameter-card/delete-all-for-parameterized-object! :model/Dashboard 2 ["param3"])
       (is (some? (t2/select-one :model/ParameterCard :id pc3-id))))))
 
 (deftest upsert-from-parameters!-insert-test
   (mt/with-temp [:model/Database {db-id :id} {}
                  :model/Card {card-id-1 :id} {:database_id db-id}
                  :model/Card {card-id-2 :id} {:database_id db-id}]
-
     (testing "creates new ParameterCards for parameters with card sources"
       (let [parameters [{:id                   "param1"
-                         :values_source_type   "card"
+                         :values_source_type   :card
                          :values_source_config {:card_id card-id-1}}
                         {:id                   "param2"
-                         :values_source_type   "card"
+                         :values_source_type   :card
                          :values_source_config {:card_id card-id-2}}]]
-        (#'parameter-card/upsert-from-parameters! "dashboard" 1 parameters)
-
+        (#'parameter-card/upsert-from-parameters! :model/Dashboard 1 parameters)
         (let [pc1 (t2/select-one :model/ParameterCard
                                  :parameterized_object_type "dashboard"
                                  :parameterized_object_id 1
@@ -79,16 +76,16 @@
                                          :card_id                   card-id-1}]
     (testing "does not error when no updates to existing ParameterCard"
       (let [parameters [{:id                   "param1"
-                         :values_source_type   "card"
+                         :values_source_type   :card
                          :values_source_config {:card_id card-id-1}}]]
         ;; test that we ran without throwing
-        (is (nil? (#'parameter-card/upsert-from-parameters! "dashboard" 1 parameters)))))
+        (is (nil? (#'parameter-card/upsert-from-parameters! :model/Dashboard 1 parameters)))))
 
     (testing "updates existing ParameterCard"
       (let [parameters [{:id                   "param1"
-                         :values_source_type   "card"
+                         :values_source_type   :card
                          :values_source_config {:card_id card-id-2}}]]
-        (#'parameter-card/upsert-from-parameters! "dashboard" 1 parameters)
+        (#'parameter-card/upsert-from-parameters! :model/Dashboard 1 parameters)
 
         (let [pc (t2/select-one :model/ParameterCard
                                 :parameterized_object_type "dashboard"
@@ -100,22 +97,20 @@
   (mt/with-temp [:model/Card {card-id-1 :id} {}
                  :model/Card {card-id-2 :id} {}
                  :model/Card {card-id-3 :id} {}]
-
     (testing "creates ParameterCards for valid card-sourced parameters"
       (let [parameters [{:id                   "param1"
-                         :type                 :test
-                         :values_source_type   "card"
+                         :type                 :text
+                         :values_source_type   :card
                          :values_source_config {:card_id card-id-1}}
                         {:id                   "param2"
-                         :type                 :test
-                         :values_source_type   "static-list"
+                         :type                 :text
+                         :values_source_type   :static-list
                          :values_source_config {:values ["a" "b" "c"]}}
                         {:id                   "param3"
-                         :type                 :test
-                         :values_source_type   "card"
+                         :type                 :text
+                         :values_source_type   :card
                          :values_source_config {:card_id card-id-2}}]]
-        (parameter-card/upsert-or-delete-from-parameters! "dashboard" 1 parameters)
-
+        (parameter-card/upsert-or-delete-from-parameters! :model/Dashboard 1 parameters)
         (let [pcs (t2/select :model/ParameterCard
                              :parameterized_object_type "dashboard"
                              :parameterized_object_id 1)]
@@ -124,64 +119,58 @@
                           (= card-id-1 (:card_id %))) pcs))
           (is (some #(and (= "param3" (:parameter_id %))
                           (= card-id-2 (:card_id %))) pcs))
-          (is (not (some #(= "param2" (:parameter_id %)) pcs))))))
-
+          (is (not (some #(= "param2" (:parameter_id %)) pcs))))))=
     (testing "deletes ParameterCards no longer in use"
       (mt/with-temp [:model/ParameterCard _ {:parameterized_object_type "dashboard"
                                              :parameterized_object_id   1
                                              :parameter_id              "old-param"
                                              :card_id                   card-id-3}]
         (let [parameters [{:id                   "param1"
-                           :type :test
-                           :values_source_type   "card"
+                           :type :text
+                           :values_source_type   :card
                            :values_source_config {:card_id card-id-1}}]]
-          (parameter-card/upsert-or-delete-from-parameters! "dashboard" 1 parameters)
-
+          (parameter-card/upsert-or-delete-from-parameters! :model/Dashboard 1 parameters)
           (let [pcs (t2/select :model/ParameterCard
                                :parameterized_object_type "dashboard"
                                :parameterized_object_id 1)]
             (is (= 1 (count pcs)))
             (is (= "param1" (:parameter_id (first pcs))))
             (is (= card-id-1 (:card_id (first pcs))))))))
-
     (testing "handles nil parameters gracefully"
-      (parameter-card/upsert-or-delete-from-parameters! "dashboard" 1 nil)
+      (parameter-card/upsert-or-delete-from-parameters! :model/Dashboard 1 nil)
       (let [pcs (t2/select :model/ParameterCard
                            :parameterized_object_type "dashboard"
                            :parameterized_object_id 1)]
         (is (empty? pcs))))
-
     (testing "handles empty parameters list"
-      (parameter-card/upsert-or-delete-from-parameters! "dashboard" 1 [])
+      (parameter-card/upsert-or-delete-from-parameters! :model/Dashboard 1 [])
       (let [pcs (t2/select :model/ParameterCard
                            :parameterized_object_type "dashboard"
                            :parameterized_object_id 1)]
         (is (empty? pcs))))
-
     (testing "parameters without required fields"
       (let [parameters [{:id                   "param1"
-                         :type                 :test
-                         :values_source_type   "card"
+                         :type                 :text
+                         :values_source_type   :card
                          :values_source_config {:card_id card-id-1}}
                         {:id                   "param2"
-                         :type                 :test
-                         :values_source_type   "card"
+                         :type                 :text
+                         :values_source_type   :card
                          :values_source_config {}} ; missing card_id
                         {:id                   "param3"
                          :values_source_config {:card_id card-id-2}} ; missing values_source_type
-                        {:values_source_type   "card"
+                        {:values_source_type   :card
                          :values_source_config {:card_id card-id-3}}]]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Invalid input:"
-             (parameter-card/upsert-or-delete-from-parameters! "dashboard" 1 parameters)))))
-
+             (parameter-card/upsert-or-delete-from-parameters! :model/Dashboard 1 parameters)))))
     (testing "works with card parameterized objects"
       (let [parameters [{:id                   "param1"
-                         :type                 :test
-                         :values_source_type   "card"
+                         :type                 :text
+                         :values_source_type   :card
                          :values_source_config {:card_id card-id-1}}]]
-        (parameter-card/upsert-or-delete-from-parameters! "card" 1 parameters)
+        (parameter-card/upsert-or-delete-from-parameters! :model/Card 1 parameters)
 
         (let [pcs (t2/select :model/ParameterCard
                              :parameterized_object_type "card"
@@ -192,7 +181,6 @@
 
 (deftest model-validation-test
   (mt/with-temp [:model/Card {card-id :id} {}]
-
     (testing "ParameterCard creation with valid parameterized_object_type"
       (is (some? (t2/insert! :model/ParameterCard
                              {:parameterized_object_type "dashboard"
@@ -205,7 +193,6 @@
                               :parameterized_object_id   1
                               :parameter_id              "param2"
                               :card_id                   card-id}))))
-
     (testing "ParameterCard creation with invalid parameterized_object_type throws exception"
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
@@ -215,7 +202,6 @@
                         :parameterized_object_id   1
                         :parameter_id              "param1"
                         :card_id                   card-id}))))
-
     (testing "ParameterCard update with invalid parameterized_object_type throws exception"
       (mt/with-temp [:model/ParameterCard {pc-id :id} {:parameterized_object_type "dashboard"
                                                        :parameterized_object_id   1

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -774,9 +774,9 @@
             (is (= [nil nil 3 2009] (last rows)))))))))
 
 (deftest ^:parallel parameter-values-test
-  (testing "static-list"
+  (testing :static-list
     (let [parameter {:values_query_type "list",
-                     :values_source_type "static-list",
+                     :values_source_type :static-list,
                      :values_source_config {:values ["foo1" "foo2" "bar"]},
                      :name "Text",
                      :slug "text",
@@ -906,7 +906,7 @@
     (let [parameter {:name                 "Static Category label"
                      :id                   "list-param-id"
                      :type                 "category"
-                     :values_source_type   "static-list"
+                     :values_source_type   :static-list
                      :values_source_config {:values [["A frican" "Af"]
                                                      ["American" "Am"]
                                                      ["A   sian" "As"]]}}

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -131,6 +131,7 @@
   ([table-name & body]
    (mbql-query-impl/parse-tokens table-name `(do ~@body))))
 
+;;; TODO (Cam 9/8/25) -- rename this to `legacy-mbql-query`
 (defmacro mbql-query
   "Macro for easily building MBQL queries for test purposes.
 

--- a/test/metabase/util/malli/describe_test.cljc
+++ b/test/metabase/util/malli/describe_test.cljc
@@ -1,6 +1,9 @@
 (ns metabase.util.malli.describe-test
   "Additional tests for this live in [[metabase.util.malli-test]]."
   (:require
+   #?@(:clj
+       ([metabase.lib.schema :as lib.schema]
+        [metabase.util :as u]))
    [clojure.test :refer [are deftest is testing]]
    [metabase.util.malli.describe :as umd]
    [metabase.util.malli.registry :as mr]))
@@ -60,3 +63,9 @@
   (is (mr/validate ::map {:k :child, :parent {:k :parent}}))
   (is (= "map where {:k -> <keyword>, :parent (optional) -> <recursive :metabase.util.malli.describe-test/map>}"
          (umd/describe ::map))))
+
+#?(:clj
+   (deftest ^:synchronized mega-schemas-test
+     ;; force it to recurse into nested schemas instead of using `:description`
+     (with-redefs [umd/description (constantly nil)]
+       (is (string? (u/with-timeout 500 (umd/describe ::lib.schema/query)))))))

--- a/test/metabase/xrays/automagic_dashboards/filters_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/filters_test.clj
@@ -31,7 +31,7 @@
               [:< [:field 2 nil] 100]]]
             [:= [:field 3 nil] 42])))))
 
-(deftest ^:parallel interesting-fields-test
+(deftest ^:parallel w
   (testing "Should return only :type/Temporal and :type/Boolean fields, or fields with the :type/Category semantic type"
     (is (=? ["DATE" "CATEGORY" "BOOLEAN"]
             (->> [{:name "ID" :base_type :type/Integer :semantic_type :type/PK}

--- a/test/metabase/xrays/automagic_dashboards/names_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/names_test.clj
@@ -36,7 +36,9 @@
                                :week-of-year    (u.date/extract dt :week-of-year)}]
         (testing (format "unit = %s" unit)
           (is (= (str expected)
-                 (str (names/humanize-datetime t-str unit))))))))
+                 (str (names/humanize-datetime t-str unit)))))))))
+
+(deftest ^:parallel temporal-humanization-test-2
   (testing "Extracted unit handling"
     (is (= :sunday (#'u.date/start-of-week)) "adjust the test, it assumes Sunday as first day of the week")
     (let [t 3]                          ; t = 2 or t = 4 would also work


### PR DESCRIPTION
Right now the app DB sort of allegedly supports either MBQL 4 or 5 queries coming out, but to simplify the code let's just normalize to MBQL 5 on the way out.