### PR TITLE
Closes EMB-791 custom pivot column title not being translated

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -16,6 +16,7 @@ import _ from "underscore";
 
 import ExplicitSize from "metabase/common/components/ExplicitSize";
 import CS from "metabase/css/core/index.css";
+import { useTranslateContent } from "metabase/i18n/hooks";
 import { sumArray } from "metabase/lib/arrays";
 import {
   COLUMN_SHOW_TOTALS,
@@ -133,14 +134,16 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
     const leftHeaderRef = useRef<Collection>(null);
     const topHeaderRef = useRef<Collection>(null);
 
+    const tc = useTranslateContent();
+
     const getColumnTitle = useCallback(
       function (columnIndex: number) {
         const column = data.cols.filter((col) => !isPivotGroupColumn(col))[
           columnIndex
         ];
-        return getTitleForColumn(column, settings);
+        return tc(getTitleForColumn(column, settings));
       },
-      [data, settings],
+      [data, settings, tc],
     );
 
     function isColumnCollapsible(columnIndex: number) {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63296
Closes [EMB-791: Content Translation doesn't work on Pivots when columns are renamed.](https://linear.app/metabase/issue/EMB-791/content-translation-doesnt-work-on-pivots-when-columns-are-renamed)

### How to verify

1. Make a new question with a Pivot table
2. Rename one of its columns
3. It should be translated in a static embedding context

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
