### PR TITLE
Use raw data for finding object detail PKs

### DIFF
--- a/frontend/src/metabase/list-view/components/ListView/ListView.tsx
+++ b/frontend/src/metabase/list-view/components/ListView/ListView.tsx
@@ -51,7 +51,7 @@ export function ListView({
   const { titleColumn, subtitleColumn, imageColumn, rightColumns } =
     useListColumns(cols, settings?.["list.columns"]);
 
-  const openObjectDetail = useObjectDetail(data);
+  const openObjectDetail = useObjectDetail();
 
   // Get the appropriate icon based on entity type
   const entityIcon =

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -220,7 +220,7 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
     return getColumnSizing(cols, columnWidths);
   }, [cols, columnWidths]);
 
-  const onOpenObjectDetail = useObjectDetail(data);
+  const onOpenObjectDetail = useObjectDetail();
 
   const getIsCellClickable = useMemoizedCallback(
     (clicked: ClickObject) => {

--- a/frontend/src/metabase/visualizations/components/TableInteractive/hooks/use-object-detail.ts
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/hooks/use-object-detail.ts
@@ -1,48 +1,37 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { resetRowZoom, zoomInRow } from "metabase/query_builder/actions";
 import {
+  getPKColumnIndex,
+  getQueryResults,
   getRowIndexToPKMap,
   getZoomedObjectId,
 } from "metabase/query_builder/selectors";
 import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
-import type { ColumnDescriptor } from "metabase/visualizations/lib/graph/columns";
-import { isPK } from "metabase-lib/v1/types/utils/isa";
-import type { DatasetData } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 const getZoomedObjectIdSafe = (state: State) => {
   return state.qb ? getZoomedObjectId(state) : undefined;
 };
 
-export const useObjectDetail = ({ rows, cols }: DatasetData) => {
+export const useObjectDetail = () => {
   const dispatch = useDispatch();
   const zoomedObjectId = useSelector(getZoomedObjectIdSafe);
   const rowIndexToPkMap: Record<number, ObjectId> = useSelector((state) =>
     state.qb != null ? getRowIndexToPKMap(state) : {},
   );
 
-  const primaryKeyColumn: ColumnDescriptor | null = useMemo(() => {
-    const primaryKeyColumns = cols.filter(isPK);
-
-    if (primaryKeyColumns.length !== 1) {
-      return null;
-    }
-    const primaryKeyColumn = primaryKeyColumns[0];
-
-    return {
-      column: primaryKeyColumn,
-      index: cols.indexOf(primaryKeyColumn),
-    };
-  }, [cols]);
+  const pkIndex = useSelector(getPKColumnIndex);
+  const queryResults = useSelector(getQueryResults);
 
   const onOpenObjectDetail = useCallback(
     (rowIndex: number) => {
+      const rows = queryResults?.[0]?.data?.rows || [];
       let objectId: number | string;
 
-      if (primaryKeyColumn) {
-        const value = rows[rowIndex][primaryKeyColumn.index];
+      if (pkIndex > -1) {
+        const value = rows[rowIndex][pkIndex];
         objectId =
           typeof value === "number" || typeof value === "string"
             ? value
@@ -57,7 +46,7 @@ export const useObjectDetail = ({ rows, cols }: DatasetData) => {
         dispatch(zoomInRow({ objectId }));
       }
     },
-    [dispatch, primaryKeyColumn, rowIndexToPkMap, rows, zoomedObjectId],
+    [dispatch, pkIndex, rowIndexToPkMap, queryResults, zoomedObjectId],
   );
 
   return onOpenObjectDetail;


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #51393

Closes UXW-45

### Description

This puppy took a lot of debugging. A certain question on stats ((linked in the issue) was returning errors for all object details. We suspected it was because there's multiple primary keys, but that's actually not it. The issue was in a case where we have a joined table with multiple primary keys, and we use Viz Settings to hide the first primary key, we get this weird broken case.

This is because in the use-object-detail hook, we're passing in the row and column data from the table viz, which can have fewer columns that are returned by the query. In these cases, it would find the first primary key in the visible data, but that would actually be the second key in the actual data. However, the machinery that shows object details is looking at the full raw data, which still has both keys, so it would be looking for the keys from the second key column while it actually had 2 primary key columns.

The solution is pretty simple: just make them all work off of the raw query data and use the first primary key, regardless of whether it is actually visible.

Note: in some narrow cases, this could break some urls to specific object details, since we're changing which PK we're using (always the first one from the raw query results before observing hidden columns from viz settings).

Before 
https://github.com/user-attachments/assets/daaf5343-01c2-4959-b3b2-08c90b667627

After
https://github.com/user-attachments/assets/23eedcc8-5d10-4822-9e3c-5c121319e677


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
