### PR TITLE
[METABOT] Default use_verified_content to false; tweak prompts

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/suggested_prompts.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/suggested_prompts.clj
@@ -36,11 +36,11 @@
   [metabot-id & {:as opts}]
   (let [opts (merge default-opts opts)]
     (lib.metadata.jvm/with-metadata-provider-cache
-      (let [cards (->> (metabot-v3.tools.u/get-metrics-and-models metabot-id opts)
-                       (sort-by :view_count #(compare %2 %1)))
+      (let [{metrics :metric models :model} (->> (metabot-v3.tools.u/get-metrics-and-models metabot-id opts)
+                                                 (sort-by :view_count >)
+                                                 (group-by :type))
             ;; Limit to 5 metrics and 5 models
-            limited-cards (concat (take 5 (filter #(= (:type %) :metric) cards))
-                                  (take 5 (filter #(= (:type %) :model) cards)))
+            limited-cards (concat (take 5 metrics) (take 5 models))
             {metrics :metric, models :model}
             (->> (for [[[card-type database-id] group-cards] (group-by (juxt :type :database_id) limited-cards)
                        detail (map (fn [detail card] (assoc detail ::origin card))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
@@ -25,12 +25,11 @@
         metabot (t2/select-one :model/Metabot :entity_id metabot-eid)
         metabot-id (:id metabot)
         suggested-prompts-cnt (t2/count :model/MetabotPrompt :metabot_id metabot-id)]
-    (if (and (zero? suggested-prompts-cnt)
-             (:use_verified_content metabot))
+    (if (zero? suggested-prompts-cnt)
       (do
         (log/info "No suggested prompts found. Generating suggested prompts.")
         (metabot-v3.suggested-prompts/generate-sample-prompts metabot-id)
-        (log/info "Suggested prompts generated succesfully."))
+        (log/info "Suggested prompts generated successfully."))
       (log/info "Suggested prompts are present. Not generating."))))
 
 (task/defjob ^{DisallowConcurrentExecution true

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/task/suggested_prompts_generator_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/task/suggested_prompts_generator_test.clj
@@ -5,7 +5,6 @@
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.task.suggested-prompts-generator
     :as metabot-v3.task.suggested-prompts-generator]
-   [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -16,82 +15,67 @@
 (deftest suggested-prompts-generator-test
   (when (and (premium-features/has-feature? :metabot-v3)
              (premium-features/has-feature? :content-verification))
-    (let [original-metabot (t2/select-one :model/Metabot
-                                          :entity_id (get-in metabot-v3.config/metabot-config
-                                                             [metabot-v3.config/internal-metabot-id :entity-id]))
-          mp (mt/metadata-provider)
-          query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                    lib.convert/->legacy-MBQL)
-          admin-id (:id (mt/fetch-user :crowberto))]
-      (mt/with-model-cleanup [:model/MetabotPrompt]
-        (mt/with-temp
-          [:model/Card
-           {card-id :id}
-           {:type :model
-            :dataset_query query}]
-          (with-redefs [metabot-v3.tools.u/get-metrics-and-models
-                        (fn [metabot-id & _opts]
-                          ;; Simulate verification filtering logic
-                          (let [metabot (t2/select-one :model/Metabot :id metabot-id)
-                                card (t2/select-one :model/Card :id card-id)
-                                use-verified-content? (:use_verified_content metabot)]
-                            (if use-verified-content?
-                              ;; If using verified content, check if card is verified
-                              (let [verified? (t2/exists? :model/ModerationReview
-                                                          :moderated_item_id card-id
-                                                          :moderated_item_type "card"
-                                                          :status "verified"
-                                                          :most_recent true)]
-                                (if verified? [card] []))
-                              [card])))
-
-                        metabot-v3.client/generate-example-questions
-                        (fn [input]
+    (mt/with-empty-h2-app-db!
+      (let [original-metabot (t2/select-one :model/Metabot
+                                            :entity_id (get-in metabot-v3.config/metabot-config
+                                                               [metabot-v3.config/internal-metabot-id :entity-id]))
+            mp (mt/metadata-provider)
+            query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                      lib.convert/->legacy-MBQL)
+            admin-id (:id (mt/fetch-user :crowberto))]
+        (mt/with-model-cleanup [:model/MetabotPrompt]
+          (mt/with-temp
+            [:model/Card
+             {card-id :id}
+             {:type :model
+              :dataset_query query}]
+            (with-redefs [metabot-v3.client/generate-example-questions
+                          (fn [input]
                           ;; Return fake prompts if we have cards, empty otherwise
-                          (if (or (seq (:metrics input)) (seq (:tables input)))
-                            {:table_questions [{:questions ["What is the total for this model?"
-                                                            "How many items are in this model?"]}]
-                             :metric_questions [{:questions ["What is the current value of this metric?"
-                                                             "How has this metric changed over time?"]}]}
-                            {:table_questions []
-                             :metric_questions []}))]
+                            (if (or (seq (:metrics input)) (seq (:tables input)))
+                              {:table_questions [{:questions ["What is the total for this model?"
+                                                              "How many items are in this model?"]}]
+                               :metric_questions [{:questions ["What is the current value of this metric?"
+                                                               "How has this metric changed over time?"]}]}
+                              {:table_questions []
+                               :metric_questions []}))]
 
-            (testing "Non-verified card with use_verified_content=false generates prompts"
-              (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
-              (#'metabot-v3.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
-              (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
-                (is (seq prompts))))
+              (testing "Non-verified card with use_verified_content=false generates prompts"
+                (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
+                (#'metabot-v3.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
+                  (is (seq prompts))))
 
-            (testing "Non-verified card with use_verified_content=true generates no prompts"
-              (t2/delete! :model/MetabotPrompt)
-              (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content true})
-              (#'metabot-v3.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
-              (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
-                (is (empty? prompts))))
+              (testing "Non-verified card with use_verified_content=true generates no prompts"
+                (t2/delete! :model/MetabotPrompt)
+                (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content true})
+                (#'metabot-v3.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
+                  (is (empty? prompts))))
 
-            (testing "Verified card generates prompts regardless of use_verified_content"
-              (mt/with-temp
-                [:model/ModerationReview
-                 _
-                 {:moderator_id admin-id
-                  :moderated_item_id card-id
-                  :moderated_item_type "card"
-                  :status "verified"
-                  :most_recent true}]
+              (testing "Verified card generates prompts regardless of use_verified_content"
+                (mt/with-temp
+                  [:model/ModerationReview
+                   _
+                   {:moderator_id admin-id
+                    :moderated_item_id card-id
+                    :moderated_item_type "card"
+                    :status "verified"
+                    :most_recent true}]
 
-                (testing "with use_verified_content=true"
-                  (t2/delete! :model/MetabotPrompt)
-                  (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content true})
-                  (#'metabot-v3.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
-                  (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
-                    (is (seq prompts))))
+                  (testing "with use_verified_content=true"
+                    (t2/delete! :model/MetabotPrompt)
+                    (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content true})
+                    (#'metabot-v3.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                    (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
+                      (is (seq prompts))))
 
-                (testing "with use_verified_content=false"
-                  (t2/delete! :model/MetabotPrompt)
-                  (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
-                  (#'metabot-v3.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
-                  (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
-                    (is (seq prompts))))))
+                  (testing "with use_verified_content=false"
+                    (t2/delete! :model/MetabotPrompt)
+                    (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
+                    (#'metabot-v3.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                    (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
+                      (is (seq prompts))))))
 
             ;; Reset metabot state
-            (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})))))))
+              (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false}))))))))

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -786,20 +786,6 @@ databaseChangeLog:
                   name: conversation_id
       rollback: # will be dropped with table
 
-  - changeSet:
-      id: v56.2025-09-15T17:12:11
-      author: lbrdnk
-      comment: Make the use_verified_content default to true for internal Metabot
-      changes:
-        - update:
-            tableName: metabot
-            columns:
-              - column:
-                  name: use_verified_content
-                  valueBoolean: true
-            where: entity_id = 'metabotmetabotmetabot'
-      rollback:
-
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
  ## Summary
  - Remove dependency on `use_verified_content` flag for suggested prompt generation job
  - Set `use_verified_content` default to false (remove migration)
  - Limit prompt generation to top 5 metrics and 5 models by view count
  - Fix typo in log message

  ## Changes
  - Startup job now generates prompts regardless of verification setting
  - Prompts use verified content when available, fall back to unverified content
  - Sort cards by view count before limiting to ensure most popular content generates prompts
  - Updated tests to reflect new default behavior