### PR TITLE
Handle dropping cards onto paragraphs

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -245,7 +245,6 @@ export const DocumentPage = ({
 
   const handleChange = useCallback(
     (content: JSONContent) => {
-      console.log({ content });
       // For new documents, any content means changes
       if (isNewDocument) {
         // when navigating to `/new`, handleChange is fired but the editor instance hasn't been set yet

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -245,6 +245,7 @@ export const DocumentPage = ({
 
   const handleChange = useCallback(
     (content: JSONContent) => {
+      console.log({ content });
       // For new documents, any content means changes
       if (isNewDocument) {
         // when navigating to `/new`, handleChange is fired but the editor instance hasn't been set yet

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
@@ -554,14 +554,14 @@ const handleCardDropOnParagraph = (
 
   const targetPos = insertBefore ? resolvedPos.start() : resolvedPos.end();
   // Create a transaction that inserts the slice at the computed target position.
-  //const tr = view.state.tr.insert(targetPos, slice.content);
   moveNode(
     view,
     originalPos,
     targetPos,
     wrapCardWithResizeNode ? view.state.schema.nodes.resizeNode : undefined,
   );
-  //view.dispatch(tr);
+  // If we have moved content out of a flex container, we may need to unwrap an unneeded flex container
+  cleanupFlexContainerNodes(view);
   return true; // Indicate that we've handled the drop.
 };
 
@@ -601,4 +601,18 @@ const moveNode = (
   tr.insert(adjustedToPos, possiblyWrappedNode);
 
   view.dispatch(tr);
+};
+
+// Traverses the document and unwraps any flexContainer nodes that only have 1 child
+const cleanupFlexContainerNodes = (view: PMEditorView) => {
+  view.state.doc.descendants((node, pos) => {
+    if (node.type.name === "flexContainer" && node.childCount === 1) {
+      const child = node.firstChild;
+      if (child) {
+        view.dispatch(
+          view.state.tr.replaceWith(pos, pos + node.nodeSize, child),
+        );
+      }
+    }
+  });
 };

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
@@ -6,7 +6,7 @@ import {
   Slice,
 } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
-import type { EditorView } from "@tiptap/pm/view";
+import type { EditorView as PMEditorView } from "@tiptap/pm/view";
 import type { NodeViewProps } from "@tiptap/react";
 
 import {
@@ -307,7 +307,6 @@ export const HandleEditorDrop = Extension.create({
               }
 
               if (dropToParent.type.name === "paragraph") {
-                e.preventDefault();
                 return handleCardDropOnParagraph(
                   cardEmbedInitialData,
                   cameFromFlexContainer,
@@ -567,12 +566,12 @@ const handleCardDropOnParagraph = (
 };
 
 const moveNode = (
-  editor: EditorView,
+  view: PMEditorView,
   fromPos: number,
   toPos: number,
   wrapper?: PMNodeType,
 ) => {
-  const { state } = editor;
+  const { state } = view;
   const { tr, doc } = state;
 
   // Get the node at the fromPos.
@@ -601,5 +600,5 @@ const moveNode = (
 
   tr.insert(adjustedToPos, possiblyWrappedNode);
 
-  editor.dispatch(tr);
+  view.dispatch(tr);
 };

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/utils.ts
@@ -44,22 +44,26 @@ export const getTargetCardEmbedNode = (e: DragEvent, view: EditorView) => {
   return null;
 };
 
+export interface DroppedCardEmbedNodeData {
+  cardEmbedNode: Node;
+  originalPos: number;
+  originalParent: Node;
+  cameFromFlexContainer: boolean;
+  dropPos: number;
+  dropToParentPos: ResolvedPos;
+  dropToParent: Node;
+  event: DragEvent;
+  slice: Slice;
+  moved: boolean;
+  view: EditorView;
+}
+
 export const getDroppedCardEmbedNodeData = (
   view: EditorView,
   event: DragEvent,
   slice: Slice,
   moved: boolean,
-):
-  | {
-      cardEmbedNode: Node;
-      originalPos: number;
-      originalParent: Node;
-      cameFromFlexContainer: boolean;
-      dropPos: number;
-      dropToParentPos: ResolvedPos;
-      dropToParent: Node;
-    }
-  | undefined => {
+): DroppedCardEmbedNodeData | undefined => {
   // Check if we're moving a cardEmbed node
   if (slice.content.childCount === 1) {
     const droppedNode = slice.content.child(0);
@@ -115,6 +119,10 @@ export const getDroppedCardEmbedNodeData = (
           dropPos,
           dropToParentPos,
           dropToParent,
+          event,
+          slice,
+          view,
+          moved,
         };
       }
     }


### PR DESCRIPTION
### Description
Adds logic to the drop handler to detect when a card is being dropped onto a paragraph. Rather than split the paragraph, which is the default logic, we determine if the card should be placed before or after the paragraph using the coordinates, and move it to the apropriate place

### How to verify
1. Create a document with a card and a long paragraph
2. Drag the card onto the paragraph, it should either go before or after, but not split the paragraph
3. Grab a card from a flex container onto a paragraph, it should behave the same, but also wrap the dropped card in a resizeNode
