### PR TITLE
fix date picker month navigation timezone issue

### DIFF
--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePickerBody/SingleDatePickerBody.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePickerBody/SingleDatePickerBody.tsx
@@ -36,7 +36,7 @@ export function SingleDatePickerBody({
         popoverProps={{ opened: false }}
         aria-label={t`Date`}
         onChange={handleDateChange}
-        onDateChange={(val) => val && setDate(new Date(val))}
+        onDateChange={(val) => val && setDate(dayjs(val).toDate())}
       />
       {hasTime && (
         <TimeInput
@@ -49,7 +49,7 @@ export function SingleDatePickerBody({
         value={value}
         date={date}
         onChange={handleDateChange}
-        onDateChange={(val) => val && setDate(new Date(val))}
+        onDateChange={(val) => val && setDate(dayjs(val).toDate())}
       />
     </Stack>
   );

--- a/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePickerBody/SingleDatePickerBody.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePickerBody/SingleDatePickerBody.unit.spec.tsx
@@ -1,0 +1,54 @@
+import _userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { SingleDatePickerBody } from "./SingleDatePickerBody";
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
+
+interface SetupOpts {
+  value?: Date;
+  hasTime?: boolean;
+}
+
+function setup({
+  value = new Date(2020, 0, 10),
+  hasTime = false,
+}: SetupOpts = {}) {
+  renderWithProviders(
+    <SingleDatePickerBody
+      value={value}
+      hasTime={hasTime}
+      onChange={jest.fn()}
+    />,
+  );
+}
+
+describe("SingleDatePickerBody", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2020, 0, 15));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it("should navigate back one month when clicking previous month button from September 1st (metabase#63308)", async () => {
+    setup({ value: new Date(2020, 8, 1) });
+
+    expect(screen.getByText("September 2020")).toBeInTheDocument();
+
+    const prevButton = screen
+      .getAllByRole("button")
+      .find((button) => button.getAttribute("data-direction") === "previous");
+
+    expect(prevButton).toBeTruthy();
+    await userEvent.click(prevButton!);
+
+    expect(await screen.findByText("August 2020")).toBeInTheDocument();
+    expect(screen.queryByText("July 2020")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63308
### Description

Fixes date picker jumping back 2 months instead of 1 when clicking previous month from Sept 1st - dayjs parses dates in local timezone while new Date() can interpret them as UTC causing shifts

### How to verify

1. Go to E-Commerce Insights -> Date Range -> Fixed Date Range -> On...
2. Choose September 1 then click on the left arrow to go back 1 month

<img width="326" height="226" alt="Image" src="https://github.com/user-attachments/assets/fe33178c-4638-4a59-b258-265d1784a503" />

3. Ensure it shows August instead of July

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
