### PR TITLE
Fix: #60843 Prevents dashboard from being saved when clicking "Discard changes"

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -645,6 +645,33 @@ describe("scenarios > dashboard", () => {
         H.getDashboardCard(1).contains("bottom");
       },
     );
+
+    it("should not save the dashboard when the user clicks 'Discard changes'", () => {
+      // Navigate to the dashboard via client-side navigation (to trigger the client-side "Discard changes" prompt)
+      cy.visit("/");
+      cy.findByTestId("main-navbar-root").findByText("Our analytics").click();
+      cy.findByTestId("collection-table")
+        .findByText(originalDashboardName)
+        .click();
+
+      cy.log("Make a change to the dashboard");
+      H.editDashboard();
+      cy.findByTestId("dashboard-empty-state")
+        .findByText("Add a chart")
+        .click();
+      H.sidebar().findByText("Orders, Count").click();
+      H.getDashboardCards().should("have.length", 1);
+
+      cy.log("Navigate back and discard changes");
+      cy.go("back");
+      H.modal().button("Discard changes").click();
+      cy.findByTestId("collection-table")
+        .findByText(originalDashboardName)
+        .click();
+
+      cy.log("Verify changes were not saved");
+      cy.findByTestId("dashboard-empty-state").should("exist");
+    });
   });
 
   describe("iframe cards", () => {

--- a/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardLeaveConfirmationModal/DashboardLeaveConfirmationModal.tsx
@@ -27,12 +27,6 @@ export const DashboardLeaveConfirmationModal = withRouter(
       router,
     });
 
-    const onSave = async () => {
-      dispatch(dismissAllUndo());
-      await dispatch(updateDashboardAndCards());
-      confirm?.();
-    };
-
     const content = isNavigatingToCreateADashboardQuestion(nextLocation)
       ? {
           title: t`Save your changes?`,
@@ -40,6 +34,7 @@ export const DashboardLeaveConfirmationModal = withRouter(
           actionBtn: {
             message: t`Save changes`,
           },
+          onConfirm: () => dispatch(updateDashboardAndCards()),
         }
       : {
           title: t`Discard your changes?`,
@@ -77,7 +72,11 @@ export const DashboardLeaveConfirmationModal = withRouter(
             <Button
               color={content.actionBtn.color}
               variant="filled"
-              onClick={onSave}
+              onClick={async () => {
+                dispatch(dismissAllUndo());
+                await content.onConfirm?.();
+                confirm?.();
+              }}
             >
               {content.actionBtn.message}
             </Button>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/60843
Closes UXW-333

### Description

Updates `DashboardLeaveConfirmationModal` so `updateDashboardAndCards` is only called when clicking save, not when clicking "Discard changes".

### How to verify

See #60843 for repro steps.

### Demo

https://github.com/user-attachments/assets/6c1cfb6a-31e5-4728-9511-ff0be2fc88e3

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
