### PR TITLE
Change the default editor height for transforms

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.tsx
@@ -22,7 +22,7 @@ import type {
 import S from "./EditorBody.module.css";
 import { ResizableBoxHandle } from "./ResizableBoxHandle";
 
-const EDITOR_HEIGHT = 400;
+const EDITOR_HEIGHT = 550;
 
 const NATIVE_EDITOR_SIDEBAR_FEATURES = {
   dataReference: true,


### PR DESCRIPTION
Fixes https://linear.app/metabase/issue/QUE-2478/fe-make-the-query-results-section-smaller

Makes the notebook fully visible on the initial page load.

<img width="1728" height="870" alt="Screenshot 2025-09-19 at 13 15 15" src="https://github.com/user-attachments/assets/64b2e4a6-a88d-4277-af2a-9f445297eee5" />
