### PR TITLE
Revert clickhouse jdbc driver to 0.8.4

### DIFF
--- a/modules/drivers/clickhouse/deps.edn
+++ b/modules/drivers/clickhouse/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
  :deps
- {com.clickhouse/clickhouse-jdbc {:mvn/version "0.9.2"
+ {com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.4"
                                   :exclusions [org.apache.commons/commons-lang3]}
   org.lz4/lz4-java {:mvn/version "1.8.0"}}}

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -243,7 +243,7 @@
 
 (defmethod sql.qp/->honeysql [:clickhouse LocalDate]
   [_ ^java.time.LocalDate t]
-  t)
+  [:'parseDateTimeBestEffort t])
 
 (defn- local-date-time
   [^java.time.LocalTime t]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -390,19 +390,19 @@
          [{:field-name "mystring" :base-type :type/Text}]
          [["foo"] ["bar"] ["   "] [""] [nil]]]])
       (testing "null strings count"
-        (is (= 2
+        (is (= 2M
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:is-null $mystring]
                       :aggregation [:count]})
                    mt/first-row last))))
       (testing "nullable strings not null filter"
-        (is (= 3
+        (is (= 3M
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:not-null $mystring]
                       :aggregation [:count]})
                    mt/first-row last))))
       (testing "filter nullable string by value"
-        (is (= 1
+        (is (= 1M
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:= $mystring "foo"]
                       :aggregation [:count]})

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -353,7 +353,9 @@
 (deftest ^:parallel humanize-connection-error-message-test
   (is (= "random message" (driver/humanize-connection-error-message :clickhouse ["random message"])))
   (is (= :username-or-password-incorrect (driver/humanize-connection-error-message :clickhouse ["Failed to create connection"
-                                                                                                "Failed to get server info" "Code: 516. DB::Exception: asdf: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED) (version 25.7.4.11 (official build))"]))))
+                                                                                                "Failed to get server info"
+                                                                                                "Code: 516. DB::Exception: asdf: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED) (version 25.7.4.11 (official build))"]))))
+
 (deftest ^:parallel query-with-cte-subquery-and-param-test
   (mt/test-driver :clickhouse
     (testing "a query with a CTE in a subquery and a parameter should work correctly"

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -353,23 +353,19 @@
 (deftest ^:parallel humanize-connection-error-message-test
   (is (= "random message" (driver/humanize-connection-error-message :clickhouse ["random message"])))
   (is (= :username-or-password-incorrect (driver/humanize-connection-error-message :clickhouse ["Failed to create connection"
-                                                                                                "Failed to get server info"
-                                                                                                "Code: 516. DB::Exception: asdf: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED) (version 25.7.4.11 (official build))"]))))
-
-;; TODO(rileythomp, 2025-09-23): Enable this test once ClickHouse has fixed
-;; https://github.com/ClickHouse/clickhouse-java/issues/2595 in 0.9.3.
-#_(deftest ^:parallel query-with-cte-subquery-and-param-test
-    (mt/test-driver :clickhouse
-      (testing "a query with a CTE in a subquery and a parameter should work correctly"
-        (is (= [[1 "abc"]]
-               (mt/rows
-                (qp/process-query
-                 {:database (mt/id)
-                  :type :native
-                  :native {:query "SELECT id, val FROM ( WITH foo AS ( SELECT 1 id, 'abc' val ) SELECT * FROM foo ) WHERE val = {{val}} LIMIT 1048575"
-                           :template-tags {"val" {:type :text
-                                                  :name "val"
-                                                  :display-name "Val"}}}
-                  :parameters [{:type "string/="
-                                :target [:variable [:template-tag "val"]]
-                                :value ["abc"]}]})))))))
+                                                                                                "Failed to get server info" "Code: 516. DB::Exception: asdf: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED) (version 25.7.4.11 (official build))"]))))
+(deftest ^:parallel query-with-cte-subquery-and-param-test
+  (mt/test-driver :clickhouse
+    (testing "a query with a CTE in a subquery and a parameter should work correctly"
+      (is (= [[1 "abc"]]
+             (mt/rows
+              (qp/process-query
+               {:database (mt/id)
+                :type :native
+                :native {:query "SELECT id, val FROM ( WITH foo AS ( SELECT 1 id, 'abc' val ) SELECT * FROM foo ) WHERE val = {{val}} LIMIT 1048575"
+                         :template-tags {"val" {:type :text
+                                                :name "val"
+                                                :display-name "Val"}}}
+                :parameters [{:type "string/="
+                              :target [:variable [:template-tag "val"]]
+                              :value ["abc"]}]})))))))

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -355,3 +355,21 @@
   (is (= :username-or-password-incorrect (driver/humanize-connection-error-message :clickhouse ["Failed to create connection"
                                                                                                 "Failed to get server info"
                                                                                                 "Code: 516. DB::Exception: asdf: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED) (version 25.7.4.11 (official build))"]))))
