### PR TITLE
Fix auto-passing e2e spec changes

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           echo "Running tests with specs: $SPEC_PATH"
           node e2e/runner/run_cypress_ci.js e2e \
-          --env grepTags="${{inputs.tags}}+-@skip",grepOmitFiltered=true \
+          --env grepTags="${{inputs.tags}} -@skip",grepOmitFiltered=true \
           --spec "$SPEC_PATH" \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           echo "Running tests with specs: $SPEC_PATH"
           node e2e/runner/run_cypress_ci.js e2e \
-          --env grepTags="${{inputs.tags}} -@skip",grepOmitFiltered=true \
+          --env grepTags="${{inputs.tags && format('{0}+-@skip', inputs.tags) || '-@skip'}}",grepOmitFiltered=true \
           --spec "$SPEC_PATH" \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
 


### PR DESCRIPTION

### Description

There's a bug in the logic that only runs changed e2e specs that skips all the tests.

see: 
- https://metaboat.slack.com/archives/C0669P4AF9N/p1757546093824859
- https://metaboat.slack.com/archives/C505ZNNH4/p1758044039084729

