### PR TITLE
Handle mixed catalog table errors in Trino sync

### DIFF
--- a/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -8,6 +8,7 @@
    [metabase.driver.common.table-rows-sample :as table-rows-sample]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.starburst :as starburst]
    [metabase.query-processor :as qp]
@@ -22,7 +23,7 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
-   (java.sql Connection)))
+   (java.sql Connection PreparedStatement ResultSet SQLException)))
 
 (set! *warn-on-reflection* true)
 
@@ -32,6 +33,51 @@
 (defmethod tx/before-run :starburst
   [_]
   (alter-var-root #'timezones-test/broken-drivers conj :starburst))
+
+(deftest have-select-privilege-mixed-tables-test
+  (testing "have-select-privilege? correctly handles mixed Hive/Iceberg tables (Issue #63127)"
+    (testing "Returns true when DESCRIBE succeeds (compatible table type)"
+      (let [mock-conn (reify Connection
+                        (getCatalog [_] "hive")
+                        (prepareStatement [_ sql]
+                          (is (= "DESCRIBE \"hive\".\"sales_data\".\"hive_table\"" sql))
+                          (reify PreparedStatement
+                            (executeQuery [_]
+                              (reify ResultSet
+                                (next [_] true)
+                                (close [_] nil)))
+                            (close [_] nil))))]
+        (is (true? (sql-jdbc.sync.interface/have-select-privilege?
+                    :starburst mock-conn "sales_data" "hive_table")))))
+
+    (testing "Returns false when DESCRIBE fails (incompatible table type like Iceberg in Hive catalog)"
+      (let [mock-conn (reify Connection
+                        (getCatalog [_] "hive")
+                        (prepareStatement [_ sql]
+                          (is (= "DESCRIBE \"hive\".\"sales_data\".\"iceberg_table\"" sql))
+                          (reify PreparedStatement
+                            (executeQuery [_]
+                              ;; This simulates the actual Trino error when Hive catalog tries to describe an Iceberg table
+                              ;; See HiveMetadata.java and UnknownTableTypeException.java in trinodb/trino
+                              (throw (SQLException. "Cannot query Iceberg table 'sales_data.iceberg_table'")))
+                            (close [_] nil))))]
+        (is (false? (sql-jdbc.sync.interface/have-select-privilege?
+                     :starburst mock-conn "sales_data" "iceberg_table")))))
+
+    (testing "Rethrows SQLException for non-mixed-catalog errors"
+      (let [mock-conn (reify Connection
+                        (getCatalog [_] "hive")
+                        (prepareStatement [_ sql]
+                          (is (= "DESCRIBE \"hive\".\"sales_data\".\"restricted_table\"" sql))
+                          (reify PreparedStatement
+                            (executeQuery [_]
+                              ;; This is a regular permission error, not a mixed catalog issue
+                              (throw (SQLException. "Access Denied: Cannot access table restricted_table")))
+                            (close [_] nil))))]
+        ;; This should throw the exception rather than returning false
+        (is (thrown? SQLException
+                     (sql-jdbc.sync.interface/have-select-privilege?
+                      :starburst mock-conn "sales_data" "restricted_table")))))))
 
 (deftest describe-database-test
   (mt/test-driver :starburst


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63127

> When syncing a Trino connection in Metabase, the sync fields stage fails in some cases if the catalog’s schema includes a mix of Hive and Iceberg tables backed by the same Hive Metastore.
> 
> This seems to happen because Trino exposes Iceberg tables in the Hive catalog (and Hive tables in the Iceberg catalog) at the metadata level, even though they are not queryable through that catalog. During sync, Metabase attempts to run field introspection queries on all tables returned by Trino. For the “wrong” tables, Trino throws an error and the fields aren't available for that table in either catalog after sync.

### Description

Trino's Hive plugin shows the tables in question in its metadata, but if you try to get a handle on these tables, it will always [throw an exception](https://github.com/trinodb/trino/blob/78a46249e1e21cef726e7998d4bdf8821aa92947/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java#L541-L549) with error code `UNSUPPORTED_TABLE_TYPE`. The Iceberg plugin has a [similar exception](https://github.com/trinodb/trino/blob/dbe02cbd7a034b99b9dac3f20329db13b0a666e0/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/UnknownTableTypeException.java) for such circumstances.

For us, there doesn't seem to be much difference between not being able to query a table because it's an unsupported type and not being able to query because we don't have permissions, so this PR modifies `have-select-privilege?` in the Starburst driver to return `false` in these cases.

~I wanted to walk the exception tree, find any `TrinoException`, and check for `UNSUPPORTED_TABLE_TYPE`, but the SPI classes are not available via our trino-jdbc dependency. The current mechanism catches `SQLException` and regex-matches the exception string.~ We can examine the vendor-specific error code on the SQLException to detect these cases. H/t @dpsutton 

### How to verify

Check out the reproduction steps in #63127. The Loom recording is great and to the point.

If you use @ixipixi's amazingly helpful [Quick Lab](https://github.com/ixipixi/trino-lab), then to test the local branch with `yarn dev-ee`:
 - Don't start the metabase container
 - Modify the `trino-lab-coordinator` port to expose on something other than 8080
 - Be sure to run `.bin/build-drivers.sh` before launching the local Metabase instance
 - If the catalogs aren't showing, you may just need to start `trino-lab-data-setup` manually

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

I'm not the happiest with the CLJ testing method -- if you have better ideas let me know.
