### PR TITLE
Fix crash during reindexing of analytics on upgrade

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -80,7 +80,8 @@
   [path :- :string
    opts :- [:map
             [:backfill? {:optional true} [:maybe :boolean]]
-            [:continue-on-error {:optional true} [:maybe :boolean]]]
+            [:continue-on-error {:optional true} [:maybe :boolean]]
+            [:reindex? {:optional true} [:maybe :boolean]]]
    ;; Deliberately separate from the opts so it can't be set from the CLI.
    & {:keys [token-check?
              require-initialized-db?]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -190,4 +190,4 @@
     ;;       this means that the corresponding entries would have been missing or stale when we indexed them.
     ;;       ideally, we would delay the indexing somehow, or only reindex what we've loaded.
     ;;       while we're figuring that out, here's a crude stopgap.
-      (search/reindex!))))
+      (search/reindex! {:async? false}))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -190,4 +190,4 @@
     ;;       this means that the corresponding entries would have been missing or stale when we indexed them.
     ;;       ideally, we would delay the indexing somehow, or only reindex what we've loaded.
     ;;       while we're figuring that out, here's a crude stopgap.
-      (search/reindex! {:async? false}))))
+      (search/reindex!))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -156,9 +156,10 @@
 
 (defn load-metabase!
   "Loads in a database export from an ingestion source, which is any Ingestable instance."
-  [ingestion & {:keys [backfill? continue-on-error]
+  [ingestion & {:keys [backfill? continue-on-error reindex?]
                 :or   {backfill?         true
-                       continue-on-error false}}]
+                       continue-on-error false
+                       reindex?          true}}]
   (u/prog1
     (t2/with-transaction [_tx]
       ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared dependencies
@@ -184,8 +185,9 @@
                       (update ctx :errors conj e))))
                 ctx
                 contents)))
+    (when reindex?
     ;; Hack: the transaction above typically takes much longer than our delay on the search indexing queue.
     ;;       this means that the corresponding entries would have been missing or stale when we indexed them.
     ;;       ideally, we would delay the indexing somehow, or only reindex what we've loaded.
     ;;       while we're figuring that out, here's a crude stopgap.
-    (search/reindex!)))
+      (search/reindex!))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -188,4 +188,4 @@
     ;;       this means that the corresponding entries would have been missing or stale when we indexed them.
     ;;       ideally, we would delay the indexing somehow, or only reindex what we've loaded.
     ;;       while we're figuring that out, here's a crude stopgap.
-    (search/reindex! {:async? false})))
+    (search/reindex!)))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/round_trip_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/round_trip_test.clj
@@ -33,6 +33,7 @@
    [metabase-enterprise.serialization.v2.models :as serdes.models]
    [metabase-enterprise.serialization.v2.storage :as storage]
    [metabase.models.serialization :as serdes]
+   [metabase.search.core :as search]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.util.log :as log]
@@ -91,8 +92,9 @@
 (defn load-extract!
   "Perform a round-trip of loading an existing serialization, then serializing it again."
   [input-dir output-dir]
-  (serdes/with-cache
-    (load/load-metabase! (ingest/ingest-yaml input-dir)))
+  (mt/with-dynamic-fn-redefs [search/reindex! (constantly nil)]
+    (serdes/with-cache
+      (load/load-metabase! (ingest/ingest-yaml input-dir))))
   ;; Use a separate cache to make sure there is no cross-contamination.
   (serdes/with-cache
     (-> (extract/extract {:include-field-values true :include-metabot true})


### PR DESCRIPTION
Fixes #63830

### Description

With #62316 we should have made reindex async, but incorrectly had it marked as async: false

Also, do not reindex when loading the audit-db, since we will re-index later in the startup process anyway

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
