### PR TITLE
fix question title layout

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.module.css
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.module.css
@@ -85,7 +85,6 @@
 .HeaderContent {
   padding-top: 1rem;
   padding-bottom: 0.75rem;
-  width: 100%;
   min-width: 0;
 
   .HeaderCaptionContainer {

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.module.css
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.module.css
@@ -1,5 +1,4 @@
 .HeaderTitleContainer {
-  width: 100%;
   min-width: 0;
 }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63151
Caused by https://github.com/metabase/metabase/pull/62980

### Description

Describe the overall approach and the problem being solved.

### How to verify

- Run Metabase EE
- Open Usage Analytics -> Activity log model and ensure the layout of the model title looks correct

### Demo

Before
<img width="583" height="178" alt="Screenshot 2025-09-10 at 2 04 54 PM" src="https://github.com/user-attachments/assets/fc36bab9-42d0-4331-bf9a-ab968eef400e" />

After
<img width="455" height="163" alt="Screenshot 2025-09-10 at 2 06 15 PM" src="https://github.com/user-attachments/assets/2b0e1c08-01d1-48bb-900c-b5f3adf7f6ec" />

The fix from https://github.com/metabase/metabase/pull/62980 still works:
<img width="1304" height="259" alt="Screenshot 2025-09-10 at 2 06 57 PM" src="https://github.com/user-attachments/assets/6b942249-2481-4bb9-af6a-b87d71f00d8a" />

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
