### PR TITLE
Don't encode default JWT SSO redirect URI

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -98,7 +98,7 @@
 
 (defn- session-data
   [jwt {{redirect :return_to} :params, :as request}]
-  (let [redirect-url (or redirect (URLEncoder/encode "/"))]
+  (let [redirect-url (or redirect "/")]
     (sso-utils/check-sso-redirect redirect-url)
     (let [jwt-data     (try
                          (jwt/unsign jwt (sso-settings/jwt-shared-secret)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -15,9 +15,7 @@
    [metabase.sso.core :as sso]
    [metabase.util.i18n :refer [tru]]
    [ring.util.response :as response]
-   [toucan2.core :as t2])
-  (:import
-   (java.net URLEncoder)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63814

### Description
Doing a default SSO JWT flow was causing an "Ambiguous URI Separator". At [this](https://github.com/metabase/metabase/blob/a3364ffecca23d07e534a0a241eb56eb7a444344/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj#L101) point the redirect-url is already decoded, so from this point onward, no encoding seems to be necessary.

Before:
<img width="542" height="227" alt="image" src="https://github.com/user-attachments/assets/06f7da57-37d7-445a-bdbb-87d7f77c78d0" />

After:
<img width="691" height="219" alt="image" src="https://github.com/user-attachments/assets/42f1ee88-f783-4df5-873c-b1cce917ab31" />

