### PR TITLE
Reset colors when passing undefined to theme

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -4,9 +4,11 @@ import {
   InteractiveDashboard,
   InteractiveQuestion,
   MetabaseProvider,
+  type MetabaseTheme,
   StaticQuestion,
   defineMetabaseTheme,
 } from "@metabase/embedding-sdk-react";
+import { useState } from "react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
@@ -131,6 +133,42 @@ describe("scenarios > embedding-sdk > styles", () => {
         .findByText("Pick your starting data")
         .invoke("css", "color")
         .should("equal", "rgb(255, 0, 0)");
+    });
+
+    it('should be able to reset theme colors by setting it to "undefined" (EMB-696)', () => {
+      const THEME = defineMetabaseTheme({
+        colors: {
+          "text-primary": "#0000ff",
+        },
+      });
+      function TestComponent() {
+        const [theme, setTheme] = useState<MetabaseTheme | undefined>(
+          undefined,
+        );
+        return (
+          <MetabaseProvider
+            authConfig={DEFAULT_SDK_AUTH_PROVIDER_CONFIG}
+            theme={theme}
+          >
+            <button onClick={() => setTheme(THEME)}>Set theme</button>
+            <button onClick={() => setTheme(undefined)}>Remove theme</button>
+            <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />
+          </MetabaseProvider>
+        );
+      }
+      cy.mount(<TestComponent />);
+
+      getSdkRoot().within(() => {
+        cy.findByRole("button", { name: "Set theme" }).click();
+        cy.findByText("Orders")
+          .invoke("css", "color")
+          .should("equal", "rgb(0, 0, 255)");
+        cy.findByRole("button", { name: "Remove theme" }).click();
+        cy.findByText("Orders")
+          .invoke("css", "color")
+          // --mb-color-text-primary
+          .should("equal", "rgb(76, 87, 115)");
+      });
     });
   });
 

--- a/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
@@ -110,4 +110,15 @@ export function setGlobalEmbeddingColors(
   Object.entries(combinedThemeColors).forEach(([key, value]) => {
     colors[key as ColorName] = value;
   });
+
+  /**
+   * (EMB-696)
+   * Reset colors set previously that's now not passed in `sdkColors`.
+   * Otherwise, previously modified colors will persist, and won't be reset to default values.
+   */
+  Object.keys(colors).forEach((key) => {
+    if (!combinedThemeColors[key as ColorName]) {
+      delete colors[key as ColorName];
+    }
+  });
 }


### PR DESCRIPTION
Closes EMB-696

### Backport reasons
Pretty safe change to backport, so I backport it back to 55, and 56

### Description

The problem was that we modify the global variable `colors`. This caused a problem because we can set a new color there, but when we pass a new `theme.color`, we never unset the color previously set. So those colors persist.

This only affects colors that aren't defined in colors.ts e.g. `background`, `text-primary`, etc.
https://github.com/metabase/metabase/blob/281ec23eb14353ac149a640b30c5cfdc4d34b64a/frontend/src/metabase/lib/colors/colors.ts#L8-L53

### How to verify
1. Use this snippet to run your application with Embedding SDK (from EMB-696)
```ts
import {useState} from 'react'

import {
  MetabaseProvider,
  InteractiveQuestion,
} from '@metabase/embedding-sdk-react'

export default function App() {
  const [theme, setTheme] = useState(undefined)

  const themeA = {
    colors: {
      'text-primary': '#fff',
      background: '#2d2d30',
      brand: '#00bb00',
    },
    fontFamily: 'monospace',
  }

  return (
    <div>
      <MetabaseProvider
        authConfig={{
          metabaseInstanceUrl: 'http://localhost:3000',
          apiKey: 'your-api-key'
        }}
        theme={theme}
      >
        <div>
          <button onClick={() => setTheme(themeA)}>change theme to A</button>
          <button onClick={() => setTheme(undefined)}>clear theme</button>
        </div>

        <div
          style={{
            minHeight: '100vh',
            display: 'flex',
            justifyContent: 'center',
            alignItems: 'center',
          }}
        >
          <InteractiveQuestion
            questionId="new"
            onSave={(question, context) => {
              console.log('Question saved:', question, context)
            }}
          />
        </div>
      </MetabaseProvider>
    </div>
  )
}
```
1. When setting and removing the theme, it shouldn't leave the dark background color.

### Demo

#### After
![fixed](https://github.com/user-attachments/assets/8c8a341c-af14-4771-bcb9-ba1753efca03)

#### Before (record after already clicking the theme, so the background color already persists)
![not-fixed](https://github.com/user-attachments/assets/ac0cef3b-2906-497f-8e3a-bfa13df90731)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
