### PR TITLE
Python runner timeouts

### DIFF
--- a/.github/actions/cleanup-python-runner/action.yml
+++ b/.github/actions/cleanup-python-runner/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
 
     - name: Upload python-runner logs
-      if: inputs.upload-logs == 'true' && inputs.logs-artifact-name != ''
+      if: ${{inputs.upload-logs == 'true' && inputs.logs-artifact-suffix != ''}}
       uses: actions/upload-artifact@v4
       with:
         name: python-runner-logs-${{inputs.logs-artifact-suffix}}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -160,7 +160,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-clickhouse-ee:
     if: ${{ !inputs.skip }}
@@ -230,7 +230,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-druid-ee:
     needs: determine-driver-skips
@@ -418,7 +418,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-mysql-mariadb:
     if: ${{ !inputs.skip }}
@@ -540,7 +540,7 @@ jobs:
         uses: ./.github/actions/cleanup-python-runner
         with:
           upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-          logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
+          logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-mongo:
     needs: determine-driver-skips
@@ -609,7 +609,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-mongo-ssl:
     needs: determine-driver-skips
@@ -880,7 +880,7 @@ jobs:
         uses: ./.github/actions/cleanup-python-runner
         with:
           upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-          logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
+          logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-presto-jdbc-ee:
     needs: determine-driver-skips
@@ -1018,7 +1018,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-snowflake-ee:
     if: ${{ !inputs.skip }}
@@ -1085,7 +1085,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-sparksql-ee:
     needs: determine-driver-skips
@@ -1221,7 +1221,7 @@ jobs:
       uses: ./.github/actions/cleanup-python-runner
       with:
         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-        logs-artifact-suffix: ${{ github.job }} ${{ matrix.job.name }}
+        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   # TODO(dpsutton, 2025-08-20): Re-enable starburst when we figure out why it randomly dies in CI
   # be-tests-starburst-ee:

--- a/enterprise/backend/src/metabase_enterprise/transforms/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/core.clj
@@ -1,9 +1,12 @@
 (ns metabase-enterprise.transforms.core
   "API namespace for the `metabase-enterprise.transform` module."
   (:require
+   [metabase-enterprise.transforms.models.transform-run]
    [metabase-enterprise.transforms.settings]
    [potemkin :as p]))
 
 (p/import-vars
  [metabase-enterprise.transforms.settings
-  transform-timeout])
+  transform-timeout]
+ [metabase-enterprise.transforms.models.transform-run
+  timeout-run!])

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
@@ -6,8 +6,8 @@
    [metabase-enterprise.transforms-python.python-runner :as python-runner]
    [metabase-enterprise.transforms-python.s3 :as s3]
    [metabase-enterprise.transforms-python.settings :as transforms-python.settings]
+   [metabase-enterprise.transforms.core :as transforms]
    [metabase-enterprise.transforms.instrumentation :as transforms.instrumentation]
-   [metabase-enterprise.transforms.models.transform-run :as transform-run]
    [metabase-enterprise.transforms.util :as transforms.util]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
