### PR TITLE
Lock embed in production step in embedding hub checklist until sso configured

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -1,3 +1,5 @@
+import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
+
 const { H } = cy;
 
 describe("scenarios - embedding hub", () => {
@@ -65,6 +67,29 @@ describe("scenarios - embedding hub", () => {
 
       cy.log("Should navigate to model creation page");
       cy.url().should("include", "/model/new");
+    });
+
+    it("Embed in production step should be locked until JWT is enabled", () => {
+      cy.visit("/admin/embedding/setup-guide");
+
+      cy.findByTestId("admin-layout-content")
+        .findByText("Embed in production")
+        .scrollIntoView()
+        .should("be.visible")
+        .closest("button")
+        .icon("lock")
+        .should("be.visible");
+
+      enableJwtAuth();
+      cy.reload();
+
+      cy.findByTestId("admin-layout-content")
+        .findByText("Embed in production")
+        .scrollIntoView()
+        .should("be.visible")
+        .closest("button")
+        .icon("lock")
+        .should("not.exist");
     });
   });
 });

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -11,7 +11,10 @@ import { AddDataModal } from "metabase/nav/containers/MainNavbar/MainNavbarConta
 import { Stack, Text, Title } from "metabase/ui";
 
 import { useCompletedEmbeddingHubSteps } from "../hooks";
-import type { EmbeddingHubModalToTrigger } from "../types/embedding-checklist";
+import type {
+  EmbeddingHubModalToTrigger,
+  EmbeddingHubStepId,
+} from "../types/embedding-checklist";
 import { getEmbeddingHubSteps } from "../utils";
 
 import { EmbeddingHubXrayPickerModal } from "./EmbeddingHubXrayPickerModal";
@@ -29,6 +32,13 @@ export const EmbeddingHub = () => {
     useState<EmbeddingHubModalToTrigger | null>(null);
 
   const closeModal = () => setOpenedModal(null);
+
+  const lockedSteps: Partial<Record<EmbeddingHubStepId, boolean>> = useMemo(
+    () => ({
+      "embed-production": !completedSteps?.["secure-embeds"],
+    }),
+    [completedSteps],
+  );
 
   const stepperSteps: StepperStep[] = useMemo(() => {
     return embeddingSteps.map((step) => ({
@@ -58,12 +68,13 @@ export const EmbeddingHub = () => {
 
           // TODO: add completion checks for the 'create models' step
           done: completedSteps?.[stepId] ?? false,
+          locked: lockedSteps?.[stepId] ?? false,
 
           clickAction,
         };
       }),
     }));
-  }, [embeddingSteps, completedSteps]);
+  }, [embeddingSteps, completedSteps, lockedSteps]);
 
   return (
     <Stack mx="auto" py="xl" gap="xl" maw={800}>

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.module.css
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.module.css
@@ -57,7 +57,11 @@
   max-width: 15.625rem;
 }
 
-.stepCard:hover {
+.lockedStepCard {
+  cursor: not-allowed;
+}
+
+.stepCard:not(.lockedStepCard):hover {
   border: 1px solid var(--mb-color-focus) !important;
   box-shadow: 0 2px 24px 0 var(--mb-color-shadow-embedding-hub-card);
 }

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
@@ -82,6 +82,7 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                         component={onClick ? "button" : undefined}
                         onClick={onClick}
                         disabled={card.locked}
+                        data-testid={`step-card-${card.id}`}
                       >
                         <Stack justify="space-between" h="100%">
                           <Stack gap="xs" h="100%">

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
@@ -24,6 +24,7 @@ export interface StepperCard {
 
   optional?: boolean;
   done?: boolean;
+  locked?: boolean;
 
   clickAction?: StepperCardClickAction;
 }
@@ -76,9 +77,11 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                       <Card
                         className={cx(S.stepCard, {
                           [S.optionalStepCard]: card.optional,
+                          [S.lockedStepCard]: card.locked,
                         })}
                         component={onClick ? "button" : undefined}
                         onClick={onClick}
+                        disabled={card.locked}
                       >
                         <Stack justify="space-between" h="100%">
                           <Stack gap="xs" h="100%">
@@ -103,7 +106,7 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                             </Text>
                           </Stack>
 
-                          {(card.optional || card.done) && (
+                          {(card.optional || card.done || card.locked) && (
                             <Flex justify="flex-end">
                               {match(card)
                                 .with({ done: true }, () => (
@@ -113,6 +116,12 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                                   >
                                     {t`Done`}
                                   </Text>
+                                ))
+                                .with({ locked: true }, () => (
+                                  <Icon
+                                    name="lock"
+                                    c="var(--mb-color-text-secondary)"
+                                  />
                                 ))
                                 .with({ optional: true }, () => (
                                   <Text
@@ -153,5 +162,11 @@ const CardAction = ({
         {children}
       </DocsLink>
     ))
-    .with({ type: "link" }, ({ to }) => <Link to={to}>{children}</Link>)
+    .with({ type: "link" }, ({ to }) => {
+      if (card.locked) {
+        return children;
+      }
+
+      return <Link to={to}>{children}</Link>;
+    })
     .otherwise(() => children);


### PR DESCRIPTION
Closes EMB-803

Locks the "Embed in Production" step until JWT is enabled

### How to verify

- Ensure JWT is disabled
- Go to "Admin Settings > Embedding > Setup Guide"
- Scroll down to embed in production
- It should show a lock icon on the card
- Enable JWT
- Go to "Admin Settings > Embedding > Setup Guide"
- It should not show a lock icon on the card

### Demo

<img width="2518" height="1766" alt="CleanShot 2568-09-13 at 01 11 07@2x" src="https://github.com/user-attachments/assets/b6751b3c-afa0-4c2d-9919-a57e58c9c1eb" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
