### PR TITLE
Fix: UXW-606 Bookmark drag and drop handle shown when there's nothing to rearrange

### DIFF
--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -51,6 +51,7 @@ interface CollectionSidebarBookmarksProps {
 interface BookmarkItemProps {
   bookmark: Bookmark;
   index: number;
+  isDraggable?: boolean;
   isSorting: boolean;
   selectedItem?: SelectedItem;
   onSelect: () => void;
@@ -68,6 +69,7 @@ function isBookmarkSelected(bookmark: Bookmark, selectedItem?: SelectedItem) {
 
 const BookmarkItem = ({
   bookmark,
+  isDraggable,
   isSorting,
   selectedItem,
   onSelect,
@@ -92,6 +94,7 @@ const BookmarkItem = ({
         icon={icon}
         isSelected={isSelected}
         isDragging={isSorting}
+        isDraggable={isDraggable}
         hasDefaultIconStyle={!isIrregularCollection}
         onClick={onSelect}
         right={
@@ -172,6 +175,7 @@ const BookmarkList = ({
             {orderedBookmarks.map((bookmark, index) => (
               <BookmarkItem
                 bookmark={bookmark}
+                isDraggable={orderedBookmarks.length > 1}
                 isSorting={isSorting}
                 key={index}
                 index={index}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.unit.spec.tsx
@@ -1,0 +1,53 @@
+import type { ComponentProps } from "react";
+import { times } from "underscore";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockBookmark } from "metabase-types/api/mocks";
+
+import BookmarkList from "./BookmarkList";
+
+const mockProps: ComponentProps<typeof BookmarkList> = {
+  bookmarks: [],
+  onSelect: jest.fn(),
+  reorderBookmarks: jest.fn(),
+  onToggle: jest.fn(),
+  initialState: "expanded",
+};
+
+const createBookmarks = (howMany: number) => {
+  return times(howMany, (i) => {
+    const n = i + 1;
+    return createMockBookmark({
+      id: `bookmark-${n}`,
+      name: `Bookmark ${n}`,
+      item_id: n,
+    });
+  });
+};
+
+describe("BookmarkList", () => {
+  it("shows drag handles when there are multiple bookmarks", () => {
+    const bookmarks = createBookmarks(3);
+
+    renderWithProviders(<BookmarkList {...mockProps} bookmarks={bookmarks} />);
+
+    bookmarks.forEach((bookmark) => {
+      expect(screen.getByText(bookmark.name)).toBeInTheDocument();
+    });
+
+    const grabberIcons = screen.getAllByLabelText("grabber icon");
+    expect(grabberIcons).toHaveLength(bookmarks.length);
+  });
+
+  it("hides drag handles when there is only one bookmark", () => {
+    const bookmarks = createBookmarks(1);
+
+    renderWithProviders(<BookmarkList {...mockProps} bookmarks={bookmarks} />);
+
+    bookmarks.forEach((bookmark) => {
+      expect(screen.getByText(bookmark.name)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText("grabber icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/DraggableSidebarLink.tsx
@@ -2,9 +2,15 @@ import { DragIcon, StyledSidebarLink } from "./DraggableSidebarLink.styled";
 import type { SidebarLinkProps } from "./SidebarLink";
 
 interface Props extends Omit<SidebarLinkProps, "left"> {
+  isDraggable?: boolean;
   isDragging: boolean;
 }
 
-export function DraggableSidebarLink(props: Props) {
-  return <StyledSidebarLink {...props} left={<DragIcon name="grabber" />} />;
+export function DraggableSidebarLink({ isDraggable, ...props }: Props) {
+  return (
+    <StyledSidebarLink
+      {...props}
+      left={isDraggable && <DragIcon name="grabber" />}
+    />
+  );
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62726
Closes [UXW-606](https://linear.app/metabase/issue/UXW-606)

### Description

Hides bookmark drag handle when there's only one bookmark

### How to verify

1. Have 1 bookmark, hover over it in the sidebar
2. Verify drag handle is not shown
3. Add another bookmark, hover over it in the sidebar
4. Verify drag handle is shown

### Demo

https://github.com/user-attachments/assets/eb1cbcbc-63fb-47f6-8f49-90fc557f9ae9
