### PR TITLE
Add context to Save verb and fix similar translation issues

### DIFF
--- a/frontend/src/metabase/admin/upsells/UpsellUploads.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellUploads.tsx
@@ -24,6 +24,12 @@ export const UpsellUploads = ({ location }: { location: string }) => {
     return null;
   }
 
+  const upgrade = (
+    <strong key="upgrade">{c(
+      "in the sentence 'Upgrade to Metabase Pro to manage your uploaded files and available storage space.'",
+    ).t`Upgrade to Metabase Pro`}</strong>
+  );
+
   return (
     <UpsellCard
       title={t`Manage your uploads`}
@@ -33,9 +39,8 @@ export const UpsellUploads = ({ location }: { location: string }) => {
       location={location}
       onClick={triggerUpsellFlow}
     >
-      {c("{0} is the string 'Upgrade to Metabase Pro'").jt`${(
-        <strong key="upgrade">{t`Upgrade to Metabase Pro`}</strong>
-      )} to manage your uploaded files and available storage space.`}
+      {c("{0} is the string 'Upgrade to Metabase Pro'").jt`${upgrade}
+       to manage your uploaded files and available storage space.`}
     </UpsellCard>
   );
 };

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormFooter.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormFooter.tsx
@@ -91,15 +91,18 @@ export const DatabaseFormFooter = ({
   // to false, we can assume that the instance loads with the Sample Database.
   // https://www.metabase.com/docs/latest/configuring-metabase/environment-variables#mb_load_sample_content
   if (hasSampleDatabase !== false && showSampleDatabase) {
+    const sampleDatabaseLabel = (
+      <strong key="sample">{t`Sample Database`}</strong>
+    );
     return (
       <>
         <Button variant="filled" mb="md" mt="lg" onClick={onCancel}>
           {t`Continue with sample data`}
         </Button>
         <Text fz="sm">
-          {c("{0} is 'Sample Database'").jt`Use our ${(
-            <strong key="sample">{t`Sample Database`}</strong>
-          )} to explore and test the app.`}
+          {c("{0} is 'Sample Database'").jt`Use our ${
+            sampleDatabaseLabel
+          } to explore and test the app.`}
         </Text>
         <Text fz="sm">{t`Add your own data at any time.`}</Text>
       </>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/Panels/AddDataModalEmptyStates.tsx
@@ -175,6 +175,11 @@ export const CSVPanelEmptyState = ({
       contactAdminReason: ContactReason;
       upsell?: never;
     }) => {
+  const text = (
+    <Text component="span" td="underline">{c(
+      "in the sentence 'To work with CSVs, enable file uploads in your database.'",
+    ).t`your database`}</Text>
+  );
   const ctaSubtitle = c("{0} refers to the string 'your database'")
     .jt`To work with CSVs, enable file uploads in ${(
     <Tooltip
@@ -184,7 +189,7 @@ export const CSVPanelEmptyState = ({
       label={t`PostgreSQL, MySQL, Redshift, and ClickHouse databases are supported for file storage.`}
       key="database-tooltip"
     >
-      <Text component="span" td="underline">{t`your database`}</Text>
+      {text}
     </Tooltip>
   )}.`;
 

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -72,6 +72,8 @@ export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
     );
   }
 
+  const optional = <strong key="optional">{t`(optional)`}</strong>;
+
   return (
     <ActiveStep
       title={getStepTitle(database, invite, isStepCompleted)}
@@ -79,7 +81,7 @@ export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
     >
       <Text mt="sm" mb="md">
         {c("{0} referes to the word '(optional)'")
-          .jt`Are you ready to start exploring your data? Add it below ${(<strong key="optional">{t`(optional)`}</strong>)}.`}
+          .jt`Are you ready to start exploring your data? Add it below ${optional}.`}
       </Text>
 
       <DatabaseForm

--- a/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
@@ -24,23 +24,25 @@ export const NativeQueryClickFallback: LegacyDrill = ({ question }) => {
       name: "fallback-native",
       section: "info",
       type: "custom",
-      view: ({ dispatch }) => (
-        <Flex display="flex" align="baseline" gap="0.25rem">
-          {c('in the sentence "Save this question to drill-through"').jt`${(
-            <Button
-              key="save-button"
-              variant="subtle"
-              p={0}
-              onClick={() =>
-                dispatch(setUIControls({ modal: MODAL_TYPES.SAVE }))
-              }
-            >
-              {c('in the sentence "Save this question to drill-through"')
-                .t`Save`}
-            </Button>
-          )} this question to drill-through.`}
-        </Flex>
-      ),
+      view: ({ dispatch }) => {
+        const button = (
+          <Button
+            key="save-button"
+            variant="subtle"
+            p={0}
+            onClick={() => dispatch(setUIControls({ modal: MODAL_TYPES.SAVE }))}
+          >
+            {c('in the sentence "Save this question to drill-through"').t`Save`}
+          </Button>
+        );
+        return (
+          <Flex display="flex" align="baseline" gap="0.25rem">
+            {c('in the sentence "Save this question to drill-through"').jt`${
+              button
+            } this question to drill-through.`}
+          </Flex>
+        );
+      },
     } as CustomClickActionWithCustomView,
   ];
 };

--- a/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
@@ -1,4 +1,4 @@
-import { jt, t } from "ttag";
+import { c } from "ttag";
 
 import { isWithinIframe } from "metabase/lib/dom";
 import { setUIControls } from "metabase/query_builder/actions";
@@ -26,7 +26,7 @@ export const NativeQueryClickFallback: LegacyDrill = ({ question }) => {
       type: "custom",
       view: ({ dispatch }) => (
         <Flex display="flex" align="baseline" gap="0.25rem">
-          {jt`${(
+          {c('in the sentence "Save this question to drill-through"').jt`${(
             <Button
               key=""
               variant="subtle"
@@ -35,7 +35,8 @@ export const NativeQueryClickFallback: LegacyDrill = ({ question }) => {
                 dispatch(setUIControls({ modal: MODAL_TYPES.SAVE }))
               }
             >
-              {t`Save`}
+              {c('in the sentence "Save this question to drill-through"')
+                .t`Save`}
             </Button>
           )} this question to drill-through.`}
         </Flex>

--- a/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/NativeQueryClickFallback.tsx
@@ -28,7 +28,7 @@ export const NativeQueryClickFallback: LegacyDrill = ({ question }) => {
         <Flex display="flex" align="baseline" gap="0.25rem">
           {c('in the sentence "Save this question to drill-through"').jt`${(
             <Button
-              key=""
+              key="save-button"
               variant="subtle"
               p={0}
               onClick={() =>


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/64036

Adds context to the parts of the sentence to show what sentence it's being used in. Translators can hopefully pick that up and translate the whole sentence correctly.

Ideally, we should not be splitting translations up like this at all, since in a lot of languages the way you translate parts of sentences is super context-dependent 🙃.

That or we should switch to a library that supports whole-sentence interpolation (like `react-i18n`), but that seems like a huge lift.