### PR TITLE
Silence noisy fingerprint validation issue

### DIFF
--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -399,7 +399,8 @@
 
 (mu/defn- normalize-fingerprint :- [:maybe ::lib.schema.metadata.fingerprint/fingerprint]
   [fingerprint :- [:maybe :map]]
-  (lib.normalize/normalize ::lib.schema.metadata.fingerprint/fingerprint fingerprint))
+  (when fingerprint
+    (lib.normalize/normalize ::lib.schema.metadata.fingerprint/fingerprint fingerprint)))
 
 (mu/defn normalize-source-metadata
   "Normalize source/results metadata for a single column."


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/63891
(note master is already fixed so this is a trivial PR against 56)

the logs:

```
2025-09-24 19:39:25,002 WARN lib.normalize :: Error normalizing pMBQL: ["invalid type"]
{:value nil, :schema :metabase.lib.schema.metadata.fingerprint/fingerprint}

2025-09-24 19:39:25,003 WARN lib.normalize :: Error normalizing pMBQL: ["invalid type"]
{:value nil, :schema :metabase.lib.schema.metadata.fingerprint/fingerprint}

2025-09-24 19:39:25,004 WARN lib.normalize :: Error normalizing pMBQL: ["invalid type"]
{:value nil, :schema :metabase.lib.schema.metadata.fingerprint/fingerprint}
```

Notably these are absent in master but present in 56. They were fixed in https://github.com/metabase/metabase/pull/63360 but this PR changes lots of stuff and doesn't backport cleanly into 56. But we'll grab this silencing bit here in the meantime


Another callout: this is merging against **release-x.56.x** and not master. master is fixed so no need to backport, just commit against 56 for a trivial change.