### PR TITLE
Fix empty string linked filter handling in embedded dashboards

### DIFF
--- a/src/metabase/embedding/api/common.clj
+++ b/src/metabase/embedding/api/common.clj
@@ -116,6 +116,8 @@
         slug->type (into {} (map (juxt :slug :type)) parameters)]
     (vec (for [[slug value] slug->value
                :let [slug (u/qualified-name slug)
+                     ;; convert empty strings to nil for query processing (but preserve for parameter filtering)
+                     value (if (= value "") nil value)
                      param-type (get slug->type slug)
                      default-options (parameters.dashboard/param-type->default-options param-type)]]
            (cond-> {:slug slug

--- a/src/metabase/embedding/api/common.clj
+++ b/src/metabase/embedding/api/common.clj
@@ -150,7 +150,7 @@
   "Take a map of `query-params` and make sure they're in the right format for the rest of our code. Our
   `wrap-keyword-params` middleware normally converts all query params keys to keywords, but only if they seem like
   ones that make sense as keywords. Some params, such as ones that start with a number, do not pass this test, and are
-  not automatically converted. Thus we must do it ourselves here to make sure things are done as we'd expected.
+  not automatically converted. Thus we must do it ourselves here to make sure things are done as we'd expect.
   Empty strings are preserved to support chained filter functionality."
   [query-params]
   (-> query-params

--- a/src/metabase/embedding/api/common.clj
+++ b/src/metabase/embedding/api/common.clj
@@ -1,7 +1,6 @@
 (ns metabase.embedding.api.common
   (:require
    [clojure.set :as set]
-   [clojure.string :as str]
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.eid-translation.core :as eid-translation]
@@ -32,10 +31,9 @@
   models.resolution/keep-me)
 
 (defn- valid-param-value?
-  "Is V a valid param value? (If it is a String, is it non-blank?)"
+  "Is V a valid param value? Empty strings are considered valid for chained filters."
   [v]
-  (or (not (string? v))
-      (not (str/blank? v))))
+  (not (nil? v)))
 
 (defn- check-params-are-allowed
   "Check that the conditions specified by `object-embedding-params` are satisfied."
@@ -149,12 +147,11 @@
   "Take a map of `query-params` and make sure they're in the right format for the rest of our code. Our
   `wrap-keyword-params` middleware normally converts all query params keys to keywords, but only if they seem like
   ones that make sense as keywords. Some params, such as ones that start with a number, do not pass this test, and are
-  not automatically converted. Thus we must do it ourselves here to make sure things are done as we'd expect.
-  Also, any param values that are blank strings should be parsed as nil, representing the absence of a value."
+  not automatically converted. Thus we must do it ourselves here to make sure things are done as we'd expected.
+  Empty strings are preserved to support chained filter functionality."
   [query-params]
   (-> query-params
-      (update-keys keyword)
-      (update-vals (fn [v] (if (= v "") nil v)))))
+      (update-keys keyword)))
 
 (mu/defn validate-and-merge-params :- [:map-of :keyword :any]
   "Validate that the `token-params` passed in the JWT and the `user-params` (passed as part of the URL) are allowed, and

--- a/test/metabase/embedding/api/embed_test.clj
+++ b/test/metabase/embedding/api/embed_test.clj
@@ -1911,7 +1911,6 @@
                       "Should find at least one venue with lowercase 'red' in the name"))))))))))
 
 (deftest empty-string-linked-filter-test
-  "Test for issue #61054 - Linked filter with empty string value should work in embedded dashboards"
   (with-chain-filter-fixtures! [{:keys [dashboard values-url]}]
     (t2/update! :model/Dashboard (:id dashboard)
                 {:embedding_params {"category_id" "enabled", "category_name" "enabled", "price" "enabled"}})

--- a/test/metabase/embedding/api/embed_test.clj
+++ b/test/metabase/embedding/api/embed_test.clj
@@ -1909,3 +1909,22 @@
                       "Should find at least one venue with uppercase 'Red' in the name")
                   (is (some #(re-find #"red" %) venue-names)
                       "Should find at least one venue with lowercase 'red' in the name"))))))))))
