### PR TITLE
Fix field filters for type/TextLike

### DIFF
--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -1,5 +1,9 @@
 const { H } = cy;
-import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
+import {
+  SAMPLE_DB_ID,
+  USER_GROUPS,
+  WRITABLE_DB_ID,
+} from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
@@ -1270,5 +1274,32 @@ describe("issue 58061", () => {
       cy.wait("@cardQuery");
       H.assertQueryBuilderRowCount(1);
     });
+  });
+});
+
+describe("issue 63537", () => {
+  beforeEach(() => {
+    H.restore("postgres-writable");
+    H.resetTestTable({ type: "postgres", table: "many_data_types" });
+    cy.signInAsAdmin();
+    H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "many_data_types" });
+  });
+
+  it("should allow to use postgres enums in field filters (metabase#63537)", () => {
+    H.startNewNativeQuestion({ database: WRITABLE_DB_ID });
+    H.NativeEditor.type("SELECT * FROM many_data_types WHERE {{f}}");
+    SQLFilter.openTypePickerFromDefaultFilterType();
+    SQLFilter.chooseType("Field Filter");
+    FieldFilter.mapTo({
+      table: "Many Data Types",
+      field: "Enum",
+    });
+    H.filterWidget().click();
+    H.popover().within(() => {
+      cy.findByText("beta").click();
+      cy.button("Add filter").click();
+    });
+    H.runNativeQuery();
+    H.assertQueryBuilderRowCount(2);
   });
 });

--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
@@ -68,7 +68,7 @@ export function fieldFilterForParameter(
 ): (field: Field) => boolean {
   return (field) =>
     isParameterCompatibleWithColumn(parameter, {
-      isString: field.isString(),
+      isString: field.isString() || field.isStringLike(),
       isNumeric: field.isNumeric(),
       isBoolean: field.isBoolean(),
       isTemporal: field.isDate(),

--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.unit.spec.ts
@@ -20,6 +20,7 @@ describe("parameters/utils/field-filters", () => {
       isCountry: () => false,
       isNumeric: () => false,
       isString: () => false,
+      isStringLike: () => false,
       isBoolean: () => false,
       isAddress: () => false,
       isCoordinate: () => false,
@@ -103,6 +104,17 @@ describe("parameters/utils/field-filters", () => {
           field: () => ({
             ...field,
             isString: () => true,
+          }),
+        },
+      ],
+      [
+        { type: "string/=" },
+        {
+          type: "string",
+          field: () => ({
+            ...field,
+            isString: () => false,
+            isStringLike: () => true,
           }),
         },
       ],

--- a/frontend/src/metabase-lib/v1/parameters/utils/template-tag-options.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/template-tag-options.unit.spec.js
@@ -49,6 +49,7 @@ describe("parameters/utils/template-tag-options", () => {
       isCountry: () => false,
       isNumeric: () => false,
       isString: () => false,
+      isStringLike: () => false,
       isBoolean: () => false,
       isAddress: () => false,
     };
@@ -82,6 +83,19 @@ describe("parameters/utils/template-tag-options", () => {
         ...field,
         isString: () => true,
         isAddress: () => true,
+      };
+      const availableOptions = getParameterOptionsForField(addressField);
+      expect(
+        availableOptions.length > 0 &&
+          availableOptions.every((option) => option.type.startsWith("string")),
+      ).toBe(true);
+    });
+
+    it("should return string options for a TextLike field", () => {
+      const addressField = {
+        ...field,
+        isString: () => false,
+        isStringLike: () => true,
       };
       const availableOptions = getParameterOptionsForField(addressField);
       expect(

--- a/frontend/src/metabase-lib/v1/parameters/utils/template-tag-options.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/parameters/utils/template-tag-options.unit.spec.js
@@ -92,12 +92,12 @@ describe("parameters/utils/template-tag-options", () => {
     });
 
     it("should return string options for a TextLike field", () => {
-      const addressField = {
+      const enumField = {
         ...field,
         isString: () => false,
         isStringLike: () => true,
       };
-      const availableOptions = getParameterOptionsForField(addressField);
+      const availableOptions = getParameterOptionsForField(enumField);
       expect(
         availableOptions.length > 0 &&
           availableOptions.every((option) => option.type.startsWith("string")),


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/63537

Makes sure that the check for MLv1 fields is the same as for MLv2 https://github.com/metabase/metabase/blob/a98f21e1f8676882e627ec831360eab48ac81dc4/frontend/src/metabase-lib/v1/parameters/utils/filters.ts#L89

How to verify:
- For postgres:
```
CREATE TYPE my_enum AS ENUM('A', 'B');
CREATE TABLE field_filter_enum_test (enum_column my_enum);
INSERT INTO field_filter_enum_test (enum_column) VALUES ('A'), ('B');
```
- Sync
- New -> SQL -> `SELECT * FROM field_filter_enum_test WHERE {{f}}`
- Change `f` to `Field filter`, map to `enum_column`, add a filter value `A` or `B`, run the query