### PR TITLE
Report Metabot feedback directly to Harbormaster

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1833,6 +1833,7 @@
            search
            server
            settings
+           store-api
            sync
            system
            task

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -81,6 +81,13 @@
   (metabot-v3.context/log body :llm.log/fe->be)
   (streaming-request body))
 
+(api.macros/defendpoint :post "/feedback"
+  "Echo Metabot feedback for MVP; returns whatever is posted."
+  [_route-params
+   _query-params
+   feedback :- :map]
+  feedback)
+
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/metabot-v3` routes."
   (handlers/routes

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -1,6 +1,9 @@
 (ns metabase-enterprise.metabot-v3.api
   "`/api/ee/metabot-v3/` routes"
   (:require
+
+   [clj-http.client :as http]
+   [clojure.string :as str]
    [metabase-enterprise.metabot-v3.api.document]
    [metabase-enterprise.metabot-v3.api.metabot]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
@@ -14,7 +17,11 @@
    [metabase.api.routes.common :refer [+auth]]
    [metabase.api.util.handlers :as handlers]
    [metabase.app-db.core :as app-db]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.store-api.core :as store-api]
    [metabase.util :as u]
+   [metabase.util.json :as json]
+   [metabase.util.log :as log]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -82,11 +89,22 @@
   (streaming-request body))
 
 (api.macros/defendpoint :post "/feedback"
-  "Echo Metabot feedback for MVP; returns whatever is posted."
+  "Proxy Metabot feedback to Harbormaster, adding the premium embedding token."
   [_route-params
    _query-params
    feedback :- :map]
-  feedback)
+  (let [token (premium-features/premium-embedding-token)
+        base-url (store-api/store-api-url)]
+    (when (or (str/blank? token) (str/blank? base-url))
+      (throw (ex-info "Cannot build a request. The license token and/or Store api url are missing!" {})))
+    (try
+      (http/post (str base-url "/api/v2/metabot/feedback/" token)
+                 {:content-type :json
+                  :body         (json/encode feedback)})
+      api/generic-204-no-content
+      (catch Exception e
+        (log/error e "Failed to submit feedback to Harbormaster")
+        (throw e)))))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/metabot-v3` routes."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.metabot-v3.api
   "`/api/ee/metabot-v3/` routes"
   (:require
-
    [clj-http.client :as http]
    [clojure.string :as str]
    [metabase-enterprise.metabot-v3.api.document]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -58,3 +58,46 @@
                           :role         :assistant
                           :data         [{:role "assistant" :content "Hello from streaming!"}]}]
                         messages))))))))))