+
+(deftest empty-string-linked-filter-test
+  "Test for issue #61054 - Linked filter with empty string value should work in embedded dashboards"
+  (with-chain-filter-fixtures! [{:keys [dashboard values-url]}]
+    (t2/update! :model/Dashboard (:id dashboard)
+                {:embedding_params {"category_id" "enabled", "category_name" "enabled", "price" "enabled"}})
+
+    (testing "Empty string parameter values should be treated as valid in embedded dashboards"
+      (testing "Empty string in JWT params should work for chain filtering"
+        (let [response (client/client :get 200 (values-url {"category_name" ""}))]
+          (is (map? response))
+          (is (contains? response :values))
+          (is (contains? response :has_more_values))))
+
+      (testing "Empty string in URL query params should work for chain filtering"
+        (let [response (client/client :get 200 (str (values-url) "?_CATEGORY_NAME_="))]
+          (is (map? response))
+          (is (contains? response :values))
+          (is (contains? response :has_more_values)))))))

--- a/test/metabase/embedding/api/preview_embed_test.clj
+++ b/test/metabase/embedding/api/preview_embed_test.clj
@@ -6,7 +6,6 @@
    [metabase.dashboards.api-test :as api.dashboard-test]
    [metabase.embedding.api.embed-test :as embed-test]
    [metabase.embedding.api.preview-embed :as api.preview-embed]
-   [metabase.parameters.chain-filter-test :as chain-filter-test]
    [metabase.query-processor.pivot.test-util :as api.pivots]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -575,7 +574,6 @@
                      (mt/user-http-request :rasta :get 200 url))))))))))
 
 (deftest empty-string-parameter-values-test
-  "Test for issue #61054 - Empty string parameter values should work in preview embedded dashboards"
   (testing "Empty string parameter values in preview embedded dashboards"
     (with-embedding-enabled-and-new-secret-key!
       (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard]}]


### PR DESCRIPTION
## Summary
Fixes #61054 where linked filters with empty string values didn't work in static embedded dashboards.

- Empty string parameter values are now properly accepted in embedded dashboards
- Chain filtering now works correctly with empty string constraints  
- Both regular static embedding and preview embedding are supported

## Problem
Previously, when using linked filters in embedded dashboards:
- Empty strings were being filtered out as "invalid" parameter values
- This prevented proper chained filtering behavior
- Standard Metabase dashboards worked correctly, but embedded ones failed
- The issue occurred in both JWT parameters and URL query parameters

## Solution
**Backend Changes:**
- Modified `valid-param-value?` in `src/metabase/embedding/api/common.clj` to accept empty strings (only reject nil)
- Updated `normalize-query-params` to preserve empty strings instead of converting them to nil
- Empty strings are now treated as valid constraints for chained filtering

**Test Coverage:**
- Added `empty-string-linked-filter-test` for regular embedding
- Added `empty-string-parameter-values-test` for preview embedding
- Updated e2e test with the specific scenario from #61054

## Test plan
- [x] Unit tests pass for both regular and preview embedding scenarios
- [x] Existing embedding tests continue to pass (no regressions)
- [x] Chain filter and dashboard parameter tests pass
- [x] Empty string parameters work in both JWT and URL query parameter formats
- [x] E2e test demonstrates the fix working with linked filter scenario

## Files Changed
- `src/metabase/embedding/api/common.clj` - Fixed parameter validation logic
- `test/metabase/embedding/api/embed_test.clj` - Added comprehensive test coverage
- `test/metabase/embedding/api/preview_embed_test.clj` - Added preview embed test coverage  
- `e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js` - Updated e2e test

🤖 Generated with [Claude Code](https://claude.ai/code)