### PR TITLE
Hide empty breakout step in readonly notebook

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -821,7 +821,6 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
   describe("queries", () => {
     it("should render a readOnly preview of the MBQL query", () => {
       cy.log("create a new transform that has all the steps");
-      createMbqlTransform({ visitTransform: true });
       H.getTableId({ name: "Animals" }).then((tableId) => {
         H.getFieldId({ tableId, name: "score" }).then((ANIMAL_SCORE) => {
           H.getFieldId({ tableId, name: "name" }).then((ANIMAL_NAME) => {
@@ -965,6 +964,42 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
         H.entityPickerModal().should("not.exist");
         H.popover({ skipVisibilityCheck: true }).should("not.exist");
       }
+    });
+
+    it("should hide empty sections in read-only mode", () => {
+      H.getTableId({ name: "Animals" }).then((tableId) => {
+        H.createTransform(
+          {
+            name: "MBQL transform",
+            source: {
+              type: "query",
+              query: {
+                database: WRITABLE_DB_ID,
+                type: "query",
+                query: {
+                  "source-table": tableId,
+                  aggregation: [["count"]],
+                },
+              },
+            },
+            target: {
+              type: "table",
+              name: TARGET_TABLE,
+              schema: TARGET_SCHEMA,
+            },
+            tag_ids: [],
+          },
+          { visitTransform: true },
+        );
+
+        H.getNotebookStep("summarize")
+          .scrollIntoView()
+          .should("be.visible")
+          .within(() => {
+            cy.findByText("by").should("not.exist");
+            cy.findByTestId("breakout-step").should("not.exist");
+          });
+      });
     });
 
     it("should be able to update a MBQL query", () => {

--- a/frontend/src/metabase/querying/notebook/components/SummarizeStep/SummarizeStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/SummarizeStep/SummarizeStep.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { Box, Flex } from "metabase/ui";
+import * as Lib from "metabase-lib";
 
 import type { NotebookStepProps } from "../../types";
 import { AggregateStep } from "../AggregateStep";
@@ -10,9 +11,13 @@ export function SummarizeStep({
   step,
   color,
   isLastOpened,
+  readOnly,
   ...props
 }: NotebookStepProps) {
   const isMetric = step.question.type() === "metric";
+
+  const hasBreakouts = Lib.breakouts(step.query, step.stageIndex).length > 0;
+  const showBreakouts = !readOnly || hasBreakouts;
 
   return (
     <Flex
@@ -20,11 +25,12 @@ export function SummarizeStep({
       direction={{ base: "column", md: "row" }}
       gap={{ base: "sm", md: isMetric ? "md" : "sm" }}
     >
-      <Box w={{ base: "100%", md: "50%" }}>
+      <Box w={{ base: "100%", md: "50%" }} flex="1 1 auto">
         <AggregateStep
           step={step}
           color={color}
           isLastOpened={isLastOpened}
+          readOnly={readOnly}
           {...props}
         />
       </Box>
@@ -33,16 +39,19 @@ export function SummarizeStep({
           {t`Default time dimension`}
         </Box>
       ) : (
-        <Box c={color} fw="bold">{t`by`}</Box>
+        showBreakouts && <Box c={color} fw="bold">{t`by`}</Box>
       )}
-      <Box w={{ base: "100%", md: "50%" }}>
-        <BreakoutStep
-          step={step}
-          color={color}
-          isLastOpened={false}
-          {...props}
-        />
-      </Box>
+      {showBreakouts && (
+        <Box w={{ base: "100%", md: "50%" }}>
+          <BreakoutStep
+            step={step}
+            color={color}
+            isLastOpened={false}
+            readOnly={readOnly}
+            {...props}
+          />
+        </Box>
+      )}
     </Flex>
   );
 }


### PR DESCRIPTION
Hides empty breakout step in readonly notebook.

See [this Slack thread for context](https://metaboat.slack.com/archives/C096T8NED1S/p1757549066010369).

### Before
<img width="720" height="380" alt="image" src="https://github.com/user-attachments/assets/85567308-9ef6-4265-9d1b-f894c350a81b" />

### After

<img width="972" height="394" alt="Screenshot 2025-09-11 at 12 37 37" src="https://github.com/user-attachments/assets/349a04a9-48a7-4620-bd5d-09faf1c4f502" />
