### PR TITLE
Add simple event tracking for drill-thrus and other "click actions"

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -906,6 +906,16 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       });
 
       H.cartesianChartCircle().eq(1).should("be.visible").click();
+      H.popover().findByText(">").click();
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "click_action",
+        triggered_from: "filter",
+      });
+
+      cy.go("back");
+
+      H.cartesianChartCircle().eq(1).should("be.visible").click();
       H.popover()
         .findByText(/^Automatic insights/)
         .click();
@@ -915,12 +925,22 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
         triggered_from: "auto",
       });
 
-      H.cartesianChartCircle().eq(1).should("be.visible").click();
-      H.popover().findByText(">").click();
-
+      H.popover().findByText("X-ray").click();
       H.expectUnstructuredSnowplowEvent({
-        event: "click_action",
-        triggered_from: "filter",
+        event: "x-ray_automatic_insights_clicked",
+        event_detail: "x-ray",
+      });
+
+      cy.go("back");
+
+      H.cartesianChartCircle().eq(1).should("be.visible").click();
+      H.popover()
+        .findByText(/^Automatic insights/)
+        .click();
+      H.popover().findByText("Compare to the rest").click();
+      H.expectUnstructuredSnowplowEvent({
+        event: "x-ray_automatic_insights_clicked",
+        event_detail: "compare_to_rest",
       });
     });
   });

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -363,10 +363,16 @@ export type XRaySuggestionClickedEvent = ValidateEvent<{
   triggered_from: "suggestion_sidebar";
 }>;
 
+export type XRayAutoInsightsClicked = ValidateEvent<{
+  event: "x-ray_automatic_insights_clicked";
+  event_detail: "x-ray" | "compare_to_rest";
+}>;
+
 export type XRayClickedEvent =
   | XRayTableClickedEvent
   | XRayDataReferenceClickedEvent
-  | XRaySuggestionClickedEvent;
+  | XRaySuggestionClickedEvent
+  | XRayAutoInsightsClicked;
 
 export type XRaySavedEvent = ValidateEvent<{
   event: "x-ray_saved";

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -5,6 +5,7 @@ import type {
 } from "metabase/home/components/Onboarding/types";
 import type { MetadataEditAnalyticsDetail } from "metabase/metadata/pages/DataModel/types";
 import type { KeyboardShortcutId } from "metabase/palette/shortcuts";
+import type { ClickActionSection } from "metabase/visualizations/types";
 import type {
   Engine,
   RelatedDashboardXRays,
@@ -463,6 +464,11 @@ export type BookmarkDocumentEvent = ValidateEvent<{
   triggered_from: "collection_list" | "document_header";
 }>;
 
+export type ClickActionPerformedEvent = ValidateEvent<{
+  event: "click_action";
+  triggered_from: ClickActionSection;
+}>;
+
 export type BookmarkEvent =
   | BookmarkQuestionEvent
   | BookmarkModelEvent
@@ -521,4 +527,5 @@ export type SimpleEvent =
   | RevertVersionEvent
   | LearnAboutDataClickedEvent
   | MetadataEditEvent
-  | BookmarkEvent;
+  | BookmarkEvent
+  | ClickActionPerformedEvent;

--- a/frontend/src/metabase/visualizations/analytics.ts
+++ b/frontend/src/metabase/visualizations/analytics.ts
@@ -1,3 +1,5 @@
+import { match } from "ts-pattern";
+
 import { trackSimpleEvent } from "metabase/lib/analytics";
 
 import type { RegularClickAction } from "./types";
@@ -7,4 +9,16 @@ export const trackClickActionPerformed = (action: RegularClickAction) => {
     event: "click_action",
     triggered_from: action.section,
   });
+
+  if (action.section === "auto-popover") {
+    const event = match(action.name)
+      .with("automatic-insights.compare", () => "compare_to_rest" as const)
+      .with("automatic-insights.xray", () => "x-ray" as const)
+      .otherwise(() => "x-ray" as const);
+
+    trackSimpleEvent({
+      event: "x-ray_automatic_insights_clicked",
+      event_detail: event,
+    });
+  }
 };

--- a/frontend/src/metabase/visualizations/analytics.ts
+++ b/frontend/src/metabase/visualizations/analytics.ts
@@ -1,0 +1,10 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+import type { RegularClickAction } from "./types";
+
+export const trackClickActionPerformed = (action: RegularClickAction) => {
+  trackSimpleEvent({
+    event: "click_action",
+    triggered_from: action.section,
+  });
+};

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsView.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsView.tsx
@@ -1,5 +1,6 @@
 import type { HTMLAttributes } from "react";
 
+import { trackClickActionPerformed } from "metabase/visualizations/analytics";
 import type { RegularClickAction } from "metabase/visualizations/types";
 
 import { ClickActionControl } from "./ClickActionControl";
@@ -52,7 +53,10 @@ export const ClickActionsView = ({
                 key={action.name}
                 action={action}
                 close={close}
-                onClick={() => onClick(action)}
+                onClick={() => {
+                  trackClickActionPerformed(action);
+                  onClick(action);
+                }}
               />
             ))}
             {withBottomDivider && <Divider />}


### PR DESCRIPTION
Resolves PRG-141

> [!Note]
> We're tracking all action "sections", which are the top-level click actions. Some of them have sub-actions (popover on a popover). Out of all those, we only track "Automatic insights" as per the linked ticked.