### PR TITLE
[match] Prevent match-lite from extracting common result that depends on uncommon bindings

### DIFF
--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -339,7 +339,7 @@
     (value :guard number?)
     value
 
-    [:value (_ :guard #(= (:base-type %) :type/BigInteger)) (value :guard string?)]
+    [:value (x :guard (= (:base-type x) :type/BigInteger)) (value :guard string?)]
     (u.number/parse-bigint value)))
 
 (def ^:private NumberFilterParts
@@ -557,7 +557,7 @@
       [:time-interval
        opts
        (col-ref :guard date-col?)
-       (value :guard #(or (number? %) (= :current %)))
+       (value :guard (or (number? value) (= :current value)))
        (unit :guard keyword?)]
       {:column       (ref->col col-ref)
        :value        (if (= value :current) 0 value)

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -120,7 +120,7 @@
       [(_ :guard #{:!= :not-in}) _ [:get-year _ (a :guard temporal?)] (b :guard int?)]
       (i18n/tru "{0} excludes {1}" (->unbucketed-display-name a) (u.time/format-unit b :year))
 
-      [(op :guard #{:= :in :!= :not-in}) _ [(f :guard #{:get-hour :get-month :get-quarter :get-year}) _ (a :guard temporal?)] & (args :guard #(every? int? %))]
+      [(op :guard #{:= :in :!= :not-in}) _ [(f :guard #{:get-hour :get-month :get-quarter :get-year}) _ (a :guard temporal?)] & (args :guard (every? int? args))]
       (i18n/tru "{0} {1} {2} {3} selections"
                 (->unbucketed-display-name a)
                 (if (#{:= :in} op) "is one of" "excludes")

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -182,8 +182,8 @@
                             (keep (fn [clause]
                                     (lib.util.match/match-lite-recursive clause
                                       [(op :guard (= op target-op))
-                                       (_ :guard #(or (empty? target-opts)
-                                                      (set/subset? (set target-opts) (set %))))
+                                       (opts :guard (or (empty? target-opts)
+                                                        (set/subset? (set target-opts) (set opts))))
                                        (id :guard (= id target-ref-id))] [location clause]))))))
                    (stage-paths query stage-number))
         dead-joins (volatile! (transient []))]
@@ -196,7 +196,7 @@
                 (catch #?(:clj Exception :cljs js/Error) e
                   (let [{:keys [error join]} (ex-data e)]
                     (if (= error :metabase.lib.util/cannot-remove-final-join-condition)
-                        ;; Return the stage unchanged, but keep track of the dead joins.
+                      ;; Return the stage unchanged, but keep track of the dead joins.
                       (do (vswap! dead-joins conj! join)
                           %1)
                       (throw e)))))))

--- a/src/metabase/lib/util/match.clj
+++ b/src/metabase/lib/util/match.clj
@@ -351,7 +351,9 @@
                              (process-pattern pattern value-sym all-vectors?))
         {:keys [common-bindings common-conditions all-bindings all-conditions]}
         (collect-common processed-patterns)
-        same-result? (apply = (map second pairs))
+        same-result? (and (apply = (map second pairs))
+                          ;; Only allow extracting same result if there are no individual bindings in branches.
+                          (every? empty? all-bindings))
         value-binding (if (or (= value-sym value) recursive?)
                         [] [value-sym value])
         body `(let [~@value-binding

--- a/src/metabase/lib/util/match.clj
+++ b/src/metabase/lib/util/match.clj
@@ -277,9 +277,19 @@
               (vswap! bindings conj [s `(metabase.lib.util.match.impl/map! ~value)])
               (run! (fn [[k v]] (process-pattern v (list `get s k) bindings conditions false)) (:map parsed)))
        :guard (let [s (:symbol parsed)
-                    bind (when-not (= s '_) s)]
+                    bind (when-not (= s '_) s)
+                    ;; Treat symbol, keyword, or set predicates as functions to be called, and thus transform them
+                    ;; into invocation snippets. Be careful that if user doesn't want to bind the value in the
+                    ;; guard (signified by `_`), we should pass the directly extracted value to the predicate,
+                    ;; otherwise the binding.
+                    predicate (if (or (symbol? predicate) (keyword? predicate) (set? predicate))
+                                (list predicate (or bind value))
+                                predicate)]
                 (when bind (vswap! bindings conj [bind value]))
-                (when (:predicate parsed)
+                (when predicate
+                  ;; Make sure that the predicate is an invocation snippet, not a lambda as in regular `match` syntax.
+                  (when (and (seq? predicate) ('#{fn fn*} (first predicate)))
+                    (throw (ex-info "match-lite :guard predicate must be an invocation form or a symbol, not a lambda" {:predicate predicate})))
                   (vswap! conditions conj (with-meta (if (and (seq? predicate) (not= (first predicate) 'fn*))
                                                        predicate
                                                        (list predicate (or bind value)))
@@ -398,7 +408,7 @@
   - symbol - binds the entire value
   - keyword - must match exactly
   - set - must be one of the set items
-  - (sym :guard pred :len size) - bind with predicate check. Can optionally check for collection length.
+  - (sym :guard pred :len size) - bind with predicate check. The predicate should either be a symbol denoting a function, keyword, set, or an invocation snippet (but not a lambda). Can optionally check for collection length.
   - vector - binds positional values inside a sequence against other patterns. Can have & to bind remaining elements."
   {:style/indent :defn}
   [value & clauses]

--- a/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+++ b/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
@@ -42,7 +42,7 @@
   [_query _path-type _path clause]
   (lib.util.match/match-lite clause
     [:value
-     (opts :guard (fn [{:keys [effective-type], :as _value-options}]
+     (opts :guard (let [{:keys [effective-type]} opts]
                     (and effective-type
                          (not (isa? effective-type :type/Text)))))
      (v :guard string?)]

--- a/test/metabase/lib/util/match_test.cljc
+++ b/test/metabase/lib/util/match_test.cljc
@@ -355,3 +355,9 @@
       (t/is (= :false-value (lib.util.match/match-lite false
                               true :true-value
                               false :false-value))))))
+
+(t/deftest ^:parallel same-result-with-different-bindings-test
+  (t/testing "result here should not be treated as a common because it refers to different bindings in branches"
+    (t/is (= 1 (lib.util.match/match-lite [1 2]
+                 [(a :guard (odd? a)) (b :guard (even? b))] (- b a)
+                 [(b :guard (even? b)) (a :guard (odd? a))] (- b a))))))


### PR DESCRIPTION
See the test case.

Basically, we thought that if the result in all branches is equal symbolically, then it can be lifted up and reused. However, if different branches bind different values to the symbols used in the result, then these bindings will not be lifted, and the extracted result won't have access to them.

The fix is somewhat heuristic, erring on the side of safety. Some legal shared results won't be extracted now, but I can't think of a better solution yet.