+
+(deftest feedback-endpoint-test
+  (mt/with-premium-features #{:metabot-v3}
+    (testing "Submits feedback to Harbormaster with token and base URL"
+      (mt/with-temporary-setting-values [premium-embedding-token "tok-123"
+                                         store-api-url            "http://hm.example"]
+        (let [captured (atom nil)
+              feedback {:metabot_id 1
+                        :feedback {:positive true
+                                   :message_id "m-1"
+                                   :freeform_feedback "ok"}
+                        :conversation_data {}
+                        :version "v0.0.0"
+                        :submission_time "2025-01-01T00:00:00Z"
+                        :is_admin false}
+              expected-url "http://hm.example/api/v2/metabot/feedback/tok-123"]
+          (mt/with-dynamic-fn-redefs
+            [http/post (fn [url opts]
+                         (reset! captured {:url url
+                                           :body (json/decode+kw (String. ^bytes (:body opts) "UTF-8"))})
+                         {:status 204 :body ""})]
+            (let [_resp (mt/user-http-request :rasta :post 204 "ee/metabot-v3/feedback" feedback)]
+              (is (= expected-url (:url @captured)))
+              (is (= feedback (:body @captured))))))))
+
+    (testing "Returns 500 when http post fails"
+      (mt/with-temporary-setting-values [premium-embedding-token "tok-123"
+                                         store-api-url            "http://hm.example"]
+        (mt/with-dynamic-fn-redefs
+          [http/post (fn [_url _opts]
+                       (throw (ex-info "boom" {})))]
+          (mt/user-http-request :rasta :post 500 "ee/metabot-v3/feedback" {:any "payload"}))))
+
+    (testing "Throws when premium token is missing"
+      (mt/with-temporary-setting-values [premium-embedding-token nil
+                                         store-api-url            "http://hm.example"]
+        (mt/user-http-request :rasta :post 500 "ee/metabot-v3/feedback" {:foo "bar"})))
+
+    (testing "Throws when `store-api-url` is missing"
+      (mt/with-temporary-setting-values [premium-embedding-token "tok-123"
+                                         store-api-url            nil]
+        (mt/user-http-request :rasta :post 500 "ee/metabot-v3/feedback" {:foo "bar"})))))
+

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -86,8 +86,7 @@
               (mt/with-dynamic-fn-redefs
                 [http/post (fn [url opts]
                              (reset! captured {:url url
-                                               :body (json/decode+kw (String. ^bytes (:body opts) "UTF-8"))})
-                             {:status 204})]
+                                               :body (json/decode+kw (:body opts))}))]
                 (let [_resp (mt/user-http-request :rasta :post 204 "ee/metabot-v3/feedback" feedback)]
                   (is (= {:url expected-url :body feedback}
                          @captured)))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -92,19 +92,14 @@
                          @captured)))))))
 
         (testing "Returns 500 when http post fails"
-          (mt/with-temporary-setting-values [premium-embedding-token premium-token
-                                             store-api-url           store-url]
+          (mt/with-temporary-setting-values [premium-embedding-token premium-token]
             (mt/with-dynamic-fn-redefs
               [http/post (fn [_url _opts]
                            (throw (ex-info "boom" {})))]
               (mt/user-http-request :rasta :post 500 "ee/metabot-v3/feedback" {:any "payload"}))))
 
+        ;; We're not testing the branch where the store-api-url is missing because that defsetting
+        ;; has the default value. It doesn't work well with `with-temporary-setting-values` helper.
         (testing "Throws when premium token is missing"
-          (mt/with-temporary-setting-values [premium-embedding-token nil
-                                             store-api-url           store-url]
-            (mt/user-http-request :rasta :post 500 "ee/metabot-v3/feedback" {:foo "bar"})))
-
-        (testing "Throws when `store-api-url` is missing"
-          (mt/with-temporary-setting-values [premium-embedding-token premium-token
-                                             store-api-url           nil]
+          (mt/with-temporary-setting-values [premium-embedding-token nil]
             (mt/user-http-request :rasta :post 500 "ee/metabot-v3/feedback" {:foo "bar"})))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -89,8 +89,8 @@
                                                :body (json/decode+kw (String. ^bytes (:body opts) "UTF-8"))})
                              {:status 204 :body ""})]
                 (let [_resp (mt/user-http-request :rasta :post 204 "ee/metabot-v3/feedback" feedback)]
-                  (is (= expected-url (:url @captured)))
-                  (is (= feedback (:body @captured))))))))
+                  (is (= {:url expected-url :body feedback} 
+                         @captured)))))))
 
         (testing "Returns 500 when http post fails"
           (mt/with-temporary-setting-values [premium-embedding-token premium-token

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -6,6 +6,7 @@
    [medley.core :as m]
    [metabase-enterprise.metabot-v3.client-test :as client-test]
    [metabase-enterprise.metabot-v3.util :as metabot.u]
+   [metabase.premium-features.token-check :as token-check]
    [metabase.premium-features.token-check-test :as token-check-test]
    [metabase.test :as mt]
    [metabase.util.json :as json]
@@ -62,9 +63,13 @@
 
 (deftest feedback-endpoint-test
   (mt/with-premium-features #{:metabot-v3}
+    (with-redefs [token-check/fetch-token-status (fn [_x]
+                                                                 {:valid    true
+                                                                  :status   "fake"
+                                                                  :features ["test" "fixture"]
+                                                                  :trial    false})]
     (let [premium-token (token-check-test/random-token)
           store-url     "http://hm.example"]
-
       (testing "Submits feedback to Harbormaster with token and base URL"
         (mt/with-temporary-setting-values [premium-embedding-token premium-token
                                            store-api-url           store-url]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -64,10 +64,10 @@
 (deftest feedback-endpoint-test
   (mt/with-premium-features #{:metabot-v3}
     (with-redefs [token-check/fetch-token-status (fn [_x]
-                                                                 {:valid    true
-                                                                  :status   "fake"
-                                                                  :features ["test" "fixture"]
-                                                                  :trial    false})]
+                                                   {:valid    true
+                                                    :status   "fake"
+                                                    :features ["test" "fixture"]
+                                                    :trial    false})]
       (let [premium-token (token-check-test/random-token)
             store-url     "http://hm.example"]
         (testing "Submits feedback to Harbormaster with token and base URL"
@@ -89,7 +89,7 @@
                                                :body (json/decode+kw (String. ^bytes (:body opts) "UTF-8"))})
                              {:status 204 :body ""})]
                 (let [_resp (mt/user-http-request :rasta :post 204 "ee/metabot-v3/feedback" feedback)]
-                  (is (= {:url expected-url :body feedback} 
+                  (is (= {:url expected-url :body feedback}
                          @captured)))))))
 
         (testing "Returns 500 when http post fails"
@@ -107,5 +107,5 @@
 
         (testing "Throws when `store-api-url` is missing"
           (mt/with-temporary-setting-values [premium-embedding-token premium-token
-                                           store-api-url           nil]
-          (mt/user-http-request :rasta :post 500 "ee/metabot-v3/feedback" {:foo "bar"}))))))
+                                             store-api-url           nil]
+            (mt/user-http-request :rasta :post 500 "ee/metabot-v3/feedback" {:foo "bar"})))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -87,7 +87,7 @@
                 [http/post (fn [url opts]
                              (reset! captured {:url url
                                                :body (json/decode+kw (String. ^bytes (:body opts) "UTF-8"))})
-                             {:status 204 :body ""})]
+                             {:status 204})]
                 (let [_resp (mt/user-http-request :rasta :post 204 "ee/metabot-v3/feedback" feedback)]
                   (is (= {:url expected-url :body feedback}
                          @captured)))))))

