### PR TITLE
docs: update H2 volume mount instructions

### DIFF
--- a/docs/installation-and-operation/running-metabase-on-docker.md
+++ b/docs/installation-and-operation/running-metabase-on-docker.md
@@ -16,6 +16,7 @@ If you're trying to upgrade your Metabase version on Docker, check out these [up
 
 Use this quick start to run the Open Source version of Metabase locally. See below for instructions on [running Metabase in production](#production-installation).
 
+
 Assuming you have [Docker](https://www.docker.com/) installed and running, get the latest Docker image:
 
 ```
@@ -24,11 +25,19 @@ docker pull metabase/metabase:latest
 
 Then start the Metabase container:
 
+> ⚠️ **Important**: The basic command below will lose all your data when the container is stopped. For data persistence, use the version with volume mounting instead.
+
 ```
 docker run -d -p 3000:3000 --name metabase metabase/metabase
 ```
 
 This will launch an Metabase server on port 3000 by default.
+
+With mounting the H2 database into a local directory:
+
+```
+docker run -d -p 3000:3000 -v ./metabase.db:/metabase.db --name metabase metabase/metabase
+```
 
 Optional: to view the logs as your Open Source Metabase initializes, run:
 


### PR DESCRIPTION
### Description

Clarify how to mount the H2 database into a local directory for data persistence.  
Adds instructions and a warning about data loss when the container is stopped without volume mounting.

### How to verify

1. Follow the updated documentation to run Metabase with H2 mounted in a local directory.
2. Stop the container and verify that data is persisted in the specified local directory.
3. Optionally, run `docker rm -f metabase` and `docker run` again to ensure persistence works as described.

### Checklist

- [ ] Documentation has been updated to reflect the change.
- [ ] Verified that instructions work correctly.