### PR TITLE
[malli] Don't include docstrings in mu/defn when compiling CLJS

### DIFF
--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -91,22 +91,24 @@
   (let [parsed           (mu.fn/parse-fn-tail fn-tail)
         cosmetic-name    (gensym (munge (str fn-name)))
         {attr-map :meta} (:values parsed)
+        docstring        (annotated-docstring parsed)
         attr-map         (merge
                           {:arglists (list 'quote (deparameterized-arglists parsed))
                            :schema   (mu.fn/fn-schema parsed {:target :target/metadata})}
-                          attr-map)
-        docstring        (annotated-docstring parsed)
+                          attr-map
+                          ;; Don't include docstrings in CLJS to prevent them slipping into release build and
+                          ;; inflating the bundle.
+                          (macros/case
+                            :clj  {:doc docstring}
+                            :cljs nil))
         instrument?      (mu.fn/instrument-ns? *ns*)]
-    (if-not instrument?
-      `(def ~(vary-meta fn-name merge attr-map)
-         ~docstring
-         ~(mu.fn/deparameterized-fn-form parsed))
-      `(def ~(vary-meta fn-name merge attr-map)
-         ~docstring
-         ~(macros/case
+    `(def ~(vary-meta fn-name merge attr-map)
+       ~(if instrument?
+          (macros/case
             :clj  (let [error-context {:fn-name (list 'quote fn-name)}]
                     (mu.fn/instrumented-fn-form error-context parsed cosmetic-name))
-            :cljs (mu.fn/deparameterized-fn-form parsed cosmetic-name))))))
+            :cljs (mu.fn/deparameterized-fn-form parsed cosmetic-name))
+          (mu.fn/deparameterized-fn-form parsed)))))
 
 (defmacro defn-
   "Same as defn, but creates a private def."

--- a/test/metabase/util/malli/defn_test.clj
+++ b/test/metabase/util/malli/defn_test.clj
@@ -174,14 +174,12 @@
     (testing "returns a simple fn*"
       (mt/with-dynamic-fn-redefs [mu.fn/instrument-ns? (constantly false)]
         (let [expansion (macroexpand `(mu/defn ~'f :- :int [] "foo"))]
-          (is (= '(def f
-                    "Inputs: []\n  Return: :int" (clojure.core/fn [] "foo"))
+          (is (= '(def f (clojure.core/fn [] "foo"))
                  (deanon-fn-names expansion))))))
     (testing "returns an instrumented fn"
       (mt/with-dynamic-fn-redefs [mu.fn/instrument-ns? (constantly true)]
         (let [expansion (macroexpand `(mu/defn ~'f :- :int [] "foo"))]
           (is (= '(def f
-                    "Inputs: []\n  Return: :int"
                     (clojure.core/let
                      [&f (clojure.core/fn f [] "foo")]
                       (clojure.core/fn


### PR DESCRIPTION
I've discovered that for whatever reason, CLJS compiler doesn't elide automatically docstrings from functions produced with   `mu/defn`. After trying to grapple with the compiler for a while, I decided to simply remove the docstring itself at the macroexpansion time.

Overall, this reduces the CLJS bundle size, as I assume the docstrings are not needed there by anybody.