### PR TITLE
DSN-72 Variables and parameters tabs should use actual Tab component

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp/TagEditorHelp.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp/TagEditorHelp.tsx
@@ -259,7 +259,7 @@ export const TagEditorHelp = ({
   );
 
   return (
-    <div className={cx(CS.px3, CS.textSpaced)}>
+    <div className={CS.textSpaced}>
       <h4>{t`What's this for?`}</h4>
       <p>
         {t`Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL.`}

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -316,7 +316,7 @@ class TagEditorParamInner extends Component<
         className={TagEditorParamS.TagContainer}
         data-testid={`tag-editor-variable-${tag.name}`}
       >
-        <ContainerLabel paddingTop>{t`Variable name`}</ContainerLabel>
+        <ContainerLabel>{t`Variable name`}</ContainerLabel>
         <Box component="h3" className={TagEditorParamS.TagName}>
           {tag.name}
         </Box>

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TagEditorParam.tsx
@@ -8,17 +8,12 @@ import S from "./TagEditorParam.module.css";
 
 type BoxPropsWithChildren = BoxProps & { children: React.ReactNode };
 interface ContainerLabelProps extends BoxPropsWithChildren {
-  paddingTop?: boolean;
   id?: string | undefined;
 }
 
-const ContainerLabel = ({
-  paddingTop,
-  children,
-  ...props
-}: ContainerLabelProps) => {
+const ContainerLabel = ({ children, ...props }: ContainerLabelProps) => {
   return (
-    <Box className={S.ContainerLabel} pt={paddingTop ? "sm" : 0} {...props}>
+    <Box className={S.ContainerLabel} {...props}>
       {children}
     </Box>
   );

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -1,12 +1,10 @@
-import cx from "classnames";
 import { useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import ButtonsS from "metabase/css/components/buttons.module.css";
-import CS from "metabase/css/core/index.css";
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
+import { Box, Tabs } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
@@ -22,6 +20,8 @@ import type {
 
 import { TagEditorHelp } from "./TagEditorHelp";
 import { TagEditorParam } from "./TagEditorParam";
+
+type TabId = "settings" | "help";
 
 type GetEmbeddedParamVisibility = (
   slug: string,
@@ -50,7 +50,7 @@ export function TagEditorSidebar({
   onClose,
   getEmbeddedParameterVisibility,
 }: TagEditorSidebarProps) {
-  const [section, setSection] = useState<"settings" | "help">(() => {
+  const [section, setSection] = useState<TabId>(() => {
     const tags = query.variableTemplateTags();
     return tags.length === 0 ? "help" : "settings";
   });
@@ -62,35 +62,22 @@ export function TagEditorSidebar({
 
   const effectiveSection = tags.length === 0 ? "help" : section;
 
+  const handleTabChange = (tab: string | null) => {
+    if (tab) {
+      setSection(tab as TabId);
+    }
+  };
+
   return (
     <SidebarContent title={t`Variables and parameters`} onClose={onClose}>
       <div data-testid="tag-editor-sidebar">
-        <div
-          className={cx(
-            CS.mx3,
-            CS.textCentered,
-            ButtonsS.ButtonGroup,
-            ButtonsS.ButtonGroupBrand,
-            CS.textUppercase,
-            CS.mb2,
-            CS.flex,
-            CS.flexFull,
-          )}
-        >
-          <a
-            className={cx(ButtonsS.Button, CS.flexFull, ButtonsS.ButtonSmall, {
-              [ButtonsS.ButtonActive]: effectiveSection === "settings",
-              [CS.disabled]: tags.length === 0,
-            })}
-            onClick={() => setSection("settings")}
-          >{t`Settings`}</a>
-          <a
-            className={cx(ButtonsS.Button, CS.flexFull, ButtonsS.ButtonSmall, {
-              [ButtonsS.ButtonActive]: effectiveSection === "help",
-            })}
-            onClick={() => setSection("help")}
-          >{t`Help`}</a>
-        </div>
+        <Tabs radius={0} value={effectiveSection} onChange={handleTabChange}>
+          <Tabs.List grow>
+            <Tabs.Tab value="settings">{t`Settings`}</Tabs.Tab>
+            <Tabs.Tab value="help">{t`Help`}</Tabs.Tab>
+          </Tabs.List>
+        </Tabs>
+
         {effectiveSection === "settings" ? (
           <SettingsPane
             tags={tags}
@@ -102,12 +89,14 @@ export function TagEditorSidebar({
             getEmbeddedParameterVisibility={getEmbeddedParameterVisibility}
           />
         ) : (
-          <TagEditorHelp
-            database={database}
-            sampleDatabaseId={sampleDatabaseId}
-            setDatasetQuery={setDatasetQuery}
-            switchToSettings={() => setSection("settings")}
-          />
+          <Box p="lg">
+            <TagEditorHelp
+              database={database}
+              sampleDatabaseId={sampleDatabaseId}
+              setDatasetQuery={setDatasetQuery}
+              switchToSettings={() => setSection("settings")}
+            />
+          </Box>
         )}
       </div>
     </SidebarContent>


### PR DESCRIPTION
Closes [DSN-72](https://linear.app/metabase/issue/DSN-72/variables-and-parameters-tabs-should-use-actual-tab-component)

### Description

Uses Mantine `Tabs` component in SQL editor's parameter sidebar

### How to verify

1. New > Native query
2. `select {{x}}`
3. Put cursor inside the `x` parameter

The parameter sidebar should use Mantine `Tabs` component
