### PR TITLE
Allow going back to snippet root collection

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/SnippetSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/SnippetSidebar.jsx
@@ -93,14 +93,15 @@ class SnippetSidebarInner extends React.Component {
         )
       : _.sortBy(search, "model"); // relies on "collection" sorting before "snippet";
 
-    const hasParentCollection = snippetCollection.parent_id !== null;
     const onSnippetCollectionBack = () => {
+      const parentCollectionId = snippetCollection.parent_id ?? "root";
+
       // if this collection's parent isn't in the list,
       // we don't have perms to see it, return to the root instead
       const hasPermissionToSeeParent = snippetCollections.some(
         (collection) =>
           canonicalCollectionId(collection.id) ===
-          canonicalCollectionId(snippetCollection.parent_id),
+          canonicalCollectionId(parentCollectionId),
       );
 
       const targetId = hasPermissionToSeeParent
@@ -151,9 +152,7 @@ class SnippetSidebarInner extends React.Component {
                   ) : (
                     <SidebarHeader
                       title={snippetCollection.name}
-                      onBack={
-                        hasParentCollection ? onSnippetCollectionBack : null
-                      }
+                      onBack={onSnippetCollectionBack}
                     />
                   )}
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63405

### To verify

1. New SQL Question
2. Open snippet sidebar
3. Create a snippet folder
4. Navigate to the folder
5. You should be able to go back to the root folder

I added tests for the base case. 

I'm not sure how to test the case where the user does not have access to the parent folder, since it's also impossible to navigate to nested folders if that is the case. 