### PR TITLE
Closes EMB-407 transparent background download pdf

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-pdf-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-pdf-downloads.cy.spec.ts
@@ -1,0 +1,97 @@
+const { H } = cy;
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+import type { BaseEmbedTestPageOptions } from "e2e/support/helpers";
+
+H.describeWithSnowplowEE(
+  "scenarios > embedding > sdk iframe embedding > pdf downloads",
+  () => {
+    beforeEach(() => {
+      H.resetSnowplow();
+      cy.deleteDownloadsFolder();
+    });
+
+    afterEach(() => {
+      H.expectNoBadSnowplowEvents();
+    });
+
+    describe("Dashboard PDF downloads", () => {
+      const setup = (options: Partial<BaseEmbedTestPageOptions>) => {
+        const frame = H.loadSdkIframeEmbedTestPage({
+          elements: [
+            {
+              component: "metabase-dashboard",
+              attributes: {
+                dashboardId: ORDERS_DASHBOARD_ID,
+                withDownloads: true,
+              },
+            },
+          ],
+          ...options,
+        });
+
+        cy.wait("@getDashCardQuery");
+
+        // Check that the dashboard loaded fine
+        frame.within(() => {
+          cy.findByText("Orders in a dashboard").should("be.visible");
+          cy.findByText("Orders").should("be.visible");
+          H.assertTableRowsCount(2000);
+        });
+
+        return frame;
+      };
+
+      beforeEach(() => {
+        H.prepareSdkIframeEmbedTest({ signOut: true });
+      });
+
+      it("should download dashboard as PDF with analytics tracking", () => {
+        const frame = setup({
+          metabaseConfig: {
+            theme: {
+              components: {
+                dashboard: {
+                  backgroundColor: "transparent",
+                },
+              },
+            },
+          },
+        });
+
+        frame
+          .should("contain", "Orders in a dashboard")
+          .findByLabelText("Download as PDF")
+          .should("be.visible")
+          .click();
+
+        // Verify PDF file download
+        cy.verifyDownload("Orders in a dashboard.pdf");
+
+        // Verify analytics tracking
+        H.expectUnstructuredSnowplowEvent({
+          dashboard_accessed_via: "sdk-embed",
+          event: "dashboard_pdf_exported",
+        });
+      });
+
+      it("should hide PDF download button when with-downloads is false", () => {
+        const frame = setup({
+          elements: [
+            {
+              component: "metabase-dashboard",
+              attributes: {
+                dashboardId: ORDERS_DASHBOARD_ID,
+                withDownloads: false,
+              },
+            },
+          ],
+        });
+
+        frame
+          .should("contain", "Orders in a dashboard")
+          .findByLabelText("Download as PDF")
+          .should("not.exist");
+      });
+    });
+  },
+);

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-pdf-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-pdf-downloads.cy.spec.ts
@@ -5,6 +5,32 @@ import type { BaseEmbedTestPageOptions } from "e2e/support/helpers";
 H.describeWithSnowplowEE(
   "scenarios > embedding > sdk iframe embedding > pdf downloads",
   () => {
+    const setup = (options: Partial<BaseEmbedTestPageOptions>) => {
+      const frame = H.loadSdkIframeEmbedTestPage({
+        elements: [
+          {
+            component: "metabase-dashboard",
+            attributes: {
+              dashboardId: ORDERS_DASHBOARD_ID,
+              withDownloads: true,
+            },
+          },
+        ],
+        ...options,
+      });
+
+      cy.wait("@getDashCardQuery");
+
+      // Check that the dashboard loaded fine
+      frame.within(() => {
+        cy.findByText("Orders in a dashboard").should("be.visible");
+        cy.findByText("Orders").should("be.visible");
+        H.assertTableRowsCount(2000);
+      });
+
+      return frame;
+    };
+
     beforeEach(() => {
       H.resetSnowplow();
       cy.deleteDownloadsFolder();
@@ -15,32 +41,6 @@ H.describeWithSnowplowEE(
     });
 
     describe("Dashboard PDF downloads", () => {
-      const setup = (options: Partial<BaseEmbedTestPageOptions>) => {
-        const frame = H.loadSdkIframeEmbedTestPage({
-          elements: [
-            {
-              component: "metabase-dashboard",
-              attributes: {
-                dashboardId: ORDERS_DASHBOARD_ID,
-                withDownloads: true,
-              },
-            },
-          ],
-          ...options,
-        });
-
-        cy.wait("@getDashCardQuery");
-
-        // Check that the dashboard loaded fine
-        frame.within(() => {
-          cy.findByText("Orders in a dashboard").should("be.visible");
-          cy.findByText("Orders").should("be.visible");
-          H.assertTableRowsCount(2000);
-        });
-
-        return frame;
-      };
-
       beforeEach(() => {
         H.prepareSdkIframeEmbedTest({ signOut: true });
       });

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -156,6 +156,18 @@ interface SavePdfProps {
   includeBranding: boolean;
 }
 
+async function isValidColor(str: string) {
+  const { default: jspdf } = await import("jspdf");
+  const pdf = new jspdf();
+  try {
+    pdf.setFillColor(str);
+    return true;
+  } catch {
+    console.warn(`Unsupported color string: "${str}"`);
+    return false;
+  }
+}
+
 export const saveDashboardPdf = async ({
   selector,
   dashboardName,
@@ -204,9 +216,13 @@ export const saveDashboardPdf = async ({
     headerHeight + parametersHeight + (includeBranding ? brandingHeight : 0);
   const contentHeight = gridNode.offsetHeight + verticalOffset;
 
-  const backgroundColor = getComputedStyle(document.documentElement)
+  let backgroundColor = getComputedStyle(document.documentElement)
     .getPropertyValue("--mb-color-bg-dashboard")
     .trim();
+
+  if (!(await isValidColor(backgroundColor))) {
+    backgroundColor = "white"; // Fallback to white if the color is invalid
+  }
 
   const { default: html2canvas } = await import("html2canvas-pro");
   const image = await html2canvas(gridNode, {


### PR DESCRIPTION
Closes [EMB-407: Dashboard PDF download does not work with transparent backgrounds.](https://linear.app/metabase/issue/EMB-407/dashboard-pdf-download-does-not-work-with-transparent-backgrounds)

### Description

jsPDF uses an in-house library to handle colors, whch means we have to rely on it to check the validity of colors.

### How to verify

This can be reproduced on Shoppy for [ProficiencyLabs](http://localhost:4400/admin/products) when withDownloads is enabled for the <InteractiveDashboard/>.
