### PR TITLE
WRK-899 Detail view: keep fields used as titles & sub-titles in the regular list of fields

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -553,7 +553,10 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.wait("@dataset").then((xhr) => {
       expect(xhr.response.body.error).not.to.exist;
     });
-    cy.findByTestId("object-detail").findByText("Fantastic Wool Shirt");
+    cy.findByTestId("object-detail")
+      .findAllByText("Fantastic Wool Shirt")
+      .should("have.length", 2)
+      .and("be.visible");
   });
 
   it("should apply correct date range on a graph drill-through (metabase#13785)", () => {

--- a/e2e/test/scenarios/detail-view/detail-view.cy.spec.ts
+++ b/e2e/test/scenarios/detail-view/detail-view.cy.spec.ts
@@ -44,7 +44,9 @@ describe("detail view", () => {
       });
 
       DetailView.verifyDetails([
+        ["ID", "1"],
         ["Ean", "1018947080336"],
+        ["Title", "Rustic Paper Wallet"],
         ["Category", "Gizmo"],
         ["Vendor", "Swaniawski, Casper and Hilll"],
         ["Price", "29.46"],
@@ -122,6 +124,7 @@ describe("detail view", () => {
       });
 
       DetailView.verifyDetails([
+        ["ID", "1"],
         ["User ID", "1"],
         ["Product ID", "14"],
         ["Subtotal", "37.65"],
@@ -137,6 +140,7 @@ describe("detail view", () => {
         ["Products → Ean", "8833419218504"],
         ["Products → Price", "25.1"],
         ["Products → Rating", "4"],
+        ["Products → Title", "Awesome Concrete Shoes"],
         ["Products → Vendor", "McClure-Lockman"],
       ]);
 
@@ -273,6 +277,7 @@ describe("detail view", () => {
       });
 
       DetailView.verifyDetails([
+        ["ID", "1"],
         ["User", "Hudson Borer"],
         ["Product", "Product: Awesome Concrete Shoes"],
         ["Subtotal ($)", "37.65"],
@@ -281,17 +286,19 @@ describe("detail view", () => {
         ["Discount ($)", "empty"],
         ["Created At", "February 11, 2025, 9:40 PM"],
         ["Quantity", "two"],
+        ["Order image", "https://example.com/order/1.jpg"],
         ["Product image", "https://example.com/product/14.jpg"],
         ["Products → Category", "Widget"],
         ["Products → Created At", "December 31, 2023, 2:41 PM"],
         ["Products → Ean", "8833419218504"],
         ["Products → Price", "25.1"],
         ["Products → Rating", "4"],
+        ["Products → Title", "Awesome Concrete Shoes"],
         ["Products → Vendor", "McClure-Lockman"],
       ]);
 
       cy.log("user id remapped to user name");
-      DetailView.getDetailsRowValue({ index: 0, rowsCount: 15 }).within(() => {
+      DetailView.getDetailsRowValue({ index: 1, rowsCount: 18 }).within(() => {
         cy.findByRole("link", { name: "Hudson Borer" })
           .should("be.visible")
           .and("have.attr", "href", `/table/${PEOPLE_ID}/detail/1`);
@@ -300,7 +307,7 @@ describe("detail view", () => {
       cy.log(
         "product id remapped to product title, and custom view_as setting",
       );
-      DetailView.getDetailsRowValue({ index: 1, rowsCount: 15 }).within(() => {
+      DetailView.getDetailsRowValue({ index: 2, rowsCount: 18 }).within(() => {
         cy.findByRole("link", { name: "Product: Awesome Concrete Shoes" })
           .should("be.visible")
           .and("have.attr", "href", "https://example.com/14")
@@ -314,13 +321,13 @@ describe("detail view", () => {
       });
 
       cy.log("image should be rendered in a frame with a link");
-      DetailView.getDetailsRowValue({ index: 8, rowsCount: 15 }).within(() => {
+      DetailView.getDetailsRowValue({ index: 10, rowsCount: 18 }).within(() => {
         cy.findByRole("img")
           .should("exist") // do not wait for image to load
           .and("have.attr", "src", "https://example.com/product/14.jpg");
 
         cy.findByRole("link")
-          .should("be.visible")
+          .should("exist")
           .and("have.text", "https://example.com/product/14.jpg")
           .and("have.attr", "href", "https://example.com/product/14.jpg")
           .and("have.attr", "target", "_blank")
@@ -332,7 +339,7 @@ describe("detail view", () => {
   it("displays emails as links", () => {
     DetailView.visitTable(PEOPLE_ID, 1);
 
-    DetailView.getDetailsRowValue({ index: 1, rowsCount: 11 }).within(() => {
+    DetailView.getDetailsRowValue({ index: 2, rowsCount: 13 }).within(() => {
       cy.findByRole("link", { name: "borer-hudson@yahoo.com" }).should(
         "have.attr",
         "href",

--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -139,7 +139,7 @@ describe("scenarios > model indexes", () => {
       cy.findByRole("heading", { name: "Small Marble Shoes" }).should(
         "be.visible",
       );
-      cy.findAllByText("Small Marble Shoes").should("have.length", 1);
+      cy.findAllByText("Small Marble Shoes").should("have.length", 2);
       cy.findByText("Doohickey").should("be.visible");
     });
   });
@@ -176,7 +176,7 @@ describe("scenarios > model indexes", () => {
     cy.findByTestId("object-detail").within(() => {
       cy.findByText(/We're a little lost/i).should("not.exist");
       cy.findByRole("heading", { name: "Anais Zieme" }).should("be.visible");
-      cy.findAllByText("Anais Zieme").should("have.length", 1);
+      cy.findAllByText("Anais Zieme").should("have.length", 2);
     });
   });
 
@@ -196,7 +196,7 @@ describe("scenarios > model indexes", () => {
       cy.findByRole("heading", { name: "Small Marble Shoes" }).should(
         "be.visible",
       );
-      cy.findAllByText("Small Marble Shoes").should("have.length", 1);
+      cy.findAllByText("Small Marble Shoes").should("have.length", 2);
       cy.findByText("Doohickey").should("be.visible");
     });
 

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -429,28 +429,30 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     H.openObjectDetail(0);
 
     cy.findByTestId("object-detail").within(() => {
-      cy.findByText("Link to review 1")
-        .should("be.visible")
-        .should("have.attr", "href")
+      cy.findAllByText("Link to review 1")
+        .should("have.length", 2)
+        .and("be.visible")
+        .and("have.attr", "href")
         .and("eq", "https://metabase.test?review=1");
 
       cy.findByText("Rating: 5")
         .should("be.visible")
-        .should("have.attr", "href")
+        .and("have.attr", "href")
         .and("eq", "https://metabase.test?rating=5");
     });
 
     cy.findByLabelText("Next row").click();
 
     cy.findByTestId("object-detail").within(() => {
-      cy.findByText("Link to review 2")
-        .should("be.visible")
-        .should("have.attr", "href")
+      cy.findAllByText("Link to review 2")
+        .should("have.length", 2)
+        .and("be.visible")
+        .and("have.attr", "href")
         .and("eq", "https://metabase.test?review=2");
 
       cy.findByText("Rating: 4")
         .should("be.visible")
-        .should("have.attr", "href")
+        .and("have.attr", "href")
         .and("eq", "https://metabase.test?rating=4");
     });
   });

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -154,7 +154,7 @@ describe("scenarios > visualizations > table", () => {
     H.openObjectDetail(5);
 
     // Ensure click on row index opens the object detail
-    H.modal().findByText("6").should("be.visible");
+    H.modal().findAllByText("6").should("have.length", 2).and("be.visible");
 
     // Close object detail modal
     cy.realType("{esc}");

--- a/frontend/src/metabase/detail-view/components/DetailsGroup/DetailsGroup.tsx
+++ b/frontend/src/metabase/detail-view/components/DetailsGroup/DetailsGroup.tsx
@@ -1,7 +1,4 @@
-import { useMemo } from "react";
-
 import {
-  getBodyColumns,
   getColumnTitle,
   getRowValue,
   renderValue,
@@ -30,19 +27,13 @@ export const DetailsGroup = ({
   table,
 }: Props) => {
   const tc = useTranslateContent();
-  const bodyColumns = useMemo(() => getBodyColumns(columns), [columns]);
-  const columnIndexMap = useMemo(
-    () => new Map(columns.map((column, index) => [column, index])),
-    [columns],
-  );
 
   return (
     <Stack data-testid="object-details" gap="lg">
-      {bodyColumns.map((column, index) => {
+      {columns.map((column, index) => {
         const field = table?.fields?.find((field) => field.id === column.id);
         const value = getRowValue(columns, column, row);
-        const realIndex = columnIndexMap.get(column) ?? -1;
-        const columnSettings = columnsSettings?.[realIndex] ?? {};
+        const columnSettings = columnsSettings?.[index] ?? {};
 
         return (
           <Group

--- a/frontend/src/metabase/detail-view/utils.ts
+++ b/frontend/src/metabase/detail-view/utils.ts
@@ -117,11 +117,6 @@ export function getAvatarColumn(
   return avatar ?? image;
 }
 
-export function getBodyColumns(columns: DatasetColumn[]): DatasetColumn[] {
-  const headerColumns = getHeaderColumns(columns);
-  return columns.filter((column) => !headerColumns.includes(column));
-}
-
 export function getRowName(
   columns: DatasetColumn[],
   row: RowValue[] | undefined,


### PR DESCRIPTION
Closes [WRK-899](https://linear.app/metabase/issue/WRK-899/detail-view-keep-fields-used-as-titles-and-sub-titles-in-the-regular)

### Demo

[before](https://github.com/user-attachments/assets/b87181c7-92d6-4676-9549-dcfcc4948de3) vs [after](https://github.com/user-attachments/assets/922bf021-0dab-4f9c-863f-920951880e77)
