### PR TITLE
Semantic search token usage tracking

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -182,12 +182,11 @@
   (try
     (log/debug "Calling AI Service embeddings API" {:documents (count texts) :tokens (count-tokens-batch texts)})
     (let [response (metabot-v3.client/generate-embeddings model-name texts)
-          prompt-tokens (->> response :usage :prompt_tokens)
           total-tokens (->> response :usage :total_tokens)]
       (analytics/inc! :metabase-search/semantic-embedding-tokens
                       {:provider "ai-service", :model model-name}
                       (->> response :usage :total_tokens))
-      (semantic.models.token-tracking/record-tokens model-name (:type opts) total-tokens prompt-tokens)
+      (semantic.models.token-tracking/record-tokens model-name (:type opts) total-tokens)
       (extract-base64-response-embeddings response))
     (catch Exception e
       (log/error e "AI Service embeddings API call failed" {:documents (count texts) :tokens (count-tokens-batch texts)})

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -186,7 +186,7 @@
           total-tokens (->> response :usage :total_tokens)]
       (analytics/inc! :metabase-search/semantic-embedding-tokens
                       {:provider "ai-service", :model model-name}
-                      (->> response :usage :total_tokens))
+                      total-tokens)
       (semantic.models.token-tracking/record-tokens model-name (:type opts) total-tokens)
       (extract-base64-response-embeddings response))
     (catch Exception e

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -192,7 +192,7 @@
 (defn- ai-service-get-embedding [model-name text & {:as opts}]
   (try
     (log/debug "Generating AI Service embedding for text of length:" (count text))
-    (first (ai-service-get-embeddings-batch model-name [text]))
+    (first (ai-service-get-embeddings-batch model-name [text] opts))
     (catch Exception e
       (log/error e "Failed to generate AI Service embedding for text of length:" (count text))
       (throw e))))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/init.clj
@@ -4,4 +4,5 @@
    [metabase-enterprise.semantic-search.task.index-cleanup]
    [metabase-enterprise.semantic-search.task.index-repair]
    [metabase-enterprise.semantic-search.task.indexer]
-   [metabase-enterprise.semantic-search.task.metric-collector]))
+   [metabase-enterprise.semantic-search.task.metric-collector]
+   [metabase-enterprise.semantic-search.task.usage-trimmer]))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/models/token_tracking.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/models/token_tracking.clj
@@ -1,0 +1,20 @@
+(ns metabase-enterprise.semantic-search.models.token-tracking
+  (:require
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(derive :model/SemanticSearchTokenTracking :metabase/model)
+
+(methodical/defmethod t2/table-name :model/SemanticSearchTokenTracking [_model] :semantic_search_token_tracking)
+
+(t2/deftransforms :model/SemanticSearchTokenTracking
+  {:request_type mi/transform-keyword})
+
+(defn record-tokens
+  "Record semantic search token usage."
+  [model request-type total-tokens prompt-tokens]
+  (t2/insert! :model/SemanticSearchTokenTracking {:model_name model
+                                                  :request_type request-type
+                                                  :prompt_tokens prompt-tokens
+                                                  :total_tokens total-tokens}))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/models/token_tracking.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/models/token_tracking.clj
@@ -13,8 +13,7 @@
 
 (defn record-tokens
   "Record semantic search token usage."
-  [model request-type total-tokens prompt-tokens]
+  [model request-type total-tokens]
   (t2/insert! :model/SemanticSearchTokenTracking {:model_name model
                                                   :request_type request-type
-                                                  :prompt_tokens prompt-tokens
                                                   :total_tokens total-tokens}))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/usage_trimmer.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/usage_trimmer.clj
@@ -1,0 +1,45 @@
+(ns metabase-enterprise.semantic-search.task.usage-trimmer
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2])
+  (:import
+   (java.sql Timestamp)
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private trimmer-job-key (jobs/key "metabase.task.semantic-search.usage-trimmer.job"))
+(def ^:private trimmer-trigger-key (triggers/key "metabase.task.semantic-search.usage-trimmer.trigger"))
+
+(def ^:private storage-months 2)
+
+(defn- trim-old-token-data!
+  []
+  (log/info "Attempting to delete old semantic search usage data.")
+  (let [t (Timestamp/valueOf (.minusMonths (java.time.LocalDateTime/now) storage-months))]
+    (t2/delete! :model/SemanticSearchTokenTracking {:where [:< :created_at t]}))
+  (log/info "Semantic search old data cleanup successful."))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc "Clean up inactive semantic search index tables"}
+  SemanticSearchUsageTrimmer [_ctx]
+  (trim-old-token-data!))
+
+(defmethod task/init! ::SemanticSearchUsageTrimmer
+  []
+  (when (premium-features/has-feature? :semantic-search)
+    (let [job (jobs/build
+               (jobs/of-type SemanticSearchUsageTrimmer)
+               (jobs/with-identity trimmer-job-key))
+          trigger (triggers/build
+                   (triggers/with-identity trimmer-trigger-key)
+                   (triggers/start-now)
+                   (triggers/with-schedule
+                     ;; daily at 22:59:42
+                    (cron/cron-schedule "42 59 22 * * ?")))]
+      (task/schedule-task! job trigger))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -96,6 +96,7 @@
    "Sandbox"
    "SearchIndexMetadata"
    "Secret"
+   "SemanticSearchTokenTracking"
    "Session"
    "TaskHistory"
    "Transform"

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -79,6 +79,7 @@
     :model/QueryTable
     :model/RecentViews
     :model/Revision
+    :model/SemanticSearchTokenTracking
     :model/SearchIndexMetadata
     :model/Secret
     :model/Session

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -295,18 +295,16 @@
           (testing "Indexing tokens are tracked"
             (semantic.indexer/indexing-step pgvector index-metadata index indexing-state)
             (is (= 1 (t2/count :model/SemanticSearchTokenTracking)))
-            (let [{:keys [request_type total_tokens prompt_tokens]}
+            (let [{:keys [request_type total_tokens]}
                   (t2/select-one :model/SemanticSearchTokenTracking)]
               (is (= :index request_type))
-              (is (= 11 prompt_tokens))
               (is (= 11 total_tokens))))
 
           (testing "Querying tokens are tracked"
             (t2/delete! :model/SemanticSearchTokenTracking)
             (semantic.index/query-index pgvector index {:search-string "elephant"})
             (is (= 1 (t2/count :model/SemanticSearchTokenTracking)))
-            (let [{:keys [request_type total_tokens prompt_tokens]}
+            (let [{:keys [request_type total_tokens]}
                   (t2/select-one :model/SemanticSearchTokenTracking)]
               (is (= :query request_type))
-              (is (= 5 total_tokens))
-              (is (= 5 prompt_tokens)))))))))
+              (is (= 5 total_tokens)))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -245,7 +245,6 @@
                        (-> tokens-calls first second second)))
                 (is (= 2 (t2/count :model/SemanticSearchTokenTracking)))))))))))
 
