### PR TITLE
fix typo in WhatsNewNotification: 'dimiss' -> 'dismiss'

### DIFF
--- a/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.tsx
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.tsx
@@ -40,7 +40,7 @@ export function WhatsNewNotification() {
     isWhiteLabeling,
   ]);
 
-  const dimiss = useCallback(() => {
+  const dismiss = useCallback(() => {
     dispatch(
       updateSetting({
         key: "last-acknowledged-version",
@@ -57,7 +57,7 @@ export function WhatsNewNotification() {
       <Stack gap="sm">
         <Flex justify="space-between">
           <Sparkles color={color("brand")} />
-          <DismissIconButtonWrapper onClick={dimiss}>
+          <DismissIconButtonWrapper onClick={dismiss}>
             <Icon name="close" />
           </DismissIconButtonWrapper>
         </Flex>


### PR DESCRIPTION
i sometimes use that component to test things and noticed the typo
