### PR TITLE
Add result ID to search click event tracking

### DIFF
--- a/e2e/test/scenarios/search/search-snowplow.cy.spec.js
+++ b/e2e/test/scenarios/search/search-snowplow.cy.spec.js
@@ -54,6 +54,7 @@ H.describeWithSnowplow("scenarios > search > snowplow", () => {
               search_engine: P.string,
               request_id: P.string,
               entity_model: P.string,
+              entity_id: P.number,
               search_term_hash: P.string,
               search_term: null,
             },

--- a/frontend/src/metabase-types/analytics/search.ts
+++ b/frontend/src/metabase-types/analytics/search.ts
@@ -75,6 +75,7 @@ export type SearchClickEvent = ValidateEvent<{
   search_engine: string | null;
   request_id: string | null;
   entity_model: string | null;
+  entity_id: number | null;
   search_term_hash: string | null;
   search_term: string | null;
 }>;

--- a/frontend/src/metabase-types/analytics/search.ts
+++ b/frontend/src/metabase-types/analytics/search.ts
@@ -18,6 +18,7 @@ type SearchEventSchema = {
   request_id?: string | null;
   offset?: number | null;
   entity_model?: string | null;
+  entity_id?: number | null;
   search_term_hash?: string | null;
   search_term?: string | null;
 };

--- a/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/SearchTab/SearchResults.tsx
@@ -61,6 +61,7 @@ export const SearchResults = <
                     searchEngine: searchEngine || "unknown",
                     requestId: searchRequestId,
                     entityModel: item.model,
+                    entityId: typeof item.id === "number" ? item.id : null,
                     searchTerm,
                   });
                   onItemSelect(item as unknown as Item);

--- a/frontend/src/metabase/lib/analytics.ts
+++ b/frontend/src/metabase/lib/analytics.ts
@@ -29,7 +29,7 @@ const VERSIONS: Record<SchemaType, SchemaVersion> = {
   invite: "1-0-1",
   model: "1-0-0",
   question: "1-0-6",
-  search: "1-1-1",
+  search: "1-1-2",
   serialization: "1-0-1",
   settings: "1-0-2",
   setup: "1-0-3",

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -188,6 +188,7 @@ export const useCommandPalette = ({
                 searchEngine: searchResults?.engine || "unknown",
                 requestId: searchRequestId,
                 entityModel: null,
+                entityId: null,
                 searchTerm: debouncedSearchText,
               });
             },
@@ -216,6 +217,7 @@ export const useCommandPalette = ({
                   searchEngine: searchResults?.engine || "unknown",
                   requestId: searchRequestId,
                   entityModel: result.model,
+                  entityId: typeof result.id === "number" ? result.id : null,
                   searchTerm: debouncedSearchText,
                 });
               },

--- a/frontend/src/metabase/search/analytics.ts
+++ b/frontend/src/metabase/search/analytics.ts
@@ -79,6 +79,7 @@ type TrackSearchClickParams = {
   searchEngine: string;
   requestId?: string | null;
   entityModel?: string | null;
+  entityId?: number | null;
   searchTerm?: string | null;
 };
 
@@ -89,6 +90,7 @@ export const trackSearchClick = ({
   searchEngine,
   requestId = null,
   entityModel = null,
+  entityId = null,
   searchTerm = null,
 }: TrackSearchClickParams) => {
   const dispatchTrackSearchClick = async () => {
@@ -100,6 +102,7 @@ export const trackSearchClick = ({
       search_engine: searchEngine,
       request_id: requestId,
       entity_model: entityModel,
+      entity_id: entityId,
       search_term_hash: searchTerm ? await hashSearchTerm(searchTerm) : null,
       search_term: shouldReportSearchTerm() && searchTerm ? searchTerm : null,
     });

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
@@ -97,6 +97,7 @@ export function SearchResult({
       searchEngine: searchEngine || "unknown",
       requestId: searchRequestId,
       entityModel: result.model,
+      entityId: typeof result.id === "number" ? result.id : null,
       searchTerm,
     });
     onChangeLocation(result.getUrl());

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/search/jsonschema/1-1-2
@@ -1,0 +1,217 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Search events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "search",
+    "format": "jsonschema",
+    "version": "1-1-2"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "search_query",
+        "search_click",
+        "new_search_query",
+        "search_results_filtered"
+      ],
+      "maxLength": 1024
+    },
+    "runtime_milliseconds": {
+      "description": "Number of milliseconds it took to successfully run the search query",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "context": {
+      "description": "Source of the search event",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "search-app",
+        "search-bar",
+        "command-palette",
+        "entity-picker"
+      ],
+      "maxLength": 1024
+    },
+    "total_results": {
+      "description": "The total number of results that matched the query",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "page_results": {
+      "description": "The number of results returned per page",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "position": {
+      "description": "The position of the result in the list that was clicked. Zero indexed",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "target_type": {
+      "description": "The type of item in the search list that was clicked.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "item",
+        "view_more"
+      ]
+    },
+    "content_type": {
+      "description": "Filter for entity types (question, database, model, etc.)",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "description": "An entity type (card, question, dashboard, etc.)",
+        "type": "string",
+        "enum": [
+          "dashboard",
+          "card",
+          "dataset",
+          "collection",
+          "database",
+          "table",
+          "action"
+        ],
+        "maxLength": 1024
+      }
+    },
+    "creator": {
+      "description": "Filter for created by a user",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "last_editor": {
+      "description": "Filter for last edited by a user",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "creation_date": {
+      "description": "Filter for a time when a user creates an entity",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "last_edit_date": {
+      "description": "Filter for a time when a user last edited an entity",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "verified_items": {
+      "description": "Filter for entities that have been marked as verified",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "search_native_queries": {
+      "description": "Toggles whether search should include SQL and/or native queries",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "search_archived": {
+      "description": "Toggles whether search should include archived items",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "search_engine": {
+      "description": "The search engine used to perform the search",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "request_id": {
+      "description": "The unique request ID for the search request",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "offset": {
+      "description": "The offset of the search results (for pagination)",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "entity_model": {
+      "description": "The model type of the clicked entity",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "entity_id": {
+      "description": "The ID of the clicked entity",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "search_term_hash": {
+      "description": "A hash of the search term and instance id",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "search_term": {
+      "description": "The search term as a string (only reported for specific analytics UUIDs)",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    }
+  },
+  "required": [
+    "event"
+  ],
+  "additionalProperties": true
+}


### PR DESCRIPTION
Follow up to #62200

Including the `id` of the entity that is clicked during the tracking of a search click event

To do this we need to add a column and thus introduce a new search event schema `1-1-2` which is a copy of `1-1-1` but with a new numeric `entity_id` column