### PR TITLE
Cleanup and prioritize verified content

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
@@ -38,8 +38,7 @@
 
 (defmethod task/init! ::SuggestedPromptsGenerator
   [_]
-  (when (and (premium-features/has-feature? :metabot-v3)
-             (premium-features/has-feature? :content-verification))
+  (when (premium-features/has-feature? :metabot-v3)
     (let [job
           (jobs/build
            (jobs/of-type SuggestedPromptsGenerator)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -148,14 +148,14 @@
                                   collection-ids (conj (collection/descendant-ids collection) metabot-collection-id)]
                               [:in :collection_id collection-ids])
                             [:and true])
-        base-query (merge {:select [:report_card.*]
-                           :from   [[:report_card]]
-                           :where [:and
-                                   collection-filter
-                                   [:in :type [:inline ["metric" "model"]]]
-                                   [:= :archived false]
-                                   (when api/*current-user-id*
-                                     (collection/visible-collection-filter-clause :collection_id))]})]
+        base-query {:select [:report_card.*]
+                    :from   [[:report_card]]
+                    :where [:and
+                            collection-filter
+                            [:in :type [:inline ["metric" "model"]]]
+                            [:= :archived false]
+                            (when api/*current-user-id*
+                              (collection/visible-collection-filter-clause :collection_id))]}]
     (cond-> base-query
 
       ;; Prioritize verified content.

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -165,7 +165,8 @@
                                              [:= :mr.moderated_item_id :report_card.id]
                                              [:= :mr.moderated_item_type [:inline "card"]]
                                              [:= :mr.most_recent true]]]
-       :order-by [[[:case [:= :mr.status [:inline "verified"]] [:inline 0] :else [:inline 1]]
+       :order-by [[[:case [:= :mr.status [:inline "verified"]] [:inline 0]
+                    :else [:inline 1]]
                    :asc]])
 
       ;; Filter verified items only when that's desired.

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/util_test.clj
@@ -164,4 +164,10 @@
               (is (contains? card-ids (:id verified-model)))
               (is (contains? card-ids (:id verified-metric)))
               (is (contains? card-ids (:id unverified-model)))
-              (is (contains? card-ids (:id unverified-metric))))))))))
+              (is (contains? card-ids (:id unverified-metric)))
+              (testing "Verified content comes first"
+                (let [ordered-ids (map :id result)
+                      verified-ids #{(:id verified-model) (:id verified-metric)}
+                      unverified-ids #{(:id unverified-model) (:id unverified-metric)}]
+                  (is (every? verified-ids (take 2 ordered-ids)))
+                  (is (every? unverified-ids (drop 2 ordered-ids))))))))))))


### PR DESCRIPTION
Generated prompts are not dependent on verified content anymore. This PR adjusts the startup job accordingly.

EDIT: Also make verified content prioritized. (Even if it is not filtered only for that.)