### PR TITLE
Clean up transforms test schemas

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/execute_test.clj
@@ -5,7 +5,7 @@
    [metabase-enterprise.transforms.execute :as transforms.execute]
    [metabase-enterprise.transforms.query-test-util :as query-test-util]
    [metabase-enterprise.transforms.test-dataset :as transforms-dataset]
-   [metabase-enterprise.transforms.test-util :refer [with-transform-cleanup!]]
+   [metabase-enterprise.transforms.test-util :refer [with-transform-cleanup! delete-schema!]]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.lib.core :as lib]
@@ -133,32 +133,36 @@
 (deftest transform-schema-created-if-needed-test
   (mt/test-drivers (mt/normal-driver-select {:+features [:transforms/table :schemas]})
     (mt/dataset transforms-dataset/transforms-test
-      (with-transform-cleanup! [target-table {:type   "table"
-                                              :schema (str "transform_schema_" (mt/random-name))
-                                              :name   "widget_products"}]
-        (let [mp (mt/metadata-provider)
-              transforms-products (lib.metadata/table mp (mt/id :transforms_products))
-              products-category (lib.metadata/field mp (mt/id :transforms_products :category))
-              products-id (lib.metadata/field mp (mt/id :transforms_products :id))
-              query (-> (lib/query mp transforms-products)
-                        (lib/filter (lib/= products-category "Widget"))
-                        (lib/order-by products-id :asc))]
-          (mt/with-temp [:model/Transform transform {:name   "transform"
-                                                     :source {:type  :query
-                                                              :query query}
-                                                     :target target-table}]
-            (transforms.execute/run-mbql-transform! transform {:run-method :manual})
-            (let [table-result      (wait-for-table (:name target-table) 10000)
-                  query-result (->> (lib/query mp table-result)
-                                    (qp/process-query)
-                                    (mt/formatted-rows [int str str 2.0 str])
-                                    (sort-by first <))]
-              (is (= [[1 "Widget A" "Widget" 19.99 "2024-01-01T10:00:00Z"]
-                      [7 "Widget B" "Widget" 24.99 "2024-01-07T10:00:00Z"]
-                      [9 "Widget C" "Widget" 14.99 "2024-01-09T10:00:00Z"]
-                      [10 "Widget D" "Widget" 34.99 "2024-01-10T10:00:00Z"]
-                      [15 "Widget E" "Widget" 44.99 "2024-01-15T10:00:00Z"]]
-                     query-result)))))))))
+      (let [schema (str "transform_schema_" (mt/random-name))]
+        (try
+          (with-transform-cleanup! [target-table {:type   :table
+                                                  :schema schema
+                                                  :name   "widget_products"}]
+            (let [mp (mt/metadata-provider)
+                  transforms-products (lib.metadata/table mp (mt/id :transforms_products))
+                  products-category (lib.metadata/field mp (mt/id :transforms_products :category))
+                  products-id (lib.metadata/field mp (mt/id :transforms_products :id))
+                  query (-> (lib/query mp transforms-products)
+                            (lib/filter (lib/= products-category "Widget"))
+                            (lib/order-by products-id :asc))]
+              (mt/with-temp [:model/Transform transform {:name   "transform"
+                                                         :source {:type  :query
+                                                                  :query query}
+                                                         :target target-table}]
+                (transforms.execute/run-mbql-transform! transform {:run-method :manual})
+                (let [table-result      (wait-for-table (:name target-table) 10000)
+                      query-result (->> (lib/query mp table-result)
+                                        (qp/process-query)
+                                        (mt/formatted-rows [int str str 2.0 str])
+                                        (sort-by first <))]
+                  (is (= [[1 "Widget A" "Widget" 19.99 "2024-01-01T10:00:00Z"]
+                          [7 "Widget B" "Widget" 24.99 "2024-01-07T10:00:00Z"]
+                          [9 "Widget C" "Widget" 14.99 "2024-01-09T10:00:00Z"]
+                          [10 "Widget D" "Widget" 34.99 "2024-01-10T10:00:00Z"]
+                          [15 "Widget E" "Widget" 44.99 "2024-01-15T10:00:00Z"]]
+                         query-result))))))
+          (finally
+            (delete-schema! driver/*driver* (mt/db) schema)))))))
 
 ;; TODO(rileythomp, 2025-08-28): Make this test driver agnostic
 (deftest no-create-schema-permissions-test

--- a/enterprise/backend/test/metabase_enterprise/transforms/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/test_util.clj
@@ -93,8 +93,3 @@
   (let [conn-spec (driver/connection-spec driver db)
         sql [[(format "DROP DATABASE IF EXISTS `%s`;" schema)]]]
     (driver/execute-raw-queries! driver/*driver* conn-spec sql)))
-
-(defmethod delete-schema! :bigquery-cloud-sdk [driver db schema]
-  (let [conn-spec (driver/connection-spec driver db)
-        sql [[(format "DROP SCHEMA IF EXISTS `%s` CASCADE;" schema)]]]
-    (driver/execute-raw-queries! driver/*driver* conn-spec sql)))

--- a/enterprise/backend/test/metabase_enterprise/transforms/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/test_util.clj
@@ -4,6 +4,7 @@
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.test :as mt]
+   [metabase.test.data.interface :as tx]
    [metabase.util :as u]
    [toucan2.core :as t2])
   (:import
@@ -68,3 +69,32 @@
   "Parse a local datetime and convert it to a string encoding a ZonedDateTime in the default timezone."
   ^String [timestamp-string]
   (-> timestamp-string parse-instant str))
+
+(defmulti delete-schema!
+  "Deletes a schema."
+  {:arglists '([driver db schema])}
+  tx/dispatch-on-driver-with-test-extensions
+  :hierarchy #'driver/hierarchy)
+
+(defmethod delete-schema! :default [_driver _db _schema] nil)
+
+(doseq [driver [:postgres :snowflake]]
+  (defmethod delete-schema! driver [driver db schema]
+    (let [conn-spec (driver/connection-spec driver db)
+          sql [[(format "DROP SCHEMA IF EXISTS \"%s\" CASCADE;" schema)]]]
+      (driver/execute-raw-queries! driver/*driver* conn-spec sql))))
+
+(defmethod delete-schema! :sqlserver [driver db schema]
+  (let [conn-spec (driver/connection-spec driver db)
+        sql [[(format "IF EXISTS (SELECT * FROM sys.schemas WHERE name = '%s') DROP SCHEMA [%s];" schema schema)]]]
+    (driver/execute-raw-queries! driver/*driver* conn-spec sql)))
+
+(defmethod delete-schema! :clickhouse [driver db schema]
+  (let [conn-spec (driver/connection-spec driver db)
+        sql [[(format "DROP DATABASE IF EXISTS `%s`;" schema)]]]
+    (driver/execute-raw-queries! driver/*driver* conn-spec sql)))
+
+(defmethod delete-schema! :bigquery-cloud-sdk [driver db schema]
+  (let [conn-spec (driver/connection-spec driver db)
+        sql [[(format "DROP SCHEMA IF EXISTS `%s` CASCADE;" schema)]]]
+    (driver/execute-raw-queries! driver/*driver* conn-spec sql)))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [medley.core :as m]
+   [metabase-enterprise.transforms.test-util :as transforms.test-util]
    [metabase.driver :as driver]
    [metabase.driver.bigquery-cloud-sdk :as bigquery]
    [metabase.driver.ddl.interface :as ddl.i]
@@ -471,6 +472,9 @@
 (defmethod tx/drop-view! :bigquery-cloud-sdk
   [driver database view-name options]
   (apply execute! (sql.tx/drop-view-sql driver database view-name options)))
+
+(defmethod transforms.test-util/delete-schema! :bigquery-cloud-sdk [_driver _db schema]
+  (destroy-dataset! schema))
 
 (comment
   "REPL utilities for static datasets"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

https://metaboat.slack.com/archives/C864UT5CZ/p1757574396726549

I've verified the schemas are gone when the test is finished in all the DBs

### How to verify

Transforms test schemas (i.e. `transform_schema_LETTERS`) should not be present in DBs after tests run

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
