### PR TITLE
Index analytics collections

### DIFF
--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1798,7 +1798,7 @@
                   :collection_name            :name
                   :collection_type            :type
                   :location                   true}
-   :where        [:= :namespace nil]
+   :where        [:or [:= :namespace nil] [:= :namespace "analytics"]]
    ;; depends on the current user, used for rendering and ranking
    ;; TODO not sure this is what it'll look like
    :bookmark     [:model/CollectionBookmark [:and


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59133
These were excluded from the index, but they should really be in there.

<img width="822" height="687" alt="Screenshot 2025-09-25 at 11 38 45" src="https://github.com/user-attachments/assets/45aa9759-841b-4df0-9634-db0ce492ab14" />

Fixes [UXW-614: search doesn't find usage analytics](https://linear.app/metabase/issue/UXW-614/search-doesnt-find-usage-analytics)