### PR TITLE
add environment var to disable embedding builds

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -4,7 +4,7 @@
 
 const configs = [require("./rspack.main.config")];
 
-if (process.env.MB_EDITION === "ee") {
+if (process.env.MB_EDITION === "ee" && process.env.SKIP_EMBEDDING_SDK !== "true") {
   // Build the embed.js script for the sdk iframe embedding.
   configs.push(require("./rspack.iframe-sdk-embed.config"));
   // Build the Embedding SDK npm package.


### PR DESCRIPTION
### Description

Most of our frontend developers are not actively developing the embedding sdk, and disabling it in local development saves ~15 seconds on every build (and probably a good chunk of memory too).

Add `SKIP_EMBEDDING_SDK=true` to make your frontend build faster

Before | After
---|---
<img width="811" height="334" alt="CleanShot 2025-09-12 at 08 12 22" src="https://github.com/user-attachments/assets/68dd87d1-de77-43fc-b35a-7b85bc10901d" /> | <img width="825" height="245" alt="CleanShot 2025-09-12 at 08 15 48" src="https://github.com/user-attachments/assets/f118e374-fb27-4280-b686-d446ab32e278" />
<img width="789" height="294" alt="CleanShot 2025-09-12 at 08 09 32" src="https://github.com/user-attachments/assets/6223496d-6cb9-4994-83ed-8a23e6adb5db" /> | <img width="788" height="157" alt="CleanShot 2025-09-12 at 08 08 04" src="https://github.com/user-attachments/assets/104a9d2b-738f-429b-8d24-87123c73e2b1" />
