### PR TITLE
Update related settings copy and alignment on embedding hub

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.unit.spec.tsx
@@ -102,7 +102,7 @@ describe("InteractiveEmbeddingSettings", () => {
     expect(await screen.findByText("Databases")).toBeInTheDocument();
     expect(await screen.findByText("People")).toBeInTheDocument();
     expect(await screen.findByText("Permissions")).toBeInTheDocument();
-    expect(await screen.findByText("Metabot")).toBeInTheDocument();
+    expect(await screen.findByText("Embedded Metabot")).toBeInTheDocument();
     expect(await screen.findByText("Appearance")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/admin/components/RelatedSettingsSection/constants.ts
+++ b/frontend/src/metabase/admin/components/RelatedSettingsSection/constants.ts
@@ -87,7 +87,7 @@ export const getInteractiveEmbeddingRelatedSettingItems =
     },
     {
       icon: "metabot",
-      name: t`Metabot`,
+      name: t`Embedded Metabot`,
       to: "/admin/metabot/2",
     },
     {

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.tsx
@@ -73,7 +73,6 @@ export const EmbeddingHub = () => {
   return (
     <>
       <StepperWithCards steps={stepperSteps} />
-
       <AddDataModal
         opened={openedModal?.type === "add-data"}
         onClose={closeModal}

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubAdminSettingsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHubAdminSettingsPage.tsx
@@ -22,9 +22,11 @@ export const EmbeddingHubAdminSettingsPage = () => {
 
       <EmbeddingHub />
 
-      <RelatedSettingsSection
-        items={getModularEmbeddingRelatedSettingItems()}
-      />
+      <Stack ml="2.9rem">
+        <RelatedSettingsSection
+          items={getModularEmbeddingRelatedSettingItems()}
+        />
+      </Stack>
     </Stack>
   );
 };


### PR DESCRIPTION
Closes EMB-818

Addresses two design feedbacks:

1. The "Related settings" cards should be left-aligned to the checklist cards, not the numbers.
2. In Interactive embedding, the setting card should say "Embedded Metabot". The destination is correct already.

### How to verify

- Go to "Admin Settings > Embedding > Setup guide"
- Related settings cards should be left-aligned to the checklist cards.
- Interactive embedding's related settings card should have "Embedded Metabot"

### Demo

Alignment corrected:

<img width="1836" height="1208" alt="CleanShot 2568-09-18 at 00 42 23@2x" src="https://github.com/user-attachments/assets/6f851bec-747b-4ed0-b1df-c9c7b808a8a7" />

Metabot

<img width="1568" height="342" alt="CleanShot 2568-09-18 at 00 42 43@2x" src="https://github.com/user-attachments/assets/51e25967-7808-4389-b8ab-bc98d1cfb082" />
