### PR TITLE
WRK-900 [Bug] Detail View: related records are messed up in tables with no PK

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -596,6 +596,8 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
       cy.findByTestId("object-detail").within(() => {
         cy.findByLabelText("Copy link to this record").should("not.exist");
         cy.findByLabelText("Open in full page").should("not.exist");
+
+        cy.log("should not show relationships when there is no PK (WRK-900)");
         cy.findByText(/is connected to/).should("not.exist");
         cy.findByRole("link", { name: /Orders/ }).should("not.exist");
       });
@@ -675,7 +677,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
   });
 
   describe("detail page links - models", () => {
-    it("no primary keys", () => {
+    it("no primary keys (WRK-900)", () => {
       H.createQuestion(
         {
           type: "model",
@@ -696,6 +698,10 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
       cy.findByTestId("object-detail").within(() => {
         cy.findByLabelText("Copy link to this record").should("not.exist");
         cy.findByLabelText("Open in full page").should("not.exist");
+
+        cy.log("should not show relationships when there is no PK (WRK-900)");
+        cy.findByText(/is connected to/).should("not.exist");
+        cy.findByRole("link", { name: /Orders/ }).should("not.exist");
       });
     });
 

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -574,7 +574,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
   });
 
   describe("detail page links - questions", () => {
-    it("no primary keys", () => {
+    it("no primary keys (WRK-900)", () => {
       H.visitQuestionAdhoc({
         display: "table",
         dataset_query: {
@@ -596,6 +596,8 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
       cy.findByTestId("object-detail").within(() => {
         cy.findByLabelText("Copy link to this record").should("not.exist");
         cy.findByLabelText("Open in full page").should("not.exist");
+        cy.findByText(/is connected to/).should("not.exist");
+        cy.findByRole("link", { name: /Orders/ }).should("not.exist");
       });
     });
 

--- a/frontend/src/metabase/detail-view/components/DetailViewPage/DetailViewPage.tsx
+++ b/frontend/src/metabase/detail-view/components/DetailViewPage/DetailViewPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "metabase/detail-view/utils";
 import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
 import { Box, Group, Stack, rem } from "metabase/ui";
+import { isPK } from "metabase-lib/v1/types/utils/isa";
 import type {
   DatasetColumn,
   ForeignKey,
@@ -52,6 +53,7 @@ export function DetailViewPage({
   const isMediumBreakpoint = width <= BREAKPOINT_MEDIUM;
   const isSmallBreakpoint = width <= BREAKPOINT_SMALL;
   const paddingLeft = isSmallBreakpoint ? 32 : DETAIL_VIEW_PADDING_LEFT;
+  const hasPk = columns.some(isPK);
 
   return (
     <Stack
@@ -105,7 +107,7 @@ export function DetailViewPage({
           </Stack>
         </Group>
 
-        {tableForeignKeys && tableForeignKeys.length > 0 && (
+        {hasPk && tableForeignKeys && tableForeignKeys.length > 0 && (
           <Box
             flex={isMediumBreakpoint ? undefined : "0 0 auto"}
             pl={rem(isMediumBreakpoint ? paddingLeft : 40)}

--- a/frontend/src/metabase/detail-view/components/DetailViewSidesheet/DetailViewSidesheet.tsx
+++ b/frontend/src/metabase/detail-view/components/DetailViewSidesheet/DetailViewSidesheet.tsx
@@ -40,6 +40,7 @@ import {
 } from "metabase/ui";
 import { DeleteObjectModal } from "metabase/visualizations/components/ObjectDetail/DeleteObjectModal";
 import * as Lib from "metabase-lib";
+import { isPK } from "metabase-lib/v1/types/utils/isa";
 import type {
   DatasetColumn,
   ForeignKey,
@@ -108,6 +109,7 @@ export function DetailViewSidesheet({
   const icon = getEntityIcon(table?.entity_type);
   const modelId = getModelId(table);
   const isNavEnabled = rowFromProps != null && showNav;
+  const hasPk = columns.some(isPK);
 
   const [actionId, setActionId] = useState<WritebackActionId>();
   const [deleteActionId, setDeleteActionId] = useState<WritebackActionId>();
@@ -361,24 +363,27 @@ export function DetailViewSidesheet({
             </Stack>
           </Group>
 
-          {table && tableForeignKeys && tableForeignKeys.length > 0 && (
-            <Box
-              flex="1"
-              bg="var(--mb-color-background-light)"
-              px={rem(56)}
-              py={rem(48)}
-            >
-              <Relationships
-                columns={columns}
-                row={row}
-                rowId={rowId}
-                rowName={rowName}
-                table={table}
-                tableForeignKeys={tableForeignKeys}
-                onClick={onClose}
-              />
-            </Box>
-          )}
+          {table &&
+            hasPk &&
+            tableForeignKeys &&
+            tableForeignKeys.length > 0 && (
+              <Box
+                flex="1"
+                bg="var(--mb-color-background-light)"
+                px={rem(56)}
+                py={rem(48)}
+              >
+                <Relationships
+                  columns={columns}
+                  row={row}
+                  rowId={rowId}
+                  rowName={rowName}
+                  table={table}
+                  tableForeignKeys={tableForeignKeys}
+                  onClick={onClose}
+                />
+              </Box>
+            )}
         </Stack>
       </Sidesheet>
 


### PR DESCRIPTION
Closes [WRK-900](https://linear.app/metabase/issue/WRK-900/bug-detail-view-related-records-are-messed-up-in-tables-with-no-pk)

### How to verify

1. New > Question > Products
2. Deselect "ID" column
3. Visualize
4. Open object details for any row

There should be no relationships shown.