### PR TITLE
Logs pass 1

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/api.clj
@@ -244,9 +244,6 @@
     (if (transforms.util/python-transform? transform)
       (u.jvm/in-virtual-thread*
        (transforms.execute/execute-python-transform! transform {:start-promise start-promise
-                                                                :message-log   (atom {:pre-python  []
-                                                                                      :python      nil
-                                                                                      :post-python []})
                                                                 :run-method :manual}))
       (u.jvm/in-virtual-thread*
        (transforms.execute/run-mbql-transform! transform {:start-promise start-promise

--- a/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
@@ -206,7 +206,7 @@
                   (future-cancel fut)
                   (if (= ::timeout (try (deref fut 10000 ::timeout) (catch Throwable _)))
                     (log/fatalf "Log polling task did not respond to interrupt, run-id: %s" run-id)
-                    (log/debugf "Log polling task done, run-id: %s")))
+                    (log/debugf "Log polling task done, run-id: %s" run-id)))
         fut     (u.jvm/in-virtual-thread*
                  (python-message-update-loop! run-id message-log))]
     (reify Closeable

--- a/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
@@ -264,7 +264,7 @@
        :output   output})))
 
 (defn- run-python-transform! [{:keys [source] :as transform} db run-id cancel-chan message-log]
-  (with-open [log-thread-ref     (open-log-future! run-id message-log)
+  (with-open [log-future-ref     (open-log-future! run-id message-log)
               shared-storage-ref (python-runner/open-s3-shared-storage! (:source-tables source))]
     (let [driver     (:engine db)
           server-url (transforms.settings/python-execution-server-url)
@@ -284,7 +284,7 @@
           ;; TODO temporary to keep more code stable while refactoring
           ;; no need to materialize these early (i.e output we can stream directly into a tmp file or db if small)
           {:keys [output output-manifest events]} (python-runner/read-output-objects @shared-storage-ref)]
-      (.close log-thread-ref)           ; early close to force any writes to flush
+      (.close log-future-ref)           ; early close to force any writes to flush
       (when (seq events)
         (replace-python-logs! message-log events))
       (if (not= 200 status)

--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -1,8 +1,10 @@
 (ns ^:mb/driver-tests metabase-enterprise.transforms.api-test
   "Tests for /api/transform endpoints."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [medley.core :as m]
+   [metabase-enterprise.transforms.execute :as transforms.execute]
    [metabase-enterprise.transforms.models.transform-run]
    [metabase-enterprise.transforms.models.transform-tag]
    [metabase-enterprise.transforms.models.transform-transform-tag]
@@ -18,7 +20,10 @@
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import (clojure.lang IDeref)
+           (java.io Closeable)
+           (java.time Duration)))
 
 (set! *warn-on-reflection* true)
 
@@ -308,6 +313,178 @@
                 (is (true? (transforms.util/target-table-exists? original)))
                 (is (true? (transforms.util/target-table-exists? updated)))
                 (check-query-results table2-name [2 3 4 13] "Doohickey")))))))))
