### PR TITLE
Make SDK backward compat tests as optional

### DIFF
--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -160,7 +160,6 @@ jobs:
       - embedding-sdk-docs-snippets-type-check
       - embedding-sdk-api-documentation-generation-validation
       - sdk-e2e-tests
-      - e2e-component-tests-embedding-sdk-backward-compatibility
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
Make SDK backward compat tests as optional, context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1757407536703569