### PR TITLE
Ensure we parse template tags for transform edits in Metabot sidebar

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-query-results/use-query-results.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/hooks/use-query-results/use-query-results.ts
@@ -27,7 +27,7 @@ export function useQueryResults(
       ? Question.create({
           dataset_query: lastRunQuery,
           metadata,
-          visualization_settings: question.settings(),
+          visualization_settings: currentQuestion.settings(),
         })
       : null;
     const result = results ? results[0] : null;


### PR DESCRIPTION
Ensures that transform changes suggested by Metabot get any template tags parsed so that query execution can succeed, using a similar approach to https://github.com/metabase/metabase/pull/63691