### PR TITLE
DSN-74 People page should use tabs instead of radios for active/deactivated control

### DIFF
--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.module.css
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.module.css
@@ -1,0 +1,5 @@
+.tabs {
+  &:before {
+    display: none;
+  }
+}

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
@@ -78,7 +78,7 @@ export function PeopleListingApp({ children }: { children: React.ReactNode }) {
                   <Tabs.Tab value={USER_STATUS.active}>{t`Active`}</Tabs.Tab>
                   <Tabs.Tab
                     value={USER_STATUS.deactivated}
-                  >{t`Deactived`}</Tabs.Tab>
+                  >{t`Deactivated`}</Tabs.Tab>
                 </Tabs.List>
               </Tabs>
             )}

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
@@ -93,7 +93,7 @@ export function PeopleListingApp({ children }: { children: React.ReactNode }) {
           <div data-testid="admin-panel">
             <Box px="md">
               <Flex wrap="wrap" gap="md" justify="space-between">
-                <Box>{headingContent && <>{headingContent}</>}</Box>
+                <Box>{headingContent}</Box>
 
                 {buttonText && (
                   <Box>

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
@@ -94,11 +94,14 @@ export function PeopleListingApp({ children }: { children: React.ReactNode }) {
             <Box px="md">
               <Flex wrap="wrap" gap="md" justify="space-between">
                 <Box>{headingContent && <>{headingContent}</>}</Box>
-                <Box>
-                  <Link to={Urls.newUser()}>
-                    <Button primary>{buttonText}</Button>
-                  </Link>
-                </Box>
+
+                {buttonText && (
+                  <Box>
+                    <Link to={Urls.newUser()}>
+                      <Button primary>{buttonText}</Button>
+                    </Link>
+                  </Box>
+                )}
               </Flex>
             </Box>
 

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
@@ -83,9 +83,9 @@ export function PeopleListingApp({ children }: { children: React.ReactNode }) {
               </Tabs>
             )}
 
-            <Box>
+            <Box mb="xl">
               <Flex wrap="wrap" gap="md" justify="space-between">
-                <Flex align="center" mb="xl">
+                <Flex align="center">
                   <Input
                     miw="14rem"
                     mr="xl"

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
@@ -11,11 +11,13 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
-import { Box, Button, Flex, Icon, Input, Tabs } from "metabase/ui";
+import { Box, Button, Flex, Icon, Input, Stack, Tabs } from "metabase/ui";
 
 import { PeopleList } from "../components/PeopleList";
 import { USER_STATUS, type UserStatus } from "../constants";
 import { usePeopleQuery } from "../hooks/use-people-query";
+
+import S from "./PeopleListingApp.module.css";
 
 const PAGE_SIZE = 25;
 
@@ -52,92 +54,94 @@ export function PeopleListingApp({ children }: { children: React.ReactNode }) {
   const buttonText =
     isAdmin && status === USER_STATUS.active ? t`Invite someone` : undefined;
 
-  useEffect(() => {
-    if (!hasDeactivatedUsers) {
-      updateStatus("active");
-    }
-  }, [hasDeactivatedUsers, updateStatus]);
-
   const handleTabChange = (tab: string | null) => {
     if (tab) {
       updateStatus(tab as UserStatus);
     }
   };
 
+  useEffect(() => {
+    if (!hasDeactivatedUsers) {
+      updateStatus("active");
+    }
+  }, [hasDeactivatedUsers, updateStatus]);
+
   return (
     <SettingsPageWrapper title={t`People`}>
-      <SettingsSection>
-        <LoadingAndErrorWrapper
-          error={error}
-          loading={isLoading || !currentUser}
-        >
-          <div data-testid="admin-panel">
-            {isAdmin && hasDeactivatedUsers && (
-              <Tabs mb="lg" value={status} onChange={handleTabChange}>
-                <Tabs.List>
-                  <Tabs.Tab value={USER_STATUS.active}>{t`Active`}</Tabs.Tab>
-                  <Tabs.Tab
-                    value={USER_STATUS.deactivated}
-                  >{t`Deactivated`}</Tabs.Tab>
-                </Tabs.List>
-              </Tabs>
-            )}
+      <Stack gap={0}>
+        {isAdmin && hasDeactivatedUsers && (
+          <Tabs value={status} onChange={handleTabChange} pl="md">
+            <Tabs.List className={S.tabs}>
+              <Tabs.Tab value={USER_STATUS.active}>{t`Active`}</Tabs.Tab>
+              <Tabs.Tab
+                value={USER_STATUS.deactivated}
+              >{t`Deactivated`}</Tabs.Tab>
+            </Tabs.List>
+          </Tabs>
+        )}
 
-            <Flex
-              align="center"
-              gap="xl"
-              justify="space-between"
-              mb="xl"
-              wrap="wrap"
-            >
-              <Input
-                miw="14rem"
-                fz="sm"
-                flex="1"
-                type="text"
-                placeholder={t`Find someone`}
-                value={searchInputValue}
-                onChange={handleSearchChange}
-                leftSection={
-                  <Icon c="text-secondary" name="search" size={16} />
-                }
-                rightSectionPointerEvents="all"
-                rightSection={
-                  searchInputValue === "" ? (
-                    <div /> // rendering null causes width change
-                  ) : (
-                    <Input.ClearButton
-                      c={"text-secondary"}
-                      onClick={() => updateSearchInputValue("")}
-                    />
-                  )
-                }
-              />
+        <SettingsSection>
+          <LoadingAndErrorWrapper
+            error={error}
+            loading={isLoading || !currentUser}
+          >
+            <div data-testid="admin-panel">
+              <Flex
+                align="center"
+                gap="xl"
+                justify="space-between"
+                mb="xl"
+                wrap="wrap"
+              >
+                <Input
+                  miw="14rem"
+                  fz="sm"
+                  flex="1"
+                  type="text"
+                  placeholder={t`Find someone`}
+                  value={searchInputValue}
+                  onChange={handleSearchChange}
+                  leftSection={
+                    <Icon c="text-secondary" name="search" size={16} />
+                  }
+                  rightSectionPointerEvents="all"
+                  rightSection={
+                    searchInputValue === "" ? (
+                      <div /> // rendering null causes width change
+                    ) : (
+                      <Input.ClearButton
+                        c={"text-secondary"}
+                        onClick={() => updateSearchInputValue("")}
+                      />
+                    )
+                  }
+                />
 
-              {buttonText && (
-                <Box>
-                  <Link to={Urls.newUser()}>
-                    <Button variant="filled">{buttonText}</Button>
-                  </Link>
-                </Box>
+                {buttonText && (
+                  <Box>
+                    <Link to={Urls.newUser()}>
+                      <Button variant="filled">{buttonText}</Button>
+                    </Link>
+                  </Box>
+                )}
+              </Flex>
+
+              {currentUser && (
+                <PeopleList
+                  groups={groups}
+                  isAdmin={isAdmin}
+                  currentUser={currentUser}
+                  query={query}
+                  onNextPage={handleNextPage}
+                  onPreviousPage={handlePreviousPage}
+                />
               )}
-            </Flex>
 
-            {currentUser && (
-              <PeopleList
-                groups={groups}
-                isAdmin={isAdmin}
-                currentUser={currentUser}
-                query={query}
-                onNextPage={handleNextPage}
-                onPreviousPage={handlePreviousPage}
-              />
-            )}
-
-            {children}
-          </div>
-        </LoadingAndErrorWrapper>
-      </SettingsSection>
+              {children}
+            </div>
+          </LoadingAndErrorWrapper>
+        </SettingsSection>
+      </Stack>
     </SettingsPageWrapper>
   );
 }

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
@@ -6,12 +6,11 @@ import {
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
 import { useListPermissionsGroupsQuery } from "metabase/api";
-import Button from "metabase/common/components/Button";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
-import { Box, Flex, Group, Icon, Input, Radio } from "metabase/ui";
+import { Box, Button, Flex, Group, Icon, Input, Radio } from "metabase/ui";
 
 import { PeopleList } from "../components/PeopleList";
 import { USER_STATUS } from "../constants";
@@ -98,7 +97,7 @@ export function PeopleListingApp({ children }: { children: React.ReactNode }) {
                 {buttonText && (
                   <Box>
                     <Link to={Urls.newUser()}>
-                      <Button primary>{buttonText}</Button>
+                      <Button variant="filled">{buttonText}</Button>
                     </Link>
                   </Box>
                 )}

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
@@ -83,43 +83,45 @@ export function PeopleListingApp({ children }: { children: React.ReactNode }) {
               </Tabs>
             )}
 
-            <Box mb="xl">
-              <Flex wrap="wrap" gap="md" justify="space-between">
-                <Flex align="center">
-                  <Input
-                    miw="14rem"
-                    mr="xl"
-                    fz="sm"
-                    type="text"
-                    placeholder={t`Find someone`}
-                    value={searchInputValue}
-                    onChange={handleSearchChange}
-                    leftSection={
-                      <Icon c="text-secondary" name="search" size={16} />
-                    }
-                    rightSectionPointerEvents="all"
-                    rightSection={
-                      searchInputValue === "" ? (
-                        <div /> // rendering null causes width change
-                      ) : (
-                        <Input.ClearButton
-                          c={"text-secondary"}
-                          onClick={() => updateSearchInputValue("")}
-                        />
-                      )
-                    }
-                  />
-                </Flex>
+            <Flex
+              align="center"
+              gap="xl"
+              justify="space-between"
+              mb="xl"
+              wrap="wrap"
+            >
+              <Input
+                miw="14rem"
+                fz="sm"
+                flex="1"
+                type="text"
+                placeholder={t`Find someone`}
+                value={searchInputValue}
+                onChange={handleSearchChange}
+                leftSection={
+                  <Icon c="text-secondary" name="search" size={16} />
+                }
+                rightSectionPointerEvents="all"
+                rightSection={
+                  searchInputValue === "" ? (
+                    <div /> // rendering null causes width change
+                  ) : (
+                    <Input.ClearButton
+                      c={"text-secondary"}
+                      onClick={() => updateSearchInputValue("")}
+                    />
+                  )
+                }
+              />
 
-                {buttonText && (
-                  <Box>
-                    <Link to={Urls.newUser()}>
-                      <Button variant="filled">{buttonText}</Button>
-                    </Link>
-                  </Box>
-                )}
-              </Flex>
-            </Box>
+              {buttonText && (
+                <Box>
+                  <Link to={Urls.newUser()}>
+                    <Button variant="filled">{buttonText}</Button>
+                  </Link>
+                </Box>
+              )}
+            </Flex>
 
             {currentUser && (
               <PeopleList

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router";
 import { t } from "ttag";
 
 import {
@@ -5,12 +6,12 @@ import {
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
 import { useListPermissionsGroupsQuery } from "metabase/api";
-import { AdminPaneLayout } from "metabase/common/components/AdminPaneLayout";
+import Button from "metabase/common/components/Button";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
-import { Flex, Group, Icon, Input, Radio } from "metabase/ui";
+import { Box, Flex, Group, Icon, Input, Radio } from "metabase/ui";
 
 import { PeopleList } from "../components/PeopleList";
 import { USER_STATUS } from "../constants";
@@ -89,11 +90,18 @@ export function PeopleListingApp({ children }: { children: React.ReactNode }) {
           error={error}
           loading={isLoading || !currentUser}
         >
-          <AdminPaneLayout
-            headingContent={headingContent}
-            buttonText={buttonText}
-            buttonLink={Urls.newUser()}
-          >
+          <div data-testid="admin-panel">
+            <Box px="md">
+              <Flex wrap="wrap" gap="md" justify="space-between">
+                <Box>{headingContent && <>{headingContent}</>}</Box>
+                <Box>
+                  <Link to={Urls.newUser()}>
+                    <Button primary>{buttonText}</Button>
+                  </Link>
+                </Box>
+              </Flex>
+            </Box>
+
             {currentUser && (
               <PeopleList
                 groups={groups}
@@ -104,8 +112,9 @@ export function PeopleListingApp({ children }: { children: React.ReactNode }) {
                 onPreviousPage={handlePreviousPage}
               />
             )}
+
             {children}
-          </AdminPaneLayout>
+          </div>
         </LoadingAndErrorWrapper>
       </SettingsSection>
     </SettingsPageWrapper>

--- a/frontend/src/metabase/admin/people/hooks/use-people-query.ts
+++ b/frontend/src/metabase/admin/people/hooks/use-people-query.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { usePagination } from "metabase/common/hooks/use-pagination";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
@@ -31,10 +31,13 @@ export const usePeopleQuery = (pageSize: number) => {
     return () => clearTimeout(timerId);
   }, [searchInputValue, setPage]);
 
-  const updateStatus = (status: UserStatus) => {
-    setPage(0);
-    setStatus(status);
-  };
+  const updateStatus = useCallback(
+    (status: UserStatus) => {
+      setPage(0);
+      setStatus(status);
+    },
+    [setPage],
+  );
 
   const query = useMemo(
     () => ({


### PR DESCRIPTION
Closes [DSN-74](https://linear.app/metabase/issue/DSN-74/people-page-should-use-tabs-instead-of-radios-for-activedeactivated)

### Description

Turns "Active"/"Deactivated" radio button toggle to tabs in Admin > People page.

### How to verify

1. Admin > People

If there are no deactivated users, tabs should not be rendered

2. Deactivate some users

"Active"/"Deactivated" tabs should be shown

3. Open "Deactivated" tab

"Invite someone" button should not be shown

4. Reactivate all deactivated users

Tabs should disappear and active users lists should be shown