### PR TITLE
Do not URL-encode default redirect URL

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -15,9 +15,7 @@
    [metabase.sso.core :as sso]
    [metabase.util.i18n :refer [tru]]
    [ring.util.response :as response]
-   [toucan2.core :as t2])
-  (:import
-   (java.net URLEncoder)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -98,7 +96,7 @@
 
 (defn- session-data
   [jwt {{redirect :return_to} :params, :as request}]
-  (let [redirect-url (or redirect (URLEncoder/encode "/"))]
+  (let [redirect-url (or redirect "/")]
     (sso-utils/check-sso-redirect redirect-url)
     (let [jwt-data     (try
                          (jwt/unsign jwt (sso-settings/jwt-shared-secret)


### PR DESCRIPTION
I think this was just a mistake - there's no need to URL-encode this and it actually breaks the redirect.

[UXW-1753: JWT SSO login without return_to shows "Ambiguous URI path separator" error](https://linear.app/metabase/issue/UXW-1753/jwt-sso-login-without-return-to-shows-ambiguous-uri-path-separator)