### PR TITLE
✨ Make u/profile log lines look nicer

### DIFF
--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -750,7 +750,7 @@
                2 :magenta
                3 :yellow) "%s%s took %s"
              (if (pos? *profile-level*)
-               (str (str/join (repeat (dec *profile-level*) "  ")) " ⮦ ")
+               (str "┌" (str/join (repeat (dec *profile-level*) "─")) "─> ")
                "")
              (message-thunk)
              (u.format/format-nanoseconds (- #?(:cljs (* 1000000 (js/performance.now))


### PR DESCRIPTION
We want to make it clear when `profile` log lines are indented due to being sub-profiles of subsequent log lines. Previously whatever character was being used was not rendering correctly in my terminal so I've switched them to box-drawing characters.

Before:
<img width="2712" height="294" alt="image" src="https://github.com/user-attachments/assets/888f5a63-b696-456c-a3a9-98b628c61e99" />

After:
<img width="1358" height="117" alt="image" src="https://github.com/user-attachments/assets/7720585b-bade-4c72-99bc-713f6a43592f" />
