### PR TITLE
DSN-71 Hover state on field cards in table metadata section should be light blue instead of same color as background

### DIFF
--- a/frontend/src/metabase/metadata/components/SortableFieldItem/SortableFieldItem.module.css
+++ b/frontend/src/metabase/metadata/components/SortableFieldItem/SortableFieldItem.module.css
@@ -16,7 +16,7 @@
 
   &:hover {
     &:not(.active) {
-      background-color: var(--mb-color-background-light) !important;
+      background-color: var(--mb-color-brand-lighter) !important;
     }
 
     .grabber {

--- a/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.module.css
+++ b/frontend/src/metabase/metadata/pages/DataModel/components/TableSection/FieldList/FieldItem/FieldItem.module.css
@@ -4,7 +4,7 @@
 
   &:hover {
     &:not(.active) {
-      background-color: var(--mb-color-background-light) !important;
+      background-color: var(--mb-color-brand-lighter) !important;
     }
   }
 }


### PR DESCRIPTION
Closes [DSN-71](https://linear.app/metabase/issue/DSN-71/hover-state-on-field-cards-in-table-metadata-section-should-be-light)

### Description

Changes bg color of field items on hover (both when viewing fields and when changing order of fields).

### Demo

[before](https://github.com/user-attachments/assets/baeb0bd0-f6fa-43a2-8991-4b1bfc5f94f5) vs [after](https://github.com/user-attachments/assets/27abfe2e-20f8-4c2b-aaad-87a8ab6a258c) (it's the "Account ID" field)
