### PR TITLE
Improved `mu/defn` and `mu/fn` macros: only evaluate schemas once

### DIFF
--- a/src/metabase/util/malli/fn.clj
+++ b/src/metabase/util/malli/fn.clj
@@ -314,6 +314,58 @@
       (for [schema schemas]
         (instrumented-arity error-context schema)))))
 
+(defn- should-capture-schema? [schema]
+  (cond
+    (keyword? schema)    false
+    ;; (fn? schema)      (not ((mc/predicate-schemas) schema))
+    ;;
+    ;; default varargs schema (no validation)
+    (= schema [:* :any]) false
+    :else                true))
+
+(defn- capture-input-schema [arity-number input-schema]
+  (if (= input-schema :cat)
+    [input-schema {}]
+    (let [[input-schema-tag & arg-schemas] input-schema]
+      (assert (= input-schema-tag :cat))
+      (reduce
+       (core/fn [[schema captured] arg-schema]
+         (if-not (should-capture-schema? arg-schema)
+           [(conj schema arg-schema)
+            captured]
+           (let [symb (symbol (format "&input-schema-%d-%s"
+                                      arity-number
+                                      (str (char (+ (int \a) (count captured))))))]
+             [(conj schema symb)
+              (assoc captured symb arg-schema)])))
+       [(-> [:cat]
+            (with-meta (meta input-schema)))
+        {}]
+       arg-schemas))))
+
+(defn- capture-arity [arity-number [_=> input-schema return-schema]]
+  (let [[input-schema captured] (capture-input-schema arity-number input-schema)]
+    (if-not (should-capture-schema? return-schema)
+      [[:=> input-schema return-schema]
+       captured]
+      ;; return schema has to be the same for each arity so use the same symbol across the fn
+      [[:=> input-schema '&return-schema]
+       (assoc captured '&return-schema return-schema)])))
+
+(defn- capture-function [[_function & arity-schemas]]
+  (reduce
+   (core/fn [[schema captured] [arity-number arity-schema]]
+     (let [[arity-schema arity-captured] (capture-arity arity-number arity-schema)]
+       [(conj schema arity-schema)
+        (merge captured arity-captured)]))
+   [[:function] {}]
+   (map-indexed vector arity-schemas)))
+
+(defn- capture-schemas [fn-schema]
+  (case (first fn-schema)
+    :=>       (capture-arity 0 fn-schema)
+    :function (capture-function fn-schema)))
+
 (defn instrumented-fn-form
   "Nota Bene: not safe for expansion into Clojurescript!
   Given a `fn-tail` like
@@ -327,8 +379,10 @@
     (mc/-instrument {:schema [:=> [:cat :int :any] :any]}
                     (fn [x y] (+ 1 2)))"
   [error-context parsed & [fn-name]]
-  `(let [~'&f ~(deparameterized-fn-form parsed fn-name)]
-     (core/fn ~@(instrumented-fn-tail error-context (fn-schema parsed)))))
+  (let [[fn-schema captured] (capture-schemas (fn-schema parsed))]
+    `(let [~'&f ~(deparameterized-fn-form parsed fn-name)
+           ~@(into [] cat captured)]
+       (core/fn ~@(instrumented-fn-tail error-context fn-schema)))))
 
 ;; ------------------------------ Skipping Namespace Enforcement in prod ------------------------------
 

--- a/src/metabase/util/malli/fn.clj
+++ b/src/metabase/util/malli/fn.clj
@@ -317,8 +317,6 @@
 (defn- should-capture-schema? [schema]
   (cond
     (keyword? schema)    false
-    ;; (fn? schema)      (not ((mc/predicate-schemas) schema))
-    ;;
     ;; default varargs schema (no validation)
     (= schema [:* :any]) false
     :else                true))


### PR DESCRIPTION
Change the way the macroexpansion of `mu.fn` works to capture non-keyword schemas OUTSIDE of the generated `fn` form.

```clj
(mu/defn my-plus :- :map
  [x :- :int
   y :- [:fn {:error/message "non-negative int"} (every-pred int? (complement neg-int?))]
   & {:as options} :- [:map [:integer? :boolean]]]
  {:options options, :output (+ x y)})
```         

### BEFORE

```clj
(def my-plus
 "Inputs: [x :- :int y :- [:fn #:error{:message \"non-negative int\"} (every-pred int? (complement neg-int?))] & {:as options} :- [:map [:integer? :boolean]]]\n  Return: :map"
  (let [&f (fn my_plus1495950 [x y & {:as options}] {:options options, :output (+ x y)})]
    (fn ([a b & {:as kvs}]
         (try
           (mu.fn/validate-input {:fn-name 'my-plus} :int a)
           (mu.fn/validate-input {:fn-name 'my-plus} [:fn #:error{:message "non-negative int"} (every-pred int? (complement neg-int?))] b)
           (mu.fn/validate-input {:fn-name 'my-plus} [:map [:integer? :boolean]] kvs)
           (->> (&f a b kvs) (mu.fn/validate-output {:fn-name 'my-plus} :map))
           (catch java.lang.Exception error (throw (mu.fn/fixup-stacktrace error))))))))
```

### AFTER

```clj
(def my-plus
 "Inputs: [x :- :int y :- [:fn #:error{:message \"non-negative int\"} (every-pred int? (complement neg-int?))] & {:as options} :- [:map [:integer? :boolean]]]\n  Return: :map"
  (let [&f                (fn my_plus1495950 [x y & {:as options}] {:options options, :output (+ x y)})
        &input-schema-0-a [:fn #:error{:message "non-negative int"} (every-pred int? (complement neg-int?))]
        &input-schema-0-b [:map [:integer? :boolean]]]
    (fn ([a b & {:as kvs}]
         (try
           (mu.fn/validate-input {:fn-name 'my-plus} :int a)
           (mu.fn/validate-input {:fn-name 'my-plus} &input-schema-0-a b)
           (mu.fn/validate-input {:fn-name 'my-plus} &input-schema-0-b kvs)
           (->> (&f a b kvs) (mu.fn/validate-output {:fn-name 'my-plus} :map))
           (catch java.lang.Exception error (throw (mu.fn/fixup-stacktrace error))))))))
```

### WHY?

In the former the schemas forms are evaluated in every function call (even in prod where Malli schema validation is disabled in regular `mu/fn` and `mu/defn`), which a) results in wasteful object allocation and b) breaks the validator/explainer cache for schemas that are only equal by identity (i.e., equal when they're the same object), leading to memory leaks:
           
```clj
(let [a (every-pred int? (complement neg-int?))
      b (every-pred int? (complement neg-int?))]
  (= a b))
;; => false
```

### DOWNSIDES

The only downside of this change is that the value of a schema defined with regular `def` like

```clj
(def MySchema ...)
```

Gets captured when the `mu/defn`/`mu/fn` form is evaluated and we no longer do fresh var resolution whenever the function is called, meaning it won't pick up changes to the schema until you re-evaluate the `mu/defn`/`mu/fn` form. This is not a problem for `def`fed schemas in the same namespace if you reload the entire namespace when you change it, but for stuff that is required from a different namespace the schema can change and you will not necessarily see the results right away.

This is a general problem when using `def` with schemas, since you'd run into the same issue if a `def`fed schema recursively included another `def`fed schema.

All the more reason to prefer using `mr/def` and the registry I guess, since this has zero such problems in either case.

### CONCLUSION

I think the performance and memory usage benefits clearly outweigh the downside, and there's an easy workaround for reloading issues (use `mr/def`).

### ALTERNATIVES CONSIDERED

I know what you're thinking, I could have just used `&env` to check if a **symbol** was local and if not keep the old inline schema form (to force var resolution every time), but this only solves half the problem -- it would fix `[x :- MySchema]` but it wouldn't fix `[:x :- [:map [:y MySchema]]]`. And I didn't want to make the macro even more complicated. So just use `mr/def` and call it a day.