### PR TITLE
Improve python error feedback capability

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -66,8 +66,8 @@
   "Execute a transform with cancellation support and proper error handling.
 
   Options:
-  - `:ex-message` change how caught exceptions are presented to the user in run logs, by default the same as"
-  [run-id driver {:keys [db-id conn-spec output-schema]} run-transform! & {:keys [ex-message] :or {ex-message ex-message}}]
+  - `:ex-message-fn` change how caught exceptions are presented to the user in run logs, by default the same as clojure.core/ex-message"
+  [run-id driver {:keys [db-id conn-spec output-schema]} run-transform! & {:keys [ex-message-fn] :or {ex-message-fn ex-message}}]
   ;; local run is responsible for status, using canceling lifecycle
   (try
     (when-not (driver/schema-exists? driver db-id output-schema)
@@ -80,7 +80,7 @@
       (transform-run/succeed-started-run! run-id)
       ret)
     (catch Throwable t
-      (transform-run/fail-started-run! run-id {:message (ex-message t)})
+      (transform-run/fail-started-run! run-id {:message (ex-message-fn t)})
       (throw t))
     (finally
       (canceling/chan-end-run! run-id))))

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
@@ -11,6 +11,8 @@
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
    [metabase.util :as u]
+   [metabase.util.format :as u.format]
+   [metabase.util.i18n :as i18n]
    [metabase.util.jvm :as u.jvm]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
@@ -306,7 +308,7 @@
           {driver :engine :as db} (t2/select-one :model/Database (:database target))
           {run-id :id} (transforms.util/try-start-unless-already-running transform-id run-method)]
       (some-> start-promise (deliver [:started run-id]))
-      (log! message-log "Executing Python transform")
+      (log! message-log (i18n/tru "Executing Python transform"))
       (log/info "Executing Python transform" transform-id "with target" (pr-str target))
       (let [start-ms          (u/start-timer)
             transform-details {:db-id          (:id db)
@@ -316,7 +318,7 @@
                                :output-table   (transforms.util/qualified-table-name driver target)}
             run-fn            (fn [cancel-chan]
                                 (run-python-transform! transform db run-id cancel-chan message-log)
-                                (log! message-log (format "Python execution finished successfully in %s" (Duration/ofMillis (u/since-ms start-ms))))
+                                (log! message-log (i18n/tru "Python execution finished successfully in {0}" (u.format/format-milliseconds (u/since-ms start-ms))))
                                 (save-log-to-transform-run-message! run-id message-log))
             result            (transforms.util/run-cancelable-transform! run-id driver transform-details run-fn)]
         (transforms.instrumentation/with-stage-timing [run-id :table-sync]


### PR DESCRIPTION
Quick PR to establish more control over exception messaging during python transforms.

We want to avoid giving out technical specifics or raw / low level error messages in the user facing message. This information should instead be viewed (with stacktraces etc) in the metabase logs.

- Raw exception messages continue to be used for query transforms (existing behaviour).
- Explicit error messages are defined for python as a `:transform-message` in the `ex-data`.
   - Now using `i18n/tru` to support translation 
   - Included a new error message for table copy step which includes the table name and id for context.
- If no explicit error message is found, a generic 'Something went wrong' is used instead.
- No change to python messages

A follow up PR will introduce a bit of additional context to support users knowing more about the progress of the run if a failure occurs.