### PR TITLE
Fix flaky "Change target" behavior for transforms

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -694,7 +694,7 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
         .should("be.visible");
       H.assertQueryBuilderRowCount(3);
 
-      cy.log("verify that the original question still works");
+      cy.log("verify that the original question does not work");
       visitTableQuestion();
       assertTableDoesNotExistError();
     });

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -699,43 +699,37 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
       assertTableDoesNotExistError();
     });
 
-    it(
-      "should be able to delete the target and restore the same target back",
-      { tags: "@flaky" },
-      () => {
-        cy.log("create and run a transform");
-        createMbqlTransform({ visitTransform: true });
-        runTransformAndWaitForSuccess();
+    it("should be able to delete the target and restore the same target back", () => {
+      cy.log("create and run a transform");
+      createMbqlTransform({ visitTransform: true });
+      runTransformAndWaitForSuccess();
 
-        cy.log("delete the old target without creating the new one");
-        getTransformPage().button("Change target").click();
-        H.modal().within(() => {
-          cy.findByLabelText("Table name").clear().type(TARGET_TABLE_2);
-          cy.findByLabelText("Delete transform_table").click();
-          cy.button("Change target and delete the old one").click();
-          cy.wait("@deleteTransformTable");
-          cy.wait("@updateTransform");
-        });
+      cy.log("delete the old target without creating the new one");
+      getTransformPage().button("Change target").click();
+      H.modal().within(() => {
+        cy.findByLabelText("Table name").clear().type(TARGET_TABLE_2);
+        cy.findByLabelText("Delete transform_table").click();
+        cy.button("Change target and delete the old one").click();
+        cy.wait("@deleteTransformTable");
+        cy.wait("@updateTransform");
+      });
 
-        cy.log("change the target back to the original one");
-        getTransformPage().button("Change target").click();
-        H.modal().within(() => {
-          cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
-          cy.button("Change target").click();
-          cy.wait("@updateTransform");
-        });
+      cy.log("change the target back to the original one");
+      getTransformPage().button("Change target").click();
+      H.modal().within(() => {
+        cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
+        cy.button("Change target").click();
+        cy.wait("@updateTransform");
+      });
 
-        cy.log("run the transform to re-create the original target");
-        runTransformAndWaitForSuccess();
+      cy.log("run the transform to re-create the original target");
+      runTransformAndWaitForSuccess();
 
-        cy.log("verify the target is available");
-        getTableLink().click();
-        H.queryBuilderHeader()
-          .findByText("Transform Table")
-          .should("be.visible");
-        H.assertQueryBuilderRowCount(3);
-      },
-    );
+      cy.log("verify the target is available");
+      getTableLink().click();
+      H.queryBuilderHeader().findByText("Transform Table").should("be.visible");
+      H.assertQueryBuilderRowCount(3);
+    });
 
     it("should not allow to overwrite an existing table when changing the target", () => {
       createMbqlTransform({ visitTransform: true });

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobPage/JobPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobPage/JobPage.tsx
@@ -152,12 +152,12 @@ function JobPageBody({ job }: JobPageBodyProps) {
   );
 }
 
-export function getParsedParams({ jobId }: JobPageParams): JobPageParsedParams {
+function getParsedParams({ jobId }: JobPageParams): JobPageParsedParams {
   return {
     jobId: Urls.extractEntityId(jobId),
   };
 }
 
-export function isPollingNeeded(job?: TransformJob) {
+function isPollingNeeded(job?: TransformJob) {
   return job?.last_run?.status === "started";
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
@@ -28,7 +28,6 @@ import {
 } from "metabase/ui";
 import {
   useDeleteTransformTargetMutation,
-  useLazyGetTransformQuery,
   useUpdateTransformMutation,
 } from "metabase-enterprise/api";
 import { SchemaFormSelect } from "metabase-enterprise/transforms/components/SchemaFormSelect";
@@ -85,7 +84,6 @@ function UpdateTargetForm({
 }: UpdateTargetFormProps) {
   const { source, target, table } = transform;
   const { database: databaseId } = source.query;
-  const [fetchTransform] = useLazyGetTransformQuery();
   const [updateTransform] = useUpdateTransformMutation();
   const [deleteTransformTarget] = useDeleteTransformTargetMutation();
   const initialValues = useMemo(() => getInitialValues(transform), [transform]);
@@ -107,7 +105,6 @@ function UpdateTargetForm({
 
   const isLoading = isDatabaseLoading || isSchemasLoading;
   const error = databaseError ?? schemasError;
-
   const supportsSchemas = database && hasFeature(database, "schemas");
 
   if (isLoading || error != null) {
@@ -115,13 +112,10 @@ function UpdateTargetForm({
   }
 
   const handleSubmit = async (values: EditTransformValues) => {
-    // check that the new target is valid before deleting the old target
     await updateTransform(getUpdateRequest(transform, values)).unwrap();
     if (shouldDeleteTarget) {
       await deleteTransformTarget(transform.id).unwrap();
     }
-    // postpone closing the modal until we fetch the up-to-date transform
-    await fetchTransform(transform.id).unwrap();
     onUpdate();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
@@ -115,10 +115,12 @@ function UpdateTargetForm({
   }
 
   const handleSubmit = async (values: EditTransformValues) => {
+    // `updateTransform` throws when the target exists, so it needs to be called first
     await updateTransform(getUpdateRequest(transform, values)).unwrap();
     if (shouldDeleteTarget) {
       await deleteTransformTarget(transform.id).unwrap();
     }
+    // postpone closing the modal until we fetch the up-to-date transform
     await fetchTransform(transform.id).unwrap();
     onUpdate();
   };

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
@@ -119,7 +119,7 @@ function UpdateTargetForm({
     if (shouldDeleteTarget) {
       await deleteTransformTarget(transform.id).unwrap();
     }
-    await fetchTransform(transform.id);
+    await fetchTransform(transform.id).unwrap();
     onUpdate();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
@@ -28,6 +28,7 @@ import {
 } from "metabase/ui";
 import {
   useDeleteTransformTargetMutation,
+  useLazyGetTransformQuery,
   useUpdateTransformMutation,
 } from "metabase-enterprise/api";
 import { SchemaFormSelect } from "metabase-enterprise/transforms/components/SchemaFormSelect";
@@ -84,6 +85,7 @@ function UpdateTargetForm({
 }: UpdateTargetFormProps) {
   const { source, target, table } = transform;
   const { database: databaseId } = source.query;
+  const [fetchTransform] = useLazyGetTransformQuery();
   const [updateTransform] = useUpdateTransformMutation();
   const [deleteTransformTarget] = useDeleteTransformTargetMutation();
   const initialValues = useMemo(() => getInitialValues(transform), [transform]);
@@ -113,10 +115,11 @@ function UpdateTargetForm({
   }
 
   const handleSubmit = async (values: EditTransformValues) => {
+    await updateTransform(getUpdateRequest(transform, values)).unwrap();
     if (shouldDeleteTarget) {
       await deleteTransformTarget(transform.id).unwrap();
     }
-    await updateTransform(getUpdateRequest(transform, values)).unwrap();
+    await fetchTransform(transform.id);
     onUpdate();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
@@ -115,7 +115,7 @@ function UpdateTargetForm({
   }
 
   const handleSubmit = async (values: EditTransformValues) => {
-    // `updateTransform` throws when the target exists, so it needs to be called first
+    // check that the new target is valid before deleting the old target
     await updateTransform(getUpdateRequest(transform, values)).unwrap();
     if (shouldDeleteTarget) {
       await deleteTransformTarget(transform.id).unwrap();

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TargetSection/UpdateTargetModal/UpdateTargetModal.tsx
@@ -112,10 +112,10 @@ function UpdateTargetForm({
   }
 
   const handleSubmit = async (values: EditTransformValues) => {
-    await updateTransform(getUpdateRequest(transform, values)).unwrap();
     if (shouldDeleteTarget) {
       await deleteTransformTarget(transform.id).unwrap();
     }
+    await updateTransform(getUpdateRequest(transform, values)).unwrap();
     onUpdate();
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TransformPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TransformPage.tsx
@@ -67,7 +67,7 @@ export function TransformPage({ params }: TransformPageProps) {
   );
 }
 
-export function getParsedParams({
+function getParsedParams({
   transformId,
 }: TransformPageParams): TransformPageParsedParams {
   return {
@@ -75,7 +75,7 @@ export function getParsedParams({
   };
 }
 
-export function isPollingNeeded(transform?: Transform) {
+function isPollingNeeded(transform?: Transform) {
   const lastRun = transform?.last_run;
 
   if (transform == null || lastRun == null) {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TransformPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TransformPage.tsx
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { useState } from "react";
 import { t } from "ttag";
 
@@ -77,16 +76,21 @@ export function getParsedParams({
 }
 
 export function isPollingNeeded(transform?: Transform) {
-  if (transform == null || transform.last_run == null) {
+  const lastRun = transform?.last_run;
+  if (transform == null || lastRun == null) {
     return false;
   }
-  if (transform.last_run.status === "started") {
+  if (lastRun.status === "started") {
     return true;
   }
-  if (transform.last_run.status === "succeeded" && transform.table == null) {
-    const now = dayjs();
+  if (
+    transform.table == null &&
+    lastRun.status === "succeeded" &&
+    lastRun.end_time != null
+  ) {
+    const endedAt = parseTimestamp(lastRun.end_time);
     const updatedAt = parseTimestamp(transform.updated_at);
-    return updatedAt.isBefore(now);
+    return endedAt.isAfter(updatedAt);
   }
   return false;
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TransformPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/TransformPage.tsx
@@ -77,12 +77,18 @@ export function getParsedParams({
 
 export function isPollingNeeded(transform?: Transform) {
   const lastRun = transform?.last_run;
+
   if (transform == null || lastRun == null) {
     return false;
   }
+
   if (lastRun.status === "started") {
     return true;
   }
+
+  // If the last run succeeded but there is no table yet, wait for the sync to
+  // finish. If the transform is changed until the sync finishes, stop polling,
+  // because the table could be already deleted.
   if (
     transform.table == null &&
     lastRun.status === "succeeded" &&
@@ -92,5 +98,6 @@ export function isPollingNeeded(transform?: Transform) {
     const updatedAt = parseTimestamp(transform.updated_at);
     return endedAt.isAfter(updatedAt);
   }
+
   return false;
 }


### PR DESCRIPTION
Previously, when the target is deleted after a successful run, we indefinitely polled the transform endpoint. This caused issues with e2e tests. This behavior is now fixed, and the test is un-ignored.