### PR TITLE
Disable transforms when db routing is enabled

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/api.clj
@@ -69,7 +69,9 @@
     (api/check-400 (not (:is_audit database))
                    (deferred-tru "Cannot run transforms on audit databases."))
     (api/check-400 (driver.u/supports? (:engine database) feature database)
-                   (deferred-tru "The database does not support the requested transform target type."))))
+                   (deferred-tru "The database does not support the requested transform target type."))
+    (api/check-400 (not (transforms.util/db-routing-enabled? database))
+                   (deferred-tru "Transforms are not supported on databases with DB routing enabled."))))
 
 (api.macros/defendpoint :get "/"
   "Get a list of transforms."

--- a/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/execute.clj
@@ -37,7 +37,7 @@
    (log/info "Syncing target" (pr-str target) "for transform")
    (transforms.util/activate-table-and-mark-computed! database target)))
 
-(defn run-transform!
+(defn- run-transform!
   "Run a compiled transform"
   [run-id driver {:keys [db-id conn-spec output-schema] :as transform-details} opts]
   ;; local run is responsible for status
@@ -74,6 +74,9 @@
                               :output-schema (:schema target)
                               :output-table (transforms.util/qualified-table-name driver target)}
            opts {:overwrite? true}]
+       (when (transforms.util/db-routing-enabled? database)
+         (throw (ex-info "Transforms are not supported on databases with DB routing enabled."
+                         {:driver driver, :database database})))
        (when-not (driver.u/supports? driver feature database)
          (throw (ex-info "The database does not support the requested transform target type."
                          {:driver driver, :database database, :feature feature})))

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -122,3 +122,10 @@
   (-> run
       (u/update-some :start_time utc-timestamp-string)
       (u/update-some :end_time   utc-timestamp-string)))
+
+(defn db-routing-enabled?
+  "Returns whether or not the given database is either a router or destination database"
+  [db-or-id]
+  (or (t2/exists? :model/DatabaseRouter :database_id (u/the-id db-or-id))
+      (some->> (:router-database-id db-or-id)
+               (t2/exists? :model/DatabaseRouter :database_id))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/execute_test.clj
@@ -224,3 +224,27 @@
             (driver/execute-raw-queries! driver/*driver* spec
                                          [[(format "DROP OWNED BY %s;" no-schema-user)]
                                           [(format "DROP ROLE IF EXISTS %s;" no-schema-user)]])))))))
+
+(deftest run-mbql-transform-fails-with-routing-test
+  (mt/test-drivers (mt/normal-driver-select {:+features [:transforms/table]})
+    (mt/with-premium-features #{:database-routing}
+      (with-transform-cleanup! [target-table {:type   :table
+                                              :schema (t2/select-one-fn :schema :model/Table (mt/id :products))
+                                              :name   "products"}]
+        (let [mp (mt/metadata-provider)
+              products (lib.metadata/table mp (mt/id :products))
+              query (lib/query mp products)]
+          (mt/with-temp [:model/Database _destination {:engine driver/*driver*
+                                                       :router_database_id (mt/id)
+                                                       :details {:destination_database true}}
+                         :model/DatabaseRouter _ {:database_id (mt/id)
+                                                  :user_attribute "db_name"}
+                         :model/Transform transform {:name   "transform"
+                                                     :source {:type  :query
+                                                              :query query}
+                                                     :target target-table}]
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"Transforms are not supported on databases with DB routing enabled."
+                 (mt/with-current-user (mt/user->id :crowberto)
+                   (transforms.execute/run-mbql-transform! transform {:run-method :manual}))))))))))

--- a/enterprise/frontend/src/metabase-enterprise/transforms/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/utils.ts
@@ -53,6 +53,8 @@ export function doesDatabaseSupportTransforms(database?: Database): boolean {
   return (
     !database.is_sample &&
     !database.is_audit &&
+    !database.router_user_attribute &&
+    !database.router_database_id &&
     hasFeature(database, "transforms/table")
   );
 }


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-2439/disable-transforms-with-db-routing

### Description

Disables creating or running transforms when db routing is enabled. 

### How to verify

1. Set up db routing
2. Try to create a transform
3. You should get an error

---

1. Create a transform
2. Set up db routing
3. Try to edit and run the transform
5. You should get errors

### Demo

https://www.loom.com/share/bcb37962d0d845d1a17a72dcfb201d9c?sid=5ad2de74-92a7-4c00-aea0-90cf1699e8ed

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
