### PR TITLE
Fix: UXW-683 Saving document resets undo history

### DIFF
--- a/e2e/test/scenarios/documents/documents.cy.spec.ts
+++ b/e2e/test/scenarios/documents/documents.cy.spec.ts
@@ -262,6 +262,30 @@ H.describeWithSnowplowEE("documents", () => {
         cy.realPress([metaKey, "z"]);
         H.documentContent().should("have.text", "");
       });
+
+      it("should not clear undo history on save", () => {
+        const isMac = Cypress.platform === "darwin";
+        const metaKey = isMac ? "Meta" : "Control";
+
+        const originalText = "Lorem Ipsum and some more words";
+        const originalExact = new RegExp(`^${originalText}$`);
+        cy.get("@documentId").then((id) => cy.visit(`/document/${id}`));
+        H.documentContent().contains(originalExact).click();
+
+        const modification = " etc.";
+        const modifiedExact = new RegExp(`^${originalText}${modification}$`);
+        H.addToDocument(modification, false);
+        H.documentContent().contains(modifiedExact);
+
+        cy.realPress([metaKey, "s"]);
+        cy.findByTestId("toast-undo")
+          .findByText("Document saved")
+          .should("be.visible");
+
+        cy.realPress([metaKey, "z"]);
+        cy.realPress([metaKey, "z"]);
+        H.documentContent().contains(originalExact);
+      });
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -105,7 +105,6 @@ export const DocumentPage = ({
   const [sendToast] = useToast();
 
   const documentId = entityId === "new" ? "new" : extractEntityId(entityId);
-  const previousDocumentId = usePrevious(documentId);
   const [isNavigationScheduled, scheduleNavigation] = useCallbackEffect();
   const isNewDocument = documentId === "new";
 
@@ -165,25 +164,6 @@ export const DocumentPage = ({
     // warn if you try to navigate away with unsaved changes
     return hasUnsavedChanges();
   });
-
-  // Reset state when document changes
-  useEffect(() => {
-    if (documentId !== previousDocumentId) {
-      dispatch(setHasUnsavedChanges(false));
-      if (isNewDocument && previousDocumentId !== "new") {
-        setDocumentTitle("");
-        setDocumentContent(null);
-        dispatch(resetDocuments());
-      }
-    }
-  }, [
-    documentId,
-    previousDocumentId,
-    isNewDocument,
-    setDocumentTitle,
-    setDocumentContent,
-    dispatch,
-  ]);
 
   // Reset state when we navigate back to /new
   const resetDocument = useCallback(() => {

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.tsx
@@ -6,6 +6,7 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import cx from "classnames";
 import type React from "react";
 import { useEffect, useMemo } from "react";
+import { useLatest, usePrevious } from "react-use";
 import { t } from "ttag";
 
 import { DND_IGNORE_CLASS_NAME } from "metabase/common/components/dnd";
@@ -37,6 +38,7 @@ import { createSuggestionRenderer } from "metabase-enterprise/rich_text_editing/
 import S from "./Editor.module.css";
 import { useCardEmbedsTracking, useQuestionSelection } from "./hooks";
 import type { CardEmbedRef } from "./types";
+
 const BUBBLE_MENU_DISALLOWED_NODES: string[] = [
   CardEmbed.name,
   MetabotNode.name,
@@ -160,18 +162,20 @@ export const Editor: React.FC<EditorProps> = ({
   );
 
   // Handle content updates when initialContent changes
+  const previousContentRef = useLatest(usePrevious(initialContent));
   useEffect(() => {
+    const previousContent = previousContentRef.current;
     if (editor && initialContent !== undefined) {
       // Use Promise.resolve() to avoid flushSync warning
       Promise.resolve().then(() => {
         editor
           .chain()
-          .setMeta("addToHistory", false)
+          .setMeta("addToHistory", previousContent != null)
           .setContent(initialContent || "")
           .run();
       });
     }
-  }, [editor, initialContent]);
+  }, [editor, initialContent, previousContentRef]);
 
   // Notify parent when editor is ready
   useEffect(() => {

--- a/enterprise/frontend/src/metabase-enterprise/documents/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/routes.tsx
@@ -1,11 +1,23 @@
+import type { ComponentProps } from "react";
+
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 import { Route } from "metabase/hoc/Title";
+import { extractEntityId } from "metabase/lib/urls";
 
 import { CommentsSidesheet } from "./components/CommentsSidesheet";
 import { DocumentPage } from "./components/DocumentPage";
 
+const DocumentPageOuter = (props: ComponentProps<typeof DocumentPage>) => {
+  const { entityId } = props.params;
+  const documentId = entityId === "new" ? "new" : extractEntityId(entityId);
+
+  // Remounts DocumentPage when navigating to a new document.
+  // Prevents data, state, undo history, etc from bleeding between documents.
+  return <DocumentPage key={documentId} {...props} />;
+};
+
 export const getRoutes = () => (
-  <Route path="document/:entityId" component={DocumentPage}>
+  <Route path="document/:entityId" component={DocumentPageOuter}>
     <ModalRoute
       path="comments/:childTargetId"
       modal={CommentsSidesheet}

--- a/enterprise/frontend/src/metabase-enterprise/documents/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/routes.tsx
@@ -11,7 +11,7 @@ const DocumentPageOuter = (props: ComponentProps<typeof DocumentPage>) => {
   const { entityId } = props.params;
   const documentId = entityId === "new" ? "new" : extractEntityId(entityId);
 
-  // Remounts DocumentPage when navigating to a new document.
+  // Remounts DocumentPage when navigating to a different document.
   // Prevents data, state, undo history, etc from bleeding between documents.
   return <DocumentPage key={documentId} {...props} />;
 };


### PR DESCRIPTION
Closes [UXW-683](https://linear.app/metabase/issue/UXW-683)

### Description

Fixes issue where undo history is cleared on save by remounting the DocumentPage when the entityId route param changes.

### How to verify

See [UXW-683](https://linear.app/metabase/issue/UXW-683) for repro steps.

Verify [UXW-564: CMD-Z on an existing Document removes all content (+ other edge case)](https://linear.app/metabase/issue/UXW-564/cmd-z-on-an-existing-document-removes-all-content-other-edge-case) is still fixed.

### Demo

https://github.com/user-attachments/assets/05759959-5eb4-426e-9509-ed5ffd69a221

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
