### PR TITLE
Fix starbust query cancellation with isClosed proxy implementations

### DIFF
--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -226,9 +226,6 @@
         (.close stmt)
         (throw e)))))
 
-;; the current HiveConnection doesn't support .createStatement
-(defmethod sql-jdbc.execute/statement-supported? :sparksql [_] false)
-
 (doseq [[feature supported?] {:basic-aggregations              true
                               :binning                         true
                               :expression-aggregations         true
@@ -242,7 +239,8 @@
                               :test/jvm-timezone-setting       false
                               ;; disabled for now, see issue #40991 to fix this.
                               :window-functions/cumulative     false
-                              :database-routing                false}]
+                              :database-routing                false
+                              :statements                      false}]
   (defmethod driver/database-supports? [:sparksql feature] [_driver _feature _db] supported?))
 
 (defmethod sql.qp/quote-style :sparksql

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -240,7 +240,7 @@
                               ;; disabled for now, see issue #40991 to fix this.
                               :window-functions/cumulative     false
                               :database-routing                false
-                              :statements                      false}]
+                              :jdbc/statements                 false}]
   (defmethod driver/database-supports? [:sparksql feature] [_driver _feature _db] supported?))
 
 (defmethod sql.qp/quote-style :sparksql

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -61,7 +61,8 @@
                               :regex                                  false
                               :test/jvm-timezone-setting              false
                               :metadata/table-existence-check         true
-                              :transforms/table                       true}]
+                              :transforms/table                       true
+                              :statements                             false}]
   (defmethod driver/database-supports? [:sqlserver feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:sqlserver :percentile-aggregations]
@@ -788,11 +789,6 @@
   [driver inner-query]
   (let [parent-method (get-method sql.qp/preprocess :sql)]
     (fix-order-bys (parent-method driver inner-query))))
-
-;; In order to support certain native queries that might return results at the end, we have to use only prepared
-;; statements (see #9940)
-(defmethod sql-jdbc.execute/statement-supported? :sqlserver [_]
-  false)
 
 ;; SQL server only supports setting holdability at the connection level, not the statement level, as per
 ;; https://docs.microsoft.com/en-us/sql/connect/jdbc/using-holdability?view=sql-server-ver15

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -62,7 +62,7 @@
                               :test/jvm-timezone-setting              false
                               :metadata/table-existence-check         true
                               :transforms/table                       true
-                              :statements                             false}]
+                              :jdbc/statements                        false}]
   (defmethod driver/database-supports? [:sqlserver feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:sqlserver :percentile-aggregations]

--- a/modules/drivers/starburst/src/metabase/driver/starburst.clj
+++ b/modules/drivers/starburst/src/metabase/driver/starburst.clj
@@ -726,7 +726,8 @@
              (setFloat [index val] (.setFloat stmt index val))
              (setDouble [index val] (.setDouble stmt index val))
              (cancel [] (.cancel stmt))
-             (close [] (.close stmt)))]
+             (close [] (.close stmt))
+             (isClosed [] (.isClosed stmt)))]
     (sql-jdbc.execute/set-parameters! driver ps params)
     ps))
 
@@ -749,7 +750,8 @@
         (catch Throwable e (handle-execution-error e))))
     (setMaxRows [nb] (.setMaxRows stmt nb))
     (cancel [] (.cancel stmt))
-    (close [] (.close stmt))))
+    (close [] (.close stmt))
+    (isClosed [] (.isClosed stmt))))
 
 (defmethod sql-jdbc.execute/prepared-statement :starburst
   [driver ^Connection conn ^String sql params]
@@ -765,8 +767,7 @@
         (.setFetchDirection stmt ResultSet/FETCH_FORWARD)
         (catch Throwable e
           (log/debug e "Error setting prepared statement fetch direction to FETCH_FORWARD")))
-      (if
-       (.useExplicitPrepare ^TrinoConnection (.unwrap conn TrinoConnection))
+      (if (.useExplicitPrepare ^TrinoConnection (.unwrap conn TrinoConnection))
         (proxy-prepared-statement driver conn stmt params)
         (proxy-optimized-prepared-statement driver conn stmt params))
       (catch Throwable e
@@ -795,7 +796,8 @@
       (getResultSet [] (.getResultSet stmt))
       (setMaxRows [nb] (.setMaxRows stmt nb))
       (cancel [] (.cancel stmt))
-      (close [] (.close stmt)))))
+      (close [] (.close stmt))
+      (isClosed [] (.isClosed stmt)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Prepared Statement Substitutions                                      |

--- a/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -423,24 +423,8 @@
                    (qp/process-query
                     (mt/native-query {:query "SELECT current_user"})))))))))))
 
