### PR TITLE
Adjust the embedding homepage copy and add upsell for OSS

### DIFF
--- a/frontend/src/metabase/admin/upsells/UpsellEmbedHomepage.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellEmbedHomepage.tsx
@@ -1,0 +1,28 @@
+import { t } from "ttag";
+
+import { Text } from "metabase/ui";
+
+import { UpsellCard } from "./components";
+import { UPGRADE_URL } from "./constants";
+
+const campaign = "embed-homepage";
+
+export const UpsellEmbedHomepage = ({ location }: { location: string }) => {
+  return (
+    <UpsellCard
+      title={t`More advanced embeds`}
+      campaign={campaign}
+      buttonText={t`Try Metabase Pro`}
+      buttonLink={UPGRADE_URL}
+      location={location}
+      style={{
+        minWidth: "13.5rem",
+        backgroundColor: "transparent",
+      }}
+    >
+      <Text size="sm" lh="md" ta="center">
+        {t`Give your customers the full power of Metabase in your own app, with SSO, advanced permissions, customization, and more.`}
+      </Text>
+    </UpsellCard>
+  );
+};

--- a/frontend/src/metabase/admin/upsells/UpsellEmbedHomepage.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellEmbedHomepage.tsx
@@ -5,7 +5,7 @@ import { Text } from "metabase/ui";
 import { UpsellCard } from "./components";
 import { UPGRADE_URL } from "./constants";
 
