### PR TITLE
Handle legacy viz settings where `base-type` might not be present

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1069,11 +1069,7 @@ describe("issue 50346", () => {
         ["sum", ["field", ORDERS.TOTAL, { "base-type": "type/Float" }]],
       ],
       breakout: [
-        [
-          "field",
-          PRODUCTS.CATEGORY,
-          { "base-type": "type/Text", "source-field": ORDERS.PRODUCT_ID },
-        ],
+        ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
         [
           "field",
           PRODUCTS.VENDOR,

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1085,12 +1085,10 @@ describe("issue 50346", () => {
     display: "pivot",
     visualization_settings: {
       "pivot_table.column_split": {
+        // mix field refs with and without `base-type` to make sure we support
+        // both cases
         rows: [
-          [
-            "field",
-            PRODUCTS.CATEGORY,
-            { "base-type": "type/Text", "source-field": ORDERS.PRODUCT_ID },
-          ],
+          ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
           [
             "field",
             PRODUCTS.VENDOR,

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1069,7 +1069,11 @@ describe("issue 50346", () => {
         ["sum", ["field", ORDERS.TOTAL, { "base-type": "type/Float" }]],
       ],
       breakout: [
-        ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+        [
+          "field",
+          PRODUCTS.CATEGORY,
+          { "base-type": "type/Text", "source-field": ORDERS.PRODUCT_ID },
+        ],
         [
           "field",
           PRODUCTS.VENDOR,

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1085,8 +1085,7 @@ describe("issue 50346", () => {
     display: "pivot",
     visualization_settings: {
       "pivot_table.column_split": {
-        // mix field refs with and without `base-type` to make sure we support
-        // both cases
+        // mix field refs with and without `base-type` to make sure we support both cases
         rows: [
           ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
           [

--- a/frontend/src/metabase-lib/v1/queries/utils/column-key.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/column-key.ts
@@ -22,12 +22,12 @@ export const getColumnKey = (column: DatasetColumnReference) => {
 };
 
 export type LegacyColumnKeyOptions = {
-  ignoreBaseType?: boolean;
+  excludeBaseType?: boolean;
 };
 
 export const getLegacyColumnKey = (
   column: DatasetColumnReference,
-  { ignoreBaseType }: LegacyColumnKeyOptions = {},
+  { excludeBaseType }: LegacyColumnKeyOptions = {},
 ) => {
   let fieldRef = column.field_ref;
 
@@ -44,7 +44,7 @@ export const getLegacyColumnKey = (
 
   if (isDimensionReferenceWithOptions(fieldRef)) {
     fieldRef = getDimensionReferenceWithoutTemporalUnitAndBinning(fieldRef);
-    if (ignoreBaseType) {
+    if (excludeBaseType) {
       fieldRef = getDimensionReferenceWithoutBaseType(fieldRef);
     }
   }
@@ -90,7 +90,7 @@ export const getObjectColumnSettings = (
 ) => {
   return (
     settings?.[getLegacyColumnKey(column)] ??
-    settings?.[getLegacyColumnKey(column, { ignoreBaseType: true })] ??
+    settings?.[getLegacyColumnKey(column, { excludeBaseType: true })] ??
     settings?.[getColumnKey(column)]
   );
 };

--- a/frontend/src/metabase-lib/v1/queries/utils/column-key.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/column-key.ts
@@ -21,7 +21,7 @@ export const getColumnKey = (column: DatasetColumnReference) => {
   return JSON.stringify(["name", column.name]);
 };
 
-type LegacyColumnKeyOptions = {
+export type LegacyColumnKeyOptions = {
   ignoreBaseType?: boolean;
 };
 

--- a/frontend/src/metabase-lib/v1/queries/utils/column-key.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/column-key.ts
@@ -1,10 +1,11 @@
 import {
   createFieldReference,
-  getBaseDimensionReference,
+  getDimensionReferenceWithoutBaseType,
+  getDimensionReferenceWithoutTemporalUnitAndBinning,
   getNormalizedDimensionReference,
   hasStringFieldName,
   isAggregationReference,
-  isExpressionReference,
+  isDimensionReferenceWithOptions,
   isFieldReference,
   isValidDimensionReference,
 } from "metabase-lib/v1/references";
@@ -20,7 +21,14 @@ export const getColumnKey = (column: DatasetColumnReference) => {
   return JSON.stringify(["name", column.name]);
 };
 
-export const getLegacyColumnKey = (column: DatasetColumnReference) => {
+type LegacyColumnKeyOptions = {
+  ignoreBaseType?: boolean;
+};
+
+export const getLegacyColumnKey = (
+  column: DatasetColumnReference,
+  { ignoreBaseType }: LegacyColumnKeyOptions = {},
+) => {
   let fieldRef = column.field_ref;
 
   if (!fieldRef) {
@@ -34,12 +42,11 @@ export const getLegacyColumnKey = (column: DatasetColumnReference) => {
 
   fieldRef = getNormalizedDimensionReference(fieldRef);
 
-  if (
-    isFieldReference(fieldRef) ||
-    isExpressionReference(fieldRef) ||
-    isAggregationReference(fieldRef)
-  ) {
-    fieldRef = getBaseDimensionReference(fieldRef);
+  if (isDimensionReferenceWithOptions(fieldRef)) {
+    fieldRef = getDimensionReferenceWithoutTemporalUnitAndBinning(fieldRef);
+    if (ignoreBaseType) {
+      fieldRef = getDimensionReferenceWithoutBaseType(fieldRef);
+    }
   }
 
   const isLegacyRef =
@@ -67,15 +74,23 @@ export const getColumnSettings = (
   return getObjectColumnSettings(settings?.column_settings, column);
 };
 
-// Gets the corresponding viz settings for the column. We check for both
-// legacy and modern keys because not all viz settings have been migrated.
-// To be extra safe and maintain backward compatibility, we check for the
-// legacy key first.
+/**
+ * Gets the corresponding viz settings for the column. We check for both
+ * legacy and modern keys because not all viz settings have been migrated.
+ * To be extra safe and maintain backward compatibility, we check for the
+ * legacy key first.
+ *
+ * Sometimes the `field_ref` has the `base-type`, sometimes it doesn't. To not
+ * break legacy viz settings, try to get the column settings with and without
+ * `base-type`.
+ */
 export const getObjectColumnSettings = (
   settings: Record<string, ColumnSettings> | null | undefined,
   column: DatasetColumnReference,
 ) => {
   return (
-    settings?.[getLegacyColumnKey(column)] ?? settings?.[getColumnKey(column)]
+    settings?.[getLegacyColumnKey(column)] ??
+    settings?.[getLegacyColumnKey(column, { ignoreBaseType: true })] ??
+    settings?.[getColumnKey(column)]
   );
 };

--- a/frontend/src/metabase-lib/v1/queries/utils/column-key.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/column-key.unit.spec.ts
@@ -114,7 +114,7 @@ describe("getLegacyColumnKey", () => {
         field_ref: ["field", 1, { "base-type": "type/DateTime" }],
       }),
       options: {
-        ignoreBaseType: true,
+        excludeBaseType: true,
       },
       expectedKey: JSON.stringify(["ref", ["field", 1, null]]),
     },
@@ -129,7 +129,7 @@ describe("getLegacyColumnKey", () => {
         ],
       }),
       options: {
-        ignoreBaseType: true,
+        excludeBaseType: true,
       },
       expectedKey: JSON.stringify(["ref", ["field", 1, { "source-field": 2 }]]),
     },
@@ -241,7 +241,7 @@ describe("getObjectColumnSettings", () => {
 
   it("should be able to find the setting when `base-type` is not present", () => {
     const settings = {
-      [getLegacyColumnKey(column, { ignoreBaseType: true })]: {
+      [getLegacyColumnKey(column, { excludeBaseType: true })]: {
         column_title: "A",
       },
     };

--- a/frontend/src/metabase-lib/v1/queries/utils/column-key.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/queries/utils/column-key.unit.spec.ts
@@ -1,4 +1,5 @@
 import {
+  type LegacyColumnKeyOptions,
   getColumnKey,
   getColumnNameFromKey,
   getColumnSettings,
@@ -14,6 +15,7 @@ import {
 type TestCase = {
   title: string;
   column: DatasetColumn;
+  options?: LegacyColumnKeyOptions;
   expectedKey: string;
 };
 
@@ -94,9 +96,49 @@ describe("getLegacyColumnKey", () => {
       }),
       expectedKey: JSON.stringify(["ref", ["expression", "foo"]]),
     },
-  ])("should create a ref-based key: $title", ({ column, expectedKey }) => {
-    expect(getLegacyColumnKey(column)).toEqual(expectedKey);
-  });
+    {
+      title: "should include `base-type` by default",
+      column: createMockColumn({
+        name: "foo",
+        field_ref: ["field", 1, { "base-type": "type/DateTime" }],
+      }),
+      expectedKey: JSON.stringify([
+        "ref",
+        ["field", 1, { "base-type": "type/DateTime" }],
+      ]),
+    },
+    {
+      title: "should allow to exclude `base-type`",
+      column: createMockColumn({
+        name: "foo",
+        field_ref: ["field", 1, { "base-type": "type/DateTime" }],
+      }),
+      options: {
+        ignoreBaseType: true,
+      },
+      expectedKey: JSON.stringify(["ref", ["field", 1, null]]),
+    },
+    {
+      title: "should allow to exclude `base-type` when there are other options",
+      column: createMockColumn({
+        name: "foo",
+        field_ref: [
+          "field",
+          1,
+          { "base-type": "type/DateTime", "source-field": 2 },
+        ],
+      }),
+      options: {
+        ignoreBaseType: true,
+      },
+      expectedKey: JSON.stringify(["ref", ["field", 1, { "source-field": 2 }]]),
+    },
+  ])(
+    "should create a ref-based key: $title",
+    ({ column, options, expectedKey }) => {
+      expect(getLegacyColumnKey(column, options)).toEqual(expectedKey);
+    },
+  );
 
   it.each<TestCase>([
     {
@@ -191,6 +233,17 @@ describe("getObjectColumnSettings", () => {
     const settings = {
       [getLegacyColumnKey(column)]: { column_title: "A" },
       [getColumnKey(column)]: { column_title: "B" },
+    };
+    expect(getObjectColumnSettings(settings, column)).toEqual({
+      column_title: "A",
+    });
+  });
+
+  it("should be able to find the setting when `base-type` is not present", () => {
+    const settings = {
+      [getLegacyColumnKey(column, { ignoreBaseType: true })]: {
+        column_title: "A",
+      },
     };
     expect(getObjectColumnSettings(settings, column)).toEqual({
       column_title: "A",

--- a/frontend/src/metabase-lib/v1/references.ts
+++ b/frontend/src/metabase-lib/v1/references.ts
@@ -49,6 +49,16 @@ export const isValidDimensionReference = (
   ].some((predicate) => predicate(mbql));
 };
 
+export const isDimensionReferenceWithOptions = (
+  mbql: unknown,
+): mbql is DimensionReferenceWithOptions => {
+  return (
+    isFieldReference(mbql) ||
+    isExpressionReference(mbql) ||
+    isAggregationReference(mbql)
+  );
+};
+
 export const normalizeReferenceOptions = (
   options?: ReferenceOptions | null,
 ): ReferenceOptions | null => {
@@ -83,7 +93,7 @@ export const getNormalizedDimensionReference = (
   return mbql;
 };
 
-export const getDimensionReferenceWithoutOptions = (
+const getDimensionReferenceWithoutOptions = (
   mbql: DimensionReferenceWithOptions,
   optionsKeysToOmit: string[],
 ): DimensionReferenceWithOptions => {
@@ -109,13 +119,19 @@ export const BASE_DIMENSION_REFERENCE_OMIT_OPTIONS = [
   "binning",
 ];
 
-export const getBaseDimensionReference = (
+export const getDimensionReferenceWithoutTemporalUnitAndBinning = (
   mbql: DimensionReferenceWithOptions,
 ) =>
   getDimensionReferenceWithoutOptions(
     mbql,
     BASE_DIMENSION_REFERENCE_OMIT_OPTIONS,
   );
+
+const BASE_TYPE_OPTIONS = ["base-type"];
+
+export const getDimensionReferenceWithoutBaseType = (
+  mbql: DimensionReferenceWithOptions,
+) => getDimensionReferenceWithoutOptions(mbql, BASE_TYPE_OPTIONS);
 
 /**
  * Whether this Field clause has a string Field name (as opposed to an integer Field ID). This generally means the

--- a/frontend/src/metabase-lib/v1/references.ts
+++ b/frontend/src/metabase-lib/v1/references.ts
@@ -83,7 +83,7 @@ export const getNormalizedDimensionReference = (
   return mbql;
 };
 
-const getDimensionReferenceWithoutOptions = (
+export const getDimensionReferenceWithoutOptions = (
   mbql: DimensionReferenceWithOptions,
   optionsKeysToOmit: string[],
 ): DimensionReferenceWithOptions => {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -18,6 +18,10 @@ import { ChartSettingsTableFormatting } from "metabase/visualizations/components
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import { migratePivotColumnSplitSetting } from "metabase-lib/v1/queries/utils/pivot";
+import {
+  getDimensionReferenceWithoutOptions,
+  isFieldReference,
+} from "metabase-lib/v1/references";
 import { isDimension } from "metabase-lib/v1/types/utils/isa";
 import type {
   Card,
@@ -340,10 +344,7 @@ export const _columnSettings = {
   names only and do not depend on field refs.
  */
 function getFieldRefForComparison(fieldRef: DimensionReference) {
-  if (fieldRef[2] == null) {
-    return fieldRef;
-  }
-  const newFieldRef = [...fieldRef];
-  newFieldRef[2] = _.omit(fieldRef[2], "base-type");
-  return newFieldRef;
+  return isFieldReference(fieldRef)
+    ? getDimensionReferenceWithoutOptions(fieldRef, ["base-type"])
+    : fieldRef;
 }

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -23,6 +23,7 @@ import type {
   Card,
   DatasetColumn,
   DatasetData,
+  DimensionReference,
   PivotTableColumnSplitSetting,
   RawSeries,
   Series,
@@ -303,7 +304,13 @@ export const _columnSettings = {
         .slice(0, -1)
         .some(
           (row) =>
-            _.isEqual(row, column.name) || _.isEqual(row, column.field_ref),
+            _.isEqual(row, column.name) ||
+            (Array.isArray(row) &&
+              column.field_ref != null &&
+              _.isEqual(
+                getFieldRefForComparison(row),
+                getFieldRefForComparison(column.field_ref),
+              )),
         );
     },
     getHidden: (
@@ -326,3 +333,16 @@ export const _columnSettings = {
     getDefault: displayNameForColumn,
   },
 };
+
+/*
+  HACK: when comparing field refs for pivot viz settings, ignore `base-type`.
+  Sometimes it's present, sometimes it's not. New pivot settings use column
+  names only and do not depend on field refs.
+ */
+function getFieldRefForComparison(fieldRef: DimensionReference) {
+  const newFieldRef = [...fieldRef];
+  if (newFieldRef[2] != null) {
+    newFieldRef[2] = _.omit(fieldRef[2], "base-type");
+  }
+  return newFieldRef;
+}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -19,8 +19,8 @@ import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import { migratePivotColumnSplitSetting } from "metabase-lib/v1/queries/utils/pivot";
 import {
-  getDimensionReferenceWithoutOptions,
-  isFieldReference,
+  getDimensionReferenceWithoutBaseType,
+  isDimensionReferenceWithOptions,
 } from "metabase-lib/v1/references";
 import { isDimension } from "metabase-lib/v1/types/utils/isa";
 import type {
@@ -339,12 +339,12 @@ export const _columnSettings = {
 };
 
 /*
-  HACK: when comparing field refs for pivot viz settings, ignore `base-type`.
+  When comparing field refs for pivot viz settings, ignore `base-type`.
   Sometimes it's present, sometimes it's not. New pivot settings use column
   names only and do not depend on field refs.
  */
 function getFieldRefForComparison(fieldRef: DimensionReference) {
-  return isFieldReference(fieldRef)
-    ? getDimensionReferenceWithoutOptions(fieldRef, ["base-type"])
+  return isDimensionReferenceWithOptions(fieldRef)
+    ? getDimensionReferenceWithoutBaseType(fieldRef)
     : fieldRef;
 }

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -340,9 +340,10 @@ export const _columnSettings = {
   names only and do not depend on field refs.
  */
 function getFieldRefForComparison(fieldRef: DimensionReference) {
-  const newFieldRef = [...fieldRef];
-  if (newFieldRef[2] != null) {
-    newFieldRef[2] = _.omit(fieldRef[2], "base-type");
+  if (fieldRef[2] == null) {
+    return fieldRef;
   }
+  const newFieldRef = [...fieldRef];
+  newFieldRef[2] = _.omit(fieldRef[2], "base-type");
   return newFieldRef;
 }


### PR DESCRIPTION
https://metaboat.slack.com/archives/C0645JP1W81/p1757724361507789

For legacy viz settings that are field_ref-based, make sure everything works when the BE doesn't return `base-type` for field refs.