### PR TITLE
Allow empty strings for parameter values in embedding

### DIFF
--- a/src/metabase/embedding/api/common.clj
+++ b/src/metabase/embedding/api/common.clj
@@ -129,19 +129,14 @@
   problem with this approach is that we cannot reliably distinguish between numbers and numeric strings, as well as
   booleans and boolean strings. To fix this issue we introduced another query string parameter `:parameters` which
   contains serialized JSON with parameter values. If this object cannot be found or parsed, we fallback to plain query
-  string parameters.
-
-  For legacy query string parameters only, we replace empty strings with `nil`, representing the absence of a value. In
-  the old format, there is no way to distinguish between `nil` and an empty string; we keep this behavior for backward
-  compatibility. In the new format with JSON, there is no such an issue, and we don't do any replacement to support both
-  values."
+  string parameters."
   [query-params]
   (or (try
         (when-let [parameters (:parameters query-params)]
           (json/decode+kw parameters))
         (catch Throwable _
           nil))
-      (update-vals query-params (fn [v] (if (= v "") nil v)))
+      query-params
       {}))
 
 (mu/defn normalize-query-params :- [:map-of :keyword :any]

--- a/src/metabase/embedding/api/common.clj
+++ b/src/metabase/embedding/api/common.clj
@@ -1,7 +1,6 @@
 (ns metabase.embedding.api.common
   (:require
    [clojure.set :as set]
-   [clojure.string :as str]
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.eid-translation.core :as eid-translation]

--- a/test/metabase/embedding/api/embed_test.clj
+++ b/test/metabase/embedding/api/embed_test.clj
@@ -546,13 +546,12 @@
                                         :display-name "Filter"
                                         :id           "_filter_"
                                         :type         "text"}}}}
-   :enable_embedding true
-   :embedding_params {:filter :enabled}})
+   :enable_embedding true})
 
 (deftest empty-string-value-card-query-test
   (testing "GET /api/embed/card/:token/query"
     (with-embedding-enabled-and-new-secret-key!
-      (mt/with-temp [:model/Card card (card-with-empty-string-filter)]
+      (mt/with-temp [:model/Card card (assoc (card-with-empty-string-filter) :embedding_params {:filter :enabled})]
         (testing "an empty string value should be passed to the query"
           (is (= [[10]]
                  (mt/rows (client/client :get 202 (card-query-url card "")
@@ -977,9 +976,10 @@
           (testing "check this is the same result as when a default value is provided"
             (is (= [[107]]
                    (mt/rows (client/client :get 202 (str (dashcard-url dashcard) "?date=Q1-2014")))))))
-        (testing "an empty value should apply if provided as an empty string in the query params"
+        (testing "an empty value should apply if provided as nil in the query params"
           (is (= [[1000]]
-                 (mt/rows (client/client :get 202 (str (dashcard-url dashcard) "?date="))))))
+                 (mt/rows (client/client :get 202 (str (dashcard-url dashcard))
+                                         :parameters (json/encode {:date nil}))))))
         (testing "an empty value should apply if provided as nil in the JWT params"
           (is (= [[1000]]
                  (mt/rows (client/client :get 202 (dashcard-url dashcard {:params {:date nil}}))))))

--- a/test/metabase/embedding/api/embed_test.clj
+++ b/test/metabase/embedding/api/embed_test.clj
@@ -25,6 +25,7 @@
    [metabase.test.http-client :as client]
    [metabase.tiles.api-test :as tiles.api-test]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [toucan2.core :as t2])
   (:import
    (java.io ByteArrayInputStream)))
@@ -504,9 +505,10 @@
             (testing "check this is the same result as when a default value is provided"
               (is (= [[107]]
                      (mt/rows (client/client :get 202 (str (card-query-url card "") "?date=Q1-2014")))))))
-          (testing "an empty value should apply if provided as an empty string in the query params"
+          (testing "an empty value should apply if provided as nil in the query params"
             (is (= [[1000]]
-                   (mt/rows (client/client :get 202 (str (card-query-url card "") "?date="))))))
+                   (mt/rows (client/client :get 202 (str (card-query-url card ""))
+                                           :parameters (json/encode {:date nil}))))))
           (testing "an empty value should apply if provided as nil in the JWT params"
             (is (= [[1000]]
                    (mt/rows (client/client :get 202 (card-query-url card "" {:params {:date nil}}))))))))
