### PR TITLE
fix(scim): support patch requests without a path

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/scim/v2/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/scim/v2/api.clj
@@ -68,7 +68,9 @@
    [:Operations
     [:sequential [:map
                   [:op ms/NonBlankString]
-                  [:value [:or ms/NonBlankString ms/BooleanValue]]]]]])
+                  [:value [:or [:map-of [:or :keyword :string]
+                                [:or ms/NonBlankString ms/BooleanValue]]
+                           ms/NonBlankString ms/BooleanValue]]]]]])
 
 (def SCIMGroup
   "Malli schema for a SCIM group."
@@ -280,6 +282,18 @@
                                :status      400
                                :status-code 400})))))))))
 
+(defn- patch->user-updates
+  [acc path value]
+  (if (and (nil? path) (map? value))
+    (reduce-kv patch->user-updates acc value)
+    (let [path-str (some-> path name)]
+      (case path-str
+        "active"          (assoc acc :is_active (Boolean/valueOf (u/lower-case-en value)))
+        "userName"        (assoc acc :email value)
+        "name.givenName"  (assoc acc :first_name value)
+        "name.familyName" (assoc acc :last_name value)
+        (throw-scim-error 400 (format "Unsupported path: %s" path-str))))))
+
 (api.macros/defendpoint :patch ["/Users/:id" :id #"[^/]+"]
   "Activate or deactivate a user. Supports specific replace operations, but not arbitrary patches."
   [{:keys [id]} :- [:map
@@ -292,14 +306,8 @@
             updates (reduce
                      (fn [acc operation]
                        (let [{:keys [op path value]} operation]
-                         (if (= (u/lower-case-en op) "replace")
-                           (case path
-                             "active"          (assoc acc :is_active (Boolean/valueOf (u/lower-case-en value)))
-                             "userName"        (assoc acc :email value)
-                             "name.givenName"  (assoc acc :first_name value)
-                             "name.familyName" (assoc acc :last_name value)
-                             (throw-scim-error 400 (format "Unsupported path: %s" path)))
-                           acc)))
+                         (cond-> acc
+                           (= (u/lower-case-en op) "replace") (patch->user-updates path value))))
                      {}
                      (:Operations patch-ops))]
         (t2/update! :model/User (u/the-id user) updates)

--- a/enterprise/backend/test/metabase_enterprise/scim/v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/scim/v2/api_test.clj
@@ -297,64 +297,127 @@
             (is (= ["urn:ietf:params:scim:api:messages:2.0:Error"] (get response :schemas)))
             (is (= "User not found" (get response :detail)))))))))
 
