### PR TITLE
fix: don't ignore db sync/rescan promise

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseConnectionInfoSection/DatabaseConnectionInfoSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseConnectionInfoSection/DatabaseConnectionInfoSection.tsx
@@ -36,7 +36,7 @@ export const DatabaseConnectionInfoSection = ({
   const [dismissSyncSpinner] = useDismissDatabaseSyncSpinnerMutation();
 
   const handleSyncDatabaseSchema = async () => {
-    await syncDatabaseSchema(database.id);
+    await syncDatabaseSchema(database.id).unwrap();
     // FIXME remove when MetadataEditor uses RTK query directly to load tables
     dispatch({ type: Tables.actionTypes.INVALIDATE_LISTS_ACTION });
   };
@@ -85,7 +85,7 @@ export const DatabaseConnectionInfoSection = ({
         />
         <ActionButton
           className={S.actionButton}
-          actionFn={() => rescanDatabaseFieldValues(database.id)}
+          actionFn={() => rescanDatabaseFieldValues(database.id).unwrap()}
           normalText={t`Re-scan field values`}
           activeText={t`Starting…`}
           failedText={t`Failed to start scan`}

--- a/frontend/src/metabase/admin/databases/components/DatabaseConnectionInfoSection/DatabaseConnectionInfoSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseConnectionInfoSection/DatabaseConnectionInfoSection.unit.spec.tsx
@@ -102,8 +102,8 @@ describe("DatabaseConnectionInfoSection", () => {
     });
 
     it("shows an error when a schema sync fails", async () => {
-      setup();
-      fetchMock.modifyRoute(`database-sync-schema`, {
+      const { database } = setup();
+      fetchMock.modifyRoute(`database-${database.id}-sync-schema`, {
         response: 500,
       });
 
@@ -112,8 +112,8 @@ describe("DatabaseConnectionInfoSection", () => {
     });
 
     it("shows an error when a field sync fails", async () => {
-      setup();
-      fetchMock.modifyRoute(`database-rescan-values`, {
+      const { database } = setup();
+      fetchMock.modifyRoute(`database-${database.id}-rescan-values`, {
         response: 500,
       });
 

--- a/frontend/src/metabase/admin/databases/components/DatabaseConnectionInfoSection/DatabaseConnectionInfoSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseConnectionInfoSection/DatabaseConnectionInfoSection.unit.spec.tsx
@@ -101,6 +101,28 @@ describe("DatabaseConnectionInfoSection", () => {
       });
     });
 
+    it("shows an error when a schema sync fails", async () => {
+      setup();
+      fetchMock.modifyRoute(`database-sync-schema`, {
+        response: 500,
+      });
+
+      await userEvent.click(screen.getByText(/Sync database schema/i));
+      expect(await screen.findByText(/Failed to sync/i)).toBeInTheDocument();
+    });
+
+    it("shows an error when a field sync fails", async () => {
+      setup();
+      fetchMock.modifyRoute(`database-rescan-values`, {
+        response: 500,
+      });
+
+      await userEvent.click(screen.getByText(/Re-scan field values/i));
+      expect(
+        await screen.findByText(/failed to start scan/i),
+      ).toBeInTheDocument();
+    });
+
     it("re-scans database field values", async () => {
       const { database } = setup();
       await userEvent.click(screen.getByText(/Re-scan field values/i));

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -10,8 +10,16 @@ import { setupTableEndpoints } from "./table";
 
 export function setupDatabaseEndpoints(db: Database) {
   fetchMock.get(`path:/api/database/${db.id}`, db);
-  fetchMock.post(`path:/api/database/${db.id}/sync_schema`, {});
-  fetchMock.post(`path:/api/database/${db.id}/rescan_values`, {});
+  fetchMock.post(
+    `path:/api/database/${db.id}/sync_schema`,
+    {},
+    { name: "database-sync-schema" },
+  );
+  fetchMock.post(
+    `path:/api/database/${db.id}/rescan_values`,
+    {},
+    { name: "database-rescan-values" },
+  );
   fetchMock.post(`path:/api/database/${db.id}/discard_values`, {});
   fetchMock.get(
     `path:/api/database/${db.id}/healthcheck`,

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -13,12 +13,12 @@ export function setupDatabaseEndpoints(db: Database) {
   fetchMock.post(
     `path:/api/database/${db.id}/sync_schema`,
     {},
-    { name: "database-sync-schema" },
+    { name: `database-${db.id}-sync-schema` },
   );
   fetchMock.post(
     `path:/api/database/${db.id}/rescan_values`,
     {},
-    { name: "database-rescan-values" },
+    { name: `database-${db.id}-rescan-values` },
   );
   fetchMock.post(`path:/api/database/${db.id}/discard_values`, {});
   fetchMock.get(


### PR DESCRIPTION
When the call returns non-200, the button still says it's fine instead of showing a failure.

You can test this by trying to sync "Metabase Cloud Storage" DWH.

See https://metaboat.slack.com/archives/CKZEMT1MJ/p1749830993738189
