### PR TITLE
fix: make drill icons visible on hover in click actions menu

### DIFF
--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionControl.module.css
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionControl.module.css
@@ -25,4 +25,5 @@
 
 .ClickActionButtonIcon {
   margin-right: 0.2rem;
+  color: var(--mb-color-text-medium);
 }


### PR DESCRIPTION
## Summary

• Fixes drill icons not being visible when hovering over "Is" and "Is not" drill options
• Adds default color to `.ClickActionButtonIcon` class in ClickActionControl.module.css
• Icons now display with medium text color by default and turn white on hover

## Test plan

- [x] Navigate to a table view in Metabase
- [x] Click on any cell value
- [x] Hover over drill options like "Is" or "Is not"  
- [x] Verify that drill icons are now visible with medium color
- [x] Verify that drill icons turn white on hover

## Screenshots

**Before:** Drill icons were invisible/transparent
**After:** Drill icons are visible with medium text color and turn white on hover

Fixes #63956

🤖 Generated with [Claude Code](https://claude.ai/code)