### PR TITLE
Generate suggested prompts on startup

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1809,6 +1809,7 @@
            settings
            sync
            system
+           task
            users
            util
            warehouse-schema

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/init.clj
@@ -1,3 +1,4 @@
 (ns metabase-enterprise.metabot-v3.init
   (:require
-   [metabase-enterprise.metabot-v3.settings]))
+   [metabase-enterprise.metabot-v3.settings]
+   [metabase-enterprise.metabot-v3.task.suggested-prompts-generator]))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/suggested_prompts.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/suggested_prompts.clj
@@ -1,0 +1,66 @@
+(ns metabase-enterprise.metabot-v3.suggested-prompts
+  (:require
+   [medley.core :as m]
+   [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
+   [metabase-enterprise.metabot-v3.dummy-tools :as metabot-v3.dummy-tools]
+   [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
+   [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
+   [toucan2.core :as t2]))
+
+(defn- column-input
+  [answer-source-column]
+  (some-> answer-source-column (select-keys [:name :type :description :table-reference])))
+
+(defn- metric-input
+  [{:keys [queryable-dimensions default-time-dimension-field-id] :as answer-source-metric}]
+  (let [default-time-dimension (when default-time-dimension-field-id
+                                 (-> (m/find-first (comp #{default-time-dimension-field-id} :field-id)
+                                                   queryable-dimensions)
+                                     column-input))]
+    (-> answer-source-metric
+        (select-keys [:name :description])
+        (assoc :queryable-dimensions (map column-input queryable-dimensions))
+        (m/assoc-some :default-time-dimension default-time-dimension))))
+
+(defn- model-input
+  [answer-source-model]
+  (-> answer-source-model
+      (select-keys [:name :description :fields])
+      (update :fields #(map column-input %))))
+
+(def ^:private default-opts
+  {:limit 20})
+
+(defn generate-sample-prompts
+  "Generate suggested propmpts for instance of Metabot."
+  [metabot-id & {:as opts}]
+  (let [opts (merge default-opts opts)]
+    (lib.metadata.jvm/with-metadata-provider-cache
+      (let [cards (metabot-v3.tools.u/get-metrics-and-models metabot-id opts)
+            {metrics :metric, models :model}
+            (->> (for [[[card-type database-id] group-cards] (group-by (juxt :type :database_id) cards)
+                       detail (map (fn [detail card] (assoc detail ::origin card))
+                                   (metabot-v3.dummy-tools/cards-details card-type database-id group-cards nil)
+                                   group-cards)]
+                   detail)
+                 (group-by :type))
+            metric-inputs (map metric-input metrics)
+            model-inputs (map model-input models)
+            {:keys [table_questions metric_questions]}
+            (metabot-v3.client/generate-example-questions {:metrics metric-inputs, :tables model-inputs})
+            ->prompt (fn [{:keys [questions]} {::keys [origin]}]
+                       (let [base {:metabot_id metabot-id
+                                   :model      (:type origin)
+                                   :card_id    (:id origin)}]
+                         (map #(assoc base :prompt %) questions)))
+            metric-prompts (mapcat ->prompt metric_questions metrics)
+            model-prompts (mapcat ->prompt table_questions models)]
+        (when (seq metric-prompts)
+          (t2/insert! :model/MetabotPrompt metric-prompts))
+        (when (seq model-prompts)
+          (t2/insert! :model/MetabotPrompt model-prompts))))))
+
+(defn delete-all-metabot-prompts
+  "Drop suggested propmpts for instance of Metabot."
+  [metabot-id]
+  (t2/delete! :model/MetabotPrompt {:where [:= :metabot_id metabot-id]}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
@@ -1,0 +1,53 @@
+(ns metabase-enterprise.metabot-v3.task.suggested-prompts-generator
+  "Job to execute on start of an instance"
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
+   [metabase-enterprise.metabot-v3.suggested-prompts :as metabot-v3.suggested-prompts]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2])
+  (:import
+   (java.time Instant)
+   (java.util Date)
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private generator-job-key (jobs/key "metabase.task.metabot-v3.suggested-prompts-generator.job"))
+(def ^:private generator-trigger-key (triggers/key "metabase.task.metabot-v3.suggested-prompts-generator.trigger"))
+
+(defn- maybe-generate-suggested-prompts! []
+  (let [metabot-eid (get-in metabot-v3.config/metabot-config
+                            [metabot-v3.config/internal-metabot-id :entity-id])
+        metabot (t2/select-one :model/Metabot :entity_id metabot-eid)
+        metabot-id (:id metabot)
+        suggested-prompts-cnt (t2/count :model/MetabotPrompt :metabot_id metabot-id)]
+    (if (and (zero? suggested-prompts-cnt)
+             (:use_verified_content metabot))
+      (do
+        (log/info "No suggested prompts found. Generating suggested prompts.")
+        (metabot-v3.suggested-prompts/generate-sample-prompts metabot-id)
+        (log/info "Suggested prompts generated succesfully."))
+      (log/info "Suggested prompts are present. Not generating."))))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc "Initial _suggested prompts_ generation for internal Metabot."}
+  SuggestedPromptsGenerator [_ctx]
+  (maybe-generate-suggested-prompts!))
+
+(defmethod task/init! ::SuggestedPromptsGenerator
+  [_]
+  (when (and (premium-features/has-feature? :metabot-v3)
+             (premium-features/has-feature? :content-verification))
+    (let [job
+          (jobs/build
+           (jobs/of-type SuggestedPromptsGenerator)
+           (jobs/with-identity generator-job-key))
+          trigger (triggers/build
+                   (triggers/with-identity generator-trigger-key)
+                   ;; Start the job a moment after startup.
+                   (triggers/start-at (Date/from (.plusSeconds (Instant/now) 10))))]
+      (task/schedule-task! job trigger))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/metabot_test.clj
@@ -2,9 +2,9 @@
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
-   [metabase-enterprise.metabot-v3.api.metabot :as metabot-v3.api.metabot]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
+   [metabase-enterprise.metabot-v3.suggested-prompts :as metabot-v3.suggested-prompts]
    [metabase.collections.models.collection :as collection]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -215,7 +215,7 @@
                                                       :collection_id collection-id-1}]
 
         (testing "should update use_verified_content field"
-          (with-redefs [metabot-v3.api.metabot/generate-sample-prompts (constantly nil)]
+          (with-redefs [metabot-v3.suggested-prompts/generate-sample-prompts (constantly nil)]
             (let [response (mt/user-http-request :crowberto :put 200
                                                  (format "ee/metabot-v3/metabot/%d" metabot-id)
                                                  {:use_verified_content true})]
@@ -226,7 +226,7 @@
                 (is (true? (:use_verified_content updated-metabot)))))))
 
         (testing "should update collection_id field"
-          (with-redefs [metabot-v3.api.metabot/generate-sample-prompts (constantly nil)]
+          (with-redefs [metabot-v3.suggested-prompts/generate-sample-prompts (constantly nil)]
             (let [response (mt/user-http-request :crowberto :put 200
                                                  (format "ee/metabot-v3/metabot/%d" metabot-id)
                                                  {:collection_id collection-id-2})]
@@ -237,7 +237,7 @@
                 (is (= collection-id-2 (:collection_id updated-metabot)))))))
 
         (testing "should update collection_id to null"
-          (with-redefs [metabot-v3.api.metabot/generate-sample-prompts (constantly nil)]
+          (with-redefs [metabot-v3.suggested-prompts/generate-sample-prompts (constantly nil)]
             (let [response (mt/user-http-request :crowberto :put 200
                                                  (format "ee/metabot-v3/metabot/%d" metabot-id)
                                                  {:collection_id nil})]
@@ -247,7 +247,7 @@
                 (is (= nil (:collection_id updated-metabot)))))))
 
         (testing "should update all fields simultaneously"
-          (with-redefs [metabot-v3.api.metabot/generate-sample-prompts (constantly nil)]
+          (with-redefs [metabot-v3.suggested-prompts/generate-sample-prompts (constantly nil)]
             (let [response (mt/user-http-request :crowberto :put 200
                                                  (format "ee/metabot-v3/metabot/%d" metabot-id)
                                                  {:use_verified_content false
@@ -286,7 +286,7 @@
               (is (= nil (:collection_id unchanged-metabot))))
 
             ;; Verify that updating other fields still works
-            (with-redefs [metabot-v3.api.metabot/generate-sample-prompts (constantly nil)]
+            (with-redefs [metabot-v3.suggested-prompts/generate-sample-prompts (constantly nil)]
               (let [response (mt/user-http-request :crowberto :put 200
                                                    (format "ee/metabot-v3/metabot/%d" metabot-id)
                                                    {:use_verified_content true})]
@@ -331,7 +331,7 @@
             (let [original-prompt-ids #{prompt-id-1 prompt-id-2}]
 
               (testing "should regenerate prompts when use_verified_content changes"
-                (with-redefs [metabot-v3.api.metabot/generate-sample-prompts
+                (with-redefs [metabot-v3.suggested-prompts/generate-sample-prompts
                               (fn [metabot-id]
                                 (t2/insert! :model/MetabotPrompt {:metabot_id metabot-id
                                                                   :prompt "new prompt after verified change"
@@ -349,7 +349,7 @@
                     (is (= "new prompt after verified change" (:prompt (first current-prompts)))))))
 
               (testing "should regenerate prompts when collection_id changes"
-                (with-redefs [metabot-v3.api.metabot/generate-sample-prompts
+                (with-redefs [metabot-v3.suggested-prompts/generate-sample-prompts
                               (fn [metabot-id]
                                 (t2/insert! :model/MetabotPrompt {:metabot_id metabot-id
                                                                   :prompt "new prompt after collection change"
@@ -376,7 +376,7 @@
 
                             ;; Make a PUT request that doesn't change verified content or collection_id
                             ;; (This would be if we add other fields to update in the future)
-                  (with-redefs [metabot-v3.api.metabot/generate-sample-prompts
+                  (with-redefs [metabot-v3.suggested-prompts/generate-sample-prompts
                                 (fn [_] (throw (Exception. "Should not be called")))]
                     (mt/user-http-request :crowberto :put 200
                                           (format "ee/metabot-v3/metabot/%d" metabot-id)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/task/suggested_prompts_generator_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/task/suggested_prompts_generator_test.clj
@@ -1,0 +1,47 @@
+(ns metabase-enterprise.metabot-v3.task.suggested-prompts-generator-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
+   [metabase-enterprise.metabot-v3.task.suggested-prompts-generator
+    :as metabot-v3.task.suggested-prompts-generator]
+   [metabase.lib.convert :as lib.convert]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest suggested-prompts-generator-test
+  (when (and (premium-features/has-feature? :metabot-v3)
+             (premium-features/has-feature? :content-verification))
+    (let [original-metabot (t2/select-one :model/Metabot
+                                          :entity_id (get-in metabot-v3.config/metabot-config
+                                                             [metabot-v3.config/internal-metabot-id :entity-id]))
+          mp (mt/metadata-provider)
+          query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                    lib.convert/->legacy-MBQL)
+          admin-id (:id (mt/fetch-user :crowberto))]
+      (testing "Internal Metabot defaults to truthy use_verified_content"
+        (is (true? (:use_verified_content original-metabot))))
+      (mt/with-model-cleanup [:model/MetabotPrompt]
+        (mt/with-temp
+          [:model/Card
+           {card-id :id}
+           {:type :model
+            :dataset_query query}]
+          (testing "No prompts generated for non-verified cards"
+            (#'metabot-v3.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+            (is (empty? (t2/select :model/MetabotPrompt))))
+          (testing "Prompts generated with verified card"
+            (mt/with-temp
+              [:model/ModerationReview
+               _
+               {:moderator_id admin-id
+                :moderated_item_id card-id
+                :moderated_item_type "card"
+                :status "verified"
+                :most_recent true}]
+              (#'metabot-v3.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+              (let [prompts (t2/select :model/MetabotPrompt)]
+                (is (and (seq prompts)
+                         (every? (comp #{card-id} :card_id) prompts)))))))))))

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -786,6 +786,20 @@ databaseChangeLog:
                   name: conversation_id
       rollback: # will be dropped with table
 
+  - changeSet:
+      id: v56.2025-09-15T17:12:11
+      author: lbrdnk
+      comment: Make the use_verified_content default to true for internal Metabot
+      changes:
+        - update:
+            tableName: metabot
+            columns:
+              - column:
+                  name: use_verified_content
+                  valueBoolean: true
+            where: entity_id = 'metabotmetabotmetabot'
+      rollback:
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-373/suggested-prompts

This PR adds one-off job that (1) checks whether there are some suggested prompts present and (2) internal Metabot has truthy `use_verified_content`. Prompts are generated if both conditions are met.

It adds migration that changes value of `use_verified_content` to true. Hence prompts will be generated automatically for instances migrating into this version, having verified content.

Instances with no verified content will have blank suggested prompts unless explicitly generated by an admin.