### PR TITLE
Completing later steps on embedding hub should not tick off the former steps

### DIFF
--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.module.css
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.module.css
@@ -13,14 +13,15 @@
   --stepper-outline-color: var(--mb-color-border);
 }
 
-.stepCompletedIcon > svg {
-  width: 0.75rem !important;
-}
-
-.stepIcon:not([data-completed]) {
+.step:not(.stepDone) .stepIcon {
   color: var(--mb-color-text-dark);
   border-color: transparent;
   background: var(--mb-color-focus);
+}
+
+.step.stepDone .stepIcon {
+  color: var(--mb-color-bg-white);
+  background: var(--mb-color-success-darker);
 }
 
 .stepWrapper {

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
@@ -3,10 +3,9 @@ import type { ReactNode } from "react";
 import { Link } from "react-router";
 import { match } from "ts-pattern";
 import { t } from "ttag";
-import _ from "underscore";
 
 import type { UtmProps } from "metabase/selectors/settings";
-import { Card, Flex, Group, Stack, Stepper, Text } from "metabase/ui";
+import { Card, Flex, Group, Icon, Stack, Stepper, Text } from "metabase/ui";
 
 import { DocsLink } from "../DocsLink";
 
@@ -41,20 +40,13 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
     return null;
   }
 
-  // A step is done when every non-optional card is done.
-  const lastDoneIndex = _.findLastIndex(steps, (step) =>
-    step.cards.every((card) => card.done || card.optional),
-  );
-
   return (
     <Stepper
-      active={lastDoneIndex + 1}
+      active={0}
       orientation="vertical"
       classNames={{
-        step: S.step,
         stepLabel: S.stepLabel,
         verticalSeparator: S.verticalSeparator,
-        stepCompletedIcon: S.stepCompletedIcon,
         stepIcon: S.stepIcon,
         stepWrapper: S.stepWrapper,
         stepBody: S.stepBody,
@@ -62,82 +54,88 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
       }}
       iconSize={28}
     >
-      {steps.map((step) => (
-        <Stepper.Step
-          key={step.id}
-          label={step.title}
-          color="var(--mb-color-success-darker)"
-          description={
-            <Group align="stretch">
-              {step.cards.map((card) => {
-                const onClick =
-                  card.clickAction?.type === "click"
-                    ? card.clickAction.onClick
-                    : undefined;
+      {steps.map((step) => {
+        const isDone = step.cards.every((card) => card.done || card.optional);
 
-                return (
-                  <CardAction card={card} key={card.id}>
-                    <Card
-                      className={cx(S.stepCard, {
-                        [S.optionalStepCard]: card.optional,
-                      })}
-                      component={onClick ? "button" : undefined}
-                      onClick={onClick}
-                    >
-                      <Stack justify="space-between" h="100%">
-                        <Stack gap="xs" h="100%">
-                          <Text
-                            size={card.optional ? "md" : "lg"}
-                            fw="bold"
-                            c={
-                              card.done
-                                ? "var(--mb-color-text-secondary)"
-                                : "var(--mb-color-text-primary)"
-                            }
-                          >
-                            {card.title}
-                          </Text>
+        return (
+          <Stepper.Step
+            key={step.id}
+            label={step.title}
+            className={cx(S.step, isDone && S.stepDone)}
+            icon={isDone ? <Icon name="check" /> : undefined}
+            description={
+              <Group align="stretch">
+                {step.cards.map((card) => {
+                  const onClick =
+                    card.clickAction?.type === "click"
+                      ? card.clickAction.onClick
+                      : undefined;
 
-                          <Text
-                            c="var(--mb-color-text-secondary)"
-                            size="sm"
-                            lh="lg"
-                          >
-                            {card.description}
-                          </Text>
+                  return (
+                    <CardAction card={card} key={card.id}>
+                      <Card
+                        className={cx(S.stepCard, {
+                          [S.optionalStepCard]: card.optional,
+                        })}
+                        component={onClick ? "button" : undefined}
+                        onClick={onClick}
+                      >
+                        <Stack justify="space-between" h="100%">
+                          <Stack gap="xs" h="100%">
+                            <Text
+                              size={card.optional ? "md" : "lg"}
+                              fw="bold"
+                              c={
+                                card.done
+                                  ? "var(--mb-color-text-secondary)"
+                                  : "var(--mb-color-text-primary)"
+                              }
+                            >
+                              {card.title}
+                            </Text>
+
+                            <Text
+                              c="var(--mb-color-text-secondary)"
+                              size="sm"
+                              lh="lg"
+                            >
+                              {card.description}
+                            </Text>
+                          </Stack>
+
+                          {(card.optional || card.done) && (
+                            <Flex justify="flex-end">
+                              {match(card)
+                                .with({ done: true }, () => (
+                                  <Text
+                                    size="sm"
+                                    c="var(--mb-color-success-darker)"
+                                  >
+                                    {t`Done`}
+                                  </Text>
+                                ))
+                                .with({ optional: true }, () => (
+                                  <Text
+                                    size="sm"
+                                    c="var(--mb-color-text-secondary)"
+                                  >
+                                    {t`Optional`}
+                                  </Text>
+                                ))
+                                .otherwise(() => null)}
+                            </Flex>
+                          )}
                         </Stack>
-
-                        {(card.optional || card.done) && (
-                          <Flex justify="flex-end">
-                            {match(card)
-                              .with({ done: true }, () => (
-                                <Text
-                                  size="sm"
-                                  c="var(--mb-color-success-darker)"
-                                >
-                                  {t`Done`}
-                                </Text>
-                              ))
-                              .with({ optional: true }, () => (
-                                <Text
-                                  size="sm"
-                                  c="var(--mb-color-text-secondary)"
-                                >
-                                  {t`Optional`}
-                                </Text>
-                              ))
-                              .otherwise(() => null)}
-                          </Flex>
-                        )}
-                      </Stack>
-                    </Card>
-                  </CardAction>
-                );
-              })}
-            </Group>
-          }
-        ></Stepper.Step>
-      ))}
+                      </Card>
+                    </CardAction>
+                  );
+                })}
+              </Group>
+            }
+            data-done={isDone}
+          ></Stepper.Step>
+        );
+      })}
     </Stepper>
   );
 };

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
@@ -36,7 +36,7 @@ describe("StepperWithCards", () => {
         id: "step2",
         title: "Second Step",
         cards: [
-          { id: "3", done: false },
+          { id: "3", done: true }, // both must be done to complete the step
           { id: "4", done: false },
         ],
       },

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "__support__/ui";
+
+import type { StepperStep } from "./StepperWithCards";
+import { StepperWithCards } from "./StepperWithCards";
+
+const createMockSteps = (
+  stepConfigs: {
+    id: string;
+    title: string;
+    cards: { id: string; done?: boolean; optional?: boolean }[];
+  }[],
+): StepperStep[] => {
+  return stepConfigs.map(({ id, title, cards }) => ({
+    id,
+    title,
+    cards: cards.map((card) => ({
+      ...card,
+      title: "Title",
+      description: "Description",
+    })),
+  }));
+};
+
+describe("StepperWithCards", () => {
+  it("should not automatically tick off former steps when completing a later step", () => {
+    const steps = createMockSteps([
+      {
+        id: "step1",
+        title: "First Step",
+        cards: [
+          { id: "1", done: false },
+          { id: "2", done: false },
+        ],
+      },
+      {
+        id: "step2",
+        title: "Second Step",
+        cards: [
+          { id: "3", done: false },
+          { id: "4", done: false },
+        ],
+      },
+      {
+        id: "step3",
+        title: "Third Step",
+        cards: [
+          { id: "5", done: true },
+          { id: "6", done: true },
+        ],
+      },
+    ]);
+
+    render(<StepperWithCards steps={steps} />);
+
+    const allSteps = screen.getAllByRole("button");
+    expect(allSteps).toHaveLength(3);
+
+    // Only the last step should be marked as done.
+    expect(allSteps[0]).toHaveAttribute("data-done", "false");
+    expect(allSteps[1]).toHaveAttribute("data-done", "false");
+    expect(allSteps[2]).toHaveAttribute("data-done", "true");
+
+    // Only one check icon should be visible.
+    const checkIcons = screen.getAllByLabelText("check icon");
+    expect(checkIcons).toHaveLength(1);
+  });
+
+  it("should consider optional cards as completed when determining step completion", () => {
+    const steps = createMockSteps([
+      {
+        id: "step1",
+        title: "First Step",
+        cards: [
+          { id: "1", done: true },
+          { id: "2", done: false, optional: true },
+        ],
+      },
+    ]);
+
+    render(<StepperWithCards steps={steps} />);
+
+    const allSteps = screen.getAllByRole("button");
+    expect(allSteps).toHaveLength(1);
+
+    // Only the first step should be marked as done.
+    expect(allSteps[0]).toHaveAttribute("data-done", "true");
+
+    const checkIcons = screen.getAllByLabelText("check icon");
+    expect(checkIcons).toHaveLength(1);
+  });
+});

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
@@ -25,10 +25,11 @@ export const useCompletedEmbeddingHubSteps = (): {
         "configure-row-column-security": false,
         "secure-embeds": false,
         "embed-production": false,
+        "create-models": false,
       };
     }
 
