### PR TITLE
[advanced-config] uppercased letter in users email should not fail

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/users.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/users.clj
@@ -56,4 +56,5 @@
 (defmethod advanced-config.file.i/initialize-section! :users
   [_section-name users]
   (doseq [user users]
-    (init-from-config-file! user)))
+    ;; we're lower-casing emails in :model/User, so we should do the same here
+    (init-from-config-file! (update user :email u/lower-case-en))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/users_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/users_test.clj
@@ -157,3 +157,21 @@
      :last_name  "Era"
      :email      "cam+config-file-test@metabase.com"}
     (re-pattern (java.util.regex.Pattern/quote "failed: (contains? % :password)"))))
+
+(deftest email-case-irrelevant-test
+  (testing "Using any case in email still works #62894"
+    (try
+      (binding [advanced-config.file/*config* {:version 1
+                                               :config  {:users [{:first_name       "Cam"
+                                                                  :last_name        "Era"
+                                                                  :email            "Cam+config-file-test@metabase.com"
+                                                                  :password         "2cans"
+                                                                  :login_attributes {"a" 1}}]}}]
+        (is (= :ok
+               (advanced-config.file/initialize!)))
+        (testing "It should not fail with 'duplicate'"
+          (is (= :ok
+                 (advanced-config.file/initialize!)))))
+      (finally
+        (t2/delete! :model/User :email "cam+config-file-test@metabase.com")
+        (t2/delete! :model/User :email "Cam+config-file-test@metabase.com")))))


### PR DESCRIPTION
fixes #62894
