### PR TITLE
fix(sdk-package): Accept null expiration from JWT sessions

### DIFF
--- a/enterprise/frontend/src/embedding/auth-common/validate-session-token.ts
+++ b/enterprise/frontend/src/embedding/auth-common/validate-session-token.ts
@@ -26,7 +26,10 @@ export function validateSessionToken(session: any) {
 
   // We should also receive `iat` and `status` in the response, but we don't actually need them
   // as we don't use them, so we don't throw an error if they are missing
-  if (typeof session.id !== "string" || typeof session.exp !== "number" && session.exp !== null) {
+  if (
+    typeof session.id !== "string" ||
+    (typeof session.exp !== "number" && session.exp !== null)
+  ) {
     throw MetabaseError.INVALID_SESSION_SCHEMA({
       expected: "{ id: string, exp: number, iat: number }",
       actual: JSON.stringify(session, null, 2),

--- a/enterprise/frontend/src/embedding/auth-common/validate-session-token.ts
+++ b/enterprise/frontend/src/embedding/auth-common/validate-session-token.ts
@@ -26,7 +26,7 @@ export function validateSessionToken(session: any) {
 
   // We should also receive `iat` and `status` in the response, but we don't actually need them
   // as we don't use them, so we don't throw an error if they are missing
-  if (typeof session.id !== "string" || typeof session.exp !== "number") {
+  if (typeof session.id !== "string" || typeof session.exp !== "number" && session.exp !== null) {
     throw MetabaseError.INVALID_SESSION_SCHEMA({
       expected: "{ id: string, exp: number, iat: number }",
       actual: JSON.stringify(session, null, 2),


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

### Description

When calling `/auth/sso?jwt=...` with a JWT that does not have an exp claim, the returned session does not have an exp property. Example:

```
{"status":"ok","id":"6af10a77-aaad-4f96-940e-d25165390208","exp":null,"iat":1758053940}
```

This causes the SDK to reject this session.


### How to verify

Using the [SDK sample application](https://github.com/metabase/metabase-nodejs-react-sdk-embedding-sample), remove the `exp` from generated tokens:

```diff
diff --git a/server/index.js b/server/index.js
index e943001..d41cfc4 100644
--- a/server/index.js
+++ b/server/index.js
@@ -40,7 +40,7 @@ app.get("/sso/metabase", async (req, res) => {
       first_name: user.firstName,
       last_name: user.lastName,
       groups: [user.group],
-      exp: Math.round(Date.now() / 1000) + 60 * 10, // 10 minutes expiration
+      // exp: Math.round(Date.now() / 1000) + 60 * 10, // 10 minutes expiration
     },
     // This is the JWT signing secret in your Metabase JWT authentication setting
     METABASE_JWT_SHARED_SECRET,
```

This will cause a session with a null `exp` to be returned, which causes the SDK to throw an error:

<img width="1512" height="944" alt="image" src="https://github.com/user-attachments/assets/a0f2417b-7b30-4edd-8d31-6b2418775fc2" />

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
