### PR TITLE
Fix: #62731 Use display_name if it exists in SmartLinks

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
@@ -387,7 +387,7 @@ export const SmartLinkComponent = memo(
         >
           <span className={styles.smartLinkInner}>
             <Icon name={iconData.name} className={styles.icon} />
-            {entity.name}
+            {("display_name" in entity && entity.display_name) || entity.name}
           </span>
         </a>
       </NodeViewWrapper>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62731

### Description

Uses display_name if it exists in SmartLinks

### How to verify

See #62731 for repro steps

### Demo

https://github.com/user-attachments/assets/94327dab-d787-4b19-840d-ae43d3e58a74

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