-(deftest list-groups-test
+(deftest patch-user-test-without-path
   (with-scim-setup!
-    (mt/with-temp [:model/PermissionsGroup _group1 {:name "Group 1"}]
-      (testing "Fetch groups with default pagination"
-        (let [response (scim-client :get 200 "ee/scim/v2/Groups")]
-          (is (malli= scim-api/SCIMGroupList response))))
+    (mt/with-temp [:model/User user {:email "testuser@metabase.com"
+                                     :first_name "Test"
+                                     :last_name "User"
+                                     :is_active true
+                                     :locale "en-US"}]
+      (let [entity-id (t2/select-one-fn :entity_id :model/User :id (:id user))]
+        (testing "Deactivate an existing user"
+          (let [patch-body {:schemas ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+                            :Operations [{:op "Replace"
+                                          :value {"active" false}}]}
+                response   (scim-client :patch 200 (format "ee/scim/v2/Users/%s" entity-id) patch-body)]
+            (is (malli= scim-api/SCIMUser response))
+            (is (= false (:active response)))))
 
-      (testing "Fetch groups with custom pagination"
-        (let [response (scim-client :get 200 (format "ee/scim/v2/Groups?startIndex=%d&count=%d" 1 2))]
-          (is (= ["urn:ietf:params:scim:api:messages:2.0:ListResponse"] (get response :schemas)))
-          (is (integer? (get response :totalResults)))
-          (is (= 1 (get response :startIndex)))
-          (is (= 2 (get response :itemsPerPage)))
-          (is (= 2 (count (get response :Resources))))))
+        (testing "Reactivate an existing user"
+          (let [patch-body {:schemas ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+                            :Operations [{:op "Replace"
+                                          :value {"active" "True"}}]}
+                response   (scim-client :patch 200 (format "ee/scim/v2/Users/%s" entity-id) patch-body)]
+            (is (malli= scim-api/SCIMUser response))
+            (is (true? (:active response)))))
 
-      (testing "Fetch group by name"
-        (let [response (scim-client :get 200 (format "ee/scim/v2/Groups?filter=%s"
-                                                     (codec/url-encode "displayName eq \"Group 1\"")))]
-          (is (malli= scim-api/SCIMGroupList response))
-          (is (= 1 (get response :totalResults)))
-          (is (= 1 (count (get response :Resources))))))
+        (testing "Update family name of an existing user"
+          (let [patch-body {:schemas ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+                            :Operations [{:op "Replace"
+                                          :value {"name.familyName" "UpdatedUser"}}]}
+                response   (scim-client :patch 200 (format "ee/scim/v2/Users/%s" entity-id) patch-body)]
+            (is (malli= scim-api/SCIMUser response))
+            (is (= "UpdatedUser" (get-in response [:name :familyName])))))
 
-      (testing "Fetch non-existant group by name"
-        (let [response (scim-client :get 200 (format "ee/scim/v2/Groups?filter=%s"
-                                                     (codec/url-encode "displayName eq \"Fake Group\"")))]
-          (is (malli= scim-api/SCIMUserList response))
-          (is (= 0 (get response :totalResults)))
-          (is (= 0 (count (get response :Resources))))))
+        (testing "Update multiple attributes of an existing user"
+          (let [patch-body {:schemas ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+                            :Operations [{:op "Replace"
+                                          :value {"name.givenName" "UpdatedFirstName"}}
+                                         {:op "Replace"
+                                          :value {"name.familyName" "UpdatedLastName"}}
+                                         ;; Unsupported operations are ignored
+                                         {:op "Add"
+                                          :value {"name.active" "False"}}]}
+                response   (scim-client :patch 200 (format "ee/scim/v2/Users/%s" entity-id) patch-body)]
+            (is (malli= scim-api/SCIMUser response))
+            (is (= "UpdatedFirstName" (get-in response [:name :givenName])))
+            (is (= "UpdatedLastName" (get-in response [:name :familyName])))
+            (is (true? (response :active)))))
 
-      (testing "Error if unsupported filter operation is provided"
-        (scim-client :get 400 (format "ee/scim/v2/Users?filter=%s"
-                                      (codec/url-encode "displayName ne \"Group 1\"")))))))
+        (testing "Error when using unsupported path"
+          (let [patch-body {:schemas ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+                            :Operations [{:op "replace"
+                                          :value {"name.displayName" "unsupported"}}]}
+                response   (scim-client :patch 400 (format "ee/scim/v2/Users/%s" entity-id) patch-body)]
+            (is (= ["urn:ietf:params:scim:api:messages:2.0:Error"] (get response :schemas)))
+            (is (= "Unsupported path: name.displayName" (get response :detail)))))
 
-(deftest fetch-group-test
-  (with-scim-setup!
-    (testing "A single group can be fetched in the SCIM format by entity ID with its members"
-      (mt/with-temp [:model/PermissionsGroup           group {:name "Test Group"}
-                     :model/PermissionsGroupMembership _     {:user_id (mt/user->id :rasta) :group_id (:id group)}]
-        (let [entity-id (t2/select-one-fn :entity_id :model/PermissionsGroup :id (:id group))
-              response  (scim-client :get 200 (format "ee/scim/v2/Groups/%s" entity-id))]
-          (is (malli= scim-api/SCIMGroup response))
-          (is (=?
-               {:schemas     ["urn:ietf:params:scim:schemas:core:2.0:Group"]
-                :id          entity-id
-                :displayName "Test Group"
-                :members     [{:value (t2/select-one-fn :entity_id :model/User (mt/user->id :rasta))
-                               :display "rasta@metabase.com"}]
-                :meta        {:resourceType "Group"}}
-               response)))))
+        (testing "Error when trying to update a non-existent user"
+          (let [patch-body {:schemas ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+                            :Operations [{:op "Replace"
+                                          :value {"name.familyName" "NonexistentUser"}}]}
+                response   (scim-client :patch 404 (format "ee/scim/v2/Users/%s" (random-uuid)) patch-body)]
+            (is (= ["urn:ietf:params:scim:api:messages:2.0:Error"] (get response :schemas)))
+            (is (= "User not found" (get response :detail)))))
 
-    (testing "404 is returned when fetching a non-existant group"
-      (scim-client :get 404 (format "ee/scim/v2/Groups/%s" (random-uuid))))
+        (deftest list-groups-test
+          (with-scim-setup!
+            (mt/with-temp [:model/PermissionsGroup _group1 {:name "Group 1"}]
+              (testing "Fetch groups with default pagination"
+                (let [response (scim-client :get 200 "ee/scim/v2/Groups")]
+                  (is (malli= scim-api/SCIMGroupList response))))
 
-    (testing "404 is returned when fetching the Admin or All Users group"
-      (let [entity-ids (t2/select-fn-set :entity_id :model/PermissionsGroup
-                                         {:where [:in :id #{(:id (perms-group/admin)) (:id (perms-group/all-users))}]})]
-        (doseq [entity-id entity-ids]
-          (scim-client :get 404 (format "ee/scim/v2/Groups/%s" entity-id)))))))
+              (testing "Fetch groups with custom pagination"
+                (let [response (scim-client :get 200 (format "ee/scim/v2/Groups?startIndex=%d&count=%d" 1 2))]
+                  (is (= ["urn:ietf:params:scim:api:messages:2.0:ListResponse"] (get response :schemas)))
+                  (is (integer? (get response :totalResults)))
+                  (is (= 1 (get response :startIndex)))
+                  (is (= 2 (get response :itemsPerPage)))
+                  (is (= 2 (count (get response :Resources))))))
+
+              (testing "Fetch group by name"
+                (let [response (scim-client :get 200 (format "ee/scim/v2/Groups?filter=%s"
+                                                             (codec/url-encode "displayName eq \"Group 1\"")))]
+                  (is (malli= scim-api/SCIMGroupList response))
+                  (is (= 1 (get response :totalResults)))
+                  (is (= 1 (count (get response :Resources))))))
+
+              (testing "Fetch non-existant group by name"
+                (let [response (scim-client :get 200 (format "ee/scim/v2/Groups?filter=%s"
+                                                             (codec/url-encode "displayName eq \"Fake Group\"")))]
+                  (is (malli= scim-api/SCIMUserList response))
+                  (is (= 0 (get response :totalResults)))
+                  (is (= 0 (count (get response :Resources))))))
+
+              (testing "Error if unsupported filter operation is provided"
+                (scim-client :get 400 (format "ee/scim/v2/Users?filter=%s"
+                                              (codec/url-encode "displayName ne \"Group 1\"")))))))))
+
+    (deftest fetch-group-test
+      (with-scim-setup!
+        (testing "A single group can be fetched in the SCIM format by entity ID with its members"
+          (mt/with-temp [:model/PermissionsGroup           group {:name "Test Group"}
+                         :model/PermissionsGroupMembership _     {:user_id (mt/user->id :rasta) :group_id (:id group)}]
+            (let [entity-id (t2/select-one-fn :entity_id :model/PermissionsGroup :id (:id group))
+                  response  (scim-client :get 200 (format "ee/scim/v2/Groups/%s" entity-id))]
+              (is (malli= scim-api/SCIMGroup response))
+              (is (=?
+                   {:schemas     ["urn:ietf:params:scim:schemas:core:2.0:Group"]
+                    :id          entity-id
+                    :displayName "Test Group"
+                    :members     [{:value (t2/select-one-fn :entity_id :model/User (mt/user->id :rasta))
+                                   :display "rasta@metabase.com"}]
+                    :meta        {:resourceType "Group"}}
+                   response)))))
+
+        (testing "404 is returned when fetching a non-existant group"
+          (scim-client :get 404 (format "ee/scim/v2/Groups/%s" (random-uuid))))
+
+        (testing "404 is returned when fetching the Admin or All Users group"
+          (let [entity-ids (t2/select-fn-set :entity_id :model/PermissionsGroup
+                                             {:where [:in :id #{(:id (perms-group/admin)) (:id (perms-group/all-users))}]})]
+            (doseq [entity-id entity-ids]
+              (scim-client :get 404 (format "ee/scim/v2/Groups/%s" entity-id)))))))))
 
 (deftest create-group-test
   (with-scim-setup!


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64038
### Description

Supports SCIM patch requests without a specified path. Where the path is instead provided by a JSON object contained under value. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
