### PR TITLE
Migrate last direct usage of settings store url, to useStoreUrl

### DIFF
--- a/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/CloudPanel.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import {
   useCreateCloudMigrationMutation,
   useGetCloudMigrationQuery,
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { useSetting } from "metabase/common/hooks";
+import { useStoreUrl } from "metabase/common/hooks";
 import { useDispatch } from "metabase/lib/redux";
 import { refreshSiteSettings } from "metabase/redux/settings";
 import { Box } from "metabase/ui";
@@ -26,7 +26,7 @@ import {
 
 interface CloudPanelProps {
   getPollingInterval?: (migration: CloudMigration) => number | undefined;
-  onMigrationStart?: (storeUrl: string, migration: CloudMigration) => void;
+  onMigrationStart?: (checkoutUrl: string, migration: CloudMigration) => void;
 }
 
 export const CloudPanel = ({
@@ -68,21 +68,15 @@ export const CloudPanel = ({
     [dispatch, migrationState],
   );
 
-  const storeUrl = useSetting("store-url");
-
-  const checkoutUrl = useMemo(() => {
-    return migration
-      ? `${storeUrl}/checkout?migration-id=${migration.external_id}`
-      : `${storeUrl}/checkout`;
-  }, [migration, storeUrl]);
-
   const [createCloudMigration, createCloudMigrationResult] =
     useCreateCloudMigrationMutation();
+
+  const checkoutUrl = useStoreUrl("checkout");
 
   const handleCreateMigration = async () => {
     const newMigration = await createCloudMigration().unwrap();
     await dispatch(refreshSiteSettings());
-    onMigrationStart(storeUrl, newMigration);
+    onMigrationStart(checkoutUrl, newMigration);
   };
 
   return (

--- a/frontend/src/metabase/admin/settings/components/CloudPanel/MigrationInProgress.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/MigrationInProgress.tsx
@@ -21,6 +21,7 @@ import {
 
 import { MigrationCard } from "./CloudPanel.styled";
 import type { InProgressCloudMigration, InProgressStates } from "./utils";
+import { getMigrationUrl } from "./utils";
 
 interface MigrationInProgressProps {
   migration: InProgressCloudMigration;
@@ -58,6 +59,8 @@ export const MigrationInProgress = ({
       }),
     );
   };
+
+  const migrationUrl = getMigrationUrl(checkoutUrl, migration);
 
   return (
     <>
@@ -103,7 +106,7 @@ export const MigrationInProgress = ({
               <Button
                 mt="md"
                 component={ExternalLink}
-                href={checkoutUrl}
+                href={migrationUrl}
                 variant="filled"
               >{t`Go to Metabase Store`}</Button>
             </Flex>

--- a/frontend/src/metabase/admin/settings/components/CloudPanel/MigrationSuccess.tsx
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/MigrationSuccess.tsx
@@ -6,7 +6,7 @@ import { Box, Button, Flex, Icon, Text } from "metabase/ui";
 import type { CloudMigration } from "metabase-types/api/cloud-migration";
 
 import { LargeIconContainer, MigrationCard } from "./CloudPanel.styled";
-import { getMigrationEventTime } from "./utils";
+import { getMigrationEventTime, getMigrationUrl } from "./utils";
 
 interface MigrationSuccessProps {
   migration: CloudMigration;
@@ -22,6 +22,7 @@ export const MigrationSuccess = ({
   checkoutUrl,
 }: MigrationSuccessProps) => {
   const uploadedAt = getMigrationEventTime(migration.updated_at);
+  const migrationUrl = getMigrationUrl(checkoutUrl, migration);
 
   return (
     <>
@@ -41,7 +42,7 @@ export const MigrationSuccess = ({
             </Text>
 
             <Box mt="1.5rem">
-              <ExternalLink href={checkoutUrl}>
+              <ExternalLink href={migrationUrl}>
                 <Button variant="filled">{t`Go to Metabase Store`}</Button>
               </ExternalLink>
             </Box>

--- a/frontend/src/metabase/admin/settings/components/CloudPanel/utils.ts
+++ b/frontend/src/metabase/admin/settings/components/CloudPanel/utils.ts
@@ -70,13 +70,16 @@ export const getMigrationEventTime = (isoString: string) =>
   dayjs(isoString).format("MMMM DD, YYYY, hh:mm A");
 
 export const openCheckoutInNewTab = (
-  storeUrl: string,
+  checkoutUrl: string,
   migration: CloudMigration,
 ) => {
-  window
-    .open(
-      `${storeUrl}/checkout?migration-id=${migration.external_id}`,
-      "_blank",
-    )
-    ?.focus();
+  const migrationUrl = getMigrationUrl(checkoutUrl, migration);
+  window.open(migrationUrl, "_blank")?.focus();
 };
+
+export function getMigrationUrl(
+  checkoutUrl: string,
+  migration: CloudMigration,
+) {
+  return `${checkoutUrl}?migration-id=${migration.external_id}`;
+}


### PR DESCRIPTION
Closes  https://linear.app/metabase/issue/PRG-126/migrate-cloudpanel-to-use-usestoreurl-for-store-url-retrieval

### Description

Migrate last spot to a centralized usage of `useStoreUrl`.
I've simplified the code by removing one conditional along the way.

### How to verify

go to `admin/settings/cloud` and initiate migration to Cloud. Check if the links when migration is in progress and is successful, are correct. 


### Checklist

- [x] Tests are still passing; no new functionality here.
