### PR TITLE
Better error handling when sync-tracking-atoms fails

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -255,8 +255,12 @@
         (if (table-not-found-exception? e)
           ;; If resetting tracking atoms resolves the issue (which is likely happened because of stale tracking data),
           ;; suppress the issue - but throw it all the way to the caller if the issue persists
-          (do (sync-tracking-atoms!)
-              (specialization/batch-upsert! table-name entries))
+          (try
+            (sync-tracking-atoms!)
+            (specialization/batch-upsert! table-name entries)
+            (catch Exception e2
+              (log/error e2 "Error syncing index tracking atoms after table not found exception")
+              (throw e)))
           (throw e))))))
 
 (defn- batch-update!


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64102
### Description

If we attempt to sync the tracking atoms after a SQL exception, the actual exception gets lost.

This PR catches and logs the atom syncing error and throws the root exception for better debugging.  


### Checklist

- [X] Tests have been added/updated to cover changes in this PR
