### PR TITLE
Add guards to metabot and semantic search job implementations

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/task/suggested_prompts_generator.clj
@@ -20,16 +20,17 @@
 (def ^:private generator-trigger-key (triggers/key "metabase.task.metabot-v3.suggested-prompts-generator.trigger"))
 
 (defn- maybe-generate-suggested-prompts! []
-  (let [metabot-eid (get-in metabot-v3.config/metabot-config
-                            [metabot-v3.config/internal-metabot-id :entity-id])
-        metabot-id (t2/select-one-pk :model/Metabot :entity_id metabot-eid)
-        suggested-prompts-cnt (t2/count :model/MetabotPrompt :metabot_id metabot-id)]
-    (if (zero? suggested-prompts-cnt)
-      (do
-        (log/info "No suggested prompts found. Generating suggested prompts.")
-        (metabot-v3.suggested-prompts/generate-sample-prompts metabot-id)
-        (log/info "Suggested prompts generated successfully."))
-      (log/info "Suggested prompts are present. Not generating."))))
+  (when (premium-features/has-feature? :metabot-v3)
+    (let [metabot-eid (get-in metabot-v3.config/metabot-config
+                              [metabot-v3.config/internal-metabot-id :entity-id])
+          metabot-id (t2/select-one-pk :model/Metabot :entity_id metabot-eid)
+          suggested-prompts-cnt (t2/count :model/MetabotPrompt :metabot_id metabot-id)]
+      (if (zero? suggested-prompts-cnt)
+        (do
+          (log/info "No suggested prompts found. Generating suggested prompts.")
+          (metabot-v3.suggested-prompts/generate-sample-prompts metabot-id)
+          (log/info "Suggested prompts generated successfully."))
+        (log/info "Suggested prompts are present. Not generating.")))))
 
 (task/defjob ^{DisallowConcurrentExecution true
                :doc "Initial _suggested prompts_ generation for internal Metabot."}

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/indexer.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/indexer.clj
@@ -3,10 +3,9 @@
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.simple :as simple]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
    [metabase-enterprise.semantic-search.env :as semantic.env]
    [metabase-enterprise.semantic-search.indexer :as semantic-search.indexer]
-   [metabase.premium-features.core :as premium-features]
+   [metabase-enterprise.semantic-search.util :as semantic.u]
    [metabase.search.engine :as search.engine]
    [metabase.task.core :as task]
    [metabase.util.log :as log])
@@ -32,14 +31,15 @@
  SemanticSearchIndexer []
   org.quartz.Job
   (execute [_ _]
-    (log/with-context {:quartz-job-type 'SemanticSearchIndexer}
-      (when (search.engine/supported-engine? :search.engine/semantic)
-        (try
-          (vreset! execution-thread-ref (Thread/currentThread))
-          (semantic-search.indexer/quartz-job-run! (semantic.env/get-pgvector-datasource!) (semantic.env/get-index-metadata))
-          (finally
-            (locking execution-thread-ref
-              (vreset! execution-thread-ref nil)))))))
+    (when (semantic.u/semantic-search-available?)
+      (log/with-context {:quartz-job-type 'SemanticSearchIndexer}
+        (when (search.engine/supported-engine? :search.engine/semantic)
+          (try
+            (vreset! execution-thread-ref (Thread/currentThread))
+            (semantic-search.indexer/quartz-job-run! (semantic.env/get-pgvector-datasource!) (semantic.env/get-index-metadata))
+            (finally
+              (locking execution-thread-ref
+                (vreset! execution-thread-ref nil))))))))
   org.quartz.InterruptableJob
   (interrupt [_]
    ;; locking required here to avoid racing with the unset in the finally
@@ -52,8 +52,7 @@
 (def ^:private ^Duration run-frequency (Duration/parse "PT20S"))
 
 (defmethod task/init! ::SemanticSearchIndexer [_]
-  (when (and (string? (not-empty semantic.db.datasource/db-url))
-             (premium-features/has-feature? :semantic-search))
+  (when (semantic.u/semantic-search-available?)
     (let [job         (jobs/build
                        (jobs/of-type SemanticSearchIndexer)
                        (jobs/store-durably)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/task/usage_trimmer.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/task/usage_trimmer.clj
@@ -31,7 +31,7 @@
   (trim-old-token-data!))
 
 (defmethod task/init! ::SemanticSearchUsageTrimmer
-  []
+  [_]
   (when (premium-features/has-feature? :semantic-search)
     (let [job (jobs/build
                (jobs/of-type SemanticSearchUsageTrimmer)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/util.clj
@@ -1,5 +1,7 @@
 (ns metabase-enterprise.semantic-search.util
   (:require
+   [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
+   [metabase.premium-features.core :as premium-features]
    [next.jdbc :as jdbc]
    [next.jdbc.result-set :as jdbc.rs]))
 
@@ -11,3 +13,9 @@
                           table-name]
                          {:builder-fn jdbc.rs/as-unqualified-lower-maps})
       (:table_exists false)))
+
+(defn semantic-search-available?
+  "Predicate to check whether semantic search is available on the instance."
+  []
+  (and (string? (not-empty semantic.db.datasource/db-url))
+       (premium-features/has-feature? :semantic-search)))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/task/usage_trimmer_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/task/usage_trimmer_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.semantic-search.task.usage-trimmer :as semantic.task.trimmer]
-   [metabase.test :as mt]
+   [metabase-enterprise.semantic-search.util :as semantic.u]
    [toucan2.core :as t2])
   (:import
    (java.sql Timestamp)
@@ -11,7 +11,7 @@
 (set! *warn-on-reflection* true)
 
 (deftest trim-test
-  (mt/with-premium-features #{:semantic-search}
+  (when (semantic.u/semantic-search-available?)
     (t2/delete! :model/SemanticSearchTokenTracking)
     (let [now (LocalDateTime/now)
           ;; semantic.task.trimmer/storage-months is set to 2


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-449/fix-error-initializing-task-metabase-enterprisesemantic

This PR
- fixes `init!` arity for usage trimmer job,
- adds guards to metabot and semantic search _job implementations_.

Previously the guards were top level only -- the jobs were not _scheduled_ if conditions were not met. However if the job was scheduled, then instance re-started e.g. with no pgvector variable set, the job would be triggered anyway after the restart, resulting in failure. This change prevents that.