### PR TITLE
Fix links in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Once one or more people have started to work on a feature, it should be marked [
 
 ### E) Verification and merging
 
-All PRs that involve more than an insignificant change should be reviewed. See our [Code Review Process](https://github.com/metabase/metabase/blob/master/docs/developers-guide/code-reviews.md).
+All PRs that involve more than an insignificant change should be reviewed. See our [Code Review Process](https://www.metabase.com/docs/master/developers-guide/code-reviews).
 
 If all goes well, the feature gets coded up, verified and then the pull request gets merged! High-fives all around.
 
@@ -95,7 +95,7 @@ By our definition, "Bugs" are situations where the program doesn't do what it wa
 
 There are a lot of docs, which means keeping them up to date is hard. If you notice inconsistencies, errors, or outdated information, please help us keep them current!
 
-Note that **we cannot accept translations for documentation at this time**. We support [in-app translations](https://github.com/metabase/metabase/blob/master/docs/configuring-metabase/localization.md), and only support languages that have 100% coverage. But 1) the in-app text is orders of magnitude shorter than our docs, 2) it changes at a slower pace, and 3) we have a lot of people help out. We may consider supporting docs in multiple languages in the future, but for now we need to focus our resources on improving our existing documentation (and expanding it to include all of the new features we're adding).
+Note that **we cannot accept translations for documentation at this time**. We support [in-app translations](https://www.metabase.com/docs/master/configuring-metabase/localization), and only support languages that have 100% coverage. But 1) the in-app text is orders of magnitude shorter than our docs, 2) it changes at a slower pace, and 3) we have a lot of people help out. We may consider supporting docs in multiple languages in the future, but for now we need to focus our resources on improving our existing documentation (and expanding it to include all of the new features we're adding).
 
 ### Working on features
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Once one or more people have started to work on a feature, it should be marked [
 
 ### E) Verification and merging
 
-All PRs that involve more than an insignificant change should be reviewed. See our [Code Review Process](./developers-guide/code-reviews.md).
+All PRs that involve more than an insignificant change should be reviewed. See our [Code Review Process](https://github.com/metabase/metabase/blob/master/docs/developers-guide/code-reviews.md).
 
 If all goes well, the feature gets coded up, verified and then the pull request gets merged! High-fives all around.
 
@@ -95,7 +95,7 @@ By our definition, "Bugs" are situations where the program doesn't do what it wa
 
 There are a lot of docs, which means keeping them up to date is hard. If you notice inconsistencies, errors, or outdated information, please help us keep them current!
 
-Note that **we cannot accept translations for documentation at this time**. We support [in-app translations](./configuring-metabase/localization.md), and only support languages that have 100% coverage. But 1) the in-app text is orders of magnitude shorter than our docs, 2) it changes at a slower pace, and 3) we have a lot of people help out. We may consider supporting docs in multiple languages in the future, but for now we need to focus our resources on improving our existing documentation (and expanding it to include all of the new features we're adding).
+Note that **we cannot accept translations for documentation at this time**. We support [in-app translations](https://github.com/metabase/metabase/blob/master/docs/configuring-metabase/localization.md), and only support languages that have 100% coverage. But 1) the in-app text is orders of magnitude shorter than our docs, 2) it changes at a slower pace, and 3) we have a lot of people help out. We may consider supporting docs in multiple languages in the future, but for now we need to focus our resources on improving our existing documentation (and expanding it to include all of the new features we're adding).
 
 ### Working on features
 


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

### Description

Currently, opening these links using contributing file from the root (https://github.com/metabase/metabase?tab=contributing-ov-file) results in non-existing page (eg. https://github.com/metabase/metabase/blob/master/configuring-metabase/localization.md).
This PR fixes wrong behavior using same approach as for the zen link in the existing `CONTRIBUTING.md` file:
```
To get a sense for the end goals, make sure to read the [Zen of Metabase](https://github.com/metabase/metabase/blob/master/zen.md).
```

### How to verify

1. Open https://github.com/metabase/metabase?tab=contributing-ov-file
2. Click on `in-app translations`
3. Verify that it opens existing file

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
