### PR TITLE
Add analytics to Metabot events

### DIFF
--- a/e2e/support/helpers/e2e-metabot-helpers.ts
+++ b/e2e/support/helpers/e2e-metabot-helpers.ts
@@ -30,7 +30,7 @@ export function openMetabotViaShortcutKey(assertVisibility = true) {
     assertChatVisibility("not.visible");
   }
 
-  cy.realPress(["Meta", "b"]);
+  cy.get("body").type("{ctrl+b}{cmd+b}");
 
   if (assertVisibility) {
     assertChatVisibility("visible");
@@ -42,7 +42,7 @@ export function closeMetabotViaShortcutKey(assertVisibility = true) {
     assertChatVisibility("visible");
   }
 
-  cy.realPress(["Meta", "b"]);
+  cy.get("body").type("{ctrl+b}{cmd+b}");
 
   if (assertVisibility) {
     assertChatVisibility("not.visible");

--- a/e2e/test/scenarios/metabot/metabot.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/metabot.cy.spec.ts
@@ -161,6 +161,33 @@ d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
       });
     });
 
+    it("Metabot chat should be controlled from the native editor", () => {
+      H.startNewNativeQuestion();
+      H.NativeEditor.get().should("be.visible");
+
+      cy.findByTestId("native-query-top-bar")
+        .findByLabelText("Open Metabot chat")
+        .should("be.enabled")
+        .click();
+      H.expectUnstructuredSnowplowEvent({
+        event: "metabot_chat_opened",
+        triggered_from: "native_editor",
+      });
+
+      cy.findByTestId("native-query-top-bar")
+        .findByLabelText("Close Metabot chat")
+        .should("be.enabled")
+        .click();
+      cy.log("We don't track closing the chat");
+      H.expectUnstructuredSnowplowEvent(
+        {
+          event: "metabot_chat_opened",
+          triggered_from: "native_editor",
+        },
+        1,
+      );
+    });
+
     describe("Metabot chat", () => {
       beforeEach(() => {
         cy.visit("/");

--- a/e2e/test/scenarios/metabot/metabot.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/metabot.cy.spec.ts
@@ -12,13 +12,15 @@ describe("Metabot UI", () => {
     cy.intercept("POST", "/api/ee/metabot-v3/v2/agent-streaming").as(
       "agentReq",
     );
-    cy.intercept("GET", "/api/session/properties").as("sessionProperties");
+    cy.intercept("GET", "/api/automagic-dashboards/database/*/candidates").as(
+      "xrayCandidates",
+    );
   });
 
   describe("OSS", { tags: "@OSS" }, () => {
     beforeEach(() => {
       cy.visit("/");
-      cy.wait("@sessionProperties");
+      cy.wait("@xrayCandidates");
     });
 
     it("should not be available in OSS", () => {
@@ -36,7 +38,7 @@ describe("Metabot UI", () => {
     beforeEach(() => {
       H.activateToken("bleeding-edge");
       cy.visit("/");
-      cy.wait("@sessionProperties");
+      cy.wait("@xrayCandidates");
     });
 
     describe("scroll management", () => {
@@ -162,7 +164,7 @@ d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
     describe("Metabot chat", () => {
       beforeEach(() => {
         cy.visit("/");
-        cy.wait("@sessionProperties");
+        cy.wait("@xrayCandidates");
       });
 
       it("should be able to be opened and closed", () => {
@@ -179,21 +181,23 @@ d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
           triggered_from: "command_palette",
         });
         H.closeMetabotViaCloseButton();
+      });
 
-        // H.openMetabotViaShortcutKey();
-        // H.expectUnstructuredSnowplowEvent({
-        //   event: "metabot_chat_opened",
-        //   triggered_from: "keyboard_shortcut",
-        // });
-        // H.closeMetabotViaShortcutKey();
-        // cy.log("We don't track closing the chat via kbd");
-        // H.expectUnstructuredSnowplowEvent(
-        //   {
-        //     event: "metabot_chat_opened",
-        //     triggered_from: "keyboard_shortcut",
-        //   },
-        //   1,
-        // );
+      it("should be controlled via keyboard shortcut", () => {
+        H.openMetabotViaShortcutKey();
+        H.expectUnstructuredSnowplowEvent({
+          event: "metabot_chat_opened",
+          triggered_from: "keyboard_shortcut",
+        });
+        H.closeMetabotViaShortcutKey();
+        cy.log("We don't track closing the chat via kbd");
+        H.expectUnstructuredSnowplowEvent(
+          {
+            event: "metabot_chat_opened",
+            triggered_from: "keyboard_shortcut",
+          },
+          1,
+        );
       });
 
       it("should allow a user to send a message to the agent and handle successful or failed responses", () => {

--- a/e2e/test/scenarios/metabot/metabot.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/metabot.cy.spec.ts
@@ -180,20 +180,20 @@ d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
         });
         H.closeMetabotViaCloseButton();
 
-        H.openMetabotViaShortcutKey();
-        H.expectUnstructuredSnowplowEvent({
-          event: "metabot_chat_opened",
-          triggered_from: "keyboard_shortcut",
-        });
-        H.closeMetabotViaShortcutKey();
-        cy.log("We don't track closing the chat via kbd");
-        H.expectUnstructuredSnowplowEvent(
-          {
-            event: "metabot_chat_opened",
-            triggered_from: "keyboard_shortcut",
-          },
-          1,
-        );
+        // H.openMetabotViaShortcutKey();
+        // H.expectUnstructuredSnowplowEvent({
+        //   event: "metabot_chat_opened",
+        //   triggered_from: "keyboard_shortcut",
+        // });
+        // H.closeMetabotViaShortcutKey();
+        // cy.log("We don't track closing the chat via kbd");
+        // H.expectUnstructuredSnowplowEvent(
+        //   {
+        //     event: "metabot_chat_opened",
+        //     triggered_from: "keyboard_shortcut",
+        //   },
+        //   1,
+        // );
       });
 
       it("should allow a user to send a message to the agent and handle successful or failed responses", () => {

--- a/e2e/test/scenarios/metabot/metabot.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/metabot.cy.spec.ts
@@ -1,3 +1,5 @@
+import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+
 const { H } = cy;
 
 const loremIpsum =
@@ -35,48 +37,6 @@ describe("Metabot UI", () => {
       H.activateToken("bleeding-edge");
       cy.visit("/");
       cy.wait("@sessionProperties");
-    });
-
-    it("should be able to be opened and closed", () => {
-      H.openMetabotViaSearchButton();
-      H.closeMetabotViaCloseButton();
-
-      H.openMetabotViaCommandPalette();
-      H.closeMetabotViaCloseButton();
-
-      // FIXME: shortcut keys aren't working in CI only, but work locally
-      // openMetabotViaShortcutKey();
-      // closeMetabotViaShortcutKey();
-    });
-
-    it("should allow a user to send a message to the agent and handle successful or failed responses", () => {
-      H.openMetabotViaSearchButton();
-      H.chatMessages().should("not.exist");
-
-      H.mockMetabotResponse({
-        statusCode: 200,
-        body: whoIsYourFavoriteResponse,
-      });
-      H.sendMetabotMessage("Who is your favorite?");
-
-      H.lastChatMessage().should("have.text", "You, but don't tell anyone.");
-
-      H.mockMetabotResponse({ statusCode: 500 });
-      H.sendMetabotMessage("Who is your favorite?");
-      H.lastChatMessage().should(
-        "have.text",
-        "Metabot is currently offline. Please try again later.",
-      );
-    });
-
-    it("should allow starting a new metabot conversation via the /metabot/new", () => {
-      H.mockMetabotResponse({
-        statusCode: 200,
-        body: whoIsYourFavoriteResponse,
-      });
-      cy.visit("/metabot/new?q=Who%20is%20your%20favorite%3F");
-      H.assertChatVisibility("visible");
-      H.lastChatMessage().should("have.text", "You, but don't tell anyone.");
     });
 
     describe("scroll management", () => {
@@ -173,6 +133,100 @@ d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
           const isAtBottom = el.scrollTop + el.clientHeight >= el.scrollHeight;
           expect(isAtBottom).to.be.true;
         });
+      });
+    });
+  });
+
+  H.describeWithSnowplowEE("metabot events", () => {
+    beforeEach(() => {
+      H.resetSnowplow();
+      H.restore();
+      cy.signInAsAdmin();
+      H.enableTracking();
+      H.activateToken("bleeding-edge");
+    });
+
+    afterEach(() => {
+      H.expectNoBadSnowplowEvents();
+    });
+
+    it("should track Metabot chart explainer", () => {
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      cy.findByLabelText("Explain this chart").should("be.visible").click();
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "metabot_explain_chart_clicked",
+      });
+    });
+
+    describe("Metabot chat", () => {
+      beforeEach(() => {
+        cy.visit("/");
+        cy.wait("@sessionProperties");
+      });
+
+      it("should be able to be opened and closed", () => {
+        H.openMetabotViaSearchButton();
+        H.expectUnstructuredSnowplowEvent({
+          event: "metabot_chat_opened",
+          triggered_from: "search",
+        });
+        H.closeMetabotViaCloseButton();
+
+        H.openMetabotViaCommandPalette();
+        H.expectUnstructuredSnowplowEvent({
+          event: "metabot_chat_opened",
+          triggered_from: "command_palette",
+        });
+        H.closeMetabotViaCloseButton();
+
+        H.openMetabotViaShortcutKey();
+        H.expectUnstructuredSnowplowEvent({
+          event: "metabot_chat_opened",
+          triggered_from: "keyboard_shortcut",
+        });
+        H.closeMetabotViaShortcutKey();
+        cy.log("We don't track closing the chat via kbd");
+        H.expectUnstructuredSnowplowEvent(
+          {
+            event: "metabot_chat_opened",
+            triggered_from: "keyboard_shortcut",
+          },
+          1,
+        );
+      });
+
+      it("should allow a user to send a message to the agent and handle successful or failed responses", () => {
+        H.openMetabotViaSearchButton();
+        H.chatMessages().should("not.exist");
+
+        H.mockMetabotResponse({
+          statusCode: 200,
+          body: whoIsYourFavoriteResponse,
+        });
+        H.sendMetabotMessage("Who is your favorite?");
+        H.expectUnstructuredSnowplowEvent({
+          event: "metabot_request_sent",
+        });
+
+        H.lastChatMessage().should("have.text", "You, but don't tell anyone.");
+
+        H.mockMetabotResponse({ statusCode: 500 });
+        H.sendMetabotMessage("Who is your favorite?");
+        H.lastChatMessage().should(
+          "have.text",
+          "Metabot is currently offline. Please try again later.",
+        );
+      });
+
+      it("should allow starting a new metabot conversation via the /metabot/new", () => {
+        H.mockMetabotResponse({
+          statusCode: 200,
+          body: whoIsYourFavoriteResponse,
+        });
+        cy.visit("/metabot/new?q=Who%20is%20your%20favorite%3F");
+        H.assertChatVisibility("visible");
+        H.lastChatMessage().should("have.text", "You, but don't tell anyone.");
       });
     });
   });

--- a/e2e/test/scenarios/native/ai-sql-fixer.cy.spec.ts
+++ b/e2e/test/scenarios/native/ai-sql-fixer.cy.spec.ts
@@ -2,14 +2,18 @@ import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 const { H } = cy;
 
-const FIX_MESSAGE = "Fixes applied. Run your query to view results.";
-
-describe("scenarios > native > ai sql fixer", { tags: "@skip" }, () => {
+H.describeWithSnowplow("scenarios > native > ai sql fixer", () => {
   beforeEach(() => {
+    H.resetSnowplow();
     H.restore();
     cy.signInAsAdmin();
-    H.activateToken("pro-self-hosted");
+    H.enableTracking();
+    H.activateToken("bleeding-edge");
     cy.intercept("POST", "/api/ee/ai-sql-fixer/fix").as("fixSql");
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should be able to fix SQL with AI", () => {
@@ -19,22 +23,23 @@ describe("scenarios > native > ai sql fixer", { tags: "@skip" }, () => {
         database: SAMPLE_DB_ID,
         type: "native",
         native: {
-          query: "SELECT1 * FROM ORDERS",
+          query: "SELECT1",
         },
       },
     });
-    cy.wait("@fixSql");
     cy.findByTestId("query-visualization-root").within(() => {
       cy.button(/Have Metabot fix it/).click();
-      cy.findByText(FIX_MESSAGE).should("be.visible");
     });
-    H.runNativeQuery();
-    H.NativeEditor.get()
-      .should("be.visible")
-      .and("contain", "SELECT * FROM ORDERS");
-    cy.findByTestId("query-visualization-root").within(() => {
-      H.tableInteractive().should("be.visible");
-      cy.findByText(FIX_MESSAGE).should("not.exist");
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "metabot_fix_query_clicked",
     });
+
+    // TODO: Unskip this part once we have the means to run AI in CI
+    // cy.findByTestId("metabot-chat-messages").should(
+    //   "contain",
+    //   "Fix this SQL query",
+    // );
+    // H.NativeEditor.get().should("be.visible").and("contain", "SELECT 1");
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/analytics.ts
@@ -1,0 +1,7 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackExplainChartClicked = () => {
+  trackSimpleEvent({
+    event: "metabot_explain_chart_clicked",
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-entity-analysis/components/AIQuestionAnalysisButton.tsx
@@ -3,10 +3,15 @@ import { t } from "ttag";
 import { ToolbarButton } from "metabase/common/components/ToolbarButton";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
+import { trackExplainChartClicked } from "../analytics";
+
 export const AIQuestionAnalysisButton = () => {
   const { submitInput } = useMetabotAgent();
 
-  const handleClick = () => submitInput("Analyze this chart");
+  const handleClick = () => {
+    trackExplainChartClicked();
+    submitInput("Analyze this chart");
+  };
 
   const tooltipLabel = t`Explain this chart`;
 

--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/analytics.ts
@@ -1,0 +1,7 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackQueryFixClicked = () => {
+  trackSimpleEvent({
+    event: "metabot_fix_query_clicked",
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-sql-fixer/components/FixSqlQueryButton/FixSqlQueryButton.tsx
@@ -3,10 +3,15 @@ import { t } from "ttag";
 import { Button } from "metabase/ui";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
+import { trackQueryFixClicked } from "../../analytics";
+
 export function FixSqlQueryButton() {
   const { submitInput } = useMetabotAgent();
 
-  const handleClick = () => submitInput("Fix this SQL query");
+  const handleClick = () => {
+    trackQueryFixClicked();
+    submitInput("Fix this SQL query");
+  };
 
   return <Button onClick={handleClick}>{t`Have Metabot fix it`}</Button>;
 }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/analytics.ts
@@ -6,3 +6,9 @@ export const trackMetabotChatOpened = () => {
     triggered_from: "search",
   });
 };
+
+export const trackMetabotRequestSent = () => {
+  trackSimpleEvent({
+    event: "metabot_request_sent",
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/analytics.ts
@@ -1,0 +1,8 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackMetabotChatOpened = () => {
+  trackSimpleEvent({
+    event: "metabot_chat_opened",
+    triggered_from: "search",
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/analytics.ts
@@ -1,9 +1,11 @@
 import { trackSimpleEvent } from "metabase/lib/analytics";
 
-export const trackMetabotChatOpened = () => {
+export const trackMetabotChatOpened = (
+  origin: "search" | "command_palette" | "keyboard_shortcut",
+) => {
   trackSimpleEvent({
     event: "metabot_chat_opened",
-    triggered_from: "search",
+    triggered_from: origin,
   });
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/analytics.ts
@@ -1,7 +1,7 @@
 import { trackSimpleEvent } from "metabase/lib/analytics";
 
 export const trackMetabotChatOpened = (
-  origin: "search" | "command_palette" | "keyboard_shortcut",
+  origin: "search" | "command_palette" | "keyboard_shortcut" | "native_editor",
 ) => {
   trackSimpleEvent({
     event: "metabot_chat_opened",

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/Metabot.tsx
@@ -5,6 +5,7 @@ import ErrorBoundary from "metabase/ErrorBoundary";
 import { useSelector } from "metabase/lib/redux";
 import { getUser } from "metabase/selectors/user";
 
+import { trackMetabotChatOpened } from "../analytics";
 import { useMetabotAgent } from "../hooks";
 
 import { MetabotChat } from "./MetabotChat";
@@ -20,6 +21,9 @@ export const MetabotAuthenticated = ({ hide }: MetabotProps) => {
     return tinykeys(window, {
       "$mod+b": (e) => {
         e.preventDefault(); // prevent FF from opening bookmark menu
+        if (!visible) {
+          trackMetabotChatOpened("keyboard_shortcut");
+        }
         setVisible(!visible);
       },
     });

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -20,6 +20,7 @@ import {
 import { useGetSuggestedMetabotPromptsQuery } from "metabase-enterprise/api";
 import { MetabotResetLongChatButton } from "metabase-enterprise/metabot/components/MetabotChat/MetabotResetLongChatButton";
 
+import { trackMetabotRequestSent } from "../../analytics";
 import { useMetabotAgent, useMetabotChatHandlers } from "../../hooks";
 
 import Styles from "./MetabotChat.module.css";
@@ -202,6 +203,7 @@ export const MetabotChat = () => {
                   // prevent event from inserting new line + interacting with other content
                   e.preventDefault();
                   e.stopPropagation();
+                  trackMetabotRequestSent();
                   handleSubmitInput(metabot.prompt);
                 }
               }}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -20,7 +20,6 @@ import {
 import { useGetSuggestedMetabotPromptsQuery } from "metabase-enterprise/api";
 import { MetabotResetLongChatButton } from "metabase-enterprise/metabot/components/MetabotChat/MetabotResetLongChatButton";
 
-import { trackMetabotRequestSent } from "../../analytics";
 import { useMetabotAgent, useMetabotChatHandlers } from "../../hooks";
 
 import Styles from "./MetabotChat.module.css";
@@ -203,7 +202,6 @@ export const MetabotChat = () => {
                   // prevent event from inserting new line + interacting with other content
                   e.preventDefault();
                   e.stopPropagation();
-                  trackMetabotRequestSent();
                   handleSubmitInput(metabot.prompt);
                 }
               }}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotSearchButton/MetabotSearchButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotSearchButton/MetabotSearchButton.tsx
@@ -24,6 +24,8 @@ export const MetabotSearchButton = () => {
 
   const label = c("'Search' here is a verb").t`Ask Metabot or search`;
 
+  const tooltipMessage = metabot.visible ? t`Close Metabot` : t`Open Metabot`;
+
   if (isSmallScreen) {
     return (
       <Button
@@ -61,7 +63,7 @@ export const MetabotSearchButton = () => {
       >
         <Tooltip
           offset={{ mainAxis: 20 }}
-          label={`${t`Open Metabot`} (${METAKEY}+b)`}
+          label={`${tooltipMessage} (${METAKEY}+b)`}
         >
           <Icon name="metabot" h="1rem" />
         </Tooltip>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotSearchButton/MetabotSearchButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotSearchButton/MetabotSearchButton.tsx
@@ -8,6 +8,8 @@ import S from "metabase/nav/components/search/SearchButton/SearchButton.module.c
 import { Button, Flex, Icon, Text, Tooltip, UnstyledButton } from "metabase/ui";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
+import { trackMetabotChatOpened } from "../../analytics";
+
 export const MetabotSearchButton = () => {
   const kbar = useKBar();
   const metabot = useMetabotAgent();
@@ -49,7 +51,13 @@ export const MetabotSearchButton = () => {
       <UnstyledButton
         className={S.iconButton}
         aria-label={t`Metabot`}
-        onClick={() => metabot.setVisible(!metabot.visible)}
+        onClick={() => {
+          if (!metabot.visible) {
+            trackMetabotChatOpened("search");
+          }
+
+          metabot.setVisible(!metabot.visible);
+        }}
       >
         <Tooltip
           offset={{ mainAxis: 20 }}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotToggleButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotToggleButton.tsx
@@ -14,8 +14,10 @@ export function MetabotToggleButton({ className }: MetabotToggleButtonProps) {
     metabot.setVisible(!metabot.visible);
   };
 
+  const label = metabot.visible ? t`Close Metabot chat` : t`Open Metabot chat`;
+
   return (
-    <Tooltip label={t`Open Metabot chat`}>
+    <Tooltip label={label}>
       <Button
         className={className}
         variant="subtle"
@@ -23,7 +25,7 @@ export function MetabotToggleButton({ className }: MetabotToggleButtonProps) {
         h="fit-content"
         bd="none"
         leftSection={<Icon name="metabot" />}
-        aria-label={t`Open Metabot chat`}
+        aria-label={label}
         onClick={handleClick}
       />
     </Tooltip>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotToggleButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotToggleButton.tsx
@@ -3,6 +3,8 @@ import { t } from "ttag";
 import { Button, Icon, Tooltip } from "metabase/ui";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
+import { trackMetabotChatOpened } from "../analytics";
+
 interface MetabotToggleButtonProps {
   className?: string;
 }
@@ -11,6 +13,10 @@ export function MetabotToggleButton({ className }: MetabotToggleButtonProps) {
   const metabot = useMetabotAgent();
 
   const handleClick = () => {
+    if (!metabot.visible) {
+      trackMetabotChatOpened("native_editor");
+    }
+
     metabot.setVisible(!metabot.visible);
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { useMetabotContext } from "metabase/metabot";
 
+import { trackMetabotRequestSent } from "../analytics";
 import {
   type MetabotPromptSubmissionResult,
   getAgentErrorMessages,
@@ -95,6 +96,8 @@ export const useMetabotAgent = () => {
           metabot_id: metabotRequestId,
         }),
       );
+
+      trackMetabotRequestSent();
 
       if (isFulfilled(action)) {
         prepareRetryIfUnsuccesful(action.payload);

--- a/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
@@ -10,6 +10,7 @@ import { PLUGIN_METABOT, PLUGIN_REDUCERS } from "metabase/plugins";
 import { MetabotPurchasePage } from "metabase-enterprise/metabot/components/MetabotAdmin/MetabotPurchasePage";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
+import { trackMetabotChatOpened } from "./analytics";
 import { Metabot } from "./components/Metabot";
 import { MetabotAdminPage } from "./components/MetabotAdmin/MetabotAdminPage";
 import { getMetabotQuickLinks } from "./components/MetabotQuickLinks";
@@ -62,7 +63,10 @@ if (hasPremiumFeature("metabot_v3")) {
           section: "metabot",
           keywords: searchText,
           icon: "metabot",
-          perform: () => startNewConversation(searchText),
+          perform: () => {
+            trackMetabotChatOpened();
+            startNewConversation(searchText);
+          },
         },
       ];
       return ret;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/index.tsx
@@ -51,7 +51,7 @@ if (hasPremiumFeature("metabot_v3")) {
   PLUGIN_METABOT.getMetabotVisible =
     getMetabotVisible as unknown as typeof PLUGIN_METABOT.getMetabotVisible;
   PLUGIN_METABOT.useMetabotPalletteActions = (searchText: string) => {
-    const { startNewConversation } = useMetabotAgent();
+    const { startNewConversation, visible } = useMetabotAgent();
 
     return useMemo(() => {
       const ret: PaletteAction[] = [
@@ -64,13 +64,15 @@ if (hasPremiumFeature("metabot_v3")) {
           keywords: searchText,
           icon: "metabot",
           perform: () => {
-            trackMetabotChatOpened();
+            if (!visible) {
+              trackMetabotChatOpened("command_palette");
+            }
             startNewConversation(searchText);
           },
         },
       ];
       return ret;
-    }, [searchText, startNewConversation]);
+    }, [searchText, startNewConversation, visible]);
   };
 
   PLUGIN_METABOT.SearchButton = MetabotSearchButton;

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -386,7 +386,11 @@ export type TableEditingEvent =
 
 export type MetabotChatOpenedEvent = ValidateEvent<{
   event: "metabot_chat_opened";
-  triggered_from: "search" | "command_palette" | "keyboard_shortcut";
+  triggered_from:
+    | "search"
+    | "command_palette"
+    | "keyboard_shortcut"
+    | "native_editor";
 }>;
 
 export type MetabotRequestSentEvent = ValidateEvent<{

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -384,6 +384,29 @@ export type TableEditingEvent =
   | TableEditButtonClickedEvent
   | TableEditingRecordModifiedEvent;
 
+export type MetabotChatOpenedEvent = ValidateEvent<{
+  event: "metabot_chat_opened";
+  triggered_from: "search";
+}>;
+
+export type MetabotRequestSentEvent = ValidateEvent<{
+  event: "metabot_request_sent";
+}>;
+
+export type MetabotFixQueryClickedEvent = ValidateEvent<{
+  event: "metabot_fix_query_clicked";
+}>;
+
+export type MetabotExplainChartClickedEvent = ValidateEvent<{
+  event: "metabot_explain_chart_clicked";
+}>;
+
+export type MetabotEvent =
+  | MetabotChatOpenedEvent
+  | MetabotRequestSentEvent
+  | MetabotFixQueryClickedEvent
+  | MetabotExplainChartClickedEvent;
+
 export type SimpleEvent =
   | CustomSMTPSetupClickedEvent
   | CustomSMTPSetupSuccessEvent
@@ -429,4 +452,5 @@ export type SimpleEvent =
   | DocumentUpdatedEvent
   | DocumentPrintEvent
   | DatabaseHelpClickedEvent
-  | XRayEvent;
+  | XRayEvent
+  | MetabotEvent;

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -386,7 +386,7 @@ export type TableEditingEvent =
 
 export type MetabotChatOpenedEvent = ValidateEvent<{
   event: "metabot_chat_opened";
-  triggered_from: "search";
+  triggered_from: "search" | "command_palette" | "keyboard_shortcut";
 }>;
 
 export type MetabotRequestSentEvent = ValidateEvent<{


### PR DESCRIPTION
Resolves PRG-131

You can see the list of events here:
https://github.com/metabase/metabase/pull/63415/files#diff-43bf5c088b93a140e2a01fb0e70ca7abf9ddd9c7f24c4b55d4566166a194f593R387-R406

Events:
1. chat opened
2. chat request sent
3. fix query clicked
4. explain chart clicked

This PR also fixes [the tooltip label](https://github.com/metabase/metabase/pull/63415/commits/01bec2d30724723f8a3df591473a362669edacd6) in the main search. Context [here](https://metaboat.slack.com/archives/C07SJT1P0ET/p1758058237361279?thread_ts=1758047421.005609&cid=C07SJT1P0ET).
