### PR TITLE
Closes EMB-627: Linked filter with empty string value doesn't work in static embedded dashboard

### DIFF
--- a/src/metabase/embedding/api/common.clj
+++ b/src/metabase/embedding/api/common.clj
@@ -149,8 +149,7 @@
   "Take a map of `query-params` and make sure they're in the right format for the rest of our code. Our
   `wrap-keyword-params` middleware normally converts all query params keys to keywords, but only if they seem like
   ones that make sense as keywords. Some params, such as ones that start with a number, do not pass this test, and are
-  not automatically converted. Thus we must do it ourselves here to make sure things are done as we'd expect.
-  Also, any param values that are blank strings should be parsed as nil, representing the absence of a value."
+  not automatically converted. Thus we must do it ourselves here to make sure things are done as we'd expect."
   [query-params]
   (-> query-params
       (update-keys keyword)))

--- a/src/metabase/embedding/api/common.clj
+++ b/src/metabase/embedding/api/common.clj
@@ -153,8 +153,7 @@
   Also, any param values that are blank strings should be parsed as nil, representing the absence of a value."
   [query-params]
   (-> query-params
-      (update-keys keyword)
-      (update-vals (fn [v] (if (= v "") nil v)))))
+      (update-keys keyword)))
 
 (mu/defn validate-and-merge-params :- [:map-of :keyword :any]
   "Validate that the `token-params` passed in the JWT and the `user-params` (passed as part of the URL) are allowed, and
@@ -189,7 +188,7 @@
         slug-query-params  (normalize-query-params slug-query-params)
         merged-slug->value (validate-and-merge-params embedding-params token-params slug-query-params)]
     (into {} (for [[slug value] merged-slug->value
-                   :when        value]
+                   :when (not (nil? value))]
                [(get slug->id (name slug)) value]))))
 
 ;;; ---------------------------------------------- Other Param Util Fns ----------------------------------------------


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #61054
Closes [EMB-627: Linked filter with empty string value doesn't work in static embedded dashboard](https://linear.app/metabase/issue/EMB-627/linked-filter-with-empty-string-value-doesnt-work-in-static-embedded)

### Description

This is a two steps bug:
 1. we used to strip empty strings in `param-values-merged-params`
 2. `normalize-query-params` assumes (and this seems to be by design) that an empty string is nil

Those two functions are only called in an embedding context, which is why native was fine.