### PR TITLE
Add a timeout for slow LDAP

### DIFF
--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -137,6 +137,13 @@
   :default    false
   :audit      :getter)
 
+(defsetting ldap-timeout-seconds
+  (deferred-tru "Maximum time, in seconds, to wait for LDAP server before falling back to local authentication")
+  :type :double
+  :encryption :no
+  :export? false
+  :default 15.0)
+
 ;;;
 ;;; Google Auth
 ;;;


### PR DESCRIPTION
When the LDAP server is slow, we should fall back to normal authentication.

For now, use a configurable timeout, defaulting to 15 seconds - this seems on the high side of reasonable.

[UXW-291: When LDAP is configured, then normal email logins can be blocked if LDAP server is slow/down](https://linear.app/metabase/issue/UXW-291/when-ldap-is-configured-then-normal-email-logins-can-be-blocked-if)
