### PR TITLE
Fix transform tables for stats

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.module.css
@@ -9,3 +9,7 @@
 .wrapBreakWord {
   overflow-wrap: break-word;
 }
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.module.css
@@ -2,12 +2,8 @@
   cursor: pointer;
 }
 
-.wrapAnywhere {
+.wrap {
   overflow-wrap: anywhere;
-}
-
-.wrapBreakWord {
-  overflow-wrap: break-word;
 }
 
 .nowrap {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.module.css
@@ -2,6 +2,10 @@
   cursor: pointer;
 }
 
-.cell {
+.wrapAnywhere {
+  overflow-wrap: anywhere;
+}
+
+.wrapBreakWord {
   overflow-wrap: break-word;
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.tsx
@@ -75,8 +75,8 @@ export function JobList({ params }: { params: JobListParams }) {
             className={S.row}
             onClick={() => handleRowClick(job)}
           >
-            <td className={S.wrapAnywhere}>{job.name}</td>
-            <td className={S.wrapBreakWord}>
+            <td className={S.wrap}>{job.name}</td>
+            <td className={S.nowrap}>
               {job.last_run?.start_time
                 ? parseTimestampWithTimezone(
                     job.last_run?.start_time,
@@ -84,7 +84,7 @@ export function JobList({ params }: { params: JobListParams }) {
                   ).format("lll")
                 : null}
             </td>
-            <td className={S.wrapBreakWord}>
+            <td className={S.nowrap}>
               {job.next_run?.start_time
                 ? parseTimestampWithTimezone(
                     job.next_run?.start_time,
@@ -92,7 +92,7 @@ export function JobList({ params }: { params: JobListParams }) {
                   ).format("lll")
                 : null}
             </td>
-            <td className={S.wrapBreakWord}>
+            <td className={S.wrap}>
               <TagList tags={tags} tagIds={job.tag_ids ?? []} />
             </td>
           </tr>

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.tsx
@@ -59,10 +59,12 @@ export function JobList({ params }: { params: JobListParams }) {
         columnTitles={[
           t`Job`,
           <Flex align="center" gap="xs" key="last-run-at">
-            {t`Last run at`} <TimezoneIndicator />
+            <span className={S.nowrap}>{t`Last run at`}</span>{" "}
+            <TimezoneIndicator />
           </Flex>,
           <Flex align="center" gap="xs" key="next-run">
-            {t`Next run`} <TimezoneIndicator />
+            <span className={S.nowrap}>{t`Next run`}</span>{" "}
+            <TimezoneIndicator />
           </Flex>,
           t`Tags`,
         ]}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.tsx
@@ -73,8 +73,8 @@ export function JobList({ params }: { params: JobListParams }) {
             className={S.row}
             onClick={() => handleRowClick(job)}
           >
-            <td className={S.cell}>{job.name}</td>
-            <td className={S.cell}>
+            <td className={S.wrapAnywhere}>{job.name}</td>
+            <td className={S.wrapBreakWord}>
               {job.last_run?.start_time
                 ? parseTimestampWithTimezone(
                     job.last_run?.start_time,
@@ -82,7 +82,7 @@ export function JobList({ params }: { params: JobListParams }) {
                   ).format("lll")
                 : null}
             </td>
-            <td className={S.cell}>
+            <td className={S.wrapBreakWord}>
               {job.next_run?.start_time
                 ? parseTimestampWithTimezone(
                     job.next_run?.start_time,
@@ -90,7 +90,7 @@ export function JobList({ params }: { params: JobListParams }) {
                   ).format("lll")
                 : null}
             </td>
-            <td className={S.cell}>
+            <td className={S.wrapBreakWord}>
               <TagList tags={tags} tagIds={job.tag_ids ?? []} />
             </td>
           </tr>

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.module.css
@@ -9,3 +9,7 @@
 .wrapBreakWord {
   overflow-wrap: break-word;
 }
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.module.css
@@ -2,12 +2,8 @@
   cursor: pointer;
 }
 
-.wrapAnywhere {
+.wrap {
   overflow-wrap: anywhere;
-}
-
-.wrapBreakWord {
-  overflow-wrap: break-word;
 }
 
 .nowrap {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.module.css
@@ -2,6 +2,10 @@
   cursor: pointer;
 }
 
-.cell {
+.wrapAnywhere {
+  overflow-wrap: anywhere;
+}
+
+.wrapBreakWord {
   overflow-wrap: break-word;
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.tsx
@@ -69,10 +69,11 @@ function RunTable({ runs }: RunTableProps) {
         columnTitles={[
           t`Transform`,
           <Flex key="started-at" align="center" gap="xs">
-            {t`Started at`} <TimezoneIndicator />
+            <span className={S.nowrap}>{t`Started at`}</span>{" "}
+            <TimezoneIndicator />
           </Flex>,
           <Flex key="end-at" align="center" gap="xs">
-            {t`End at`} <TimezoneIndicator />
+            <span className={S.nowrap}>{t`End at`}</span> <TimezoneIndicator />
           </Flex>,
           t`Status`,
           t`Trigger`,

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.tsx
@@ -85,14 +85,14 @@ function RunTable({ runs }: RunTableProps) {
             className={S.row}
             onClick={() => handleRowClick(run)}
           >
-            <td className={S.wrapAnywhere}>{run.transform?.name}</td>
-            <td className={S.wrapBreakWord}>
+            <td className={S.wrap}>{run.transform?.name}</td>
+            <td className={S.nowrap}>
               {parseTimestampWithTimezone(
                 run.start_time,
                 systemTimezone,
               ).format("lll")}
             </td>
-            <td className={S.wrapBreakWord}>
+            <td className={S.nowrap}>
               {run.end_time
                 ? parseTimestampWithTimezone(
                     run.end_time,
@@ -100,7 +100,7 @@ function RunTable({ runs }: RunTableProps) {
                   ).format("lll")
                 : null}
             </td>
-            <td className={S.wrapBreakWord}>
+            <td className={S.wrap}>
               <RunStatusInfo
                 status={run.status}
                 message={run.message}
@@ -114,9 +114,7 @@ function RunTable({ runs }: RunTableProps) {
                 }
               />
             </td>
-            <td className={S.wrapBreakWord}>
-              {formatRunMethod(run.run_method)}
-            </td>
+            <td className={S.wrap}>{formatRunMethod(run.run_method)}</td>
           </tr>
         ))}
       </AdminContentTable>

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/RunListPage/RunList/RunList.tsx
@@ -84,14 +84,14 @@ function RunTable({ runs }: RunTableProps) {
             className={S.row}
             onClick={() => handleRowClick(run)}
           >
-            <td className={S.cell}>{run.transform?.name}</td>
-            <td className={S.cell}>
+            <td className={S.wrapAnywhere}>{run.transform?.name}</td>
+            <td className={S.wrapBreakWord}>
               {parseTimestampWithTimezone(
                 run.start_time,
                 systemTimezone,
               ).format("lll")}
             </td>
-            <td className={S.cell}>
+            <td className={S.wrapBreakWord}>
               {run.end_time
                 ? parseTimestampWithTimezone(
                     run.end_time,
@@ -99,7 +99,7 @@ function RunTable({ runs }: RunTableProps) {
                   ).format("lll")
                 : null}
             </td>
-            <td className={S.cell}>
+            <td className={S.wrapBreakWord}>
               <RunStatusInfo
                 status={run.status}
                 message={run.message}
@@ -113,7 +113,9 @@ function RunTable({ runs }: RunTableProps) {
                 }
               />
             </td>
-            <td className={S.cell}>{formatRunMethod(run.run_method)}</td>
+            <td className={S.wrapBreakWord}>
+              {formatRunMethod(run.run_method)}
+            </td>
           </tr>
         ))}
       </AdminContentTable>

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.module.css
@@ -9,3 +9,7 @@
 .wrapBreakWord {
   overflow-wrap: break-word;
 }
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.module.css
@@ -2,12 +2,8 @@
   cursor: pointer;
 }
 
-.wrapAnywhere {
+.wrap {
   overflow-wrap: anywhere;
-}
-
-.wrapBreakWord {
-  overflow-wrap: break-word;
 }
 
 .nowrap {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.module.css
@@ -2,6 +2,10 @@
   cursor: pointer;
 }
 
-.cell {
+.wrapAnywhere {
+  overflow-wrap: anywhere;
+}
+
+.wrapBreakWord {
   overflow-wrap: break-word;
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.tsx
@@ -71,9 +71,9 @@ export function TransformList() {
             className={S.row}
             onClick={() => handleRowClick(transform)}
           >
-            <td className={S.wrapAnywhere}>{transform.name}</td>
-            <td className={S.wrapAnywhere}>{transform.target.name}</td>
-            <td className={S.wrapBreakWord}>
+            <td className={S.wrap}>{transform.name}</td>
+            <td className={S.wrap}>{transform.target.name}</td>
+            <td className={S.nowrap}>
               {transform.last_run?.end_time
                 ? parseTimestampWithTimezone(
                     transform.last_run.end_time,
@@ -81,7 +81,7 @@ export function TransformList() {
                   ).format("lll")
                 : null}
             </td>
-            <td className={S.wrapBreakWord}>
+            <td className={S.nowrap}>
               {transform.last_run != null ? (
                 <RunStatusInfo
                   status={transform.last_run.status}
@@ -97,7 +97,7 @@ export function TransformList() {
                 />
               ) : null}
             </td>
-            <td className={S.wrapBreakWord}>
+            <td className={S.wrap}>
               <TagList tags={tags} tagIds={transform.tag_ids ?? []} />
             </td>
           </tr>

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.tsx
@@ -56,9 +56,12 @@ export function TransformList() {
           t`Transform`,
           t`Target`,
           <Flex key="last-run-at" component="span" align="center" gap="xs">
-            {t`Last run at`} <TimezoneIndicator />
+            <span className={S.nowrap}>{t`Last run at`}</span>{" "}
+            <TimezoneIndicator />
           </Flex>,
-          t`Last run status`,
+          <span key="last-run-status" className={S.nowrap}>
+            {t`Last run status`}
+          </span>,
           t`Tags`,
         ]}
       >

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformList/TransformList.tsx
@@ -68,9 +68,9 @@ export function TransformList() {
             className={S.row}
             onClick={() => handleRowClick(transform)}
           >
-            <td className={S.cell}>{transform.name}</td>
-            <td className={S.cell}>{transform.target.name}</td>
-            <td className={S.cell}>
+            <td className={S.wrapAnywhere}>{transform.name}</td>
+            <td className={S.wrapAnywhere}>{transform.target.name}</td>
+            <td className={S.wrapBreakWord}>
               {transform.last_run?.end_time
                 ? parseTimestampWithTimezone(
                     transform.last_run.end_time,
@@ -78,7 +78,7 @@ export function TransformList() {
                   ).format("lll")
                 : null}
             </td>
-            <td className={S.cell}>
+            <td className={S.wrapBreakWord}>
               {transform.last_run != null ? (
                 <RunStatusInfo
                   status={transform.last_run.status}
@@ -94,7 +94,7 @@ export function TransformList() {
                 />
               ) : null}
             </td>
-            <td className={S.cell}>
+            <td className={S.wrapBreakWord}>
               <TagList tags={tags} tagIds={transform.tag_ids ?? []} />
             </td>
           </tr>


### PR DESCRIPTION
Fixes https://linear.app/metabase/issue/QUE-2461/fe-fix-table-layout-issues

Stats uses long unbreakable words for transform names and target tables. Let's take that into account.

Could result in somewhat worse wrapping for small window sizes.