### PR TITLE
fix(white-labeling): Closes EMB-814 default to sans-serif if all else fails

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.tsx
@@ -24,7 +24,7 @@ const PublicComponentStylesWrapperInner = styled.div`
 
   font-weight: 400;
   color: var(--mb-color-text-dark);
-  font-family: var(--mb-default-font-family);
+  font-family: var(--mb-default-font-family), sans-serif;
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebar.styled.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebar.styled.tsx
@@ -26,7 +26,7 @@ export const BackButton = styled.button`
   display: flex;
   align-items: center;
   color: var(--mb-color-text-dark);
-  font-family: var(--mb-default-font-family);
+  font-family: var(--mb-default-font-family), sans-serif;
   font-weight: 700;
   font-size: 14px;
   padding: 0.5rem 0;

--- a/frontend/src/metabase/css/components/form.module.css
+++ b/frontend/src/metabase/css/components/form.module.css
@@ -28,7 +28,7 @@
 }
 
 .FormInput {
-  font-family: var(--mb-default-font-family);
+  font-family: var(--mb-default-font-family), sans-serif;
   font-weight: 700;
   font-size: 16px;
   color: var(--mb-color-text-dark);

--- a/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.module.css
+++ b/frontend/src/metabase/query_builder/components/expressions/Editor/HelpText/HelpText.module.css
@@ -42,7 +42,7 @@
 
 .info {
   color: var(--mb-color-text-primary);
-  font-family: var(--mb-default-font-family);
+  font-family: var(--mb-default-font-family), sans-serif;
   padding: 0.5rem;
   overflow: auto;
   border-top: 1px solid var(--mb-color-border);

--- a/frontend/src/metabase/ui/components/buttons/Button/Button.module.css
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.module.css
@@ -2,7 +2,7 @@
   --button-height-md: calc(2.5rem * var(--mantine-scale));
   --button-height-compact-md: calc(1.5rem * var(--mantine-scale));
 
-  font-family: var(--mb-default-font-family);
+  font-family: var(--mb-default-font-family), sans-serif;
   padding-inline: rem(15px);
   overflow: hidden;
   line-height: 1.15; /* mimic line-height ratio from mantine v6 */


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62694
Closes [EMB-814: Setting a custom font has some buttons still using browser default fonts](https://linear.app/metabase/issue/EMB-814/setting-a-custom-font-has-some-buttons-still-using-browser-default)

### Description

Some components would default to the browser's default font instead of falling back to sans-serif when an invalid custom font were used. This PR fixes the couple of places that had been forgotten when custom font were implemented.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Use a custom font that doesn't fully work (see original ticket)
2. Look at buttons