### PR TITLE
Make transform list pages wider

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/index.tsx
@@ -13,7 +13,7 @@ import { NewTransformQueryPage } from "./pages/NewTransformQueryPage";
 import { RunListPage } from "./pages/RunListPage";
 import { TransformListPage } from "./pages/TransformListPage";
 import { TransformPage } from "./pages/TransformPage";
-import { ItemPageLayout, ListPageLayout } from "./pages/TransformPageLayout";
+import { DetailsPageLayout, ListPageLayout } from "./pages/TransformPageLayout";
 import { TransformQueryPage } from "./pages/TransformQueryPage";
 
 if (hasPremiumFeature("transforms")) {
@@ -29,7 +29,7 @@ if (hasPremiumFeature("transforms")) {
           <Route path="jobs" component={JobListPage} />
           <Route path="runs" component={RunListPage} />
         </Route>
-        <Route component={ItemPageLayout}>
+        <Route component={DetailsPageLayout}>
           <Route path="jobs/new" component={NewJobPage} />
           <Route path="jobs/:jobId" component={JobPage} />
           <Route path=":transformId" component={TransformPage} />

--- a/enterprise/frontend/src/metabase-enterprise/transforms/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/index.tsx
@@ -13,7 +13,7 @@ import { NewTransformQueryPage } from "./pages/NewTransformQueryPage";
 import { RunListPage } from "./pages/RunListPage";
 import { TransformListPage } from "./pages/TransformListPage";
 import { TransformPage } from "./pages/TransformPage";
-import { TransformPageLayout } from "./pages/TransformPageLayout";
+import { ItemPageLayout, ListPageLayout } from "./pages/TransformPageLayout";
 import { TransformQueryPage } from "./pages/TransformQueryPage";
 
 if (hasPremiumFeature("transforms")) {
@@ -24,12 +24,14 @@ if (hasPremiumFeature("transforms")) {
   PLUGIN_TRANSFORMS.getAdminRoutes = () => (
     <Route path="transforms" component={createAdminRouteGuard("transforms")}>
       <Route title={t`Transforms`}>
-        <Route component={TransformPageLayout}>
+        <Route component={ListPageLayout}>
           <IndexRoute component={TransformListPage} />
           <Route path="jobs" component={JobListPage} />
+          <Route path="runs" component={RunListPage} />
+        </Route>
+        <Route component={ItemPageLayout}>
           <Route path="jobs/new" component={NewJobPage} />
           <Route path="jobs/:jobId" component={JobPage} />
-          <Route path="runs" component={RunListPage} />
           <Route path=":transformId" component={TransformPage} />
         </Route>
         <Route path="new/:type" component={NewTransformQueryPage} />

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobListPage.tsx
@@ -27,7 +27,7 @@ export function JobListPage({ location }: JobListPageProps) {
 
   return (
     <Stack gap="xl" data-testid="job-list-page">
-      <Group justify="space-between">
+      <Group justify="space-between" align="start">
         <Stack gap="sm">
           <Title order={1}>{t`Jobs`}</Title>
           <Box>{t`Jobs let you run groups of transforms on a schedule.`}</Box>

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformListPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformListPage/TransformListPage.tsx
@@ -8,7 +8,7 @@ import { TransformList } from "./TransformList";
 export function TransformListPage() {
   return (
     <Stack gap="xl" data-testid="transform-list-page">
-      <Group justify="space-between">
+      <Group justify="space-between" align="start">
         <Stack gap="sm" flex={1}>
           <Title order={1}>{t`Transforms`}</Title>
           <Box>{t`Create custom tables with transforms, and run them on a schedule.`}</Box>

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPageLayout/TransformPageLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPageLayout/TransformPageLayout.tsx
@@ -33,7 +33,10 @@ export function ListPageLayout({ params, children }: TransformPageLayoutProps) {
   );
 }
 
-export function ItemPageLayout({ params, children }: TransformPageLayoutProps) {
+export function DetailsPageLayout({
+  params,
+  children,
+}: TransformPageLayoutProps) {
   return (
     <TransformPageLayout params={params} maw="60rem">
       {children}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPageLayout/TransformPageLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPageLayout/TransformPageLayout.tsx
@@ -11,40 +11,62 @@ import { getLocation } from "metabase/selectors/routing";
 
 import { getJobListUrl, getRunListUrl, getTransformListUrl } from "../../urls";
 
-type TransformPageLayoutParams = {
+type TransformPageLayoutPropsParams = {
   transformId?: string;
   jobId?: string;
 };
 
 type TransformPageLayoutProps = {
-  params: TransformPageLayoutParams;
+  params: TransformPageLayoutPropsParams;
   children?: ReactNode;
 };
 
-export function TransformPageLayout({
+type TransformPageLayoutOwnProps = TransformPageLayoutProps & {
+  maw?: string;
+};
+
+export function ListPageLayout({ params, children }: TransformPageLayoutProps) {
+  return (
+    <TransformPageLayout params={params} maw="100rem">
+      {children}
+    </TransformPageLayout>
+  );
+}
+
+export function ItemPageLayout({ params, children }: TransformPageLayoutProps) {
+  return (
+    <TransformPageLayout params={params} maw="60rem">
+      {children}
+    </TransformPageLayout>
+  );
+}
+
+function TransformPageLayout({
   params,
+  maw,
   children,
-}: TransformPageLayoutProps) {
+}: TransformPageLayoutOwnProps) {
   return (
     <AdminSettingsLayout
-      sidebar={<TransformSidebar params={params} />}
-      maw="60rem"
+      sidebar={<TransformPageSidebar params={params} />}
+      maw={maw}
     >
       {children}
     </AdminSettingsLayout>
   );
 }
 
-type TransformSidebarProps = {
-  params: TransformPageLayoutParams;
+type TransformPageSidebarProps = {
+  params: TransformPageLayoutPropsParams;
 };
 
-function TransformSidebar({ params }: TransformSidebarProps) {
-  const { transformId } = params;
+function TransformPageSidebar({ params }: TransformPageSidebarProps) {
+  const { transformId, jobId } = params;
   const location = useSelector(getLocation);
   const pathname = location?.pathname;
   const transformListUrl = getTransformListUrl();
   const jobListUrl = getJobListUrl();
+  const runListUrl = getRunListUrl();
 
   return (
     <AdminNavWrapper data-testid="transform-sidebar">
@@ -58,9 +80,9 @@ function TransformSidebar({ params }: TransformSidebarProps) {
         label={t`Jobs`}
         path={jobListUrl}
         icon="play_outlined"
-        active={pathname?.startsWith(jobListUrl)}
+        active={pathname === jobListUrl || jobId != null}
       />
-      <AdminNavItem label={t`Runs`} path={getRunListUrl()} icon="list" />
+      <AdminNavItem label={t`Runs`} path={runListUrl} icon="list" />
     </AdminNavWrapper>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPageLayout/TransformPageLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformPageLayout/TransformPageLayout.tsx
@@ -85,7 +85,12 @@ function TransformPageSidebar({ params }: TransformPageSidebarProps) {
         icon="play_outlined"
         active={pathname === jobListUrl || jobId != null}
       />
-      <AdminNavItem label={t`Runs`} path={runListUrl} icon="list" />
+      <AdminNavItem
+        label={t`Runs`}
+        path={runListUrl}
+        icon="list"
+        active={pathname === runListUrl}
+      />
     </AdminNavWrapper>
   );
 }


### PR DESCRIPTION
Details pages still have `60rem` as `max-width`. List pages now have `100rem`.

<img width="1728" height="840" alt="Screenshot 2025-09-18 at 12 04 26" src="https://github.com/user-attachments/assets/a996d7d5-38f6-407a-82d0-54a0eba7b916" />
