### PR TITLE
refactor(sdk-bundle): Adjust SDK compatibility warning messages and banners

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/incompatibility-with-instance-banner.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/incompatibility-with-instance-banner.cy.spec.tsx
@@ -34,7 +34,7 @@ describe("scenarios > embedding-sdk > incompatibility-with-instance-banner", () 
     mockAuthProviderAndJwtSignIn();
   });
 
-  describe("when the SDK is incompatible with an instance", () => {
+  describe("when the SDK bundle is incompatible with an instance", () => {
     it("should show an error with a close button", () => {
       cy.mount(
         <MetabaseProvider authConfig={DEFAULT_SDK_AUTH_PROVIDER_CONFIG}>

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkVersionCompatibilityHandler/SdkIncompatibilityWithInstanceBanner.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkVersionCompatibilityHandler/SdkIncompatibilityWithInstanceBanner.tsx
@@ -7,31 +7,31 @@ import { getMetabaseInstanceVersion } from "embedding-sdk-bundle/store/selectors
 import { getBuildInfo } from "embedding-sdk-shared/lib/get-build-info";
 import {
   isInvalidMetabaseVersion,
-  isSdkPackageCompatibleWithSdkBundle,
+  isSdkBundleCompatibleWithMetabaseInstance,
 } from "embedding-sdk-shared/lib/version-utils";
 import { Anchor } from "metabase/ui";
 
 export function SdkIncompatibilityWithInstanceBanner() {
-  const sdkPackageVersion = getBuildInfo(
-    "METABASE_EMBEDDING_SDK_PACKAGE_BUILD_INFO",
-  ).version;
-  const sdkBundleVersion = useSdkSelector(getMetabaseInstanceVersion);
+  const sdkBundleVersion = getBuildInfo(
+    "METABASE_EMBEDDING_SDK_BUNDLE_BUILD_INFO",
+  )?.version;
+  const metabaseInstanceVersion = useSdkSelector(getMetabaseInstanceVersion);
 
   const isSdkCompatibleWithInstance = useMemo(() => {
-    if (!sdkBundleVersion || !sdkPackageVersion) {
+    if (!sdkBundleVersion || !metabaseInstanceVersion) {
       // If we don't have the Metabase version, we can't determine compatibility.
       return true;
     }
 
-    if (isInvalidMetabaseVersion(sdkBundleVersion)) {
+    if (isInvalidMetabaseVersion(metabaseInstanceVersion)) {
       return true;
     }
 
-    return isSdkPackageCompatibleWithSdkBundle({
-      sdkPackageVersion,
+    return isSdkBundleCompatibleWithMetabaseInstance({
       sdkBundleVersion,
+      metabaseInstanceVersion,
     });
-  }, [sdkPackageVersion, sdkBundleVersion]);
+  }, [sdkBundleVersion, metabaseInstanceVersion]);
 
   if (isSdkCompatibleWithInstance) {
     return null;

--- a/enterprise/frontend/src/embedding-sdk-bundle/hooks/private/use-log-version-info/use-log-version-info.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/hooks/private/use-log-version-info/use-log-version-info.unit.spec.tsx
@@ -46,14 +46,14 @@ describe("useLogVersionInfo", () => {
   describe("SDK version compatibility", () => {
     it("should show a message when the SDK version is not compatible with the Metabase version", async () => {
       await setup({
-        sdkPackageVersion: "0.52.10",
-        sdkBundleVersion: "v1.55.0",
+        sdkPackageVersion: "0.55.10",
+        sdkBundleVersion: "v1.52.0",
       });
 
       expect(
         getWarnMessages().filter((message) =>
           message.includes(
-            "SDK package version 0.52.10 is not compatible with SDK bundle version v1.55.0, this might cause issues.",
+            "SDK package version 0.55.10 is not compatible with SDK bundle version v1.52.0, this might cause issues.",
           ),
         ),
       ).toHaveLength(1);
@@ -61,7 +61,7 @@ describe("useLogVersionInfo", () => {
 
     it("should not show a warning when the SDK version is compatible with the Metabase version", async () => {
       await setup({
-        sdkPackageVersion: "0.55.10",
+        sdkPackageVersion: "0.52.10",
         sdkBundleVersion: "v1.55.1",
       });
 

--- a/enterprise/frontend/src/embedding-sdk-shared/lib/version-utils.ts
+++ b/enterprise/frontend/src/embedding-sdk-shared/lib/version-utils.ts
@@ -24,5 +24,27 @@ export const isSdkPackageCompatibleWithSdkBundle = ({
   const sdkBundleVersionComponents =
     versionToNumericComponents(sdkBundleVersion);
 
-  return sdkBundleVersionComponents?.[1] === sdkPackageVersionComponents?.[1];
+  if (!sdkPackageVersionComponents || !sdkBundleVersionComponents) {
+    return true;
+  }
+
+  return sdkBundleVersionComponents?.[1] >= sdkPackageVersionComponents?.[1];
+};
+
+export const isSdkBundleCompatibleWithMetabaseInstance = ({
+  sdkBundleVersion,
+  metabaseInstanceVersion,
+}: {
+  sdkBundleVersion: string;
+  metabaseInstanceVersion: string;
+}) => {
+  const sdkBundleVersionComponents =
+    versionToNumericComponents(sdkBundleVersion);
+  const metabaseInstanceVersionComponents = versionToNumericComponents(
+    metabaseInstanceVersion,
+  );
+
+  return (
+    sdkBundleVersionComponents?.[1] === metabaseInstanceVersionComponents?.[1]
+  );
 };


### PR DESCRIPTION
Adjust SDK compatibility warning messages and banners.

Context: https://metaboat.slack.com/archives/C094QPFH21W/p1758647900555569?thread_ts=1757955043.243729&cid=C094QPFH21W

We should not show compatibility warnings if MB instance (or bundle) is greater than SDK package because Cloud versions may be not pinned.

For breaking changes at least partially we have schemas validation
