### PR TITLE
fix(table-editing): disable row edit button when rows are selected

### DIFF
--- a/e2e/test/scenarios/table-editing/table-editing.cy.spec.ts
+++ b/e2e/test/scenarios/table-editing/table-editing.cy.spec.ts
@@ -452,6 +452,10 @@ describe("scenarios > table-editing", () => {
       cy.findAllByTestId("row-select-checkbox").eq(15).click();
       cy.findAllByTestId("row-select-checkbox").eq(16).click();
 
+      cy.log("should not show edit icon when rows are selected");
+      cy.findByTestId("row-edit-icon").should("not.exist");
+
+      cy.log("should bulk delete rows");
       cy.findByTestId("toast-card").findByText("Delete").click();
 
       H.modal().within(() => {
@@ -467,6 +471,9 @@ describe("scenarios > table-editing", () => {
       cy.findByTestId("toast-card").should("not.exist");
 
       H.undoToast().findByText("Successfully deleted").should("be.visible");
+
+      cy.log("should show edit icon when no rows are selected");
+      cy.findAllByTestId("row-edit-icon").should("exist");
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/use-table-column-row-select.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/data-grid/use-table-column-row-select.tsx
@@ -52,14 +52,19 @@ export function getRowSelectColumn({
         />
       </Flex>
     ),
-    cell: ({ row }: { row: Row<RowValues> }) => (
+    cell: ({
+      row,
+      table,
+    }: {
+      row: Row<RowValues>;
+      table: Table<RowValues>;
+    }) => (
       <BaseCell className={CellS.cell}>
         <Group align="center" justify="flex-start" h="100%">
           <Checkbox
             size={rem(16)}
             checked={row.getIsSelected()}
             disabled={!row.getCanSelect()}
-            indeterminate={row.getIsSomeSelected()}
             onChange={row.getToggleSelectedHandler()}
             data-testid="row-select-checkbox"
             styles={{
@@ -69,14 +74,17 @@ export function getRowSelectColumn({
             }}
           />
 
-          <Tooltip label="Edit record">
-            <Icon
-              name="pencil"
-              data-testid="row-edit-icon"
-              className={S.pencilIcon}
-              onClick={() => onRowEditClick(row.index)}
-            />
-          </Tooltip>
+          {/* Only show the edit icon when no rows are selected */}
+          {!table.getIsSomeRowsSelected() && !table.getIsAllRowsSelected() && (
+            <Tooltip label="Edit record">
+              <Icon
+                name="pencil"
+                data-testid="row-edit-icon"
+                className={S.pencilIcon}
+                onClick={() => onRowEditClick(row.index)}
+              />
+            </Tooltip>
+          )}
         </Group>
       </BaseCell>
     ),


### PR DESCRIPTION
Resolves [WRK-870](https://linear.app/metabase/issue/WRK-870/disable-edit-button-for-multi-select-records)
