### PR TITLE
Modular embedding toggle label should depend on toggle states

### DIFF
--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/EmbeddingSdkSettings.tsx
@@ -156,7 +156,6 @@ export function EmbeddingSdkSettings() {
 
         <Group gap="sm" align="center" justify="space-between" w="100%">
           <EmbeddingToggle
-            label={t`Enabled`}
             settingKey="enable-embedding-sdk"
             labelPosition="right"
             aria-label={t`SDK for React toggle`}
@@ -202,7 +201,6 @@ export function EmbeddingSdkSettings() {
 
           <Group gap="sm" align="center" justify="space-between" w="100%">
             <EmbeddingToggle
-              label={t`Enabled`}
               labelPosition="right"
               settingKey="enable-embedding-simple"
               disabled={!isSimpleEmbedFeatureEnabled}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSdkSettings/tests/common.unit.spec.tsx
@@ -136,6 +136,26 @@ describe("EmbeddingSdkSettings (OSS)", () => {
     expect(await screen.findByText("Permissions")).toBeInTheDocument();
     expect(await screen.findByText("Appearance")).toBeInTheDocument();
   });
+
+  it("shows the Embedded Analytics JS toggle is Disabled when token features are missing (EMB-801)", () => {
+    setup({ tokenFeatures: { embedding_simple: false } });
+
+    const toggle = screen.getByRole("switch", {
+      name: "Embedded Analytics JS toggle",
+    });
+
+    expect(toggle).toBeDisabled();
+
+    const toggleContainer = screen
+      .getAllByTestId("switch-with-env-var")
+      .find((toggleElement) =>
+        within(toggleElement).queryByRole("switch", {
+          name: "Embedded Analytics JS toggle",
+        }),
+      );
+
+    expect(within(toggleContainer!).getByText("Disabled")).toBeInTheDocument();
+  });
 });
 
 function assertLegaleseModal() {


### PR DESCRIPTION
Closes EMB-752

Ensures that the label can be "Disabled" or "Enabled", instead of always being "Enabled".

<img width="1524" height="292" alt="CleanShot 2568-09-11 at 22 17 54@2x" src="https://github.com/user-attachments/assets/c68299f3-ae5d-4ee8-8258-2d917a0d3a61" />

Before this, we always showed "Enabled" which is misleading when it's disabled:

<img width="2612" height="356" alt="image" src="https://github.com/user-attachments/assets/cfcfd5e3-1f85-46e5-9307-802ed35d7dd5" />

- [x] Tests have been added/updated to cover changes in this PR
