### PR TITLE
Make timing steps continue-on-error

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -180,6 +180,7 @@ jobs:
       - name: Extract chunk-specific changed timings
         id: extract-timings
         if: inputs.split_index >= 0 && github.ref == 'refs/heads/master'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,12 +111,12 @@ jobs:
 
       - name: Merge split timings
         id: merge
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const glob = require('glob');
 
             const chunkFiles = glob.sync('timing-files/*/chunkTimings.json');
 


### PR DESCRIPTION
Failures in these steps shouldn't mark the build red.

Also removes glob import which isn't needed because `actions/github-script@v7` already includes it