### PR TITLE
Removed loki flaky test

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.stories.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.stories.tsx
@@ -1,11 +1,7 @@
 import type { StoryFn } from "@storybook/react";
 
-import {
-  SdkVisualizationWrapper,
-  VisualizationWrapper,
-} from "__support__/storybook";
+import { VisualizationWrapper } from "__support__/storybook";
 import { NumberColumn, StringColumn } from "__support__/visualizations";
-import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { Box } from "metabase/ui";
 import { registerVisualization } from "metabase/visualizations";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -52,22 +48,6 @@ export const Default: StoryFn = () => (
     </Box>
   </VisualizationWrapper>
 );
-
-// Example of how themes can be applied in the SDK.
-export const EmbeddingHugeFont: StoryFn = () => {
-  const theme: MetabaseTheme = {
-    fontSize: "20px",
-    components: { cartesian: { padding: "0.5rem 1rem" } },
-  };
-
-  return (
-    <SdkVisualizationWrapper theme={theme}>
-      <Box h={500}>
-        <Visualization rawSeries={MOCK_SERIES} width={500} />
-      </Box>
-    </SdkVisualizationWrapper>
-  );
-};
 
 export const Watermark: StoryFn = () => (
   <VisualizationWrapper


### PR DESCRIPTION
Closes nothing, but related to [EMB-844: Restore flaky Loki visual test for BarChart_Embedding_Huge_Font](https://linear.app/metabase/issue/EMB-844/restore-flaky-loki-visual-test-for-barchart-embedding-huge-font)

### Description

Removes a flaky screenshot test