### PR TITLE
Use blue shadow on embedding hub card to highlight next step

### DIFF
--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.module.css
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.module.css
@@ -22,6 +22,9 @@
 .step.stepDone .stepIcon {
   color: var(--mb-color-bg-white);
   background: var(--mb-color-success-darker);
+
+  /** Prevent blue border color from affecting the done icon */
+  border-color: transparent;
 }
 
 .stepWrapper {
@@ -62,6 +65,10 @@
 }
 
 .stepCard:not(.lockedStepCard):hover {
+  border: 1px solid var(--mb-color-focus) !important;
+}
+
+.stepCard.nextStepCard {
   border: 1px solid var(--mb-color-focus) !important;
   box-shadow: 0 2px 24px 0 var(--mb-color-shadow-embedding-hub-card);
 }

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
@@ -41,6 +41,21 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
     return null;
   }
 
+  // Find the next actionable card (first undone, unlocked card in the first incomplete step)
+  const nextCard = (() => {
+    const firstIncompleteStep = steps.find(
+      (step) => !step.cards.every((card) => card.done || card.optional),
+    );
+
+    if (!firstIncompleteStep) {
+      return null;
+    }
+
+    return firstIncompleteStep.cards.find(
+      (card) => !card.done && !card.locked && !card.optional,
+    );
+  })();
+
   return (
     <Stepper
       active={0}
@@ -72,17 +87,21 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                       ? card.clickAction.onClick
                       : undefined;
 
+                  const isNextCard = nextCard && nextCard.id === card.id;
+
                   return (
                     <CardAction card={card} key={card.id}>
                       <Card
                         className={cx(S.stepCard, {
                           [S.optionalStepCard]: card.optional,
                           [S.lockedStepCard]: card.locked,
+                          [S.nextStepCard]: isNextCard,
                         })}
                         component={onClick ? "button" : undefined}
                         onClick={onClick}
                         disabled={card.locked}
                         data-testid={`step-card-${card.id}`}
+                        data-next-step={isNextCard}
                       >
                         <Stack justify="space-between" h="100%">
                           <Stack gap="xs" h="100%">

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
@@ -169,4 +169,104 @@ describe("StepperWithCards", () => {
     const lockIcon = screen.getByLabelText("lock icon");
     expect(lockIcon).toBeInTheDocument();
   });
+
+  it("should mark next step with data-next-step", () => {
+    const steps = createMockSteps([
+      {
+        id: "step1",
+        title: "First Step",
+        cards: [
+          { id: "1", done: true }, // done card
+          { id: "2", done: false, locked: true }, // locked, should skip
+          { id: "3", done: false, optional: true }, // optional, should skip
+          { id: "4", done: false }, // this should be the next step
+        ],
+      },
+      {
+        id: "step2",
+        title: "Second Step",
+        cards: [
+          { id: "5", done: false }, // should not be next since step 1 is incomplete
+        ],
+      },
+    ]);
+
+    render(<StepperWithCards steps={steps} />);
+
+    expect(screen.getByTestId("step-card-4")).toHaveAttribute(
+      "data-next-step",
+      "true",
+    );
+
+    ["1", "2", "3", "5"].forEach((id) => {
+      expect(screen.getByTestId(`step-card-${id}`)).not.toHaveAttribute(
+        "data-next-step",
+        "true",
+      );
+    });
+  });
+
+  it("should handle step progression and completion correctly", () => {
+    const completeFirstStep = createMockSteps([
+      {
+        id: "step1",
+        title: "First Step",
+        cards: [
+          { id: "1", done: true },
+          { id: "2", done: false, optional: true }, // optional, step is still complete
+        ],
+      },
+      {
+        id: "step2",
+        title: "Second Step",
+        cards: [
+          { id: "3", done: false }, // this should be next
+          { id: "4", done: false },
+        ],
+      },
+    ]);
+
+    render(<StepperWithCards steps={completeFirstStep} />);
+
+    // Step 1 is complete, so card 3 should be next.
+    expect(screen.getByTestId("step-card-3")).toHaveAttribute(
+      "data-next-step",
+      "true",
+    );
+
+    ["1", "2", "4"].forEach((id) => {
+      expect(screen.getByTestId(`step-card-${id}`)).not.toHaveAttribute(
+        "data-next-step",
+        "true",
+      );
+    });
+  });
+
+  it("all steps complete", () => {
+    // all steps are complete
+    const allComplete = createMockSteps([
+      {
+        id: "step1",
+        title: "First Step",
+        cards: [{ id: "1", done: true }],
+      },
+      {
+        id: "step2",
+        title: "Second Step",
+        cards: [
+          { id: "2", done: true },
+          { id: "3", done: false, optional: true }, // optional undone card
+        ],
+      },
+    ]);
+
+    render(<StepperWithCards steps={allComplete} />);
+
+    // When all steps are complete, no cards should be marked as next
+    const allCards = ["1", "2", "3"];
+    allCards.forEach((id) => {
+      const card = screen.getByTestId(`step-card-${id}`);
+      expect(card).not.toHaveAttribute("data-next-step", "true");
+    });
+  });
 });


### PR DESCRIPTION
Closes EMB-817

The blue drop shadow from the Figma design is meant to highlight the next step. It wasn't meant for a card hover state.

### How to verify

- Go to "Admin Settings > Embedding > Setup guide"
- You should see the blue drop shadow on the first card
- Complete the first card
- You should see the blue drop shadow on the card on the next step, "Generate a dashboard"

### Demo

<img width="2516" height="1774" alt="CleanShot 2568-09-18 at 00 19 32@2x" src="https://github.com/user-attachments/assets/f18aedfd-a5f6-4fca-883d-c18920318cf8" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
