### PR TITLE
Add Row Chart option to disable ‘Other’ grouping and support overflow scrolling

### DIFF
--- a/frontend/src/metabase/static-viz/components/RowChart/RowChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/RowChart/RowChart.stories.tsx
@@ -4,6 +4,8 @@ import { color } from "metabase/lib/colors";
 import {
   METRIC_COLUMN_WITH_SCALING,
   MULTIPLE_SERIES,
+  MANY_CATEGORY_GROUPED,
+  MANY_CATEGORY_UNGROUPED,
 } from "metabase/static-viz/components/RowChart/stories-data";
 
 import {
@@ -18,6 +20,21 @@ export default {
 
 const Template: StoryFn<StaticChartProps> = (args) => {
   return <StaticVisualization {...args} />;
+};
+
+const ScrollableTemplate: StoryFn<StaticChartProps> = (args) => {
+  return (
+    <div
+      style={{
+        height: 400,
+        overflowY: "auto",
+        padding: "1rem",
+        background: "#fff",
+      }}
+    >
+      <StaticVisualization {...args} />
+    </div>
+  );
 };
 
 export const Default = {
@@ -37,4 +54,20 @@ export const MetricColumnWithScaling = {
 export const Watermark = {
   render: Template,
   args: { ...MULTIPLE_SERIES, getColor: color, hasDevWatermark: true },
+};
+
+export const OverflowGrouped = {
+  render: ScrollableTemplate,
+  args: {
+    ...MANY_CATEGORY_GROUPED,
+    getColor: color,
+  },
+};
+
+export const OverflowUngrouped = {
+  render: ScrollableTemplate,
+  args: {
+    ...MANY_CATEGORY_UNGROUPED,
+    getColor: color,
+  },
 };

--- a/frontend/src/metabase/static-viz/components/RowChart/stories-data.ts
+++ b/frontend/src/metabase/static-viz/components/RowChart/stories-data.ts
@@ -410,3 +410,61 @@ export const METRIC_COLUMN_WITH_SCALING: StaticChartProps = {
   },
   renderingContext,
 } as any;
+
+const MANY_CATEGORY_ROWS = Array.from({ length: 20 }, (_, index) => [
+  `Category ${index + 1}`,
+  100 - index * 3,
+]);
+
+const MANY_CATEGORY_COLS = [
+  {
+    base_type: "type/Text",
+    semantic_type: "type/Category",
+    name: "CATEGORY",
+    display_name: "Category",
+    source: "breakout",
+    field_ref: ["field", 1, null],
+  },
+  {
+    base_type: "type/Integer",
+    semantic_type: "type/Quantity",
+    name: "count",
+    display_name: "Count",
+    source: "aggregation",
+    field_ref: ["aggregation", 0],
+  },
+];
+
+const createManyCategorySeries = (
+  groupRemainingValues: boolean,
+): StaticChartProps => ({
+  rawSeries: [
+    {
+      card: {
+        id: groupRemainingValues ? 3 : 4,
+        name: groupRemainingValues
+          ? "Row Chart Grouped Overflow"
+          : "Row Chart Ungrouped Overflow",
+        display: "row",
+        visualization_settings: {
+          "graph.dimensions": ["CATEGORY"],
+          "graph.metrics": ["count"],
+          "graph.row_chart.group_remaining_values": groupRemainingValues,
+        },
+      },
+      data: {
+        rows: MANY_CATEGORY_ROWS,
+        cols: MANY_CATEGORY_COLS,
+      },
+    },
+  ],
+  settings: {
+    "graph.dimensions": ["CATEGORY"],
+    "graph.metrics": ["count"],
+    "graph.row_chart.group_remaining_values": groupRemainingValues,
+  },
+  renderingContext,
+});
+
+export const MANY_CATEGORY_GROUPED = createManyCategorySeries(true);
+export const MANY_CATEGORY_UNGROUPED = createManyCategorySeries(false);

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.unit.spec.tsx
@@ -205,6 +205,44 @@ describe("RowChart", () => {
     });
   });
 
+  describe("overflow handling", () => {
+    const overflowData: TestDatum[] = Array.from({ length: 5 }, (_, index) => ({
+      y: `row-${index}`,
+      x: 10 * (index + 1),
+      x1: 15 * (index + 1),
+    }));
+
+    it("should skip trimming when grouping overflow rows is disabled", () => {
+      const trimData = jest.fn((rows: TestDatum[]) => rows.slice(0, 2));
+
+      const { bars } = setup({
+        data: overflowData,
+        series: [series1],
+        height: 80,
+        trimData,
+        shouldGroupRemainingValues: false,
+      });
+
+      expect(trimData).not.toHaveBeenCalled();
+      expect(bars).toHaveLength(overflowData.length);
+    });
+
+    it("should trim rows when grouping overflow rows is enabled", () => {
+      const trimData = jest.fn((rows: TestDatum[]) => rows.slice(0, 2));
+
+      const { bars } = setup({
+        data: overflowData,
+        series: [series1],
+        height: 80,
+        trimData,
+        shouldGroupRemainingValues: true,
+      });
+
+      expect(trimData).toHaveBeenCalledWith(overflowData, expect.any(Number));
+      expect(bars).toHaveLength(2);
+    });
+  });
+
   describe("data labels", () => {
     it("should not render data labels when not specified", () => {
       const { dataLabels } = setup();

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.styled.tsx
@@ -27,6 +27,8 @@ export const RowChartContainer = styled.div`
   bottom: 0;
   right: 0;
   left: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
 `;
 
 export const RowChartLegendLayout = styled(LegendLayout)`

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -67,6 +67,7 @@ import {
   getAxesVisibility,
   getLabelledSeries,
   getLabels,
+  getShouldGroupRemainingValues,
   getXValueRange,
 } from "./utils/settings";
 import { ROW_CHART_SETTINGS } from "./utils/settings-definitions";
@@ -134,6 +135,7 @@ const RowChartVisualization = ({
   );
   const goal = useMemo(() => getChartGoal(settings), [settings]);
   const stackOffset = getStackOffset(settings);
+  const shouldGroupRemainingValues = getShouldGroupRemainingValues(settings);
   const theme = useRowChartTheme(
     `${fontFamily}, Arial, sans-serif`,
     isDashboard,
@@ -300,6 +302,7 @@ const RowChartVisualization = ({
           className={CS.flexFull}
           data={groupedData}
           trimData={trimData}
+          shouldGroupRemainingValues={shouldGroupRemainingValues}
           series={series}
           seriesColors={seriesColors}
           goal={goal}

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/settings-definitions.js
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/settings-definitions.js
@@ -275,6 +275,17 @@ export const ROW_CHART_SETTINGS = {
       vizSettings["stackable.stack_type"] === "normalized",
     default: false,
   },
+  "graph.row_chart.group_remaining_values": {
+    get section() {
+      return t`Display`;
+    },
+    get title() {
+      return t`Group overflow rows into "Other"`;
+    },
+    widget: "toggle",
+    inline: true,
+    default: true,
+  },
   "graph.label_value_formatting": {
     get section() {
       return t`Display`;

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/settings.ts
@@ -62,3 +62,9 @@ export const getLabels = (settings: VisualizationSettings) => {
     yLabel,
   };
 };
+
+export const getShouldGroupRemainingValues = (
+  settings: VisualizationSettings,
+) => {
+  return settings["graph.row_chart.group_remaining_values"] !== false;
+};


### PR DESCRIPTION
### Description

RowCharts only show a limited amount of data depending on the given area provided to the chart. This adds the ability for the RowChart to scroll within the given bounds and show individual rows for all pieces of data, rather than grouping them under the "Other" option.

- Add new option called `Group overflow rows into "Other"` to RowChart Visualization options
- This will expand the "Other" group in RowChart to their individual bar rows and making the RowChart scrollable to be able to see all data

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a new RowChart that has a bunch of rows, which group the extra rows under an option called "Other"
2. Open the Visualization edit options, and uncheck `Group overflow rows into "Other"` to expand the "Other" row into individual rows

### Demo

#### Before

<img width="2133" height="1198" alt="2025-09-21_21:01:35_2133x1198" src="https://github.com/user-attachments/assets/63582121-5ebe-40fb-b47c-260cf6ba400b" />

#### After

<img width="2548" height="1333" alt="2025-09-21_20:51:42_2548x1333" src="https://github.com/user-attachments/assets/92937f86-78fe-484b-b241-79dfc08a5c50" />

https://github.com/user-attachments/assets/80777aeb-0326-4851-a4be-d67ef446c322

https://github.com/user-attachments/assets/b9081dcc-208e-4949-bf25-f4419f934648

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
