### PR TITLE
Downgrade athena

### DIFF
--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -9,4 +9,4 @@
  ;; https://github.com/metabase/metabase/actions/workflows/athena.yml
  ;; new versions of athena-jdbc appear here:
  ;; https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver.html#jdbc-v3-driver-download-uber-jar
- {com.metabase/athena-jdbc {:mvn/version "3.6.0"}}}
+ {com.metabase/athena-jdbc {:mvn/version "3.5.0"}}}


### PR DESCRIPTION
addresses but does not fix #63396
manual backport of #63894

having issues with classpath. I _think_ that athena is finding the bigquery provided version of a netty class and that is failing. but it's a bit difficult to follow.

downgrading now until we can take time to understand and sort it.
