### PR TITLE
Transforms python tests with its own CI

### DIFF
--- a/.github/scripts/setup-python-runner.sh
+++ b/.github/scripts/setup-python-runner.sh
@@ -4,7 +4,9 @@ set -e
 echo "Cloning python-runner repository..."
 git clone --depth 1 https://${METABASE_AUTOMATION_USER_TOKEN}@github.com/metabase/python-runner-container.git python-runner
 
-echo "Starting python-runner..."
-cd python-runner
-make run
-cd ..
+if [ "$SKIP_START" = false ]; then
+  echo "Starting python-runner..."
+  cd python-runner
+  make run-ci
+  cd ..
+fi

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -90,6 +90,7 @@ jobs:
         junit-name: 'be-tests-athena-ee'
         test-args: >-
           :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -106,6 +107,18 @@ jobs:
     if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - name: Driver Tests
+            test-args: >-
+              :only-tags [:mb/driver-tests]
+              :exclude-tags [:mb/transforms-python-test]
+          - name: Transforms Python Tests
+            test-args: >-
+              :only-tags [:mb/transforms-python-test]
+            needs-python-runner: true
     env:
       CI: 'true'
       DRIVERS: bigquery-cloud-sdk
@@ -116,10 +129,11 @@ jobs:
       MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING }}
