### PR TITLE
DSN-75 "Filter settings" tab label shouldn't appear if it's the only tab

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -12,7 +12,7 @@ import { slugify } from "metabase/lib/formatting";
 import { useSelector } from "metabase/lib/redux";
 import { hasMapping } from "metabase/parameters/utils/dashboards";
 import type { IconName } from "metabase/ui";
-import { Tabs, Text } from "metabase/ui";
+import { Tabs } from "metabase/ui";
 import { isFilterParameter } from "metabase-lib/v1/parameters/utils/parameter-type";
 import { parameterHasNoDisplayValue } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {
@@ -209,36 +209,22 @@ export const ParameterSidebar = (): JSX.Element | null => {
       data-testid="dashboard-parameter-sidebar"
     >
       <Tabs radius={0} value={tab} onChange={handleTabChange}>
-        <Tabs.List grow>
-          {tabs.length > 1 &&
-            tabs.map((tab) => {
-              return (
-                <Tabs.Tab
-                  pl={0}
-                  pr={0}
-                  pt="md"
-                  pb="md"
-                  value={tab.value}
-                  key={tab.value}
-                >
-                  {tab.name}
-                </Tabs.Tab>
-              );
-            })}
-          {tabs.length === 1 && (
-            <Text
-              lh="1rem"
-              pb="md"
-              pt="md"
-              fz="md"
-              fw="bold"
-              w="100%"
-              ta="center"
-            >
-              {tabs[0].name}
-            </Text>
-          )}
-        </Tabs.List>
+        {tabs.length > 1 && (
+          <Tabs.List grow>
+            {tabs.map((tab) => (
+              <Tabs.Tab
+                pl={0}
+                pr={0}
+                pt="md"
+                pb="md"
+                value={tab.value}
+                key={tab.value}
+              >
+                {tab.name}
+              </Tabs.Tab>
+            ))}
+          </Tabs.List>
+        )}
 
         <Tabs.Panel pr="md" pl="md" value="settings" key="settings">
           <ParameterSettings

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -185,9 +185,12 @@ describe("ParameterSidebar", () => {
 
       await clickNextParameterButton();
 
-      // verify Linked filters tab is not rendered
+      // verify tabs are not rendered if there's only 1 tab
       expect(
         screen.queryByRole("tab", { name: "Linked filters" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("tab", { name: "Filter settings" }),
       ).not.toBeInTheDocument();
 
       // verify tab content corresponds to Filter settings


### PR DESCRIPTION
Closes [DSN-75](https://linear.app/metabase/issue/DSN-75/filter-settings-tab-label-shouldnt-appear-if-its-the-only-tab)

### Description

Hides tabs in Parameter Sidebar in Dashboard when there's only 1 tab.

### How to verify

1. Create a dashboard
2. Add date/time grouping/number/boolean filter

Parameter sidebar should not show tabs ("Filter settings" and "Linked filters")

3. Add string/category/id/location filter

Parameter sidebar should show tabs ("Filter settings" and "Linked filters")