### PR TITLE
Do not show error when loading

### DIFF
--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -138,6 +138,7 @@ export default class VisualizationResult extends Component {
             isObjectDetail={false}
             isQueryBuilder={true}
             isShowingSummarySidebar={isShowingSummarySidebar}
+            isRunning={isRunning}
             onEditSummary={onEditSummary}
             queryBuilderMode={queryBuilderMode}
             showTitle={false}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -141,6 +141,7 @@ type VisualizationOwnProps = {
   isDashboard?: boolean;
   isDocument?: boolean;
   isMobile?: boolean;
+  isRunning?: boolean;
   isShowingSummarySidebar?: boolean;
   isSlow?: CardSlownessStatus;
   isVisible?: boolean;
@@ -602,6 +603,7 @@ class Visualization extends PureComponent<
       isPreviewing,
       isRawTable,
       isQueryBuilder,
+      isRunning,
       isSettings,
       isShowingDetailsOnlyColumns,
       isShowingSummarySidebar,
@@ -795,7 +797,7 @@ class Visualization extends PureComponent<
             replacementContent
           ) : isDashboard && noResults ? (
             <NoResultsView isSmall={small} />
-          ) : error ? (
+          ) : error && !isRunning ? (
             <ErrorView
               error={errorMessageOverride ?? error}
               icon={errorIcon}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.js
@@ -247,4 +247,16 @@ describe("Visualization", () => {
       });
     });
   });
+
+  it("should not show loader and error at the same time (metabase#63410)", async () => {
+    await renderViz(undefined, {
+      error: new Error("This is my error message"),
+      isRunning: true,
+    });
+
+    expect(
+      screen.queryByText("This is my error message"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63410 by hiding visualization errors when the query is running.

While I agree with the original issue that the stacked text looks weird, I'm not 100% sure this is the right thing to do so, since it removes the consistency with other parts of the viz where we always show the previous results underneath the loader.

@mazameli what do you think?