### PR TITLE
Simplify state management and fix the flicker with the transform run button

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -699,37 +699,43 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
       assertTableDoesNotExistError();
     });
 
-    it("should be able to delete the target and restore the same target back", () => {
-      cy.log("create and run a transform");
-      createMbqlTransform({ visitTransform: true });
-      runTransformAndWaitForSuccess();
+    it(
+      "should be able to delete the target and restore the same target back",
+      { tags: "@flaky" },
+      () => {
+        cy.log("create and run a transform");
+        createMbqlTransform({ visitTransform: true });
+        runTransformAndWaitForSuccess();
 
-      cy.log("delete the old target without creating the new one");
-      getTransformPage().button("Change target").click();
-      H.modal().within(() => {
-        cy.findByLabelText("Table name").clear().type(TARGET_TABLE_2);
-        cy.findByLabelText("Delete transform_table").click();
-        cy.button("Change target and delete the old one").click();
-        cy.wait("@deleteTransformTable");
-        cy.wait("@updateTransform");
-      });
+        cy.log("delete the old target without creating the new one");
+        getTransformPage().button("Change target").click();
+        H.modal().within(() => {
+          cy.findByLabelText("Table name").clear().type(TARGET_TABLE_2);
+          cy.findByLabelText("Delete transform_table").click();
+          cy.button("Change target and delete the old one").click();
+          cy.wait("@deleteTransformTable");
+          cy.wait("@updateTransform");
+        });
 
-      cy.log("change the target back to the original one");
-      getTransformPage().button("Change target").click();
-      H.modal().within(() => {
-        cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
-        cy.button("Change target").click();
-        cy.wait("@updateTransform");
-      });
+        cy.log("change the target back to the original one");
+        getTransformPage().button("Change target").click();
+        H.modal().within(() => {
+          cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
+          cy.button("Change target").click();
+          cy.wait("@updateTransform");
+        });
 
-      cy.log("run the transform to re-create the original target");
-      runTransformAndWaitForSuccess();
+        cy.log("run the transform to re-create the original target");
+        runTransformAndWaitForSuccess();
 
-      cy.log("verify the target is available");
-      getTableLink().click();
-      H.queryBuilderHeader().findByText("Transform Table").should("be.visible");
-      H.assertQueryBuilderRowCount(3);
-    });
+        cy.log("verify the target is available");
+        getTableLink().click();
+        H.queryBuilderHeader()
+          .findByText("Transform Table")
+          .should("be.visible");
+        H.assertQueryBuilderRowCount(3);
+      },
+    );
 
     it("should not allow to overwrite an existing table when changing the target", () => {
       createMbqlTransform({ visitTransform: true });

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -699,43 +699,37 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
       assertTableDoesNotExistError();
     });
 