@@ -528,7 +530,7 @@
             (testing "check this is different to when a non-nil value is provided"
               (is (= [[138]]
                      (mt/rows (client/client :get 202 (card-query-url card "" {:params {:date "Q2-2014"}})))))))
-          (testing "an empty string value should not be converted to nil"
+          (testing "an empty string value should not be converted to nil and should result in an error"
             (is (= {:status     "failed"
                     :error      "An error occurred while running the query."
                     :error_type "qp"}
@@ -971,7 +973,7 @@
               (testing "check this is different to when a non-nil value is provided"
                 (is (= [[138]]
                        (mt/rows (client/client :get 202 (dashcard-url dashcard {:params {:date "Q2-2014"}})))))))
-            (testing "an empty string value should not be converted to nil"
+            (testing "an empty string value should not be converted to nil and should result in an error"
               (is (= {:status     "failed"
                       :error      "An error occurred while running the query."
                       :error_type "qp"}

--- a/test/metabase/embedding/api/embed_test.clj
+++ b/test/metabase/embedding/api/embed_test.clj
@@ -550,16 +550,26 @@
 
 (deftest empty-string-value-card-query-test
   (testing "GET /api/embed/card/:token/query"
-    (with-embedding-enabled-and-new-secret-key!
-      (mt/with-temp [:model/Card card (assoc (card-with-empty-string-filter) :embedding_params {:filter :enabled})]
-        (testing "an empty string value should be passed to the query"
-          (is (= [[10]]
-                 (mt/rows (client/client :get 202 (card-query-url card "")
-                                         :parameters (json/encode {:filter ""}))))))
-        (testing "a non-empty string value should be distinguished from an empty string"
-          (is (= [[20]]
-                 (mt/rows (client/client :get 202 (card-query-url card "")
-                                         :parameters (json/encode {:filter "A"}))))))))))
+    (testing "query string params"
+      (with-embedding-enabled-and-new-secret-key!
+        (mt/with-temp [:model/Card card (assoc (card-with-empty-string-filter) :embedding_params {:filter :enabled})]
+          (testing "an empty string value should be passed to the query"
+            (is (= [[10]]
+                   (mt/rows (client/client :get 202 (card-query-url card "")
+                                           :parameters (json/encode {:filter ""}))))))
+          (testing "a non-empty string value should be distinguished from an empty string"
+            (is (= [[20]]
+                   (mt/rows (client/client :get 202 (card-query-url card "")
+                                           :parameters (json/encode {:filter "A"})))))))))
+    (testing "JWT params"
+      (with-embedding-enabled-and-new-secret-key!
+        (mt/with-temp [:model/Card card (assoc (card-with-empty-string-filter) :embedding_params {:filter :locked})]
+          (testing "an empty string value should be passed to the query"
+            (is (= [[10]]
+                   (mt/rows (client/client :get 202 (card-query-url card "" {:params {:filter ""}}))))))
+          (testing "a non-empty string value should be distinguished from an empty string"
+            (is (= [[20]]
+                   (mt/rows (client/client :get 202 (card-query-url card "" {:params {:filter "A"}})))))))))))
 
 (defn- card-with-date-field-filter []
   {:dataset_query    {:database (mt/id)

--- a/test/metabase/embedding/api/embed_test.clj
+++ b/test/metabase/embedding/api/embed_test.clj
@@ -1678,7 +1678,11 @@
                    {:test-str              "Locked filter is set to an empty list in the token."
                     :params                {:category []}
                     :expected-row-count    200
-                    :expected-values-count 199}]]
+                    :expected-values-count 199}
+                   {:test-str              "Locked filter is set to an empty string in the token."
+                    :params                {:category [""]}
+                    :expected-row-count    0
+                    :expected-values-count 0}]]
             (testing test-str
               (let [token        (dash-token dashboard-id {:params params})
                     row-count    (-> (mt/user-http-request :crowberto :get 202

--- a/test/metabase/embedding/api/embed_test.clj
+++ b/test/metabase/embedding/api/embed_test.clj
@@ -528,9 +528,11 @@
             (testing "check this is different to when a non-nil value is provided"
               (is (= [[138]]
                      (mt/rows (client/client :get 202 (card-query-url card "" {:params {:date "Q2-2014"}})))))))
-          (testing "an empty string value is invalid and should result in an error"
-            (is (= "You must specify a value for :date in the JWT."
-                   (client/client :get 400 (card-query-url card "" {:params {:date ""}}))))))))))
+          (testing "an empty string value should not be converted to nil"
+            (is (= {:status     "failed"
+                    :error      "An error occurred while running the query."
+                    :error_type "qp"}
+                   (client/client :get 202 (card-query-url card "" {:params {:date ""}}))))))))))
 
 (defn- card-with-date-field-filter []
   {:dataset_query    {:database (mt/id)
@@ -969,9 +971,11 @@
               (testing "check this is different to when a non-nil value is provided"
                 (is (= [[138]]
                        (mt/rows (client/client :get 202 (dashcard-url dashcard {:params {:date "Q2-2014"}})))))))
-            (testing "an empty string value is invalid and should result in an error"
-              (is (= "You must specify a value for :date in the JWT."
-                     (client/client :get 400 (dashcard-url dashcard {:params {:date ""}})))))))))))
+            (testing "an empty string value should not be converted to nil"
+              (is (= {:status     "failed"
+                      :error      "An error occurred while running the query."
+                      :error_type "qp"}
+                     (client/client :get 202 (dashcard-url dashcard {:params {:date ""}})))))))))))
 
 ;;; -------------------------------------------------- Other Tests ---------------------------------------------------
 

