### PR TITLE
Add a name to the null series (fix 63820)

### DIFF
--- a/frontend/src/metabase/static-viz/lib/format.ts
+++ b/frontend/src/metabase/static-viz/lib/format.ts
@@ -1,6 +1,8 @@
 import type { NumberLike, StringLike } from "@visx/scale";
 
+import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 import { formatValue } from "metabase/lib/formatting";
+import { isEmpty } from "metabase/lib/validate";
 import { getFormattingOptionsWithoutScaling } from "metabase/visualizations/echarts/cartesian/model/util";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import { getStackOffset } from "metabase/visualizations/lib/settings/stacking";
@@ -95,7 +97,8 @@ export const getLabelsStaticFormatter = (
 };
 
 export const getColumnValueStaticFormatter = () => {
-  return (value: RowValue, column: DatasetColumn) => {
-    return String(formatValue(value, { column }));
-  };
+  return (value: RowValue, column: DatasetColumn) =>
+    isEmpty(value)
+      ? NULL_DISPLAY_VALUE
+      : String(formatValue(value, { column }));
 };


### PR DESCRIPTION
For some reason the series return with a blank name, when they should return with an "(empty)" column name. This change bullet proofs the static viz's function to copy what we see in https://github.com/metabase/metabase/blob/c471c32f3ff74b11b2d5b683a4baee73b14eab23/frontend/src/metabase/visualizations/visualizations/RowChart/utils/format.ts#L83 so this does not happen

BTW, I don't know if we have shared logic between static viz and the front end, so if that's the case, feel free to modify this PR