-    it(
-      "should be able to delete the target and restore the same target back",
-      { tags: "@flaky" },
-      () => {
-        cy.log("create and run a transform");
-        createMbqlTransform({ visitTransform: true });
-        runTransformAndWaitForSuccess();
+    it("should be able to delete the target and restore the same target back", () => {
+      cy.log("create and run a transform");
+      createMbqlTransform({ visitTransform: true });
+      runTransformAndWaitForSuccess();
 
-        cy.log("delete the old target without creating the new one");
-        getTransformPage().button("Change target").click();
-        H.modal().within(() => {
-          cy.findByLabelText("Table name").clear().type(TARGET_TABLE_2);
-          cy.findByLabelText("Delete transform_table").click();
-          cy.button("Change target and delete the old one").click();
-          cy.wait("@deleteTransformTable");
-          cy.wait("@updateTransform");
-        });
+      cy.log("delete the old target without creating the new one");
+      getTransformPage().button("Change target").click();
+      H.modal().within(() => {
+        cy.findByLabelText("Table name").clear().type(TARGET_TABLE_2);
+        cy.findByLabelText("Delete transform_table").click();
+        cy.button("Change target and delete the old one").click();
+        cy.wait("@deleteTransformTable");
+        cy.wait("@updateTransform");
+      });
 
-        cy.log("change the target back to the original one");
-        getTransformPage().button("Change target").click();
-        H.modal().within(() => {
-          cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
-          cy.button("Change target").click();
-          cy.wait("@updateTransform");
-        });
+      cy.log("change the target back to the original one");
+      getTransformPage().button("Change target").click();
+      H.modal().within(() => {
+        cy.findByLabelText("Table name").clear().type(TARGET_TABLE);
+        cy.button("Change target").click();
+        cy.wait("@updateTransform");
+      });
 
-        cy.log("run the transform to re-create the original target");
-        runTransformAndWaitForSuccess();
+      cy.log("run the transform to re-create the original target");
+      runTransformAndWaitForSuccess();
 
-        cy.log("verify the target is available");
-        getTableLink().click();
-        H.queryBuilderHeader()
-          .findByText("Transform Table")
-          .should("be.visible");
-        H.assertQueryBuilderRowCount(3);
-      },
-    );
+      cy.log("verify the target is available");
+      getTableLink().click();
+      H.queryBuilderHeader().findByText("Transform Table").should("be.visible");
+      H.assertQueryBuilderRowCount(3);
+    });
 
     it("should not allow to overwrite an existing table when changing the target", () => {
       createMbqlTransform({ visitTransform: true });

--- a/enterprise/frontend/src/metabase-enterprise/api/transform-job.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/transform-job.ts
@@ -57,6 +57,29 @@ export const transformJobApi = EnterpriseApi.injectEndpoints({
           tag("transform"),
           tag("table"),
         ]),
+      onQueryStarted: async (id, { dispatch, queryFulfilled }) => {
+        const patchResult = dispatch(
+          transformJobApi.util.updateQueryData(
+            "getTransformJob",
+            id,
+            (draft) => {
+              draft.last_run = {
+                id: -1,
+                status: "started",
+                start_time: new Date().toISOString(),
+                end_time: null,
+                message: null,
+                run_method: "manual",
+              };
+            },
+          ),
+        );
+        try {
+          await queryFulfilled;
+        } catch {
+          patchResult.undo();
+        }
+      },
     }),
     createTransformJob: builder.mutation<
       TransformJob,
@@ -99,7 +122,7 @@ export const transformJobApi = EnterpriseApi.injectEndpoints({
         );
         try {
           await queryFulfilled;
-        } finally {
+        } catch {
           patchResult.undo();
         }
       },

--- a/enterprise/frontend/src/metabase-enterprise/api/transform-job.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/transform-job.ts
@@ -99,7 +99,7 @@ export const transformJobApi = EnterpriseApi.injectEndpoints({
         );
         try {
           await queryFulfilled;
-        } catch {
+        } finally {
           patchResult.undo();
         }
       },

--- a/enterprise/frontend/src/metabase-enterprise/api/transform.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/transform.ts
@@ -95,7 +95,7 @@ export const transformApi = EnterpriseApi.injectEndpoints({
         );
         try {
           await queryFulfilled;
-        } catch {
+        } finally {
           patchResult.undo();
         }
       },

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/ScheduleSection/ScheduleSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/JobView/ScheduleSection/ScheduleSection.tsx
@@ -10,10 +10,7 @@ import {
 import { timezoneToUTCOffset } from "metabase/lib/time-dayjs";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Box, Divider, Group, Icon, Tooltip } from "metabase/ui";
-import {
-  useLazyGetTransformJobQuery,
-  useRunTransformJobMutation,
-} from "metabase-enterprise/api";
+import { useRunTransformJobMutation } from "metabase-enterprise/api";
 import { trackTranformJobTriggerManualRun } from "metabase-enterprise/transforms/analytics";
 
 import { RunButton } from "../../../components/RunButton";
