### PR TITLE
Only run auto-backport when a backport label is added

### DIFF
--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -74,7 +74,7 @@ runs:
 
         git push -u origin ${BACKPORT_BRANCH}
 
-        BACKPORT_PR_URL=$(gh pr create --base "${TARGET_BRANCH}" --head "${BACKPORT_BRANCH}" --label "was-backported" --assignee "${GITHUB_ACTOR}" --title "🤖 backported \"${ORIGINAL_TITLE}\"" --body "${PR_BODY}")
+        BACKPORT_PR_URL=$(gh pr create --base "${TARGET_BRANCH}" --head "${BACKPORT_BRANCH}" --label "was-backported" --assignee "${{ github.event.pull_request.user.login }}" --title "🤖 backported \"${ORIGINAL_TITLE}\"" --body "${PR_BODY}")
         BACKPORT_PR_NUMBER=${BACKPORT_PR_URL##*/}
 
         echo "backport_pr_number=$BACKPORT_PR_NUMBER" >> $GITHUB_OUTPUT

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -6,11 +6,19 @@ on:
 
 jobs:
   create-backport:
-    if: | # the PR must be merged and have a backport label
+    if:
+      | # the PR must have a backport label when it's merged, or be labeled with a backport label after merge
       github.event.pull_request.merged == true && (
-        contains(github.event.pull_request.labels.*.name, 'backport') ||
-        contains(github.event.pull_request.labels.*.name, 'double-backport') ||
-        contains(github.event.pull_request.labels.*.name, 'triple-backport')
+        github.event.action == 'closed' && (
+          contains(github.event.pull_request.labels.*.name, 'backport') ||
+          contains(github.event.pull_request.labels.*.name, 'double-backport') ||
+          contains(github.event.pull_request.labels.*.name, 'triple-backport')
+        ) ||
+        github.event.action == 'labeled' && (
+          github.event.label.name == 'backport' ||
+          github.event.label.name == 'double-backport' ||
+          github.event.label.name == 'triple-backport'
+        )
       )
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The previous logic would create a backport if _any_ label was added to a merged PR that had a `backport` label. 

The new logic makes sure if `auto-backport` workflow is triggered by a label, that the label being added is a `backport` label

Also, change the logic to always assign the backported PR to the creator of the original PR. Previously, the backported PR would get assigned to whoever merged the PR (if it was already labeled to backport) or to whoever labeled the PR after it was merged