### PR TITLE
Factor out setup/log actions for python runner, use in driver tests

### DIFF
--- a/.github/actions/cleanup-python-runner/action.yml
+++ b/.github/actions/cleanup-python-runner/action.yml
@@ -1,0 +1,37 @@
+name: Cleanup Python Runner
+description: Cleanup python-runner services and upload logs as artifacts
+
+inputs:
+  upload-logs:
+    description: 'Whether to upload logs (typically on failure)'
+    required: false
+    default: 'false'
+  logs-artifact-suffix:
+    description: 'The unique name of the .zip artifact containing the logs'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Cleanup python-runner services
+      if: always()
+      run: |
+        echo "Stopping python-runner services..."
+        if [ -d "python-runner" ]; then
+          cd python-runner
+          make stop || echo "WARNING: Failed to stop python runner"
+          cd ..
+        fi
+      shell: bash
+
+    - name: Upload python-runner logs
+      if: inputs.upload-logs == 'true' && inputs.logs-artifact-name != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-runner-logs-${{inputs.logs-artifact-suffix}}
+        path: |
+          python-runner.out.log
+          python-runner.err.log
+        retention-days: 1
+        if-no-files-found: warn

--- a/.github/actions/cleanup-python-runner/action.yml
+++ b/.github/actions/cleanup-python-runner/action.yml
@@ -21,7 +21,6 @@ runs:
         if [ -d "python-runner" ]; then
           cd python-runner
           make stop || echo "WARNING: Failed to stop python runner"
-          cd ..
         fi
       shell: bash
 

--- a/.github/actions/setup-python-runner/action.yml
+++ b/.github/actions/setup-python-runner/action.yml
@@ -1,0 +1,14 @@
+name: Setup Python Runner
+description: Setup python-runner for tests
+inputs:
+  metabase-automation-token:
+    description: Token for accessing the python-runner repository
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup python-runner
+      run: ./.github/scripts/setup-python-runner.sh
+      shell: bash
+      env:
+        METABASE_AUTOMATION_USER_TOKEN: ${{ inputs.metabase-automation-token }}

--- a/.github/scripts/setup-python-runner.sh
+++ b/.github/scripts/setup-python-runner.sh
@@ -24,6 +24,7 @@ git clone --depth 1 https://${METABASE_AUTOMATION_USER_TOKEN}@github.com/metabas
 if [ "$SKIP_START" = false ]; then
   echo "Starting python-runner..."
   cd python-runner
-  make run-ci
+  make run-ci 1> ../python-runner.out.log 2> ../python-runner.err.log
+  make logs 1>> ../python-runner.out.log 2>> ../python-runner.err.log &
   cd ..
 fi

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -135,10 +135,11 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
-      env:
-        METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-      run: ./.github/scripts/setup-python-runner.sh
+      uses: ./.github/actions/setup-python-runner
+      with:
+        metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
     - name: Test BigQuery Cloud SDK driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-bigquery-cloud-sdk-ee'
@@ -154,6 +155,12 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+    - name: Cleanup python-runner
+      if: ${{ always() && matrix.job.needs-python-runner == true }}
+      uses: ./.github/actions/cleanup-python-runner
+      with:
+        upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
+        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
 
   be-tests-clickhouse-ee:
     if: ${{ !inputs.skip }}
@@ -183,9 +190,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
-      env:
-        METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-      run: ./.github/scripts/setup-python-runner.sh
+      uses: ./.github/actions/setup-python-runner
+      with:
+        metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
     - name: Add ClickHouse TLS instance to /etc/hosts
       run: |
         sudo echo "127.0.0.1 server.clickhouseconnect.test" | sudo tee -a /etc/hosts
@@ -202,6 +209,7 @@ jobs:
           clickhouse_cluster_node2
           nginx
     - name: Test Clickhouse driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-clickhouse-ee'
@@ -217,6 +225,12 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+    - name: Cleanup python-runner
+      if: ${{ always() && matrix.job.needs-python-runner == true }}
+      uses: ./.github/actions/cleanup-python-runner
+      with:
+        upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
+        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
 
   be-tests-druid-ee:
     needs: determine-driver-skips
@@ -377,10 +391,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup python-runner
-      env:
-        METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-      run: ./.github/scripts/setup-python-runner.sh
+      uses: ./.github/actions/setup-python-runner
+      with:
+        metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
     - name: Test H2 driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-h2'
@@ -398,6 +413,12 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+    - name: Cleanup python-runner
+      if: always()
+      uses: ./.github/actions/cleanup-python-runner
+      with:
+        upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
+        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
 
   be-tests-mysql-mariadb:
     if: ${{ !inputs.skip }}
