### PR TITLE
Pre-select dashboard and question when embed flow is opened from the embed sharing modal

### DIFF
--- a/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
@@ -1,0 +1,64 @@
+import {
+  ORDERS_DASHBOARD_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
+
+import { getEmbedSidebar } from "../embedding/sdk-iframe-embedding-setup/helpers";
+
+const { H } = cy;
+
+describe("embed flow pre-selection from sharing modal", () => {
+  beforeEach(() => {
+    H.restore();
+    H.activateToken("pro-cloud");
+    cy.signInAsAdmin();
+    H.updateSetting("enable-embedding-simple", true);
+  });
+
+  it("pre-selects dashboard in embed flow when opened from dashboard sharing modal", () => {
+    H.visitDashboard(ORDERS_DASHBOARD_ID);
+    H.openSharingMenu("Embed");
+
+    H.getEmbedModalSharingPane().within(() => {
+      cy.findByRole("button", { name: "Embedded Analytics JS" }).click();
+    });
+
+    cy.location("search").should((search) => {
+      const params = new URLSearchParams(search);
+
+      expect(params.get("resource_type")).to.equal("dashboard");
+      expect(params.get("resource_id")).to.equal(String(ORDERS_DASHBOARD_ID));
+    });
+
+    cy.findByRole("radio", { name: /Dashboard/ }).should("be.checked");
+
+    cy.findByRole("button", { name: "Next" }).click();
+
+    getEmbedSidebar().within(() => {
+      cy.findByText("Select a dashboard to embed").should("be.visible");
+    });
+  });
+
+  it("pre-selects question in embed flow when opened from question sharing modal", () => {
+    H.visitQuestion(ORDERS_QUESTION_ID);
+    H.openSharingMenu("Embed");
+
+    H.getEmbedModalSharingPane().within(() => {
+      cy.findByRole("link", { name: "Embedded Analytics JS" }).click();
+    });
+
+    cy.location("search").should((search) => {
+      const params = new URLSearchParams(search);
+      expect(params.get("resource_type")).to.equal("question");
+      expect(params.get("resource_id")).to.equal(String(ORDERS_QUESTION_ID));
+    });
+
+    cy.findByRole("radio", { name: /Chart/ }).should("be.checked");
+
+    cy.findByRole("button", { name: "Next" }).click();
+
+    getEmbedSidebar().within(() => {
+      cy.findByText("Select a chart to embed").should("be.visible");
+    });
+  });
+});

--- a/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-flow.cy.spec.ts
@@ -10,8 +10,8 @@ const { H } = cy;
 describe("embed flow pre-selection from sharing modal", () => {
   beforeEach(() => {
     H.restore();
-    H.activateToken("pro-cloud");
     cy.signInAsAdmin();
+    H.activateToken("pro-self-hosted");
     H.updateSetting("enable-embedding-simple", true);
   });
 
@@ -20,7 +20,7 @@ describe("embed flow pre-selection from sharing modal", () => {
     H.openSharingMenu("Embed");
 
     H.getEmbedModalSharingPane().within(() => {
-      cy.findByRole("button", { name: "Embedded Analytics JS" }).click();
+      cy.findByRole("link", { name: "Embedded Analytics JS" }).click();
     });
 
     cy.location("search").should((search) => {
@@ -31,12 +31,18 @@ describe("embed flow pre-selection from sharing modal", () => {
     });
 
     cy.findByRole("radio", { name: /Dashboard/ }).should("be.checked");
-
     cy.findByRole("button", { name: "Next" }).click();
 
     getEmbedSidebar().within(() => {
       cy.findByText("Select a dashboard to embed").should("be.visible");
+      cy.findByText("Orders in a dashboard").should("be.visible");
     });
+
+    H.waitForSimpleEmbedIframesToLoad();
+
+    H.getSimpleEmbedIframeContent()
+      .findByText("Orders in a dashboard", { timeout: 10_000 })
+      .should("be.visible");
   });
 
   it("pre-selects question in embed flow when opened from question sharing modal", () => {
@@ -49,16 +55,23 @@ describe("embed flow pre-selection from sharing modal", () => {
 
     cy.location("search").should((search) => {
       const params = new URLSearchParams(search);
+
       expect(params.get("resource_type")).to.equal("question");
       expect(params.get("resource_id")).to.equal(String(ORDERS_QUESTION_ID));
     });
 
     cy.findByRole("radio", { name: /Chart/ }).should("be.checked");
-
     cy.findByRole("button", { name: "Next" }).click();
 
     getEmbedSidebar().within(() => {
       cy.findByText("Select a chart to embed").should("be.visible");
+      cy.findByText("Orders").should("be.visible");
     });
+
+    H.waitForSimpleEmbedIframesToLoad();
+
+    H.getSimpleEmbedIframeContent()
+      .findByText("Orders", { timeout: 10_000 })
+      .should("be.visible");
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedSetupProvider.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from "react";
 import { useLocation } from "react-use";
-import { match } from "ts-pattern";
+import { P, match } from "ts-pattern";
 import _ from "underscore";
 
 import { useSearchQuery } from "metabase/api";
@@ -73,23 +73,19 @@ export const SdkIframeEmbedSetupProvider = ({
   }, [location.search]);
 
   const defaultSettings = useMemo(() => {
-    const { resourceType, resourceId } = urlParams;
-
-    if (resourceType === "dashboard") {
-      return getDefaultSdkIframeEmbedSettings(
-        "dashboard",
-        resourceId ?? EMBED_FALLBACK_DASHBOARD_ID,
+    return match([urlParams.resourceType, urlParams.resourceId])
+      .with(["dashboard", P.nonNullable], ([, id]) =>
+        getDefaultSdkIframeEmbedSettings("dashboard", id),
+      )
+      .with(["question", P.nonNullable], ([, id]) =>
+        getDefaultSdkIframeEmbedSettings("chart", id),
+      )
+      .otherwise(() =>
+        getDefaultSdkIframeEmbedSettings(
+          "dashboard",
+          recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID,
+        ),
       );
-    }
-
-    if (resourceType === "question" && resourceId) {
-      return getDefaultSdkIframeEmbedSettings("chart", resourceId);
-    }
-
-    return getDefaultSdkIframeEmbedSettings(
-      "dashboard",
-      recentDashboards[0]?.id ?? EMBED_FALLBACK_DASHBOARD_ID,
-    );
   }, [recentDashboards, urlParams]);
 
   const [currentStep, setCurrentStep] = useState<SdkIframeEmbedSetupStep>(

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -95,3 +95,18 @@ describe("Embed flow > forward and backward navigation", () => {
     expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
   });
 });
+
+describe("Embed flow > pre-selection via url parameter", () => {
+  it("pre-selects question when resource_type=question is in URL", async () => {
+    setup({
+      simpleEmbeddingEnabled: true,
+      urlSearchParams: "?resource_type=question&resource_id=456",
+    });
+
+    const chartRadio = screen.getByRole("radio", { name: /Chart/ });
+    expect(chartRadio).toBeChecked();
+
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Select a chart to embed")).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/tests/test-setup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/tests/test-setup.tsx
@@ -14,14 +14,26 @@ import {
 
 import { SdkIframeEmbedSetup } from "../SdkIframeEmbedSetup";
 
+const mockUseLocation = jest.fn();
+
+jest.mock("react-use", () => ({
+  ...jest.requireActual("react-use"),
+  useLocation: () => mockUseLocation(),
+}));
+
 export const setup = (options?: {
   simpleEmbeddingEnabled?: boolean;
   jwtReady?: boolean;
+  urlSearchParams?: string;
 }) => {
   setupRecentViewsAndSelectionsEndpoints([], ["selections", "views"]);
   setupDashboardEndpoints(createMockDashboard());
   setupUpdateSettingsEndpoint();
   setupUpdateSettingEndpoint();
+
+  mockUseLocation.mockReturnValue({
+    search: options?.urlSearchParams || "",
+  });
 
   renderWithProviders(<SdkIframeEmbedSetup />, {
     storeInitialState: createMockState({

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -153,19 +153,20 @@ export function SelectEmbedTypePane({
             illustration={<EmbeddedJsIllustration />}
             isDisabled={isEmbedJsAvailable && !isEmbedJsEnabled}
             disabledLink="/admin/embedding/modular"
+            actionHint={
+              !isEmbedJsAvailable ? (
+                <UpsellEmbedJsCta embedFlowUrl={embedFlowUrl} />
+              ) : undefined
+            }
           >
             <List>
               <List.Item>{t`A simple way to embed using plain JavaScript`}</List.Item>
               <List.Item>{t`Embed static or interactive dashboards and charts with drill-down, the query builder or let people browse and manage collections.`}</List.Item>
               <List.Item>
-                {t`Advanced customizations for styling.`}{" "}
+                {t`Advanced customizations for styling.`} <br />{" "}
                 {!isEmbedJsAvailable && <LearnMore url={url} />}
               </List.Item>
             </List>
-
-            {!isEmbedJsAvailable && (
-              <UpsellEmbedJsCta embedFlowUrl={embedFlowUrl} />
-            )}
           </SharingPaneButton>
         </MaybeLinkEmbedJs>
 

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -50,8 +50,6 @@ export function SelectEmbedTypePane({
   getPublicUrl,
   goToNextStep,
 }: SelectEmbedTypePaneProps) {
-  // Selecting "Embedded Analytics JS" should link to the embed flow.
-  // TODO(EMB-848): pre-select dashboard and question when embed flow is opened from the embed sharing modal
   const embedFlowUrl = useMemo(() => {
     const params = new URLSearchParams();
 


### PR DESCRIPTION
Closes EMB-848

When using the "Embedded Analytics JS" link from the embed sharing modal, we want to pre-select dashboard and question in the embed flow, using `resource_type` and `resource_id` parameters.

### How to verify

See the end-to-end test on how to verify this. In short:

- Go to a dashboard or question
- Click on the Sharing icon > "Embed"
- In the embed modal, click on "Embedded Analytics JS"
- You should be brought to Embed Flow
- The question or dashboard you chose should be preselected.

### Demo

<img width="3016" height="1534" alt="CleanShot 2568-09-24 at 14 21 53@2x" src="https://github.com/user-attachments/assets/511fee6a-e714-4bc2-a19b-c4af99cfd146" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