-    name: BigQuery
+    name: BigQuery ${{ matrix.job.name }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup python-runner
+      if: ${{ matrix.job.needs-python-runner == true }}
       env:
         METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       run: ./.github/scripts/setup-python-runner.sh
@@ -127,8 +141,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-bigquery-cloud-sdk-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
+        test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -145,6 +158,18 @@ jobs:
     if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - name: Driver Tests
+            test-args: >-
+              :only-tags [:mb/driver-tests]
+              :exclude-tags [:mb/transforms-python-test]
+          - name: Transforms Python Tests
+            test-args: >-
+              :only-tags [:mb/transforms-python-test]
+            needs-python-runner: true
     env:
       CI: 'true'
       DRIVERS: clickhouse
@@ -152,10 +177,11 @@ jobs:
       MB_CLICKHOUSE_TEST_PORT: 8123
       MB_CLICKHOUSE_TEST_OLD_PORT: 8124
       MB_CLICKHOUSE_TEST_NGINX_PORT: 8127
-    name: Clickhouse
+    name: Clickhouse ${{ matrix.job.name }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup python-runner
+      if: ${{ matrix.job.needs-python-runner == true }}
       env:
         METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       run: ./.github/scripts/setup-python-runner.sh
@@ -178,8 +204,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-clickhouse-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
+        test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -216,6 +241,7 @@ jobs:
         junit-name: 'be-tests-druid-ee'
         test-args: >-
           :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -252,6 +278,7 @@ jobs:
         junit-name: 'be-tests-druid-jdbc-ee'
         test-args: >-
           :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -288,6 +315,7 @@ jobs:
         junit-name: 'be-tests-databricks-ee'
         test-args: >-
           :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -325,6 +353,7 @@ jobs:
         junit-name: 'be-tests-databricks-multi-catalog-ee'
         test-args: >-
           :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -356,6 +385,7 @@ jobs:
         junit-name: 'be-tests-h2'
         test-args: >-
           :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -400,6 +430,11 @@ jobs:
           - name: Driver Tests
             test-args: >-
               :only-tags [:mb/driver-tests]
+              :exclude-tags [:mb/transforms-python-test]
+          - name: Transforms Python Tests
+            test-args: >-
+              :only-tags [:mb/transforms-python-test]
+            needs-python-runner: true
 
     services:
       mysql:
@@ -455,6 +490,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup python-runner
+        if: ${{ matrix.job.needs-python-runner == true }}
         env:
           METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         run: ./.github/scripts/setup-python-runner.sh
@@ -492,6 +528,15 @@ jobs:
           - name: MongoDB Latest
             junit-name: be-tests-mongo-latest-ee
             image: mongo:latest
+        job:
+          - name: Driver Tests
+            test-args: >-
+              :exclude-tags '[:mongo-sharded-cluster-tests :mb/transforms-python-test]'
+              :only-tags [:mb/driver-tests]
+          - name: Transforms Python Tests
+            test-args: >-
+              :only-tags [:mb/transforms-python-test]
+            needs-python-runner: true
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -505,10 +550,11 @@ jobs:
         env:
           MONGO_INITDB_ROOT_USERNAME: metabase
           MONGO_INITDB_ROOT_PASSWORD: metasample123
-    name: ${{ matrix.version.name }}
+    name: ${{ matrix.version.name }} ${{ matrix.job.name }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup python-runner
+      if: ${{ matrix.job.needs-python-runner == true }}
       env:
         METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       run: ./.github/scripts/setup-python-runner.sh
@@ -516,9 +562,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: ${{ matrix.version.junit-name }}
-        test-args: >-
-          :exclude-tags [:mongo-sharded-cluster-tests]
-          :only-tags [:mb/driver-tests]
+        test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -582,7 +626,7 @@ jobs:
         with:
           junit-name: ${{ matrix.version.junit-name }}
           test-args: >-
-            :exclude-tags [:mongo-sharded-cluster-tests]
+            :exclude-tags '[:mongo-sharded-cluster-tests :mb/transforms-python-test]'
             :only-tags [:mb/driver-tests]
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
@@ -690,6 +734,7 @@ jobs:
         junit-name: ${{ matrix.version.junit-name }}
         test-args: >-
           :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -724,6 +769,11 @@ jobs:
           - name: Driver Tests
             test-args: >-
               :only-tags [:mb/driver-tests]
+              :exclude-tags [:mb/transforms-python-test]
+          - name: Transforms Python Tests
+            test-args: >-
+              :only-tags [:mb/transforms-python-test]
+            needs-python-runner: true
     name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
@@ -766,6 +816,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup python-runner
+        if: ${{ matrix.job.needs-python-runner == true }}
         env:
           METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         run: ./.github/scripts/setup-python-runner.sh
@@ -845,6 +896,7 @@ jobs:
         junit-name: 'be-tests-presto-jdbc-ee'
         test-args: >-
           :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -874,8 +926,14 @@ jobs:
             skip: false
             test-args: >-
               :only-tags [:mb/driver-tests]
-              :exclude-tags [:mb/upload-tests]
+              :exclude-tags '[:mb/upload-tests :mb/transforms-python-test]'
               :fail-fast? true
+          - name: Redshift Transforms Python Tests
+            skip: false
+            test-args: >-
+              :only-tags [:mb/transforms-python-test]
+              :fail-fast? true
+            needs-python-runner: true
 
     env:
       CI: 'true'
@@ -889,6 +947,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup python-runner
+      if: ${{ matrix.job.needs-python-runner == true }}
       env:
         METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       run: ./.github/scripts/setup-python-runner.sh
@@ -915,6 +974,18 @@ jobs:
     if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - name: Driver Tests
+            test-args: >-
+              :only-tags [:mb/driver-tests]
+              :exclude-tags [:mb/transforms-python-test]
+          - name: Transforms Python Tests
+            test-args: >-
+              :only-tags [:mb/transforms-python-test]
+            needs-python-runner: true
     env:
       CI: 'true'
       DRIVERS: snowflake
@@ -933,10 +1004,11 @@ jobs:
       MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_CUSTOM_USER: RSA_ROLE_TEST_CUSTOM_USER
       MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_ROLE: RSA_ROLE_TEST_ROLE
       MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_DB: RSA_ROLE_TEST_DB
-    name: Snowflake
+    name: Snowflake ${{ matrix.job.name }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup python-runner
+      if: ${{ matrix.job.needs-python-runner == true }}
       env:
         METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       run: ./.github/scripts/setup-python-runner.sh
@@ -944,8 +1016,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-snowflake-ee'
-        test-args: >-
-          :only-tags [:mb/driver-tests]
+        test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -980,6 +1051,7 @@ jobs:
         junit-name: 'be-tests-sparksql-ee'
         test-args: >-
           :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1009,6 +1081,7 @@ jobs:
         junit-name: 'be-tests-sqlite-ee'
         test-args: >-
           :only-tags [:mb/driver-tests]
+          :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -1036,6 +1109,15 @@ jobs:
           - name: SQL Server 2022
             junit-name: be-tests-sqlserver-2022-ee
             image: mcr.microsoft.com/mssql/server:2022-latest
+        job:
+          - name: Driver Tests
+            test-args: >-
+              :only-tags [:mb/driver-tests]
+              :exclude-tags [:mb/transforms-python-test]
+          - name: Transforms Python Tests
+            test-args: >-
+              :only-tags [:mb/transforms-python-test]
+            needs-python-runner: true
     env:
       CI: 'true'
       DRIVERS: sqlserver
@@ -1051,10 +1133,11 @@ jobs:
           ACCEPT_EULA: Y
           SA_PASSWORD: 'P@ssw0rd'
           MSSQL_MEMORY_LIMIT_MB: 1024
-    name: ${{ matrix.version.name }}
+    name: ${{ matrix.version.name }} ${{ matrix.job.name }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup python-runner
+      if: ${{ matrix.job.needs-python-runner == true }}
       env:
         METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       run: ./.github/scripts/setup-python-runner.sh
@@ -1062,8 +1145,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: ${{ matrix.version.junit-name }}
-        test-args: >-
-          :only-tags [:mb/driver-tests]
+        test-args: ${{ matrix.job.test-args }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/s3_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/s3_test.clj
@@ -1,7 +1,7 @@
 ;; This is a driver test currently to benefit from the localstack S3 setup in driver tests.
 ;; Perhaps we should create a new testing category?
 ;; This code otherwise runs in the appdb section, but it does not touch the appdb.
-(ns ^:mb/driver-tests metabase-enterprise.transforms-python.s3-test
+(ns ^:mb/driver-tests ^:mb/transforms-python-test metabase-enterprise.transforms-python.s3-test
   "Tests for S3 operations in transforms-python module."
   (:require
    [clj-http.client :as http]


### PR DESCRIPTION


Motivation: we have a new features for transforms using python, in order for e2e tests to work properly we need to have CI starts a python runner service (see .github/scripts/setup-python-runner.sh). This is quite expensive and it's not needed for most of the driver tests, so we've decided to separate our tests for transforms-python to run on its own CI.

To do that we've added :mb/transforms-python-test tag to all transforms-python test files and updated CI workflow to run transforms-python tests as a separate matrix job.