@@ -267,7 +267,7 @@
       (if (not= 200 status)
         (do
           (when (:timeout body)
-            (transform-run/timeout-run! run-id))
+            (transforms/timeout-run! run-id))
           (throw (ex-info "Python runner call failed"
                           {:transform-message (i18n/tru "Python execution failure (exit code {0})" (:exit_code body "?"))
                            :status-code       400

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/execute.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.transforms-python.s3 :as s3]
    [metabase-enterprise.transforms-python.settings :as transforms-python.settings]
    [metabase-enterprise.transforms.instrumentation :as transforms.instrumentation]
+   [metabase-enterprise.transforms.models.transform-run :as transform-run]
    [metabase-enterprise.transforms.util :as transforms.util]
    [metabase.driver :as driver]
    [metabase.driver.util :as driver.u]
@@ -264,12 +265,15 @@
       (when (seq events)
         (replace-python-logs! message-log events))
       (if (not= 200 status)
-        (throw (ex-info "Python runner call failed"
-                        {:transform-message (i18n/tru "Python execution failure (exit code {0})" (:exit_code body "?"))
-                         :status-code       400
-                         :api-status-code   status
-                         :body              body
-                         :events            events}))
+        (do
+          (when (:timeout body)
+            (transform-run/timeout-run! run-id))
+          (throw (ex-info "Python runner call failed"
+                          {:transform-message (i18n/tru "Python execution failure (exit code {0})" (:exit_code body "?"))
+                           :status-code       400
+                           :api-status-code   status
+                           :body              body
+                           :events            events})))
         (try
           (let [temp-path (Files/createTempFile "transform-output-" ".jsonl" (u/varargs FileAttribute))
                 temp-file (.toFile temp-path)]

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
@@ -183,7 +183,7 @@
 
         payload                  {:code                code
                                   :library             (t2/select-fn->fn :path :source :model/PythonLibrary)
-                                  :timeout             (* 30 60) ;; 30 mins harcoded for now
+                                  :timeout             (transforms-python.settings/python-runner-timeout-seconds)
                                   :request_id          run-id
                                   :output_url          (:url output)
                                   :output_manifest_url (:url output-manifest)

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/settings.clj
@@ -113,3 +113,14 @@
   :export?    false
   :encryption :no
   :audit      :getter)
+
+(setting/defsetting python-runner-timeout-seconds
+  (deferred-tru "Timeout in seconds for Python script execution. Defaults to 30 minutes (1800 seconds).")
+  :type       :integer
+  :visibility :admin
+  :default    1800 ;; 30 minutes
+  :feature    :transforms-python
+  :doc        false
+  :export?    false
+  :encryption :no
+  :audit      :getter)

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/execute_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.transforms-python.execute :as transforms-python.execute]
-   [metabase-enterprise.transforms-python.settings :as transforms-python.settings]
    [metabase-enterprise.transforms.test-dataset :as transforms-dataset]
    [metabase-enterprise.transforms.test-util :as transforms.tu :refer [with-transform-cleanup!]]
    [metabase-enterprise.transforms.util :as transforms.util]
@@ -104,7 +103,7 @@
             (with-transform-cleanup! [target {:type   "table"
                                               :schema schema
                                               :name   "timeout_test"}]
-              (test.util/with-temporary-setting-values [transforms-python.settings/python-runner-timeout-seconds 5]
+              (test.util/with-temporary-setting-values [python-runner-timeout-seconds 5]
                 (let [long-running-code (str "import time\n"
                                              "import pandas as pd\n"
                                              "\n"

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/python_runner_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/python_runner_test.clj
@@ -498,14 +498,15 @@
 
 (deftest python-runner-timeout-test
   (testing "Python script execution respects timeout setting"
-    (tu/with-temporary-setting-values [python-runner-timeout-seconds 5]
-      (let [long-running-code (str "import time\n"
-                                   "import pandas as pd\n"
-                                   "\n"
-                                   "def transform():\n"
-                                   "    time.sleep(10)  # Sleep longer than timeout\n"
-                                   "    return pd.DataFrame({'result': ['should_not_reach_here']})")
-            result (execute! {:code long-running-code})]
-        (testing "Script should timeout after 5 seconds"
-          (is (contains? result :error))
-          (is (str/includes? (:error result) "timeout")))))))
+    (mt/with-premium-features #{:transforms-python}
+      (tu/with-temporary-setting-values [python-runner-timeout-seconds 5]
+        (let [long-running-code (str "import time\n"
+                                     "import pandas as pd\n"
+                                     "\n"
+                                     "def transform():\n"
+                                     "    time.sleep(10)  # Sleep longer than timeout\n"
+                                     "    return pd.DataFrame({'result': ['should_not_reach_here']})")
+              result            (execute! {:code long-running-code})]
+          (testing "Script should timeout after 5 seconds"
+            (is (contains? result :error))
+            (is (str/includes? (:error result) "timeout"))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/python_runner_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/python_runner_test.clj
@@ -498,7 +498,7 @@
 
 (deftest python-runner-timeout-test
   (testing "Python script execution respects timeout setting"
-    (tu/with-temporary-setting-values [transforms-python.settings/python-runner-timeout-seconds 5]
+    (tu/with-temporary-setting-values [python-runner-timeout-seconds 5]
       (let [long-running-code (str "import time\n"
                                    "import pandas as pd\n"
                                    "\n"

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/python_runner_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/python_runner_test.clj
@@ -499,7 +499,12 @@
 (deftest python-runner-timeout-test
   (testing "Python script execution respects timeout setting"
     (tu/with-temporary-setting-values [transforms-python.settings/python-runner-timeout-seconds 5]
-      (let [long-running-code "import time\ntime.sleep(10)\nprint('This should timeout')"
+      (let [long-running-code (str "import time\n"
+                                   "import pandas as pd\n"
+                                   "\n"
+                                   "def transform():\n"
+                                   "    time.sleep(10)  # Sleep longer than timeout\n"
+                                   "    return pd.DataFrame({'result': ['should_not_reach_here']})")
             result (execute! {:code long-running-code})]
         (testing "Script should timeout after 5 seconds"
           (is (contains? result :error))

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/pages/PythonRunnerSettingsPage/PythonRunnerSettingsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/pages/PythonRunnerSettingsPage/PythonRunnerSettingsPage.tsx
@@ -17,6 +17,13 @@ export function PythonRunnerSettingsPage() {
           placeholder="http://localhost:5001"
           inputType="text"
         />
+        <AdminSettingInput
+          name="python-runner-timeout-seconds"
+          title={t`Python Script Execution Timeout`}
+          description={t`Timeout in seconds for Python script execution. Defaults to 30 minutes (1800 seconds).`}
+          placeholder="1800"
+          inputType="number"
+        />
       </SettingsSection>
       <SettingsSection title={t`S3 Storage Configuration`}>
         <AdminSettingInput

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -687,6 +687,7 @@ export interface EnterpriseSettings extends Settings {
   "python-storage-s-3-secret-key"?: string | null;
   "python-storage-s-3-container-endpoint"?: string | null;
   "python-storage-s-3-path-style-access"?: boolean | null;
+  "python-runner-timeout-seconds"?: number | null;
   /**
    * @deprecated
    */


### PR DESCRIPTION
Closes QUE-2572

We also correctly report timeout status from runner timeouts in the UI now

<img width="1890" height="318" alt="image" src="https://github.com/user-attachments/assets/ecb68ae5-bf37-4b58-be50-f3d80dfa35df" />
<img width="1814" height="193" alt="image" src="https://github.com/user-attachments/assets/81b5442a-6b45-4c09-8192-b23dc168701d" />
