### PR TITLE
Fix: #63463 Loosens condition that forces saving to dashboard

### DIFF
--- a/frontend/src/metabase/common/components/SaveQuestionForm/context.tsx
+++ b/frontend/src/metabase/common/components/SaveQuestionForm/context.tsx
@@ -164,9 +164,10 @@ export const SaveQuestionProvider = ({
     originalQuestion.type() !== "metric" &&
     originalQuestion.canWrite();
 
-  const saveToDashboard = originalQuestion
-    ? undefined
-    : (question.dashboardId() ?? undefined);
+  const saveToDashboard =
+    originalQuestion || !question.creationType()
+      ? undefined
+      : (question.dashboardId() ?? undefined);
 
   return (
     <FormProvider

--- a/frontend/src/metabase/common/components/SaveQuestionForm/context.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/SaveQuestionForm/context.unit.spec.tsx
@@ -137,13 +137,14 @@ describe("SaveQuestionContext", () => {
         );
 
         setup({
-          question: new Question(
-            createMockCard({
+          question: new Question({
+            ...createMockCard({
               collection_id: 11,
               collection: createMockCollection({ id: 11 }),
               dashboard_id: 20,
             }),
-          ),
+            creationType: "custom_question",
+          }),
         });
 
         expect(screen.getByTestId("saveToDashboard")).toBeInTheDocument();

--- a/frontend/src/metabase/common/components/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -177,6 +177,7 @@ function getQuestion({
   collection_id = null,
   dashboard_id = null,
   can_write = true,
+  creationType,
 }: {
   isSaved?: boolean;
   name?: string;
@@ -184,8 +185,9 @@ function getQuestion({
   collection_id?: CollectionId | null;
   dashboard_id?: DashboardId | null;
   can_write?: boolean;
+  creationType?: string;
 } = {}) {
-  const extraCardParams: Record<string, any> = {};
+  const extraCardParams: Record<string, any> = { creationType };
 
   if (isSaved) {
     extraCardParams.id = 1; // if a card has an id, it means it's saved
@@ -555,6 +557,7 @@ describe("SaveQuestionModal", () => {
           isSaved: true,
           collection_id: FOO_DASH.collection_id,
           dashboard_id: FOO_DASH.id, // <- question already has a dashboard save location
+          creationType: "custom_question",
         }),
       );
 
@@ -565,6 +568,20 @@ describe("SaveQuestionModal", () => {
           screen.queryByLabelText(/Where do you want to save this/),
         ).not.toBeInTheDocument();
       });
+    });
+
+    it("should show collection input if modifying a dashboard question", async () => {
+      await setup(
+        getQuestion({
+          isSaved: true,
+          collection_id: FOO_DASH.collection_id,
+          dashboard_id: FOO_DASH.id, // <- question already has a dashboard save location
+        }),
+      );
+
+      expect(
+        screen.getByLabelText(/Where do you want to save this/),
+      ).toBeInTheDocument();
     });
 
     it("should show tab input w/ default value if select dashboard has tabs", async () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63463
Closes UXW-709

### Description

When drilling into a dashboard card that had a filter applied, the resulting query can now be saved outside of the original dashboard. The "New Question"/"New SQL query" behavior  (via dashboard edit screen) is unaffected, still forces you to save to that dashboard.

This was done by updating the condition that forces saving to a dashboard. Before, it only checked if there was an `originalQuestion`. But when drilling into a dashboard question _**with filters applied**_, the `originalQuestion` will be null. So the condition additionally checks `question.creationType()`, which is only set when creating questions from scratch. No creationType means we can save it anywhere (even if it's a dashboard question).

### How to verify

See #63463 for repro steps.

Verify Edit dashboard -> Add questions -> "New Question"/"New SQL query" still force you to save to that dashboard.

### Demo

https://github.com/user-attachments/assets/bbf8113b-e7e0-44c3-9c16-73da6acb59d0

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
