### PR TITLE
Hide cursor in the readonly native editor

### DIFF
--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -812,10 +812,7 @@ function openActionEditorFor(actionName, { isReadOnly = false } = {}) {
 }
 
 function assertQueryEditorDisabled() {
-  // Ace doesn't act as a normal input, so we can't use `should("be.disabled")`
-  // Instead we'd assert that a user can't type in the editor
-  H.fillActionQuery("QWERTY");
-  cy.findByText("QWERTY").should("not.exist");
+  H.NativeEditor.get().should("have.attr", "contenteditable", "false");
 }
 
 function enableSharingFor(actionName, { publicUrlAlias }) {

--- a/frontend/src/metabase/common/components/CodeMirror/CodeMirror.tsx
+++ b/frontend/src/metabase/common/components/CodeMirror/CodeMirror.tsx
@@ -28,6 +28,7 @@ export const CodeMirror = forwardRef(function CodeMirrorInner(
     autoCorrect,
     tabIndex,
     extensions,
+    readOnly,
     ...rest
   } = props;
 
@@ -53,6 +54,8 @@ export const CodeMirror = forwardRef(function CodeMirrorInner(
       className={cx(S.editor, className)}
       basicSetup={setup}
       extensions={extendedExtensions}
+      readOnly={readOnly}
+      editable={!readOnly}
     />
   );
 });


### PR DESCRIPTION
Fixes https://linear.app/metabase/issue/QUE-2489/fe-remove-cursor-in-the-readonly-sql-query
Follows this https://discuss.codemirror.net/t/hide-cursors-and-prevent-selection-in-readonly/4815/2

How to verify:
- Create a native transform
- On the transform page, there should be no cursor on page load