-const campaign = "embed-homepage";
+const campaign = "advanced-embeds";
 
 export const UpsellEmbedHomepage = ({ location }: { location: string }) => {
   return (

--- a/frontend/src/metabase/admin/upsells/index.ts
+++ b/frontend/src/metabase/admin/upsells/index.ts
@@ -1,3 +1,4 @@
+export * from "./UpsellEmbedHomepage";
 export * from "./UpsellBetterSupport";
 export * from "./UpsellCacheConfig";
 export * from "./UpsellCloud";

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -1,7 +1,8 @@
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
-import { Box, Card, Stack, Text, Title } from "metabase/ui";
+import { UpsellEmbedHomepage } from "metabase/admin/upsells";
+import { Box, Card, Flex, Stack, Text, Title } from "metabase/ui";
 import type { EmbeddingHomepageDismissReason } from "metabase-types/api";
 
 import { EmbedJsContent } from "./EmbedJsContent";
@@ -91,27 +92,35 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
     .exhaustive();
 
   return (
-    <Stack maw={550}>
-      <HeaderWithDismiss onDismiss={onDismiss} />
+    <Flex gap="lg" align="flex-start" maw={1000}>
+      <Stack maw={550}>
+        <HeaderWithDismiss onDismiss={onDismiss} />
 
-      <Card px="xl" py="lg">
-        <Stack gap="xl">
-          <Box>
-            {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
-            <Title order={2} mb="md">{t`Embedding Metabase`}</Title>
-            <Text>
+        <Card px="xl" py="lg">
+          <Stack gap="xl">
+            <Box>
               {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
-              {t`Give your customers secure, multi-tenant access to their data with as much (or as little) interactivity and tools to explore data as you want, with as much customization as you need. Embed dashboards, charts—even Metabase's query editor—with iframes or as individual React components.`}
-            </Text>
-          </Box>
-          {content}
-        </Stack>
-      </Card>
+              <Title order={2} mb="md">{t`Embedding Metabase`}</Title>
+              <Text>
+                {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
+                {t`Give your customers secure, multi-tenant access to their data with as much (or as little) interactivity and tools to explore data as you want, with as much customization as you need. Embed dashboards, charts—even Metabase's query editor—with iframes or as individual React components.`}
+              </Text>
+            </Box>
+            {content}
+          </Stack>
+        </Card>
 
-      <NeedMoreInfoCard
-        embeddingDocsUrl={embeddingDocsUrl}
-        analyticsDocsUrl={analyticsDocsUrl}
-      />
-    </Stack>
+        <NeedMoreInfoCard
+          embeddingDocsUrl={embeddingDocsUrl}
+          analyticsDocsUrl={analyticsDocsUrl}
+        />
+      </Stack>
+
+      {variant === "oss/starter" && (
+        <Box mt="2.5rem">
+          <UpsellEmbedHomepage location="embedding-homepage" />
+        </Box>
+      )}
+    </Flex>
   );
 };

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedJsContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedJsContent.tsx
@@ -48,7 +48,7 @@ export const EmbedJsContent = ({
       >{t`Embedded analytics JS`}</Text>
       <Text mb="md">
         {/* eslint-disable-next-line no-literal-metabase-strings -- This string only shows for admins. */}
-        {t`Embedded analytics JS is a JavaScript library built on top of Metabase’s Embedded analytics SDK for React, but it does not require using React or setting up full SDK embedding. Unlike with interactive embedding, where you embed the entire Metabase app in an iframe, Embedded analytics JS lets you choose from a set of predefined components like a single chart, a dashboard with optional drill-through, or query builder, and customize those components.`}
+        {t`A JavaScript library built on top of Metabase’s React SDK that lets you embed individual components (charts, dashboards, query builder) using plain JS — no React setup required. You get per-component controls like drill-through, parameters, downloads, theming.`}
       </Text>
       {showImage && (
         <EmbedJsImage

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/EmbedHomepage.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/EmbedHomepage.unit.spec.tsx
@@ -216,5 +216,12 @@ describe("EmbedHomepage (OSS)", () => {
     expect(
       screen.getByRole("link", { name: "Try Metabase Pro" }),
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", { name: "Try Metabase Pro" }),
+    ).toHaveAttribute(
+      "href",
+      "https://www.metabase.com/upgrade?utm_source=product&utm_medium=upsell&utm_campaign=advanced-embeds&utm_content=embedding-homepage&source_plan=oss",
+    );
   });
 });

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/EmbedHomepage.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/EmbedHomepage.unit.spec.tsx
@@ -201,4 +201,20 @@ describe("EmbedHomepage (OSS)", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("should show the advanced embeds upsell for OSS users", () => {
+    setup({ isAdmin: true });
+
+    expect(screen.getByText("More advanced embeds")).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        "Give your customers the full power of Metabase in your own app, with SSO, advanced permissions, customization, and more.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", { name: "Try Metabase Pro" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
@@ -11,6 +11,7 @@ import type { Settings, TokenFeatures } from "metabase-types/api";
 import {
   createMockSettings,
   createMockTokenFeatures,
+  createMockUser,
 } from "metabase-types/api/mocks";
 import {
   createMockSettingsState,
@@ -23,12 +24,14 @@ export interface SetupOpts {
   tokenFeatures?: Partial<TokenFeatures>;
   hasEnterprisePlugins?: boolean;
   settings?: Partial<Settings>;
+  isAdmin?: boolean;
 }
 
 export async function setup({
   tokenFeatures = createMockTokenFeatures(),
   hasEnterprisePlugins = false,
   settings = {},
+  isAdmin = false,
 }: SetupOpts = {}) {
   jest.clearAllMocks();
 
@@ -38,6 +41,7 @@ export async function setup({
   setupPropertiesEndpoints(createMockSettings());
 
   const state = createMockState({
+    currentUser: createMockUser({ is_superuser: isAdmin }),
     settings: createMockSettingsState({
       "token-features": createMockTokenFeatures(tokenFeatures),
       ...settings,


### PR DESCRIPTION
Closes EMB-823

Adjusts the embedding homepage's copy for "Embedded Analytics JS" and add a new upsell for advanced embedding on OSS.

### How to verify

- Start a fresh **OSS** instance
- Select "Embedding"
- You should see the new copy "A JavaScript library built on top of Metabase’s React SDK that lets you embed individual components (charts, dashboards, query builder) using plain JS — no React setup required. You get per-component controls like drill-through, parameters, downloads, theming." ([Figma](https://www.figma.com/design/5ZpoBYjn70prjvqDXVfT5e/Embedding-Hub?node-id=15639-1471&t=Fxsz410ymOEEYYap-0))
- You should see the new upsell for advanced embeds

### Demo

<img width="2512" height="1772" alt="CleanShot 2568-09-17 at 22 46 15@2x" src="https://github.com/user-attachments/assets/0ec997f8-4998-4ccf-a019-7082737c79e5" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
