### PR TITLE
Send pulse skip legacy alerts

### DIFF
--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -126,5 +126,7 @@
                       ;; to fetch the Pulse.
                       models.pulse/hydrate-notification
                       (merge (when channel-ids {:channel-ids channel-ids})))]
-    (when (not (:archived dashboard))
+    (when (and (not (:archived dashboard))
+               ;; alerts now should be sent by notifications
+               (nil? (:alert_condition pulse)))
       (send-pulse!* pulse dashboard async?))))

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -126,7 +126,5 @@
                       ;; to fetch the Pulse.
                       models.pulse/hydrate-notification
                       (merge (when channel-ids {:channel-ids channel-ids})))]
-    (when (and (not (:archived dashboard))
-               ;; alerts now should be sent by notifications
-               (nil? (:alert_condition pulse)))
+    (when (not (:archived dashboard))
       (send-pulse!* pulse dashboard async?))))

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -52,11 +52,16 @@
     (task-history/with-task-history {:task         "send-pulse"
                                      :task_details {:pulse-id    pulse-id
                                                     :channel-ids (seq channel-ids)}}
-      (when-let [pulse (models.pulse/retrieve-notification pulse-id :archived false)]
-        (log/debugf "Starting Pulse Execution: %d" pulse-id)
-        (pulse.send/send-pulse! pulse :channel-ids channel-ids :async? true)
-        (log/debugf "Finished Pulse Execution: %d" pulse-id)
-        :done))
+      (if-let [pulse (models.pulse/retrieve-notification pulse-id
+                                                         :archived false
+                                                         ;; alerts should all be migrated to notifications by now
+                                                         :alert_condition nil)]
+        (do
+          (log/debugf "Starting Pulse Execution: %d" pulse-id)
+          (pulse.send/send-pulse! pulse :channel-ids channel-ids :async? true)
+          (log/debugf "Finished Pulse Execution: %d" pulse-id)
+          :done)
+        (log/debugf "Pulse %d not found, Skipping." pulse-id)))
     (catch Throwable e
       (log/errorf e "Error sending Pulse %d to channel ids: %s" pulse-id (str/join ", " channel-ids)))))
 

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -980,14 +980,13 @@
                                                        :type     :native
                                                        :native   {:query "SELECT 1 as A FROM generate_series(1,109);"}}}]
         (let [results (all-outputs! card {:export-format :csv})]
-          (is (= {:card-download            110
-                  :unsaved-card-download    110
-                  :alert-attachment         110
-                  :dashcard-download        110
-                  :subscription-attachment  110
-                  :public-question-download 110
-                  :public-dashcard-download 110}
-                 (update-vals results count)))))))
+          (is (=? {:card-download            110
+                   :unsaved-card-download    110
+                   :dashcard-download        110
+                   :subscription-attachment  110
+                   :public-question-download 110
+                   :public-dashcard-download 110}
+                  (update-vals results count)))))))
   (testing "Downloads row limit can be raised"
     (binding [qp.settings/*minimum-download-row-limit* 100]
       (mt/with-temporary-setting-values [download-row-limit 109]
@@ -996,14 +995,13 @@
                                                          :type     :native
                                                          :native   {:query "SELECT 1 as A FROM generate_series(1,109);"}}}]
           (let [results (all-outputs! card {:export-format :csv})]
-            (is (= {:card-download            110
-                    :unsaved-card-download    110
-                    :alert-attachment         110
-                    :dashcard-download        110
-                    :subscription-attachment  110
-                    :public-question-download 110
-                    :public-dashcard-download 110}
-                   (update-vals results count)))))))))
+            (is (=? {:card-download            110
+                     :unsaved-card-download    110
+                     :dashcard-download        110
+                     :subscription-attachment  110
+                     :public-question-download 110
+                     :public-dashcard-download 110}
+                    (update-vals results count)))))))))
 
 (deftest ^:parallel model-viz-settings-downloads-test
   (testing "A model's visualization settings are respected in downloads."

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -983,6 +983,7 @@
           (is (=? {:card-download            110
                    :unsaved-card-download    110
                    :dashcard-download        110
+                   :alert-attachment         110
                    :subscription-attachment  110
                    :public-question-download 110
                    :public-dashcard-download 110}
@@ -998,6 +999,7 @@
             (is (=? {:card-download            110
                      :unsaved-card-download    110
                      :dashcard-download        110
+                     :alert-attachment         110
                      :subscription-attachment  110
                      :public-question-download 110
                      :public-dashcard-download 110}

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -687,9 +687,9 @@
                                      :as pulse}   {:creator_id      (mt/user->id :rasta)
                                                    :name            (mt/random-name)
                                                    :alert_condition "rows"}
-                       :model/PulseChannel _      (merge {:pulse_id       pulse-id
-                                                          :channel_type   :slack
-                                                          :enabled        true
-                                                          :details        {:channel "#random"}})]
+                       :model/PulseChannel _      {:pulse_id       pulse-id
+                                                   :channel_type   :slack
+                                                   :enabled        true
+                                                   :details        {:channel "#random"}}]
           (pulse.send/send-pulse! pulse)
           (is (false? @pulse-sent-called?)))))))

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -678,3 +678,18 @@
     (is (empty? (-> (pulse.test-util/with-captured-channel-send-messages!
                       (pulse.send/send-pulse! (models.pulse/retrieve-notification pulse-id)))
                     :channel/email)))))
+
+(deftest send-skip-alert-test
+  (testing "alerts are skipped (#63189)"
+    (let [pulse-sent-called? (atom false)]
+      (with-redefs [pulse.send/send-pulse!* (fn [& _args])]
+        (mt/with-temp [:model/Pulse {pulse-id :id
+                                     :as pulse}   {:creator_id      (mt/user->id :rasta)
+                                                   :name            (mt/random-name)
+                                                   :alert_condition "rows"}
+                       :model/PulseChannel _      (merge {:pulse_id       pulse-id
+                                                          :channel_type   :slack
+                                                          :enabled        true
+                                                          :details        {:channel "#random"}})]
+          (pulse.send/send-pulse! pulse)
+          (is (false? @pulse-sent-called?)))))))

--- a/test/metabase/pulse/task/send_pulses_test.clj
+++ b/test/metabase/pulse/task/send_pulses_test.clj
@@ -246,9 +246,9 @@
                   original-send-pulse!* @#'task.send-pulses/send-pulse!*]
               (with-redefs [;; run the job every second - must be before creating PulseChannel
                             u.cron/schedule-map->cron-string (constantly "* * * 1/1 * ? *")
-                            task.send-pulses/send-pulse!*    (fn [pulse-id channel-ids trigger]
+                            task.send-pulses/send-pulse!*    (fn [pulse-id channel-ids]
                                                                (swap! send-pulse-called inc)
-                                                               (original-send-pulse!* pulse-id channel-ids trigger))
+                                                               (original-send-pulse!* pulse-id channel-ids))
                             pulse.send/send-pulse! (fn [pulse-id & _args]
                                                      (swap! sent-pulse-ids conj pulse-id))]
                 (mt/with-temp [:model/Pulse {pulse-id :id} {:creator_id      (mt/user->id :rasta)
@@ -265,7 +265,7 @@
                   (testing "waiting for cron job to fire"
                     (is (u/poll {:thunk      #(pos? @send-pulse-called)
                                  :done?      identity
-                                 :timeout-ms 2000})
+                                 :timeout-ms 5000})
                         "send-pulse!* was never called - cron job may not be firing"))
 
                   (testing "alert was not sent (no call to pulse.send/send-pulse!)"

--- a/test/metabase/pulse/task/send_pulses_test.clj
+++ b/test/metabase/pulse/task/send_pulses_test.clj
@@ -5,6 +5,7 @@
    [clojurewerkz.quartzite.triggers :as triggers]
    [java-time.api :as t]
    [metabase.driver :as driver]
+   [metabase.notification.test-util :as notification.tu]
    [metabase.pulse.models.pulse-channel-test :as pulse-channel-test]
    [metabase.pulse.send :as pulse.send]
    [metabase.pulse.task.send-pulses :as task.send-pulses]
@@ -233,6 +234,42 @@
                          :done?      #(= pc-count (count %))
                          :timeout-ms 3000})
                 (is (= (set pc-ids) @sent-channel-ids))))))))))
+
+(deftest send-pulse-skip-alert-test
+  (testing "alerts should not be sent even if they have triggers (#63189)"
+    (mt/test-helpers-set-global-values!
+      (pulse-channel-test/with-send-pulse-setup!
+        (mt/with-model-cleanup [:model/Pulse]
+          (notification.tu/with-captured-channel-send!
+            (let [sent-pulse-ids (atom #{})
+                  send-pulse-called (atom 0)]
+              (let [original-send-pulse!* @#'task.send-pulses/send-pulse!*]
+                (with-redefs [;; run the job every second - must be before creating PulseChannel
+                              u.cron/schedule-map->cron-string (constantly "* * * 1/1 * ? *")
+                              task.send-pulses/send-pulse!*    (fn [pulse-id channel-ids trigger]
+                                                                 (swap! send-pulse-called inc)
+                                                                 (original-send-pulse!* pulse-id channel-ids trigger))
+                              pulse.send/send-pulse! (fn [pulse-id & _args]
+                                                       (swap! sent-pulse-ids conj pulse-id))]
+                  (mt/with-temp [:model/Pulse {pulse-id :id} {:creator_id      (mt/user->id :rasta)
+                                                              :name            (mt/random-name)
+                                                              :alert_condition "rows"}
+                                 :model/PulseChannel _ (merge {:pulse_id       pulse-id
+                                                               :channel_type   :slack
+                                                               :enabled        true
+                                                               :details        {:channel "#random"}}
+                                                              daily-at-6pm)]
+                    (testing "trigger exists after creation"
+                      (is (= 1 (count (pulse-channel-test/send-pulse-triggers pulse-id)))))
+
+                    (testing "waiting for cron job to fire"
+                      (is (u/poll {:thunk      #(pos? @send-pulse-called)
+                                   :done?      identity
+                                   :timeout-ms 2000})
+                          "send-pulse!* was never called - cron job may not be firing"))
+
+                    (testing "alert was not sent (no call to pulse.send/send-pulse!)"
+                      (is (empty? @sent-pulse-ids)))))))))))))
 
 (def ^:private daily-at-8am
   {:schedule_type  "daily"

--- a/test/metabase/pulse/task/send_pulses_test.clj
+++ b/test/metabase/pulse/task/send_pulses_test.clj
@@ -242,34 +242,34 @@
         (mt/with-model-cleanup [:model/Pulse]
           (notification.tu/with-captured-channel-send!
             (let [sent-pulse-ids (atom #{})
-                  send-pulse-called (atom 0)]
-              (let [original-send-pulse!* @#'task.send-pulses/send-pulse!*]
-                (with-redefs [;; run the job every second - must be before creating PulseChannel
-                              u.cron/schedule-map->cron-string (constantly "* * * 1/1 * ? *")
-                              task.send-pulses/send-pulse!*    (fn [pulse-id channel-ids trigger]
-                                                                 (swap! send-pulse-called inc)
-                                                                 (original-send-pulse!* pulse-id channel-ids trigger))
-                              pulse.send/send-pulse! (fn [pulse-id & _args]
-                                                       (swap! sent-pulse-ids conj pulse-id))]
-                  (mt/with-temp [:model/Pulse {pulse-id :id} {:creator_id      (mt/user->id :rasta)
-                                                              :name            (mt/random-name)
-                                                              :alert_condition "rows"}
-                                 :model/PulseChannel _ (merge {:pulse_id       pulse-id
-                                                               :channel_type   :slack
-                                                               :enabled        true
-                                                               :details        {:channel "#random"}}
-                                                              daily-at-6pm)]
-                    (testing "trigger exists after creation"
-                      (is (= 1 (count (pulse-channel-test/send-pulse-triggers pulse-id)))))
+                  send-pulse-called (atom 0)
+                  original-send-pulse!* @#'task.send-pulses/send-pulse!*]
+              (with-redefs [;; run the job every second - must be before creating PulseChannel
+                            u.cron/schedule-map->cron-string (constantly "* * * 1/1 * ? *")
+                            task.send-pulses/send-pulse!*    (fn [pulse-id channel-ids trigger]
+                                                               (swap! send-pulse-called inc)
+                                                               (original-send-pulse!* pulse-id channel-ids trigger))
+                            pulse.send/send-pulse! (fn [pulse-id & _args]
+                                                     (swap! sent-pulse-ids conj pulse-id))]
+                (mt/with-temp [:model/Pulse {pulse-id :id} {:creator_id      (mt/user->id :rasta)
+                                                            :name            (mt/random-name)
+                                                            :alert_condition "rows"}
+                               :model/PulseChannel _ (merge {:pulse_id       pulse-id
+                                                             :channel_type   :slack
+                                                             :enabled        true
+                                                             :details        {:channel "#random"}}
+                                                            daily-at-6pm)]
+                  (testing "trigger exists after creation"
+                    (is (= 1 (count (pulse-channel-test/send-pulse-triggers pulse-id)))))
 
-                    (testing "waiting for cron job to fire"
-                      (is (u/poll {:thunk      #(pos? @send-pulse-called)
-                                   :done?      identity
-                                   :timeout-ms 2000})
-                          "send-pulse!* was never called - cron job may not be firing"))
+                  (testing "waiting for cron job to fire"
+                    (is (u/poll {:thunk      #(pos? @send-pulse-called)
+                                 :done?      identity
+                                 :timeout-ms 2000})
+                        "send-pulse!* was never called - cron job may not be firing"))
 
-                    (testing "alert was not sent (no call to pulse.send/send-pulse!)"
-                      (is (empty? @sent-pulse-ids)))))))))))))
+                  (testing "alert was not sent (no call to pulse.send/send-pulse!)"
+                    (is (empty? @sent-pulse-ids))))))))))))
 
 (def ^:private daily-at-8am
   {:schedule_type  "daily"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63189
Thread: https://metaboat.slack.com/archives/C052ZBWRG3W/p1757704378937449

Background: in 54, we've migrated alerts from pulse to the new notification system, as part of that process we don't archive the alerts on pulse tables because we want to be able to rollback. 
What we did to make sure the legacy won't be send is by deleting the quartz triggers for legacy pulse as part of the migration process. 

Though the above solution should ensure no old pulses will be sent, but it's might be that some naming pattern change and the we haven't fully deleted all the triggers of the legacy pulse. so some customers might experience this issue.

This PR add another layer of safeguard by making sure the send pulse api skip pulse that are alerts.
Ideally we should be able to clean up those triggers but unfortunately quartz doesn't allow self-cleaning a trigger while it's running.
I think it's alright as this should be a rare case and also we plan to migrate dashboard subscription to notification soon, once we do that we can clean up all of the remaining pulse triggers.
