### PR TITLE
Fix CI job conditions for better handling of ci-skip

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,7 +74,7 @@ jobs:
     secrets: inherit
 
   backend-tests:
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.files-changed.result == 'success' }}
     needs: [files-changed, static-viz-files-changed]
     uses: ./.github/workflows/backend.yml
     secrets: inherit
@@ -112,7 +112,7 @@ jobs:
 
   e2e-tests:
     needs: [files-changed, uberjar]
-    if: always() && !cancelled()
+    if: always() && !cancelled() && needs.files-changed.result == 'success'
     uses: ./.github/workflows/e2e-tests.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Adjust CI job conditions to properly account for the ci-skip scenario, ensuring jobs only run when necessary.

IF a job specify a 'if' condition we need to manually account for 'needed' parent job to run or the condition is skipped 