### PR TITLE
fix missing tooltip max width

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -495,3 +495,39 @@ describe("issue 54755", () => {
     cy.findByTestId("visualization-placeholder").should("be.visible");
   });
 });
+
+describe("issue 63026", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should show tooltips with reasonable width for pie charts with long text labels (metabase#63026)", () => {
+    const query = `select '${"a".repeat(1000)}' as category, 45 as count
+union all select 'Short name', 25 as count
+union all select 'Medium length category', 30 as count`;
+
+    H.visitQuestionAdhoc({
+      display: "pie",
+      dataset_query: {
+        type: "native",
+        native: {
+          query,
+        },
+        database: SAMPLE_DB_ID,
+      },
+      visualization_settings: {
+        "pie.show_labels": true,
+      },
+    });
+
+    H.chartPathWithFillColor("#88BF4D").trigger("mousemove");
+
+    cy.get("[data-testid='echarts-tooltip']")
+      .should("be.visible")
+      .then(($tooltip) => {
+        const width = $tooltip.width();
+        expect(width).to.be.lte(550);
+      });
+  });
+});

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.module.css
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.module.css
@@ -79,6 +79,7 @@
   padding-left: 0.375rem;
   font-weight: 400;
   text-align: left;
+  max-width: 360px;
 }
 
 .MainValueCell,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63026
### Description



### How to verify

```sql
select 'aaaaa' x, 100 y
union all select 'aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaa aaaaaaaaaaaa aaaaaa aaaaaaaaaaaa aaaaaa aaaaaaaaaaaa aaaaaa aaaaaaaaaaaa aaaaaa aaaaaaaaaaaa aaaaaa aaaaaaaaaaaa aaaaaa aaaaaaaaaaaa aaaaaa aaaaaa', 200
```
- Create a pie chart from the query above
- Hover on slices and ensure the tooltip has reasonable max width and the long row name is ellipsified

### Demo

Before
<img width="1728" height="944" alt="Screenshot 2025-09-10 at 2 39 55 PM" src="https://github.com/user-attachments/assets/959f218f-0fa8-475b-95dc-d850212e87c0" />

After
<img width="1728" height="931" alt="Screenshot 2025-09-10 at 2 39 42 PM" src="https://github.com/user-attachments/assets/134559cf-7552-4410-9580-582734c69285" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
