### PR TITLE
refactor(sdk): Replase Zod with Yup for SDK bundle schema validation

### DIFF
--- a/enterprise/frontend/src/.eslintrc.js
+++ b/enterprise/frontend/src/.eslintrc.js
@@ -59,10 +59,6 @@ module.exports = {
             paths: [
               ...baseRestrictredConfig.paths,
               {
-                name: "zod",
-                message: "Please import from `zod/mini` instead.",
-              },
-              {
                 name: "metabase/lib/redux",
                 importNames: ["useStore", "useDispatch"],
                 message: 'Please use "useSdkStore", "useSdkDispatch"',

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/CollectionBrowser/CollectionBrowser.schema.ts
@@ -1,30 +1,20 @@
-import {
-  any,
-  function as functionSchema,
-  optional,
-  strictObject,
-} from "zod/mini";
-import type { infer as zInfer } from "zod/v4/core/core";
+import * as Yup from "yup";
 
-import type { ValidateInferredSchema } from "embedding-sdk-bundle/types/schema";
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
 import type { CollectionBrowserProps } from "./CollectionBrowser";
 
-const rawPropsSchema = strictObject({
-  EmptyContentComponent: optional(any()),
-  className: optional(any()),
-  collectionId: optional(any()),
-  onClick: optional(any()),
-  pageSize: optional(any()),
-  style: optional(any()),
-  visibleColumns: optional(any()),
-  visibleEntityTypes: optional(any()),
-});
-const propsSchema: ValidateInferredSchema<
-  CollectionBrowserProps,
-  zInfer<typeof rawPropsSchema>
-> = rawPropsSchema;
+const propsSchema: Yup.SchemaOf<CollectionBrowserProps> = Yup.object({
+  EmptyContentComponent: Yup.mixed().optional(),
+  className: Yup.mixed().optional(),
+  collectionId: Yup.mixed().optional(),
+  onClick: Yup.mixed().optional(),
+  pageSize: Yup.mixed().optional(),
+  style: Yup.mixed().optional(),
+  visibleColumns: Yup.mixed().optional(),
+  visibleEntityTypes: Yup.mixed().optional(),
+}).noUnknown();
 
-export const collectionBrowserPropsSchema = functionSchema({
+export const collectionBrowserPropsSchema: FunctionSchema = {
   input: [propsSchema],
-});
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/CreateDashboardModal/CreateDashboardModal.schema.ts
@@ -1,27 +1,16 @@
-import {
-  any,
-  function as functionSchema,
-  nonoptional,
-  optional,
-  strictObject,
-} from "zod/mini";
-import type { infer as zInfer } from "zod/v4/core/core";
+import * as Yup from "yup";
 
-import type { ValidateInferredSchema } from "embedding-sdk-bundle/types/schema";
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
 import type { CreateDashboardModalProps } from "./CreateDashboardModal";
 
-const rawPropsSchema = strictObject({
-  initialCollectionId: optional(any()),
-  isOpen: optional(any()),
-  onClose: optional(any()),
-  onCreate: nonoptional(any()),
-});
-const propsSchema: ValidateInferredSchema<
-  CreateDashboardModalProps,
-  zInfer<typeof rawPropsSchema>
-> = rawPropsSchema;
+const propsSchema: Yup.SchemaOf<CreateDashboardModalProps> = Yup.object({
+  initialCollectionId: Yup.mixed().optional(),
+  isOpen: Yup.mixed().optional(),
+  onClose: Yup.mixed().optional(),
+  onCreate: Yup.object().required(),
+}).noUnknown();
 
-export const createDashboardModalSchema = functionSchema({
+export const createDashboardModalSchema: FunctionSchema = {
   input: [propsSchema],
-});
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
@@ -1,56 +1,45 @@
-import {
-  any,
-  function as functionSchema,
-  nonoptional,
-  optional,
-  strictObject,
-  type infer as zInfer,
-} from "zod/mini";
+import * as Yup from "yup";
 
-import type { ValidateInferredSchema } from "embedding-sdk-bundle/types/schema";
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
 import type { InteractiveQuestionProps } from "./InteractiveQuestion";
 
-const rawPropsSchema = strictObject({
-  children: optional(any()),
-  className: optional(any()),
-  componentPlugins: optional(
-    strictObject({
-      mapQuestionClickActions: optional(any()),
-      dashboard: optional(any()),
-    }),
-  ),
-  deserializedCard: optional(any()),
-  entityTypes: optional(any()),
-  height: optional(any()),
-  initialSqlParameters: optional(any()),
-  isSaveEnabled: optional(any()),
-  onBeforeSave: optional(any()),
-  onNavigateBack: optional(any()),
-  onRun: optional(any()),
-  onSave: optional(any()),
-  options: optional(any()),
-  plugins: optional(
-    strictObject({
-      mapQuestionClickActions: optional(any()),
-      dashboard: optional(any()),
-    }),
-  ),
-  questionId: nonoptional(any()),
-  style: optional(any()),
-  targetCollection: optional(any()),
-  targetDashboardId: optional(any()),
-  title: optional(any()),
-  width: optional(any()),
-  withChartTypeSelector: optional(any()),
-  withDownloads: optional(any()),
-  withResetButton: optional(any()),
-});
-const propsSchema: ValidateInferredSchema<
-  InteractiveQuestionProps,
-  zInfer<typeof rawPropsSchema>
-> = rawPropsSchema;
+const propsSchema: Yup.SchemaOf<InteractiveQuestionProps> = Yup.object({
+  children: Yup.mixed().optional(),
+  className: Yup.mixed().optional(),
+  componentPlugins: Yup.object({
+    mapQuestionClickActions: Yup.mixed().optional(),
+    dashboard: Yup.mixed().optional(),
+  })
+    .optional()
+    .noUnknown(),
+  deserializedCard: Yup.mixed().optional(),
+  entityTypes: Yup.mixed().optional(),
+  height: Yup.mixed().optional(),
+  initialSqlParameters: Yup.mixed().optional(),
+  isSaveEnabled: Yup.mixed().optional(),
+  onBeforeSave: Yup.mixed().optional(),
+  onNavigateBack: Yup.mixed().optional(),
+  onRun: Yup.mixed().optional(),
+  onSave: Yup.mixed().optional(),
+  options: Yup.mixed().optional(),
+  plugins: Yup.object({
+    mapQuestionClickActions: Yup.mixed().optional(),
+    dashboard: Yup.mixed().optional(),
+  })
+    .optional()
+    .noUnknown(),
+  questionId: Yup.mixed().required(),
+  style: Yup.mixed().optional(),
+  targetCollection: Yup.mixed().optional(),
+  targetDashboardId: Yup.mixed().optional(),
+  title: Yup.mixed().optional(),
+  width: Yup.mixed().optional(),
+  withChartTypeSelector: Yup.mixed().optional(),
+  withDownloads: Yup.mixed().optional(),
+  withResetButton: Yup.mixed().optional(),
+}).noUnknown();
 
-export const interactiveQuestionSchema = functionSchema({
+export const interactiveQuestionSchema: FunctionSchema = {
   input: [propsSchema],
-});
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.schema.ts
@@ -1,5 +1,5 @@
-import { function as functionSchema } from "zod/mini";
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
-export const metabotQuestionSchema = functionSchema({
+export const metabotQuestionSchema: FunctionSchema = {
   input: [],
-});
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/SdkDebugInfo/SdkDebugInfo.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/SdkDebugInfo/SdkDebugInfo.schema.ts
@@ -1,5 +1,5 @@
-import { function as functionSchema } from "zod/mini";
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
-export const sdkDebugInfoSchema = functionSchema({
+export const sdkDebugInfoSchema: FunctionSchema = {
   input: [],
-});
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
@@ -1,33 +1,22 @@
-import {
-  any,
-  function as functionSchema,
-  nonoptional,
-  optional,
-  strictObject,
-} from "zod/mini";
-import type { infer as zInfer } from "zod/v4/core/core";
+import * as Yup from "yup";
 
-import type { ValidateInferredSchema } from "embedding-sdk-bundle/types/schema";
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
 import type { StaticQuestionProps } from "./StaticQuestion";
 
-const rawPropsSchema = strictObject({
-  children: optional(any()),
-  className: optional(any()),
-  height: optional(any()),
-  initialSqlParameters: optional(any()),
-  questionId: nonoptional(any()),
-  style: optional(any()),
-  title: optional(any()),
-  width: optional(any()),
-  withChartTypeSelector: optional(any()),
-  withDownloads: optional(any()),
-});
-const propsSchema: ValidateInferredSchema<
-  StaticQuestionProps,
-  zInfer<typeof rawPropsSchema>
-> = rawPropsSchema;
+const propsSchema: Yup.SchemaOf<StaticQuestionProps> = Yup.object({
+  children: Yup.mixed().optional(),
+  className: Yup.mixed().optional(),
+  height: Yup.mixed().optional(),
+  initialSqlParameters: Yup.mixed().optional(),
+  questionId: Yup.mixed().required(),
+  style: Yup.mixed().optional(),
+  title: Yup.mixed().optional(),
+  width: Yup.mixed().optional(),
+  withChartTypeSelector: Yup.mixed().optional(),
+  withDownloads: Yup.mixed().optional(),
+}).noUnknown();
 
-export const staticQuestionSchema = functionSchema({
+export const staticQuestionSchema: FunctionSchema = {
   input: [propsSchema],
-});
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/EditableDashboard.schema.ts
@@ -1,68 +1,57 @@
-import {
-  any,
-  function as functionSchema,
-  nonoptional,
-  optional,
-  strictObject,
-} from "zod/mini";
-import type { infer as zInfer } from "zod/v4/core/core";
+import * as Yup from "yup";
 
-import type { ValidateInferredSchema } from "embedding-sdk-bundle/types/schema";
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
 import type { EditableDashboardProps } from "./EditableDashboard";
 
-const rawPropsSchema = strictObject({
-  children: optional(any()),
-  className: optional(any()),
-  dashboardId: nonoptional(any()),
-  dataPickerProps: optional(
-    strictObject({
-      entityTypes: optional(any()),
-    }),
-  ),
-  drillThroughQuestionHeight: optional(any()),
-  drillThroughQuestionProps: optional(
-    strictObject({
-      children: optional(any()),
-      className: optional(any()),
-      entityTypes: optional(any()),
-      height: optional(any()),
-      initialSqlParameters: optional(any()),
-      isSaveEnabled: optional(any()),
-      onBeforeSave: optional(any()),
-      onRun: optional(any()),
-      onSave: optional(any()),
-      plugins: optional(any()),
-      style: optional(any()),
-      targetCollection: optional(any()),
-      title: optional(any()),
-      width: optional(any()),
-      withChartTypeSelector: optional(any()),
-      withDownloads: optional(any()),
-      withResetButton: optional(any()),
-    }),
-  ),
-  hiddenParameters: optional(any()),
-  initialParameters: optional(any()),
-  onLoad: optional(any()),
-  onLoadWithoutCards: optional(any()),
-  plugins: optional(
-    strictObject({
-      mapQuestionClickActions: optional(any()),
-      dashboard: optional(any()),
-    }),
-  ),
-  renderDrillThroughQuestion: optional(any()),
-  style: optional(any()),
-  withCardTitle: optional(any()),
-  withDownloads: optional(any()),
-  withTitle: optional(any()),
-});
-const propsSchema: ValidateInferredSchema<
-  EditableDashboardProps,
-  zInfer<typeof rawPropsSchema>
-> = rawPropsSchema;
+const propsSchema: Yup.SchemaOf<EditableDashboardProps> = Yup.object({
+  children: Yup.mixed().optional(),
+  className: Yup.mixed().optional(),
+  dashboardId: Yup.mixed().required(),
+  dataPickerProps: Yup.object({
+    entityTypes: Yup.mixed().optional(),
+  })
+    .optional()
+    .noUnknown(),
+  drillThroughQuestionHeight: Yup.mixed().optional(),
+  drillThroughQuestionProps: Yup.object({
+    children: Yup.mixed().optional(),
+    className: Yup.mixed().optional(),
+    entityTypes: Yup.mixed().optional(),
+    height: Yup.mixed().optional(),
+    initialSqlParameters: Yup.mixed().optional(),
+    isSaveEnabled: Yup.mixed().optional(),
+    onBeforeSave: Yup.mixed().optional(),
+    onRun: Yup.mixed().optional(),
+    onSave: Yup.mixed().optional(),
+    plugins: Yup.mixed().optional(),
+    style: Yup.mixed().optional(),
+    targetCollection: Yup.mixed().optional(),
+    title: Yup.mixed().optional(),
+    width: Yup.mixed().optional(),
+    withChartTypeSelector: Yup.mixed().optional(),
+    withDownloads: Yup.mixed().optional(),
+    withResetButton: Yup.mixed().optional(),
+  })
+    .optional()
+    .noUnknown(),
+  hiddenParameters: Yup.mixed().optional(),
+  initialParameters: Yup.mixed().optional(),
+  onLoad: Yup.mixed().optional(),
+  onLoadWithoutCards: Yup.mixed().optional(),
+  plugins: Yup.object({
+    mapQuestionClickActions: Yup.mixed().optional(),
+    dashboard: Yup.mixed().optional(),
+  })
+    .optional()
+    .noUnknown(),
+  renderDrillThroughQuestion: Yup.mixed().optional(),
+  style: Yup.mixed().optional(),
+  withCardTitle: Yup.mixed().optional(),
+  withDownloads: Yup.mixed().optional(),
+  withTitle: Yup.mixed().optional(),
+}).noUnknown();
 
-export const editableDashboardSchema = functionSchema({
+export const editableDashboardSchema: FunctionSchema = {
   input: [propsSchema],
-});
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.schema.ts
@@ -24,7 +24,7 @@ const propsSchema: Yup.SchemaOf<InteractiveDashboardProps> = Yup.object({
     onBeforeSave: Yup.mixed().optional(),
     onRun: Yup.mixed().optional(),
     onSave: Yup.mixed().optional(),
-    plugins: Yup.object().optional(),
+    plugins: Yup.mixed().optional(),
     style: Yup.mixed().optional(),
     targetCollection: Yup.mixed().optional(),
     title: Yup.mixed().optional(),

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.schema.ts
@@ -1,68 +1,57 @@
-import {
-  any,
-  function as functionSchema,
-  nonoptional,
-  optional,
-  strictObject,
-} from "zod/mini";
-import type { infer as zInfer } from "zod/v4/core/core";
+import * as Yup from "yup";
 
-import type { ValidateInferredSchema } from "embedding-sdk-bundle/types/schema";
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
 import type { InteractiveDashboardProps } from "./InteractiveDashboard";
 
-const rawPropsSchema = strictObject({
-  children: optional(any()),
-  className: optional(any()),
-  dashboardId: nonoptional(any()),
-  dataPickerProps: optional(
-    strictObject({
-      entityTypes: optional(any()),
-    }),
-  ),
-  drillThroughQuestionHeight: optional(any()),
-  drillThroughQuestionProps: optional(
-    strictObject({
-      children: optional(any()),
-      className: optional(any()),
-      entityTypes: optional(any()),
-      height: optional(any()),
-      initialSqlParameters: optional(any()),
-      isSaveEnabled: optional(any()),
-      onBeforeSave: optional(any()),
-      onRun: optional(any()),
-      onSave: optional(any()),
-      plugins: optional(any()),
-      style: optional(any()),
-      targetCollection: optional(any()),
-      title: optional(any()),
-      width: optional(any()),
-      withChartTypeSelector: optional(any()),
-      withDownloads: optional(any()),
-      withResetButton: optional(any()),
-    }),
-  ),
-  hiddenParameters: optional(any()),
-  initialParameters: optional(any()),
-  onLoad: optional(any()),
-  onLoadWithoutCards: optional(any()),
-  plugins: optional(
-    strictObject({
-      mapQuestionClickActions: optional(any()),
-      dashboard: optional(any()),
-    }),
-  ),
-  renderDrillThroughQuestion: optional(any()),
-  style: optional(any()),
-  withCardTitle: optional(any()),
-  withDownloads: optional(any()),
-  withTitle: optional(any()),
-});
-const propsSchema: ValidateInferredSchema<
-  InteractiveDashboardProps,
-  zInfer<typeof rawPropsSchema>
-> = rawPropsSchema;
+const propsSchema: Yup.SchemaOf<InteractiveDashboardProps> = Yup.object({
+  children: Yup.mixed().optional(),
+  className: Yup.mixed().optional(),
+  dashboardId: Yup.mixed().required(),
+  dataPickerProps: Yup.object({
+    entityTypes: Yup.mixed().optional(),
+  })
+    .optional()
+    .noUnknown(),
+  drillThroughQuestionHeight: Yup.mixed().optional(),
+  drillThroughQuestionProps: Yup.object({
+    children: Yup.mixed().optional(),
+    className: Yup.mixed().optional(),
+    entityTypes: Yup.mixed().optional(),
+    height: Yup.mixed().optional(),
+    initialSqlParameters: Yup.mixed().optional(),
+    isSaveEnabled: Yup.mixed().optional(),
+    onBeforeSave: Yup.mixed().optional(),
+    onRun: Yup.mixed().optional(),
+    onSave: Yup.mixed().optional(),
+    plugins: Yup.object().optional(),
+    style: Yup.mixed().optional(),
+    targetCollection: Yup.mixed().optional(),
+    title: Yup.mixed().optional(),
+    width: Yup.mixed().optional(),
+    withChartTypeSelector: Yup.mixed().optional(),
+    withDownloads: Yup.mixed().optional(),
+    withResetButton: Yup.mixed().optional(),
+  })
+    .optional()
+    .noUnknown(),
+  hiddenParameters: Yup.mixed().optional(),
+  initialParameters: Yup.mixed().optional(),
+  onLoad: Yup.mixed().optional(),
+  onLoadWithoutCards: Yup.mixed().optional(),
+  plugins: Yup.object({
+    mapQuestionClickActions: Yup.mixed().optional(),
+    dashboard: Yup.mixed().optional(),
+  })
+    .optional()
+    .noUnknown(),
+  renderDrillThroughQuestion: Yup.mixed().optional(),
+  style: Yup.mixed().optional(),
+  withCardTitle: Yup.mixed().optional(),
+  withDownloads: Yup.mixed().optional(),
+  withTitle: Yup.mixed().optional(),
+}).noUnknown();
 
-export const interactiveDashboardSchema = functionSchema({
+export const interactiveDashboardSchema: FunctionSchema = {
   input: [propsSchema],
-});
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/StaticDashboard/StaticDashboard.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/StaticDashboard/StaticDashboard.schema.ts
@@ -1,45 +1,34 @@
-import {
-  any,
-  function as functionSchema,
-  nonoptional,
-  optional,
-  strictObject,
-} from "zod/mini";
-import type { infer as zInfer } from "zod/v4/core/core";
+import * as Yup from "yup";
 
-import type { ValidateInferredSchema } from "embedding-sdk-bundle/types/schema";
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
 import type { StaticDashboardProps } from "./StaticDashboard";
 
-const rawPropsSchema = strictObject({
-  children: optional(any()),
-  className: optional(any()),
-  dashboardId: nonoptional(any()),
-  dataPickerProps: optional(
-    strictObject({
-      entityTypes: optional(any()),
-    }),
-  ),
-  hiddenParameters: optional(any()),
-  initialParameters: optional(any()),
-  onLoad: optional(any()),
-  onLoadWithoutCards: optional(any()),
-  plugins: optional(
-    strictObject({
-      mapQuestionClickActions: optional(any()),
-      dashboard: optional(any()),
-    }),
-  ),
-  style: optional(any()),
-  withCardTitle: optional(any()),
-  withDownloads: optional(any()),
-  withTitle: optional(any()),
-});
-const propsSchema: ValidateInferredSchema<
-  StaticDashboardProps,
-  zInfer<typeof rawPropsSchema>
-> = rawPropsSchema;
+const propsSchema: Yup.SchemaOf<StaticDashboardProps> = Yup.object({
+  children: Yup.mixed().optional(),
+  className: Yup.mixed().optional(),
+  dashboardId: Yup.mixed().required(),
+  dataPickerProps: Yup.object({
+    entityTypes: Yup.mixed().optional(),
+  })
+    .optional()
+    .noUnknown(),
+  hiddenParameters: Yup.mixed().optional(),
+  initialParameters: Yup.mixed().optional(),
+  onLoad: Yup.mixed().optional(),
+  onLoadWithoutCards: Yup.mixed().optional(),
+  plugins: Yup.object({
+    mapQuestionClickActions: Yup.mixed().optional(),
+    dashboard: Yup.mixed().optional(),
+  })
+    .optional()
+    .noUnknown(),
+  style: Yup.mixed().optional(),
+  withCardTitle: Yup.mixed().optional(),
+  withDownloads: Yup.mixed().optional(),
+  withTitle: Yup.mixed().optional(),
+}).noUnknown();
 
-export const staticDashboardSchema = functionSchema({
+export const staticDashboardSchema: FunctionSchema = {
   input: [propsSchema],
-});
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/lib/validate-function-schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/lib/validate-function-schema.ts
@@ -1,13 +1,11 @@
-import type { ZodMiniFunction, ZodMiniTuple, core } from "zod/mini";
-import { safeParse } from "zod/mini";
+import type * as Yup from "yup";
 
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 import type {
   FunctionParametersSchemaValidationErrorMetadata,
   FunctionSchemaValidationResult,
   SchemaValidationErrorMetadata,
 } from "embedding-sdk-shared/types/validation";
-
-type FunctionSchema = ZodMiniFunction<ZodMiniTuple<any, null> | never, any>;
 
 const getErrorMetadata = <
   TMetadata extends
@@ -17,28 +15,22 @@ const getErrorMetadata = <
   error,
   parameterIndex,
 }: {
-  error: core.$ZodError;
+  error: Yup.ValidationError;
   parameterIndex?: number;
 }): TMetadata | null => {
-  for (const issue of error.issues) {
-    switch (issue.code) {
-      case "invalid_type":
-        if (issue.expected !== "nonoptional") {
-          break;
-        }
-
-        return {
-          errorCode: "missing_required_property",
-          data: issue.path[0]?.toString() ?? "",
-          parameterIndex,
-        } as TMetadata;
-      case "unrecognized_keys":
-        return {
-          errorCode: "unrecognized_keys",
-          data: issue.keys[0]?.toString() ?? "",
-          parameterIndex,
-        } as TMetadata;
-    }
+  switch (error.type) {
+    case "required":
+      return {
+        errorCode: "missing_required_property",
+        data: error.params?.path ?? "",
+        parameterIndex,
+      } as TMetadata;
+    case "noUnknown":
+      return {
+        errorCode: "unrecognized_keys",
+        data: error.params?.unknown ?? "",
+        parameterIndex,
+      } as TMetadata;
   }
 
   return null;
@@ -51,20 +43,25 @@ export const validateFunctionSchema = <
 >(
   schema: TSchema,
 ): FunctionSchemaValidationResult<TParameters, TReturnValue> => {
-  const parameterSchemas = schema.def.input.def.items;
-  const returnValueSchema = schema.def.output.def;
+  const parameterSchemas = schema.input;
+  const returnValueSchema = schema.output;
 
   const validateParameters = (parameters: TParameters) => {
     for (let i = 0; i < parameterSchemas.length; i++) {
       const parameter = parameters[i];
       const parameterSchema = parameterSchemas[i];
 
-      const parseResult = safeParse(parameterSchema, parameter);
+      try {
+        parameterSchema.validateSync(parameter, {
+          strict: true,
+        });
 
-      if (!parseResult.success) {
+        return { success: true };
+      } catch (_error: unknown) {
+        const error = _error as Yup.ValidationError;
         const errorMetadata =
           getErrorMetadata<FunctionParametersSchemaValidationErrorMetadata>({
-            error: parseResult.error,
+            error,
             parameterIndex: i,
           });
 
@@ -80,11 +77,20 @@ export const validateFunctionSchema = <
     return { success: true };
   };
   const validateReturnValue = (returnValue: TReturnValue) => {
-    const parseResult = safeParse(returnValueSchema, returnValue);
+    if (!returnValueSchema) {
+      return { success: true };
+    }
 
-    if (!parseResult.success) {
+    try {
+      returnValueSchema.validateSync(returnValue, {
+        strict: true,
+      });
+
+      return { success: true };
+    } catch (_error: unknown) {
+      const error = _error as Yup.ValidationError;
       const errorMetadata = getErrorMetadata<SchemaValidationErrorMetadata>({
-        error: parseResult.error,
+        error,
       });
 
       if (errorMetadata) {

--- a/enterprise/frontend/src/embedding-sdk-bundle/types/schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/types/schema.ts
@@ -1,19 +1,6 @@
-type ValidateTypeAgainstInferredSchema<TType, TSchemaInferType> =
-  Required<TType> extends Required<TSchemaInferType>
-    ? TType
-    : Required<TSchemaInferType>;
+import type * as Yup from "yup";
 
-type ValidateInferredSchemaAgainstType<TType, TSchemaInferType> =
-  Required<TSchemaInferType> extends Required<TType>
-    ? TSchemaInferType
-    : Required<TType>;
-
-export type ValidateInferredSchema<
-  TType extends ValidateTypeAgainstInferredSchema<_TType, _TSchemaInferType>,
-  TSchemaInferType extends ValidateInferredSchemaAgainstType<
-    _TType,
-    _TSchemaInferType
-  >,
-  _TType = TType,
-  _TSchemaInferType = TSchemaInferType,
-> = any;
+export type FunctionSchema = {
+  input: Yup.ObjectSchema<any>[];
+  output?: Yup.ObjectSchema<any>;
+};

--- a/package.json
+++ b/package.json
@@ -149,8 +149,7 @@
     "ttag": "1.7.21",
     "typescript": "^5.4.5",
     "underscore": "~1.13.3",
-    "yup": "^0.32.11",
-    "zod": "^4.1.5"
+    "yup": "^0.32.11"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22366,11 +22366,6 @@ yup@^0.32.11:
     property-expr "^2.0.4"
     toposort "^2.0.2"
 
-zod@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.5.tgz#7a21fc3178928ede50a28f7d0db4414c4cdb0161"
-  integrity sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==
-
 zrender@5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.6.0.tgz#01325b0bb38332dd5e87a8dbee7336cafc0f4a5b"


### PR DESCRIPTION
Replace Zod with Yup for SDK bundle schema validation

Context:
https://metaboat.slack.com/archives/C505ZNNH4/p1757607915951479

How to validate: 
- CI should pass