### PR TITLE
fix: do not display value in options when editing FKs

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputSearchableSelect.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/inputs/TableActionInputSearchableSelect.tsx
@@ -197,7 +197,6 @@ export const TableActionInputSearchableSelect = ({
                 key={item.value}
               >
                 {item.label}
-                {searchFieldId ? ` [${item.value}]` : ""}
               </Combobox.Option>
             ))
           ) : isLoading ? (


### PR DESCRIPTION
Resolves [WRK-627](https://linear.app/metabase/issue/WRK-627/remove-original-value-from-fks-with-display-settings-configured)
