### PR TITLE
MariaDB transform cancellation fix

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform_run_cancelation.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform_run_cancelation.clj
@@ -14,16 +14,12 @@
   [run-id]
   (t2/query-one
    [(str "INSERT INTO transform_run_cancelation (run_id) "
-         "SELECT ? "
-         "WHERE "
-         "      EXISTS (SELECT 1 "
-         "              FROM transform_run "
-         "              WHERE (transform_run.id = ?) "
-         "                AND transform_run.is_active)"
-         "      AND NOT EXISTS (SELECT 1 "
-         "                      FROM transform_run_cancelation "
-         "                      WHERE run_id = ?)")
-    run-id run-id run-id])
+         "SELECT transform_run.id "
+         "FROM transform_run "
+         "WHERE transform_run.id = ? "
+         "AND transform_run.is_active "
+         "AND NOT EXISTS (SELECT 1 FROM transform_run_cancelation WHERE run_id = ?)")
+    run-id run-id])
   (t2/update! :model/TransformRun
               :id run-id
               {:status "canceling"})


### PR DESCRIPTION
`mark-cancel-started-run!` fails when executed against a MariaDB 10.2 AppDB. It seems this is because older versions of MySQL/MariaDB would require a `FROM` clause: e.g. `SELECT ... FROM dual WHERE`.

The query is rewritten to include a FROM clause.

No test is included in this PR, but this behaviour is covered by #63833  which tests cancellation for python and triggers the error.