### PR TITLE
Use entities' display name if possible

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
@@ -47,7 +47,7 @@ import {
 
 import styles from "./SmartLinkNode.module.css";
 
-type SmartLinkEntity =
+export type SmartLinkEntity =
   | Card
   | Dashboard
   | Collection
@@ -398,7 +398,7 @@ export const SmartLinkComponent = memo(
         >
           <span className={styles.smartLinkInner}>
             <Icon name={iconData.name} className={styles.icon} />
-            {entity.name}
+            {getName(entity)}
           </span>
         </a>
       </NodeViewWrapper>
@@ -426,4 +426,14 @@ function entityToObjectWithModel(
     display: (entity as Card).display as CardDisplayType,
     is_personal: (entity as Collection).is_personal,
   };
+}
+
+function getName(entity: SmartLinkEntity) {
+  if ("display_name" in entity && entity.display_name !== "") {
+    return entity.display_name;
+  }
+  if ("name" in entity && entity.name !== "") {
+    return entity.name;
+  }
+  return "";
 }

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.unit.spec.tsx
@@ -1,0 +1,146 @@
+import type { NodeViewProps } from "@tiptap/react";
+
+import {
+  setupCardEndpoints,
+  setupCollectionByIdEndpoint,
+  setupDashboardEndpoints,
+  setupDatabaseEndpoints,
+  setupDocumentEndpoints,
+  setupTableEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import type { SuggestionModel } from "metabase-enterprise/documents/components/Editor/types";
+import {
+  createMockCard,
+  createMockCollection,
+  createMockDashboard,
+  createMockDatabase,
+  createMockDocument,
+  createMockTable,
+} from "metabase-types/api/mocks";
+
+import { SmartLinkComponent, type SmartLinkEntity } from "./SmartLinkNode";
+
+function createProps(model: SuggestionModel, entity: SmartLinkEntity) {
+  const node = { attrs: { entityId: entity.id, model } };
+  return { node } as unknown as NodeViewProps;
+}
+
+function setup({
+  entity,
+  model,
+}: {
+  model: SuggestionModel;
+  entity: SmartLinkEntity;
+}) {
+  const props = createProps(model, entity);
+  renderWithProviders(<SmartLinkComponent {...props} />);
+}
+
+describe("SmartLink", () => {
+  describe("for Card", () => {
+    it("should render the name of a card", async () => {
+      const card = createMockCard({
+        name: "My Card",
+      });
+
+      setupCardEndpoints(card);
+      setup({ model: "card", entity: card });
+
+      await waitFor(() => {
+        expect(screen.getByText("My Card")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("for Dashboard", () => {
+    it("should render the name of a dashboard", async () => {
+      const dashboard = createMockDashboard({
+        name: "My Dashboard",
+      });
+
+      setupDashboardEndpoints(dashboard);
+      setup({ model: "dashboard", entity: dashboard });
+
+      await waitFor(() => {
+        expect(screen.getByText("My Dashboard")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("for Collection", () => {
+    it("should render the name of a collection", async () => {
+      const collection = createMockCollection({
+        name: "My Collection",
+      });
+
+      setupCollectionByIdEndpoint({ collections: [collection] });
+      setup({ model: "collection", entity: collection });
+
+      await waitFor(() => {
+        expect(screen.getByText("My Collection")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("for Table", () => {
+    it("should render the display name of a table when possible", async () => {
+      const table = createMockTable({
+        name: "TABLE_A",
+        display_name: "Table A",
+      });
+
+      setupTableEndpoints(table);
+      setup({ model: "table", entity: table });
+
+      await waitFor(() => {
+        expect(screen.getByText("Table A")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("TABLE_A")).not.toBeInTheDocument();
+    });
+
+    it("should fall back to the name of a table when not possible", async () => {
+      const table = createMockTable({
+        name: "TABLE_A",
+        display_name: "",
+      });
+
+      setupTableEndpoints(table);
+      setup({ model: "table", entity: table });
+
+      await waitFor(() => {
+        expect(screen.getByText("TABLE_A")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("for Database", () => {
+    it("should render the name of a database", async () => {
+      const database = createMockDatabase({
+        name: "DATABASE_A",
+      });
+
+      setupDatabaseEndpoints(database);
+      setup({ model: "database", entity: database });
+
+      await waitFor(() => {
+        expect(screen.getByText("DATABASE_A")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("for Document", () => {
+    it("should render the name of a document", async () => {
+      const document = createMockDocument({
+        name: "My Document",
+      });
+
+      setupDocumentEndpoints(document);
+      setup({ model: "document", entity: document });
+
+      await waitFor(() => {
+        expect(screen.getByText("My Document")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/test/__support__/server-mocks/document.ts
+++ b/frontend/test/__support__/server-mocks/document.ts
@@ -1,0 +1,13 @@
+import fetchMock from "fetch-mock";
+
+import type { Document } from "metabase-types/api";
+
+export function setupDocumentEndpoints(doc: Document) {
+  fetchMock.get(`path:/api/ee/document/${doc.id}`, doc);
+  fetchMock.post(`path:/api/ee/document/${doc.id}`, {});
+  fetchMock.put(`path:/api/ee/document/${doc.id}`, async (call) => {
+    const body = await call?.request?.json();
+    return { ...doc, ...body };
+  });
+  fetchMock.delete(`path:/api/ee/document/${doc.id}`, {});
+}

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -14,6 +14,7 @@ export * from "./constants";
 export * from "./dashboard";
 export * from "./database";
 export * from "./dataset";
+export * from "./document";
 export * from "./email";
 export * from "./embed";
 export * from "./field";


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/62731

### To verify

1. New -> Document
2. Type `@orders` and select the orders table from the popover
3. It should render as `Orders`, not `ORDERS` or `orders`