### PR TITLE
Closes EMB-303 search bar in embedding no longer awfully long

### DIFF
--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.styled.tsx
@@ -19,6 +19,7 @@ export const SearchBarRoot = styled.div`
   width: 100%;
 
   ${breakpointMinSmall} {
+    max-width: 14.5rem;
     position: relative;
   }
 `;
@@ -38,6 +39,7 @@ export const SearchInputContainer = styled.div<{
     }
     return css`
       background-color: var(--mb-color-bg-white);
+
       &:hover {
         background-color: var(--mb-color-bg-light);
       }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #56444
Closes [EMB-303: Interactive embed search bar is awfully long](https://linear.app/metabase/issue/EMB-303/interactive-embed-search-bar-is-awfully-long)

### Description

Before:
<img width="1417" height="1005" alt="image" src="https://github.com/user-attachments/assets/3cd1920d-2b08-49d0-a461-b1b980188912" />


After:
<img width="1417" height="1005" alt="image" src="https://github.com/user-attachments/assets/e5aff9ff-0a61-470d-b434-5d098e893dec" />
