### PR TITLE
DSN-68 Headings in Info panel should all be the same color

### DIFF
--- a/frontend/src/metabase/common/components/Sidesheet/SidesheetCard.tsx
+++ b/frontend/src/metabase/common/components/Sidesheet/SidesheetCard.tsx
@@ -41,5 +41,5 @@ export const SidesheetCard = ({
 };
 
 export const SidesheetCardTitle = (props: TitleProps) => (
-  <Title lh={1} mb=".75rem" c="text-medium" order={4} {...props} />
+  <Title mb="sm" c="text-medium" order={4} {...props} />
 );

--- a/frontend/src/metabase/common/components/Sidesheet/SidesheetCardSection.tsx
+++ b/frontend/src/metabase/common/components/Sidesheet/SidesheetCardSection.tsx
@@ -17,7 +17,7 @@ export const SidesheetCardSection = ({
   return (
     <Box {...styleProps}>
       {title && (
-        <Title mb="sm" c="text-light" order={4}>
+        <Title mb="sm" c="text-medium" order={4}>
           {title}
         </Title>
       )}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/QuestionInfoSidebar.tsx
@@ -97,16 +97,19 @@ export const QuestionInfoSidebar = ({
           <Tabs.Panel value="overview">
             <Stack gap="lg">
               <SidesheetCard pb="md">
-                <Stack gap="sm">
+                <Stack gap={0}>
                   <SidesheetCardTitle>{t`Description`}</SidesheetCardTitle>
-                  <SidesheetEditableDescription
-                    description={description}
-                    onChange={handleSave}
-                    canWrite={canWrite}
-                  />
-                  <PLUGIN_MODERATION.ModerationReviewTextForQuestion
-                    question={question}
-                  />
+
+                  <Stack gap="sm">
+                    <SidesheetEditableDescription
+                      description={description}
+                      onChange={handleSave}
+                      canWrite={canWrite}
+                    />
+                    <PLUGIN_MODERATION.ModerationReviewTextForQuestion
+                      question={question}
+                    />
+                  </Stack>
                 </Stack>
               </SidesheetCard>
               <SidesheetCard>


### PR DESCRIPTION
Closes [DSN-68](https://linear.app/metabase/issue/DSN-68/headings-in-info-panel-should-all-be-the-same-color)

### Description

Makes section titles in dashboard info sidebar and question info sidebar consistent when it comes to `color`, `margin-bottom`, and `line-height`.

### Demo

[before](https://github.com/user-attachments/assets/04786671-89ec-4669-ab4e-ee244542ba36) vs [after](https://github.com/user-attachments/assets/669f93b2-97d8-4196-adf4-b66b5a9f0d35)
