### PR TITLE
Replace the language selection step on the setup flow with the language selector

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -34,8 +34,6 @@ describe("scenarios > setup", () => {
         skipWelcomePage();
 
         cy.findByTestId("setup-forms").within(() => {
-          selectPreferredLanguageAndContinue();
-
           // ====
           // User
           // ====
@@ -153,8 +151,6 @@ describe("scenarios > setup", () => {
     skipWelcomePage();
 
     cy.findByTestId("setup-forms").within(() => {
-      selectPreferredLanguageAndContinue();
-
       // User
       fillUserAndContinue({
         ...admin,
@@ -212,8 +208,6 @@ describe("scenarios > setup", () => {
 
     skipWelcomePage();
 
-    selectPreferredLanguageAndContinue();
-
     cy.findByTestId("setup-forms").within(() => {
       cy.findByLabelText("First name").should("have.value", "Testy");
       cy.findByLabelText("Last name").should("have.value", "McTestface");
@@ -233,7 +227,6 @@ describe("scenarios > setup", () => {
     );
 
     skipWelcomePage();
-    selectPreferredLanguageAndContinue();
 
     cy.findByTestId("setup-forms").within(() => {
       cy.findByDisplayValue("John").should("exist");
@@ -321,9 +314,9 @@ describe("scenarios > setup", () => {
       .should("be.visible");
   });
 
-  it("should allow localization in the 'embedding' setup flow", () => {
+  it("should allow localization in the setup flow", () => {
     cy.visit(
-      "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited&use_case=embedding",
+      "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited",
     );
 
     cy.log("English is the initial language");
@@ -373,8 +366,6 @@ describe("scenarios > setup", () => {
     cy.visit("/setup#123456");
 
     skipWelcomePage();
-
-    selectPreferredLanguageAndContinue();
 
     cy.findByLabelText(/What should we call you/);
 
@@ -455,8 +446,6 @@ describe("scenarios > setup", () => {
 
     skipWelcomePage();
 
-    selectPreferredLanguageAndContinue();
-
     cy.findByTestId("setup-forms").within(() => {
       // User
       fillUserAndContinue({
@@ -532,8 +521,6 @@ describe("scenarios > setup (EE)", () => {
 
     skipWelcomePage();
 
-    selectPreferredLanguageAndContinue();
-
     cy.findByTestId("setup-forms").within(() => {
       fillUserAndContinue({
         ...admin,
@@ -591,7 +578,6 @@ H.describeWithSnowplow("scenarios > setup", () => {
       step_number: 1,
       step: "language",
     });
-    selectPreferredLanguageAndContinue();
 
     H.expectUnstructuredSnowplowEvent({
       event: "step_seen",
@@ -684,7 +670,6 @@ H.describeWithSnowplow("scenarios > setup", () => {
     H.blockSnowplow();
     cy.visit("/setup");
     skipWelcomePage();
-    selectPreferredLanguageAndContinue();
     H.assertNoUnstructuredSnowplowEvent({
       event: "step_seen",
     });
@@ -696,13 +681,6 @@ const skipWelcomePage = () => {
     cy.findByText("Welcome to Metabase");
     cy.findByText("Let's get started").click();
   });
-};
-
-const selectPreferredLanguageAndContinue = () => {
-  cy.findByTestId("step-number").should("have.text", "1");
-  cy.findByText("What's your preferred language?");
-  cy.findByLabelText("English");
-  cy.findByText("Next").click();
 };
 
 const fillUserAndContinue = ({
@@ -764,7 +742,6 @@ const navigateToDatabaseStep = () => {
   );
 
   skipWelcomePage();
-  selectPreferredLanguageAndContinue();
 
   cy.findByTestId("setup-forms").within(() => {
     const password = "12341234";

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -358,6 +358,8 @@ describe("scenarios > setup", () => {
   });
 
   it("should update the site locale setting when changing language in setup", () => {
+    cy.intercept("PUT", "/api/setting/site-locale").as("updateSiteLocale");
+
     cy.visit(
       "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited&use_case=embedding",
     );
@@ -370,6 +372,9 @@ describe("scenarios > setup", () => {
       .click();
 
     H.popover().findByText("Dutch").should("be.visible").click();
+
+    cy.log("Verify site locale does not get updated before a user is created");
+    cy.get("@updateSiteLocale.all").should("have.length", 0);
 
     cy.findByTestId("setup-forms").within(() => {
       const password = "12341234";

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -362,6 +362,7 @@ describe("scenarios > setup", () => {
       "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited&use_case=embedding",
     );
 
+    cy.log("Change language to Dutch before user creation");
     cy.get("header")
       .should("be.visible")
       .findByLabelText("Select a language")
@@ -381,13 +382,35 @@ describe("scenarios > setup", () => {
       cy.findByLabelText("Hallo, John. Leuk je te ontmoeten!").should(
         "be.visible",
       );
+    });
 
-      cy.findByText("Breng me naar Metabase").click();
+    cy.log("After user creation, change language to German");
+    cy.get("header")
+      .should("be.visible")
+      .findByLabelText("Selecteer een taal")
+      .should("have.value", "Dutch")
+      .click();
+
+    H.popover()
+      .findByText("German")
+      .scrollIntoView()
+      .should("be.visible")
+      .click();
+
+    cy.findByTestId("setup-forms").within(() => {
+      cy.findByText("Ich aktiviere später").click();
+      cy.findByText("Beenden").click();
+      cy.findByText("Führe mich zu Metabase").click();
     });
 
     cy.location("pathname").should("eq", "/");
 
-    H.main().findByText("Metabase insluiten").should("be.visible");
+    cy.log("Verify final language (German) is preserved");
+    H.main()
+      .findByText(
+        "Erste Schritte mit der Einbettung der Metabase in Ihre Anwendung",
+      )
+      .should("be.visible");
   });
 
   it("should allow you to connect a db during setup", () => {

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -357,6 +357,39 @@ describe("scenarios > setup", () => {
       .should("be.visible");
   });
 
+  it("should update the site locale setting when changing language in setup", () => {
+    cy.visit(
+      "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited&use_case=embedding",
+    );
+
+    cy.get("header")
+      .should("be.visible")
+      .findByLabelText("Select a language")
+      .should("have.value", "English")
+      .click();
+
+    H.popover().findByText("Dutch").should("be.visible").click();
+
+    cy.findByTestId("setup-forms").within(() => {
+      const password = "12341234";
+
+      cy.findByDisplayValue("John").should("exist");
+      cy.findByLabelText("Maak een wachtwoord").type(password);
+      cy.findByLabelText("Bevestig je wachtwoord").type(password);
+      cy.button("Volgende").click();
+
+      cy.findByLabelText("Hallo, John. Leuk je te ontmoeten!").should(
+        "be.visible",
+      );
+
+      cy.findByText("Breng me naar Metabase").click();
+    });
+
+    cy.location("pathname").should("eq", "/");
+
+    H.main().findByText("Metabase insluiten").should("be.visible");
+  });
+
   it("should allow you to connect a db during setup", () => {
     const dbName = "SQLite db";
 

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -255,7 +255,7 @@ describe("scenarios > setup", () => {
     H.mockSessionProperty("email-configured?", true);
 
     navigateToDatabaseStep();
-    cy.findByTestId("step-number").should("have.text", "4");
+    cy.findByTestId("step-number").should("have.text", "3");
 
     cy.findByLabelText("Setup section").click();
     cy.findByLabelText("First name").type("TeammateFirstName");
@@ -280,7 +280,7 @@ describe("scenarios > setup", () => {
     });
 
     // Checks we are now in the next step
-    cy.findByTestId("step-number").should("have.text", "5");
+    cy.findByTestId("step-number").should("have.text", "4");
   });
 
   it("should allow a quick setup for the 'embedding' use case", () => {
@@ -314,9 +314,9 @@ describe("scenarios > setup", () => {
       .should("be.visible");
   });
 
-  it("should allow localization in the setup flow", () => {
+  it("should allow localization in the 'embedding' setup flow", () => {
     cy.visit(
-      "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited",
+      "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited&use_case=embedding",
     );
 
     cy.log("English is the initial language");
@@ -576,12 +576,6 @@ H.describeWithSnowplow("scenarios > setup", () => {
     H.expectUnstructuredSnowplowEvent({
       event: "step_seen",
       step_number: 1,
-      step: "language",
-    });
-
-    H.expectUnstructuredSnowplowEvent({
-      event: "step_seen",
-      step_number: 2,
       step: "user_info",
     });
 
@@ -594,7 +588,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
       cy.findByText("What will you use Metabase for?").should("exist");
       H.expectUnstructuredSnowplowEvent({
         event: "step_seen",
-        step_number: 3,
+        step_number: 2,
         step: "usage_question",
       });
       cy.button("Next").click();
@@ -606,7 +600,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "step_seen",
-        step_number: 4,
+        step_number: 3,
         step: "db_connection",
       });
       cy.findByText("Continue with sample data").click();
@@ -619,7 +613,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
       if (IS_ENTERPRISE) {
         H.expectUnstructuredSnowplowEvent({
           event: "step_seen",
-          step_number: 5,
+          step_number: 4,
           step: "license_token",
         });
 
@@ -632,7 +626,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "step_seen",
-        step_number: IS_ENTERPRISE ? 6 : 5,
+        step_number: IS_ENTERPRISE ? 5 : 4,
         step: "data_usage",
       });
 
@@ -640,7 +634,7 @@ H.describeWithSnowplow("scenarios > setup", () => {
 
       H.expectUnstructuredSnowplowEvent({
         event: "step_seen",
-        step_number: IS_ENTERPRISE ? 7 : 6,
+        step_number: IS_ENTERPRISE ? 6 : 5,
         step: "completed",
       });
 

--- a/frontend/src/metabase/setup/components/LanguageSelector/LanguageSelector.tsx
+++ b/frontend/src/metabase/setup/components/LanguageSelector/LanguageSelector.tsx
@@ -4,7 +4,11 @@ import { findWhere } from "underscore";
 
 import { useUpdateSettingsMutation } from "metabase/api";
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import { getAvailableLocales, getLocale } from "metabase/setup/selectors";
+import {
+  getAvailableLocales,
+  getLocale,
+  getUser,
+} from "metabase/setup/selectors";
 import { Select } from "metabase/ui";
 
 import { updateLocale } from "../../actions";
@@ -14,6 +18,7 @@ export const LanguageSelector = () => {
   const dispatch = useDispatch();
   const locale = useSelector(getLocale);
   const localeData = useSelector(getAvailableLocales);
+  const user = useSelector(getUser);
   const [updateSettings] = useUpdateSettingsMutation();
 
   const locales = useMemo(() => getLocales(localeData), [localeData]);
@@ -24,7 +29,12 @@ export const LanguageSelector = () => {
 
     if (locale) {
       dispatch(updateLocale(locale));
-      await updateSettings({ "site-locale": locale.code });
+
+      // Only update site-locale setting if the user has been created.
+      // This prevents the API request from failing before the user creation step.
+      if (user) {
+        await updateSettings({ "site-locale": locale.code });
+      }
     }
   };
 

--- a/frontend/src/metabase/setup/components/LanguageSelector/LanguageSelector.tsx
+++ b/frontend/src/metabase/setup/components/LanguageSelector/LanguageSelector.tsx
@@ -35,6 +35,7 @@ export const LanguageSelector = () => {
       data={languages}
       value={locale?.name || "English"}
       onChange={handleLocaleChange}
+      comboboxProps={{ width: "12.5rem", position: "bottom-end" }}
     />
   );
 };

--- a/frontend/src/metabase/setup/components/LanguageSelector/LanguageSelector.tsx
+++ b/frontend/src/metabase/setup/components/LanguageSelector/LanguageSelector.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { t } from "ttag";
 import { findWhere } from "underscore";
 
+import { useUpdateSettingsMutation } from "metabase/api";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { getAvailableLocales, getLocale } from "metabase/setup/selectors";
 import { Select } from "metabase/ui";
@@ -13,15 +14,17 @@ export const LanguageSelector = () => {
   const dispatch = useDispatch();
   const locale = useSelector(getLocale);
   const localeData = useSelector(getAvailableLocales);
+  const [updateSettings] = useUpdateSettingsMutation();
 
   const locales = useMemo(() => getLocales(localeData), [localeData]);
   const languages = useMemo(() => locales.map(({ name }) => name), [locales]);
 
-  const handleLocaleChange = (language: string) => {
+  const handleLocaleChange = async (language: string) => {
     const locale = findWhere(locales, { name: language });
 
     if (locale) {
       dispatch(updateLocale(locale));
+      await updateSettings({ "site-locale": locale.code });
     }
   };
 

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { getLocalizationNoticeText } from "metabase/common/components/CommunityLocalizationNotice";
 import LogoIcon from "metabase/common/components/LogoIcon";
 import { useSelector } from "metabase/lib/redux";
-import { getIsEmbeddingUseCase, getSteps } from "metabase/setup/selectors";
+import { getSteps } from "metabase/setup/selectors";
 import type { SetupStep } from "metabase/setup/types";
 import { Box, Flex, Icon, Text, Tooltip } from "metabase/ui";
 
@@ -33,7 +33,6 @@ const STEP_COMPONENTS: Partial<
 
 export const SettingsPage = (): JSX.Element => {
   const steps = useSelector(getSteps);
-  const isEmbeddingUseCase = useSelector(getIsEmbeddingUseCase);
   const SELECT_WIDTH = "10rem";
   const tooltipText = getLocalizationNoticeText({ mentionMetabase: true });
   const TOOLTIP_WIDTH = 220;
@@ -51,23 +50,21 @@ export const SettingsPage = (): JSX.Element => {
           <Box w={SELECT_WIDTH} className={S.Decoy} />
           <LogoIcon height={51} />
           <Box w={SELECT_WIDTH}>
-            {isEmbeddingUseCase && (
-              <Flex align="center" justify="space-between" gap="sm">
-                <LanguageSelector />
-                <div>
-                  <Tooltip
-                    label={label}
-                    position="bottom"
-                    withArrow
-                    multiline
-                    w={TOOLTIP_WIDTH}
-                    ta="center"
-                  >
-                    <Icon name="info_filled" aria-label={tooltipText} />
-                  </Tooltip>
-                </div>
-              </Flex>
-            )}
+            <Flex align="center" justify="space-between" gap="sm">
+              <LanguageSelector />
+              <div>
+                <Tooltip
+                  label={label}
+                  position="bottom"
+                  withArrow
+                  multiline
+                  w={TOOLTIP_WIDTH}
+                  ta="center"
+                >
+                  <Icon name="info_filled" aria-label={tooltipText} />
+                </Tooltip>
+              </div>
+            </Flex>
           </Box>
         </Flex>
       </Box>

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -136,7 +136,6 @@ export const getSteps = createSelector(
 
     const steps: SetupStep[] = [
       "welcome",
-      ...maybeAddStep("language", !isEmbeddingUseCase),
       "user_info",
       ...maybeAddStep("usage_question", !isEmbeddingUseCase),
       ...maybeAddStep(

--- a/frontend/src/metabase/setup/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/common.unit.spec.tsx
@@ -13,7 +13,6 @@ import {
   getSection,
   selectUsageReason,
   setup,
-  skipLanguageStep,
   skipWelcomeScreen,
   submitUserInfoStep,
 } from "./setup";
@@ -22,11 +21,10 @@ describe("setup (OSS)", () => {
   it("default step order should be correct", async () => {
     await setup();
     await skipWelcomeScreen();
-    expectSectionToHaveLabel("What's your preferred language?", "1");
-    expectSectionToHaveLabel("What should we call you?", "2");
-    expectSectionToHaveLabel("What will you use Metabase for?", "3");
-    expectSectionToHaveLabel("Add your data", "4");
-    expectSectionToHaveLabel("Usage data preferences", "5");
+    expectSectionToHaveLabel("What should we call you?", "1");
+    expectSectionToHaveLabel("What will you use Metabase for?", "2");
+    expectSectionToHaveLabel("Add your data", "3");
+    expectSectionToHaveLabel("Usage data preferences", "4");
 
     expectSectionsToHaveLabelsInOrder();
   });
@@ -36,24 +34,20 @@ describe("setup (OSS)", () => {
     await skipWelcomeScreen();
     expectSectionsToHaveLabelsInOrder({ from: 0 });
 
-    await skipLanguageStep();
+    await submitUserInfoStep();
     expectSectionsToHaveLabelsInOrder({ from: 1 });
 
-    await submitUserInfoStep();
+    await clickNextStep(); // Usage question
     expectSectionsToHaveLabelsInOrder({ from: 2 });
 
-    await clickNextStep(); // Usage question
-    expectSectionsToHaveLabelsInOrder({ from: 3 });
-
     await userEvent.click(screen.getByText("Continue with sample data"));
-    expectSectionsToHaveLabelsInOrder({ from: 4 });
+    expectSectionsToHaveLabelsInOrder({ from: 3 });
   });
 
   describe("Usage question", () => {
     async function setupForUsageQuestion() {
       await setup();
       await skipWelcomeScreen();
-      await skipLanguageStep();
       await submitUserInfoStep();
     }
 
@@ -70,8 +64,8 @@ describe("setup (OSS)", () => {
           "step",
         );
 
-        expectSectionToHaveLabel("Add your data", "4");
-        expectSectionToHaveLabel("Usage data preferences", "5");
+        expectSectionToHaveLabel("Add your data", "3");
+        expectSectionToHaveLabel("Usage data preferences", "4");
       });
     });
 
@@ -88,7 +82,7 @@ describe("setup (OSS)", () => {
           "step",
         );
 
-        expectSectionToHaveLabel("Usage data preferences", "4");
+        expectSectionToHaveLabel("Usage data preferences", "3");
       });
     });
 
@@ -105,8 +99,8 @@ describe("setup (OSS)", () => {
           "step",
         );
 
-        expectSectionToHaveLabel("Add your data", "4");
-        expectSectionToHaveLabel("Usage data preferences", "5");
+        expectSectionToHaveLabel("Add your data", "3");
+        expectSectionToHaveLabel("Usage data preferences", "4");
       });
     });
 
@@ -123,8 +117,8 @@ describe("setup (OSS)", () => {
           "step",
         );
 
-        expectSectionToHaveLabel("Add your data", "4");
-        expectSectionToHaveLabel("Usage data preferences", "5");
+        expectSectionToHaveLabel("Add your data", "3");
+        expectSectionToHaveLabel("Usage data preferences", "4");
       });
     });
   });
@@ -133,7 +127,6 @@ describe("setup (OSS)", () => {
     it("should set the correct flags when interested in embedding", async () => {
       await setup();
       await skipWelcomeScreen();
-      await skipLanguageStep();
       await submitUserInfoStep();
 
       await selectUsageReason("embedding");
@@ -150,7 +143,6 @@ describe("setup (OSS)", () => {
     it("should not set 'embedding-homepage' when not interested in embedding", async () => {
       await setup();
       await skipWelcomeScreen();
-      await skipLanguageStep();
       await submitUserInfoStep();
 
       await selectUsageReason("self-service-analytics");
@@ -178,7 +170,6 @@ describe("setup (OSS)", () => {
         ],
       });
       await skipWelcomeScreen();
-      await skipLanguageStep();
       await submitUserInfoStep();
 
       await selectUsageReason("embedding");
@@ -211,7 +202,6 @@ describe("setup (OSS)", () => {
     it("should call navigator.sendBeacon if the user checked the box", async () => {
       await setup();
       await skipWelcomeScreen();
-      await skipLanguageStep();
       await submitUserInfoStep();
       await selectUsageReason("self-service-analytics");
       await clickNextStep();
@@ -239,7 +229,6 @@ describe("setup (OSS)", () => {
     it("should *NOT* call navigator.sendBeacon if the user has not checked the box", async () => {
       await setup();
       await skipWelcomeScreen();
-      await skipLanguageStep();
       await submitUserInfoStep();
       await selectUsageReason("self-service-analytics");
       await clickNextStep();

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -14,7 +14,6 @@ import {
   getSection,
   selectUsageReason,
   setup,
-  skipLanguageStep,
   skipTokenStep,
   skipWelcomeScreen,
   submitUserInfoStep,
@@ -39,12 +38,11 @@ describe("setup (EE build, but no token)", () => {
   it("default step order should be correct, with the license step and data usage steps", async () => {
     await setupEnterprise();
     await skipWelcomeScreen();
-    expectSectionToHaveLabel("What's your preferred language?", "1");
-    expectSectionToHaveLabel("What should we call you?", "2");
-    expectSectionToHaveLabel("What will you use Metabase for?", "3");
-    expectSectionToHaveLabel("Add your data", "4");
-    expectSectionToHaveLabel("Activate your commercial license", "5");
-    expectSectionToHaveLabel("Usage data preferences", "6");
+    expectSectionToHaveLabel("What should we call you?", "1");
+    expectSectionToHaveLabel("What will you use Metabase for?", "2");
+    expectSectionToHaveLabel("Add your data", "3");
+    expectSectionToHaveLabel("Activate your commercial license", "4");
+    expectSectionToHaveLabel("Usage data preferences", "5");
 
     expectSectionsToHaveLabelsInOrder();
   });
@@ -53,7 +51,6 @@ describe("setup (EE build, but no token)", () => {
     async function setupForLicenseStep() {
       await setupEnterprise();
       await skipWelcomeScreen();
-      await skipLanguageStep();
       await submitUserInfoStep();
       await selectUsageReason("embedding"); // to skip the db connection step
       await clickNextStep();

--- a/frontend/src/metabase/setup/tests/premium-pro-cloud.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium-pro-cloud.unit.spec.tsx
@@ -9,7 +9,6 @@ import {
   getLastSettingsPutPayload,
   selectUsageReason,
   setup,
-  skipLanguageStep,
   skipWelcomeScreen,
   submitUserInfoStep,
 } from "./setup";
@@ -26,10 +25,9 @@ describe("setup (EE build, `hosting` and `embedding` features to simulate pro on
   it("default step order should be correct, without the license and data usage steps", async () => {
     await setupPremium();
     await skipWelcomeScreen();
-    expectSectionToHaveLabel("What's your preferred language?", "1");
-    expectSectionToHaveLabel("What should we call you?", "2");
-    expectSectionToHaveLabel("What will you use Metabase for?", "3");
-    expectSectionToHaveLabel("Add your data", "4");
+    expectSectionToHaveLabel("What should we call you?", "1");
+    expectSectionToHaveLabel("What will you use Metabase for?", "2");
+    expectSectionToHaveLabel("Add your data", "3");
     // no "Activate your commercial license" as this has token-features
     // no "Usage data preferences" as this is a hosted instance
 
@@ -56,7 +54,6 @@ describe("setup (EE build, `hosting` and `embedding` features to simulate pro on
   it("should set 'setup-license-active-at-setup' to true", async () => {
     await setupPremium();
     await skipWelcomeScreen();
-    await skipLanguageStep();
     await submitUserInfoStep();
 
     await selectUsageReason("embedding");

--- a/frontend/src/metabase/setup/tests/premium-pro-selfhosted.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium-pro-selfhosted.unit.spec.tsx
@@ -11,7 +11,6 @@ import {
   getLastSettingsPutPayload,
   selectUsageReason,
   setup,
-  skipLanguageStep,
   skipWelcomeScreen,
   submitUserInfoStep,
 } from "./setup";
@@ -28,12 +27,11 @@ describe("setup (EE build, `embedding` feature but no `hosting` to simulate pro 
   it("default step order should be correct, without the commercial step but with the data usage step", async () => {
     await setupPremium();
     await skipWelcomeScreen();
-    expectSectionToHaveLabel("What's your preferred language?", "1");
-    expectSectionToHaveLabel("What should we call you?", "2");
-    expectSectionToHaveLabel("What will you use Metabase for?", "3");
-    expectSectionToHaveLabel("Add your data", "4");
+    expectSectionToHaveLabel("What should we call you?", "1");
+    expectSectionToHaveLabel("What will you use Metabase for?", "2");
+    expectSectionToHaveLabel("Add your data", "3");
     // no "Activate your commercial license" as this has token-features
-    expectSectionToHaveLabel("Usage data preferences", "5");
+    expectSectionToHaveLabel("Usage data preferences", "4");
 
     expectSectionsToHaveLabelsInOrder();
   });
@@ -56,7 +54,6 @@ describe("setup (EE build, `embedding` feature but no `hosting` to simulate pro 
   it("should set 'setup-license-active-at-setup' to true", async () => {
     await setupPremium();
     await skipWelcomeScreen();
-    await skipLanguageStep();
     await submitUserInfoStep();
 
     await selectUsageReason("embedding");

--- a/frontend/src/metabase/setup/tests/premium-starter-cloud.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium-starter-cloud.unit.spec.tsx
@@ -9,7 +9,6 @@ import {
   getLastSettingsPutPayload,
   selectUsageReason,
   setup,
-  skipLanguageStep,
   skipWelcomeScreen,
   submitUserInfoStep,
 } from "./setup";
@@ -26,10 +25,9 @@ describe("setup (EE build, only `hosting` feature to simulate starter plan on cl
   it("default step order should be correct, without the license and data usage steps", async () => {
     await setupPremium();
     await skipWelcomeScreen();
-    expectSectionToHaveLabel("What's your preferred language?", "1");
-    expectSectionToHaveLabel("What should we call you?", "2");
-    expectSectionToHaveLabel("What will you use Metabase for?", "3");
-    expectSectionToHaveLabel("Add your data", "4");
+    expectSectionToHaveLabel("What should we call you?", "1");
+    expectSectionToHaveLabel("What will you use Metabase for?", "2");
+    expectSectionToHaveLabel("Add your data", "3");
     // no "Activate your commercial license" as this has token-features
     // no "Usage data preferences" as this is a hosted instance
 
@@ -57,7 +55,6 @@ describe("setup (EE build, only `hosting` feature to simulate starter plan on cl
   it("should set 'setup-license-active-at-setup' to false", async () => {
     await setupPremium();
     await skipWelcomeScreen();
-    await skipLanguageStep();
     await submitUserInfoStep();
 
     await selectUsageReason("embedding");


### PR DESCRIPTION
Closes EMB-821

Replaces the language selection step on the setup flow with the language selector.

### How to verify

- Start a new Metabase instance.
- You should no longer see the language selection step.
- You should see the language selector instead on the top right.

### Demo

<img width="2520" height="1768" alt="image" src="https://github.com/user-attachments/assets/eebb9990-baff-4ff4-b443-4044fe190deb" />

See [Loom video](https://www.loom.com/share/0fb44b1ec6ae4ac49c6d18ca806acaad?sid=404dc5ad-6523-43fd-92c5-4059818794ca) of the language selector.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
