### PR TITLE
Temporarily disable python transforms tests for BQ/Snowflake

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -115,10 +115,11 @@ jobs:
             test-args: >-
               :only-tags [:mb/driver-tests]
               :exclude-tags [:mb/transforms-python-test]
-          - name: Transforms Python Tests
-            test-args: >-
-              :only-tags [:mb/transforms-python-test]
-            needs-python-runner: true
+# DS 2025-09-26 temporarily disabled while we diagnose flakes
+#          - name: Transforms Python Tests
+#            test-args: >-
+#              :only-tags [:mb/transforms-python-test]
+#            needs-python-runner: true
     env:
       CI: 'true'
       DRIVERS: bigquery-cloud-sdk
@@ -982,10 +983,11 @@ jobs:
             test-args: >-
               :only-tags [:mb/driver-tests]
               :exclude-tags [:mb/transforms-python-test]
-          - name: Transforms Python Tests
-            test-args: >-
-              :only-tags [:mb/transforms-python-test]
-            needs-python-runner: true
+# DS 2025-09-26 temporarily disabled while we diagnose flakes
+#          - name: Transforms Python Tests
+#            test-args: >-
+#              :only-tags [:mb/transforms-python-test]
+#            needs-python-runner: true
     env:
       CI: 'true'
       DRIVERS: snowflake


### PR DESCRIPTION
The new tests seem to flaking since landing in master yesterday. We have had issues with BigQuery/Snowflake before but we thought we had everything. For now disabling the tests to not block master.