### PR TITLE
Make question moving errors bubble correctly

### DIFF
--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -464,7 +464,7 @@ describe("question moving", () => {
     cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
       statusCode: 400,
       body: { message: "Sorry buddy, only cool kids in this collection" },
-    });
+    }).as("updateQuestion");
 
     H.appBar().findByText("Our analytics").should("be.visible");
     cy.findByTestId("qb-header-action-panel")

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -437,6 +437,50 @@ describe(
   },
 );
 
+describe("question moving", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`).as("updateQuestion");
+    H.visitQuestion(ORDERS_QUESTION_ID);
+  });
+
+  it("should move a question between collections", () => {
+    H.appBar().findByText("Our analytics").should("be.visible");
+    cy.findByTestId("qb-header-action-panel")
+      .icon("ellipsis")
+      .closest("button")
+      .click();
+    H.popover().findByTestId("move-button").click();
+    H.modal().findByText("Second collection").click();
+    H.modal().button("Move").click();
+    cy.wait("@updateQuestion").its("response.statusCode").should("eq", 200);
+    cy.findAllByRole("status").contains("Question moved to Second collection");
+    H.appBar().findByText("Second collection").should("be.visible");
+    H.modal().should("not.exist");
+  });
+
+  it("should show an error when moving a question fails", () => {
+    cy.intercept("PUT", `/api/card/${ORDERS_QUESTION_ID}`, {
+      statusCode: 400,
+      body: { message: "Sorry buddy, only cool kids in this collection" },
+    });
+
+    H.appBar().findByText("Our analytics").should("be.visible");
+    cy.findByTestId("qb-header-action-panel")
+      .icon("ellipsis")
+      .closest("button")
+      .click();
+    H.popover().findByTestId("move-button").click();
+    H.modal().findByText("Second collection").click();
+    H.modal().button("Move").click();
+    cy.wait("@updateQuestion");
+    H.modal()
+      .findByText("Sorry buddy, only cool kids in this collection")
+      .should("be.visible");
+  });
+});
+
 H.describeWithSnowplow("send snowplow question events", () => {
   beforeEach(() => {
     H.restore();

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { t } from "ttag";
 
+import { getErrorMessage } from "metabase/api/utils";
 import { Button, Flex, Text } from "metabase/ui";
 
 export const ButtonBar = ({
@@ -63,7 +64,7 @@ export const ButtonBar = ({
               await onConfirm();
             } catch (e: any) {
               console.error(e);
-              setError(e?.data?.message ?? t`An error occurred`);
+              setError(getErrorMessage(e));
             }
           }}
           disabled={!canConfirm}

--- a/frontend/src/metabase/lib/errors/messages.ts
+++ b/frontend/src/metabase/lib/errors/messages.ts
@@ -1,5 +1,8 @@
 import type { GenericErrorResponse } from "./types";
 
+/**
+ * @deprecated Use `getErrorMessage` from `metabase/api/utils` instead.
+ */
 export function getResponseErrorMessage(error: unknown): string | undefined {
   const response = error as GenericErrorResponse | undefined;
 
@@ -25,8 +28,4 @@ export function getResponseErrorMessage(error: unknown): string | undefined {
   }
 
   return undefined;
-}
-
-export function isResourceNotFoundError(error: any) {
-  return error?.status === 404;
 }

--- a/frontend/src/metabase/query_builder/components/MoveQuestionModal/MoveQuestionModal.tsx
+++ b/frontend/src/metabase/query_builder/components/MoveQuestionModal/MoveQuestionModal.tsx
@@ -4,6 +4,7 @@ import { c, t } from "ttag";
 import _ from "underscore";
 
 import { getDashboard, useUpdateCardMutation } from "metabase/api";
+import { getErrorMessage } from "metabase/api/utils";
 import { QuestionMoveConfirmModal } from "metabase/collections/components/CollectionBulkActions/QuestionMoveConfirmModal";
 import type { MoveDestination } from "metabase/collections/types";
 import { canonicalCollectionId } from "metabase/collections/utils";
@@ -12,7 +13,6 @@ import { MoveModal } from "metabase/common/components/MoveModal";
 import type { CollectionPickerItem } from "metabase/common/components/Pickers/CollectionPicker";
 import Dashboards from "metabase/entities/dashboards";
 import { INJECT_RTK_QUERY_QUESTION_VALUE } from "metabase/entities/questions";
-import { getResponseErrorMessage } from "metabase/lib/errors";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { API_UPDATE_QUESTION } from "metabase/query_builder/actions";
@@ -51,7 +51,7 @@ export const MoveQuestionModal = ({
 
   const [errorMessage, setErrorMessage] = useState<string>();
 
-  const handleMove = async (
+  const handleMove = (
     destination: MoveDestination,
     deleteOldDashcards?: boolean | undefined,
   ) => {
@@ -63,7 +63,7 @@ export const MoveQuestionModal = ({
             collection_id: canonicalCollectionId(destination.id),
           };
 
-    await updateQuestion({
+    return updateQuestion({
       id: question.id(),
       delete_old_dashcards: deleteOldDashcards,
       ...update,
@@ -116,13 +116,18 @@ export const MoveQuestionModal = ({
         onClose();
       })
       .catch((e) => {
-        setErrorMessage(getResponseErrorMessage(e));
+        setErrorMessage(getErrorMessage(e));
+        if (destination.model !== "dashboard") {
+          // we want this error to bubble up to the modal if we're not
+          // showing the dashboard confirm modal
+          throw new Error(getErrorMessage(e));
+        }
       });
   };
 
-  const handleMoveConfirm = () => {
+  const handleMoveConfirm = async () => {
     if (confirmMoveState?.destination) {
-      handleMove(confirmMoveState?.destination, true);
+      await handleMove(confirmMoveState?.destination, true);
     }
   };
 
@@ -142,7 +147,7 @@ export const MoveQuestionModal = ({
         destination,
       });
     } else {
-      handleMove(destination);
+      await handleMove(destination);
     }
   };
 
@@ -243,7 +248,7 @@ export const MoveQuestionModal = ({
         ]}
         onConfirm={handleMoveConfirm}
         onClose={onClose}
-        destination={confirmMoveState.destination}
+        destination={confirmMoveState?.destination}
         errorMessage={errorMessage}
       />
     );


### PR DESCRIPTION
### Description

We were swallowing errors half way up the stack of event handlers.

<img width="1002" height="700" alt="CleanShot 2025-09-11 at 14 13 03" src="https://github.com/user-attachments/assets/fd9a2af7-0682-422d-ba3f-75ecdcd8e4c7" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
