### PR TITLE
Fix: #63258 + UXW-570 Fix truncated dashboard notifications

### DIFF
--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-3-stage.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-3-stage.cy.spec.ts
@@ -403,6 +403,8 @@ describe("scenarios > dashboard > filters > query stages", () => {
               .click();
           });
 
+          H.undoToast().icon("close").click();
+
           H.getDashboardCard(1).findByText("Select…").click();
           H.popover().within(() => {
             QSHelpers.getPopoverItem("Product → Category", 1)

--- a/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
@@ -655,13 +655,12 @@ export function setup2ndStageBreakoutFilter() {
   H.popover().within(() => {
     getPopoverItem("Product → Category", 1).scrollIntoView().click();
   });
+  closeToasts();
 
   H.getDashboardCard(1).findByText("Select…").click();
   H.popover().within(() => {
     getPopoverItem("Product → Category", 1).scrollIntoView().click();
   });
-
-  closeToasts();
 
   H.getDashboardCard(2).findByText("Select…").click();
   H.popover().within(() => {

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -656,8 +656,7 @@ describe("issue 28756", () => {
 
   const TOAST_TIMEOUT_SAFETY_MARGIN = 1000;
   const TOAST_TIMEOUT = DASHBOARD_SLOW_TIMEOUT + TOAST_TIMEOUT_SAFETY_MARGIN;
-  const TOAST_MESSAGE =
-    "Would you like to be notified when this dashboard is done loading?";
+  const TOAST_MESSAGE = "Want to get notified when this dashboard loads?";
 
   function restrictCollectionForNonAdmins(collectionId) {
     cy.request("GET", "/api/collection/graph").then(

--- a/frontend/src/metabase/common/components/UndoListing.styled.tsx
+++ b/frontend/src/metabase/common/components/UndoListing.styled.tsx
@@ -70,6 +70,7 @@ export const UndoButton = styled(Link)`
   padding: 4px 12px;
   margin-left: ${space(1)};
   border-radius: 8px;
+  white-space: nowrap; /* Prevents button from truncating message */
 
   :hover {
     background-color: ${() => alpha(color("bg-white"), 0.3)};

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/use-slow-card-notification.ts
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/use-slow-card-notification.ts
@@ -54,9 +54,9 @@ export const useSlowCardNotification = () => {
         addUndo({
           id: slowToastId,
           timeout: false,
-          message: t`Would you like to be notified when this dashboard is done loading?`,
+          message: t`Want to get notified when this dashboard loads?`,
           action: onConfirmToast,
-          actionLabel: t`Turn on`,
+          actionLabel: t`Notify me`,
         }),
       );
     }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63258

Also closes related issue UXW-570

### Description

The tooltips truncate prematurely, but adding `white-space: nowrap` to the `UndoButton` seems to fix it.

Also updated a toast message copy while I was in there (UXW-570).

### How to verify

See repro steps for [UXW-570](https://linear.app/metabase/issue/UXW-570) and https://github.com/metabase/metabase/issues/63258

You can trigger the slow-loading message (UXW-570) by making these changes locally:

<img width="474" height="401" alt="Screenshot 2025-09-19 at 5 37 25 PM" src="https://github.com/user-attachments/assets/508841b5-902e-4298-9f82-c772efb72b1f" />


### Demo
#63258
<img width="1312" height="745" alt="Screenshot 2025-09-19 at 4 31 58 PM" src="https://github.com/user-attachments/assets/5a5ddaaa-a669-4ef0-a497-0948ec94dc78" />

UXW-570
<img width="1312" height="745" alt="demo" src="https://github.com/user-attachments/assets/e1485428-4453-4809-82de-c54b16455fd0" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