@@ -492,10 +513,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup python-runner
       #if: ${{ matrix.job.needs-python-runner == true }}
-        env:
-          METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-        run: ./.github/scripts/setup-python-runner.sh
+        uses: ./.github/actions/setup-python-runner
+        with:
+          metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       - name: Test ${{ matrix.version.name }}
+        id: test-driver
         uses: ./.github/actions/test-driver
         with:
           junit-name: ${{ matrix.version.junit-name }}
@@ -513,6 +535,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - name: Cleanup python-runner
+        if: always()
+        uses: ./.github/actions/cleanup-python-runner
+        with:
+          upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
+          logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
 
   be-tests-mongo:
     needs: determine-driver-skips
@@ -556,10 +584,11 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
-      env:
-        METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-      run: ./.github/scripts/setup-python-runner.sh
+      uses: ./.github/actions/setup-python-runner
+      with:
+        metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
     - name: Test ${{ matrix.version.name }}
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: ${{ matrix.version.junit-name }}
@@ -575,6 +604,12 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+    - name: Cleanup python-runner
+      if: ${{ always() && matrix.job.needs-python-runner == true }}
+      uses: ./.github/actions/cleanup-python-runner
+      with:
+        upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
+        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
 
   be-tests-mongo-ssl:
     needs: determine-driver-skips
@@ -818,10 +853,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup python-runner
       #if: ${{ matrix.job.needs-python-runner == true }}
-        env:
-          METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-        run: ./.github/scripts/setup-python-runner.sh
+        uses: ./.github/actions/setup-python-runner
+        with:
+          metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       - name: Test ${{ matrix.version.name }} (${{ matrix.job.name }})
+        id: test-driver
         uses: ./.github/actions/test-driver
         with:
           junit-name: 'be-tests-${{ matrix.version.junit-name }}'
@@ -839,6 +875,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+      - name: Cleanup python-runner
+        if: always()
+        uses: ./.github/actions/cleanup-python-runner
+        with:
+          upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
+          logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
 
   be-tests-presto-jdbc-ee:
     needs: determine-driver-skips
@@ -949,10 +991,11 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
-      env:
-        METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-      run: ./.github/scripts/setup-python-runner.sh
+      uses: ./.github/actions/setup-python-runner
+      with:
+        metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
     - name: Test ${{ matrix.job.name }}
+      id: test-driver
       if: ${{ !matrix.job.skip }}
       uses: ./.github/actions/test-driver
       with:
@@ -970,6 +1013,12 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+    - name: Cleanup python-runner
+      if: ${{ always() && matrix.job.needs-python-runner == true }}
+      uses: ./.github/actions/cleanup-python-runner
+      with:
+        upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
+        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
 
   be-tests-snowflake-ee:
     if: ${{ !inputs.skip }}
@@ -1011,10 +1060,11 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
-      env:
-        METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-      run: ./.github/scripts/setup-python-runner.sh
+      uses: ./.github/actions/setup-python-runner
+      with:
+        metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
     - name: Test Snowflake driver
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-snowflake-ee'
@@ -1030,6 +1080,12 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+    - name: Cleanup python-runner
+      if: ${{ always() && matrix.job.needs-python-runner == true }}
+      uses: ./.github/actions/cleanup-python-runner
+      with:
+        upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
+        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
 
   be-tests-sparksql-ee:
     needs: determine-driver-skips
@@ -1140,10 +1196,11 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
-      env:
-        METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-      run: ./.github/scripts/setup-python-runner.sh
+      uses: ./.github/actions/setup-python-runner
+      with:
+        metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
     - name: Test ${{ matrix.version.name }}
+      id: test-driver
       uses: ./.github/actions/test-driver
       with:
         junit-name: ${{ matrix.version.junit-name }}
@@ -1159,6 +1216,12 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+    - name: Cleanup python-runner
+      if: ${{ always() && matrix.job.needs-python-runner == true }}
+      uses: ./.github/actions/cleanup-python-runner
+      with:
+        upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
+        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
 
   # TODO(dpsutton, 2025-08-20): Re-enable starburst when we figure out why it randomly dies in CI
   # be-tests-starburst-ee:


### PR DESCRIPTION
It can be useful when debugging test failures to have python runner logs available as an artifact. e.g. if you get some unexpected behaviour (such as a crash). 

Otherwise the logs are not observable, the container is short lived and its log output only exists while the CI job runs (via docker)