### PR TITLE
Do not autopivot transform query results

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -441,6 +441,40 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
       testCardSource({ type: "question", label: "Questions" });
       testCardSource({ type: "model", label: "Models" });
     });
+
+    it("should not auto-pivot query results for MBQL transforms", () => {
+      cy.log("create a new transform");
+      visitTransformListPage();
+      getTransformListPage().button("Create a transform").click();
+      H.popover().findByText("Query builder").click();
+
+      cy.log("build a query with 1 aggregation and 2 breakouts");
+      H.entityPickerModal().within(() => {
+        cy.findByText(DB_NAME).click();
+        cy.findByText(SOURCE_TABLE).click();
+      });
+      H.getNotebookStep("summarize")
+        .findByText("Pick a function or metric")
+        .click();
+      H.popover().findByText("Count of rows").click();
+      H.getNotebookStep("summarize")
+        .findByText("Pick a column to group by")
+        .click();
+      H.popover().findByText("Name").click();
+      H.getNotebookStep("summarize")
+        .findByTestId("breakout-step")
+        .icon("add")
+        .click();
+      H.popover().findByText("Score").click();
+      H.runButtonOverlay().click();
+
+      cy.log("verify that no pivoting is applied");
+      H.tableInteractiveHeader().within(() => {
+        cy.findByText("Name").should("be.visible");
+        cy.findByText(/Score/).should("be.visible");
+        cy.findByText("Count").should("be.visible");
+      });
+    });
   });
 
   describe("name and description", () => {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-query-results/use-query-results.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-query-results/use-query-results.ts
@@ -19,7 +19,11 @@ export function useQueryResults(question: Question) {
 
   const { result, rawSeries, isRunnable, isResultDirty } = useMemo(() => {
     const lastRunQuestion = lastRunQuery
-      ? Question.create({ dataset_query: lastRunQuery, metadata })
+      ? Question.create({
+          dataset_query: lastRunQuery,
+          metadata,
+          visualization_settings: question.settings(),
+        })
       : null;
     const result = results ? results[0] : null;
     const rawSeries =

--- a/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-query-state/use-query-state.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-query-state/use-query-state.ts
@@ -4,14 +4,23 @@ import { useSelector } from "metabase/lib/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
-import type { DatasetQuery } from "metabase-types/api";
+import type { DatasetQuery, VisualizationSettings } from "metabase-types/api";
+
+const DEFAULT_VIZ_SETTINGS: VisualizationSettings = {
+  "table.pivot": false,
+};
 
 export function useQueryState(initialQuery: DatasetQuery) {
   const [query, setQuery] = useState(initialQuery);
   const metadata = useSelector(getMetadata);
 
   const question = useMemo(
-    () => Question.create({ dataset_query: query, metadata }),
+    () =>
+      Question.create({
+        dataset_query: query,
+        metadata,
+        visualization_settings: DEFAULT_VIZ_SETTINGS,
+      }),
     [query, metadata],
   );
 


### PR DESCRIPTION
Fixes https://linear.app/metabase/issue/QUE-2479/fe-remove-auto-pivoting-of-query-results

How to verify:
- Transforms -> New -> Query builder -> Table
- Pick 1 aggregation and 2 breakouts, e.g. `Category` and `Price`
- Results should not be pivoted

Before:
<img width="1659" height="837" alt="Screenshot 2025-09-17 at 21 43 00" src="https://github.com/user-attachments/assets/9d2e8c7a-f65d-456e-942c-53043a3d5561" />

After:
<img width="1664" height="827" alt="Screenshot 2025-09-17 at 21 43 16" src="https://github.com/user-attachments/assets/dad7ead4-3998-4fe9-80b0-9f08f2be8b6c" />
