### PR TITLE
revert nett-common and netty-buffer bumps

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -15,5 +15,6 @@
   org.apache.arrow/arrow-memory-core     {:mvn/version "18.3.0"}
   org.apache.arrow/arrow-memory-netty    {:mvn/version "17.0.0"}
   org.apache.arrow/arrow-vector          {:mvn/version "17.0.0"}
-  io.netty/netty-common                  {:mvn/version "4.2.4.Final"}
-  io.netty/netty-buffer                  {:mvn/version "4.2.4.Final"}}}
+  ;; matches those in athena
+  io.netty/netty-common                  {:mvn/version "4.1.118.Final"}
+  io.netty/netty-buffer                  {:mvn/version "4.1.118.Final"}}}


### PR DESCRIPTION
fixes https://github.com/metabase/metabase/issues/63396


rather than 4.2.4.Final, they will now be "io.netty/netty-buffer 4.1.118.Final" which puts it the same as that in 3.5.0.

The issue is that both the bigquery-cloud-sdk driver and athena driver get put onto the classpath and it depends on which order the drivers are added for resolving which version of this netty buffer dep you get.

```clojure
user=> (metabase.classloader.core/the-classloader)
user=> (enumeration-seq (.. (Thread/currentThread) getContextClassLoader (getResources "io/netty/buffer/ByteBufAllocator.class")))
(#object[java.net.URL 0x3bb34fe "jar:file:/private/tmp/fixed-athena/plugins/bigquery-cloud-sdk.metabase-driver.jar!/io/netty/buffer/ByteBufAllocator.class"]
 #object[java.net.URL 0x4ac1867d "jar:file:/private/tmp/fixed-athena/plugins/athena.metabase-driver.jar!/io/netty/buffer/ByteBufAllocator.class"])
```

One annoying bit to keep track of this is that bigquery uses a regular jar that specifies its dependencies, so you can you regular tooling:

```
clj -X:deps tree :aliases '[:drivers]' > /tmp/deps.with.netty.downgrade
```

And then see those deps:

```
  . metabase/bigquery-cloud-sdk /Users/dan/projects/work/metabase/modules/drivers/bigquery-cloud-sdk
    . com.google.cloud/google-cloud-bigquery 2.54.2
      . com.google.cloud/google-cloud-core 2.60.0
      . ... [lots omitted]
    . org.apache.arrow/arrow-memory-netty 17.0.0
      X org.apache.arrow/arrow-memory-core 17.0.0 :older-version
      . org.apache.arrow/arrow-memory-netty-buffer-patch 17.0.0
        X org.apache.arrow/arrow-memory-core 17.0.0 :older-version
        . io.netty/netty-buffer 4.1.110.Final
```

This version was created without any pinning of netty. Checking the athena version is a bit more tricky. We use a fat jar. But you can download the source from amazon as a jar with deps:

```
athena-jdbc-3.5.0-lean-jar-and-separate-dependencies-jars
```

https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-previous-versions.html

This zip includes `runtime-dependencies` which includes `netty-buffer-4.1.jar`

The pom inside of this jar specifies

```xml
  <parent>
    <groupId>io.netty</groupId>
    <artifactId>netty-parent</artifactId>
    <version>4.1.118.Final</version>
  </parent>
```

And `META-INF/maven/io.netty/netty-buffer/pom.properties` specifies

```
artifactId=netty-buffer
groupId=io.netty
version=4.1.118.Final
```

So i am confident now that with the pinning in bigquery and this version here that regardless of class resolution from
"jar:file:/private/tmp/fixed-athena/plugins/bigquery-cloud-sdk.metabase-driver.jar!/io/netty/buffer/ByteBufAllocator.class" or
"jar:file:/private/tmp/fixed-athena/plugins/athena.metabase-driver.jar!/io/netty/buffer/ByteBufAllocator.class" you will get the same class and athena shall work again.

Final deps resolution:

```
  . metabase/bigquery-cloud-sdk /Users/dan/projects/work/metabase/modules/drivers/bigquery-cloud-sdk
    . com.google.cloud/google-cloud-bigquery 2.54.2
      . com.google.cloud/google-cloud-core 2.60.0
      . ... [omitted]
    . org.apache.arrow/arrow-memory-netty 17.0.0
      X org.apache.arrow/arrow-memory-core 17.0.0 :older-version
      . org.apache.arrow/arrow-memory-netty-buffer-patch 17.0.0
        X org.apache.arrow/arrow-memory-core 17.0.0 :older-version
        X io.netty/netty-buffer 4.1.110.Final :older-version        <--- specified in pom
        X io.netty/netty-common 4.1.110.Final :older-version
        X org.slf4j/slf4j-api 2.0.13 :use-top
      X io.netty/netty-common 4.1.110.Final :older-version
    . io.netty/netty-common 4.1.118.Final                           <--- overriden and matching athena
    . io.netty/netty-buffer 4.1.118.Final
```