### PR TITLE
Extract native query content for search indexing rather than the entire dataset_query structure

### DIFF
--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1278,7 +1278,6 @@
 (defn- maybe-extract-native-query
   "Return the native SQL text (truncated to `max-search-len`) if `dataset_query` is native; else nil."
   [{:keys [dataset_query]}]
-  (def dataset_query dataset_query)
   (let [query ((:out mi/transform-metabase-query) dataset_query)
         query-text (when (= :native (:type query))
                      (get-in query [:native :query]))]

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1325,7 +1325,7 @@
    :bookmark     [:model/CardBookmark [:and
                                        [:= :bookmark.card_id :this.id]
                                        [:= :bookmark.user_id :current_user/id]]]
-   :where [:and [:= :collection.namespace nil] [:= :this.document_id nil]]
+   :where        [:and [:= :collection.namespace nil] [:= :this.document_id nil]]
    :joins        {:collection [:model/Collection [:= :collection.id :this.collection_id]]
                   :r          [:model/Revision [:and
                                                 [:= :r.model_id :this.id]

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1297,7 +1297,7 @@
                   :database-id          true
                   :last-viewed-at       :last_used_at
                   :native-query         {:fn maybe-extract-native-query
-                                         :req-fields [:dataset_query]}
+                                         :fields [:dataset_query]}
                   :official-collection  [:= "official" :collection.authority_level]
                   :last-edited-at       :r.timestamp
                   :last-editor-id       :r.user_id
@@ -1308,9 +1308,9 @@
                   :updated-at           true
                   :display-type         :this.display
                   :non-temporal-dim-ids {:fn extract-non-temporal-dimension-ids
-                                         :req-fields [:dataset_query]}
+                                         :fields [:dataset_query]}
                   :has-temporal-dim     {:fn has-temporal-dimension?
-                                         :req-fields [:dataset_query]}}
+                                         :fields [:dataset_query]}}
    :search-terms [:name :description]
    :render-terms {:archived-directly          true
                   :collection-authority_level :collection.authority_level

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1276,7 +1276,7 @@
     (boolean (some lib.types/temporal? dimensions))))
 
 (defn- maybe-extract-native-query
-  "Return the native SQL text (truncated to `max-search-len`) if `dataset_query` is native; else nil."
+  "Return the native SQL text (truncated to `max-searchable-value-length`) if `dataset_query` is native; else nil."
   [{:keys [dataset_query]}]
   (let [query ((:out mi/transform-metabase-query) dataset_query)
         query-text (when (= :native (:type query))

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -44,6 +44,7 @@
 
  [search.ingestion
   bulk-ingest!
+  max-searchable-value-length
   searchable-value-trim-sql]
 
  [search.spec

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -64,8 +64,12 @@
   "Execute a single function attribute and return the result"
   [attr-key attr-def record]
   (try
-    (let [f (:fn attr-def)]
-      (f record))
+    (let [f (:fn attr-def)
+          fields (:fields attr-def)
+          input (if fields
+                  (select-keys record fields)
+                  record)]
+      (f input))
     (catch Exception e
       (log/warn e "Function execution failed for attribute" attr-key)
       false)))

--- a/src/metabase/search/spec.clj
+++ b/src/metabase/search/spec.clj
@@ -204,7 +204,10 @@
     (find-fields-kw expr)
 
     (and (vector? expr) (> (count expr) 1))
-    (into [] (mapcat find-fields-expr) (subvec expr 1))))
+    (into [] (mapcat find-fields-expr) (subvec expr 1))
+
+    (and (map? expr) (:req-fields expr))
+    (into [] (mapcat find-fields-expr) (:req-fields expr))))
 
 (defn- find-fields-attr [[k v]]
   (when v

--- a/test/metabase/search/spec_test.clj
+++ b/test/metabase/search/spec_test.clj
@@ -66,7 +66,6 @@
                                                       :document_id
                                                       :last_used_at
                                                       :name
-                                                      :query_type
                                                       :type
                                                       :view_count
                                                       :created_at


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/64121

Piggybacks on the newish `:fn` option in search specs to parse and extract native query content for native cards, so that we index _only_ the actual SQL vs the entire `dataset_query` JSON structure. Some relevant Slack discussion is [here](https://metaboat.slack.com/archives/C09CR3MT1KR/p1758906143847679). I don't think we necessarily need to update existing search indexes, as the original bug is not too severe, but we can let this change be picked up as indexes are re-built & cards are updated.