### PR TITLE
Upgrade clickhouse jdbc driver to 0.9.2

### DIFF
--- a/modules/drivers/clickhouse/deps.edn
+++ b/modules/drivers/clickhouse/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
  :deps
- {com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.4"
+ {com.clickhouse/clickhouse-jdbc {:mvn/version "0.9.2"
                                   :exclusions [org.apache.commons/commons-lang3]}
   org.lz4/lz4-java {:mvn/version "1.8.0"}}}

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -243,7 +243,7 @@
 
 (defmethod sql.qp/->honeysql [:clickhouse LocalDate]
   [_ ^java.time.LocalDate t]
-  [:'parseDateTimeBestEffort t])
+  t)
 
 (defn- local-date-time
   [^java.time.LocalTime t]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -371,19 +371,19 @@
          [{:field-name "mystring" :base-type :type/Text}]
          [["foo"] ["bar"] ["   "] [""] [nil]]]])
       (testing "null strings count"
-        (is (= 2M
+        (is (= 2
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:is-null $mystring]
                       :aggregation [:count]})
                    mt/first-row last))))
       (testing "nullable strings not null filter"
-        (is (= 3M
+        (is (= 3
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:not-null $mystring]
                       :aggregation [:count]})
                    mt/first-row last))))
       (testing "filter nullable string by value"
-        (is (= 1M
+        (is (= 1
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:= $mystring "foo"]
                       :aggregation [:count]})
@@ -591,17 +591,8 @@
                   unsigned_int_types
                   {}))))))))
 
-;; FIXME: blocked by https://github.com/ClickHouse/clickhouse-java/issues/2218
-#_(deftest ^:parallel clickhouse-fixed-strings
-    (mt/test-driver
-      :clickhouse
-      (is (= [["val1" "val2" "val3" "val4"]]
-             (qp.test/formatted-rows
-              [str str str str]
-              :format-nil-values
-              (ctd/do-with-test-db
-               (fn [db]
-                 (data/with-db db
-                   (data/run-mbql-query
-                    fixed_strings
-                    {})))))))))
+(deftest ^:parallel clickhouse-fixed-strings
+  (mt/test-driver :clickhouse
+    (mt/dataset metabase_test
+      (is (= [[1 "val1" "val2" "val3" "val4"]]
+             (mt/rows (mt/run-mbql-query fixed_strings)))))))

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -147,7 +147,9 @@
                  {:ssl true
                   :host "server.clickhouseconnect.test"
                   :port 8443
-                  :dbname "default system"
+                  :enable-multiple-db true
+                  :db-filters-patterns "default, system"
+                  :db-filters-type "inclusion"
                   :additional-options additional-options}))))))))
 
 (deftest ^:parallel clickhouse-nippy

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -229,9 +229,6 @@
                (mt/rows (qp/process-query q))))))))
 
 (deftest ^:parallel comment-question-mark-test
-  ;; broken in 0.8.3, fixed in 0.8.4
-  ;; https://github.com/metabase/metabase/issues/56690
-  ;; https://github.com/ClickHouse/clickhouse-java/issues/2290
   (mt/test-driver :clickhouse
     (testing "a query with a question mark in the comment and has a variable should work correctly"
       (let [query "SELECT *
@@ -252,9 +249,6 @@
                                 :value  "African"}]}))))))))
 
 (deftest ^:parallel select-question-mark-test
-  ;; broken in 0.8.3, fixed in 0.8.4
-  ;; https://github.com/metabase/metabase/issues/56690
-  ;; https://github.com/ClickHouse/clickhouse-java/issues/2290
   (mt/test-driver :clickhouse
     (testing "a query that selects a question mark and has a variable should work correctly"
       (let [query "SELECT *, '?'

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -277,47 +277,36 @@
                                 :target [:dimension [:template-tag "category_name"]]
                                 :value  ["African"]}]}))))))))
 
