### PR TITLE
feat(embed-js): Implement mechanism of calling functions via message bus

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/hooks/use-sdk-iframe-embed-event-bus.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/hooks/use-sdk-iframe-embed-event-bus.ts
@@ -63,6 +63,7 @@ export function useSdkIframeEmbedEventBus({
 
           if (isExpectedMessage) {
             window.clearTimeout(waitTimeout);
+            window.removeEventListener("message", messageHandler);
             resolve(message.data.result as TResult);
           }
         };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/hooks/use-sdk-iframe-embed-event-bus.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/hooks/use-sdk-iframe-embed-event-bus.ts
@@ -1,13 +1,18 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { match } from "ts-pattern";
 
 import { trackSchemaEvent } from "metabase/lib/analytics";
 import { isWithinIframe } from "metabase/lib/dom";
+import { uuid } from "metabase/lib/uuid";
 import type { EmbeddedAnalyticsJsEventSchema } from "metabase-types/analytics/embedded-analytics-js";
 
 import type {
+  SdkIframeEmbedFunctionResultMessage,
   SdkIframeEmbedMessage,
   SdkIframeEmbedSettings,
+  SdkIframeEmbedTagFunctionCallMessage,
+  SdkIframeEmbedTagMessage,
+  SdkIframeEventBusCalledFunctionName,
 } from "../types/embed";
 
 type Handler = (event: MessageEvent<SdkIframeEmbedMessage>) => void;
@@ -17,17 +22,78 @@ type UsageAnalytics = {
   embedHostUrl: string;
 };
 
+// The parent frame logic may be async, so we give it up to 15 seconds to respond to cover possible slow network connection
+const WAIT_FOR_FUNCTION_RESULT_MESSAGE_MAX_WAIT_TIME = 15000;
+
 export function useSdkIframeEmbedEventBus({
   onSettingsChanged,
 }: {
   onSettingsChanged?: (settings: SdkIframeEmbedSettings) => void;
-}): {
-  embedSettings: SdkIframeEmbedSettings | null;
-} {
+}) {
   const [embedSettings, setEmbedSettings] =
     useState<SdkIframeEmbedSettings | null>(null);
   const [usageAnalytics, setUsageAnalytics] = useState<UsageAnalytics | null>(
     null,
+  );
+
+  const sendMessage = useCallback((message: SdkIframeEmbedTagMessage) => {
+    window.parent.postMessage(message, "*");
+  }, []);
+
+  const waitForIncomingMessage = useCallback(
+    async <
+      TResult extends SdkIframeEmbedFunctionResultMessage["data"]["result"],
+    >(
+      functionName: SdkIframeEventBusCalledFunctionName,
+      messageId: string,
+    ): Promise<TResult> => {
+      return new Promise<TResult>((resolve, reject) => {
+        let waitTimeout = 0;
+
+        waitTimeout = window.setTimeout(() => {
+          window.removeEventListener("message", messageHandler);
+          reject(new Error("Timeout waiting for incoming message"));
+        }, WAIT_FOR_FUNCTION_RESULT_MESSAGE_MAX_WAIT_TIME);
+
+        const messageHandler = (event: MessageEvent<SdkIframeEmbedMessage>) => {
+          const message = event.data as SdkIframeEmbedFunctionResultMessage;
+          const isExpectedMessage =
+            message.type === `metabase.embed.functionResult.${functionName}` &&
+            message.data?.messageId === messageId;
+
+          if (isExpectedMessage) {
+            window.clearTimeout(waitTimeout);
+            resolve(message.data.result as TResult);
+          }
+        };
+
+        window.addEventListener("message", messageHandler);
+      });
+    },
+    [],
+  );
+
+  const transferFunctionCallMessages = useCallback(
+    async <
+      TFunctionCallMessage extends SdkIframeEmbedTagFunctionCallMessage,
+      TFunctionResultMessage extends SdkIframeEmbedFunctionResultMessage,
+    >(
+      functionName: SdkIframeEventBusCalledFunctionName,
+      params: TFunctionCallMessage["data"]["params"],
+    ): Promise<TFunctionResultMessage["data"]["result"]> => {
+      const messageId = uuid();
+
+      sendMessage({
+        type: `metabase.embed.functionCall.${functionName}`,
+        data: {
+          messageId,
+          params,
+        },
+      });
+
+      return waitForIncomingMessage(functionName, messageId);
+    },
+    [sendMessage, waitForIncomingMessage],
   );
 
   useEffect(() => {
@@ -52,15 +118,15 @@ export function useSdkIframeEmbedEventBus({
     window.addEventListener("message", messageHandler);
 
     // notify embed.js that the iframe is ready
-    window.parent.postMessage({ type: "metabase.embed.iframeReady" }, "*");
+    sendMessage({ type: "metabase.embed.iframeReady" });
 
     return () => {
       window.removeEventListener("message", messageHandler);
     };
-  }, [onSettingsChanged]);
+  }, [onSettingsChanged, sendMessage]);
 
   useEffect(() => {
-    if (embedSettings?.instanceUrl && usageAnalytics) {
+    if (embedSettings?.instanceUrl && usageAnalytics?.embedHostUrl) {
       const isEmbeddedAnalyticsJsPreview = isMetabaseInstance(
         embedSettings.instanceUrl,
         usageAnalytics.embedHostUrl,
@@ -71,7 +137,7 @@ export function useSdkIframeEmbedEventBus({
     }
   }, [embedSettings?.instanceUrl, usageAnalytics]);
 
-  return { embedSettings };
+  return { sendMessage, transferFunctionCallMessages, embedSettings };
 }
 
 export function isMetabaseInstance(instanceUrl: string, embedHostUrl: string) {

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -13,7 +13,7 @@ import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 import type { EmbeddedAnalyticsJsEventSchema } from "metabase-types/analytics/embedded-analytics-js";
 import type { CollectionId } from "metabase-types/api";
 
-export type SdkIframeEventBusCalledFunctionName = "fetchStaticToken";
+export type SdkIframeEventBusCalledFunctionName = string;
 
 export type SdkIframeEventFunctionCallMessageHandler = (
   handlerData: SdkIframeFunctionCallHandlerData,

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -13,37 +13,86 @@ import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 import type { EmbeddedAnalyticsJsEventSchema } from "metabase-types/analytics/embedded-analytics-js";
 import type { CollectionId } from "metabase-types/api";
 
+export type SdkIframeEventBusCalledFunctionName = "fetchStaticToken";
+
+export type SdkIframeEventFunctionCallMessageHandler = (
+  handlerData: SdkIframeFunctionCallHandlerData,
+  message: SdkIframeEmbedTagFunctionCallMessage,
+) => void | Promise<void>;
+
+export type SdkIframeFunctionCallHandlerData = {
+  functionCallMessageType: SdkIframeEmbedTagFunctionCallMessage["type"];
+  functionResultMessageType: SdkIframeEmbedFunctionResultMessage["type"];
+  handler: SdkIframeEventFunctionCallMessageHandler;
+};
+
+export type SdkIframeEventBusFunctionCallMessage<TParams> = {
+  type: `metabase.embed.functionCall.${SdkIframeEventBusCalledFunctionName}`;
+  data: {
+    messageId: string;
+    params: TParams;
+  };
+};
+
+export type SdkIframeEventBusFunctionResultMessage<TResult> = {
+  type: `metabase.embed.functionResult.${SdkIframeEventBusCalledFunctionName}`;
+  data: {
+    messageId: string;
+    result: TResult;
+  };
+};
+
 /** Events that the embed.js script listens for */
 export type SdkIframeEmbedTagMessage =
-  | { type: "metabase.embed.iframeReady" }
-  | { type: "metabase.embed.requestSessionToken" };
+  | SdkIframeEmbedTagIframeReadyMessage
+  | SdkIframeEmbedTagRequestSessionTokenMessage
+  | SdkIframeEmbedTagFunctionCallMessage;
+
+export type SdkIframeEmbedTagFunctionCallMessage =
+  SdkIframeEventBusFunctionCallMessage<unknown>;
+
+export type SdkIframeEmbedTagIframeReadyMessage = {
+  type: "metabase.embed.iframeReady";
+};
+export type SdkIframeEmbedTagRequestSessionTokenMessage = {
+  type: "metabase.embed.requestSessionToken";
+};
 
 /** Events that the sdk embed route listens for */
 export type SdkIframeEmbedMessage =
-  | {
-      type: "metabase.embed.setSettings";
-      data: SdkIframeEmbedSettings;
-    }
-  | {
-      type: "metabase.embed.submitSessionToken";
-      data: {
-        authMethod: MetabaseAuthMethod;
-        sessionToken: MetabaseEmbeddingSessionToken;
-      };
-    }
-  | {
-      type: "metabase.embed.reportAuthenticationError";
-      data: {
-        error: MetabaseError<MetabaseErrorCode, unknown>;
-      };
-    }
-  | {
-      type: "metabase.embed.reportAnalytics";
-      data: {
-        usageAnalytics: EmbeddedAnalyticsJsEventSchema;
-        embedHostUrl: string;
-      };
-    };
+  | SdkIframeEmbedSetSettingsMessage
+  | SdkIframeEmbedSubmitSessionTokenMessage
+  | SdkIframeEmbedReportAuthenticationError
+  | SdkIframeEmbedReportAnalytics
+  | SdkIframeEmbedFunctionResultMessage;
+
+export type SdkIframeEmbedFunctionResultMessage =
+  SdkIframeEventBusFunctionResultMessage<unknown>;
+
+export type SdkIframeEmbedSetSettingsMessage = {
+  type: "metabase.embed.setSettings";
+  data: SdkIframeEmbedSettings;
+};
+export type SdkIframeEmbedSubmitSessionTokenMessage = {
+  type: "metabase.embed.submitSessionToken";
+  data: {
+    authMethod: MetabaseAuthMethod;
+    sessionToken: MetabaseEmbeddingSessionToken;
+  };
+};
+export type SdkIframeEmbedReportAuthenticationError = {
+  type: "metabase.embed.reportAuthenticationError";
+  data: {
+    error: MetabaseError<MetabaseErrorCode, unknown>;
+  };
+};
+export type SdkIframeEmbedReportAnalytics = {
+  type: "metabase.embed.reportAnalytics";
+  data: {
+    usageAnalytics: EmbeddedAnalyticsJsEventSchema;
+    embedHostUrl: string;
+  };
+};
 
 // --- Embed Option Interfaces ---
 


### PR DESCRIPTION
Implement mechanism of calling functions via message busю

Currently it's unused, it's used in Static Embedding POC for `fetchStaticToken`
Can be also used for `fetchAuthToken` or for any other function that must be passed from metabase config of embed JS to iframe and <MetabaseProvider>

Tests are not added, i assume we have to cover it on e2e level for a specific function like `fetchAuthToken` or `fetchStaticToken`