### PR TITLE
Install ca-certificates prior to attempting curl

### DIFF
--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -6,7 +6,8 @@ ARG GIT_COMMIT_SHA
 ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
 
 # dependencies
-RUN apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-cjk font-noto-thai java-cacerts && \
+RUN apk add -U bash fontconfig curl ca-certificates font-noto font-noto-arabic font-noto-hebrew font-noto-cjk font-noto-thai java-cacerts && \
+    update-ca-certificates && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /app/certs && \


### PR DESCRIPTION
We've been seeing a lot of failures of the `containerize` job in the CI lately. It fails with the following error:

```
Error: buildx failed with: ERROR: failed to build: failed to solve: process "/bin/sh -c apk add -U bash fontconfig curl font-noto font-noto-arabic font-noto-hebrew font-noto-cjk font-noto-thai java-cacerts &&     apk upgrade &&     rm -rf /var/cache/apk/* &&     mkdir -p /app/certs &&     curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  &&     /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit &&     curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /app/certs/DigiCertGlobalRootG2.crt.pem  &&     /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias azure-cert -file /app/certs/DigiCertGlobalRootG2.crt.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit &&     mkdir -p /plugins && chmod a+rwx /plugins" did not complete successfully: exit code: 35
```

EDIT:
Here's a concise error that proves the SSL handshake is the culprit
`24.83 curl: (35) TLS connect error: error:0A000410:SSL routines::ssl/tls alert handshake failure`

Since this is not my area of expertise, I asked GPT to investigate and offer some potential solutions. The absolute minimal attempt is to first install `ca-certificates` and to update them because, according to GPT, the exit code 35 is an internal `curl` code stands for "SSL connect error", which suggests that the SSL handshake failed.

This is a quote from the chat:
> Common causes in GitHub Actions / Docker Buildx multi-arch context:
>   - ❌ Outdated CA bundle in the base image (e.g. Alpine variants sometimes miss roots).
>   - ❌ qemu emulation quirks on ARM builds (TLS libraries fail under emulation).
>   - ❌ Temporary network hiccup or GitHub runner blocking a specific endpoint.
>   - ❌ Missing ca-certificates package (in Alpine, you need apk add ca-certificates).


I have tried both:
- `curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem` and
- `curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`

They both worked just fine from my mac. This suggests that the links are correct. The next place to look at was the environment in which these commands are executed - which is a GitHub runner. Hence, why I'm adding the ca-certificates to the runner prior to running curl.

> If your build environment (like Alpine, or under qemu emulation) has an outdated or missing root CA set prior to doing curl, the SSL handshake may fail. Even with a correct URL, curl (or the TLS library in the container) may not trust the download unless your CA trust store is properly populated.