### PR TITLE
Fix: #50011 Hides "Here are some explorations of" when there are no explorations

### DIFF
--- a/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.tsx
+++ b/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.tsx
@@ -90,12 +90,12 @@ const HomeXrayView = ({ database, candidates = [] }: HomeXrayViewProps) => {
           {t`schema in`}
           <DatabaseInfo database={database} />
         </HomeCaption>
-      ) : (
+      ) : (candidate?.tables.length ?? 0) > 0 ? (
         <HomeCaption primary>
           {t`Here are some explorations of`}
           <DatabaseInfo database={database} />
         </HomeCaption>
-      )}
+      ) : null}
       <SectionBody>
         {candidate?.tables.map((table, index) => (
           <HomeXrayCard

--- a/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.tsx
+++ b/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.tsx
@@ -72,6 +72,7 @@ const HomeXrayView = ({ database, candidates = [] }: HomeXrayViewProps) => {
   const tableMessages = useMemo(() => getMessages(tableCount), [tableCount]);
   const canSelectSchema = schemas.length > 1 && schema !== null;
   const applicationName = useSelector(getApplicationName);
+  const hasTables = (candidate?.tables.length ?? 0) > 0;
 
   return (
     <div>
@@ -90,7 +91,7 @@ const HomeXrayView = ({ database, candidates = [] }: HomeXrayViewProps) => {
           {t`schema in`}
           <DatabaseInfo database={database} />
         </HomeCaption>
-      ) : (candidate?.tables.length ?? 0) > 0 ? (
+      ) : hasTables ? (
         <HomeCaption primary>
           {t`Here are some explorations of`}
           <DatabaseInfo database={database} />

--- a/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/HomeXraySection/HomeXraySection.unit.spec.tsx
@@ -97,4 +97,15 @@ describe("HomeXraySection", () => {
 
     expect(screen.getByTestId("xray-schema-name")).toHaveTextContent("public");
   });
+
+  it("should not render a caption when there are no x-rays", async () => {
+    await setup({
+      database: createMockDatabase(),
+      candidates: [],
+    });
+
+    expect(
+      screen.queryByText(/Here are some explorations/),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/50011
Closes UXW-245

### Description

Hides "Here are some explorations of" when there are no explorations.

### How to verify

See #50011 for repro steps. I repro'd by moving `metabase.db.mv.db` out of the repo root so it'd take me through the setup flow, then I pointed it at a db started using `mage start-db postgres latest` so it wouldn't start with x-rays of sample data.

### Demo

<img width="1312" height="745" alt="Screenshot 2025-09-22 at 11 56 27 AM" src="https://github.com/user-attachments/assets/549d66df-3d32-4953-9bb3-e07e190cefd6" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
