### PR TITLE
[normalize] Optimize metabase.lib.schema.util

### DIFF
--- a/src/metabase/lib/schema/util.cljc
+++ b/src/metabase/lib/schema/util.cljc
@@ -1,11 +1,11 @@
 (ns metabase.lib.schema.util
-  (:refer-clojure :exclude [ref run! every? mapv empty?])
+  (:refer-clojure :exclude [ref run! every? mapv empty? first second])
   (:require
    [medley.core :as m]
    [metabase.lib.options :as lib.options]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [run! every? mapv empty?]]))
+   [metabase.util.performance :as perf :refer [run! every? mapv empty? first second]]))
 
 (declare collect-uuids*)
 
@@ -84,13 +84,18 @@
 (mu/defn mbql-clause-distinct-key
   "For deduplicating MBQL clauses: keep just the keys in options that are essential to distinguish one clause from
   another. Removes namespaced keywords and type information keys like `:base-type`."
-  [[tag opts & children]]
-  (into [tag
-         (opts-distinct-key opts)]
-        (map (fn [child]
-               (cond-> child
-                 (mbql-clause? child) mbql-clause-distinct-key)))
-        children))
+  [clause]
+  (let [tag (first clause)
+        opts (second clause)
+        f #(cond-> %
+             (mbql-clause? %) mbql-clause-distinct-key)]
+    (if (= (count clause) 3)
+      ;; Fastpath: this verbosity was introduced for performance reasons. Most clauses have only one child, and
+      ;; constructing a vector directly is more efficient than appending to a vector with `into`.
+      [tag (opts-distinct-key opts) (f (nth clause 2))]
+      (into [tag (opts-distinct-key opts)]
+            (map f)
+            (drop 2 clause)))))
 
 (defn distinct-mbql-clauses?
   "Is a sequence of `mbql-clauses` distinct for the purposes of appearing in things like `:fields`, `:breakouts`, or

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -1,13 +1,14 @@
 (ns metabase.util.performance
   "Functions and utilities for faster processing. This namespace is compatible with both Clojure and ClojureScript.
   However, some functions are either not only available in CLJS, or offer passthrough non-improved functions."
-  (:refer-clojure :exclude [reduce mapv run! some every? concat select-keys update-keys empty? not-empty doseq for #?(:cljs clj->js)])
+  (:refer-clojure :exclude [reduce mapv run! some every? concat select-keys update-keys empty? not-empty doseq for
+                            first second update-vals #?(:cljs clj->js)])
   #?(:clj (:require
            [net.cgrand.macrovich :as macros])
      :cljs (:require
             [cljs.core :as core]
             [goog.object :as gobject]))
-  #?(:clj (:import (clojure.lang Counted ITransientCollection LazilyPersistentVector RT)
+  #?(:clj (:import (clojure.lang ITransientCollection LazilyPersistentVector RT)
                    (java.util ArrayList HashMap Iterator List))))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -45,20 +46,44 @@
 ;; Collection functions
 
 (defn empty?
-  "Returns true if coll has no items. Tries to avoid using `seq` for better performance."
+  "Like `clojure.core/empty?`, but uses `List.isEmpty()` method or `count` which are usually allocation-free."
   [coll]
-  #?(:clj
-     (cond (instance? List coll) (.isEmpty ^List coll)
-           (instance? Counted coll) (= (.count ^Counted coll) 0)
-           :else (not (seq coll)))
-     :cljs (not (seq coll))))
+  #?(:clj (if (instance? List coll)
+            (.isEmpty ^List coll)
+            (= (count coll) 0))
+     :cljs (clojure.core/empty? coll)))
 
 (defn not-empty
-  "If coll is empty, returns nil, else coll. Tries to avoid using `seq` for better performance."
+  "Like `clojure.core/not-empty`, but uses more efficient `empty?` implementation."
   [coll]
-  #?(:clj
-     (when-not (empty? coll) coll)
+  #?(:clj (when-not (empty? coll)
+            coll)
      :cljs (clojure.core/not-empty coll)))
+
+#?(:clj
+   (defn first
+     "Like `clojure.core/first`, but is allocation-free when `coll` implements java.util.List."
+     [coll]
+     (if (instance? List coll)
+       (when-not (.isEmpty ^List coll)
+         (.get ^List coll 0))
+       (clojure.core/first coll)))
+
+   :cljs
+   (def first
+     "Returns the first item in the collection. Calls seq on its argument. If coll is nil, returns nil."
+     clojure.core/first))
+
+#?(:clj
+   (defn second
+     "Like `clojure.core/second`, but uses `RT/nth` directly for allocation-free access."
+     [coll]
+     (RT/nth coll 1 nil))
+
+   :cljs
+   (def second
+     "Same as (first (next x))"
+     clojure.core/second))
 
 #?(:clj
    (defn reduce
@@ -314,6 +339,25 @@
                              m m)
                   maybe-persistent!
                   (add-original-meta m))))
+
+(defn update-vals
+  "Like `clojure.core/update-vals`, but doesn't recreate the collection if no vals are changed after applying `f`. Works
+  for both maps and vectors."
+  [coll f]
+  (cond (nil? coll) {}
+        ;; Fallback for non-editable collections where transients aren't supported.
+        (not (editable? coll))
+        #_{:clj-kondo/ignore [:discouraged-var]}
+        (clojure.core/update-vals coll f)
+        :else (-> (reduce-kv (fn [acc k v]
+                               (let [v' (f v)]
+                                 ;; Skip update if val is unchanged (=), but check for identity as it is faster.
+                                 (if (or (identical? v v') (= v v'))
+                                   acc
+                                   (assoc+ acc k v'))))
+                             coll coll)
+                  maybe-persistent!
+                  (with-meta (meta coll)))))
 
 ;; List comprehension reimplementation.
 


### PR DESCRIPTION
~Query normalization happens in many scenarios of query processing IIUC. I stumbled upon it when working on pivots. This PR mostly reduces the allocation pressure of `metabase.legacy-mbql.normalize/canonicalize-mbql-clauses` and its subfunctions (around 3% of the allocations spent on generate pivotted tables), and some of the time too.~

Code that this PR improves has been removed in master, so only little bits in schema.util have remained.