### PR TITLE
Add last run status info to jobs

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.tsx
@@ -17,6 +17,7 @@ import type { JobListParams } from "metabase-enterprise/transforms/types";
 import type { TransformJob, TransformJobId } from "metabase-types/api";
 
 import { ListEmptyState } from "../../../components/ListEmptyState";
+import { RunStatusInfo } from "../../../components/RunStatusInfo";
 import { TagList } from "../../../components/TagList";
 import { getJobUrl } from "../../../urls";
 import { parseTimestampWithTimezone } from "../../../utils";
@@ -68,8 +69,11 @@ export function JobList({ params }: { params: JobListParams }) {
             <span className={S.nowrap}>{t`Last run at`}</span>{" "}
             <TimezoneIndicator />
           </Flex>,
+          <span key="last-run-status" className={S.nowrap}>
+            {t`Last run status`}
+          </span>,
           <Flex align="center" gap="xs" key="next-run">
-            <span className={S.nowrap}>{t`Next run`}</span>{" "}
+            <span className={S.nowrap}>{t`Next run at`}</span>{" "}
             <TimezoneIndicator />
           </Flex>,
           t`Transforms`,
@@ -90,6 +94,22 @@ export function JobList({ params }: { params: JobListParams }) {
                     systemTimezone,
                   ).format("lll")
                 : null}
+            </td>
+            <td className={S.nowrap}>
+              {job.last_run != null ? (
+                <RunStatusInfo
+                  status={job.last_run.status}
+                  message={job.last_run.message}
+                  endTime={
+                    job.last_run.end_time != null
+                      ? parseTimestampWithTimezone(
+                          job.last_run.end_time,
+                          systemTimezone,
+                        ).toDate()
+                      : null
+                  }
+                />
+              ) : null}
             </td>
             <td className={S.nowrap}>
               {job.next_run?.start_time

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/JobListPage/JobList/JobList.unit.spec.tsx
@@ -19,6 +19,7 @@ import type {
 import {
   createMockTransform,
   createMockTransformJob,
+  createMockTransformRun,
 } from "metabase-types/api/mocks";
 
 import { JobList } from "./JobList";
@@ -62,6 +63,17 @@ function setup({
 }
 
 describe("JobList", () => {
+  it("should show the last run status", async () => {
+    setup({
+      jobs: [
+        createMockTransformJob({
+          last_run: createMockTransformRun({ status: "started" }),
+        }),
+      ],
+    });
+    expect(await screen.findByText("In progress")).toBeInTheDocument();
+  });
+
   it("should show the number of transforms per job", async () => {
     const job1Id = 1;
     const job2Id = 2;


### PR DESCRIPTION
Fixes https://linear.app/metabase/issue/QUE-2570/fe-add-last-run-status-to-the-jobs-list

<img width="1451" height="461" alt="Screenshot 2025-09-24 at 13 51 59" src="https://github.com/user-attachments/assets/5d403fd3-3bed-4995-a6a2-05d7764e7ac8" />
