### PR TITLE
Closes EMB-792 dashcard title and description translation

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -27,6 +27,96 @@ import { uploadTranslationDictionaryViaAPI } from "./helpers/e2e-content-transla
 const { H } = cy;
 
 describe("scenarios > content translation > static embedding > dashboards", () => {
+  describe("card titles and descriptions", () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+
+      uploadTranslationDictionaryViaAPI([
+        { locale: "fr", msgid: "Gadget", msgstr: "Le gadget" },
+        { locale: "fr", msgid: "Doohickey", msgstr: "Le doohickey" },
+        { locale: "fr", msgid: "Gizmo", msgstr: "Le gizmo" },
+        { locale: "fr", msgid: "Widget", msgstr: "Le widget" },
+        {
+          locale: "fr",
+          msgid: "Products by Category (Pie)",
+          msgstr: "Produits par catégorie (Camembert)",
+        },
+        {
+          locale: "fr",
+          msgid: "A breakdown of products by category",
+          msgstr: "Une répartition des produits par catégorie",
+        },
+      ]);
+
+      cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+      cy.intercept("GET", "/api/embed/dashboard/*").as("dashboard");
+
+      cy.signInAsAdmin();
+
+      H.createQuestion(ORDERS_COUNT_BY_CREATED_AT_AND_PRODUCT_CATEGORY, {
+        idAlias: "productsCountByCreatedAtQuestionId",
+        wrapId: true,
+      });
+
+      H.createQuestion(
+        {
+          ...PRODUCTS_COUNT_BY_CATEGORY_PIE,
+          description: "A breakdown of products by category",
+        },
+        {
+          idAlias: "productsCountByCategoryPieQuestionId",
+          wrapId: true,
+        },
+      );
+    });
+
+    it("should translate static embedding dashboard card titles and descriptions", () => {
+      H.createDashboard({
+        name: "the_dashboard",
+      }).then(({ body: { id: dashboardId } }) => {
+        H.visitDashboard(dashboardId);
+        H.editDashboard();
+        H.openQuestionsSidebar();
+
+        H.sidebar().findByText(PRODUCTS_COUNT_BY_CATEGORY_PIE.name).click();
+        H.saveDashboard();
+
+        H.openStaticEmbeddingModal({
+          acceptTerms: false,
+        });
+        H.publishChanges("dashboard", () => {});
+
+        H.visitEmbeddedPage(
+          {
+            resource: { dashboard: dashboardId as number },
+            params: {},
+          },
+          {
+            additionalHashOptions: {
+              locale: "fr",
+            },
+          },
+        );
+
+        cy.wait("@dashboard");
+        cy.wait("@cardQuery");
+
+        // Check that the title is translated
+        cy.findByText("Produits par catégorie (Camembert)").should("exist");
+
+        H.getDashboardCard(0).realHover().icon("info").realHover();
+        H.tooltip().within(() => {
+          // Check that the description is translated
+          cy.findByText("Une répartition des produits par catégorie").should(
+            "exist",
+          );
+        });
+      });
+    });
+  });
+
   describe("values translation", () => {
     beforeEach(() => {
       H.restore();

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.tsx
@@ -6,6 +6,7 @@ import { Ellipsified } from "metabase/common/components/Ellipsified";
 import Markdown from "metabase/common/components/Markdown";
 import CS from "metabase/css/core/index.css";
 import DashboardS from "metabase/css/dashboard.module.css";
+import { useTranslateContent } from "metabase/i18n/hooks";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import type { IconProps } from "metabase/ui";
 import { Icon, Menu, Tooltip } from "metabase/ui";
@@ -68,6 +69,8 @@ export const LegendCaption = ({
    */
   const [href, setHref] = useState(getHref ? HREF_PLACEHOLDER : undefined);
 
+  const tc = useTranslateContent();
+
   const handleFocus = useCallback(() => {
     if (getHref) {
       setHref(getHref());
@@ -102,7 +105,7 @@ export const LegendCaption = ({
         data-testid="legend-caption-title"
         className={SAVING_DOM_IMAGE_OVERFLOW_VISIBLE_CLASS}
       >
-        {title}
+        {tc(title)}
       </Ellipsified>
       {title && hasTitleMenuItems && (
         <Icon
@@ -133,7 +136,7 @@ export const LegendCaption = ({
         <Tooltip
           label={
             <Markdown dark disallowHeading unstyleLinks lineClamp={8}>
-              {description}
+              {tc(description)}
             </Markdown>
           }
           maw="22em"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63297
Closes [EMB-792: Content Translation doesn't work when there are Visualizer Settings applied on a chart](https://linear.app/metabase/issue/EMB-792/content-translation-doesnt-work-when-there-are-visualizer-settings)

### Description

The title and description of a dash card wasn't translated in embedded dashboards. This is now fixed.

### How to verify

 1. Make a new question (anything works)
 2. Add this question to a dashboard
 3. Publish the dashboard as static
 4. Make sure there's a translation for the dashcard title and description in the static embedding translations file
 5. The title and description should be translated when opening the static embedded dashboard with a `locale` query parameter

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
