### PR TITLE
Allow setting additional JDBC connection string options in destination DBs when routing

### DIFF
--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -133,8 +133,7 @@
   have their visibility controlled using the `visible-if` property."
   {:name    "advanced-options"
    :type    :section
-   :default false
-   :visible-if {"destination-database" false}})
+   :default false})
 
 (def auto-run-queries
   "Map representing the `auto-run-queries` option in a DB connection form."
@@ -145,7 +144,8 @@
    :description  (deferred-tru
                   (str "We execute the underlying query when you explore data using Summarize or Filter. "
                        "This is on by default but you can turn it off if performance is slow."))
-   :visible-if   {"advanced-options" true}})
+   :visible-if   {"advanced-options" true
+                  "destination-database" false}})
 
 (def let-user-control-scheduling
   "Map representing the `let-user-control-scheduling` option in a DB connection form."
@@ -153,7 +153,8 @@
    :type         :boolean
    :display-name (deferred-tru "Choose when syncs and scans happen")
    :description  (deferred-tru "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values. If you have a large database, turn this on to make changes.")
-   :visible-if   {"advanced-options" true}})
+   :visible-if   {"advanced-options" true
+                  "destination-database" false}})
 
 (def metadata-sync-schedule
   "Map representing the `schedules.metadata_sync` option in a DB connection form, which should be only visible if
@@ -182,7 +183,8 @@
   {:name         "json-unfolding"
    :display-name (deferred-tru "Allow unfolding of JSON columns")
    :type         :boolean
-   :visible-if   {"advanced-options" true}
+   :visible-if   {"advanced-options" true
+                  "destination-database" false}
    :description  (deferred-tru
                   (str "This enables unfolding JSON columns into their component fields. "
                        "Disable unfolding if performance is slow. If enabled, you can still disable unfolding for "
@@ -197,7 +199,8 @@
    :description  (deferred-tru
                   (str "This enables Metabase to scan for additional field values during syncs allowing smarter "
                        "behavior, like improved auto-binning on your bar charts."))
-   :visible-if   {"advanced-options" true}})
+   :visible-if   {"advanced-options" true
+                  "destination-database" false}})
 
 (def multi-level-schema
   "Map representing the `multi-level-schema` option for databases. Stores schemas with multiple levels of hierarchy."


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61990

### Description

When setting up destination DBs with DB routing enabled, destination databases don't allow you to set up additional JDBC connection string options. This is still possible through the API, but it would be easier to do it through the UI. This would give flexibility to do funky things like routing to set timezones at the JDBC level or switching default schemas with routing.

This PR enables the "advanced options" section in destination DBs, but continues to hide settings like sync and refingerprinting. Some driver-specific advanced settings are surfaced now (like "Quote DB name (to ensure case sensitive matching)" from Snowflake) but I would say it shouldn't have much impact

### How to verify

Before this change (master), add a DB, enable routing, go to Destination Databases -> Add: there's no Advanced options button.
With this change, there's an advanced options button that allows you to set additional JDBC options.

### Demo
before:
<img width="617" height="809" alt="image" src="https://github.com/user-attachments/assets/c911879a-a064-487a-bf3e-888346d61eb0" />

after:
<img width="603" height="766" alt="image" src="https://github.com/user-attachments/assets/5a3b1df6-d14f-4277-a700-1c0fa9ffb885" />
