### PR TITLE
Tag iframe locale e2e test as flaky instead of skipped

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -161,10 +161,9 @@ H.describeWithSnowplow(suiteTitle, () => {
     );
   });
 
-  // TODO: fix this flaky test
   it(
     "localizes the iframe preview when ?locale is passed",
-    { tags: "@skip" },
+    { tags: "@flaky" },
     () => {
       visitNewEmbedPage({ locale: "fr" });
 


### PR DESCRIPTION
Tag iframe locale e2e test as flaky instead of skipped