### PR TITLE
Adjust DB form page width and form fields spacing

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseHelpSidePanel/DatabaseHelpSidePanel.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseHelpSidePanel/DatabaseHelpSidePanel.tsx
@@ -56,6 +56,7 @@ export const DatabaseHelpSidePanel = ({ engineKey, onClose }: Props) => {
       display="flex"
       flex={{ sm: "1 0 20rem", md: "1 0 26.5rem", base: "1 0 100%" }}
       h="100%"
+      bg="var(--mb-color-bg-white)"
     >
       <Box p="xl" w="100%">
         <Flex align="baseline" justify="space-between" mb="md">

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
@@ -66,8 +66,8 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
         <Box
           w="100%"
           maw={{
-            base: `calc(28.5rem + 2rem)`,
-            md: `calc(28.5rem + 4rem)`,
+            base: `calc(48rem + 2rem)`,
+            md: `calc(46rem + 4rem)`,
           }}
           mx="auto"
           p={{

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import type { Route } from "react-router";
 import { t } from "ttag";
 
+import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { getEngines } from "metabase/databases/selectors";
 import { useSelector } from "metabase/lib/redux";
 import {
@@ -61,7 +62,11 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
   };
 
   return (
-    <Flex direction="row" h="100%">
+    <Flex
+      direction="row"
+      h="100%"
+      style={{ backgroundColor: "var(--mb-color-bg-light)" }}
+    >
       <Box h="100%" w="100%" component={ScrollArea}>
         <Box
           w="100%"
@@ -98,17 +103,19 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
               </Text>
             )}
           </Flex>
-          <DatabaseEditConnectionForm
-            database={database}
-            isAttachedDWH={database?.is_attached_dwh ?? false}
-            initializeError={databaseReq.error}
-            onSubmitted={handleOnSubmit}
-            route={route}
-            onCancel={handleCancel}
-            config={config}
-            formLocation="full-page"
-            onEngineChange={onEngineChange}
-          />
+          <SettingsSection>
+            <DatabaseEditConnectionForm
+              database={database}
+              isAttachedDWH={database?.is_attached_dwh ?? false}
+              initializeError={databaseReq.error}
+              onSubmitted={handleOnSubmit}
+              route={route}
+              onCancel={handleCancel}
+              config={config}
+              formLocation="full-page"
+              onEngineChange={onEngineChange}
+            />
+          </SettingsSection>
         </Box>
       </Box>
       {showSidePanel && (

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
@@ -66,8 +66,8 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
         <Box
           w="100%"
           maw={{
-            base: `calc(48rem + 2rem)`,
-            md: `calc(46rem + 4rem)`,
+            base: "50rem",
+            md: "52rem",
           }}
           mx="auto"
           p={{

--- a/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabasePage.tsx
@@ -65,14 +65,11 @@ export function DatabasePage({ params, route }: DatabasePageProps) {
       <Box h="100%" w="100%" component={ScrollArea}>
         <Box
           w="100%"
-          maw={{
-            base: "50rem",
-            md: "52rem",
-          }}
+          maw="54rem"
           mx="auto"
           p={{
             base: `md`,
-            md: `xl`,
+            sm: `xl`,
           }}
         >
           <Flex

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
@@ -10,6 +10,7 @@ import { isEngineKey } from "metabase-types/guards";
 
 import type { FormLocation } from "../../types";
 import { setDatabaseFormValues } from "../../utils/schema";
+import { sharedFieldStyleProps } from "../styles";
 
 import {
   connectionStringParsedFailed,
@@ -133,13 +134,10 @@ export function DatabaseConnectionStringField({
       onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setConnectionString(event.target.value);
       }}
-      mb="xl"
       placeholder={placeholder}
       name="connection-string"
-      labelProps={{
-        mb: "sm",
-      }}
       onBlur={handleBlur}
+      {...sharedFieldStyleProps}
     />
   );
 }

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
@@ -133,7 +133,7 @@ export function DatabaseConnectionStringField({
       onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setConnectionString(event.target.value);
       }}
-      mb="md"
+      mb="xl"
       placeholder={placeholder}
       name="connection-string"
       labelProps={{

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/DatabaseConnectionStringField.tsx
@@ -10,7 +10,7 @@ import { isEngineKey } from "metabase-types/guards";
 
 import type { FormLocation } from "../../types";
 import { setDatabaseFormValues } from "../../utils/schema";
-import { sharedFieldStyleProps } from "../styles";
+import { getSharedFieldStyleProps } from "../styles";
 
 import {
   connectionStringParsedFailed,
@@ -137,7 +137,7 @@ export function DatabaseConnectionStringField({
       placeholder={placeholder}
       name="connection-string"
       onBlur={handleBlur}
-      {...sharedFieldStyleProps}
+      {...getSharedFieldStyleProps()}
     />
   );
 }

--- a/frontend/src/metabase/databases/components/DatabaseDetailField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField.tsx
@@ -14,12 +14,13 @@ import type {
   EngineKey,
 } from "metabase-types/api";
 
-import { FIELD_OVERRIDES } from "../../constants";
-import type { EngineFieldOverride, FieldType } from "../../types";
-import { DatabaseHostnameWithProviderField } from "../DatabaseHostnameWithProviderField/DatabaseHostnameWithProviderField";
-import DatabaseInfoField from "../DatabaseInfoField";
-import DatabaseSectionField from "../DatabaseSectionField";
-import { getSharedFieldStyleProps } from "../styles";
+import { FIELD_OVERRIDES } from "../constants";
+import type { EngineFieldOverride, FieldType } from "../types";
+
+import { DatabaseHostnameWithProviderField } from "./DatabaseHostnameWithProviderField/DatabaseHostnameWithProviderField";
+import DatabaseInfoField from "./DatabaseInfoField";
+import DatabaseSectionField from "./DatabaseSectionField";
+import { getSharedFieldStyleProps } from "./styles";
 
 export interface DatabaseDetailFieldProps {
   field: EngineField;
@@ -28,7 +29,7 @@ export interface DatabaseDetailFieldProps {
   engine: Engine | undefined;
 }
 
-const DatabaseDetailField = ({
+export const DatabaseDetailField = ({
   field,
   autoFocus,
   engineKey,
@@ -151,6 +152,3 @@ const convertEngineFieldOptionsToSelectOptions = (
 ) => {
   return options.map((option) => ({ label: option.name, value: option.value }));
 };
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DatabaseDetailField;

--- a/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
@@ -19,6 +19,7 @@ import type { EngineFieldOverride } from "../../types";
 import { DatabaseHostnameWithProviderField } from "../DatabaseHostnameWithProviderField/DatabaseHostnameWithProviderField";
 import DatabaseInfoField from "../DatabaseInfoField";
 import DatabaseSectionField from "../DatabaseSectionField";
+import { sharedFieldStyleProps } from "../styles";
 
 export interface DatabaseDetailFieldProps {
   field: EngineField;
@@ -107,10 +108,7 @@ const getFieldProps = (field: EngineField, override?: EngineFieldOverride) => {
     description: override?.description ?? field.description,
     placeholder: placeholder != null ? String(placeholder) : undefined,
     encoding: field["treat-before-posting"],
-    mb: "xl",
-    labelProps: {
-      mb: "sm",
-    },
+    ...sharedFieldStyleProps,
   };
 };
 

--- a/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
@@ -107,7 +107,7 @@ const getFieldProps = (field: EngineField, override?: EngineFieldOverride) => {
     description: override?.description ?? field.description,
     placeholder: placeholder != null ? String(placeholder) : undefined,
     encoding: field["treat-before-posting"],
-    mb: "md",
+    mb: "xl",
     labelProps: {
       mb: "sm",
     },

--- a/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
@@ -15,11 +15,11 @@ import type {
 } from "metabase-types/api";
 
 import { FIELD_OVERRIDES } from "../../constants";
-import type { EngineFieldOverride } from "../../types";
+import type { EngineFieldOverride, FieldType } from "../../types";
 import { DatabaseHostnameWithProviderField } from "../DatabaseHostnameWithProviderField/DatabaseHostnameWithProviderField";
 import DatabaseInfoField from "../DatabaseInfoField";
 import DatabaseSectionField from "../DatabaseSectionField";
-import { sharedFieldStyleProps } from "../styles";
+import { getSharedFieldStyleProps } from "../styles";
 
 export interface DatabaseDetailFieldProps {
   field: EngineField;
@@ -38,7 +38,7 @@ const DatabaseDetailField = ({
   const type = getFieldType(field, override);
   const props = {
     ...(autoFocus ? { autoFocus, "data-autofocus": autoFocus } : {}),
-    ...getFieldProps(field, override),
+    ...getFieldProps(field, override, type),
   };
 
   if (field.name === "host" && engineKey === "postgres") {
@@ -97,7 +97,11 @@ const getFieldType = (field: EngineField, override?: EngineFieldOverride) => {
   return override?.type ?? field.type;
 };
 
-const getFieldProps = (field: EngineField, override?: EngineFieldOverride) => {
+const getFieldProps = (
+  field: EngineField,
+  override: EngineFieldOverride | undefined,
+  type: FieldType | undefined,
+) => {
   const placeholder =
     override?.placeholder ?? field.placeholder ?? field.default;
 
@@ -108,7 +112,7 @@ const getFieldProps = (field: EngineField, override?: EngineFieldOverride) => {
     description: override?.description ?? field.description,
     placeholder: placeholder != null ? String(placeholder) : undefined,
     encoding: field["treat-before-posting"],
-    ...sharedFieldStyleProps,
+    ...getSharedFieldStyleProps(type),
   };
 };
 

--- a/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
@@ -140,13 +140,13 @@ const getPasswordProps = (field: EngineField) => {
 
 const getSelectProps = (field: EngineField, override?: EngineFieldOverride) => {
   return {
-    data: convertEnginFeildOptionsToSelectOptions(
+    data: convertEngineFieldOptionsToSelectOptions(
       override?.options ?? field.options ?? [],
     ),
   };
 };
 
-const convertEnginFeildOptionsToSelectOptions = (
+const convertEngineFieldOptionsToSelectOptions = (
   options: EngineFieldOption[],
 ) => {
   return options.map((option) => ({ label: option.name, value: option.value }));

--- a/frontend/src/metabase/databases/components/DatabaseDetailField/index.ts
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField/index.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DatabaseDetailField";

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineSelect.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineSelect.tsx
@@ -11,7 +11,7 @@ import {
   type SelectProps,
 } from "metabase/ui";
 
-import { sharedFieldStyleProps } from "../styles";
+import { getSharedFieldStyleProps } from "../styles";
 
 const ICON_SIZE = 16;
 
@@ -46,7 +46,7 @@ export const DatabaseEngineSelect = ({
       searchable
       leftSection={<DatabaseIcon engineKey={engineKey} />}
       renderOption={renderSelectOption}
-      {...sharedFieldStyleProps}
+      {...getSharedFieldStyleProps()}
     />
   );
 };

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineSelect.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineSelect.tsx
@@ -41,7 +41,7 @@ export const DatabaseEngineSelect = ({
       data={options}
       disabled={disabled}
       onChange={handleChange}
-      mb="md"
+      mb="xl"
       searchable
       leftSection={<DatabaseIcon engineKey={engineKey} />}
       renderOption={renderSelectOption}

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineSelect.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineSelect.tsx
@@ -11,6 +11,8 @@ import {
   type SelectProps,
 } from "metabase/ui";
 
+import { sharedFieldStyleProps } from "../styles";
+
 const ICON_SIZE = 16;
 
 export interface DatabaseEngineSelectProps {
@@ -41,13 +43,10 @@ export const DatabaseEngineSelect = ({
       data={options}
       disabled={disabled}
       onChange={handleChange}
-      mb="xl"
       searchable
       leftSection={<DatabaseIcon engineKey={engineKey} />}
       renderOption={renderSelectOption}
-      labelProps={{
-        mb: "sm",
-      }}
+      {...sharedFieldStyleProps}
     />
   );
 };

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormBody.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormBody.tsx
@@ -11,7 +11,7 @@ import { Box } from "metabase/ui";
 import type { DatabaseData, Engine, EngineKey } from "metabase-types/api";
 
 import { DatabaseConnectionStringField } from "../DatabaseConnectionUri";
-import DatabaseDetailField from "../DatabaseDetailField";
+import { DatabaseDetailField } from "../DatabaseDetailField";
 import { DatabaseEngineField } from "../DatabaseEngineField";
 import DatabaseEngineWarning from "../DatabaseEngineWarning";
 import { DatabaseFormError } from "../DatabaseFormError";

--- a/frontend/src/metabase/databases/components/DatabaseNameField/DatabaseNameField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseNameField/DatabaseNameField.tsx
@@ -37,7 +37,7 @@ export const DatabaseNameField = ({
           <Icon name="info" />
         </Tooltip>
       }
-      mb="md"
+      mb="xl"
       {...autoFocusProps}
       {...props}
       labelProps={{

--- a/frontend/src/metabase/databases/components/DatabaseNameField/DatabaseNameField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseNameField/DatabaseNameField.tsx
@@ -6,6 +6,8 @@ import { PLUGIN_DB_ROUTING } from "metabase/plugins";
 import { Icon, Tooltip } from "metabase/ui";
 import type { Engine } from "metabase-types/api";
 
+import { sharedFieldStyleProps } from "../styles";
+
 export interface DatabaseNameFieldProps {
   engine: Engine;
   config: DatabaseFormConfig;
@@ -37,12 +39,9 @@ export const DatabaseNameField = ({
           <Icon name="info" />
         </Tooltip>
       }
-      mb="xl"
       {...autoFocusProps}
       {...props}
-      labelProps={{
-        mb: "sm",
-      }}
+      {...sharedFieldStyleProps}
     />
   );
 };

--- a/frontend/src/metabase/databases/components/DatabaseNameField/DatabaseNameField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseNameField/DatabaseNameField.tsx
@@ -6,7 +6,7 @@ import { PLUGIN_DB_ROUTING } from "metabase/plugins";
 import { Icon, Tooltip } from "metabase/ui";
 import type { Engine } from "metabase-types/api";
 
-import { sharedFieldStyleProps } from "../styles";
+import { getSharedFieldStyleProps } from "../styles";
 
 export interface DatabaseNameFieldProps {
   engine: Engine;
@@ -41,7 +41,7 @@ export const DatabaseNameField = ({
       }
       {...autoFocusProps}
       {...props}
-      {...sharedFieldStyleProps}
+      {...getSharedFieldStyleProps()}
     />
   );
 };

--- a/frontend/src/metabase/databases/components/styles.ts
+++ b/frontend/src/metabase/databases/components/styles.ts
@@ -1,0 +1,6 @@
+export const sharedFieldStyleProps = {
+  mb: "xl",
+  labelProps: {
+    mb: "sm",
+  },
+} as const;

--- a/frontend/src/metabase/databases/components/styles.ts
+++ b/frontend/src/metabase/databases/components/styles.ts
@@ -1,5 +1,5 @@
 export const sharedFieldStyleProps = {
-  mb: "xl",
+  mb: "lg",
   labelProps: {
     mb: "sm",
   },

--- a/frontend/src/metabase/databases/components/styles.ts
+++ b/frontend/src/metabase/databases/components/styles.ts
@@ -1,6 +1,18 @@
-export const sharedFieldStyleProps = {
-  mb: "lg",
-  labelProps: {
-    mb: "sm",
-  },
-} as const;
+import type { FieldType } from "../types";
+
+export function getSharedFieldStyleProps(type?: FieldType) {
+  // our boolean (Switch) fields don't support the labelProps
+  const labelProps =
+    type !== "boolean"
+      ? {
+          labelProps: {
+            mb: "sm",
+          },
+        }
+      : undefined;
+
+  return {
+    mb: "lg",
+    ...labelProps,
+  };
+}

--- a/frontend/src/metabase/databases/types.ts
+++ b/frontend/src/metabase/databases/types.ts
@@ -44,3 +44,5 @@ export interface DatabaseFormConfig {
 export type ContinueWithoutDataComponent = (props: {
   onCancel?: () => void;
 }) => JSX.Element;
+
+export type FieldType = EngineFieldType | ComponentType<EngineFieldProps>;


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-136/change-width-to-800px-and-increase-vertical-space-between-form

### Description

- Increate the width of DB page in admin
- Adjust (increase) spacing between fields
- Extract field settings, as they change always together and were repeated 4 times.

### How to verify

Take a look at DB page and DB form in the setup flow.

### Demo

| Header | Header |
|--------|--------|
| ![localhost_3000_admin_databases_create (6)](https://github.com/user-attachments/assets/3a34a950-6291-41c4-a25b-ae7cb2b41877) |<img  alt="localhost_3000_admin_databases_create (1)" src="https://github.com/user-attachments/assets/ea3499d4-04de-46fa-8291-40403d0e3fd0" />| 
