### PR TITLE
Closes EMB-853 renamed legends get ignored by translation

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -137,17 +137,21 @@ export const translateFieldValuesInSeries = (
     let translatedRows: RowValue[][];
 
     if (singleSeries.card?.display === "pie") {
-      const pieRows = singleSeries.card.visualization_settings?.["pie.rows"];
-      const keyToNameMap = pieRows
-        ? pieRows.reduce(
-            (acc, row) => {
-              acc[row.key] = row.name;
-              return acc;
-            },
-            {} as Record<string, string>,
-          )
-        : {};
+      const pieRows =
+        singleSeries.card.visualization_settings?.["pie.rows"] ?? [];
+      const keyToNameMap = Object.fromEntries(
+        pieRows.map((row) => [row.key, row.name]),
+      );
 
+      // The pie chart relies on the rows to generate its legend,
+      // which is why we need to translate them too
+      // They're in the format of:
+      // [
+      //   ["Doohickey", 123],
+      //   ["Widget", 456],
+      //   ...
+      // ]
+      //
       translatedRows = singleSeries.data.rows.map((row) =>
         row.map((value) => {
           if (typeof value === "string" && keyToNameMap[value] !== undefined) {

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.unit.spec.ts
@@ -1,0 +1,220 @@
+import type { ContentTranslationFunction } from "metabase/i18n/types";
+import type {
+  MaybeTranslatedSeries,
+  Series,
+  SingleSeries,
+} from "metabase-types/api";
+import { createMockDatasetData } from "metabase-types/api/mocks";
+
+import { leaveUntranslated } from "./use-translate-content";
+import { translateFieldValuesInSeries } from "./utils";
+
+const mockTranslateWithTranslations: ContentTranslationFunction = (value) => {
+  if (typeof value === "string") {
+    return `translated_${value}`;
+  }
+  return value;
+};
+
+const mockTranslateWithoutTranslations: ContentTranslationFunction =
+  leaveUntranslated;
+
+describe("translateFieldValuesInSeries", () => {
+  it("should return original series when translation function has no translations", () => {
+    const series: Series = [
+      {
+        data: {
+          rows: [
+            ["apple", 10],
+            ["banana", 20],
+          ],
+        },
+      } as SingleSeries,
+    ];
+
+    const result = translateFieldValuesInSeries(
+      series,
+      mockTranslateWithoutTranslations,
+    );
+
+    expect(result).toBe(series);
+  });
+
+  it("should return original series item when it has no data", () => {
+    const series: Series = [
+      {
+        card: { name: "Test Chart" },
+      } as SingleSeries,
+    ];
+
+    const result = translateFieldValuesInSeries(
+      series,
+      mockTranslateWithTranslations,
+    );
+
+    expect(result).toEqual([
+      {
+        card: { name: "Test Chart" },
+      },
+    ]);
+  });
+
+  it("should translate field values in regular series data", () => {
+    const series: Series = [
+      {
+        data: {
+          rows: [
+            ["apple", 10],
+            ["banana", 20],
+            ["cherry", 30],
+          ],
+        },
+      } as SingleSeries,
+    ];
+
+    const result = translateFieldValuesInSeries(
+      series,
+      mockTranslateWithTranslations,
+    ) as MaybeTranslatedSeries;
+
+    expect(result[0].data?.rows).toEqual([
+      ["translated_apple", 10],
+      ["translated_banana", 20],
+      ["translated_cherry", 30],
+    ]);
+    expect(result[0].data?.untranslatedRows).toEqual([
+      ["apple", 10],
+      ["banana", 20],
+      ["cherry", 30],
+    ]);
+  });
+
+  it("should handle mixed data types in rows", () => {
+    const series: Series = [
+      {
+        data: {
+          rows: [
+            ["text", 123, null, true],
+            [456, "more text", false, undefined],
+          ],
+        },
+      } as SingleSeries,
+    ];
+
+    const result = translateFieldValuesInSeries(
+      series,
+      mockTranslateWithTranslations,
+    ) as MaybeTranslatedSeries;
+
+    expect(result[0].data?.rows).toEqual([
+      ["translated_text", 123, null, true],
+      [456, "translated_more text", false, undefined],
+    ]);
+  });
+
+  it("should handle pie chart display with pie.rows visualization settings", () => {
+    const series: Series = [
+      {
+        card: {
+          display: "pie",
+          visualization_settings: {
+            "pie.rows": [
+              { key: "A", name: "Apple" },
+              { key: "B", name: "Banana" },
+              { key: "C", name: "Cherry" },
+            ],
+          },
+        },
+        data: {
+          rows: [
+            ["A", 10],
+            ["B", 20],
+            ["C", 30],
+            ["D", 40], // key not in pie.rows
+          ],
+        },
+      } as SingleSeries,
+    ];
+
+    const result = translateFieldValuesInSeries(
+      series,
+      mockTranslateWithTranslations,
+    ) as MaybeTranslatedSeries;
+
+    expect(result[0].data?.rows).toEqual([
+      ["translated_Apple", 10],
+      ["translated_Banana", 20],
+      ["translated_Cherry", 30],
+      ["translated_D", 40], // falls back to translating the key itself
+    ]);
+  });
+
+  it("should handle pie chart display without pie.rows visualization settings", () => {
+    const series: Series = [
+      {
+        card: {
+          display: "pie",
+          visualization_settings: {},
+        },
+        data: {
+          rows: [
+            ["apple", 10],
+            ["banana", 20],
+          ],
+        },
+      } as SingleSeries,
+    ];
+
+    const result = translateFieldValuesInSeries(
+      series,
+      mockTranslateWithTranslations,
+    ) as MaybeTranslatedSeries;
+
+    expect(result[0].data?.rows).toEqual([
+      ["translated_apple", 10],
+      ["translated_banana", 20],
+    ]);
+  });
+
+  it("should handle multiple series", () => {
+    const series: Series = [
+      {
+        data: {
+          rows: [["apple", 10]],
+        },
+      } as SingleSeries,
+      {
+        data: {
+          rows: [["banana", 20]],
+        },
+      } as SingleSeries,
+    ];
+
+    const result = translateFieldValuesInSeries(
+      series,
+      mockTranslateWithTranslations,
+    ) as MaybeTranslatedSeries;
+
+    expect(result).toHaveLength(2);
+    expect(result[0].data?.rows).toEqual([["translated_apple", 10]]);
+    expect(result[1].data?.rows).toEqual([["translated_banana", 20]]);
+  });
+
+  it("should handle empty rows", () => {
+    const series: Series = [
+      {
+        data: createMockDatasetData({
+          rows: [],
+        }),
+      } as SingleSeries,
+    ];
+
+    const result = translateFieldValuesInSeries(
+      series,
+      mockTranslateWithTranslations,
+    ) as MaybeTranslatedSeries;
+
+    expect(result[0].data?.rows).toEqual([]);
+    expect(result[0].data?.untranslatedRows).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63972
Closes [EMB-853: Renamed legends get ignored by Content Translation](https://linear.app/metabase/issue/EMB-853/renamed-legends-get-ignored-by-content-translation)

### Description

Consider special case of `pie.rows` when translating datasets

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
