### PR TITLE
DSN-70 Custom maps section in Admin should have a nicer empty state for its table

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx
@@ -2,6 +2,7 @@ import cx from "classnames";
 import { type ChangeEvent, memo, useCallback, useState } from "react";
 import { t } from "ttag";
 
+import noResultsSource from "assets/img/no_results.svg";
 import { useLazyLoadGeoJSONQuery } from "metabase/api/geojson";
 import { useAdminSetting } from "metabase/api/utils";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
@@ -13,7 +14,7 @@ import AdminS from "metabase/css/admin.module.css";
 import ButtonsS from "metabase/css/components/buttons.module.css";
 import CS from "metabase/css/core/index.css";
 import { uuid } from "metabase/lib/uuid";
-import { Button } from "metabase/ui";
+import { Button, Image, Stack, Text } from "metabase/ui";
 import LeafletChoropleth from "metabase/visualizations/components/LeafletChoropleth";
 import type {
   CustomGeoJSONMap,
@@ -109,6 +110,10 @@ export const CustomGeoJSONWidget = () => {
     return null;
   }
 
+  const hasCustomMaps = Object.values(customGeoJsonSetting).some(
+    (map) => !map.builtin,
+  );
+
   return (
     <div className={CS.flexFull}>
       <div className={cx(CS.flex, CS.justifyBetween)}>
@@ -127,11 +132,22 @@ export const CustomGeoJSONWidget = () => {
           </Button>
         )}
       </div>
-      <ListMaps
-        maps={customGeoJsonSetting}
-        onEditMap={handleEditMap}
-        onDeleteMap={handleDelete}
-      />
+
+      {!hasCustomMaps && (
+        <Stack p="xl" align="center" gap="md">
+          <Image w={120} h={120} src={noResultsSource} />
+          <Text fw="700" c="text-light">{t`No custom maps yet`}</Text>
+        </Stack>
+      )}
+
+      {hasCustomMaps && (
+        <ListMaps
+          maps={customGeoJsonSetting}
+          onEditMap={handleEditMap}
+          onDeleteMap={handleDelete}
+        />
+      )}
+
       {map ? (
         <Modal wide>
           <div className={CS.p4}>
@@ -163,6 +179,7 @@ const ListMaps = ({ maps, onEditMap, onDeleteMap }: ListMapsProps) => {
   const [mapIdToDelete, setMapIdToDelete] = useState<string | undefined>(
     undefined,
   );
+
   return (
     <section>
       <table className={AdminS.ContentTable}>

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.unit.spec.tsx
@@ -9,7 +9,10 @@ import {
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { UndoListing } from "metabase/common/components/UndoListing";
-import type { CustomGeoJSONMap } from "metabase-types/api";
+import type {
+  CustomGeoJSONMap,
+  CustomGeoJSONSetting,
+} from "metabase-types/api";
 import {
   createMockGeoJSONFeatureCollection,
   createMockSettingDefinition,
@@ -19,29 +22,36 @@ import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import { CustomGeoJSONWidget } from "./CustomGeoJSONWidget";
 
-const setup = async ({ isEnvVar }: { isEnvVar?: boolean }) => {
-  const customGeoJSON = {
-    "666c2779-15ee-0ad9-f5ab-0ccbcc694efa": {
-      name: "Test",
-      url: "https://test.com/download/GeoJSON_one.json",
-      region_key: "POLICY_NO",
-      region_name: "TABLE_NAME",
-    },
-    us_states: {
-      name: "United States",
-      url: "app/assets/geojson/us-states.json",
-      region_key: "STATE",
-      region_name: "NAME",
-      builtin: true,
-    },
-    world_countries: {
-      name: "World",
-      url: "app/assets/geojson/world.json",
-      region_key: "ISO_A2",
-      region_name: "NAME",
-      builtin: true,
-    },
-  };
+const CUSTOM_GEO_JSON = {
+  "666c2779-15ee-0ad9-f5ab-0ccbcc694efa": {
+    name: "Test",
+    url: "https://test.com/download/GeoJSON_one.json",
+    region_key: "POLICY_NO",
+    region_name: "TABLE_NAME",
+  },
+  us_states: {
+    name: "United States",
+    url: "app/assets/geojson/us-states.json",
+    region_key: "STATE",
+    region_name: "NAME",
+    builtin: true,
+  },
+  world_countries: {
+    name: "World",
+    url: "app/assets/geojson/world.json",
+    region_key: "ISO_A2",
+    region_name: "NAME",
+    builtin: true,
+  },
+};
+
+const setup = async ({
+  customGeoJSON = CUSTOM_GEO_JSON,
+  isEnvVar,
+}: {
+  customGeoJSON?: CustomGeoJSONSetting;
+  isEnvVar?: boolean;
+}) => {
   const settings = createMockSettings({
     "custom-geojson": customGeoJSON,
   });
@@ -83,7 +93,7 @@ const setup = async ({ isEnvVar }: { isEnvVar?: boolean }) => {
 };
 
 describe("CustomGeoJSONWIdget", () => {
-  it("render correctly", async () => {
+  it("renders correctly", async () => {
     await setup({});
     const tableRows = screen.getAllByRole("row");
 
@@ -100,6 +110,15 @@ describe("CustomGeoJSONWIdget", () => {
     ).toBeInTheDocument();
 
     expect(screen.getByText("Custom maps")).toBeInTheDocument();
+  });
+
+  it("renders empty state", async () => {
+    const { "666c2779-15ee-0ad9-f5ab-0ccbcc694efa": _, ...customGeoJSON } =
+      CUSTOM_GEO_JSON;
+    await setup({ customGeoJSON });
+
+    expect(screen.queryByRole("row")).not.toBeInTheDocument();
+    expect(screen.getByText("No custom maps yet")).toBeInTheDocument();
   });
 
   it("should remove a saved map", async () => {


### PR DESCRIPTION
Closes [DSN-70](https://linear.app/metabase/issue/DSN-70/custom-maps-section-in-admin-should-have-a-nicer-empty-state-for-its)

### How to verify

1. Admin > Maps
2. Make sure you have no custom maps

See empty state

### Demo

[before](https://github.com/user-attachments/assets/95d90621-c86a-47ef-a0de-2d3757be98ea) vs [after](https://github.com/user-attachments/assets/a930aa71-26a5-4a3e-8e5a-2b0528c2b093)
