### PR TITLE
Add the interactive embedding upsell to the settings page

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts
@@ -1,8 +1,16 @@
+const { H } = cy;
+
 // These tests will run on both OSS and EE instances, both without a token.
 describe(
   "scenarios > embedding > admin settings > oss",
   { tags: "@OSS" },
   () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.updateSetting("show-sdk-embed-terms", false);
+    });
+
     it("shows all embedding types without the setup guide", () => {
       cy.log("Navigate to Embedding admin section");
       cy.visit("/admin/embedding");
@@ -35,7 +43,7 @@ describe(
     it("should show interactive embedding upsell on oss", () => {
       cy.visit("/admin/embedding/interactive");
 
-      mainPage().within(() => {
+      cy.findByTestId("admin-layout-content").within(() => {
         cy.findByRole("heading", { name: "Interactive embedding" }).should(
           "be.visible",
         );


### PR DESCRIPTION
Closes EMB-799
Closes EMB-802

Un-hides the interactive embedding page from the embedding sidebar, and shows the interactive embedding upsell page. It also removes all unused files.

### How to verify

- Start an OSS instance
- Visit embedding settings > Interactive
- You should see the Upsell card

### Demo

<img width="2250" height="596" alt="CleanShot 2568-09-12 at 01 53 10@2x" src="https://github.com/user-attachments/assets/806bca61-29c8-40f1-910c-fe8389c5c8bd" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
