### PR TITLE
Fix test issues in semantic search module

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -336,12 +336,12 @@
 (defmacro with-index!
   "Ensure a clean, small index for testing populated with a few collections, cards, and dashboards."
   [& body]
-  `(with-indexable-documents!
-     (with-redefs [semantic.embedding/get-configured-model        (fn [] mock-embedding-model)
-                   semantic.index-metadata/default-index-metadata mock-index-metadata
-                   semantic.index/model-table-suffix              mock-table-suffix]
-       (with-open [_# (open-temp-index-and-metadata!)]
-         (binding [search.ingestion/*force-sync* true]
+  `(binding [search.ingestion/*disable-updates* true]
+     (with-indexable-documents!
+       (with-redefs [semantic.embedding/get-configured-model        (fn [] mock-embedding-model)
+                     semantic.index-metadata/default-index-metadata mock-index-metadata
+                     semantic.index/model-table-suffix              mock-table-suffix]
+         (with-open [_# (open-temp-index-and-metadata!)]
            (blocking-index!
             (semantic.pgvector-api/gate-updates! (semantic.env/get-pgvector-datasource!)
                                                  mock-index-metadata

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -275,7 +275,7 @@
   N.B. *disable-updates* is bound to avoid processing of those entities by logic in [[search.ingestion]] ns.
   The processing is triggered by means :hook/search-index which :model/Card (and others) derive.
 
-  As of 2025-09-10, processing triggered by insertion, combined with manual gating of documents that callers 
+  As of 2025-09-10, processing triggered by insertion, combined with manual gating of documents that callers
   of this fn do, would result in duplicate processing and deletion of those entitities from index
   due to [[search.ingestion/bulk-ingest!]].
 

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1247,13 +1247,13 @@
   "Extract dimensions (non-aggregation columns) from a dataset query."
   [dataset-query-str]
   (when dataset-query-str
-    (lib.metadata.jvm/with-metadata-provider-cache
-      (let [dataset-query     ((:out mi/transform-metabase-query) dataset-query-str)
-            metadata-provider (lib.metadata.jvm/application-database-metadata-provider (:database dataset-query))
-            lib-query         (lib/query metadata-provider dataset-query)
-            columns           (lib/returned-columns lib-query)]
+    (when-some [dataset-query (not-empty ((:out mi/transform-metabase-query) dataset-query-str))]
+      (lib.metadata.jvm/with-metadata-provider-cache
+        (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (:database dataset-query))
+              lib-query         (lib/query metadata-provider dataset-query)
+              columns           (lib/returned-columns lib-query)]
         ;; Dimensions are columns that are not aggregations
-        (remove (comp #{:source/aggregations} :lib/source) columns)))))
+          (remove (comp #{:source/aggregations} :lib/source) columns))))))
 
 (defn extract-non-temporal-dimension-ids
   "Extract list of nontemporal dimension field IDs, stored as JSON string. See PR 60912"

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1247,13 +1247,17 @@
   "Extract dimensions (non-aggregation columns) from a dataset query."
   [dataset-query-str]
   (when dataset-query-str
+    ;; In production the :database should be always present and correct. That is not the case for some test mocks.
+    ;; As e.g. in [[metabase-enterprise.semantic-search.test-util/do-with-indexable-documents!]]. Hence the thorough
+    ;; checking.
     (when-some [dataset-query (not-empty ((:out mi/transform-metabase-query) dataset-query-str))]
-      (lib.metadata.jvm/with-metadata-provider-cache
-        (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (:database dataset-query))
-              lib-query         (lib/query metadata-provider dataset-query)
-              columns           (lib/returned-columns lib-query)]
-        ;; Dimensions are columns that are not aggregations
-          (remove (comp #{:source/aggregations} :lib/source) columns))))))
+      (when (pos-int? (:database dataset-query))
+        (lib.metadata.jvm/with-metadata-provider-cache
+          (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (:database dataset-query))
+                lib-query         (lib/query metadata-provider dataset-query)
+                columns           (lib/returned-columns lib-query)]
+            ;; Dimensions are columns that are not aggregations
+            (remove (comp #{:source/aggregations} :lib/source) columns)))))))
 
 (defn extract-non-temporal-dimension-ids
   "Extract list of nontemporal dimension field IDs, stored as JSON string. See PR 60912"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-404/address-tests-failing-in-the-repl

This PR addresses:
1. Stacktraces pointing to `dataset-query->dimensions` in tests, by making the function more resilient to mock data we use for testing.
2. Twisted race condition popping up in tests regularly, for the more context see [this thread](https://metaboat.slack.com/archives/C07SJT1P0ET/p1757452434713309?thread_ts=1757410361.879029&cid=C07SJT1P0ET), by adding a binding wrapper around `do-with-indexable-documents`.

Rest of the PR is just a cleanup along "move macro body into a function so we can do defs for debugging", "remove macro with single use".