### PR TITLE
Closes EMB-851 static embed pin map

### DIFF
--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -240,7 +240,8 @@ function embedDashboardTileUrl(
   lonField: string,
   parameters?: unknown[],
 ): string {
-  let url = `/api/${IS_EMBED_PREVIEW ? "preview_" : ""}embed/tiles/dashboard/${token}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  const endpoint = IS_EMBED_PREVIEW ? "preview_embed" : "embed";
+  let url = `/api/${endpoint}/tiles/dashboard/${token}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
   if (parameters && parameters.length > 0) {
     url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
   }

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -1,3 +1,4 @@
+import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 import { isJWT } from "metabase/lib/utils";
 import { isUuid } from "metabase/lib/uuid";
 import type { DashboardId, Dataset, JsonQuery } from "metabase-types/api";
@@ -239,7 +240,7 @@ function embedDashboardTileUrl(
   lonField: string,
   parameters?: unknown[],
 ): string {
-  let url = `/api/embed/tiles/dashboard/${token}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
+  let url = `/api/${IS_EMBED_PREVIEW ? "preview_" : ""}embed/tiles/dashboard/${token}/dashcard/${dashcardId}/card/${cardId}/${zoom}/${coord.x}/${coord.y}/${latField}/${lonField}`;
   if (parameters && parameters.length > 0) {
     url += `?parameters=${encodeURIComponent(JSON.stringify(parameters))}`;
   }

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -1,3 +1,4 @@
+import { isJWT } from "metabase/lib/utils";
 import { isUuid } from "metabase/lib/uuid";
 import type { DashboardId, Dataset, JsonQuery } from "metabase-types/api";
 
@@ -45,9 +46,14 @@ export function getTileUrl(params: TileUrlParams): string {
       return adhocQueryTileUrl(zoom, coord, latField, lonField, datasetQuery);
     }
 
-    if (typeof dashboardId === "string" && !isUuid(dashboardId)) {
+    if (
+      typeof dashboardId === "string" &&
+      !isUuid(dashboardId) && // public dashboard
+      !isJWT(dashboardId) // embedded dashboard
+    ) {
       throw Error("dashboardId must be an int or a uuid");
     }
+
     const isPublicDashboard = uuid;
 
     if (isPublicDashboard) {

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -52,7 +52,7 @@ export function getTileUrl(params: TileUrlParams): string {
       !isUuid(dashboardId) && // public dashboard
       !isJWT(dashboardId) // embedded dashboard
     ) {
-      throw Error("dashboardId must be an int, an uuid or a jwt");
+      throw new Error("dashboardId must be an int, an uuid or a jwt");
     }
 
     const isPublicDashboard = uuid;

--- a/frontend/src/metabase/visualizations/lib/map.ts
+++ b/frontend/src/metabase/visualizations/lib/map.ts
@@ -52,7 +52,7 @@ export function getTileUrl(params: TileUrlParams): string {
       !isUuid(dashboardId) && // public dashboard
       !isJWT(dashboardId) // embedded dashboard
     ) {
-      throw Error("dashboardId must be an int or a uuid");
+      throw Error("dashboardId must be an int, an uuid or a jwt");
     }
 
     const isPublicDashboard = uuid;

--- a/frontend/src/metabase/visualizations/lib/map.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/map.unit.spec.ts
@@ -265,9 +265,12 @@ describe("map", () => {
     });
 
     describe("embed dashboard", () => {
+      const jwt = "th1s-l00ks-lik3.a-jwt-t0k3n.bu7-1s-n07"; // embedded dashboards have a JWT instead of an id
+
       it("should generate url for embed dashboard without parameters", () => {
         const url = getTileUrl({
-          dashboardId: 10,
+          // embedded dashboards have a JWT instead of an id
+          dashboardId: jwt,
           dashcardId: 20,
           cardId: 30,
           zoom,
@@ -290,7 +293,7 @@ describe("map", () => {
         });
 
         const url = getTileUrl({
-          dashboardId: 10,
+          dashboardId: jwt,
           dashcardId: 20,
           cardId: 30,
           zoom,

--- a/src/metabase/embedding/api/preview_embed.clj
+++ b/src/metabase/embedding/api/preview_embed.clj
@@ -15,6 +15,9 @@
    [metabase.embedding.jwt :as embed]
    [metabase.embedding.validation :as embedding.validation]
    [metabase.query-processor.pivot :as qp.pivot]
+   [metabase.request.core :as request]
+   [metabase.tiles.api :as api.tiles]
+   [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
    [ring.util.codec :as codec]))
 
@@ -144,3 +147,41 @@
      :token-params     token-params
      :query-params     (api.embed.common/parse-query-params query-params)
      :qp               qp.pivot/run-pivot-query)))
+
+(api.macros/defendpoint :get "/tiles/card/:token/:zoom/:x/:y/:lat-field/:lon-field"
+  "Generates a single tile image for an embedded Card using the map visualization."
+  [{:keys [token zoom x y lat-field lon-field]}
+   :- [:merge
+       :api.tiles/route-params
+       [:map
+        [:token string?]]]
+   {:keys [parameters]}
+   :- [:map
+       [:parameters {:optional true} ms/JSONString]]]
+  (let [unsigned-token   (check-and-unsign token)
+        card-id    (api.embed.common/unsigned-token->card-id unsigned-token)
+        parameters (json/decode+kw parameters)
+        lat-field    (json/decode+kw lat-field)
+        lon-field    (json/decode+kw lon-field)]
+    (request/as-admin
+      (api.tiles/process-tiles-query-for-card card-id parameters zoom x y lat-field lon-field))))
+
+(api.macros/defendpoint :get "/tiles/dashboard/:token/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y/:lat-field/:lon-field"
+  "Generates a single tile image for a Card on an embedded Dashboard using the map visualization."
+  [{:keys [token dashcard-id card-id zoom x y lat-field lon-field]}
+   :- [:merge
+       :api.tiles/route-params
+       [:map
+        [:token       string?]
+        [:dashcard-id ms/PositiveInt]
+        [:card-id     ms/PositiveInt]]]
+   {:keys [parameters]}
+   :- [:map
+       [:parameters {:optional true} ms/JSONString]]]
+  (let [unsigned-token   (check-and-unsign token)
+        dashboard-id     (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
+        parameters       (json/decode+kw parameters)
+        lat-field        (json/decode+kw lat-field)
+        lon-field        (json/decode+kw lon-field)]
+    (request/as-admin
+      (api.tiles/process-tiles-query-for-dashcard dashboard-id dashcard-id card-id parameters zoom x y lat-field lon-field))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63860
Closes [EMB-851: Static Embed of Pin Map Fails with "dashboardId must be an int or a uuid"](https://linear.app/metabase/issue/EMB-851/static-embed-of-pin-map-fails-with-dashboardid-must-be-an-int-or-a)

### Description

Dashboard ID can also be a JWT token for static embedded dashboards.
This also adds `preview_embed` API endpoints for tiles, which were missing.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
