### PR TITLE
Fix failing transform tags test

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -622,7 +622,6 @@ LIMIT
       getTagsInput().type("New tag");
       H.popover().findByText("New tag").click();
       cy.wait("@createTag");
-      H.popover().findByText("New tag").should("be.visible");
 
       cy.log("Navigate to transform B");
       getNavSidebar().findByText("Transforms").click();

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -566,7 +566,6 @@ LIMIT
       getTagsInput().type("New tag");
       H.popover().findByText("New tag").click();
       cy.wait("@createTag");
-      H.popover().findByText("New tag").should("be.visible");
       H.undoToast().should("contain.text", "Transform tags updated");
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/api/transform-tag.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/transform-tag.ts
@@ -55,8 +55,13 @@ export const transformTagApi = EnterpriseApi.injectEndpoints({
         method: "DELETE",
         url: `/api/ee/transform-tag/${id}`,
       }),
-      invalidatesTags: (_, error) =>
-        invalidateTags(error, [listTag("transform-tag")]),
+      invalidatesTags: (_, error, id) =>
+        invalidateTags(error, [
+          listTag("transform-tag"),
+          // Invalidate transforms that are tagged with this tag, since
+          // they are not tagged with listTag("transform-tag").
+          idTag("transform-tag", id),
+        ]),
     }),
   }),
 });


### PR DESCRIPTION
Fixes a test that is failing on master for transform tags.

1. The e2e test was execting the tag to show up in the popover, even though we removed it https://github.com/metabase/metabase/pull/63714
2. Fix the invalidations for tags, which was broken in https://github.com/metabase/metabase/pull/63647