### PR TITLE
Fix stray bracket in version-info

### DIFF
--- a/release/src/version-info.ts
+++ b/release/src/version-info.ts
@@ -1,5 +1,6 @@
 import fetch from "node-fetch";
 
+import { getChangelogUrl } from "./release-notes";
 import type {
   ReleaseChannel,
   ReleaseProps,
@@ -7,8 +8,6 @@ import type {
   VersionInfoFile,
 } from "./types";
 import {
-  getMajorVersion,
-  getMinorVersion,
   getVersionType,
   isEnterpriseVersion,
   isPatchVersion,
@@ -19,14 +18,11 @@ const generateVersionInfo = ({
 }: {
   version: string;
 }): VersionInfo => {
-  const majorVersion = getMajorVersion(version);
-  const minorVersion = getMinorVersion(version);
-
   return {
     version,
     released: new Date().toISOString().slice(0, 10),
     patch: ["patch", "minor"].includes(getVersionType(version)),
-    highlights: [ `see https://www.metabase.com/changelog/${majorVersion}#metabase-${majorVersion}${minorVersion}}` ],
+    highlights: [ `see ${getChangelogUrl(version)}` ],
   };
 };
 

--- a/release/src/version-info.unit.spec.ts
+++ b/release/src/version-info.unit.spec.ts
@@ -8,7 +8,7 @@ describe("version-info", () => {
         version: "v0.2.3",
         released: "2021-01-01",
         patch: true,
-        highlights: ["see https://www.metabase.com/changelog/2#metabase-23}"],
+        highlights: ["see https://www.metabase.com/changelog/2#metabase-23"],
       },
       older: [],
     } as VersionInfoFile;
@@ -23,7 +23,7 @@ describe("version-info", () => {
         version: "v0.3.0",
         released: expect.any(String),
         patch: false,
-        highlights: ["see https://www.metabase.com/changelog/3#metabase-30}"],
+        highlights: ["see https://www.metabase.com/changelog/3#metabase-30"],
       }]);
     });
 
@@ -64,7 +64,7 @@ describe("version-info", () => {
         version: "v0.1.9",
         released: expect.any(String),
         patch: true,
-        highlights: ["see https://www.metabase.com/changelog/1#metabase-19}"],
+        highlights: ["see https://www.metabase.com/changelog/1#metabase-19"],
       });
     });
 


### PR DESCRIPTION

### Description
oops:

```
"latest": {
    "version": "v1.56.5",
    "released": "2025-09-10",
    "patch": true,
    "highlights": [
      "see https://www.metabase.com/changelog/56#metabase-565}"
    ],
    "rollout": 100
  },
```

- removes stray bracket
- uses existing function for url-generation
