### PR TITLE
Rename `Field` in legacy MBQL schema to `FieldOrExpressionDef`

### DIFF
--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -564,7 +564,7 @@
   "Takes a string description of a *date* (not datetime) range such as 'lastmonth' or '2016-07-15~2016-08-6', or
   an absolute date *or datetime* string, and returns a corresponding MBQL filter clause for a given field reference."
   [date-string :- :string
-   field       :- [:or ::lib.schema.id/field mbql.s/Field]]
+   field       :- [:or ::lib.schema.id/field mbql.s/FieldOrExpressionRef]]
   (or (execute-decoders all-date-string-decoders :filter (mbql.u/wrap-field-id-if-needed field) date-string)
       (throw (ex-info (tru "Don''t know how to parse date string {0}" (pr-str date-string))
                       {:type        qp.error-type/invalid-parameter

--- a/src/metabase/indexed_entities/models/model_index.clj
+++ b/src/metabase/indexed_entities/models/model_index.clj
@@ -48,13 +48,13 @@
   "Filter function for valid tuples for indexing: an id and a value."
   [[id v]] (and id v))
 
-(mu/defn- fix-expression-refs :- mbql.s/Field
+(mu/defn- fix-expression-refs :- mbql.s/FieldOrExpressionRef
   "Convert expression ref into a field ref.
 
   Expression refs (`[:expression \"full-name\"]`) are how the _query_ refers to a custom column. But nested queries
   don't, (and shouldn't) care that those are expressions. They are just another field. The field type is always
   `:type/Text` enforced by the endpoint to create model indexes."
-  [field-ref :- mbql.s/Field
+  [field-ref :- mbql.s/FieldOrExpressionRef
    base-type :- ::lib.schema.common/base-type]
   (case (first field-ref)
     :field field-ref

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -872,7 +872,7 @@
     [:field field-form nil]
     (lib.util.match/match-lite-recursive field-form :field field-form)))
 
-(mu/defn unwrap-field-or-expression-clause :- mbql.s/Field
+(mu/defn unwrap-field-or-expression-clause :- mbql.s/FieldOrExpressionRef
   "Unwrap a `:field` clause or expression clause, such as a template tag. Also handles unwrapped integers for
   legacy compatibility."
   [field-or-ref-form]

--- a/src/metabase/parameters/params.clj
+++ b/src/metabase/parameters/params.clj
@@ -67,7 +67,7 @@
   [[_ tag] card]
   (get-in card [:dataset_query :native :template-tags (u/qualified-name tag) :dimension]))
 
-(mu/defn param-target->field-clause :- [:maybe mbql.s/Field]
+(mu/defn param-target->field-clause :- [:maybe mbql.s/FieldOrExpressionRef]
   "Parse a Card parameter `target` form, which looks something like `[:dimension [:field-id 100]]`, and return the Field
   ID it references (if any)."
   [target card]

--- a/src/metabase/parameters/schema.clj
+++ b/src/metabase/parameters/schema.clj
@@ -15,7 +15,7 @@
   "Schema for a valid legacy `:field` or `:expression` reference (possibly not yet normalized)."
   [:fn
    (fn [k]
-     ((comp (mr/validator mbql.s/Field)
+     ((comp (mr/validator mbql.s/FieldOrExpressionRef)
             mbql.normalize/normalize-tokens) k))])
 
 (mr/def ::values-source-config


### PR DESCRIPTION
This is overdue by like 5 years, but `Field` in the legacy MBQL schema has meant either a `:field` or `:expression` ref for a really long time.