-(deftest starburst-implements-isclosed-test
+(deftest optimized-prepared-statement-is-closed-test
   (mt/test-driver :starburst
-    (testing "can check isClosed on statement"
-      (sql-jdbc.execute/do-with-connection-with-options
-       driver/*driver* (mt/id) nil
-       (fn [^Connection conn]
-         (let [stmt (sql-jdbc.execute/statement driver/*driver* conn)]
-           (is (false? (.isClosed stmt)))
-           (.close stmt)
-           (is (true? (.isClosed stmt)))))))
-    (testing "can check isClosed on prepared statement"
-      (sql-jdbc.execute/do-with-connection-with-options
-       driver/*driver* (mt/id) nil
-       (fn [^Connection conn]
-         (let [prepared-stmt (sql-jdbc.execute/prepared-statement driver/*driver* conn "select 1" [])]
-           (is (false? (.isClosed prepared-stmt)))
-           (.close prepared-stmt)
-           (is (true? (.isClosed prepared-stmt)))))))
     (testing "can check isClosed on optimized prepared statement"
       (sql-jdbc.execute/do-with-connection-with-options
        driver/*driver* (mt/id) nil

--- a/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -427,7 +427,7 @@
   (mt/test-driver :starburst
     (testing "can check isClosed on statement"
       (sql-jdbc.execute/do-with-connection-with-options
-       driver/*driver* 2538 nil
+       driver/*driver* (mt/id) nil
        (fn [^Connection conn]
          (let [stmt (sql-jdbc.execute/statement driver/*driver* conn)]
            (is (false? (.isClosed stmt)))
@@ -435,7 +435,7 @@
            (is (true? (.isClosed stmt)))))))
     (testing "can check isClosed on prepared statement"
       (sql-jdbc.execute/do-with-connection-with-options
-       driver/*driver* 2538 nil
+       driver/*driver* (mt/id) nil
        (fn [^Connection conn]
          (let [prepared-stmt (sql-jdbc.execute/prepared-statement driver/*driver* conn "select 1" [])]
            (is (false? (.isClosed prepared-stmt)))
@@ -443,7 +443,7 @@
            (is (true? (.isClosed prepared-stmt)))))))
     (testing "can check isClosed on optimized prepared statement"
       (sql-jdbc.execute/do-with-connection-with-options
-       driver/*driver* 2538 nil
+       driver/*driver* (mt/id) nil
        (fn [^Connection conn]
          (let [stmt (.prepareStatement conn "select 1" ResultSet/TYPE_FORWARD_ONLY ResultSet/CONCUR_READ_ONLY)
                prepared-stmt (#'starburst/proxy-optimized-prepared-statement driver/*driver* conn stmt [])]

--- a/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
+++ b/modules/drivers/starburst/test/metabase/driver/starburst_test.clj
@@ -422,3 +422,31 @@
                    #"Access Denied: Cannot set role sysadmin"
                    (qp/process-query
                     (mt/native-query {:query "SELECT current_user"})))))))))))
+
+(deftest starburst-implements-isclosed-test
+  (mt/test-driver :starburst
+    (testing "can check isClosed on statement"
+      (sql-jdbc.execute/do-with-connection-with-options
+       driver/*driver* 2538 nil
+       (fn [^Connection conn]
+         (let [stmt (sql-jdbc.execute/statement driver/*driver* conn)]
+           (is (false? (.isClosed stmt)))
+           (.close stmt)
+           (is (true? (.isClosed stmt)))))))
+    (testing "can check isClosed on prepared statement"
+      (sql-jdbc.execute/do-with-connection-with-options
+       driver/*driver* 2538 nil
+       (fn [^Connection conn]
+         (let [prepared-stmt (sql-jdbc.execute/prepared-statement driver/*driver* conn "select 1" [])]
+           (is (false? (.isClosed prepared-stmt)))
+           (.close prepared-stmt)
+           (is (true? (.isClosed prepared-stmt)))))))
+    (testing "can check isClosed on optimized prepared statement"
+      (sql-jdbc.execute/do-with-connection-with-options
+       driver/*driver* 2538 nil
+       (fn [^Connection conn]
+         (let [stmt (.prepareStatement conn "select 1" ResultSet/TYPE_FORWARD_ONLY ResultSet/CONCUR_READ_ONLY)
+               prepared-stmt (#'starburst/proxy-optimized-prepared-statement driver/*driver* conn stmt [])]
+           (is (false? (.isClosed prepared-stmt)))
+           (.close stmt)
+           (is (true? (.isClosed prepared-stmt)))))))))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -761,7 +761,7 @@
     :metadata/table-writable-check
 
     ;; Does this driver support creating a java.sql.Statement via a Connection?
-    :statements})
+    :jdbc/statements})
 
 (defmulti database-supports?
   "Does this driver and specific instance of a database support a certain `feature`?

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -758,7 +758,10 @@
     :database-replication
 
     ;; whether this driver supports checking table writeable permissions
-    :metadata/table-writable-check})
+    :metadata/table-writable-check
+
+    ;; Does this driver support creating a java.sql.Statement via a Connection?
+    :statements})
 
 (defmulti database-supports?
   "Does this driver and specific instance of a database support a certain `feature`?

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -69,7 +69,7 @@
   [driver _feature _db]
   (boolean (seq (sql-jdbc.execute/set-timezone-sql driver))))
 
-(defmethod driver/database-supports? [:sql-jdbc :statements] [_driver _feature _db] true)
+(defmethod driver/database-supports? [:sql-jdbc :jdbc/statements] [_driver _feature _db] true)
 
 (defmethod driver/db-default-timezone :sql-jdbc
   [driver database]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -69,6 +69,8 @@
   [driver _feature _db]
   (boolean (seq (sql-jdbc.execute/set-timezone-sql driver))))
 
+(defmethod driver/database-supports? [:sql-jdbc :statements] [_driver _feature _db] true)
+
 (defmethod driver/db-default-timezone :sql-jdbc
   [driver database]
   ;; if the driver has a non-default implementation of [[sql-jdbc.sync/db-default-timezone]], use that.

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -150,7 +150,7 @@
   :hierarchy #'driver/hierarchy)
 
 (defmulti ^Statement statement
-  "Create a Statement object using the given connection. Only called if the `:statements` feature is supported. This
+  "Create a Statement object using the given connection. Only called if the `:jdbc/statements` feature is supported. This
   is to be used to execute native queries, which implies there are no parameters. As with prepared-statement, you
   shouldn't need to override the default implementation for this method; if you do, take care to set options to maximize
   result set read performance (e.g. `ResultSet/TYPE_FORWARD_ONLY`); refer to the default implementation."
@@ -559,7 +559,7 @@
     (wire-up-canceled-chan-to-cancel-Statement! canceled-chan)))
 
 (defn- use-statement? [driver params]
-  (and (driver/database-supports? driver :statements nil) (empty? params)))
+  (and (driver/database-supports? driver :jdbc/statements nil) (empty? params)))
 
 (defn- statement* ^Statement [driver conn canceled-chan]
   (doto (statement driver conn)

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -147,7 +147,7 @@
 (deftest statement-is-closed-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
     (testing "can check isClosed on statement"
-      (when (driver/database-supports? driver/*driver* :statements nil)
+      (when (driver/database-supports? driver/*driver* :jdbc/statements nil)
         (sql-jdbc.execute/do-with-connection-with-options
          driver/*driver* (mt/id) nil
          (fn [^Connection conn]

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -147,13 +147,14 @@
 (deftest statement-is-closed-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
     (testing "can check isClosed on statement"
-      (sql-jdbc.execute/do-with-connection-with-options
-       driver/*driver* (mt/id) nil
-       (fn [^Connection conn]
-         (let [stmt (sql-jdbc.execute/statement driver/*driver* conn)]
-           (is (false? (.isClosed stmt)))
-           (.close stmt)
-           (is (true? (.isClosed stmt)))))))
+      (when (driver/database-supports? driver/*driver* :statements nil)
+        (sql-jdbc.execute/do-with-connection-with-options
+         driver/*driver* (mt/id) nil
+         (fn [^Connection conn]
+           (let [stmt (sql-jdbc.execute/statement driver/*driver* conn)]
+             (is (false? (.isClosed stmt)))
+             (.close stmt)
+             (is (true? (.isClosed stmt))))))))
     (testing "can check isClosed on prepared statement"
       (sql-jdbc.execute/do-with-connection-with-options
        driver/*driver* (mt/id) nil

--- a/test/metabase/driver/sql_jdbc/execute_test.clj
+++ b/test/metabase/driver/sql_jdbc/execute_test.clj
@@ -143,3 +143,22 @@
         (is (false? (sql-jdbc.execute/is-conn-open? conn :check-valid? true)))
         (is (true? @close-called?) "Connection should be closed when invalid")
         (is (true? (.isClosed conn)))))))
+
+(deftest statement-is-closed-test
+  (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc})
+    (testing "can check isClosed on statement"
+      (sql-jdbc.execute/do-with-connection-with-options
+       driver/*driver* (mt/id) nil
+       (fn [^Connection conn]
+         (let [stmt (sql-jdbc.execute/statement driver/*driver* conn)]
+           (is (false? (.isClosed stmt)))
+           (.close stmt)
+           (is (true? (.isClosed stmt)))))))
+    (testing "can check isClosed on prepared statement"
+      (sql-jdbc.execute/do-with-connection-with-options
+       driver/*driver* (mt/id) nil
+       (fn [^Connection conn]
+         (let [prepared-stmt (sql-jdbc.execute/prepared-statement driver/*driver* conn "select 1" [])]
+           (is (false? (.isClosed prepared-stmt)))
+           (.close prepared-stmt)
+           (is (true? (.isClosed prepared-stmt)))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63731

### Description

Adds `isClosed` proxy implementations for statements and prepared statements. 

### How to verify

See repro steps in reported issue. The query should be cancelled without an exception. 

### Demo

todo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
