### PR TITLE
Don't send new user login for SDK or Embedded Analytics JS

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -502,6 +502,7 @@
            metabase.embedding.init
            metabase.embedding.jwt
            metabase.embedding.settings
+           metabase.embedding.util
            metabase.embedding.validation}
    :uses #{analytics
            api
@@ -1020,6 +1021,7 @@
            metabase.request.schema}
    :uses #{api
            config
+           embedding
            permissions ; FIXME
            session
            settings

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -9,6 +9,7 @@
    [metabase-enterprise.sso.integrations.token-utils :as token-utils]
    [metabase-enterprise.sso.settings :as sso-settings]
    [metabase.embedding.settings :as embed.settings]
+   [metabase.embedding.util :as embed.util]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.session.models.session :as session]
@@ -155,14 +156,14 @@
   [{{:keys [jwt redirect]} :params, :as request}]
   (premium-features/assert-has-feature :sso-jwt (tru "JWT-based authentication"))
   (let [jwt-data (when jwt (session-data jwt request))
-        is-react-sdk? (sso-utils/is-react-sdk-header? request)
-        is-simple-embed? (sso-utils/is-simple-embed-header? request)
-        is-embed? (or is-react-sdk? is-simple-embed?)]
+        is-react-sdk? (embed.util/has-react-sdk-header? request)
+        is-embedded-analytics-js? (embed.util/has-embedded-analytics-js-header? request)
+        is-modular-embedding? (or is-react-sdk? is-embedded-analytics-js?)]
     (cond
       (and is-react-sdk? (not (embed.settings/enable-embedding-sdk))) (throw-react-sdk-embedding-disabled)
-      (and is-simple-embed? (not (embed.settings/enable-embedding-simple))) (throw-simple-embedding-disabled)
-      (and is-embed? jwt (token-utils/has-token request)) (generate-response-token (:session jwt-data) (:jwt-data jwt-data))
-      is-embed?           (response/response (token-utils/with-token {:url (sso-settings/jwt-identity-provider-uri) :method "jwt"}))
+      (and is-embedded-analytics-js? (not (embed.settings/enable-embedding-simple))) (throw-simple-embedding-disabled)
+      (and is-modular-embedding? jwt (token-utils/has-token request)) (generate-response-token (:session jwt-data) (:jwt-data jwt-data))
+      is-modular-embedding?           (response/response (token-utils/with-token {:url (sso-settings/jwt-identity-provider-uri) :method "jwt"}))
       jwt               (request/set-session-cookies request
                                                      (response/redirect (:redirect-url jwt-data))
                                                      (:session jwt-data)

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -39,6 +39,7 @@
    [metabase-enterprise.sso.settings :as sso-settings]
    [metabase.api.common :as api]
    [metabase.channel.urls :as urls]
+   [metabase.embedding.util :as embed.util]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
@@ -135,7 +136,7 @@
   [req]
   (let [redirect (get-in req [:params :redirect])
         origin (get-in req [:headers "origin"])
-        embedding-sdk-header? (or (sso-utils/is-react-sdk-header? req) (sso-utils/is-simple-embed-header? req))]
+        embedding-sdk-header? (embed.util/is-modular-embedding-request? req)]
 
     (cond
       ;; Case 1: Embedding SDK header is present - use ACS URL with token and origin
@@ -163,7 +164,7 @@
   (premium-features/assert-has-feature :sso-saml (tru "SAML-based authentication"))
   (check-saml-enabled)
   (let [redirect (get-in req [:params :redirect])
-        embedding-sdk-header? (or (sso-utils/is-react-sdk-header? req) (sso-utils/is-simple-embed-header? req))
+        embedding-sdk-header? (embed.util/is-modular-embedding-request? req)
         redirect-url (construct-redirect-url req)]
     (sso-utils/check-sso-redirect redirect)
     (try

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -126,16 +126,6 @@
                       {:status-code  400
                        :redirect-url redirect-url})))))
 
