### PR TITLE
Fix removing all tags from a transform job

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/api/transform_job.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/api/transform_job.clj
@@ -74,7 +74,7 @@
     (api/check-400 (transforms.schedule/validate-cron-expression schedule)
                    (deferred-tru "Invalid cron expression: {0}" schedule)))
   ;; Validate tag IDs if provided
-  (when tag-ids
+  (when (seq tag-ids)
     (let [existing-tags (set (t2/select-pks-vec :model/TransformTag :id [:in tag-ids]))]
       (api/check-400 (= (set tag-ids) existing-tags)
                      (deferred-tru "Some tag IDs do not exist"))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/api/transform_job_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api/transform_job_test.clj
@@ -158,6 +158,17 @@
               (is (string? response))
               (is (re-find #"Invalid cron expression" response)))))))))
 
+(deftest update-job-remove-tags-test
+  (testing "PUT /api/ee/transform-job/:id"
+    (mt/with-premium-features #{:transforms}
+      (testing "should be able to remove all tags from a job"
+        (mt/with-temp [:model/TransformTag tag {:name "tag-1"}
+                       :model/TransformJob job {}
+                       :model/TransformJobTransformTag _ {:job_id (:id job) :tag_id (:id tag) :position 0}]
+          (let [response (mt/user-http-request :crowberto :put 200 (str "ee/transform-job/" (:id job))
+                                               {:tag_ids []})]
+            (is (= [] (:tag_ids response)))))))))
+
 (deftest delete-job-test
   (testing "DELETE /api/ee/transform-job/:id"
     (mt/with-premium-features #{:transforms}

--- a/enterprise/backend/test/metabase_enterprise/transforms/api/transform_job_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/api/transform_job_test.clj
@@ -162,7 +162,7 @@
   (testing "PUT /api/ee/transform-job/:id"
     (mt/with-premium-features #{:transforms}
       (testing "should be able to remove all tags from a job"
-        (mt/with-temp [:model/TransformTag tag {:name "tag-1"}
+        (mt/with-temp [:model/TransformTag tag {}
                        :model/TransformJob job {}
                        :model/TransformJobTransformTag _ {:job_id (:id job) :tag_id (:id tag) :position 0}]
           (let [response (mt/user-http-request :crowberto :put 200 (str "ee/transform-job/" (:id job))


### PR DESCRIPTION
Fixes https://linear.app/metabase/issue/QUE-2493/fe-investigate-an-issue-with-deleting-transform-tags

`(when tag-ids` -> `(when (seq tag-ids)`