### PR TITLE
fix(table-editing): display error messages from BE in Editable Data settings

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
@@ -65,7 +65,7 @@ export function AdminDatabaseTableEditingSection({
         settings: { [DATABASE_TABLE_EDITING_SETTING]: enabled },
       });
     } catch (err) {
-      setError(getResponseErrorMessage(err) || t`An error occurred`);
+      setError(getResponseErrorMessageReason(err) || t`An error occurred`);
     }
   };
 
@@ -111,4 +111,20 @@ export function AdminDatabaseTableEditingSection({
       </Box>
     </DatabaseInfoSection>
   );
+}
+
+function getResponseErrorMessageReason(error: unknown): string | undefined {
+  if (
+    error &&
+    typeof error === "object" &&
+    "data" in error &&
+    typeof error.data === "object" &&
+    error.data &&
+    "reasons" in error.data &&
+    Array.isArray(error.data.reasons)
+  ) {
+    return error.data.reasons[0]?.message ?? undefined;
+  }
+
+  return getResponseErrorMessage(error);
 }


### PR DESCRIPTION
Resolves [WRK-869](https://linear.app/metabase/issue/WRK-869/display-error-messages-from-be-in-editable-data-settings)