### PR TITLE
Use ee plugins to check embedding enabled in nav

### DIFF
--- a/frontend/src/metabase/admin/embedding/components/EmbeddingNav.tsx
+++ b/frontend/src/metabase/admin/embedding/components/EmbeddingNav.tsx
@@ -8,12 +8,13 @@ import {
 import { UpsellGem } from "metabase/admin/upsells/components/UpsellGem";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
+import { PLUGIN_EMBEDDING } from "metabase/plugins";
 import { getLocation } from "metabase/selectors/routing";
 import { Divider, Flex, Stack } from "metabase/ui";
 
 export function EmbeddingNav() {
   const hasSimpleEmbedding = useHasTokenFeature("embedding_simple");
-  const hasInteractiveEmbedding = useHasTokenFeature("embedding");
+  const hasInteractiveEmbedding = PLUGIN_EMBEDDING.isEnabled();
   const hasSdkEmbedding = useHasTokenFeature("embedding_sdk");
 
   return (


### PR DESCRIPTION
Closes EMB-813

There is a strange bug where `useHasTokenFeature("embedding")` sometimes return true in OSS, and so the upsell gem icon is sometimes not shown. Let's switch this to use proper EE plugins. I haven't been able to reproduce this, but Roman can.

### Checklist

- ~Tests have been added/updated to cover changes in this PR~ we already have tests for this in `e2e/test/scenarios/embedding/embedding-admin-settings-oss.cy.spec.ts`
