### PR TITLE
Double scrollbars are showing up on metabase-browser when always show scrollbar is set

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/MetabaseBrowser.tsx
@@ -139,7 +139,7 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
       ),
     )
     .with({ type: "collection" }, (view) => (
-      <Box px="xl" pt="lg" style={{ overflowY: "scroll" }}>
+      <Box px="xl" pt="lg" style={{ overflowY: "auto" }}>
         <CollectionBrowser
           collectionId={view.id}
           visibleColumns={settings.collectionVisibleColumns}
@@ -153,7 +153,6 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
 
             setCurrentView({ type, id: item.id });
           }}
-          style={{ overflowY: "scroll" }}
         />
       </Box>
     ))


### PR DESCRIPTION
Closes EMB-763

Prevent double scrollbars from being shown when "always show scrollbar" setting is set on operating system level.

### How to verify

- Go to "System Settings"
- Set your "Scroll bar behavior > Show scroll bars"  to **always**

<img width="1416" height="1068" alt="CleanShot 2568-09-24 at 21 00 45@2x" src="https://github.com/user-attachments/assets/98d63179-41a0-4b01-b974-93f6a04873a9" />

- Go to embed flow (/embed-js)
- Select the "Browser" experience
- Visit a collection with many items e.g. the Examples collection
- There should only be one scrollbar shown

### Demo

Before: two scrollbars

<img width="2954" height="1768" alt="CleanShot 2568-09-24 at 20 57 43@2x" src="https://github.com/user-attachments/assets/8c67143b-1062-4686-b2d4-972976383b39" />

After: one scrollbar

<img width="2948" height="1774" alt="CleanShot 2568-09-24 at 20 57 12@2x" src="https://github.com/user-attachments/assets/35708e4b-aa7f-48c9-a07f-5c79881054e1" />