### PR TITLE
Fix: #60182 Fix is-neg condition

### DIFF
--- a/src/metabase/channel/render/table.clj
+++ b/src/metabase/channel/render/table.clj
@@ -125,7 +125,7 @@
   - Formatted value alone if not a valid numeric value"
   [val {:keys [min max]} col-styles]
   (if-let [num (:num-value val)] ;; Assumes NumericWrapper
-    (let [is-neg?        (< num 1)
+    (let [is-neg?        (< num 0)
           has-neg?       (< min 0)
           normalized-max (clojure.core/max (abs min) (abs max))
           pct-full       (if (zero? normalized-max) 0 (int (* (/ (abs num) normalized-max) 100)))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/60182
Closes UXW-172

### Description

Fixes incorrect "is negative" condition.

### How to verify

See #60182 for repro steps.

### Demo

**BEFORE**
<img width="850" height="566" alt="before" src="https://github.com/user-attachments/assets/8ee538b4-33c9-4a8a-9726-f0a80e766d1f" />

**AFTER**
<img width="849" height="565" alt="after" src="https://github.com/user-attachments/assets/b8c7ba7e-49b9-49ff-96ed-679a289174a5" />

**SITE**
<img width="849" height="565" alt="site" src="https://github.com/user-attachments/assets/3d6dadbf-18dd-4b3b-86b7-a751e5d4c106" />


### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
