### PR TITLE
PRG-130 Send parse connection string parsing events only on blur

### DIFF
--- a/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
@@ -359,13 +359,12 @@ describe("Database connection strings", () => {
   });
 });
 
-describe("Database connection strings events", () => {
+H.describeWithSnowplow("Database connection strings events", () => {
   beforeEach(() => {
     H.resetSnowplow();
     H.restore();
     H.enableTracking();
-    cy.visit("/admin/databases/create");
-    chooseDatabase("MySQL");
+    cy.visit("/admin/databases/create?engine=mysql");
   });
 
   it("should track success events correctly", () => {

--- a/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
@@ -369,6 +369,11 @@ describe("Database connection strings events", () => {
   });
 
   it("should track success events correctly", () => {
+    const successEvent = {
+      event: "connection_string_parsed_success",
+      triggered_from: "full-page",
+    };
+
     cy.findByLabelText("Connection string (optional)")
       .focus()
       .paste("jdbc:mysql://testuser:testpass@host:3306/dbname?ssl=true")
@@ -380,13 +385,13 @@ describe("Database connection strings events", () => {
 
     cy.findByLabelText("Display name").click();
 
-    H.expectUnstructuredSnowplowEvent(
-      {
-        event: "connection_string_parsed_success",
-        triggered_from: "full-page",
-      },
-      1,
-    );
+    H.expectUnstructuredSnowplowEvent(successEvent, 1);
+
+    cy.findByLabelText("Connection string (optional)").click();
+    cy.findByLabelText("Display name").click();
+
+    // Should not track the same event again
+    H.expectUnstructuredSnowplowEvent(successEvent, 1);
   });
 
   it("should track failure events correctly", () => {

--- a/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
@@ -199,8 +199,6 @@ const databaseTestCases = [
 ];
 
 describe("Database connection strings", () => {
-  beforeEach(() => {});
-
   it("should parse connection strings for all supported databases", () => {
     cy.visit("/admin/databases/create");
 
@@ -244,47 +242,6 @@ describe("Database connection strings", () => {
     cy.findByLabelText("Connection string (optional)").paste("invalid");
 
     cy.findByTextEnsureVisible("Couldn’t use this connection string.");
-  });
-
-  it("should track correctly", () => {
-    H.resetSnowplow();
-    H.restore();
-    H.enableTracking();
-    cy.visit("/admin/databases/create");
-
-    chooseDatabase("MySQL");
-
-    cy.findByLabelText("Connection string (optional)")
-      .focus()
-      .paste("jdbc:mysql://testuser:testpass@host:3306/dbname?ssl=true")
-      .paste("jdbc:mysql://a:b@c:3/dbname?ssl=false");
-
-    // go to the next field
-    cy.findByLabelText("Display name").click();
-
-    H.expectUnstructuredSnowplowEvent(
-      {
-        event: "connection_string_parsed_success",
-        triggered_from: "full-page",
-      },
-      1,
-    );
-
-    cy.findByLabelText("Connection string (optional)")
-      .focus()
-      .paste("broken string")
-      .type("also not a valid string");
-
-    // go to the next field
-    cy.findByLabelText("Display name").click();
-
-    H.expectUnstructuredSnowplowEvent(
-      {
-        event: "connection_string_parsed_failed",
-        triggered_from: "full-page",
-      },
-      1,
-    );
   });
 
   it("should not clear the existing values", () => {
@@ -399,5 +356,48 @@ describe("Database connection strings", () => {
 
       cy.button("Failed").should("exist");
     });
+  });
+});
+
+describe("Database connection strings events", () => {
+  it("should track correctly", () => {
+    H.resetSnowplow();
+    H.restore();
+    H.enableTracking();
+    cy.visit("/admin/databases/create");
+
+    chooseDatabase("MySQL");
+
+    cy.findByLabelText("Connection string (optional)")
+      .focus()
+      .paste("jdbc:mysql://testuser:testpass@host:3306/dbname?ssl=true")
+      .paste("jdbc:mysql://a:b@c:3/dbname?ssl=false");
+
+    // go to the next field
+    cy.findByLabelText("Display name").click();
+
+    H.expectUnstructuredSnowplowEvent(
+      {
+        event: "connection_string_parsed_success",
+        triggered_from: "full-page",
+      },
+      1,
+    );
+
+    cy.findByLabelText("Connection string (optional)")
+      .focus()
+      .paste("broken string")
+      .type("also not a valid string");
+
+    // go to the next field
+    cy.findByLabelText("Display name").click();
+
+    H.expectUnstructuredSnowplowEvent(
+      {
+        event: "connection_string_parsed_failed",
+        triggered_from: "full-page",
+      },
+      1,
+    );
   });
 });

--- a/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-connection-strings.cy.spec.ts
@@ -360,20 +360,24 @@ describe("Database connection strings", () => {
 });
 
 describe("Database connection strings events", () => {
-  it("should track correctly", () => {
+  beforeEach(() => {
     H.resetSnowplow();
     H.restore();
     H.enableTracking();
     cy.visit("/admin/databases/create");
-
     chooseDatabase("MySQL");
+  });
 
+  it("should track success events correctly", () => {
     cy.findByLabelText("Connection string (optional)")
       .focus()
       .paste("jdbc:mysql://testuser:testpass@host:3306/dbname?ssl=true")
       .paste("jdbc:mysql://a:b@c:3/dbname?ssl=false");
 
-    // go to the next field
+    cy.findByTextEnsureVisible("Connection details pre-filled below.").should(
+      "exist",
+    );
+
     cy.findByLabelText("Display name").click();
 
     H.expectUnstructuredSnowplowEvent(
@@ -383,13 +387,18 @@ describe("Database connection strings events", () => {
       },
       1,
     );
+  });
 
+  it("should track failure events correctly", () => {
     cy.findByLabelText("Connection string (optional)")
       .focus()
       .paste("broken string")
       .type("also not a valid string");
 
-    // go to the next field
+    cy.findByTextEnsureVisible("Couldn’t use this connection string.").should(
+      "exist",
+    );
+
     cy.findByLabelText("Display name").click();
 
     H.expectUnstructuredSnowplowEvent(

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
@@ -2,7 +2,6 @@ import { usePrevious, useTimeout } from "@mantine/hooks";
 import type { FormikErrors } from "formik";
 import { useField } from "formik";
 import { type SetStateAction, useEffect, useRef, useState } from "react";
-import { match } from "ts-pattern";
 import { c, t } from "ttag";
 
 import { Group, Icon, Text, Textarea, Transition } from "metabase/ui";
@@ -102,17 +101,13 @@ export function DatabaseConnectionStringField({
   ]);
 
   function handleBlur() {
-    match(lastClearedStatusRef.current)
-      .with("success", () => {
-        connectionStringParsedSuccess(location);
-      })
-      .with("failure", () => {
-        connectionStringParsedFailed(location);
-      })
-      .with(null, () => {
-        return;
-      })
-      .exhaustive();
+    if (lastClearedStatusRef.current === "success") {
+      connectionStringParsedSuccess(location);
+    }
+
+    if (lastClearedStatusRef.current === "failure") {
+      connectionStringParsedFailed(location);
+    }
 
     lastClearedStatusRef.current = null;
   }

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
@@ -113,6 +113,8 @@ export function DatabaseConnectionStringField({
         return;
       })
       .exhaustive();
+
+    lastClearedStatusRef.current = null;
   }
 
   if (!isEngineKey(engineKey)) {


### PR DESCRIPTION
Closes [PRG-130: Limit input change events to paste or focus out only](https://linear.app/metabase/issue/PRG-130/limit-input-change-events-to-paste-or-focus-out-only)

### Description

The events are now only send on blur (focus out). 
Since the status of the field is cleared after a delay, I had to introduce another state variable, so correct event even after UI status is cleared.

### How to verify

Paste good and bad connection strings and type into field and observe if only after blur a correct (last one) even types is sent.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
