### PR TITLE
Hide non-customer-facing embedding hub settings

### DIFF
--- a/src/metabase/embedding/settings.clj
+++ b/src/metabase/embedding/settings.clj
@@ -300,11 +300,15 @@
   :type       :boolean
   :default    false
   :export?    true
-  :visibility :admin)
+  :visibility :admin
+  :can-read-from-env? false
+  :doc false)
 
 (defsetting embedding-hub-production-embed-snippet-created
   (deferred-tru "Indicates if a production embed snippet has been created for tracking in the embedding hub")
   :type       :boolean
   :default    false
   :export?    true
-  :visibility :admin)
+  :visibility :admin
+  :can-read-from-env? false
+  :doc false)


### PR DESCRIPTION
Closes EMB-843

Marks the embedding hub env variables as non customer facing: exclude them from docs and being read by environment variables. It should still be serializable though, same as the show-sdk-embed-terms.