--- a/enterprise/frontend/src/metabase-enterprise/api/metabot.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/metabot.ts
@@ -1,5 +1,6 @@
 import type {
   DeleteSuggestedMetabotPromptRequest,
+  MetabotFeedback,
   MetabotGenerateContentRequest,
   MetabotGenerateContentResponse,
   MetabotId,
@@ -87,6 +88,13 @@ export const metabotApi = EnterpriseApi.injectEndpoints({
         body: params,
       }),
     }),
+    submitMetabotFeedback: builder.mutation<void, MetabotFeedback>({
+      query: (params) => ({
+        method: "POST",
+        url: "/api/ee/metabot-v3/feedback",
+        body: params,
+      }),
+    }),
   }),
 });
 
@@ -97,4 +105,5 @@ export const {
   useDeleteSuggestedMetabotPromptMutation,
   useRegenerateSuggestedMetabotPromptsMutation,
   useLazyMetabotGenerateContentQuery,
+  useSubmitMetabotFeedbackMutation,
 } = metabotApi;

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -266,11 +266,8 @@ export const Messages = ({
   const submitFeedback = async (metabotFeedback: MetabotFeedback) => {
     const { message_id, positive } = metabotFeedback.feedback;
 
-    const { error } = await submitMetabotFeedback(metabotFeedback);
-
-    if (error) {
-      sendToast({ icon: "warning", message: t`Failed to submit feedback` });
-    } else {
+    try {
+      await submitMetabotFeedback(metabotFeedback).unwrap();
       sendToast({ icon: "check", message: t`Feedback submitted` });
 
       setFeedbackState((prevState) => ({
@@ -280,6 +277,8 @@ export const Messages = ({
         },
         modal: undefined,
       }));
+    } catch (error) {
+      sendToast({ icon: "warning", message: t`Failed to submit feedback` });
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -265,19 +265,21 @@ export const Messages = ({
   const submitFeedback = async (metabotFeedback: MetabotFeedback) => {
     const { message_id, positive } = metabotFeedback.feedback;
 
-    const { data, error } = await submitMetabotFeedback(metabotFeedback);
+    const { error } = await submitMetabotFeedback(metabotFeedback);
 
-    console.log("METABOT FEEDBACK", data, error);
+    if (error) {
+      sendToast({ icon: "warning", message: "Failed to submit feedback" });
+    } else {
+      sendToast({ icon: "check", message: "Feedback submitted" });
 
-    sendToast({ icon: "check", message: "Feedback submitted" });
-
-    setFeedbackState((prevState) => ({
-      submitted: {
-        ...prevState.submitted,
-        [message_id]: positive ? "positive" : "negative",
-      },
-      modal: undefined,
-    }));
+      setFeedbackState((prevState) => ({
+        submitted: {
+          ...prevState.submitted,
+          [message_id]: positive ? "positive" : "negative",
+        },
+        modal: undefined,
+      }));
+    }
   };
 
   const onAgentMessageCopy = useCallback(

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -3,7 +3,6 @@ import cx from "classnames";
 import { useCallback, useState } from "react";
 
 import { useToast } from "metabase/common/hooks";
-import { downloadObjectAsJson } from "metabase/lib/download";
 import {
   ActionIcon,
   Flex,
@@ -12,6 +11,7 @@ import {
   type IconName,
   Text,
 } from "metabase/ui";
+import { useSubmitMetabotFeedbackMutation } from "metabase-enterprise/api/metabot";
 import type {
   MetabotChatMessage,
   MetabotErrorMessage,
@@ -260,11 +260,16 @@ export const Messages = ({
     modal: undefined,
   });
 
+  const [submitMetabotFeedback] = useSubmitMetabotFeedbackMutation();
+
   const submitFeedback = async (metabotFeedback: MetabotFeedback) => {
     const { message_id, positive } = metabotFeedback.feedback;
 
-    downloadObjectAsJson(metabotFeedback, `metabot-feedback-${message_id}`);
-    sendToast({ icon: "check", message: "Feedback downloaded successfully" });
+    const { data, error } = await submitMetabotFeedback(metabotFeedback);
+
+    console.log("METABOT FEEDBACK", data, error);
+
+    sendToast({ icon: "check", message: "Feedback submitted" });
 
     setFeedbackState((prevState) => ({
       submitted: {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -1,6 +1,7 @@
 import { useClipboard } from "@mantine/hooks";
 import cx from "classnames";
 import { useCallback, useState } from "react";
+import { t } from "ttag";
 
 import { useToast } from "metabase/common/hooks";
 import {
@@ -268,9 +269,9 @@ export const Messages = ({
     const { error } = await submitMetabotFeedback(metabotFeedback);
 
     if (error) {
-      sendToast({ icon: "warning", message: "Failed to submit feedback" });
+      sendToast({ icon: "warning", message: t`Failed to submit feedback` });
     } else {
-      sendToast({ icon: "check", message: "Feedback submitted" });
+      sendToast({ icon: "check", message: t`Feedback submitted` });
 
       setFeedbackState((prevState) => ({
         submitted: {

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotFeedbackModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotFeedbackModal.tsx
@@ -126,7 +126,7 @@ export const MetabotFeedbackModal = ({
               </Button>
               <Button variant="filled" type="submit">{c(
                 "This is a verb, not a noun",
-              ).t`Download`}</Button>
+              ).t`Submit`}</Button>
             </Group>
           </Stack>
         </Form>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -16,7 +16,6 @@ import {
 } from "__support__/ui";
 import { logout } from "metabase/auth/actions";
 import * as domModule from "metabase/lib/dom";
-import { downloadObjectAsJson } from "metabase/lib/download";
 import { useRegisterMetabotContextProvider } from "metabase/metabot";
 import {
   type MockStreamedEndpointParams,
@@ -51,10 +50,6 @@ import {
   metabotReducer,
   setVisible,
 } from "./state";
-
-jest.mock("metabase/lib/download", () => ({
-  downloadObjectAsJson: jest.fn(),
-}));
 
 const mockAgentEndpoint = (params: MockStreamedEndpointParams) =>
   mockStreamedEndpoint("/api/ee/metabot-v3/agent-streaming", params);
@@ -282,7 +277,10 @@ describe("metabot-streaming", () => {
     });
 
     it("should present the user an option to provide feedback", async () => {
+      const feedbackPath = "path:/api/ee/metabot-v3/feedback";
+
       setup();
+      fetchMock.post(feedbackPath, 204);
       mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
 
       await enterChatMessage("Who is your favorite?");
@@ -294,10 +292,6 @@ describe("metabot-streaming", () => {
         within(lastMessage!).findByTestId("metabot-chat-message-thumbs-up");
       const thumbsDown = () =>
         within(lastMessage!).findByTestId("metabot-chat-message-thumbs-down");
-      const mockDownloadObjectAsJson =
-        downloadObjectAsJson as jest.MockedFunction<
-          typeof downloadObjectAsJson
-        >;
 
       expect(await thumbsUp()).toBeInTheDocument();
       expect(await thumbsDown()).toBeInTheDocument();
@@ -306,11 +300,11 @@ describe("metabot-streaming", () => {
       expect(await feedbackModal()).toBeInTheDocument();
       await userEvent.click(
         await within(await feedbackModal()).findByRole("button", {
-          name: /Download/,
+          name: /Submit/,
         }),
       );
 
-      expect(mockDownloadObjectAsJson).toHaveBeenCalledTimes(1);
+      expect(fetchMock.callHistory.calls(feedbackPath)).toHaveLength(1);
 
       expect(await thumbsUp()).toBeDisabled();
       expect(await thumbsDown()).toBeDisabled();


### PR DESCRIPTION
Resolves PRG-135

We're introducing a new endpoint in metabase/metabase. It sends the `feedback` to the backend which then (1) fetches the premium token and (2) constructs the correct store api URL with the same `feedback` as the payload.

The only way to test this was to ask the Cloud team if they see a new entry in the DB. They do.

Relevant PRs on the HM side:
- https://github.com/metabase/harbormaster/pull/6540
- https://github.com/metabase/harbormaster/pull/6564