### PR TITLE
Properly run tiles-query as admin user for static endpoints if JWT token is valid

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -516,6 +516,7 @@
            public-sharing
            queries
            query-processor
+           request
            server
            settings
            tiles

--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1,8 +1,8 @@
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+import { questionAsPinMapWithTiles } from "e2e/test/scenarios/embedding/shared/embedding-questions";
 import { defer } from "metabase/lib/promise";
-
 const { PRODUCTS, PRODUCTS_ID, ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("issue 15860", { tags: "@skip" }, () => {
@@ -1495,4 +1495,27 @@ describe("issue 51934 (EMB-189)", () => {
       });
     });
   }
+});
+
+describe("issue 63687", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should properly display pin map tiles without auth errors for a valid JWT token", () => {
+    H.createNativeQuestion(questionAsPinMapWithTiles, {
+      visitQuestion: true,
+    });
+
+    H.openStaticEmbeddingModal({ activeTab: "parameters" });
+
+    cy.intercept("/api/embed/tiles/**").as("getTiles");
+
+    H.visitIframe();
+
+    cy.wait("@getTiles").then(({ response: tileResponse }) => {
+      expect(tileResponse?.statusCode).to.equal(200);
+    });
+  });
 });

--- a/e2e/test/scenarios/embedding/shared/embedding-questions.js
+++ b/e2e/test/scenarios/embedding/shared/embedding-questions.js
@@ -73,3 +73,19 @@ export const joinedQuestion = {
     ],
   },
 };
+
+export const questionAsPinMapWithTiles = {
+  name: "Orders",
+  description: "Foo",
+  enable_embedding: true,
+  native: {
+    query: "SELECT LATITUDE, LONGITUDE FROM PEOPLE ORDER BY ID LIMIT 10",
+  },
+  display: "map",
+  visualization_settings: {
+    "map.type": "pin",
+    "map.pin_type": "tiles",
+    "map.longitude_column": "LONGITUDE",
+    "map.latitude_column": "LATITUDE",
+  },
+};

--- a/src/metabase/embedding/api/common.clj
+++ b/src/metabase/embedding/api/common.clj
@@ -314,6 +314,11 @@
               :qp          qp
               options)))
 
+(defn unsigned-token->card-id
+  [unsigned-token]
+  (->> (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])
+       (eid-translation/->id :model/Card)))
+
 ;;; -------------------------- Dashboard Fns used by both /api/embed and /api/preview_embed --------------------------
 
 (defn- remove-locked-parameters [dashboard embedding-params]
@@ -479,7 +484,7 @@
                       (u/pprint-to-str (u/all-ex-data e)))
           (throw e))))))
 
-(defn- unsigned-token->dashboard-id
+(defn unsigned-token->dashboard-id
   [unsigned-token]
   (->> (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
        (eid-translation/->id :model/Dashboard)))

--- a/src/metabase/embedding/api/common.clj
+++ b/src/metabase/embedding/api/common.clj
@@ -315,6 +315,7 @@
               options)))
 
 (defn unsigned-token->card-id
+  "Get the Card ID from an unsigned token."
   [unsigned-token]
   (->> (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :question])
        (eid-translation/->id :model/Card)))
@@ -485,6 +486,7 @@
           (throw e))))))
 
 (defn unsigned-token->dashboard-id
+  "Get the Dashboard ID from an unsigned token."
   [unsigned-token]
   (->> (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
        (eid-translation/->id :model/Dashboard)))

--- a/src/metabase/embedding/api/embed.clj
+++ b/src/metabase/embedding/api/embed.clj
@@ -29,7 +29,6 @@
    [metabase.tiles.api :as api.tiles]
    [metabase.util :as u]
    [metabase.util.json :as json]
-   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [ring.util.codec :as codec]

--- a/src/metabase/embedding/api/embed.clj
+++ b/src/metabase/embedding/api/embed.clj
@@ -25,9 +25,11 @@
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.schema :as qp.schema]
+   [metabase.request.core :as request]
    [metabase.tiles.api :as api.tiles]
    [metabase.util :as u]
    [metabase.util.json :as json]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [ring.util.codec :as codec]
@@ -327,12 +329,13 @@
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]
   (let [unsigned   (unsign-and-translate-ids token)
-        card-id    (embedding.jwt/get-in-unsigned-token-or-throw unsigned [:resource :question])
+        card-id    (api.embed.common/unsigned-token->card-id unsigned)
         parameters (json/decode+kw parameters)
         lat-field    (json/decode+kw lat-field)
         lon-field    (json/decode+kw lon-field)]
     (api.embed.common/check-embedding-enabled-for-card card-id)
-    (api.tiles/process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field)))
+    (request/as-admin
+      (api.tiles/process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field))))
 
 (api.macros/defendpoint :get "/tiles/dashboard/:token/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
   "Generates a single tile image for a Card on an embedded Dashboard using the map visualization."
@@ -347,8 +350,10 @@
    :- [:map
        [:parameters {:optional true} ms/JSONString]]]
   (let [unsigned     (unsign-and-translate-ids token)
-        dashboard-id (embedding.jwt/get-in-unsigned-token-or-throw unsigned [:resource :dashboard])
+        dashboard-id    (api.embed.common/unsigned-token->dashboard-id unsigned)
         parameters   (json/decode+kw parameters)
         lat-field    (json/decode+kw lat-field)
         lon-field    (json/decode+kw lon-field)]
-    (api.tiles/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field)))
+    (api.embed.common/check-embedding-enabled-for-dashboard dashboard-id)
+    (request/as-admin
+      (api.tiles/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63687
Properly run tiles-query as admin user for static endpoints if JWT token is valid

Currently, even though we have separate endpoints for pin map tiles, they don't properly disable the auth check if a JWT token is valid.

How to verify:
- `yarn dev-ee`
- create any question, set its viz type as `map`
- select `map type` as `pin map` and `pin type` as `tiles`
- save it
- statically embed it, get its iframe URL in a `preview` window, open the iframe in an incognito tab
- you should see blue pit tiles