### PR TITLE
Fix: #63745 Detail view field reordering does not update correctly

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1,4 +1,6 @@
 const { H } = cy;
+import { chunk } from "underscore";
+
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ADMIN_USER_ID } from "e2e/support/cypress_sample_instance_data";
@@ -1503,5 +1505,46 @@ describe("issue 55637", () => {
 
     H.tableHeaderColumn("Tax").realHover();
     cy.findByTestId("column-info").should("not.exist");
+  });
+});
+
+describe("issue 63745", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should display correct data when toggling columns (metabase#63745)", () => {
+    H.visitQuestionAdhoc({
+      name: "63745",
+      display: "object",
+      dataset_query: {
+        type: "query",
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": ORDERS_ID,
+          limit: 5,
+        },
+      },
+    });
+
+    H.openVizSettingsSidebar();
+    cy.findByTestId("chartsettings-sidebar")
+      .button("Add or remove columns")
+      .click();
+
+    cy.findAllByTestId("object-details-table-cell").should(($cells) => {
+      const cellsFlat = $cells.toArray().map((el) => el.textContent);
+      const map = new Map(chunk(cellsFlat, 2));
+      expect(map.get("User ID")).to.eq("1");
+    });
+
+    cy.findByTestId("orders-table-columns").findByLabelText("ID").click();
+
+    cy.findAllByTestId("object-details-table-cell").should(($cells) => {
+      const cellsFlat = $cells.toArray().map((el) => el.textContent);
+      const map = new Map(chunk(cellsFlat, 2));
+      expect(map.get("User ID")).to.eq("1");
+    });
   });
 });

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailBody.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailBody.tsx
@@ -1,6 +1,6 @@
 import type ForeignKey from "metabase-lib/v1/metadata/ForeignKey";
 import type {
-  DatasetData,
+  DatasetColumn,
   RowValue,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -11,7 +11,7 @@ import { Relationships } from "./ObjectRelationships";
 import type { OnVisualizationClickType } from "./types";
 
 export interface ObjectDetailBodyProps {
-  data: DatasetData;
+  columns: DatasetColumn[];
   objectName: string;
   zoomedRow: RowValue[];
   settings: VisualizationSettings;
@@ -26,7 +26,7 @@ export interface ObjectDetailBodyProps {
 }
 
 export function ObjectDetailBody({
-  data,
+  columns,
   objectName,
   zoomedRow,
   settings,
@@ -40,7 +40,7 @@ export function ObjectDetailBody({
   return (
     <ObjectDetailBodyWrapper>
       <DetailsTable
-        data={data}
+        columns={columns}
         zoomedRow={zoomedRow}
         settings={settings}
         onVisualizationClick={onVisualizationClick}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailBody.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailBody.unit.spec.tsx
@@ -7,7 +7,7 @@ describe("ObjectDetailBody", () => {
   it("renders an object detail body", () => {
     render(
       <ObjectDetailBody
-        data={testDataset}
+        columns={testDataset.cols}
         objectName="Large Sandstone Socks"
         zoomedRow={testDataset.rows[2]}
         settings={{

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.tsx
@@ -362,7 +362,7 @@ export function ObjectDetailView({
               />
             )}
             <ObjectDetailBody
-              data={data}
+              columns={passedData.cols}
               objectName={objectName}
               zoomedRow={zoomedRow ?? []}
               settings={settings}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -19,7 +19,7 @@ import {
   isa,
 } from "metabase-lib/v1/types/utils/isa";
 import type {
-  DatasetData,
+  DatasetColumn,
   RowValue,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -133,7 +133,7 @@ export function DetailsTableCell({
 }
 
 export interface DetailsTableProps {
-  data: DatasetData;
+  columns: DatasetColumn[];
   zoomedRow: RowValue[];
   settings: VisualizationSettings;
   onVisualizationClick: OnVisualizationClickType;
@@ -141,13 +141,12 @@ export interface DetailsTableProps {
 }
 
 export function DetailsTable({
-  data,
+  columns,
   zoomedRow,
   settings,
   onVisualizationClick,
   visualizationIsClickable,
 }: DetailsTableProps): JSX.Element {
-  const { cols: columns } = data;
   const columnSettings = settings["table.columns"];
 
   const { cols, row } = useMemo(() => {

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.unit.spec.tsx
@@ -97,7 +97,7 @@ describe("ObjectDetailsTable", () => {
   it("renders an object details table", () => {
     render(
       <DetailsTable
-        data={testDataset as any}
+        columns={testDataset.cols}
         zoomedRow={testDataset.rows[1]}
         onVisualizationClick={() => null}
         visualizationIsClickable={() => false}
@@ -117,7 +117,7 @@ describe("ObjectDetailsTable", () => {
     const onVisualizationClickSpy = jest.fn();
     render(
       <DetailsTable
-        data={testDataset as any}
+        columns={testDataset.cols}
         zoomedRow={testDataset.rows[1]}
         onVisualizationClick={() => null}
         visualizationIsClickable={onVisualizationClickSpy}
@@ -137,7 +137,7 @@ describe("ObjectDetailsTable", () => {
     it("should render an image if the column is an image url", () => {
       render(
         <DetailsTable
-          data={objectDetailImageCard.data}
+          columns={objectDetailImageCard.data.cols}
           zoomedRow={objectDetailImageCard.data.rows[1]}
           onVisualizationClick={() => null}
           visualizationIsClickable={() => false}
@@ -155,7 +155,7 @@ describe("ObjectDetailsTable", () => {
     it("should render an image if the column is an avatar image url", () => {
       render(
         <DetailsTable
-          data={objectDetailImageCard.data}
+          columns={objectDetailImageCard.data.cols}
           zoomedRow={objectDetailImageCard.data.rows[1]}
           onVisualizationClick={() => null}
           visualizationIsClickable={() => false}
@@ -175,7 +175,7 @@ describe("ObjectDetailsTable", () => {
     it("should properly display JSON semantic type data as JSON", () => {
       render(
         <DetailsTable
-          data={objectDetailCard.data}
+          columns={objectDetailCard.data.cols}
           zoomedRow={objectDetailCard.data.rows[0]}
           onVisualizationClick={() => null}
           visualizationIsClickable={() => false}
@@ -190,7 +190,7 @@ describe("ObjectDetailsTable", () => {
     it("should not crash rendering invalid JSON", () => {
       render(
         <DetailsTable
-          data={invalidObjectDetailCard.data}
+          columns={invalidObjectDetailCard.data.cols}
           zoomedRow={invalidObjectDetailCard.data.rows[0]}
           onVisualizationClick={() => null}
           visualizationIsClickable={() => false}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63745
Closes [UXW-753](https://linear.app/metabase/issue/UXW-753)

### Description

Fixes issues with Detail visualization columns getting out of sync.

This seems to be the crux of the issue. `data` is a from a `useState` hook, and it's not updated when `passedData` changes. So even though the api is sending the right column data, that updated column data wasn't making it down to the child components.

<img width="725" height="211" alt="Screenshot 2025-09-19 at 1 36 41 PM" src="https://github.com/user-attachments/assets/c635ac90-e971-4a85-9dbf-d16ded50df27" />


### How to verify

See #63745 and comments for repro steps. I wasn't able to reproduce the issue exactly as reported, but I found several issues related to column data getting out of sync that this change fixes (e.g. [this comment](https://github.com/metabase/metabase/issues/63745#issuecomment-3311360808) and in the demo below).

### Demo

https://github.com/user-attachments/assets/e3d3f763-0abe-4d6d-a748-3c812ec869a3

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
