### PR TITLE
Fix - Allow to unresolve deleted comments

### DIFF
--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -894,7 +894,7 @@ H.describeWithSnowplowEE("document comments", () => {
       Comments.getCommentByText("Reply 1").should("be.visible");
     });
 
-    it("should be possible to resolve a thread when the first comment is deleted", () => {
+    it("should be possible to resolve and unresolve a thread when the first comment is deleted", () => {
       startNewCommentIn1ParagraphDocument();
 
       cy.realType("Main comment");
@@ -929,6 +929,14 @@ H.describeWithSnowplowEE("document comments", () => {
 
       cy.findByTestId("comments-resolved-tab").should("be.visible");
       cy.findByTestId("discussion-comment-deleted").should("not.exist");
+
+      cy.log("unresolving a thread when the first comment is deleted");
+      cy.findByRole("tab", { name: "Resolved (1)" }).click();
+      cy.findByTestId("discussion-comment-deleted").realHover();
+      cy.findByLabelText("Re-open").click();
+
+      cy.findAllByRole("tab").should("have.length", 0);
+      Comments.getNewThreadInput().should("be.visible");
     });
 
     it("should be possible to resolve a thread created by another user", () => {

--- a/enterprise/frontend/src/metabase-enterprise/comments/components/Discussion/DiscussionActionPanel.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/comments/components/Discussion/DiscussionActionPanel.tsx
@@ -18,29 +18,29 @@ import type { Comment } from "metabase-types/api";
 import S from "./Discussion.module.css";
 
 export type DiscussionActionPanelProps = {
-  canResolve?: boolean;
   canReact?: boolean;
+  canResolve?: boolean;
   comment: Comment;
-  onResolve?: (comment: Comment) => void;
-  onReopen?: (comment: Comment) => void;
-  onReaction?: (comment: Comment, emoji: string) => void;
+  onCopyLink?: (comment: Comment) => void;
   onDelete?: (comment: Comment) => void;
   onEdit?: (comment: Comment) => void;
-  onCopyLink?: (comment: Comment) => void;
+  onReaction?: (comment: Comment, emoji: string) => void;
+  onReopen: (comment: Comment) => void;
+  onResolve: (comment: Comment) => void;
 };
 
 const ACTION_ICON_SIZE = "md";
 
 export function DiscussionActionPanel({
-  canResolve,
   canReact = true,
+  canResolve,
   comment,
-  onResolve,
-  onReopen,
+  onCopyLink,
   onDelete,
   onEdit,
-  onCopyLink,
   onReaction,
+  onReopen,
+  onResolve,
 }: DiscussionActionPanelProps) {
   const [emojiPickerOpened, setEmojiPickerOpened] = useState(false);
   const [popoverOpened, setPopoverOpened] = useState(false);

--- a/enterprise/frontend/src/metabase-enterprise/comments/components/Discussion/DiscussionComment.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/comments/components/Discussion/DiscussionComment.tsx
@@ -22,8 +22,8 @@ import { DiscussionReactions } from "./DiscussionReactions";
 type DiscussionCommentProps = {
   canResolve?: boolean;
   comment: Comment;
-  onResolve?: (comment: Comment) => void;
-  onReopen?: (comment: Comment) => void;
+  onResolve: (comment: Comment) => void;
+  onReopen: (comment: Comment) => void;
   onReaction?: (comment: Comment, emoji: string) => void;
   onReactionRemove?: (comment: Comment, emoji: string) => void;
   onDelete?: (comment: Comment) => void;
@@ -85,11 +85,12 @@ export function DiscussionComment({
           {t`This comment was deleted.`}
         </Text>
         <DiscussionActionPanel
-          canResolve={canResolve}
           canReact={false}
+          canResolve={canResolve}
           comment={comment}
-          onResolve={onResolve}
           onCopyLink={onCopyLink}
+          onReopen={onReopen}
+          onResolve={onResolve}
         />
       </Timeline.Item>
     );
@@ -111,12 +112,12 @@ export function DiscussionComment({
         <DiscussionActionPanel
           canResolve={canResolve}
           comment={comment}
-          onResolve={onResolve}
-          onReopen={onReopen}
-          onReaction={onReaction}
+          onCopyLink={onCopyLink}
           onDelete={isCurrentUsersComment ? onDelete : undefined}
           onEdit={isCurrentUsersComment ? handleEditClick : undefined}
-          onCopyLink={onCopyLink}
+          onReaction={onReaction}
+          onReopen={onReopen}
+          onResolve={onResolve}
         />
       )}
 


### PR DESCRIPTION
Part of https://linear.app/metabase/project/document-comments-4a94e4c4f2ea/overview

### Description

It was not possible to unresolve a thread where first comment was deleted.
`onReopen` prop was not passed to `DiscussionActionPanel`.