@@ -93,8 +90,7 @@ type RunButtonSectionProps = {
 };
 
 function RunButtonSection({ job }: RunButtonSectionProps) {
-  const [fetchJob, { isFetching }] = useLazyGetTransformJobQuery();
-  const [runJob, { isLoading: isRunning }] = useRunTransformJobMutation();
+  const [runJob] = useRunTransformJobMutation();
   const { sendErrorToast } = useMetadataToasts();
   const isSaved = job.id != null;
   const hasTags = job.tag_ids?.length !== 0;
@@ -113,9 +109,6 @@ function RunButtonSection({ job }: RunButtonSectionProps) {
 
     if (error) {
       sendErrorToast(t`Failed to run job`);
-    } else {
-      // fetch the job to get the correct `last_run` info
-      fetchJob(job.id);
     }
   };
 
@@ -123,7 +116,6 @@ function RunButtonSection({ job }: RunButtonSectionProps) {
     <Tooltip label={t`This job doesn't have tags to run.`} disabled={hasTags}>
       <RunButton
         run={job.last_run}
-        isLoading={isFetching || isRunning}
         isDisabled={!isSaved || !hasTags}
         onRun={handleRun}
       />

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/RunButton/RunButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/RunButton/RunButton.tsx
@@ -9,24 +9,17 @@ const RECENT_TIMEOUT = 5000;
 
 type RunButtonProps = {
   run: TransformRun | null | undefined;
-  isLoading: boolean;
   isDisabled?: boolean;
   onRun: () => void;
 };
 
 export const RunButton = forwardRef(function RunButton(
-  {
-    run,
-    isLoading,
-    isDisabled: isExternallyDisabled = false,
-    onRun,
-  }: RunButtonProps,
+  { run, isDisabled: isExternallyDisabled = false, onRun }: RunButtonProps,
   ref: Ref<HTMLButtonElement>,
 ) {
   const [isRecent, setIsRecent] = useState(false);
   const { label, color, leftSection, isDisabled } = getRunButtonInfo({
     run,
-    isLoading,
     isRecent,
     isDisabled: isExternallyDisabled,
   });
@@ -54,7 +47,6 @@ export const RunButton = forwardRef(function RunButton(
 
 type RunButtonOpts = {
   run: TransformRun | null | undefined;
-  isLoading: boolean;
   isRecent: boolean;
   isDisabled: boolean;
 };
@@ -68,11 +60,10 @@ type RunButtonInfo = {
 
 function getRunButtonInfo({
   run,
-  isLoading,
   isRecent,
   isDisabled,
 }: RunButtonOpts): RunButtonInfo {
-  if (run?.status === "started" || isLoading) {
+  if (run?.status === "started") {
     return {
       label: t`Running now…`,
       leftSection: <Loader size="sm" />,

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/RunSection/RunSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPage/RunSection/RunSection.tsx
@@ -5,7 +5,6 @@ import { useSetting } from "metabase/common/hooks";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Anchor, Box, Divider, Group, Icon, Stack } from "metabase/ui";
 import {
-  useLazyGetTransformQuery,
   useRunTransformMutation,
   useUpdateTransformMutation,
 } from "metabase-enterprise/api";
@@ -141,8 +140,7 @@ type RunButtonSectionProps = {
 };
 
 function RunButtonSection({ transform }: RunButtonSectionProps) {
-  const [fetchTransform, { isFetching }] = useLazyGetTransformQuery();
-  const [runTransform, { isLoading: isRunning }] = useRunTransformMutation();
+  const [runTransform] = useRunTransformMutation();
   const { sendErrorToast } = useMetadataToasts();
 
   const handleRun = async () => {
@@ -154,20 +152,11 @@ function RunButtonSection({ transform }: RunButtonSectionProps) {
     const { error } = await runTransform(transform.id);
     if (error) {
       sendErrorToast(t`Failed to run transform`);
-    } else {
-      // fetch the transform to get the correct `last_run` info
-      fetchTransform(transform.id);
     }
     return { error };
   };
 
-  return (
-    <RunButton
-      run={transform.last_run}
-      isLoading={isFetching || isRunning}
-      onRun={handleRun}
-    />
-  );
+  return <RunButton run={transform.last_run} onRun={handleRun} />;
 }
 
 type TagSectionProps = {


### PR DESCRIPTION
Fixes a major bug with the run button state https://www.loom.com/share/16ce77c0277449ed97be0e1a579c819d

We previously relied on `isLoading` for the `GET /api/ee/transform/:id` to determine whether the transform "has started but no `last_run` is created". This kind of works, but when we start to poll the endpoint, the Run button start to flicker. This PR fixes the issue and removes such a dependency. 