### PR TITLE
Prg 154 allow running dev env on a custom port

### DIFF
--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -7,7 +7,7 @@ title: Development environment
 The Metabase application has two basic components:
 
 1. A backend written in Clojure which contains a REST API as well as all the relevant code for talking to databases and processing queries.
-2. A frontend written as a Javascript single-page application which provides the web UI.
+2. A frontend written as a JavaScript single-page application which provides the web UI.
 
 Both components are built and assembled together into a single JAR file. In the directory where you run the JAR, you can create a JAR file (if Metabase hasn't already created it) and add drivers in there (the drivers are also JARs).
 
@@ -127,6 +127,10 @@ Unit tests use an enforced file naming convention `<test-suite-name>.unit.spec.j
 yarn test-unit # Run all tests at once
 yarn test-unit-watch # Watch for file changes
 ```
+
+### Custom FE development server port
+
+By default the Rspack runs the development server on port `8088`. If you'd like to run it on another port (e.g. to be able to run two dev servers at once), use `MB_FRONTEND_DEV_PORT` environment variable.
 
 ## Backend development
 

--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -130,7 +130,7 @@ yarn test-unit-watch # Watch for file changes
 
 ### Custom FE development server port
 
-By default the Rspack runs the development server on port `8088`. If you'd like to run it on another port (e.g. to be able to run two dev servers at once), use `MB_FRONTEND_DEV_PORT` environment variable.
+By default Rspack runs the development server on port `8088`. If you'd like use another port (e.g. to be able to run two dev servers at once), use the `MB_FRONTEND_DEV_PORT` environment variable.
 
 ## Backend development
 

--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -128,10 +128,6 @@ yarn test-unit # Run all tests at once
 yarn test-unit-watch # Watch for file changes
 ```
 
-### Custom FE development server port
-
-By default Rspack runs the development server on port `8088`. If you'd like use another port (e.g. to be able to run two dev servers at once), use the `MB_FRONTEND_DEV_PORT` environment variable.
-
 ## Backend development
 
 Clojure REPL is the main development tool for the backend. There are some directions below on how to setup your REPL for easier development.
@@ -153,15 +149,14 @@ use Metabase, don't forget to start the frontend as well (e.g. with `yarn build-
 
 ### Multiple Instances
 
-You can run multiple instances of Metabase on the same machine by specifying a different port for each instance.
+By default Rspack runs the development server on port `8088`. You can run multiple instances of Metabase on the same machine by specifying a different port for each instance.
 
 Frontend:
-- If you are running the frontend with `yarn build-hot`, set the `PORT` environment variable: `PORT=3001 MB_EDITION=ee yarn build-hot`
+- If you are running the frontend with `yarn build-hot`, set the `MB_FRONTEND_DEV_PORT` environment variable: `MB_FRONTEND_DEV_PORT=8089 MB_EDITION=ee yarn build-hot`
 - If you are building the frontend statically with `yarn build`, there is nothing different to do
 
 Backend:
-- Set the `MB_JETTY_PORT` environment variable
-- If you are running the frontend with `yarn build-hot`, set `MB_WEBPACK_PORT` to the same port as the `PORT` variable above
+- Set the `MB_JETTY_PORT` environment variable and `MB_FRONTEND_DEV_PORT` to the same one as for the frontend.
 
 ### The application database
 

--- a/rspack.iframe-sdk-embed.config.js
+++ b/rspack.iframe-sdk-embed.config.js
@@ -23,7 +23,7 @@ const SDK_BUNDLE_SRC_PATH =
 const OUT_FILE_NAME = "embed.js";
 const OUT_TEMP_PATH = path.resolve(BUILD_PATH, "tmp-embed-js");
 
-const DEV_PORT = process.env.PORT || 8080;
+const DEV_PORT = process.env.MB_FRONTEND_DEV_PORT || 8080;
 
 module.exports = {
   name: "iframe_sdk_embed_v1",

--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -42,7 +42,7 @@ const TEST_SUPPORT_PATH = __dirname + "/frontend/test/__support__";
 const BUILD_PATH = __dirname + "/resources/frontend_client";
 const E2E_PATH = __dirname + "/e2e";
 
-const PORT = process.env.PORT || 8080;
+const PORT = process.env.MB_FRONTEND_DEV_PORT || 8080;
 const isDevMode = IS_DEV_MODE;
 const shouldEnableHotRefresh = WEBPACK_BUNDLE === "hot";
 

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -119,8 +119,8 @@
   parse-allowed-iframe-hosts
   (memoize parse-allowed-iframe-hosts*))
 
-(def ^:private webpack-port (or (env/env :mb-webpack-port) "8080"))
-(def ^:private webpack-address (str "http://localhost:" webpack-port))
+(def ^:private frontend-dev-port (or (env/env :mb-frontend-dev-port) "8080"))
+(def ^:private frontend-address (str "http://localhost:" frontend-dev-port))
 
 (defn- content-security-policy-header
   "`Content-Security-Policy` header. See https://content-security-policy.com for more details."
@@ -136,7 +136,7 @@
                                     "https://www.google-analytics.com")
                                   ;; for webpack hot reloading
                                   (when config/is-dev?
-                                    webpack-address)
+                                    frontend-address)
                                   ;; for react dev tools to work in Firefox until resolution of
                                   ;; https://github.com/facebook/react/issues/17997
                                   (when config/is-dev?
@@ -155,7 +155,7 @@
                                    (format "'nonce-%s'" nonce))
                                  ;; for webpack hot reloading
                                  (when config/is-dev?
-                                   webpack-address)
+                                   frontend-address)
                                  ;; CLJS REPL
                                  (when config/is-dev?
                                    "http://localhost:9630")
@@ -174,7 +174,7 @@
                                    (setting/get-value-of-type :string :snowplow-url))
                                  ;; Webpack dev server
                                  (when config/is-dev?
-                                   (str "*:" webpack-port " ws://*:" webpack-port))
+                                   (str "*:" frontend-dev-port " ws://*:" frontend-dev-port))
                                  ;; CLJS REPL
                                  (when config/is-dev?
                                    "ws://*:9630")]

--- a/src/metabase/util/devtools.cljc
+++ b/src/metabase/util/devtools.cljc
@@ -15,6 +15,13 @@
      (devtools/install!)
      (js/console.log "CLJS Devtools loaded")
 
+     (defn- frontend-dev-port
+       "Gets the frontend dev port from environment variable, defaulting to 8080"
+       []
+       (or (when-let [port-str (.. js/process -env -MB_FRONTEND_DEV_PORT)]
+             (js/parseInt port-str))
+           8080))
+
      (defonce unload-handler-set? (atom false))
 
      (defn- ^:dev/after-load on-reload []
@@ -23,7 +30,7 @@
          (.addEventListener js/window "beforeunload"
                             (fn [_event]
                               (js/console.log "invalidating webpack build")
-                              (js/fetch "http://localhost:8080/webpack-dev-server/invalidate")
+                              (js/fetch (str "http://localhost:" (frontend-dev-port) "/webpack-dev-server/invalidate"))
                               ;; HACK: Spin-lock to buy time for webpack to actually start rebuilding. Without this
                               ;; there's a race between the invalidation and the refreshed page loading the bundles.
                               (let [target (+ (js/performance.now) 500)]


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/PRG-154/allow-running-dev-env-on-a-custom-port

### Description

Introduce env var `MB_FRONTEND_DEV_PORT` that can be used to set the Webpack port in dev mode that will be used both by JS and Clojure.
This allows to run two (or more instances) of Metabase at once.

### Demo

https://www.loom.com/share/5ee26aed352a47dc9eab252d0f1fc605