--- a/test/metabase/embedding/api/preview_embed_test.clj
+++ b/test/metabase/embedding/api/preview_embed_test.clj
@@ -163,7 +163,7 @@
                                                                              "?date=Q1-2014")))))))
           (testing "an empty value should apply if provided as nil in the query params"
             (is (= [[1000]]
-                   (mt/rows (mt/user-http-request :crowberto :get 202 (str (card-query-url card {:_embedding_params {:date "enabled"}}))
+                   (mt/rows (mt/user-http-request :crowberto :get 202 (card-query-url card {:_embedding_params {:date "enabled"}})
                                                   :parameters (json/encode {:date nil}))))))
           (testing "an empty value should apply if provided as nil in the JWT params"
             (is (= [[1000]]

--- a/test/metabase/embedding/api/preview_embed_test.clj
+++ b/test/metabase/embedding/api/preview_embed_test.clj
@@ -161,10 +161,10 @@
               (is (= [[107]]
                      (mt/rows (mt/user-http-request :crowberto :get 202 (str (card-query-url card {:_embedding_params {:date "enabled"}})
                                                                              "?date=Q1-2014")))))))
-          (testing "an empty value should apply if provided as an empty string in the query params"
+          (testing "an empty value should apply if provided as nil in the query params"
             (is (= [[1000]]
-                   (mt/rows (mt/user-http-request :crowberto :get 202 (str (card-query-url card {:_embedding_params {:date "enabled"}})
-                                                                           "?date="))))))
+                   (mt/rows (mt/user-http-request :crowberto :get 202 (str (card-query-url card {:_embedding_params {:date "enabled"}}))
+                                                  :parameters (json/encode {:date nil}))))))
           (testing "an empty value should apply if provided as nil in the JWT params"
             (is (= [[1000]]
                    (mt/rows (mt/user-http-request :crowberto :get 202 (card-query-url card {:_embedding_params {:date "enabled"}
@@ -189,9 +189,11 @@
               (is (= [[138]]
                      (mt/rows (mt/user-http-request :crowberto :get 202 (card-query-url card {:_embedding_params {:date "locked"}
                                                                                               :params            {:date "Q2-2014"}})))))))
-          (testing "an empty string value is invalid and should result in an error"
-            (is (= "You must specify a value for :date in the JWT."
-                   (mt/user-http-request :crowberto :get 400 (card-query-url card {:_embedding_params {:date "locked"}
+          (testing "an empty string value should not be converted to nil and should result in an error"
+            (is (= {:status     "failed"
+                    :error      "An error occurred while running the query."
+                    :error_type "qp"}
+                   (mt/user-http-request :crowberto :get 202 (card-query-url card {:_embedding_params {:date "locked"}
                                                                                    :params            {:date ""}}))))))))))
 
 (deftest query-max-results-constraint-test


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/61054

Removes `""` -> `nil` conversion logic for parameter values for embedding. Now these values are separate.