### PR TITLE
Fix command z not working in connection string input

### DIFF
--- a/e2e/support/commands/ui/paste.ts
+++ b/e2e/support/commands/ui/paste.ts
@@ -1,19 +1,43 @@
+const nodes = {
+  INPUT: window.HTMLInputElement.prototype,
+  TEXTAREA: window.HTMLTextAreaElement.prototype,
+} as const;
+
+function getPrototype(
+  node: string,
+): (typeof nodes)[keyof typeof nodes] | undefined {
+  return nodes[node as keyof typeof nodes];
+}
+
 Cypress.Commands.add(
   "paste",
   { prevSubject: "element" },
   (subject, text: string) => {
     cy.wrap(subject).then(($element) => {
+      // Since Cypress cannot simulate native paste events, that are handled by React onChange,
+      // we need to set the value manually and dispatch a change event.
+      const nodeName = $element[0].nodeName;
+      const prototype = getPrototype(nodeName);
+
+      if (!prototype) {
+        throw new Error(`Unsupported node type: ${nodeName}`);
+      }
+
+      const nativeTextAreaValueSetter = Object.getOwnPropertyDescriptor(
+        prototype,
+        "value",
+      )?.set;
+      nativeTextAreaValueSetter?.call($element[0], text);
+      $element[0].dispatchEvent(new Event("change", { bubbles: true }));
+
+      // Let's dispatch the simulated paste event in case components have onPaste handlers.dfs
       const clipboardData = new DataTransfer();
       clipboardData.setData("text/plain", text);
-
       const pasteEvent = new ClipboardEvent("paste", {
         bubbles: true,
         cancelable: true,
         clipboardData,
       });
-
-      console.log({ $element, element: $element[0], pasteEvent });
-
       $element[0].dispatchEvent(pasteEvent);
     });
 

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
@@ -133,11 +133,6 @@ export function DatabaseConnectionStringField({
       onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setConnectionString(event.target.value);
       }}
-      onPaste={(event: React.ClipboardEvent<HTMLTextAreaElement>) => {
-        event.preventDefault();
-        const clipboardData = event.clipboardData.getData("Text");
-        setConnectionString(clipboardData);
-      }}
       mb="md"
       placeholder={placeholder}
       name="connection-string"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> 

- Closes #63346
- Closes https://linear.app/metabase/issue/PRG-134/strange-undo-cmdz-behavior-in-connection-string-field

### Description

Custom `onPaste` handler was introduced iitially only to play nicely with the imperfect way how Cypress emulates some events, like paste. 
The handler interfered with the default way browser and React handle `paste` events and broke the undo functionality.

The fix is to remove `onPaste` handler, and let React handle this natively (`onChange` is enough to handle `paste` events  fully).

At the same time a workaround was introduced to in Cypress paste emulation logic that makes tests detect the change value correctly. The idea is taken from this post: [Testing Synthetic Events in Cypress | ryanfiller.com](https://www.ryanfiller.com/blog/tips/synthetic-events-in-cypress).

### How to verify

Paste a some string into connection string input and see if `undo` (`cmd z` on macOS) still works.
Check if valid and invalid connection strings still populate form fields.