+
+(deftest execute-python-transform-test
+  (testing "transform execution with :transforms/table target"
+    (mt/test-drivers #{:h2 :postgres}
+      (mt/with-premium-features #{:transforms}
+        (mt/dataset transforms-dataset/transforms-test
+          (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+            (with-transform-cleanup! [{table-name :name :as target} {:type   "table"
+                                                                     :schema schema
+                                                                     :name   "target_table"}]
+              (let [original           {:name   "Gadget Products"
+                                        :source {:type  "python"
+                                                 :source-database (mt/id)
+                                                 :source-tables {"transforms_customers" (mt/id :transforms_customers)}
+                                                 :body  (str "import pandas as pd\n"
+                                                             "\n"
+                                                             "def transform():\n"
+                                                             "    return pd.DataFrame({'name': ['Alice', 'Bob'], 'age': [25, 30]})")}
+                                        :target  (assoc target :database (mt/id))}
+                    {transform-id :id} (mt/user-http-request :crowberto :post 200 "ee/transform"
+                                                             original)]
+                (transforms.tu/test-run transform-id)
+                (transforms.tu/wait-for-table table-name 5000)
+                (is (true? (driver/table-exists? driver/*driver* (mt/db) target)))
+                (is (= [["Alice" 25] ["Bob" 30]]
+                       (transforms.tu/table-rows table-name)))))))))))
+
+(deftest python-transform-logging-test
+
+  ;; behaviour
+  ;; message contains expected log output post run
+  ;;   for failure, timeout, cancellation
+  ;;   - python error
+  ;;   - hang up during http
+  ;;   - crash during table write
+  ;;   - crash during sync
+  ;;   content: stdout/stderr + metabase
+  ;;      out/err interleaving
+
+  (letfn [(program->source [program]
+            (->> (concat ["import pandas as pd"
+                          "def transform():"]
+                         (for [s program] (str "  " s))
+                         ["  return pd.DataFrame({'x': [42]})"])
+                 (str/join "\n")))
+
+          (create-transform [{:keys [program]} target]
+            {:post [(integer? %)]}
+            (:id (mt/user-http-request :crowberto :post 200 "ee/transform"
+                                       {:name   "Python logging test"
+                                        :source {:type            "python"
+                                                 :body            (program->source program)
+                                                 ;; required for now even if no inputs
+                                                 :source-database (mt/id)
+                                                 :source-tables   {}}
+                                        :target (assoc target :database (mt/id))})))
+
+          (block-on-run [{:keys [expect-status]} target transform-id]
+            (try
+              (transforms.tu/test-run transform-id)
+              (catch Throwable e
+                ;; test-run throws for non success, but we want to test failures too
+                (when-not (= expect-status (:status (ex-data e)))
+                  (throw e))))
+            (when (= :succeeded expect-status)
+              (transforms.tu/wait-for-table (:name target) 5000)))
+
+          (get-last-run [transform-id]
+            (:last_run (mt/user-http-request :crowberto :get 200 (format "ee/transform/%d" transform-id))))
+
+          (open-message-value-observer [transform-id]
+            (let [states (atom [])
+                  fut    (future
+                           (try
+                             (loop []
+                               (let [{:keys [message]} (get-last-run transform-id)]
+                                 (cond
+                                   (.isInterrupted (Thread/currentThread))
+                                   nil
+
+                                  ;; same message as last time
+                                   (= message (peek @states))
+                                   (recur)
+
+                                  ;; new message value
+                                   :else (do (swap! states conj message)
+                                             (recur)))))
+                             (catch InterruptedException _ nil)))]
+              (reify IDeref
+                (deref [_] @states)
+                Closeable
+                (close [_]
+                  (future-cancel fut)
+                  (assert (not= :timeout (try (deref fut 1000 :timeout) (catch Throwable _))) "Observation thread did not exit!")))))
+
+          (run-scenario [scenario schema]
+            (with-redefs [transforms.execute/python-message-loop-poll-sleep-duration Duration/ZERO
+                          transforms.execute/transfer-file-to-db                     (if-some [e (:writeback-ex scenario)]
+                                                                                       (fn [& _] (throw e))
+                                                                                       @#'metabase-enterprise.transforms.execute/transfer-file-to-db)]
+              (with-transform-cleanup! [{table-name :name :as target} {:type   "table"
+                                                                       :schema schema
+                                                                       :name   "result"}]
+                (let [transform-id      (create-transform scenario target)
+                      observed-messages (with-open [observer ^Closeable (open-message-value-observer transform-id)]
+                                          (block-on-run scenario target transform-id)
+                                          @observer)
+                      last-run          (get-last-run transform-id)]
+                  {:observed-messages observed-messages
+                   :last-run          last-run}))))]
+    (let [scenarios [{:desc          "stdin"
+                      :program       ["print(\"hello, world\")"]
+                      :expect-status :succeeded
+                      :expected      ["hello, world"]}
+                     {:desc          "stderr"
+                      :program       ["import sys" "print(\"hello, world\", file=sys.stderr)"]
+                      :expect-status :succeeded
+                      :expected      ["hello, world"]}
+                     {:desc          "interleaved streams"
+                      :program       ["import sys"
+                                      "print(\"1\", file=sys.stderr)"
+                                      "print(\"2\", file=sys.stderr)"
+                                      "print(\"3\", file=sys.stdout)"
+                                      "print(\"4\", file=sys.stderr)"]
+                      :expect-status :succeeded
+                      :expected      ["1" "2" "3" "4"]}
+                     {:desc          "syntax error"
+                      :program       ["print(40 + 2)"
+                                      "this is not valid code"]
+                      :expect-status :failed
+                      :expected      ["SyntaxError: invalid syntax"]}
+                     {:desc                  "takes time, early feedback possible"
+                      :program               ["import time"
+                                              "print(\"a\")"
+                                              "time.sleep(0.1)"
+                                              "print(\"b\")"
+                                              "time.sleep(0.1)"
+                                              "print(\"c\")"]
+                      :expect-early-feedback true
+                      :expect-status         :succeeded
+                      :expected              ["a" "b" "c"]}
+                     {:desc "crash during writeback"
+                      :program ["print(42)" "print(\"is the answer\")"]
+                      :expect-status :failed
+                      :expected ["42", "is the answer"]
+                      :writeback-ex (Exception. "Boom!")}]]
+      (mt/test-drivers #{:h2 :postgres}                     ;; todo define driver feature (other tests do this also)
+        (mt/with-premium-features #{:transforms}
+          (mt/dataset transforms-dataset/transforms-test
+            (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
+              (doseq [{:keys [expected
+                              expect-early-feedback
+                              expect-status
+                              desc] :as scenario}
+                      scenarios]
+                (testing desc
+                  (let [{:keys [last-run observed-messages]} (run-scenario scenario schema)
+                        {:keys [status message]} last-run]
+                    (testing "sanity: status is what we expect"
+                      (is (= expect-status (some-> status keyword))))
+                    (testing "sanity: message has a value"
+                      (is message))
+                    (when message
+                      (is (str/starts-with? message "Executing Python transform"))
+                      (testing "all observed values of message reflect a prefix of the final message (ordering consistent)"
+                        (doseq [observed-message observed-messages]
+                          (is (str/starts-with? message observed-message))))
+                      (when expect-early-feedback
+                        (testing "scenario takes time, we should see partial messages for immediate feedback"
+                          (is (< 1 (count observed-messages)))))
+                      (testing "message includes the expected lines"
+                        (is (str/includes? message (str/join "\n" expected)))))))))))))))
 
 (deftest get-runs-filter-by-single-transform-id-test
   (testing "GET /api/ee/transform/run - filter by single transform ID"

--- a/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api_test.clj
@@ -412,10 +412,10 @@
             (with-redefs [transforms.execute/python-message-loop-poll-sleep-duration Duration/ZERO
                           transforms.execute/transfer-file-to-db                     (if-some [e (:writeback-ex scenario)]
                                                                                        (fn [& _] (throw e))
-                                                                                       @#'metabase-enterprise.transforms.execute/transfer-file-to-db)]
-              (with-transform-cleanup! [{table-name :name :as target} {:type   "table"
-                                                                       :schema schema
-                                                                       :name   "result"}]
+                                                                                       @#'transforms.execute/transfer-file-to-db)]
+              (with-transform-cleanup! [target {:type   "table"
+                                                :schema schema
+                                                :name   "result"}]
                 (let [transform-id      (create-transform scenario target)
                       observed-messages (with-open [observer ^Closeable (open-message-value-observer transform-id)]
                                           (block-on-run scenario target transform-id)


### PR DESCRIPTION
- Make sure python logs not lost on error during a run
  - still more complicated than I'd like, see comment
- Remove coloring which only works for demo but otherwise is a bad idea
- Various little docs, renames and simplifications
- Add tests (zero currently)

I am continuing to assume a python enforced truncation policy (so the :python events are presumably some last N events or bytes). I'd like to do that work on the python side shortly.