### PR TITLE
fix(sdk): Properly load Tiles from MB instance

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-map.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-map.cy.spec.tsx
@@ -50,18 +50,21 @@ describe("scenarios > embedding-sdk > interactive-question-map", () => {
     });
   });
 
-  it.only("should load tiles properly from an instance (#63638)", () => {
+  it("should load card tiles properly from an instance (#63638)", () => {
     setup({
       pinType: "tiles",
     });
 
+    cy.intercept("/api/tiles/**").as("getTiles");
+
     mountInteractiveQuestion();
 
-    getSdkRoot().within(() => {
-      mapPinIcon()
-        .should("be.visible")
-        .should("have.attr", "src")
-        .and("include", METABASE_INSTANCE_URL);
-    });
+    cy.wait("@getTiles").then(
+      ({ request: tilesRequest, response: tileResponse }) => {
+        expect(tilesRequest.url).to.include(METABASE_INSTANCE_URL);
+        expect(tilesRequest.headers["x-metabase-session"]).to.not.eq(undefined);
+        expect(tileResponse?.statusCode).to.equal(200);
+      },
+    );
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-map.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-map.cy.spec.tsx
@@ -11,28 +11,50 @@ import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-
 
 const { PEOPLE_ID } = SAMPLE_DATABASE;
 
-describe("scenarios > embedding-sdk > interactive-question-map", () => {
-  beforeEach(() => {
-    signInAsAdminAndEnableEmbeddingSdk();
+const setup = ({ pinType }: { pinType: "markers" | "tiles" }) => {
+  signInAsAdminAndEnableEmbeddingSdk();
 
-    createQuestion({
-      name: "13597",
-      display: "map",
-      query: {
-        "source-table": PEOPLE_ID,
-        limit: 2,
-      },
-    }).then(({ body: question }) => {
-      cy.wrap(question.id).as("questionId");
-      cy.wrap(question.entity_id).as("questionEntityId");
-    });
-
-    cy.signOut();
-
-    mockAuthProviderAndJwtSignIn();
+  createQuestion({
+    name: "13597",
+    display: "map",
+    query: {
+      "source-table": PEOPLE_ID,
+      limit: 2,
+    },
+    visualization_settings: {
+      "map.pin_type": pinType,
+    },
+  }).then(({ body: question }) => {
+    cy.wrap(question.id).as("questionId");
+    cy.wrap(question.entity_id).as("questionEntityId");
   });
 
-  it("should show pin icon", () => {
+  cy.signOut();
+
+  mockAuthProviderAndJwtSignIn();
+};
+
+describe("scenarios > embedding-sdk > interactive-question-map", () => {
+  it("should show pin icon from an instance", () => {
+    setup({
+      pinType: "markers",
+    });
+
+    mountInteractiveQuestion();
+
+    getSdkRoot().within(() => {
+      mapPinIcon()
+        .should("be.visible")
+        .should("have.attr", "src")
+        .and("include", METABASE_INSTANCE_URL);
+    });
+  });
+
+  it.only("should load tiles properly from an instance (#63638)", () => {
+    setup({
+      pinType: "tiles",
+    });
+
     mountInteractiveQuestion();
 
     getSdkRoot().within(() => {

--- a/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletTilePinMap.jsx
@@ -2,6 +2,7 @@ import L from "leaflet";
 
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { GET } from "metabase/lib/api";
+import { isWithinIframe } from "metabase/lib/dom";
 
 import { getTileUrl } from "../lib/map";
 
@@ -24,7 +25,8 @@ export default class LeafletTilePinMap extends LeafletMap {
 
     this.pinTileLayer = L.tileLayer("", {}).addTo(this.map);
 
-    if (isEmbeddingSdk()) {
+    // Override only for SDK and not for cases when SDK is used under the hood for other embed types (Embed JS)
+    if (isEmbeddingSdk() && !isWithinIframe()) {
       this._overrideCreateTileToUseFetch(this.pinTileLayer);
     }
 

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -1,4 +1,3 @@
-import api from "metabase/lib/api";
 import { isUuid } from "metabase/lib/uuid";
 import type { DashboardId, Dataset, JsonQuery } from "metabase-types/api";
 
@@ -140,7 +139,7 @@ function adhocQueryTileUrl(
   lonField: string,
   datasetQuery: any,
 ): string {
-  return `${api.basename}/api/tiles/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?query=${encodeURIComponent(
+  return `/api/tiles/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?query=${encodeURIComponent(
     JSON.stringify(datasetQuery),
   )}`;
 }
@@ -153,7 +152,7 @@ function savedQuestionTileUrl(
   lonField: string,
   parameters?: unknown[],
 ): string {
-  let url = `${api.basename}/api/tiles/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  let url = `/api/tiles/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
   if (parameters && parameters.length > 0) {
     url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
   }
@@ -170,7 +169,7 @@ function dashboardTileUrl(
   lonField: string,
   parameters?: unknown[],
 ): string {
-  let url = `${api.basename}/api/tiles/${dashboardId}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  let url = `/api/tiles/${dashboardId}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
   if (parameters && parameters.length > 0) {
     url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
   }

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -1,3 +1,4 @@
+import api from "metabase/lib/api";
 import { isUuid } from "metabase/lib/uuid";
 import type { DashboardId, Dataset, JsonQuery } from "metabase-types/api";
 
@@ -139,7 +140,7 @@ function adhocQueryTileUrl(
   lonField: string,
   datasetQuery: any,
 ): string {
-  return `/api/tiles/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?query=${encodeURIComponent(
+  return `${api.basename}/api/tiles/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}?query=${encodeURIComponent(
     JSON.stringify(datasetQuery),
   )}`;
 }
@@ -152,7 +153,7 @@ function savedQuestionTileUrl(
   lonField: string,
   parameters?: unknown[],
 ): string {
-  let url = `/api/tiles/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  let url = `${api.basename}/api/tiles/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
   if (parameters && parameters.length > 0) {
     url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
   }
@@ -169,7 +170,7 @@ function dashboardTileUrl(
   lonField: string,
   parameters?: unknown[],
 ): string {
-  let url = `/api/tiles/${dashboardId}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  let url = `${api.basename}/api/tiles/${dashboardId}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
   if (parameters && parameters.length > 0) {
     url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
   }

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -28,6 +28,7 @@
 (def ^:private ^:const tile-size             256.0)
 (def ^:private ^:const pixel-origin          (double (/ tile-size 2)))
 (def ^:private ^:const pin-size              6)
+(def ^:private ^:const pin-size-half         (/ pin-size 2))
 (def ^:private ^:const pixels-per-lon-degree (double (/ tile-size 360)))
 (def ^:private ^:const pixels-per-lon-radian (double (/ tile-size (* 2 Math/PI))))
 
@@ -97,12 +98,15 @@
               map-pixel  {:x (int (Math/floor (* (point :x) num-tiles)))
                           :y (int (Math/floor (* (point :y) num-tiles)))}
               tile-pixel {:x (mod (map-pixel :x) tile-size)
-                          :y (mod (map-pixel :y) tile-size)}]
+                          :y (mod (map-pixel :y) tile-size)}
+              ;; cx/cy is needed to put center of a pin at the tile-pixel position
+              cx   (- (tile-pixel :x) pin-size-half)
+              cy   (- (tile-pixel :y) pin-size-half)]
           ;; now draw a "pin" at the given tile pixel location
           (.setColor graphics color-white)
-          (.fillRect graphics (tile-pixel :x) (tile-pixel :y) pin-size pin-size)
+          (.fillRect graphics cx cy pin-size pin-size)
           (.setColor graphics color-blue)
-          (.fillRect graphics (inc (tile-pixel :x)) (inc (tile-pixel :y)) (- pin-size 2) (- pin-size 2))))
+          (.fillRect graphics (inc cx) (inc cy) (- pin-size 2) (- pin-size 2))))
       (catch Throwable e
         (.printStackTrace e))
       (finally


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63638
We have 2 issues with TileLayer in SDK:
- wrong base path, that points on a consumer host, instead of a MB instance host
- tiles are loaded as images, so we don't pass session via header.

Also, we have a very minor issue - pin points positioned at their location with top-left corner as the anchor.

This PR adds `basename` to a few URLs that are used in Embedding SDK
Also, we override the `createTile` method from Leaflet, to use `fetch` + img src as `data:base64` instead of a pure `img` src.
And we fix the pin points positioning, so the center of a pin point is an anchor.

https://github.com/user-attachments/assets/3d6ed118-580e-47eb-8195-4174517c0b7e


Notes:
- we don't use a pure `blob:` and use `data:base64` to avoid issues with CSP when `blob:`s are restricted.

How to verify:
- `yarn dev-ee`
- `yarn storybook-embedding-sdk`
- open `SdkQuestion` and set `map` viz type
- open viz settings, select `Map type` as `pin map` and `pin type` as `tiles`. Play with it, zoom/unzoom. Check headers of tile images, you have to see `x-metabase-session` header there.