### PR TITLE
Improve FieldValues inactive check

### DIFF
--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -239,6 +239,7 @@
      (not (or
            (t/after? (:last_used_at field-values)
                      cutoff)
+           ;; Double check that there are no other variants of Fieldvalues (e.g. advanced) that have not been used more recently
            (t/after? (t2/select-one-fn :max-last-used-at [:model/FieldValues [[:max :last_used_at] :max-last-used-at]]
                                        {:where [:= :field_id (:field_id field-values)]})
                      cutoff))))))

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -107,7 +107,7 @@
                  (sync-database!' "update-field-values" (data/db)))))
         (is (= [1 2 3 4] (venues-price-field-values)))))
     (finally
-      ; clear out our changes to not mess up other tests
+      ; clear out our changes to not mess up other tests. Changes are more than with-model-cleanup handles
       (t2/delete! :model/FieldValues :field_id (mt/id :venues :price))
       (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price))))))
 

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -70,41 +70,46 @@
              (venues-price-field-values))))))
 
 (deftest sync-should-properly-handle-last-used-at
-  (testing "Test that syncing will skip updating inactive FieldValues"
-    (mt/with-full-data-perms-for-all-users!
-      (t2/update! :model/FieldValues
-                  (t2/select-one-pk :model/FieldValues :field_id (mt/id :venues :price) :type :full)
-                  {:last_used_at (t/minus (t/offset-date-time) (t/days 20))
-                   :values [1 2 3]})
-      (is (= (repeat 2 {:errors 0, :created 0, :updated 0, :deleted 0})
-             (sync-database!' "update-field-values" (data/db))))
-      (is (= [1 2 3] (venues-price-field-values)))
-      (testing "Fetching field values causes an on-demand update and marks Field Values as active"
-        (is (partial= {:values [[1] [2] [3] [4]]}
-                      (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))
-        (is (t/after? (t2/select-one-fn :last_used_at :model/FieldValues :field_id (mt/id :venues :price) :type :full)
-                      (t/minus (t/offset-date-time) (t/hours 2))))
-        (testing "Field is syncing after usage"
-          (t2/update! :model/FieldValues
-                      (t2/select-one-pk :model/FieldValues :field_id (mt/id :venues :price) :type :full)
-                      {:values [1 2 3]})
-          (is (= (repeat 2 {:errors 0, :created 0, :updated 1, :deleted 0})
-                 (sync-database!' "update-field-values" (data/db))))
-          (is (partial= {:values [[1] [2] [3] [4]]}
-                        (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))))
-      (testing "If only advanced fields have been used recently, still sync"
+  (try
+    (testing "Test that syncing will skip updating inactive FieldValues"
+      (mt/with-full-data-perms-for-all-users!
         (t2/update! :model/FieldValues
                     (t2/select-one-pk :model/FieldValues :field_id (mt/id :venues :price) :type :full)
                     {:last_used_at (t/minus (t/offset-date-time) (t/days 20))
                      :values       [1 2 3]})
-        (t2/insert! :model/FieldValues {:field_id     (mt/id :venues :price)
-                                        :type         :advanced
-                                        :hash_key     "random-key"
-                                        :last_used_at (t/instant)})
+        (is (= (repeat 2 {:errors 0, :created 0, :updated 0, :deleted 0})
+               (sync-database!' "update-field-values" (data/db))))
+        (is (= [1 2 3] (venues-price-field-values)))
+        (testing "Fetching field values causes an on-demand update and marks Field Values as active"
+          (is (partial= {:values [[1] [2] [3] [4]]}
+                        (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))
+          (is (t/after? (t2/select-one-fn :last_used_at :model/FieldValues :field_id (mt/id :venues :price) :type :full)
+                        (t/minus (t/offset-date-time) (t/hours 2))))
+          (testing "Field is syncing after usage"
+            (t2/update! :model/FieldValues
+                        (t2/select-one-pk :model/FieldValues :field_id (mt/id :venues :price) :type :full)
+                        {:values [1 2 3]})
+            (is (= (repeat 2 {:errors 0, :created 0, :updated 1, :deleted 0})
+                   (sync-database!' "update-field-values" (data/db))))
+            (is (partial= {:values [[1] [2] [3] [4]]}
+                          (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))))
+        (testing "If only advanced fields have been used recently, still sync"
+          (t2/update! :model/FieldValues
+                      (t2/select-one-pk :model/FieldValues :field_id (mt/id :venues :price) :type :full)
+                      {:last_used_at (t/minus (t/offset-date-time) (t/days 20))
+                       :values       [1 2 3]})
+          (t2/insert! :model/FieldValues {:field_id     (mt/id :venues :price)
+                                          :type         :advanced
+                                          :hash_key     "random-key"
+                                          :last_used_at (t/instant)})
 
-        (is (= (repeat 2 {:errors 0, :created 0, :updated 1, :deleted 0})
-               (sync-database!' "update-field-values" (data/db)))))
-      (is (= [1 2 3 4] (venues-price-field-values))))))
+          (is (= (repeat 2 {:errors 0, :created 0, :updated 1, :deleted 0})
+                 (sync-database!' "update-field-values" (data/db)))))
+        (is (= [1 2 3 4] (venues-price-field-values)))))
+    (finally
+      ; clear out our changes to not mess up other tests
+      (t2/delete! :model/FieldValues :field_id (mt/id :venues :price))
+      (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price))))))
 
 (deftest sync-should-delete-expired-advanced-field-values-test
   (testing "Test that the expired Advanced FieldValues should be removed"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #62587
### Description

If a fieldvalues row looks like it is inactive, double check that there are no other variations on the row (such as 'advanced') which have been used more recently

### How to verify

Follow steps in #62587

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
