### PR TITLE
Add MB_WEBPACK_PORT env variable config

### DIFF
--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -147,6 +147,18 @@ You can also start a REPL another way (e.g., through your editor) and then call:
 To start the server (at `localhost:3000`). This will also set up or migrate your application database. To actually
 use Metabase, don't forget to start the frontend as well (e.g. with `yarn build-hot`).
 
+### Multiple Instances
+
+You can run multiple instances of Metabase on the same machine by specifying a different port for each instance.
+
+Frontend:
+- If you are running the frontend with `yarn build-hot`, set the `PORT` environment variable: `PORT=3001 MB_EDITION=ee yarn build-hot`
+- If you are building the frontend statically with `yarn build`, there is nothing different to do
+
+Backend:
+- Set the `MB_JETTY_PORT` environment variable
+- If you are running the frontend with `yarn build-hot`, set `MB_WEBPACK_PORT` to the same port as the `PORT` variable above
+
 ### The application database
 
 By default, Metabase uses H2 for its application database, but we recommend using Postgres. This is configured with

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [environ.core :as env]
    [java-time.api :as t]
    [metabase.analytics.core :as analytics]
    [metabase.config.core :as config]
@@ -113,6 +114,9 @@
   parse-allowed-iframe-hosts
   (memoize parse-allowed-iframe-hosts*))
 
+(def ^:private webpack-port (or (env/env :mb-webpack-port) "8080"))
+(def ^:private webpack-address (str "http://localhost:" webpack-port))
+
 (defn- content-security-policy-header
   "`Content-Security-Policy` header. See https://content-security-policy.com for more details."
   [nonce]
@@ -127,7 +131,7 @@
                                     "https://www.google-analytics.com")
                                   ;; for webpack hot reloading
                                   (when config/is-dev?
-                                    "http://localhost:8080")
+                                    webpack-address)
                                   ;; for react dev tools to work in Firefox until resolution of
                                   ;; https://github.com/facebook/react/issues/17997
                                   (when config/is-dev?
@@ -146,7 +150,7 @@
                                    (format "'nonce-%s'" nonce))
                                  ;; for webpack hot reloading
                                  (when config/is-dev?
-                                   "http://localhost:8080")
+                                   webpack-address)
                                  ;; CLJS REPL
                                  (when config/is-dev?
                                    "http://localhost:9630")
@@ -165,7 +169,7 @@
                                    (setting/get-value-of-type :string :snowplow-url))
                                  ;; Webpack dev server
                                  (when config/is-dev?
-                                   "*:8080 ws://*:8080")
+                                   (str "*:" webpack-port " ws://*:" webpack-port))
                                  ;; CLJS REPL
                                  (when config/is-dev?
                                    "ws://*:9630")]


### PR DESCRIPTION
### Description

When running multiple metabase instances locally, it's nice to be able to use `yarn build-hot` on both.

This adds a new `MB_WEBPACK_PORT` env variable that gets used to override the default port 8080 the dev mode backend expects webpack to be on.

Allows you to run:
`PORT=8082 yarn build-hot` 
and then run the backend with `MB_WEBPACK_PORT=8082`


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