-    return embeddingHubChecklist;
+    return { "create-models": false, ...embeddingHubChecklist };
   }, [embeddingHubChecklist, isLoading]);
 
   return { data, isLoading };

--- a/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
@@ -7,7 +7,8 @@ export type EmbeddingHubStepId =
   | "create-dashboard"
   | "configure-row-column-security"
   | "secure-embeds"
-  | "embed-production";
+  | "embed-production"
+  | "create-models";
 
 export interface EmbeddingHubStep {
   id: EmbeddingHubStepId;

--- a/frontend/src/metabase/embedding/embedding-hub/utils/embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/utils/embedding-hub-steps.ts
@@ -69,6 +69,7 @@ export const getEmbeddingHubSteps = (): EmbeddingHubStep[] => {
         description: t`Set up data models for your embedded analytics.`,
         to: "/model/new",
         optional: true,
+        stepId: "create-models",
       },
     ],
   };


### PR DESCRIPTION
Closes EMB-800

### Description

If you complete steps out-of-order, the former steps will also get completed due to how Mantine handles steps. Instead of using Mantine's `active` prop, we track the completion manually.

In addition, the "Create models" optional card does not have a completion state yet, so we make that false for now.

### How to verify

1. Create a fresh Metabase instance. Choose "Embedding" as your intent to get the embedding homepage.
2. Create a dashboard using x-ray.
3. You should see the "Prepare data" step as completed.
4. The first "Add data" step should remain incomplete.

### Demo

<img width="1410" height="1288" alt="CleanShot 2568-09-11 at 23 01 29@2x" src="https://github.com/user-attachments/assets/a333806a-549d-4ad4-bffa-43f269cd7ffe" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
