### PR TITLE
respect decimals setting when compact formatting is enabled

### DIFF
--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -265,12 +265,18 @@ function _formatNumberCompact(
     const isDefaultDecimalCount =
       options.maximumFractionDigits ===
       DEFAULT_NUMBER_OPTIONS.maximumFractionDigits;
-    const decimals =
-      options.maximumFractionDigits == null
-        ? 1
-        : isDefaultDecimalCount
+
+    let decimals: number | null =
+      typeof options.decimals === "number" && isFinite(options.decimals)
+        ? options.decimals
+        : null;
+
+    if (decimals == null) {
+      decimals =
+        options.maximumFractionDigits == null || isDefaultDecimalCount
           ? 1
           : options.maximumFractionDigits;
+    }
 
     formatted = compactNumber(value, decimals);
   } else {

--- a/frontend/src/metabase/lib/formatting/numbers.unit.spec.ts
+++ b/frontend/src/metabase/lib/formatting/numbers.unit.spec.ts
@@ -62,6 +62,47 @@ describe("formatNumber", () => {
     ).toEqual("1.000015e+0");
   });
 
+  describe("compact mode with decimals setting", () => {
+    it("should respect various decimal settings in compact mode (metabase#63145)", () => {
+      const value = 1234567;
+
+      expect(
+        formatNumber(value, {
+          compact: true,
+          decimals: 0,
+        }),
+      ).toBe("1M");
+
+      expect(
+        formatNumber(value, {
+          compact: true,
+          decimals: 1,
+        }),
+      ).toBe("1.2M");
+
+      expect(
+        formatNumber(value, {
+          compact: true,
+          decimals: 2,
+        }),
+      ).toBe("1.23M");
+
+      expect(
+        formatNumber(value, {
+          compact: true,
+          decimals: 3,
+        }),
+      ).toBe("1.235M");
+
+      expect(
+        formatNumber(value, {
+          compact: true,
+          decimals: 4,
+        }),
+      ).toBe("1.2346M");
+    });
+  });
+
   describe("formatNumber – compact rounding (metabase#59454)", () => {
     it("rounds billions with 0 decimals", () => {
       expect(


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63145
### Description

This PR fixes compact formatting ignores `Number of decimal places` setting when it is set to `2`.

### How to verify

New unit tests should pass.

### Demo

<img width="1112" height="596" alt="Screenshot 2025-09-12 at 4 15 48 PM" src="https://github.com/user-attachments/assets/7d904a38-d630-45e4-848e-33360ebedca1" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