-(defn is-react-sdk-header?
-  "Check if the client has indicated it is from the react embedding sdk"
-  [request]
-  (= (get-in request [:headers "x-metabase-client"]) "embedding-sdk-react"))
-
-(defn is-simple-embed-header?
-  "Check if the client has indicated it is from simple embedding"
-  [request]
-  (= (get-in request [:headers "x-metabase-client"]) "embedding-simple"))
-
 (defn filter-non-stringable-attributes
   "Removes vectors and map json attribute values that cannot be turned into strings."
   [attrs]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
@@ -56,13 +56,3 @@
                          (into [] cat)
                          (map :subject)
                          (filter #(str/includes? % "You're invited to join")))))))))
-
-(deftest is-embedding-header-test
-  (testing "is-react-sdk-header? detects embedding-sdk-react client header"
-    (is (sso-utils/is-react-sdk-header? {:headers {"x-metabase-client" "embedding-sdk-react"}})))
-  (testing "is-react-sdk-header? returns false for other client headers"
-    (is (not (sso-utils/is-react-sdk-header? {:headers {"x-metabase-client" "embedding-iframe"}}))))
-  (testing "is-simple-embed-header? detects embedding-simple client header"
-    (is (sso-utils/is-simple-embed-header? {:headers {"x-metabase-client" "embedding-simple"}})))
-  (testing "is-simple-embed-header? returns false for other client headers"
-    (is (not (sso-utils/is-simple-embed-header? {:headers {"x-metabase-client" "embedding-iframe"}})))))

--- a/src/metabase/embedding/util.clj
+++ b/src/metabase/embedding/util.clj
@@ -1,0 +1,22 @@
+(ns metabase.embedding.util
+  "Utility functions for common operations related to embedding.")
+
+(def ^:private embedding-sdk-client "embedding-sdk-react")
+(def ^:private embedded-analytics-js-client "embedding-simple")
+
+(defn has-react-sdk-header?
+  "Check if the client has indicated it is from the Embedding SDK for React "
+  [request]
+  (= (get-in request [:headers "x-metabase-client"]) embedding-sdk-client))
+
+(defn has-embedded-analytics-js-header?
+  "Check if the client has indicated it is from Embedded Analytics JS"
+  [request]
+  (= (get-in request [:headers "x-metabase-client"]) embedded-analytics-js-client))
+
+(defn is-modular-embedding-request?
+  "Check if the request is either from Embedding SDK for React or from Embedded Analytics JS"
+  [request]
+  (or (has-react-sdk-header? request)
+      (has-embedded-analytics-js-header? request)))
+

--- a/src/metabase/embedding/util.clj
+++ b/src/metabase/embedding/util.clj
@@ -19,4 +19,3 @@
   [request]
   (or (has-react-sdk-header? request)
       (has-embedded-analytics-js-header? request)))
-

--- a/src/metabase/request/util.clj
+++ b/src/metabase/request/util.clj
@@ -105,7 +105,7 @@
 
 (mu/defn device-info :- DeviceInfo
   "Information about the device that made this request, as recorded by the `LoginHistory` table."
-  [{{:strs [user-agent]} :headers, {:strs [token]} :query-params, :keys [browser-id], :as request}]
+  [{{:strs [user-agent x-metabase-client]} :headers, :keys [browser-id], :as request}]
   (let [id          (or browser-id
                         (log/warn "Login request is missing device ID information"))
         description (or user-agent
@@ -116,7 +116,7 @@
       (log/warn "Error determining login history for request"))
     {:device_id          (or id (trs "unknown"))
      :device_description (or description (trs "unknown")),
-     :embedded           (= "true" token)
+     :embedded           (boolean (#{"embedding-sdk-react" "embedding-simple"} x-metabase-client))
      :ip_address         (or ip-address (trs "unknown"))}))
 
 (defn describe-user-agent

--- a/src/metabase/request/util.clj
+++ b/src/metabase/request/util.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.config.core :as config]
+   [metabase.embedding.util :as embed.util]
    [metabase.request.settings :as request.settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
@@ -105,7 +106,7 @@
 
 (mu/defn device-info :- DeviceInfo
   "Information about the device that made this request, as recorded by the `LoginHistory` table."
-  [{{:strs [user-agent x-metabase-client]} :headers, :keys [browser-id], :as request}]
+  [{{:strs [user-agent]} :headers, :keys [browser-id], :as request}]
   (let [id          (or browser-id
                         (log/warn "Login request is missing device ID information"))
         description (or user-agent
@@ -116,7 +117,7 @@
       (log/warn "Error determining login history for request"))
     {:device_id          (or id (trs "unknown"))
      :device_description (or description (trs "unknown")),
-     :embedded           (boolean (#{"embedding-sdk-react" "embedding-simple"} x-metabase-client))
+     :embedded           (embed.util/is-modular-embedding-request? request)
      :ip_address         (or ip-address (trs "unknown"))}))
 
 (defn describe-user-agent

--- a/test/metabase/embedding/util_test.clj
+++ b/test/metabase/embedding/util_test.clj
@@ -1,0 +1,22 @@
+(ns metabase.embedding.util-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.embedding.util :as embed.util]))
+
+(deftest is-embedding-header-test
+  (testing "has-react-sdk-header? detects embedding-sdk-react client header"
+    (is (embed.util/has-react-sdk-header? {:headers {"x-metabase-client" "embedding-sdk-react"}})))
+  (testing "has-react-sdk-header? returns false for other client headers"
+    (is (not (embed.util/has-react-sdk-header? {:headers {"x-metabase-client" "embedding-iframe"}}))))
+  (testing "has-embedded-analytics-js-header? detects embedding-simple client header"
+    (is (embed.util/has-embedded-analytics-js-header? {:headers {"x-metabase-client" "embedding-simple"}})))
+  (testing "has-embedded-analytics-js-header? returns false for other client headers"
+    (is (not (embed.util/has-embedded-analytics-js-header? {:headers {"x-metabase-client" "embedding-iframe"}})))))
+
+(deftest is-modular-embedding-request-test
+  (testing "is-modular-embedding-request? detects embedding-sdk-react client header"
+    (is (embed.util/is-modular-embedding-request? {:headers {"x-metabase-client" "embedding-sdk-react"}})))
+  (testing "is-modular-embedding-request? detects embedding-simple client header"
+    (is (embed.util/is-modular-embedding-request? {:headers {"x-metabase-client" "embedding-simple"}})))
+  (testing "is-modular-embedding-request? returns false for other client headers"
+    (is (not (embed.util/is-modular-embedding-request? {:headers {"x-metabase-client" "embedding-iframe"}})))))

--- a/test/metabase/request/util_test.clj
+++ b/test/metabase/request/util_test.clj
@@ -34,12 +34,18 @@
             :embedded           false
             :ip_address         "0:0:0:0:0:0:0:1"}
            (req.util/device-info @mock-request))))
-  (testing "Embedded request"
+  (testing "SDK request"
     (is (= {:device_id          "129d39d1-6758-4d2c-a751-35b860007002"
             :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36"
             :embedded           true
             :ip_address         "0:0:0:0:0:0:0:1"}
-           (req.util/device-info (update @mock-request :query-params assoc "token" "true"))))))
+           (req.util/device-info (update @mock-request :headers assoc "x-metabase-client" "embedding-sdk-react")))))
+  (testing "Embedded Analytics JS request"
+    (is (= {:device_id          "129d39d1-6758-4d2c-a751-35b860007002"
+            :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36"
+            :embedded           true
+            :ip_address         "0:0:0:0:0:0:0:1"}
+           (req.util/device-info (update @mock-request :headers assoc "x-metabase-client" "embedding-simple"))))))
 
 (deftest ^:parallel describe-user-agent-test
   (are [user-agent expected] (= expected (req.util/describe-user-agent user-agent))


### PR DESCRIPTION
Closes EMB-850
### Backport reason
Double backport this since #56869 was tagged with 0.55.1 I will double backport this so we get this on both 55, and 56.
### Description

We changed the logic how JWT works with Embedding SDK since #56869, but we never updated the logic to set `:embedding` in `device-info`. This PR updates the logic to match the new one from #56869

### How to verify
Modify this function
https://github.com/metabase/metabase/blob/a695e6e743c6763888bcd90d183415e1c96ce2db/src/metabase/session/models/session.clj#L82-L90

to
```clojure
(mu/defmethod create-session! :sso :- SessionSchema
  [_ user :- CreateSessionUserInfo device-info :- request/DeviceInfo]
  (println "device-info" device-info)
  (let [session-key (generate-session-key)
        session-key-hashed (hash-session-key session-key)
        session-id (generate-session-id)
        session (first (t2/insert-returning-instances! :model/Session
                                                       :id session-id
                                                       :key_hashed session-key-hashed
                                                       :user_id (u/the-id user)))]
```

- Then run Metabase normally
- Tests SDK, and Embedded Analytics JS, when you refresh the page check BE log to see that `:embedded` in `device-info` should be `true`. If you run the same patch on master both cases should return `false`

#### `device-info` when logging in to Metabase
```
device-info {:device_id c21a88c3-0eb1-4d7b-a245-c16c819befa0, :device_description Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36, :embedded false, :ip_address 0:0:0:0:0:0:0:1}
```
#### `device-info` when loading the SDK
```
device-info {:device_id d5d40a83-d5f5-448a-bf74-1fefe2701c1e, :device_description Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36, :embedded true, :ip_address 0:0:0:0:0:0:0:1}
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
