### PR TITLE
Handle calls to current-join-alias with unexpected types like Metric metadata.

### DIFF
--- a/src/metabase/lib/join/util.cljc
+++ b/src/metabase/lib/join/util.cljc
@@ -43,12 +43,12 @@
 
 (mu/defn current-join-alias :- [:maybe ::lib.schema.join/alias]
   "Get the current join alias associated with something, if it has one."
-  [field-or-join :- [:maybe ::column-or-field-ref-or-partial-join]]
+  [field-or-join]
   (case (lib.dispatch/dispatch-value field-or-join)
-    :dispatch-type/nil nil
     :field             (:join-alias (lib.options/options field-or-join))
     :metadata/column   (:metabase.lib.join/join-alias field-or-join)
-    :mbql/join         (:alias field-or-join)))
+    :mbql/join         (:alias field-or-join)
+    nil))
 
 (mu/defn joined-field-desired-alias :- ::lib.schema.metadata/desired-column-alias
   "Desired alias for a Field that comes from a join, e.g.


### PR DESCRIPTION
Handle calls to `current-join-alias` with unexpected types like Metric metadata.

Fixes #63571