### PR TITLE
Fix static embedding dashboard calling GET: /api/dashboard unnecessarily

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -14,6 +14,31 @@ import {
 
 const { ORDERS, PEOPLE, PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;
 
+describe("scenarios > embedding > static embedding dashboard", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    cy.request("PUT", `/api/dashboard/${ORDERS_DASHBOARD_ID}`, {
+      enable_embedding: true,
+    });
+  });
+
+  it("should not call `GET /api/database` (metabase#63310)", () => {
+    cy.intercept("GET", "/api/database").as("getDatabases");
+    const payload = {
+      resource: { dashboard: ORDERS_DASHBOARD_ID },
+      params: {},
+    };
+    H.visitEmbeddedPage(payload);
+
+    cy.findByRole("heading", { name: "Orders in a dashboard" }).should(
+      "be.visible",
+    );
+    cy.log("GET /api/database should not be called");
+    cy.get("@getDatabases.all").should("have.length", 0);
+  });
+});
+
 describe("scenarios > embedding > dashboard parameters", () => {
   beforeEach(() => {
     H.restore();


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63310
Closes EMB-793

### Backport reason
The code was backported to 55 (via https://github.com/metabase/metabase/pull/60835), and 56 (via #59529), so it should be safe to double backport now.

### Description

In the original code before #59529, we render `DashboardEmptyStateWithoutAddPrompt` directly inside `PublicOrEmbeddedDashboardView` and this component doesn't need to check conditions that relies on `GET /api/database`. After the consolidation every dashboard uses the same component, so we probably missed this case.

### How to verify

1. E2E should pass.
1. Comment out this line and run E2E again, it should now fail.
        https://github.com/metabase/metabase/blob/bb6ca06a39ca33fdea12f45097ce54fa0fd6ba1b/frontend/src/metabase/dashboard/components/Dashboard/components/Grid.tsx#L59

### Demo

<img width="2482" height="1131" alt="image" src="https://github.com/user-attachments/assets/9f55cfcc-07f4-44fa-a0fc-82a51c6ee78b" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
