### PR TITLE
Check for CSV uploads in embedding-hub checklist endpoint

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -56,7 +56,7 @@ describe("scenarios - embedding hub", () => {
       });
     });
 
-    it("Uploading CSVs should mark the 'Add Data' step as done", () => {
+    it("Uploading CSVs to sample database should mark the 'Add Data' step as done", () => {
       cy.intercept("GET", "/api/ee/embedding-hub/checklist").as("getChecklist");
 
       cy.log("Enable CSV uploads");

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -57,7 +57,9 @@ describe("scenarios - embedding hub", () => {
     });
 
     it("Uploading CSVs should mark the 'Add Data' step as done", () => {
-      cy.log("Enable uploads first");
+      cy.intercept("GET", "/api/ee/embedding-hub/checklist").as("getChecklist");
+
+      cy.log("Enable CSV uploads");
       cy.request("PUT", "/api/setting/uploads-settings", {
         value: {
           db_id: 1, // Sample Database ID
@@ -68,19 +70,15 @@ describe("scenarios - embedding hub", () => {
 
       cy.visit("/admin/embedding/setup-guide");
 
-      cy.log("Set up intercept for checklist updates");
-      cy.intercept("GET", "/api/ee/embedding-hub/checklist").as("getChecklist");
-
-      cy.log("Verify 'Add data' step is initially not done");
+      cy.log("'Add data' should not be marked as done");
       cy.findByTestId("admin-layout-content")
         .findByText("Add data")
         .closest("button")
-        .should("not.have.attr", "data-done", "true");
+        .findByText("Done")
+        .should("not.exist");
 
-      cy.log("Click on 'Add data' to open modal");
       cy.findByTestId("admin-layout-content").findByText("Add data").click();
 
-      cy.log("Switch to CSV tab in Add data modal");
       H.modal().within(() => {
         cy.findByText("CSV").click();
 
@@ -98,18 +96,18 @@ describe("scenarios - embedding hub", () => {
           { force: true },
         );
 
-        cy.log("Upload the file");
         cy.button("Upload").should("be.enabled").click();
       });
 
-      cy.log("Wait for checklist to update");
       cy.wait("@getChecklist");
 
-      cy.log("Verify 'Add data' step is now marked as done");
+      cy.log("'Add data' should be marked as done");
       cy.findByTestId("admin-layout-content")
         .findByText("Add data")
         .closest("button")
-        .should("have.attr", "data-done", "true");
+        .scrollIntoView()
+        .findByText("Done")
+        .should("be.visible");
     });
 
     it('"Create models" link should navigate correctly', () => {

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -1,6 +1,6 @@
 (ns metabase-enterprise.embedding-hub.api
   (:require
-   [metabase-enterprise.sso.settings :as sso]
+   [metabase-enterprise.sso.settings :as sso-settings]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.appearance.core :as appearance]
@@ -34,11 +34,11 @@
 
 (defn- has-configured-sandboxes? []
   (and (premium-features/has-feature? :sandboxes)
-       (t2/exists? :model/GroupTableAccessPolicy)))
+       (t2/exists? :model/Sandbox)))
 
 (defn- has-configured-sso? []
-  (or (and (premium-features/has-feature? :sso-jwt) (sso/jwt-enabled) (sso/jwt-configured))
-      (and (premium-features/has-feature? :sso-saml) (sso/saml-enabled) (sso/saml-configured))))
+  (or (and (premium-features/has-feature? :sso-jwt) (sso-settings/jwt-enabled) (sso-settings/jwt-configured))
+      (and (premium-features/has-feature? :sso-saml) (sso-settings/saml-enabled) (sso-settings/saml-configured))))
 
 (defn- embedding-hub-checklist []
   {"add-data"                      (has-user-added-database?)

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -13,9 +13,13 @@
   (or (t2/exists? :model/Database {:where [:and
                                            [:= :is_sample false]
                                            [:= :is_audit false]]})
-      (t2/exists? :model/Table {:where [:and
-                                        [:= :active true]
-                                        [:= :is_upload true]]})))
+      ;; check for CSV uploads to sample db
+      ;; as the sample db is excluded from the above query
+      (when-let [sample-db-id (t2/select-one-pk :model/Database :is_sample true)]
+        (t2/exists? :model/Table {:where [:and
+                                          [:= :active true]
+                                          [:= :is_upload true]
+                                          [:= :db_id sample-db-id]]}))))
 
 (defn- has-user-created-dashboard? []
   (let [example-dashboard-id (appearance/example-dashboard-id)

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -10,9 +10,12 @@
    [toucan2.core :as t2]))
 
 (defn- has-user-added-database? []
-  (t2/exists? :model/Database {:where [:and
-                                       [:= :is_sample false]
-                                       [:= :is_audit false]]}))
+  (or (t2/exists? :model/Database {:where [:and
+                                           [:= :is_sample false]
+                                           [:= :is_audit false]]})
+      (t2/exists? :model/Table {:where [:and
+                                        [:= :active true]
+                                        [:= :is_upload true]]})))
 
 (defn- has-user-created-dashboard? []
   (let [example-dashboard-id (appearance/example-dashboard-id)

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -144,6 +144,7 @@ export const cardApi = Api.injectEndpoints({
             listTag("card"),
             listTag("schema"),
             listTag("table"),
+            listTag("embedding-hub-checklist"),
           ]),
       }),
       updateCard: builder.mutation<Card, UpdateCardRequest>({

--- a/frontend/src/metabase/api/embedding-hub.ts
+++ b/frontend/src/metabase/api/embedding-hub.ts
@@ -1,5 +1,7 @@
 import { Api } from "metabase/api";
 
+import { listTag } from "./tags";
+
 type CheckListApiStep =
   | "create-dashboard"
   | "add-data"
@@ -16,6 +18,7 @@ export const embeddingHubApi = Api.injectEndpoints({
         method: "GET",
         url: "/api/ee/embedding-hub/checklist",
       }),
+      providesTags: [listTag("embedding-hub-checklist")],
     }),
   }),
 });

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -14,6 +14,7 @@ export const TAG_TYPES = [
   "dashboard-question-candidates",
   "database",
   "document",
+  "embedding-hub-checklist",
   "field",
   "field-values",
   "indexed-entity",


### PR DESCRIPTION
Closes EMB-805

Uploading CSVs from the "Add Data" modal in the embedding setup guide should mark the step as "Done" immediately.

### How to verify

- Go to "Admin Settings > Embedding > Setup guide"
- Click "Add Data"
- Enable uploads
- Go to "Admin Settings > Embedding > Setup guide"
- Click "Add Data"
- Upload a CSV file
- "Add Data" step should be marked as "Done" now.

### Demo

<img width="2078" height="1018" alt="CleanShot 2568-09-15 at 20 18 12@2x" src="https://github.com/user-attachments/assets/4603bf67-c6e4-49d3-8510-7840dfb707b3" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - E2E tests
