### PR TITLE
Skip sync transforms temp table

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1241,6 +1241,7 @@
            events
            lib
            models
+           premium-features
            query-processor
            settings
            task

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -253,8 +253,8 @@
   (driver/drop-table! driver database-id table-name))
 
 (defn temp-table-name
-  "Generate a temporary table name with the given suffix and current timestamp in seconds.
-  If table name would exceed max table name length for the driver, fallback to using a shorter base-name"
+  "Generate a temporary table name with current timestamp in milliseconds.
+  If table name would exceed max table name length for the driver, fallback to using a shorter timestamp"
   [driver schema]
   (let [max-len   (max 1 (or (driver/table-name-length-limit driver) Integer/MAX_VALUE))
         timestamp (str (System/currentTimeMillis))

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
@@ -156,7 +156,9 @@
   [driver db-id table-name metadata data-source]
   (let [source-table-name (transforms.util/temp-table-name driver (namespace table-name))
         temp-table-name (u/poll {:thunk #(transforms.util/temp-table-name driver (namespace table-name))
-                                 :done? #(not= source-table-name %)})]
+                                 :done? #(not= source-table-name %)
+                                 ;; Poll every 1ms to quickly generate a different timestamp-based table name
+                                 :interval-ms 1})]
     (log/info "Using rename-tables strategy with atomicity guarantees")
     (try
 

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
@@ -21,14 +21,6 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:const temp-table-suffix-new
-  "Suffix used for temporary tables containing new data during swap operations."
-  "new")
-
-(def ^:const temp-table-suffix-old
-  "Suffix used for temporary tables containing old data during swap operations."
-  "old")
-
 (defn- empty-message-log
   "Returns a new message log.
 
@@ -162,8 +154,9 @@
   "Transfer data using the rename-tables*! multimethod with atomicity guarantees.
    Creates new table, then atomically renames target->old and new->target, then drops old."
   [driver db-id table-name metadata data-source]
-  (let [source-table-name (transforms.util/temp-table-name driver table-name temp-table-suffix-new)
-        temp-table-name (transforms.util/temp-table-name driver table-name temp-table-suffix-old)]
+  (let [source-table-name (transforms.util/temp-table-name driver (namespace table-name))
+        temp-table-name (u/poll {:thunk #(transforms.util/temp-table-name driver (namespace table-name))
+                                 :done? #(not= source-table-name %)})]
     (log/info "Using rename-tables strategy with atomicity guarantees")
     (try
 
@@ -183,7 +176,7 @@
   "Transfer data using create + drop + rename to minimize time without data.
    Creates new table, drops old table, then renames new->target."
   [driver db-id table-name metadata data-source]
-  (let [source-table-name (transforms.util/temp-table-name driver table-name temp-table-suffix-new)]
+  (let [source-table-name (transforms.util/temp-table-name driver (namespace table-name))]
     (log/info "Using create-drop-rename strategy to minimize downtime")
     (try
 

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/execute_test.clj
@@ -86,12 +86,9 @@
                   (transforms-python.execute/execute-python-transform! transform {:run-method :manual})
 
                   (let [db-id (mt/id)
-                        tables (t2/select :model/Table :db_id db-id :active true)
-                        new-table-pattern (re-pattern (str ".*" table-name "_" transforms-python.execute/temp-table-suffix-new "_.*"))
-                        old-table-pattern (re-pattern (str ".*" table-name "_" transforms-python.execute/temp-table-suffix-old "_.*"))]
-                    (is (not-any? #(or (re-matches new-table-pattern (:name %))
-                                       (re-matches old-table-pattern (:name %))) tables)
-                        (str "No temp tables (_" transforms-python.execute/temp-table-suffix-new "_ or _" transforms-python.execute/temp-table-suffix-old "_) should remain after successful Python transform"))
+                        tables (t2/select :model/Table :db_id db-id :active true)]
+                    (is (not-any? transforms.util/is-temp-transform-table? tables)
+                        (str "No temp tables should remain after successful Python transform"))
 
                     (is (= [[1 "a"] [2 "b"] [3 "c"]] (transforms.tu/table-rows table-name))
                         "Table should contain the expected data after swap")))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/execute_test.clj
@@ -88,7 +88,7 @@
                   (let [db-id (mt/id)
                         tables (t2/select :model/Table :db_id db-id :active true)]
                     (is (not-any? transforms.util/is-temp-transform-table? tables)
-                        (str "No temp tables should remain after successful Python transform"))
+                        "No temp tables should remain after successful Python transform")
 
                     (is (= [[1 "a"] [2 "b"] [3 "c"]] (transforms.tu/table-rows table-name))
                         "Table should contain the expected data after swap")))))))))))

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -42,6 +42,22 @@
              (set (for [table (t2/select [:model/Table :name :visibility_type :initial_sync_status] :db_id (mt/id))]
                     (into {} table))))))))
 
+(deftest transform-temp-tables-are-skipped-test
+  (mt/when-ee-evailable
+   (let [temp-table   {:name   "mb_transform_temp_table_temp_123"
+                       :schema "public"}
+         normal-table {:name   "orders"
+                       :schema "public"}
+         db-metadata  {:tables #{temp-table normal-table}}]
+     (testing "table-set excludes transform temporary tables when flagged and has transforms feature"
+       (mt/with-premium-features #{:transforms}
+         (is (= #{normal-table}
+                (#'sync-tables/table-set db-metadata)))))
+     (testing "ignroe it if transform feature is disabled"
+       (mt/with-premium-features #{}
+         (is (= #{normal-table temp-table}
+                (#'sync-tables/table-set db-metadata))))))))
+
 (deftest retire-tables-test
   (testing "`retire-tables!` should retire the Table(s) passed to it, not all Tables in the DB -- see #9593"
     (mt/with-temp [:model/Database db {}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-2424/database-sync-should-ignore-transform-temp-tables