### PR TITLE
fix: jetty stats handler tests flake

### DIFF
--- a/.clj-kondo/config/test-helpers/config.edn
+++ b/.clj-kondo/config/test-helpers/config.edn
@@ -16,6 +16,7 @@
      clojure.core.async/<!
      clojure.core.async/>!!
      clojure.core.async/>!
+     clojure.core.async/alts!
      clojure.core.async/alts!!
      clojure.core.async/close!
      clojure.core.async/poll!

--- a/.clj-kondo/config/test-helpers/config.edn
+++ b/.clj-kondo/config/test-helpers/config.edn
@@ -13,7 +13,9 @@
      toucan2.core/insert-returning-pk!
      toucan2.core/insert-returning-pks!
      clojure.core.async/<!!
+     clojure.core.async/<!
      clojure.core.async/>!!
+     clojure.core.async/>!
      clojure.core.async/alts!!
      clojure.core.async/close!
      clojure.core.async/poll!

--- a/deps.edn
+++ b/deps.edn
@@ -284,6 +284,8 @@
                  "-Duser.country=US"
                  ;; Allow clojure goes fast tooling to work
                  "-Djdk.attach.allowAttachSelf"
+                 ;; have core.async report usages of blocking operations in go blocks
+                 "-Dclojure.core.async.go-checking=true"
                  ;; This will suppress the warning about dynamically loaded agents (like clj-memory-meter)
                  "-XX:+EnableDynamicAgentLoading"
                  ;; set the logging properties set in `metabase.core.bootstrap`. calling (dev) will load it but

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -18,7 +18,8 @@
   [done-channel]
   (proxy [AsyncListener] []
     (onComplete [_]
-      (a/>!! done-channel :done))))
+      (a/go
+        (a/>! done-channel :done)))))
 
 (defn- async-servlet-handler
   ^ServletHandler [status-code chan-start-handle chan-finish-handle]

--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -31,7 +31,7 @@
           (.setStatus response status-code)
           (.setContentLength response 0)
           (.. response getOutputStream close)
-          (a/<!! chan-finish-handle)
+          (a/<! chan-finish-handle)
           (.complete async-context))
         (a/<!! chan-finish-handle)))))
 

--- a/test/metabase/util/async_test.clj
+++ b/test/metabase/util/async_test.clj
@@ -38,7 +38,7 @@
                               (a/>!! finished-chan e))))]
         ;; wait for `f` to actually start running before we kill it. Otherwise it may not get started at all
         (a/go
-          (a/alts!! [started-chan (a/timeout 1000)])
+          (a/alts! [started-chan (a/timeout 1000)])
           (a/close! result-chan))
         (is (instance?
              InterruptedException


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63903

### Description

These tests could hang indefinitely on the `(.join server)` statement because the core.async/go block handling async requests was incorrectly doing a blocking take `<!!`. This also updates our :dev alias to enable core.async to print warnings when using blocking operations in `go` blocks.