### PR TITLE
Add embed flow to the command palette

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -388,6 +388,16 @@ describe("command palette", () => {
     });
   });
 
+  it("should show the 'Create a new embed' command palette item", () => {
+    cy.visit("/");
+    cy.findByRole("button", { name: /Search/ }).click();
+
+    H.commandPalette().within(() => {
+      H.commandPaletteInput().should("exist").type("new embed");
+      cy.findByText("Create a new embed").should("be.visible");
+    });
+  });
+
   describe("ee", () => {
     beforeEach(() => {
       H.activateToken("bleeding-edge");

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -388,19 +388,19 @@ describe("command palette", () => {
     });
   });
 
-  it("should show the 'Create a new embed' command palette item", () => {
-    cy.visit("/");
-    cy.findByRole("button", { name: /Search/ }).click();
-
-    H.commandPalette().within(() => {
-      H.commandPaletteInput().should("exist").type("new embed");
-      cy.findByText("Create a new embed").should("be.visible");
-    });
-  });
-
   describe("ee", () => {
     beforeEach(() => {
       H.activateToken("bleeding-edge");
+    });
+
+    it("should show the 'Create a new embed' command palette item", () => {
+      cy.visit("/");
+      cy.findByRole("button", { name: /Search/ }).click();
+
+      H.commandPalette().within(() => {
+        H.commandPaletteInput().should("exist").type("new embed");
+        cy.findByText("Create a new embed").should("be.visible");
+      });
     });
 
     it("should have a 'New document' item", () => {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -395,7 +395,7 @@ describe("command palette", () => {
 
     it("should show the 'Create a new embed' command palette item", () => {
       cy.visit("/");
-      cy.findByRole("button", { name: /Search/ }).click();
+      cy.findByRole("button", { name: /search/ }).click();
 
       H.commandPalette().within(() => {
         H.commandPaletteInput().should("exist").type("new embed");

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -225,7 +225,7 @@ export const useCommandPaletteBasicActions = ({
       actions.push({
         id: "navigate-embed-js",
         section: "basic",
-        icon: "share",
+        icon: "embed",
         keywords: "embed flow, new embed, embed js",
         perform: () => dispatch(push("/embed-js")),
       });

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -221,6 +221,14 @@ export const useCommandPaletteBasicActions = ({
         id: "navigate-admin-settings",
         perform: () => dispatch(push("/admin/settings")),
       });
+
+      actions.push({
+        id: "navigate-embed-js",
+        section: "basic",
+        icon: "share",
+        keywords: "embed flow, new embed, embed js",
+        perform: () => dispatch(push("/embed-js")),
+      });
     }
 
     if (personalCollectionId) {

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -6,6 +6,7 @@ import { t } from "ttag";
 
 import {
   useDatabaseListQuery,
+  useHasTokenFeature,
   useSearchListQuery,
 } from "metabase/common/hooks";
 import Collections from "metabase/entities/collections/collections";
@@ -54,6 +55,7 @@ export const useCommandPaletteBasicActions = ({
   const hasDatabaseWithActionsEnabled =
     getHasDatabaseWithActionsEnabled(databases);
   const hasModels = models.length > 0;
+  const hasEmbedJsFeature = useHasTokenFeature("embedding_simple");
 
   const openNewModal = useCallback(
     (modalId: string) => {
@@ -221,7 +223,9 @@ export const useCommandPaletteBasicActions = ({
         id: "navigate-admin-settings",
         perform: () => dispatch(push("/admin/settings")),
       });
+    }
 
+    if (isAdmin && hasEmbedJsFeature) {
       actions.push({
         id: "navigate-embed-js",
         section: "basic",
@@ -262,6 +266,7 @@ export const useCommandPaletteBasicActions = ({
     openNewModal,
     isAdmin,
     personalCollectionId,
+    hasEmbedJsFeature,
   ]);
 
   useRegisterShortcut(initialActions, [initialActions]);

--- a/frontend/src/metabase/palette/shortcuts/global.ts
+++ b/frontend/src/metabase/palette/shortcuts/global.ts
@@ -139,8 +139,7 @@ export const globalShortcuts = {
       return t`Create a new embed`;
     },
 
-    // no shortcuts. command palette only.
-    shortcut: [],
+    shortcut: ["c e"],
     shortcutGroup: "global" as const,
   },
 };

--- a/frontend/src/metabase/palette/shortcuts/global.ts
+++ b/frontend/src/metabase/palette/shortcuts/global.ts
@@ -133,4 +133,14 @@ export const globalShortcuts = {
     shortcut: ["g h"],
     shortcutGroup: "global" as const,
   },
+
+  "navigate-embed-js": {
+    get name() {
+      return t`Create a new embed`;
+    },
+
+    // no shortcuts. command palette only.
+    shortcut: [],
+    shortcutGroup: "global" as const,
+  },
 };


### PR DESCRIPTION
Closes EMB-849

Adds the embed flow `(/embed-js)` to the command palette. You can verify this by pressing "CMD + K" and type in any of these keywords: `embed flow, new embed, embed js`

<img width="500" alt="CleanShot 2568-09-24 at 07 32 04@2x" src="https://github.com/user-attachments/assets/1c319280-9539-4026-bf00-0ac154f54aae" />
