### PR TITLE
Support inferring defendpoint regexes for `:or` schemas

### DIFF
--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -169,9 +169,7 @@
              (= (mc/type route-params-schema) :map))
     (some (fn [[k _options v-schema]]
             (when (= k route-param)
-              (or
-               (:api/regex (mc/properties v-schema))
-               (second (metabase.api.common.internal/->matching-regex v-schema)))))
+              (metabase.api.common.internal/->matching-regex v-schema)))
           (mc/children route-params-schema))))
 
 (mu/defn- inferred-route-regexes :- [:maybe [:map-of :keyword (ms/InstanceOfClass java.util.regex.Pattern)]]

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.api.common.internal-test
   (:require
    [clojure.test :refer :all]
-   [metabase.api.common.internal :as internal]))
+   [metabase.api.common.internal :as internal]
+   [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
 
@@ -13,3 +14,12 @@
     "/:id/card"     [:id]
     "/:id/etc/:org" [:id :org]
     "/:card-id"     [:card-id]))
+
+(deftest ^:parallel infer-regex-test
+  (are [schema expected] (=? expected
+                             (internal/->matching-regex schema))
+    `ms/PositiveInt
+    #"[1-9]\d*"
+
+    [:or ms/PositiveInt ms/NanoIdString]
+    #"(?:(?:[1-9]\d*)|(?:^[A-Za-z0-9_\-]{21}$))"))


### PR DESCRIPTION
I noticed `defendpoint` complaining that it couldn't infer a regex for 

```clj
[:or ms/PositiveInt ms/NanoIdString]
```

when used inside a REST API route (this schema is used for `:id` in `GET /api/card/:id` for example)

which I though was weird, because we can infer regexes for each of them individually (`ms/NanoIdString` is literally a regex)

Pretty simple to update the application to combine the regexes using non-capturing groups e.g. `(?:abc)|(?:def)`.

I also fixed a few minor regex bugs, the schema for `pos-int?` accepted `0` before for example.

Nice 💯 