### PR TITLE
Show the embedding hub checklist in embedding homepage

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -145,5 +145,40 @@ describe("scenarios - embedding hub", () => {
         .icon("lock")
         .should("not.exist");
     });
+
+    it("embedding checklist should show up on the embedding homepage", () => {
+      cy.log("Enable embedding homepage setting");
+      cy.request("PUT", "/api/setting/embedding-homepage", {
+        value: "visible",
+      });
+
+      cy.log("Visit homepage");
+      cy.visit("/");
+
+      cy.log("Verify embedding hub heading appears");
+      cy.findAllByText("Get started with Embedded Analytics JS")
+        .first()
+        .should("be.visible");
+
+      cy.log("Verify checklist steps are visible on homepage");
+      cy.get("main").within(() => {
+        cy.findByText("Create models").should("be.visible");
+        cy.findByText("Generate a dashboard").should("be.visible");
+        cy.findByText("Add data").should("be.visible").click();
+      });
+
+      cy.log("Sanity check: add data modal should open");
+      cy.findByRole("dialog").within(() => {
+        cy.findByRole("heading", { name: "Add data" }).should("be.visible");
+      });
+    });
+
+    it("embedding checklist should not show up on the embedding homepage if not enabled", () => {
+      cy.visit("/");
+
+      cy.get("main")
+        .findByText("Get started with Embedded Analytics JS")
+        .should("not.exist");
+    });
   });
 });

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -147,20 +147,16 @@ describe("scenarios - embedding hub", () => {
     });
 
     it("embedding checklist should show up on the embedding homepage", () => {
-      cy.log("Enable embedding homepage setting");
       cy.request("PUT", "/api/setting/embedding-homepage", {
         value: "visible",
       });
 
-      cy.log("Visit homepage");
       cy.visit("/");
 
-      cy.log("Verify embedding hub heading appears");
       cy.findAllByText("Get started with Embedded Analytics JS")
         .first()
         .should("be.visible");
 
-      cy.log("Verify checklist steps are visible on homepage");
       cy.get("main").within(() => {
         cy.findByText("Create models").should("be.visible");
         cy.findByText("Generate a dashboard").should("be.visible");
@@ -176,6 +172,51 @@ describe("scenarios - embedding hub", () => {
     it("embedding checklist should not show up on the embedding homepage if not enabled", () => {
       cy.visit("/");
 
+      cy.get("main")
+        .findByText("Get started with Embedded Analytics JS")
+        .should("not.exist");
+    });
+
+    it("overflow menu > customize homepage opens modal with correct title", () => {
+      cy.request("PUT", "/api/setting/embedding-homepage", {
+        value: "visible",
+      });
+
+      cy.visit("/");
+
+      cy.log("Click overflow menu button on the embedding homepage");
+      cy.get("main").within(() => {
+        cy.findByLabelText("More options").click();
+      });
+
+      H.menu().findByText("Customize homepage").click();
+
+      cy.findByRole("dialog").within(() => {
+        cy.findByText("Pick a dashboard to appear on the homepage").should(
+          "be.visible",
+        );
+      });
+    });
+
+    it("overflow menu > dismiss guide hides the embedding homepage", () => {
+      cy.request("PUT", "/api/setting/embedding-homepage", {
+        value: "visible",
+      });
+
+      cy.visit("/");
+
+      cy.get("main")
+        .findByText("Get started with Embedded Analytics JS")
+        .should("be.visible");
+
+      cy.log("Click overflow menu button on the embedding homepage");
+      cy.get("main").within(() => {
+        cy.findByLabelText("More options").click();
+      });
+
+      H.menu().findByText("Dismiss guide").click();
+
+      cy.log("Verify guide is dismissed and no longer visible");
       cy.get("main")
         .findByText("Get started with Embedded Analytics JS")
         .should("not.exist");

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -37,7 +37,7 @@ import {
 import { TaskModal } from "metabase/admin/tools/components/TaskModal";
 import { TasksApp } from "metabase/admin/tools/components/TasksApp";
 import { ToolsApp } from "metabase/admin/tools/components/ToolsApp";
-import { EmbeddingHub } from "metabase/embedding/embedding-hub";
+import { EmbeddingHubSetupGuidePage } from "metabase/embedding/embedding-hub";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 import { Route } from "metabase/hoc/Title";
 import { DataModel } from "metabase/metadata/pages/DataModel";
@@ -150,7 +150,7 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
           <Route
             path="setup-guide"
             title={t`Setup guide`}
-            component={EmbeddingHub}
+            component={EmbeddingHubSetupGuidePage}
           />
           <Route
             path="modular"

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -37,7 +37,7 @@ import {
 import { TaskModal } from "metabase/admin/tools/components/TaskModal";
 import { TasksApp } from "metabase/admin/tools/components/TasksApp";
 import { ToolsApp } from "metabase/admin/tools/components/ToolsApp";
-import { EmbeddingHubSetupGuidePage } from "metabase/embedding/embedding-hub";
+import { EmbeddingHubAdminSettingsPage } from "metabase/embedding/embedding-hub";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 import { Route } from "metabase/hoc/Title";
 import { DataModel } from "metabase/metadata/pages/DataModel";
@@ -150,7 +150,7 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
           <Route
             path="setup-guide"
             title={t`Setup guide`}
-            component={EmbeddingHubSetupGuidePage}
+            component={EmbeddingHubAdminSettingsPage}
           />
           <Route
             path="modular"

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -1,14 +1,8 @@
 import { useMemo, useState } from "react";
 import { P, match } from "ts-pattern";
-import { t } from "ttag";
 
-import {
-  RelatedSettingsSection,
-  getModularEmbeddingRelatedSettingItems,
-} from "metabase/admin/components/RelatedSettingsSection";
 import { CreateDashboardModal } from "metabase/dashboard/containers/CreateDashboardModal";
 import { AddDataModal } from "metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal";
-import { Stack, Text, Title } from "metabase/ui";
 
 import { useCompletedEmbeddingHubSteps } from "../hooks";
 import type {
@@ -77,19 +71,9 @@ export const EmbeddingHub = () => {
   }, [embeddingSteps, completedSteps, lockedSteps]);
 
   return (
-    <Stack mx="auto" py="xl" gap="xl" maw={800}>
-      <Stack gap="xs" ml="3rem">
-        <Title
-          order={1}
-          c="var(--mb-color-text-primary)"
-        >{t`Embedding setup guide`}</Title>
-
-        <Text c="var(--mb-color-text-secondary)">{t`Follow the guide to get started with Embedded Analytics JS`}</Text>
-      </Stack>
+    <>
       <StepperWithCards steps={stepperSteps} />
-      <RelatedSettingsSection
-        items={getModularEmbeddingRelatedSettingItems()}
-      />
+
       <AddDataModal
         opened={openedModal?.type === "add-data"}
         onClose={closeModal}
@@ -105,6 +89,6 @@ export const EmbeddingHub = () => {
         opened={openedModal?.type === "xray-dashboard"}
         onClose={closeModal}
       />
-    </Stack>
+    </>
   );
 };

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubAdminSettingsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubAdminSettingsPage.tsx
@@ -8,7 +8,7 @@ import { Stack, Text, Title } from "metabase/ui";
 
 import { EmbeddingHub } from "./EmbeddingHub";
 
-export const EmbeddingHubSetupGuidePage = () => {
+export const EmbeddingHubAdminSettingsPage = () => {
   return (
     <Stack mx="auto" py="xl" gap="xl" maw={800}>
       <Stack gap="xs" ml="3rem">

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
@@ -1,5 +1,5 @@
+import { useDisclosure } from "@mantine/hooks";
 import type { ReactNode } from "react";
-import { useState } from "react";
 import { t } from "ttag";
 
 import { CustomHomePageModal } from "metabase/home/components/CustomHomePageModal";
@@ -14,7 +14,11 @@ import { EmbeddingHub } from "./EmbeddingHub";
  * Embedding Hub shown in the embedding home page for admins in EE instances.
  */
 export const EmbeddingHubHomePage = (): ReactNode => {
-  const [showCustomHomePageModal, setShowCustomHomePageModal] = useState(false);
+  const [
+    isCustomHomePageModalOpened,
+    { open: openCustomHomePageModal, close: closeCustomHomePageModal },
+  ] = useDisclosure(false);
+
   const dispatch = useDispatch();
 
   const handleDismissGuide = () =>
@@ -42,7 +46,7 @@ export const EmbeddingHubHomePage = (): ReactNode => {
           <Menu.Dropdown>
             <Menu.Item
               leftSection={<Icon name="pencil" />}
-              onClick={() => setShowCustomHomePageModal(true)}
+              onClick={openCustomHomePageModal}
             >
               {t`Customize homepage`}
             </Menu.Item>
@@ -60,8 +64,8 @@ export const EmbeddingHubHomePage = (): ReactNode => {
       <EmbeddingHub />
 
       <CustomHomePageModal
-        isOpen={showCustomHomePageModal}
-        onClose={() => setShowCustomHomePageModal(false)}
+        isOpen={isCustomHomePageModalOpened}
+        onClose={closeCustomHomePageModal}
       />
     </Stack>
   );

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
@@ -6,6 +6,9 @@ import { ActionIcon, Group, Icon, Stack, Text } from "metabase/ui";
 
 import { EmbeddingHub } from "./EmbeddingHub";
 
+/**
+ * Embedding Hub shown in the embedding home page for admins in EE instances.
+ */
 export const EmbeddingHubHomePage = (): ReactNode => {
   return (
     <Stack mx="auto" py="xl" maw={800}>

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import { t } from "ttag";
+
+import { MetabotGreeting } from "metabase/home/components/HomeGreeting";
+import { ActionIcon, Group, Icon, Stack, Text } from "metabase/ui";
+
+import { EmbeddingHub } from "./EmbeddingHub";
+
+export const EmbeddingHubHomePage = (): ReactNode => {
+  return (
+    <Stack mx="auto" py="xl" maw={800}>
+      <Group gap="sm" justify="space-between" mb="xl">
+        <Group gap="sm">
+          <MetabotGreeting />
+
+          <Text
+            fw={700}
+            fz="lg"
+          >{t`Get started with Embedded Analytics JS`}</Text>
+        </Group>
+
+        <ActionIcon variant="subtle" aria-label={t`More options`}>
+          <Icon name="ellipsis" />
+        </ActionIcon>
+      </Group>
+
+      <EmbeddingHub />
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
@@ -1,8 +1,12 @@
 import type { ReactNode } from "react";
+import { useState } from "react";
 import { t } from "ttag";
 
+import { CustomHomePageModal } from "metabase/home/components/CustomHomePageModal";
+import { dismissEmbeddingHomepage } from "metabase/home/components/EmbedHomepage/actions";
 import { MetabotGreeting } from "metabase/home/components/HomeGreeting";
-import { ActionIcon, Group, Icon, Stack, Text } from "metabase/ui";
+import { useDispatch } from "metabase/lib/redux";
+import { ActionIcon, Group, Icon, Menu, Stack, Text } from "metabase/ui";
 
 import { EmbeddingHub } from "./EmbeddingHub";
 
@@ -10,6 +14,12 @@ import { EmbeddingHub } from "./EmbeddingHub";
  * Embedding Hub shown in the embedding home page for admins in EE instances.
  */
 export const EmbeddingHubHomePage = (): ReactNode => {
+  const [showCustomHomePageModal, setShowCustomHomePageModal] = useState(false);
+  const dispatch = useDispatch();
+
+  const handleDismissGuide = () =>
+    dispatch(dismissEmbeddingHomepage("dismissed-done"));
+
   return (
     <Stack mx="auto" py="xl" maw={800}>
       <Group gap="sm" justify="space-between" mb="xl">
@@ -22,12 +32,37 @@ export const EmbeddingHubHomePage = (): ReactNode => {
           >{t`Get started with Embedded Analytics JS`}</Text>
         </Group>
 
-        <ActionIcon variant="subtle" aria-label={t`More options`}>
-          <Icon name="ellipsis" />
-        </ActionIcon>
+        <Menu>
+          <Menu.Target>
+            <ActionIcon variant="subtle" aria-label={t`More options`}>
+              <Icon name="ellipsis" />
+            </ActionIcon>
+          </Menu.Target>
+
+          <Menu.Dropdown>
+            <Menu.Item
+              leftSection={<Icon name="pencil" />}
+              onClick={() => setShowCustomHomePageModal(true)}
+            >
+              {t`Customize homepage`}
+            </Menu.Item>
+
+            <Menu.Item
+              leftSection={<Icon name="close" />}
+              onClick={handleDismissGuide}
+            >
+              {t`Dismiss guide`}
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
       </Group>
 
       <EmbeddingHub />
+
+      <CustomHomePageModal
+        isOpen={showCustomHomePageModal}
+        onClose={() => setShowCustomHomePageModal(false)}
+      />
     </Stack>
   );
 };

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubHomePage.tsx
@@ -36,7 +36,7 @@ export const EmbeddingHubHomePage = (): ReactNode => {
           >{t`Get started with Embedded Analytics JS`}</Text>
         </Group>
 
-        <Menu>
+        <Menu position="bottom-end">
           <Menu.Target>
             <ActionIcon variant="subtle" aria-label={t`More options`}>
               <Icon name="ellipsis" />

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubSetupGuidePage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubSetupGuidePage.tsx
@@ -1,0 +1,30 @@
+import { t } from "ttag";
+
+import {
+  RelatedSettingsSection,
+  getModularEmbeddingRelatedSettingItems,
+} from "metabase/admin/components/RelatedSettingsSection";
+import { Stack, Text, Title } from "metabase/ui";
+
+import { EmbeddingHub } from "./EmbeddingHub";
+
+export const EmbeddingHubSetupGuidePage = () => {
+  return (
+    <Stack mx="auto" py="xl" gap="xl" maw={800}>
+      <Stack gap="xs" ml="3rem">
+        <Title
+          order={1}
+          c="var(--mb-color-text-primary)"
+        >{t`Embedding setup guide`}</Title>
+
+        <Text c="var(--mb-color-text-secondary)">{t`Follow the guide to get started with Embedded Analytics JS`}</Text>
+      </Stack>
+
+      <EmbeddingHub />
+
+      <RelatedSettingsSection
+        items={getModularEmbeddingRelatedSettingItems()}
+      />
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/embedding/embedding-hub/components/index.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/index.ts
@@ -1,1 +1,3 @@
 export { EmbeddingHub } from "./EmbeddingHub";
+export { EmbeddingHubSetupGuidePage } from "./EmbeddingHubSetupGuidePage";
+export { EmbeddingHubHomePage } from "./EmbeddingHubHomePage";

--- a/frontend/src/metabase/embedding/embedding-hub/components/index.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/index.ts
@@ -1,3 +1,3 @@
 export { EmbeddingHub } from "./EmbeddingHub";
-export { EmbeddingHubSetupGuidePage } from "./EmbeddingHubSetupGuidePage";
+export { EmbeddingHubAdminSettingsPage } from "./EmbeddingHubAdminSettingsPage";
 export { EmbeddingHubHomePage } from "./EmbeddingHubHomePage";

--- a/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
+++ b/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
@@ -2,9 +2,15 @@ import { useMemo } from "react";
 
 import { useListPopularItemsQuery, useListRecentsQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { useDatabaseListQuery, useSetting } from "metabase/common/hooks";
+import {
+  useDatabaseListQuery,
+  useHasTokenFeature,
+  useSetting,
+} from "metabase/common/hooks";
+import { EmbeddingHubHomePage } from "metabase/embedding/embedding-hub";
 import { useSelector } from "metabase/lib/redux";
 import { isSyncCompleted } from "metabase/lib/syncing";
+import { isEEBuild } from "metabase/lib/utils";
 import { getUser } from "metabase/selectors/user";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { PopularItem, RecentItem, User } from "metabase-types/api";
@@ -20,6 +26,9 @@ export const HomeContent = (): JSX.Element | null => {
   const user = useSelector(getUser);
   const embeddingHomepage = useSetting("embedding-homepage");
   const isXrayEnabled = useSelector(getIsXrayEnabled);
+  const isEE = isEEBuild();
+  const isSimpleEmbeddingAvailable = useHasTokenFeature("embedding_simple");
+
   const { data: databases, error: databasesError } = useDatabaseListQuery();
   const { data: recentItemsRaw, error: recentItemsError } = useListRecentsQuery(
     undefined,
@@ -43,6 +52,10 @@ export const HomeContent = (): JSX.Element | null => {
   }
 
   if (embeddingHomepage === "visible" && user.is_superuser) {
+    if (isEE && isSimpleEmbeddingAvailable) {
+      return <EmbeddingHubHomePage />;
+    }
+
     return <EmbedHomepage />;
   }
 

--- a/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
+++ b/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
@@ -2,15 +2,9 @@ import { useMemo } from "react";
 
 import { useListPopularItemsQuery, useListRecentsQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import {
-  useDatabaseListQuery,
-  useHasTokenFeature,
-  useSetting,
-} from "metabase/common/hooks";
-import { EmbeddingHubHomePage } from "metabase/embedding/embedding-hub";
+import { useDatabaseListQuery, useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { isSyncCompleted } from "metabase/lib/syncing";
-import { isEEBuild } from "metabase/lib/utils";
 import { getUser } from "metabase/selectors/user";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { PopularItem, RecentItem, User } from "metabase-types/api";
@@ -26,8 +20,6 @@ export const HomeContent = (): JSX.Element | null => {
   const user = useSelector(getUser);
   const embeddingHomepage = useSetting("embedding-homepage");
   const isXrayEnabled = useSelector(getIsXrayEnabled);
-  const isEE = isEEBuild();
-  const isSimpleEmbeddingAvailable = useHasTokenFeature("embedding_simple");
 
   const { data: databases, error: databasesError } = useDatabaseListQuery();
   const { data: recentItemsRaw, error: recentItemsError } = useListRecentsQuery(
@@ -52,10 +44,6 @@ export const HomeContent = (): JSX.Element | null => {
   }
 
   if (embeddingHomepage === "visible" && user.is_superuser) {
-    if (isEE && isSimpleEmbeddingAvailable) {
-      return <EmbeddingHubHomePage />;
-    }
-
     return <EmbedHomepage />;
   }
 

--- a/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.tsx
+++ b/frontend/src/metabase/home/components/HomeGreeting/HomeGreeting.tsx
@@ -45,7 +45,7 @@ const getMessage = (name: string | null | undefined): string => {
   return _.sample(options) ?? "";
 };
 
-const MetabotGreeting = () => {
+export const MetabotGreeting = () => {
   const [buffer, setBuffer] = useState<string[]>([]);
   const [isCooling, setIsCooling] = useState(false);
   const [isCool, setIsCool] = useState(false);

--- a/frontend/src/metabase/home/components/HomeLayout/HomeLayout.tsx
+++ b/frontend/src/metabase/home/components/HomeLayout/HomeLayout.tsx
@@ -2,8 +2,10 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import { t } from "ttag";
 
+import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
-import { getUserIsAdmin } from "metabase/selectors/user";
+import { isEEBuild } from "metabase/lib/utils";
+import { getUser, getUserIsAdmin } from "metabase/selectors/user";
 import { getLandingPageIllustration } from "metabase/selectors/whitelabel";
 import { Tooltip } from "metabase/ui";
 
@@ -21,10 +23,24 @@ interface HomeLayoutProps {
   children?: ReactNode;
 }
 
-export const HomeLayout = ({ children }: HomeLayoutProps): JSX.Element => {
+export const HomeLayout = ({ children }: HomeLayoutProps): ReactNode => {
   const [showModal, setShowModal] = useState(false);
   const isAdmin = useSelector(getUserIsAdmin);
   const landingPageIllustration = useSelector(getLandingPageIllustration);
+
+  const user = useSelector(getUser);
+  const embeddingHomepage = useSetting("embedding-homepage");
+  const isEE = isEEBuild();
+  const isSimpleEmbeddingAvailable = useHasTokenFeature("embedding_simple");
+
+  if (
+    embeddingHomepage === "visible" &&
+    user?.is_superuser &&
+    isEE &&
+    isSimpleEmbeddingAvailable
+  ) {
+    return children;
+  }
 
   return (
     <LayoutRoot data-testid="home-page">

--- a/frontend/src/metabase/home/components/HomeLayout/HomeLayout.tsx
+++ b/frontend/src/metabase/home/components/HomeLayout/HomeLayout.tsx
@@ -3,8 +3,8 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
+import { EmbeddingHubHomePage } from "metabase/embedding/embedding-hub";
 import { useSelector } from "metabase/lib/redux";
-import { isEEBuild } from "metabase/lib/utils";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
 import { getLandingPageIllustration } from "metabase/selectors/whitelabel";
 import { Tooltip } from "metabase/ui";
@@ -30,16 +30,14 @@ export const HomeLayout = ({ children }: HomeLayoutProps): ReactNode => {
 
   const user = useSelector(getUser);
   const embeddingHomepage = useSetting("embedding-homepage");
-  const isEE = isEEBuild();
   const isSimpleEmbeddingAvailable = useHasTokenFeature("embedding_simple");
 
   if (
     embeddingHomepage === "visible" &&
     user?.is_superuser &&
-    isEE &&
     isSimpleEmbeddingAvailable
   ) {
-    return children;
+    return <EmbeddingHubHomePage />;
   }
 
   return (


### PR DESCRIPTION
Closes EMB-822

Shows the Embedding Hub checklist in the embedding homepage, with overflow menus.

### How to verify

- Start a clean Metabase instance.
- Select "Embedding" as usage intent
- You should see the Hub on the embedding homepage
- You should not see the Related Settings on the Hub because we are not on the admin settings
- You should be able to either dismiss the Hub on the homepage, or replace it with other homepage content
- You should always still see the Hub in admin settings' setup guide

### Demo

<img width="2514" height="1768" alt="CleanShot 2568-09-17 at 21 39 52@2x" src="https://github.com/user-attachments/assets/707cd910-8db9-4e49-b6ed-0a2192bc0f51" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
