### PR TITLE
Fix #63629: Filter on cards causes an unnecessary horizontal scroll bar for public/static embedding

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1424,7 +1424,7 @@ describe("scenarios > dashboard > parameters", () => {
       H.createQuestionAndDashboard({
         questionDetails: ordersCountByCategory,
         dashboardDetails: {
-          parameters: [categoryParameter],
+          parameters: [categoryParameter, countParameter],
         },
       }).then(({ body: dashcard }) => {
         const dashboardId = dashcard.dashboard_id;
@@ -1440,8 +1440,9 @@ describe("scenarios > dashboard > parameters", () => {
             {
               id: dashcard.id,
               row: 1,
-              size_x: 12,
+              size_x: 24,
               size_y: 6,
+              inline_parameters: [countParameter.id],
               parameter_mappings: [
                 {
                   parameter_id: categoryParameter.id,
@@ -1450,6 +1451,15 @@ describe("scenarios > dashboard > parameters", () => {
                     "dimension",
                     categoryFieldRef,
                     { "stage-number": 0 },
+                  ],
+                },
+                {
+                  parameter_id: countParameter.id,
+                  card_id: ORDERS_BY_YEAR_QUESTION_ID,
+                  target: [
+                    "dimension",
+                    ["field", "count", { "base-type": "type/Integer" }],
+                    { "stage-number": 1 },
                   ],
                 },
               ],
@@ -1483,11 +1493,15 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       cy.location().should(({ search }) => {
-        expect(search).to.eq("?category=Gadget");
+        expect(search).to.eq("?category=Gadget&count=");
       });
 
       // Verify filter doesn't show up in the dashboard header
       H.dashboardParametersContainer().should("not.exist");
+
+      cy.findByTestId("embed-frame").then(($el) => {
+        expect(H.isScrollableHorizontally($el[0])).to.be.false;
+      });
     });
 
     [

--- a/frontend/src/metabase/dashboard/components/CollapsibleDashboardParameterList/CollapsibleDashboardParameterList.tsx
+++ b/frontend/src/metabase/dashboard/components/CollapsibleDashboardParameterList/CollapsibleDashboardParameterList.tsx
@@ -88,7 +88,13 @@ export const CollapsibleDashboardParameterList = forwardRef<
     <>
       {/* Invisible expanded parameter list for measurements */}
       <div
-        className={cx(CS.fixed, CS.hidden, CS.pointerEventsNone, CS.fullWidth)}
+        className={cx(
+          CS.fixed,
+          CS.hidden,
+          CS.pointerEventsNone,
+          CS.fullWidth,
+          CS.left,
+        )}
       >
         <DashboardParameterList
           {...parametersListCommonProps}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63629
Closes [UXW-736](https://linear.app/metabase/issue/UXW-736)

### Description

Adds `left: 0` to invisible expanded parameter list (used for measurements) to prevent scrollbar from appearing in embed frame.

### How to verify

See #63629 for repro steps.

Also verify inline filters still collapse the same as before when there's not enough room to display them (in both charts and headings).

### Demo

**BEFORE**

<img width="1029" height="675" alt="before" src="https://github.com/user-attachments/assets/0a59f92c-2068-477d-9ba8-954229780314" />


**AFTER**
<img width="1029" height="675" alt="after" src="https://github.com/user-attachments/assets/d6151feb-6a83-47aa-9f0c-5c88669fc125" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
