### PR TITLE
Fixes viz settins for details-only columns

### DIFF
--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -689,7 +689,7 @@ describe("issue 23421", () => {
     type: "model",
   };
 
-  const hiddenColumnsQuestionDetails = {
+  const hiddenColumnsModelDetails = {
     native: {
       query,
     },
@@ -734,16 +734,17 @@ describe("issue 23421", () => {
   });
 
   it("`visualization_settings` with hidden columns should not break UI (metabase#23421)", () => {
-    H.createNativeQuestion(hiddenColumnsQuestionDetails, {
+    H.createNativeQuestion(hiddenColumnsModelDetails, {
       visitQuestion: true,
     });
     H.openQuestionActions();
     H.popover().findByText("Edit query definition").click();
 
     H.NativeEditor.get().should("be.visible").and("contain", query);
-    cy.findByTestId("visualization-root")
-      .findByText("Every field is hidden right now")
-      .should("be.visible");
+    H.tableInteractiveHeader().within(() => {
+      cy.findByText("id").should("be.visible");
+      cy.findByText("created_at").should("be.visible");
+    });
     cy.button("Save changes").should("be.disabled");
   });
 });

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
@@ -723,7 +723,7 @@ const _DatasetEditorInner = (props: DatasetEditorInnerProps) => {
                 noHeader
                 queryBuilderMode="dataset"
                 onHeaderColumnReorder={handleHeaderColumnReorder}
-                isShowingDetailsOnlyColumns={datasetEditorTab === "columns"}
+                isShowingDetailsOnlyColumns={datasetEditorTab !== "metadata"}
                 hasMetadataPopovers={false}
                 handleVisualizationClick={handleTableElementClick}
                 tableHeaderHeight={isEditingColumns && TABLE_HEADER_HEIGHT}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
@@ -18,7 +18,7 @@ interface ChartSettingTableColumnsProps {
   value: TableColumnOrderSetting[];
   columns: DatasetColumn[];
   question?: Question;
-  isDashboard?: boolean;
+  isShowingDetailsOnlyColumns: boolean;
   getColumnName: (column: DatasetColumn) => string;
   onChange: (value: TableColumnOrderSetting[], question?: Question) => void;
   onShowWidget: (config: EditWidgetData, targetElement: HTMLElement) => void;
@@ -28,6 +28,7 @@ export const ChartSettingTableColumns = ({
   value,
   columns,
   question,
+  isShowingDetailsOnlyColumns,
   getColumnName,
   onChange,
   onShowWidget,
@@ -62,6 +63,7 @@ export const ChartSettingTableColumns = ({
         <TableColumnPanel
           columns={columns}
           columnSettings={value}
+          isShowingDetailsOnlyColumns={isShowingDetailsOnlyColumns}
           getColumnName={getColumnName}
           onChange={onChange}
           onShowWidget={onShowWidget}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.tsx
@@ -22,6 +22,7 @@ import {
 interface TableColumnPanelProps {
   columns: DatasetColumn[];
   columnSettings: TableColumnOrderSetting[];
+  isShowingDetailsOnlyColumns: boolean;
   getColumnName: (column: DatasetColumn) => string;
   onChange: (value: TableColumnOrderSetting[]) => void;
   onShowWidget: (config: EditWidgetData, targetElement: HTMLElement) => void;
@@ -31,13 +32,19 @@ export const TableColumnPanel = ({
   columns,
   columnSettings,
   getColumnName,
+  isShowingDetailsOnlyColumns,
   onChange,
   onShowWidget,
 }: TableColumnPanelProps) => {
   const tc = useTranslateContent();
   const columnItems = useMemo(() => {
-    return getColumnItems(columns, columnSettings, tc);
-  }, [columns, columnSettings, tc]);
+    return getColumnItems(
+      columns,
+      columnSettings,
+      tc,
+      isShowingDetailsOnlyColumns,
+    );
+  }, [columns, columnSettings, tc, isShowingDetailsOnlyColumns]);
 
   const getItemName = useCallback(
     (columnItem: ColumnItem) => {
@@ -48,16 +55,16 @@ export const TableColumnPanel = ({
 
   const handleEnableColumn = useCallback(
     (columnItem: ColumnItem) => {
-      onChange(toggleColumnInSettings(columnItem, columnItems, true));
+      onChange(toggleColumnInSettings(columnSettings, columnItem, true));
     },
-    [onChange, columnItems],
+    [columnSettings, onChange],
   );
 
   const handleDisableColumn = useCallback(
     (columnItem: ColumnItem) => {
-      onChange(toggleColumnInSettings(columnItem, columnItems, false));
+      onChange(toggleColumnInSettings(columnSettings, columnItem, false));
     },
-    [onChange, columnItems],
+    [columnSettings, onChange],
   );
 
   const handleDragColumn = useCallback(
@@ -66,9 +73,11 @@ export const TableColumnPanel = ({
         (columnItem) => getId(columnItem) === id,
       );
 
-      onChange(moveColumnInSettings(columnItems, oldIndex, newIndex));
+      onChange(
+        moveColumnInSettings(columnSettings, columnItems, oldIndex, newIndex),
+      );
     },
-    [columnItems, onChange],
+    [columnSettings, columnItems, onChange],
   );
 
   const handleEditColumn = useCallback(
@@ -80,7 +89,7 @@ export const TableColumnPanel = ({
 
   return (
     <Box role="list" data-testid="chart-settings-table-columns">
-      {columns.length > 0 && (
+      {columnItems.length > 0 && (
         <Box role="group" data-testid="visible-columns">
           <ChartSettingOrderedItems
             getId={getId}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/types.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/types.ts
@@ -1,16 +1,12 @@
 import type { IconName } from "metabase/ui";
-import type {
-  DatasetColumn,
-  TableColumnOrderSetting,
-} from "metabase-types/api";
+import type { DatasetColumn } from "metabase-types/api";
 
 export type ColumnItem = {
   name: string;
   enabled: boolean;
-  index: number;
   icon: IconName;
   column: DatasetColumn;
-  columnSetting: TableColumnOrderSetting;
+  columnSettingIndex: number;
 };
 
 export type DragColumnProps = {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/types.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/types.ts
@@ -8,8 +8,3 @@ export type ColumnItem = {
   column: DatasetColumn;
   columnSettingIndex: number;
 };
-
-export type DragColumnProps = {
-  oldIndex: number;
-  newIndex: number;
-};

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -496,56 +496,59 @@ export const getTitleForColumn = (column, series, settings) => {
   }
 };
 
-export const tableColumnSettings = {
-  // NOTE: table column settings may be identified by fieldRef (possible not normalized) or column name:
-  //   { name: "COLUMN_NAME", enabled: true }
-  //   { fieldRef: ["field", 2, {"source-field": 1}], enabled: true }
-  "table.columns": {
-    get section() {
-      return t`Columns`;
-    },
-    // title: t`Columns`,
-    widget: ChartSettingTableColumns,
-    getHidden: (series, vizSettings) => vizSettings["table.pivot"],
-    getValue: ([{ data }], vizSettings) => {
-      const { cols } = data;
-      const settings = vizSettings["table.columns"] ?? [];
-      const uniqColumnSettings = getDeduplicatedTableColumnSettings(settings);
+export function tableColumnSettings({
+  isShowingDetailsOnlyColumns = false,
+} = {}) {
+  return {
+    "table.columns": {
+      get section() {
+        return t`Columns`;
+      },
+      // title: t`Columns`,
+      widget: ChartSettingTableColumns,
+      getHidden: (series, vizSettings) => vizSettings["table.pivot"],
+      getValue: ([{ data }], vizSettings) => {
+        const { cols } = data;
+        const settings = vizSettings["table.columns"] ?? [];
+        const uniqColumnSettings = getDeduplicatedTableColumnSettings(settings);
 
-      const columnIndexes = findColumnIndexesForColumnSettings(
-        cols,
-        uniqColumnSettings,
-      );
-      const settingIndexes = findColumnSettingIndexesForColumns(
-        cols,
-        uniqColumnSettings,
-      );
+        const columnIndexes = findColumnIndexesForColumnSettings(
+          cols,
+          uniqColumnSettings,
+        );
+        const settingIndexes = findColumnSettingIndexesForColumns(
+          cols,
+          uniqColumnSettings,
+        );
 
-      return [
-        // retain settings with matching columns only
-        ...uniqColumnSettings.filter(
-          (_, settingIndex) => columnIndexes[settingIndex] >= 0,
-        ),
-        // add columns that do not have matching settings to the end
-        ...cols
-          .filter((_, columnIndex) => settingIndexes[columnIndex] < 0)
-          .map((column) => ({
-            name: column.name,
-            enabled: true,
-          })),
-      ];
-    },
-    getProps: (series, settings) => {
-      const [
-        {
-          data: { cols },
-        },
-      ] = series;
+        return [
+          // retain settings with matching columns only
+          ...uniqColumnSettings.filter(
+            (_, settingIndex) => columnIndexes[settingIndex] >= 0,
+          ),
+          // add columns that do not have matching settings to the end
+          ...cols
+            .filter((_, columnIndex) => settingIndexes[columnIndex] < 0)
+            .map((column) => ({
+              name: column.name,
+              enabled: true,
+            })),
+        ];
+      },
+      getProps: (series, settings) => {
+        const [
+          {
+            data: { cols },
+          },
+        ] = series;
 
-      return {
-        columns: cols,
-        getColumnName: (column) => getTitleForColumn(column, series, settings),
-      };
+        return {
+          columns: cols,
+          isShowingDetailsOnlyColumns,
+          getColumnName: (column) =>
+            getTitleForColumn(column, series, settings),
+        };
+      },
     },
-  },
-};
+  };
+}

--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
@@ -27,7 +27,7 @@ const ObjectDetailProperties = {
   disableClickBehavior: true,
   settings: {
     ...columnSettings({ hidden: true }),
-    ...tableColumnSettings,
+    ...tableColumnSettings({ isShowingDetailsOnlyColumns: true }),
   },
   columnSettings: (column) => {
     const settings = {

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -395,16 +395,23 @@ class Table extends Component<TableProps, TableState> {
     this._updateData(this.props);
   }
 
-  UNSAFE_componentWillReceiveProps(newProps: VisualizationProps) {
+  UNSAFE_componentWillReceiveProps(newProps: TableProps) {
     if (
       newProps.series !== this.props.series ||
-      !_.isEqual(newProps.settings, this.props.settings)
+      !_.isEqual(newProps.settings, this.props.settings) ||
+      newProps.isShowingDetailsOnlyColumns !==
+        this.props.isShowingDetailsOnlyColumns
     ) {
       this._updateData(newProps);
     }
   }
 
-  _updateData({ series, settings, metadata }: VisualizationProps) {
+  _updateData({
+    series,
+    settings,
+    metadata,
+    isShowingDetailsOnlyColumns,
+  }: TableProps) {
     const [{ card, data }] = series;
     // construct a Question that is in-sync with query results
     const question = new Question(card, metadata);
@@ -435,7 +442,7 @@ class Table extends Component<TableProps, TableState> {
       ).filter(
         (columnIndex, settingIndex) =>
           columnIndex >= 0 &&
-          (this.props.isShowingDetailsOnlyColumns ||
+          (isShowingDetailsOnlyColumns ||
             (cols[columnIndex].visibility_type !== "details-only" &&
               columnSettings[settingIndex].enabled)),
       );

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -201,7 +201,7 @@ class Table extends Component<TableProps, TableState> {
       readDependencies: ["table.pivot", "table.pivot_column"],
       persistDefault: true,
     },
-    ...tableColumnSettings,
+    ...tableColumnSettings({ isShowingDetailsOnlyColumns: false }),
     "table.column_widths": {},
     [DataGrid.COLUMN_FORMATTING_SETTING]: {
       get section() {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/63670

Makes sure that `details-only` columns are hidden in regular Table viz settings, but still visible in Object detail viz settings and in Model metadata.