### PR TITLE
QP result metadata should always populate `:lib/desired-column-alias`

### DIFF
--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -164,11 +164,22 @@
    ;; `:values`
    [:human-readable-values [:sequential :any]]])
 
+;; these can both be empty strings like `""` because SQL Server (and possibly some other DBs) allow empty strings as
+;; column identifiers
+
 (mr/def ::source-column-alias
-  ::lib.schema.common/non-blank-string)
+  "Name for a column as returned/projected by the previous stage of the query or source Table/source Card. The
+  left-hand side (LHS) of
+
+    SELECT lhs AS rhs"
+  :string)
 
 (mr/def ::desired-column-alias
-  [:string {:min 1}])
+  "Name we should use as a column alias for a column in this stage of a query. The desired column alias in stage N
+  becomes the source column alias in stage N+1. The right-hand side (RHS) in
+
+    SELECT lhs AS rhs"
+  :string)
 
 (mr/def ::original-name
   "The original name of the column as it appeared in the very first place it came from (i.e., the physical name of the

--- a/src/metabase/lib/table.cljc
+++ b/src/metabase/lib/table.cljc
@@ -32,5 +32,9 @@
   [query _stage-number table-metadata _options]
   (into []
         (comp (map #(assoc % :lib/source :source/table-defaults))
-              (lib.field.util/add-source-and-desired-aliases-xform query))
+              ;; don't truncate column names, if the database says they're ok we should assume they are and we need to
+              ;; refer back to them using their original names anyway. Note that returned columns for a table ARE NOT
+              ;; equal to returned columns for a stage with this source table and nothing else... those SHOULD get
+              ;; truncated desired aliases when they stage returned columns are calculated.
+              (lib.field.util/add-source-and-desired-aliases-xform query (lib.util/non-truncating-unique-name-generator)))
         (lib.metadata/active-fields query (:id table-metadata))))

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -262,7 +262,7 @@
 (defn- by-desired-alias
   [columns desired-alias]
   (let [columns (into []
-                      (lib.field.util/add-source-and-desired-aliases-xform meta/metadata-provider)
+                      (lib.field.util/add-source-and-desired-aliases-xform (lib/query meta/metadata-provider (meta/table-metadata :venues)))
                       columns)]
     (m/find-first (comp #{desired-alias} :lib/desired-column-alias) columns)))
 

--- a/test/metabase/lib/test_util/matrix.cljc
+++ b/test/metabase/lib/test_util/matrix.cljc
@@ -204,11 +204,11 @@
 
 (defn find-first
   "Finds the column with the matching `:lib/desired-column-alias`"
-  [metadata-providerable desired columns]
+  [query desired columns]
   ;; [[lib/visible-columns]] no longer returns desired column alias (since it's a function of which columns get
   ;; returned), however I don't feel like completely reworking this test so I'm just going to add them here.
   (let [columns (into []
-                      (lib.field.util/add-source-and-desired-aliases-xform metadata-providerable)
+                      (lib.field.util/add-source-and-desired-aliases-xform query)
                       columns)]
     (or (m/find-first (comp #(= desired %) :lib/desired-column-alias) columns)
         (throw (ex-info "Failed to find column"


### PR DESCRIPTION
Even for native queries that have no existing stage metadata... this is so we can reliably use this column for whatever purposes we might need it for.