### PR TITLE
docs: Remove the +New option for creating new models

### DIFF
--- a/docs/data-modeling/models.md
+++ b/docs/data-modeling/models.md
@@ -31,25 +31,13 @@ The idea with models is to give other people a good "starting point table" that 
 
 ## Create a model
 
-First, search for models that already exist. If you can't find one that meets your needs, you can create a model:
-
-- [from scratch](#create-a-model-from-scratch), or
-- [from a saved question](#create-a-model-from-a-saved-question).
-
-Models you create are automatically [pinned to the current collection](../exploration-and-organization/collections.md#pinned-items).
-
-### Create a model from scratch
-
-1. In the upper right, click **New +** > **Model**.
-2. Choose either the query builder or a native query (if you want to use SQL). The advantage of using the query builder is that Metabase will be able to fill out some of the metadata for you; if you use SQL, you'll have to fill out that metadata manually.
-3. Select your data.
-4. Create and save your query.
-
-### Create a model from a saved question
+First, search for models that already exist. If you can't find one that meets your needs, you can create a model from a saved question:
 
 1. [Ask a question][question] using either the query builder or the SQL editor, or select an existing saved question that you want to convert to a model.
 2. Save the question.
 3. Click on the **...** > **Turn this into a model**.
+
+Models you create are automatically [pinned to the current collection](../exploration-and-organization/collections.md#pinned-items).
 
 ![Turn a saved question into a model](./images/turn-into-a-model.png)
 

--- a/docs/data-modeling/models.md
+++ b/docs/data-modeling/models.md
@@ -40,8 +40,8 @@ Models you create are automatically [pinned to the current collection](../explor
 
 ### Create a model from scratch
 
-- Navigate to the Models tab in the sidebar. You might have to open it using the button in the top left, then scroll down to the section labeled _Data_, and pick _Models_. Then click on the **+** button in the top right.
-- Or open the [command palette](https://www.metabase.com/docs/latest/exploration-and-organization/exploration#command-palette) and type "model." Then click on the _New model_ action.
+- Navigate to the Models tab in the sidebar. You might have to open it using the button in the top left, then scroll down to the section labeled **Data**, and pick **Models**. Then click on the **+** button in the top right.
+- Or open the [command palette](https://www.metabase.com/docs/latest/exploration-and-organization/exploration#command-palette) and type "model." Then click on the **New model** action.
 
 Now choose either the query builder or a native query (if you want to use SQL). The advantage of using the query builder is that Metabase will be able to fill out some of the metadata for you; if you use SQL, you'll have to fill out that metadata manually.
 

--- a/docs/data-modeling/models.md
+++ b/docs/data-modeling/models.md
@@ -47,13 +47,13 @@ Now choose either the query builder or a native query (if you want to use SQL). 
 
 Next, select your data, create your query, and save it.
 
+Models you create are automatically [pinned to the current collection](../exploration-and-organization/collections.md#pinned-items).
+
 ### Create a model from a saved question
 
 1. [Ask a question][question] using either the query builder or the SQL editor, or select an existing saved question that you want to convert to a model.
 2. Save the question.
 3. Click on the **...** > **Turn this into a model**.
-
-Models you create are automatically [pinned to the current collection](../exploration-and-organization/collections.md#pinned-items).
 
 ![Turn a saved question into a model](./images/turn-into-a-model.png)
 

--- a/docs/data-modeling/models.md
+++ b/docs/data-modeling/models.md
@@ -31,7 +31,23 @@ The idea with models is to give other people a good "starting point table" that 
 
 ## Create a model
 
-First, search for models that already exist. If you can't find one that meets your needs, you can create a model from a saved question:
+First, search for models that already exist. If you can't find one that meets your needs, you can create a model:
+
+- [from scratch](#create-a-model-from-scratch), or
+- [from a saved question](#create-a-model-from-a-saved-question).
+
+Models you create are automatically [pinned to the current collection](../exploration-and-organization/collections.md#pinned-items).
+
+### Create a model from scratch
+
+- Navigate to the Models tab in the sidebar. You might have to open it using the button in the top left, then scroll down to the section labeled _Data_, and pick _Models_. Then click on the **+** button in the top right.
+- Or open the [command palette](https://www.metabase.com/docs/latest/exploration-and-organization/exploration#command-palette) and type "model." Then click on the _New model_ action.
+
+Now choose either the query builder or a native query (if you want to use SQL). The advantage of using the query builder is that Metabase will be able to fill out some of the metadata for you; if you use SQL, you'll have to fill out that metadata manually.
+
+Next, select your data, create your query, and save it.
+
+### Create a model from a saved question
 
 1. [Ask a question][question] using either the query builder or the SQL editor, or select an existing saved question that you want to convert to a model.
 2. Save the question.


### PR DESCRIPTION
Adapts the instructions for creating new models to no longer mention the use of the +New button.

This is the only place in the docs I could find where the New button is explicitly mentioned. I'll make a separate PR for a page on Learn in the other repo.