### PR TITLE
Fix native transform editor results UI warts

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.module.css
@@ -1,4 +1,5 @@
 .root {
   display: flex;
   border-bottom: 1px solid var(--mb-color-border);
+  border-top: 1px solid var(--mb-color-border);
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.tsx
@@ -30,13 +30,6 @@ const EDITOR_HEIGHT = 550;
 const NATIVE_HEADER_HEIGHT = 55;
 const HEADER_HEIGHT = 65 + 50;
 
-function getHeaderHeight(isNative: boolean) {
-  if (isNative) {
-    return HEADER_HEIGHT + NATIVE_HEADER_HEIGHT;
-  }
-  return HEADER_HEIGHT;
-}
-
 const NATIVE_EDITOR_SIDEBAR_FEATURES = {
   dataReference: true,
   snippets: true,
@@ -92,12 +85,7 @@ export function EditorBody({
   const [isResizing, setIsResizing] = useState(false);
   const reportTimezone = useSetting("report-timezone-long");
 
-  const { height: windowHeight } = useWindowSize();
-  const headerHeight = getHeaderHeight(isNative);
-  const editorHeight = Math.min(
-    0.8 * (windowHeight - headerHeight),
-    EDITOR_HEIGHT,
-  );
+  const editorHeight = useInitialEditorHeight(isNative);
 
   const resizableBoxProps: Partial<ResizableBoxProps> = useMemo(
     () => ({
@@ -226,4 +214,17 @@ function useDataPickerOptions({ databases }: { databases: ApiDatabase[] }) {
       },
     };
   }, [databases]);
+}
+
+function getHeaderHeight(isNative: boolean) {
+  if (isNative) {
+    return HEADER_HEIGHT + NATIVE_HEADER_HEIGHT;
+  }
+  return HEADER_HEIGHT;
+}
+
+function useInitialEditorHeight(isNative: boolean) {
+  const { height: windowHeight } = useWindowSize();
+  const headerHeight = getHeaderHeight(isNative);
+  return Math.min(0.8 * (windowHeight - headerHeight), EDITOR_HEIGHT);
 }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { ResizableBox, type ResizableBoxProps } from "react-resizable";
+import { useWindowSize } from "react-use";
 
 import type { CollectionPickerItem } from "metabase/common/components/Pickers/CollectionPicker";
 import type { DataPickerItem } from "metabase/common/components/Pickers/DataPicker";
@@ -25,6 +26,16 @@ import { ResizeHandle } from "../ResizeHandle";
 import S from "./EditorBody.module.css";
 
 const EDITOR_HEIGHT = 550;
+
+const NATIVE_HEADER_HEIGHT = 55;
+const HEADER_HEIGHT = 65 + 50;
+
+function getHeaderHeight(isNative: boolean) {
+  if (isNative) {
+    return HEADER_HEIGHT + NATIVE_HEADER_HEIGHT;
+  }
+  return HEADER_HEIGHT;
+}
 
 const NATIVE_EDITOR_SIDEBAR_FEATURES = {
   dataReference: true,
@@ -81,16 +92,23 @@ export function EditorBody({
   const [isResizing, setIsResizing] = useState(false);
   const reportTimezone = useSetting("report-timezone-long");
 
+  const { height: windowHeight } = useWindowSize();
+  const headerHeight = getHeaderHeight(isNative);
+  const editorHeight = Math.min(
+    0.8 * (windowHeight - headerHeight),
+    EDITOR_HEIGHT,
+  );
+
   const resizableBoxProps: Partial<ResizableBoxProps> = useMemo(
     () => ({
-      height: EDITOR_HEIGHT,
+      height: editorHeight,
       resizeHandles: ["s"],
       className: S.root,
       style: isResizing ? undefined : { transition: "height 0.25s" },
       onResizeStart: () => setIsResizing(true),
       onResizeStop: () => setIsResizing(false),
     }),
-    [isResizing],
+    [isResizing, editorHeight],
   );
 
   const handleResize = () => {
@@ -146,7 +164,7 @@ export function EditorBody({
     <ResizableBox
       axis="y"
       className={S.root}
-      height={EDITOR_HEIGHT}
+      height={editorHeight}
       handle={<ResizeHandle />}
       resizeHandles={["s"]}
       onResizeStart={() => setIsResizing(true)}

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.tsx
@@ -85,6 +85,7 @@ export function EditorBody({
     () => ({
       height: EDITOR_HEIGHT,
       resizeHandles: ["s"],
+      className: S.root,
       style: isResizing ? undefined : { transition: "height 0.25s" },
       onResizeStart: () => setIsResizing(true),
       onResizeStop: () => setIsResizing(false),
@@ -143,8 +144,8 @@ export function EditorBody({
     />
   ) : (
     <ResizableBox
-      className={S.root}
       axis="y"
+      className={S.root}
       height={EDITOR_HEIGHT}
       handle={<ResizeHandle />}
       resizeHandles={["s"]}


### PR DESCRIPTION
Fixes some UI warts for the SQL en Question transform editors.

- Adds missing border on results for the native query editor.
- On smaller screens, avoid pushing the results panel off the screen completely.

#### Before
<img width="1474" height="906" alt="Screenshot 2025-09-26 at 15 32 48" src="https://github.com/user-attachments/assets/ee641b60-47fe-49cd-9b61-39425b004893" />


#### After
<img width="1474" height="906" alt="Screenshot 2025-09-26 at 15 32 35" src="https://github.com/user-attachments/assets/52a14e40-ecab-4949-bc4e-dc0e45b257b1" />