+
+;; TODO(rileythomp, 2025-09-23): Enable this test once ClickHouse has fixed
+;; https://github.com/ClickHouse/clickhouse-java/issues/2595 in 0.9.3.
+#_(deftest ^:parallel query-with-cte-subquery-and-param-test
+    (mt/test-driver :clickhouse
+      (testing "a query with a CTE in a subquery and a parameter should work correctly"
+        (is (= [[1 "abc"]]
+               (mt/rows
+                (qp/process-query
+                 {:database (mt/id)
+                  :type :native
+                  :native {:query "SELECT id, val FROM ( WITH foo AS ( SELECT 1 id, 'abc' val ) SELECT * FROM foo ) WHERE val = {{val}} LIMIT 1048575"
+                           :template-tags {"val" {:type :text
+                                                  :name "val"
+                                                  :display-name "Val"}}}
+                  :parameters [{:type "string/="
+                                :target [:variable [:template-tag "val"]]
+                                :value ["abc"]}]})))))))

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -273,34 +273,36 @@
                                 :target [:dimension [:template-tag "category_name"]]
                                 :value  ["African"]}]}))))))))
 
-(deftest ^:parallel ternary-with-variable-test
-  (mt/test-driver :clickhouse
-    (testing "a query with a ternary and a variable should work correctly"
-      (is (= [[1 "African" 1]]
-             (mt/rows
-              (qp/process-query
-               {:database (mt/id)
-                :type :native
-                :native {:query "SELECT *, true ? 1 : 0 AS foo
-                                 FROM test_data.categories
-                                 WHERE name = {{category_name}};"
-                         :template-tags {"category_name" {:type         :text
-                                                          :name         "category_name"
-                                                          :display-name "Category Name"}}}
-                :parameters [{:type   :category
-                              :target [:variable [:template-tag "category_name"]]
-                              :value  "African"}]})))))))
+;; TODO(rileythomp, 2025-09-23): Enable when ClickHouse JDBC driver has been fixed
+#_(deftest ^:parallel ternary-with-variable-test
+    (mt/test-driver :clickhouse
+      (testing "a query with a ternary and a variable should work correctly"
+        (is (= [[1 "African" 1]]
+               (mt/rows
+                (qp/process-query
+                 {:database (mt/id)
+                  :type :native
+                  :native {:query "SELECT *, true ? 1 : 0 AS foo
+                                   FROM test_data.categories
+                                   WHERE name = {{category_name}};"
+                           :template-tags {"category_name" {:type         :text
+                                                            :name         "category_name"
+                                                            :display-name "Category Name"}}}
+                  :parameters [{:type   :category
+                                :target [:variable [:template-tag "category_name"]]
+                                :value  "African"}]})))))))
 
-(deftest ^:parallel line-comment-block-comment-test
-  (mt/test-driver :clickhouse
-    (testing "a query with a line comment followed by a block comment should work correctly"
-      (is (= [[1]]
-             (mt/rows
-              (qp/process-query
-               (mt/native-query
-                 {:query "-- foo
-                          /* comment */
-                          select 1;"}))))))))
+;; TODO(rileythomp, 2025-09-23): Enable when ClickHouse JDBC driver has been fixed
+#_(deftest ^:parallel line-comment-block-comment-test
+    (mt/test-driver :clickhouse
+      (testing "a query with a line comment followed by a block comment should work correctly"
+        (is (= [[1]]
+               (mt/rows
+                (qp/process-query
+                 (mt/native-query
+                   {:query "-- foo
+                            /* comment */
+                            select 1;"}))))))))
 
 (deftest ^:parallel subquery-with-cte-test
   (mt/test-driver :clickhouse


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63635

### Description

Essentially reverts https://github.com/metabase/metabase/pull/63349

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