-#_(deftest ^:parallel ternary-with-variable-test
-    ;; TODO(rileythomp): enable these tests once the jdbc driver has been fixed
-    ;; broken in 0.8.4, waiting for fix
-    ;; https://github.com/metabase/metabase/issues/56690
-    ;; https://github.com/ClickHouse/clickhouse-java/issues/2348
-    (mt/test-driver :clickhouse
-      (testing "a query with a ternary and a variable should work correctly"
-        (is (= [[1 "African" 1]]
-               (mt/rows
-                (qp/process-query
-                 {:database (mt/id)
-                  :type :native
-                  :native {:query "SELECT *, true ? 1 : 0 AS foo
-                                   FROM test_data.categories
-                                   WHERE name = {{category_name}};"
-                           :template-tags {"category_name" {:type         :text
-                                                            :name         "category_name"
-                                                            :display-name "Category Name"}}}
-                  :parameters [{:type   :category
-                                :target [:variable [:template-tag "category_name"]]
-                                :value  "African"}]})))))))
+(deftest ^:parallel ternary-with-variable-test
+  (mt/test-driver :clickhouse
+    (testing "a query with a ternary and a variable should work correctly"
+      (is (= [[1 "African" 1]]
+             (mt/rows
+              (qp/process-query
+               {:database (mt/id)
+                :type :native
+                :native {:query "SELECT *, true ? 1 : 0 AS foo
+                                 FROM test_data.categories
+                                 WHERE name = {{category_name}};"
+                         :template-tags {"category_name" {:type         :text
+                                                          :name         "category_name"
+                                                          :display-name "Category Name"}}}
+                :parameters [{:type   :category
+                              :target [:variable [:template-tag "category_name"]]
+                              :value  "African"}]})))))))
 
-#_(deftest ^:parallel line-comment-block-comment-test
-    ;; TODO(rileythomp): enable these tests once the jdbc driver has been fix
-    ;; broken in  0.8.4, waiting for fix
-    ;; https://github.com/metabase/metabase/issues/57149
-    ;; https://github.com/ClickHouse/clickhouse-java/issues/2338
-    (mt/test-driver :clickhouse
-      (testing "a query with a line comment followed by a block comment should work correctly"
-        (is (= [[1]]
-               (mt/rows
-                (qp/process-query
-                 (mt/native-query
-                   {:query "-- foo
-                            /* comment */
-                            select 1;"}))))))))
+(deftest ^:parallel line-comment-block-comment-test
+  (mt/test-driver :clickhouse
+    (testing "a query with a line comment followed by a block comment should work correctly"
+      (is (= [[1]]
+             (mt/rows
+              (qp/process-query
+               (mt/native-query
+                 {:query "-- foo
+                          /* comment */
+                          select 1;"}))))))))
 
 (deftest ^:parallel subquery-with-cte-test
-  ;; broken in 0.8.6, waiting for fix
-  ;; https://github.com/metabase/metabase/issues/59166
-  ;; https://github.com/ClickHouse/clickhouse-java/issues/2442
   (mt/test-driver :clickhouse
     (testing "a query with a CTE in a subquery should work correctly"
       (is (= [[9]]
@@ -327,10 +316,6 @@
                  {:query "select * from ( with x as ( select 9 ) select * from x ) as y;"}))))))))
 
 (deftest ^:parallel casted-params-test
-  ;; broken in 0.8.6, waiting for fix
-  ;; https://github.com/metabase/metabase/issues/58992
-  ;; https://github.com/metabase/metabase/issues/59002
-  ;; https://github.com/ClickHouse/clickhouse-java/issues/2422
   (mt/test-driver :clickhouse
     (testing "a query with a with multiple params and one of the casted should work correctly"
       (is (= [[1 "African"] [2 "American"]]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/56690
Closes https://github.com/metabase/metabase/issues/57149
Closes https://github.com/metabase/metabase/issues/62741
Closes https://linear.app/metabase/issue/QUE-2426/upgrade-clickhouse-jdbc-driver-to-092

### Description

Upgrade clickhouse jdbc driver to 0.9.2

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
