### PR TITLE
ensure type/* for base-type if otherwise not known

### DIFF
--- a/src/metabase/driver/sql_jdbc/metadata.clj
+++ b/src/metabase/driver/sql_jdbc/metadata.clj
@@ -34,5 +34,6 @@
                     {:lib/type      :metadata/column
                      :name          (.getColumnLabel rsmeta i)
                      :database-type database-type
-                     :base-type     (sql-jdbc.sync.interface/database-type->base-type driver (keyword database-type))}))
+                     :base-type     (or (sql-jdbc.sync.interface/database-type->base-type driver (keyword database-type))
+                                        :type/*)}))
                 (range 1 (inc (.getColumnCount rsmeta))))))))))

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -411,13 +411,13 @@
                                 u/->snake_case_en
                                 u/->kebab-case-en) k)
                            v (case k
-                               (:base_type
-                                :effective_type
-                                :semantic_type
+                               (:semantic_type
                                 :visibility_type
                                 :source
                                 :unit
                                 :lib/source) (keyword v)
+                               (:effective_type
+                                :base_type)  (or (keyword v) :type/*)
                                :field_ref    (normalize-field-ref v)
                                :fingerprint  (normalize-fingerprint v)
                                :binning_info (m/update-existing v :binning_strategy keyword)

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1824,6 +1824,25 @@
                   mt/process-query
                   mt/rows))))))
 
+(deftest ^:parallel arrays-have-base-type
+  (testing "queries with pg arrays have a base type on column metadata (#63909)"
+    (mt/test-driver :postgres
+      (is (=? [{:name "id"
+                :database_type "int4"
+                :base_type :type/Integer}
+               {:name "urls"
+                :database_type "_text"
+                :base_type :type/*}]
+              (->> (mt/native-query {:query "SELECT *
+                                             FROM (
+                                               VALUES
+                                                 (1, ARRAY['https://example.com', 'https://example.org']),
+                                                 (2, ARRAY['https://test.com']),
+                                                 (3, ARRAY['https://foo.com', 'https://bar.com', 'https://baz.com'])
+                                             ) AS adhoc_table (id, urls);"})
+                   mt/process-query
+                   mt/cols))))))
+
 (deftest ^:parallel detect-provider-from-database-test
   (let [tests [["Aiven" "mydb-project.aivencloud.com"]
                ["Amazon RDS" "czrs8kj4isg7.us-east-1.rds.amazonaws.com"]


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/63909

Using the follow query that returns pg arrays:

```sql
SELECT *
FROM (
  VALUES
    (1, ARRAY['https://example.com', 'https://example.org']),
    (2, ARRAY['https://test.com']),
    (3, ARRAY['https://foo.com', 'https://bar.com', 'https://baz.com'])
) AS adhoc_table (id, urls);
```

In 55 this returned a nil base-type

```clojure
user=> (metabase.query-processor.metadata/legacy-result-metadata
         {:database 2
          :type :native,
          :native {:template-tags {},
                   :query "SELECT *\nFROM (\n  VALUES\n    (1, ARRAY['https://example.com', 'https://example.org']),\n    (2, ARRAY['https://test.com']),\n    (3, ARRAY['https://foo.com', 'https://bar.com', 'https://baz.com'])\n) AS adhoc_table (id, urls);"}}
         1)
[{:display_name "id",
  :source :native,
  :field_ref [:field "id" {:base-type :type/Integer}],
  :ident "native[]__id",
  :name "id",
  :database_type "int4",
  :base_type :type/Integer,
  :semantic_type :type/PK}
 {:display_name "urls",
  :source :native,
  :field_ref [:field "urls" {:base-type nil}],
  :ident "native[]__urls",
  :name "urls",
  :database_type "_text",
  :base_type nil}] ;; <---------- base type in nil
```

In master due to some malli schema checking, this fails with a malli error. If you remove the type checking in places, it will eventually return similar. Ie, no _logic_ has changed, just assertions.

This base-type is computed in sql-jdbc/metadata

```clojure
(mu/defn query-result-metadata :- [:sequential driver-api/schema.metadata.column]
  "Default implementation of [[metabase.driver/query-result-metadata]] for JDBC-based drivers. Gets metadata without
  actually running a query."
  ([driver :- :keyword
    query  :- :map]
   (driver-api/with-qp-setup [query query]
     (let [database               (driver-api/database (driver-api/metadata-provider))
           {:keys [query params]} (driver-api/compile query)]
       (query-result-metadata driver database query params))))

  ([driver      :- :keyword
    database    :- driver-api/schema.metadata.database
    ^String sql :- :string
    params      :- [:maybe [:sequential :any]]]
   (sql-jdbc.execute/do-with-connection-with-options
    driver
    database
    nil
    (fn [^java.sql.Connection conn]
      (with-open [stmt (sql-jdbc.execute/prepared-statement driver conn sql params)]
        (let [rsmeta (.getMetaData stmt)]
          (mapv (fn [i]
                  (let [database-type (.getColumnTypeName rsmeta i)]
                    {:lib/type      :metadata/column
                     :name          (.getColumnLabel rsmeta i)
                     :database-type database-type
                     :base-type     (or (sql-jdbc.sync.interface/database-type->base-type driver (keyword database-type))
                                        :type/*)}))   ;; <---- fix here. `(or (compute) :type/*`
                (range 1 (inc (.getColumnCount rsmeta))))))))))
```

Before this change, there was no `or` and
`sql-jdbc.sync.interface/database-type->base-type` would just return nil.

```clojure
user=> (metabase.driver.sql-jdbc.sync/database-type->base-type :postgres (keyword "_text"))
nil
```

Unfortunately this is a multimethod so we can't easily update it in one spot to fall back to type/*. Each implementation must take care to do this. A few do (clickhouse does) but a few dont (snowflake does not). So we update this call site to ensure we have something from the multimethod or add our own type/*

Why did this start happening now?
> I think it's because I added :metadata/model-metadata to :metabase.lib.schema.info/info at some point

Query info stashes the model metadata which is
```clojure
[:metadata/model-metadata {:optional true} [:maybe [:sequential ::lib.schema.metadata/lib-or-legacy-column]]]
```

We had been throwing errors asynchronously when trying to save metadata, but now we have on-thread type mismatch for model metadata, which is what is in the ticket.

I'm happy to add a test ensuring we can edit a model who's query is based on the query above. I get at the root of the issue here but happy to add that test case for completeness sake since it is _slightly_ different code pathway, but hits the same underlying issue.