### PR TITLE
When deleting DB, hide cards from search

### DIFF
--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -336,6 +336,9 @@
   (unschedule-tasks! database)
   (secret/delete-orphaned-secrets! database)
   (delete-database-fields! id)
+  ;; This is a temporary hack to hide these cards from most searches.
+  ;; Once search supports deletion, we should revisit this.
+  (t2/update! :model/Card :database_id id {:archived true})
   (try
     (driver/notify-database-updated driver database)
     (catch Throwable e

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -1853,3 +1853,27 @@
                            :data count)]
       (is (>= total-count result-count))
       (is (= 1 result-count)))))
+
+(deftest ^:synchronized delete-database-hides-cards-from-search-test
+  (testing "When deleting a database, cards referring to that database should be hidden from search"
+    (let [card-name (str (random-uuid))]
+      (mt/with-temp [:model/Database {db-id :id} {:name "Test Database"}
+                     :model/Table {table-id :id} {:db_id db-id :name "Test Table"}
+                     :model/Card {card-id :id} {:name card-name
+                                                :database_id db-id
+                                                :table_id table-id
+                                                :dataset_query {:database db-id
+                                                                :type :query
+                                                                :query {:source-table table-id}}}]
+        (search/reindex! {:async? false :in-place? true})
+        (testing "Card should be visible in search before database deletion"
+          (let [search-results (mt/user-http-request :crowberto :get 200 "search" :q card-name)]
+            (is (some #(= (:id %) card-id) (:data search-results))
+                "Card should be found in search results before database deletion")))
+
+        (testing "Card should be hidden from search after database deletion"
+          (t2/delete! :model/Database :id db-id)
+          (is (not (t2/exists? :model/Card :id card-id)))
+          (let [search-results (mt/user-http-request :crowberto :get 200 "search" :q card-name)]
+            (is (not (some #(= (:id %) card-id) (:data search-results)))
+                "Card should not be found in search results after database deletion")))))))


### PR DESCRIPTION
Fixes #62730 

We have a current issue with search: deleting items does not actually remove them from search.

This is a particularly nasty version of this, because while usually a delete follows an update (that marks the card as archived, which *does* remove it from search), in this case we're just deleting the items directly as part of an `ON DELETE CASCADE`.

This is a bit hacky, but for now we can just mark them as `archived` before we delete them to hide them from search.

[UXW-602: Search API returns inexisting cards](https://linear.app/metabase/issue/UXW-602/search-api-returns-inexisting-cards)