### PR TITLE
Fix email formatting in lib/formatting

### DIFF
--- a/frontend/src/metabase/lib/formatting/email.tsx
+++ b/frontend/src/metabase/lib/formatting/email.tsx
@@ -1,13 +1,10 @@
 import ExternalLink from "metabase/common/components/ExternalLink";
+import { isEmail } from "metabase/lib/email";
 import { getDataFromClicked } from "metabase-lib/v1/parameters/utils/click-behavior";
 
 import { renderLinkTextForClick } from "./link";
 import { removeNewLines } from "./strings";
 import type { OptionsType } from "./types";
-
-// https://github.com/angular/angular.js/blob/v1.6.3/src/ng/directive/input.js#L27
-const EMAIL_ALLOW_LIST_REGEX =
-  /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/;
 
 export function formatEmail(
   value: string,
@@ -30,7 +27,7 @@ export function formatEmail(
     jsx &&
     rich &&
     (view_as === "email_link" || view_as === "auto") &&
-    EMAIL_ALLOW_LIST_REGEX.test(email)
+    isEmail(email)
   ) {
     let displayText = label || email;
     if (collapseNewlines) {

--- a/frontend/src/metabase/lib/formatting/email.unit.spec.tsx
+++ b/frontend/src/metabase/lib/formatting/email.unit.spec.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "__support__/ui";
+
+import { formatEmail } from "./email";
+
+function setup({ email }: { email: string }) {
+  render(<>{formatEmail(email, { jsx: true, rich: true })}</>);
+}
+
+describe("formatEmail", () => {
+  it("should format emails without unicode characters as links", () => {
+    const email = "foo@example.com";
+    setup({ email });
+    expect(screen.getByText(email)).toHaveAttribute("href", `mailto:${email}`);
+  });
+
+  it("should format emails with unicode characters as links", () => {
+    const email = "hafthór_júlíus_björnsson@gameofthron.es";
+    setup({ email });
+    expect(screen.getByText(email)).toHaveAttribute("href", `mailto:${email}`);
+  });
+});


### PR DESCRIPTION
- Fixes #62100  by using the email regex from `metabase/lib/email`
- Add unit tests

We should probably stop relying on regexp altogether for email validation, but that is a bigger story.

### To verify 

1. Have a table with "Email" type of column
2. Have this value in that column: `hafthór_júlíus_björnsson@gameofthron.es`
3. Visualize it as a table or a detail

You can add a line to the PEOPLE table with unicode email by running:
```sql
INSERT INTO PEOPLE(id, email) VALUES (99999, 'hafthór_júlíus_björnsson@gameofthron.es')
```