### PR TITLE
fix table search crash when pressing enter without any table selected

### DIFF
--- a/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/TablePicker.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/TablePicker.tsx
@@ -164,7 +164,7 @@ function Search({
 
   useKeyPressEvent("Enter", (event) => {
     const item = items[selectedIndex];
-    if (item.value) {
+    if (item?.value) {
       onChange?.(item.value);
       event.preventDefault();
     }

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/TablePicker.unit.spec.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TablePicker/TablePicker.unit.spec.tsx
@@ -380,6 +380,18 @@ describe("TablePicker", () => {
         tableId: FOO_RESULT.id,
       });
     });
+
+    it("should not crash when pressing Enter with no item selected (metabase#63350)", async () => {
+      const { onChange } = setup({
+        searchResults: SEARCH_RESULTS,
+      });
+
+      await userEvent.type(searchInput(), "search");
+
+      await userEvent.type(searchInput(), "{Enter}");
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63350
### Description

Fixes table search crashes in the Admin -> Table metadata when pressing "Enter" while no items selected.

### How to verify

- Open Admin -> Table Metadata
- Enter anything to the search input
- Do not select any items in the result list and press "Enter"
- Ensure it did not crash

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
