### PR TITLE
Add analytics to history revision and data reference

### DIFF
--- a/e2e/test/scenarios/models/models-revision-history.cy.spec.js
+++ b/e2e/test/scenarios/models/models-revision-history.cy.spec.js
@@ -1,14 +1,20 @@
 const { H } = cy;
 import { ORDERS_BY_YEAR_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
-describe("scenarios > models > revision history", () => {
+H.describeWithSnowplow("scenarios > models > revision history", () => {
   beforeEach(() => {
+    H.resetSnowplow();
     H.restore();
     cy.signInAsAdmin();
+    H.enableTracking();
     cy.request("PUT", `/api/card/${ORDERS_BY_YEAR_QUESTION_ID}`, {
       name: "Orders Model",
       type: "model",
     });
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
   });
 
   it("should allow reverting to a saved question state and back into a model again", () => {
@@ -16,6 +22,11 @@ describe("scenarios > models > revision history", () => {
 
     openRevisionHistory();
     revertTo("You created this");
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "revert_version_clicked",
+      event_detail: "card",
+    });
 
     cy.location("pathname").should("match", /^\/question\/\d+/);
     H.echartsContainer();

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -171,6 +171,10 @@ H.describeWithSnowplow("scenarios > browse", () => {
     H.browseDatabases().click();
     cy.findByRole("link", { name: /Learn about our data/ }).click();
     cy.location("pathname").should("eq", "/reference/databases");
+    H.expectNoBadSnowplowEvents();
+    H.expectUnstructuredSnowplowEvent({
+      event: "learn_about_our_data_clicked",
+    });
     cy.go("back");
     cy.findByRole("heading", { name: "Sample Database" }).click();
     cy.findByRole("heading", { name: "Products" }).click();

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -411,6 +411,15 @@ export type MetabotEvent =
   | MetabotFixQueryClickedEvent
   | MetabotExplainChartClickedEvent;
 
+export type RevertVersionEvent = ValidateEvent<{
+  event: "revert_version_clicked";
+  event_detail: "card" | "dashboard";
+}>;
+
+export type LearnAboutDataClickedEvent = ValidateEvent<{
+  event: "learn_about_our_data_clicked";
+}>;
+
 export type SimpleEvent =
   | CustomSMTPSetupClickedEvent
   | CustomSMTPSetupSuccessEvent
@@ -457,4 +466,6 @@ export type SimpleEvent =
   | DocumentPrintEvent
   | DatabaseHelpClickedEvent
   | XRayEvent
-  | MetabotEvent;
+  | MetabotEvent
+  | RevertVersionEvent
+  | LearnAboutDataClickedEvent;

--- a/frontend/src/metabase/browse/components/BrowseDataHeader.tsx
+++ b/frontend/src/metabase/browse/components/BrowseDataHeader.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 import { t } from "ttag";
 
+import { trackDataReferenceClicked } from "metabase/collections/analytics";
 import { color } from "metabase/lib/colors";
 import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
 import { Flex, Group, Icon, Text, Title } from "metabase/ui";
@@ -38,7 +39,7 @@ export const BrowseDataHeader = () => {
 
 const LearnAboutDataLink = () => (
   <Flex p=".75rem" justify="flex-end" align="center" gap="md">
-    <Link to="reference">
+    <Link to="reference" onClick={trackDataReferenceClicked}>
       <BrowseHeaderIconContainer>
         <LearnAboutDataIcon size={14} name="reference" />
         <Text size="md" lh="1" fw="bold" ml=".5rem" c="inherit">

--- a/frontend/src/metabase/collections/analytics.ts
+++ b/frontend/src/metabase/collections/analytics.ts
@@ -1,0 +1,7 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackDataReferenceClicked = () => {
+  trackSimpleEvent({
+    event: "learn_about_our_data_clicked",
+  });
+};

--- a/frontend/src/metabase/common/components/Timeline/Timeline.tsx
+++ b/frontend/src/metabase/common/components/Timeline/Timeline.tsx
@@ -16,6 +16,7 @@ import {
   TimelineEvent,
   Timestamp,
 } from "./Timeline.styled";
+import { trackVersionRevertClicked } from "./analytics";
 
 interface TimelineProps {
   events: RevisionOrModerationEvent[];
@@ -23,6 +24,7 @@ interface TimelineProps {
   canWrite: boolean;
   revert: (revision: Revision) => void;
   className?: string;
+  entity: "card" | "dashboard";
 }
 
 export function Timeline({
@@ -31,6 +33,7 @@ export function Timeline({
   canWrite,
   revert,
   className,
+  entity,
 }: TimelineProps) {
   return (
     <TimelineContainer className={className} data-testid={dataTestId}>
@@ -52,7 +55,10 @@ export function Timeline({
                       icon="revert"
                       onlyIcon
                       borderless
-                      onClick={() => revert(revision)}
+                      onClick={() => {
+                        trackVersionRevertClicked(entity);
+                        revert(revision);
+                      }}
                       data-testid="question-revert-button"
                       aria-label={t`revert to ${title}`}
                     />

--- a/frontend/src/metabase/common/components/Timeline/analytics.ts
+++ b/frontend/src/metabase/common/components/Timeline/analytics.ts
@@ -1,0 +1,8 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackVersionRevertClicked = (entity: "card" | "dashboard") => {
+  trackSimpleEvent({
+    event: "revert_version_clicked",
+    event_detail: entity,
+  });
+};

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.tsx
@@ -259,6 +259,7 @@ const HistoryTab = ({
           dispatch(revertToRevision(dashboard.id, revision))
         }
         canWrite={canWrite}
+        entity="dashboard"
       />
     </SidesheetCard>
   );

--- a/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActivityTimeline.tsx
@@ -56,6 +56,7 @@ export function QuestionActivityTimeline({
       data-testid="saved-question-history-list"
       revert={(revision) => dispatch(revertToRevision(question.id(), revision))}
       canWrite={question.canWrite()}
+      entity="card"
     />
   );
 }


### PR DESCRIPTION
Resolves PRG-120

## Events

Clicks on:
1. "Revert to this version" for card and a dashboard 
2. "Learn about our data" (leads to the `/reference` page

> [!NOTE]
> We decided to go with the generic `card` for tracking. At this point it doesn't matter if the reverted entity was metric, question or a model.