### PR TITLE
Add explicit import/export direction to serialization errors

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -87,8 +87,8 @@
                      (catch Exception e
                        (reset! err e)
                        (if full-stacktrace
-                         (log/error e "Error during serialization")
-                         (log/error (u/strip-error e "Error during serialization"))))))]
+                         (log/error e "Error during serialization export")
+                         (log/error (u/strip-error e "Error during serialization export"))))))]
     {:archive       (when (.exists dst)
                       dst)
      :log-file      (when (.exists log-file)
@@ -142,8 +142,8 @@
                      (catch Exception e
                        (reset! err e)
                        (if full-stacktrace
-                         (log/error e "Error during serialization")
-                         (log/error (u/strip-error e "Error during serialization"))))))]
+                         (log/error e "Error during serialization import")
+                         (log/error (u/strip-error e "Error during serialization import"))))))]
     {:log-file      log-file
      :status        (:status (ex-data @err))
      :error-message (when @err

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -269,8 +269,8 @@
                                                 (u/strip-error @err nil))})
     (when @err
       (if (:full-stacktrace opts)
-        (log/error @err "Error during serialization")
-        (log/error (u/strip-error @err "Error during deserialization")))
+        (log/error @err "Error during serialization export")
+        (log/error (u/strip-error @err "Error during serialization export")))
       (throw (ex-info (ex-message @err) {:cmd/exit true})))
     (log/info (format "Export to '%s' complete!" path) (u/emoji "🚛💨 📦"))
     report))


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

When anything goes wrong in a serialization import or export, either via API or CLI, the error is always `Error during serialization`. The serialization direction can usually be inferred from surrounding logs, but there's no reason to keep this ambiguity really.

This also fixes an incorrect log message when running an export CLI command, which would print `Error during deserialization` if stacktraces were not being logged.

### How to verify

Try to export something invalid, e.g. `POST http://localhost:3000/api/ee/serialization/export?collection=123123`

```
2025-09-19 19:15:42,509 ERROR serialization.api :: Error during serialization export: Invalid input: ["unknown error, got: nil"] {:type :metabase.util.malli.fn/invalid-input, :error {:schema [:fn #'metabase.collections.models.collection/valid-location-path?], :value nil, :errors ({:path [], :in [], :schema [:fn #'metabase.collections.models.collection/valid-location-path?], :value nil})}, :humanized ["unknown error, got: nil"], :schema [:fn #'metabase.collections.models.collection/valid-location-path?], :value nil, :fn-name location-path->ids} 
```

Try to import something invalid, e.g. intentionally corrupt a tar.gz file:

```
dd if=/dev/urandom of=corrupted.tar.gz bs=1 count=10 seek=20 conv=notrunc
```

```
❯ curl --request POST \
        --url http://localhost:3000/api/ee/serialization/import \
        -H 'x-api-key: mb_...=' \
        -F file=@corrupted.tar.gz

2025-09-19 19:34:39,529 INFO serialization.api :: Serdes import, size 543576
2025-09-19 19:34:39,532 ERROR serialization.api :: Error during serialization import: Cannot unpack archive {:status 422}
  caused by: Gzip-compressed data is corrupt.
  caused by: invalid bit length repeat
```

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