-;; NOTE: I'll modify the test if it turns out testing against exact number of tokens is not a best idea.
 (deftest token-tracking-write-test
   (mt/with-premium-features #{:semantic-search}
     (when (string? (not-empty (:mb-pgvector-db-url env/env)))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/usage_trimmer_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/usage_trimmer_test.clj
@@ -1,0 +1,32 @@
+(ns metabase-enterprise.semantic-search.task.usage-trimmer-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.semantic-search.task.usage-trimmer :as semantic.task.trimmer]
+   [metabase.test :as mt]
+   [toucan2.core :as t2])
+  (:import
+   (java.sql Timestamp)
+   (java.time LocalDateTime)))
+
+(set! *warn-on-reflection* true)
+
+(deftest trim-test
+  (mt/with-premium-features #{:semantic-search}
+    (t2/delete! :model/SemanticSearchTokenTracking)
+    (let [now (LocalDateTime/now)
+          ;; semantic.task.trimmer/storage-months is set to 2
+          long-ago (.minusMonths now 6)]
+      (t2/insert! :model/SemanticSearchTokenTracking {:model_name "model now"
+                                                      :request_type :index
+                                                      :created_at (Timestamp/valueOf now)
+                                                      :total_tokens 999})
+      (t2/insert! :model/SemanticSearchTokenTracking {:model_name "model long-ago"
+                                                      :request_type :query
+                                                      :created_at (Timestamp/valueOf long-ago)
+                                                      :total_tokens 1000})
+      (is (=? [{:model_name "model now"}
+               {:model_name "model long-ago"}]
+              (t2/select :model/SemanticSearchTokenTracking {:order-by [[:total_tokens :asc]]})))
+      (@#'semantic.task.trimmer/trim-old-token-data!)
+      (is (=? [{:model_name "model now"}]
+              (t2/select :model/SemanticSearchTokenTracking {:order-by [[:total_tokens :asc]]}))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -245,8 +245,9 @@
     (-> (semantic.index/default-index mock-embedding-model)
         (semantic.index-metadata/qualify-index mock-index-metadata))))
 
-(defmethod semantic.embedding/get-embedding        "mock" [_ text] (get-mock-embedding text))
-(defmethod semantic.embedding/get-embeddings-batch "mock" [_ texts] (get-mock-embeddings-batch texts))
+;; NOTE: opts are currently unused in following mock implementations
+(defmethod semantic.embedding/get-embedding        "mock" [_ text & {:as opts}] (get-mock-embedding text))
+(defmethod semantic.embedding/get-embeddings-batch "mock" [_ texts & {:as opts}] (get-mock-embeddings-batch texts))
 (defmethod semantic.embedding/pull-model           "mock" [_])
 
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/test_util.clj
@@ -246,8 +246,8 @@
         (semantic.index-metadata/qualify-index mock-index-metadata))))
 
 ;; NOTE: opts are currently unused in following mock implementations
-(defmethod semantic.embedding/get-embedding        "mock" [_ text & {:as opts}] (get-mock-embedding text))
-(defmethod semantic.embedding/get-embeddings-batch "mock" [_ texts & {:as opts}] (get-mock-embeddings-batch texts))
+(defmethod semantic.embedding/get-embedding        "mock" [_ text & {:as _opts}] (get-mock-embedding text))
+(defmethod semantic.embedding/get-embeddings-batch "mock" [_ texts & {:as _opts}] (get-mock-embeddings-batch texts))
 (defmethod semantic.embedding/pull-model           "mock" [_])
 
 #_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -504,6 +504,43 @@ databaseChangeLog:
                   name: conversation_id
       rollback: # will be dropped with table
 
+  - changeSet:
+      id: v56.2025-09-16T18:20:00
+      author: lbrdnk
+      comment: Semantic search token usage tracking
+      changes:
+        - createTable:
+            tableName: semantic_search_token_tracking
+            remarks: Token usage tracking info for semantic search
+            columns:
+              - column:
+                  name: id
+                  remarks: Unique ID of a request
+              - column:
+                  name: model_name
+                  remarks: Name of model used for embeddings generation
+                  type: varchar(256)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: request_type
+                  remarks: Type of request, possibly index or query
+                  type: varchar(32)
+              - column:
+                  name: created_at
+                  remarks: Datetime of insertion
+              - column:
+                  name: total_tokens
+                  remarks: Total tokens value as per OpenAI compatible API
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: prompt_tokens
+                  remarks: Prompt tokens value as per OpenAI compatible API
+                  type: int
+
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -545,6 +545,18 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  - changeSet:
+      id: v56.2025-09-19T15:33:18
+      author: lbrdnk
+      comment: Semantic search token usage tracking
+      changes:
+        - createIndex:
+            tableName: semantic_search_token_tracking
+            indexName: idx_semantic_search_token_tracking_created_at
+            columns:
+              column:
+                name: created_at
+
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -516,6 +516,11 @@ databaseChangeLog:
               - column:
                   name: id
                   remarks: Unique ID of a request
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
               - column:
                   name: model_name
                   remarks: Name of model used for embeddings generation
@@ -529,16 +534,16 @@ databaseChangeLog:
               - column:
                   name: created_at
                   remarks: Datetime of insertion
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
               - column:
                   name: total_tokens
                   remarks: Total tokens value as per OpenAI compatible API
                   type: int
                   constraints:
                     nullable: false
-              - column:
-                  name: prompt_tokens
-                  remarks: Prompt tokens value as per OpenAI compatible API
-                  type: int
 
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -85,6 +85,7 @@
     :model/SearchIndexMetadata               metabase.search.models.search-index-metadata
     :model/Secret                            metabase.secrets.models.secret
     :model/Segment                           metabase.segments.models.segment
+    :model/SemanticSearchTokenTracking       metabase-enterprise.semantic-search.models.token-tracking
     :model/Session                           metabase.session.models.session
     :model/Setting                           metabase.settings.models.setting
     :model/Table                             metabase.warehouse-schema.models.table

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -39,6 +39,7 @@
     :model/QueryField
     :model/QueryTable
     :model/SearchIndexMetadata
+    :model/SemanticSearchTokenTracking
     :model/TaskHistory
     ;; TODO we should remove these models from here once serialization is supported
     :model/Transform


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-410/implement-token-usage-tracking-for-semantic-search

This PR adds tracking of tokens consumed by embeddings api calls initiated from semantic search. Number of tokens of every request is stored in appdb. The tables is trimmed every day, storing rolling 2 months of data.

This PR
- add migration with the new appdb table,
- adds new model, `:model/SemanticSearchTokenTracking`,
- modifies `get-embedding...` implementations to take opts,
- passes opts from near toplevel (`upsert-index!`, `query-index`) with appropriate request `:type`, that is stored with token count in the new table,
- adds new daily job to trim that table,
- adds tests.