### PR TITLE
Add :metabase-search/semantic-fallback-results-usage metric

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/core.clj
@@ -68,6 +68,8 @@
                                    (catch Throwable t
                                      (log/warn t "Semantic search fallback errored, ignoring")
                                      []))
+                _ (analytics/observe! :metabase-search/semantic-fallback-results-usage
+                                      (count fallback-results))
                 combined-results (concat results fallback-results)
                 deduped-results  (m/distinct-by (juxt :model :id) combined-results)]
             (take (semantic.settings/semantic-search-results-limit) deduped-results)))))

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -320,6 +320,9 @@
    (prometheus/histogram :metabase-search/semantic-results-before-fallback
                          {:description "Distribution of result counts from semantic search when fallback is triggered"
                           :buckets [0 1 5 10 20 50 100]})
+   (prometheus/histogram :metabase-search/semantic-fallback-results-usage
+                         {:description "Distribution of count of fallback results used to supplement semantic search"
+                          :buckets [0 1 5 10 20 50 100]})
    (prometheus/histogram :metabase-search/semantic-gate-write-ms
                          {:description "Distribution of semantic search gate write latency"
                           :buckets [1 10 50 100 500 1000 2000 5000 10000 20000]})


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-403/track-number-of-fallback-results-returned-to-users