### PR TITLE
Add transforms to search for Metabot

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2016,6 +2016,7 @@
            premium-features
            query-processor
            request
+           search
            settings
            sync
            task

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -1041,13 +1041,14 @@
 (mr/def ::search-arguments
   [:and
    [:map
-    [:term_queries     {:optional true} [:maybe [:sequential :string]]]
-    [:semantic_queries {:optional true} [:maybe [:sequential :string]]]
-    [:entity_types     {:optional true} [:maybe [:sequential [:enum "table" "model" "question" "dashboard" "metric" "database"]]]]
-    [:database_id      {:optional true} [:maybe :int]]
-    [:created_at       {:optional true} [:maybe ms/NonBlankString]]
-    [:last_edited_at   {:optional true} [:maybe ms/NonBlankString]]
-    [:limit            {:optional true, :default 50} [:and :int [:fn #(<= 1 % 100)]]]]
+    [:term_queries        {:optional true} [:maybe [:sequential :string]]]
+    [:semantic_queries    {:optional true} [:maybe [:sequential :string]]]
+    [:entity_types        {:optional true} [:maybe [:sequential [:enum "table" "model" "question" "dashboard" "metric" "database" "transform"]]]]
+    [:database_id         {:optional true} [:maybe :int]]
+    [:created_at          {:optional true} [:maybe ms/NonBlankString]]
+    [:last_edited_at      {:optional true} [:maybe ms/NonBlankString]]
+    [:search_native_query {:optional true, :default false} [:maybe :boolean]]
+    [:limit               {:optional true, :default 50} [:and :int [:fn #(<= 1 % 100)]]]]
    [:map {:encode/tool-api-request
           #(update-keys % (comp keyword u/->kebab-case-en))}]])
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -155,7 +155,6 @@
         result-lists (mapv deref futures)
         fused-results (reciprocal-rank-fusion result-lists)
         entity-type-counts (frequencies (map :model fused-results))
-        _ (def fused-results fused-results) ;; For debugging
         postprocessed-results (map postprocess-search-result fused-results)]
     (log/infof "[METABOT-SEARCH] Entity type distribution: %s" entity-type-counts)
     (log/infof "[METABOT-SEARCH] Fused results sample (first 3): %s"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -99,7 +99,7 @@
   "Search for data sources (tables, models, cards, dashboards, metrics) in Metabase.
   Abstracted from the API endpoint logic."
   [{:keys [term-queries semantic-queries database-id created-at last-edited-at
-           entity-types limit metabot-id] :as params}]
+           entity-types limit metabot-id search-native-query]}]
   (log/infof "[METABOT-SEARCH] Starting search with params: %s"
              {:term-queries term-queries
               :semantic-queries semantic-queries
@@ -108,7 +108,8 @@
               :last-edited-at last-edited-at
               :entity-types entity-types
               :limit limit
-              :metabot-id metabot-id})
+              :metabot-id metabot-id
+              :search-native-query search-native-query})
   (let [search-models (if (seq entity-types)
                         (set (distinct (keep entity-type->search-model entity-types)))
                         metabot-search-models)
@@ -134,7 +135,8 @@
                                             :context :metabot
                                             :archived false
                                             :limit (or limit 50)
-                                            :offset 0}
+                                            :offset 0
+                                            :search-native-query (boolean search-native-query)}
                                            (when use-verified-content?
                                              {:verified true})))
                           _ (log/infof "[METABOT-SEARCH] Search context models for query '%s': %s"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -25,18 +25,18 @@
   [search-model]
   (get (set/map-invert search-model-mappings) search-model search-model))
 
-(defn- transform-search-result
+(defn- postprocess-search-result
   "Transform a single search result to match the appropriate entity-specific schema."
   [{:keys [verified moderated_status collection] :as result}]
   (let [model (:model result)
         verified? (or (boolean verified) (= moderated_status "verified"))
         collection-info (select-keys collection [:name :authority_level])
-        common-fields {:id           (:id result)
-                       :type         (search-model->result-type model)
-                       :name         (:name result)
-                       :description  (:description result)
-                       :updated_at   (:updated_at result)
-                       :created_at   (:created_at result)}]
+        common-fields {:id          (:id result)
+                       :type        (search-model->result-type model)
+                       :name        (:name result)
+                       :description (:description result)
+                       :updated_at  (:updated_at result)
+                       :created_at  (:created_at result)}]
     (case model
       "database"
       common-fields
@@ -50,14 +50,18 @@
 
       "dashboard"
       (merge common-fields
-             {:verified        verified?
-              :collection      collection-info})
+             {:verified    verified?
+              :collection  collection-info})
+
+      "transform"
+      (merge common-fields
+             {:database_id (:database_id result)})
 
       ;; Questions, metrics, and datasets
       (merge common-fields
-             {:database_id     (:database_id result)
-              :verified        verified?
-              :collection      collection-info}))))
+             {:database_id (:database_id result)
+              :verified    verified?
+              :collection  collection-info}))))
 
 (defn- search-result-id
   "Generate a unique identifier for a search result based on its id and model."
@@ -151,8 +155,9 @@
         result-lists (mapv deref futures)
         fused-results (reciprocal-rank-fusion result-lists)
         entity-type-counts (frequencies (map :model fused-results))
-        transformed-results (map transform-search-result fused-results)]
+        _ (def fused-results fused-results) ;; For debugging
+        postprocessed-results (map postprocess-search-result fused-results)]
     (log/infof "[METABOT-SEARCH] Entity type distribution: %s" entity-type-counts)
     (log/infof "[METABOT-SEARCH] Fused results sample (first 3): %s"
                (take 3 (map #(select-keys % [:id :model :name :table_name]) fused-results)))
-    transformed-results))
+    postprocessed-results))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -181,8 +181,7 @@
       (into (map name) search.scoring/bookmarked-models-and-sub-models)))
 
 (comment
-  (require '[clojure.set :as set]
-           '[metabase.search.spec :as search.spec])
+  (require '[metabase.search.spec :as search.spec])
   ;; #{"segment" "database" "action" "indexed-entity"}
   (set/difference (set search.spec/search-models) appdb-scorer-models))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.semantic-search.scoring
   (:require
    [clojure.core.memoize :as memoize]
+   [clojure.set :as set]
    [honey.sql :as sql]
    [honey.sql.helpers :as sql.helpers]
    [medley.core :as m]
@@ -175,7 +176,9 @@
   (into #{} (map name activity-feed/rv-models)))
 
 (def ^:private appdb-scorer-models
-  (into recent-views-models (map name search.scoring/bookmarked-models-and-sub-models)))
+  (-> recent-views-models
+      (conj "transform")
+      (into (map name) search.scoring/bookmarked-models-and-sub-models)))
 
 (comment
   (require '[clojure.set :as set]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/scoring.clj
@@ -177,6 +177,7 @@
 
 (def ^:private appdb-scorer-models
   (-> recent-views-models
+      ;; Add "transform" here because it's not a recent-views model, but should still be scored
       (conj "transform")
       (into (map name) search.scoring/bookmarked-models-and-sub-models)))
 

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -176,11 +176,11 @@
 
 (search.spec/define-spec "transform"
   {:model        :model/Transform
-   :attrs        {:archived             false
-                  :collection-id        false
-                  :created-at           true
-                  :updated-at           true
-                  :native-query         {:fn maybe-extract-transform-query-text
-                                         :req-fields [:source]}}
+   :attrs        {:archived      false
+                  :collection-id false
+                  :created-at    true
+                  :updated-at    true
+                  :native-query  {:fn maybe-extract-transform-query-text
+                                  :req-fields [:source]}}
    :search-terms [:name :description]
    :render-terms {:description true}})

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -5,6 +5,7 @@
    [metabase-enterprise.transforms.models.transform-run :as transform-run]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
+   [metabase.search.ingestion :as search]
    [metabase.search.spec :as search.spec]
    [metabase.util :as u]
    [methodical.core :as methodical]
@@ -159,13 +160,27 @@
   (let [{:keys [id label]} (-> transform serdes/path last)]
     ["transforms" (serdes/storage-leaf-file-name id label)]))
 
+(defn- maybe-extract-transform-query-text
+  "Return the query text (truncated to `max-searchable-value-length`) from transform source; else nil.
+  Extracts SQL from query-type transforms and Python code from python-type transforms."
+  [{:keys [source]}]
+  (let [source-data ((:out mi/transform-json) source)
+        query-text (case (:type source-data)
+                     "query" (get-in source-data [:query :native :query])
+                     "python" (:body source-data)
+                     nil)]
+    (when query-text
+      (subs query-text 0 (min (count query-text) search/max-searchable-value-length)))))
+
 ;;; ------------------------------------------------- Search ---------------------------------------------------
 
 (search.spec/define-spec "transform"
   {:model        :model/Transform
-   :attrs        {:archived      false
-                  :collection-id false
-                  :created-at    true
-                  :updated-at    true}
+   :attrs        {:archived             false
+                  :collection-id        false
+                  :created-at           true
+                  :updated-at           true
+                  :native-query         {:fn maybe-extract-transform-query-text
+                                         :req-fields [:source]}}
    :search-terms [:name :description]
    :render-terms {:description true}})

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -181,6 +181,6 @@
                   :created-at    true
                   :updated-at    true
                   :native-query  {:fn maybe-extract-transform-query-text
-                                  :req-fields [:source]}}
+                                  :fields [:source]}}
    :search-terms [:name :description]
    :render-terms {:description true}})

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -172,6 +172,15 @@
     (when query-text
       (subs query-text 0 (min (count query-text) search/max-searchable-value-length)))))
 
+(defn- extract-transform-db-id
+  "Return the database ID from transform source; else nil."
+  [{:keys [source]}]
+  (let [parsed-source ((:out mi/transform-json) source)]
+    (case (:type parsed-source)
+      "query" (get-in parsed-source [:query :database])
+      "python" (parsed-source :source-database)
+      nil)))
+
 ;;; ------------------------------------------------- Search ---------------------------------------------------
 
 (search.spec/define-spec "transform"
@@ -181,6 +190,8 @@
                   :created-at    true
                   :updated-at    true
                   :native-query  {:fn maybe-extract-transform-query-text
+                                  :fields [:source]}
+                  :database-id   {:fn extract-transform-db-id
                                   :fields [:source]}}
    :search-terms [:name :description]
    :render-terms {:description true}})

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -104,8 +104,8 @@
       ;; Item 99 appears in all 5 lists at position 2, so should rank very high
       (is (= 99 (:id (first result)))))))
 
-(deftest transform-search-result-test
-  (testing "table result transformation"
+(deftest postprocess-search-result-test
+  (testing "table result postprocessing"
     (let [result {:model "table"
                   :id 1
                   :table_name "orders"
@@ -124,9 +124,9 @@
                     :database_schema "public"
                     :updated_at "2024-01-01"
                     :created_at "2024-01-01"}]
-      (is (= expected (#'search/transform-search-result result)))))
+      (is (= expected (#'search/postprocess-search-result result)))))
 
-  (testing "model (dataset) result transformation"
+  (testing "model (dataset) result postprocessing"
     (let [result {:model "dataset"
                   :id 2
                   :name "Sales Model"
@@ -145,9 +145,9 @@
                     :collection {}
                     :updated_at "2024-01-02"
                     :created_at "2024-01-02"}]
-      (is (= expected (#'search/transform-search-result result)))))
+      (is (= expected (#'search/postprocess-search-result result)))))
 
-  (testing "dashboard result transformation"
+  (testing "dashboard result postprocessing"
     (let [result {:model "dashboard"
                   :id 3
                   :name "Main Dashboard"
@@ -164,9 +164,9 @@
                     :collection {:name "Finance" :authority_level "official"}
                     :updated_at "2024-01-03"
                     :created_at "2024-01-03"}]
-      (is (= expected (#'search/transform-search-result result)))))
+      (is (= expected (#'search/postprocess-search-result result)))))
 
-  (testing "question (card) result transformation with moderated_status"
+  (testing "question (card) result postprocessing with moderated_status"
     (let [result {:model "card"
                   :id 4
                   :name "Q1"
@@ -184,9 +184,9 @@
                     :collection {:name "Analytics" :authority_level nil}
                     :updated_at "2024-01-04"
                     :created_at "2024-01-04"}]
-      (is (= expected (#'search/transform-search-result result)))))
+      (is (= expected (#'search/postprocess-search-result result)))))
 
-  (testing "metric result transformation"
+  (testing "metric result postprocessing"
     (let [result {:model "metric"
                   :id 5
                   :name "Revenue"
@@ -203,9 +203,9 @@
                     :collection {}
                     :updated_at "2024-01-05"
                     :created_at "2024-01-05"}]
-      (is (= expected (#'search/transform-search-result result)))))
+      (is (= expected (#'search/postprocess-search-result result)))))
 
-  (testing "database result transformation"
+  (testing "database result postprocessing"
     (let [result {:model "database"
                   :id 6
                   :name "Production DB"
@@ -218,7 +218,7 @@
                     :description "Main database"
                     :updated_at "2024-01-06"
                     :created_at "2024-01-06"}]
-      (is (= expected (#'search/transform-search-result result))))))
+      (is (= expected (#'search/postprocess-search-result result))))))
 
 (deftest search-test
   (mt/with-premium-features #{:content-verification}
@@ -240,20 +240,20 @@
                       perms/sandboxed-user? (fn [] false)
                       api/*current-user-id* 1]
 
-          (testing "search returns transformed results for term queries"
+          (testing "search returns postprocessed results for term queries"
             (with-redefs [search-core/search (fn [_] {:data [order-table]})]
               (let [args {:term-queries ["orders"]
                           :entity-types ["table"]}
                     results (search/search args)
-                    expected [(#'search/transform-search-result order-table)]]
+                    expected [(#'search/postprocess-search-result order-table)]]
                 (is (= expected results)))))
 
-          (testing "search returns transformed results for semantic queries"
+          (testing "search returns postprocessed results for semantic queries"
             (with-redefs [search-core/search (fn [_] {:data [dashboard]})]
               (let [args {:semantic-queries ["sales metrics"]
                           :entity-types ["dashboard"]}
                     results (search/search args)
-                    expected [(#'search/transform-search-result dashboard)]]
+                    expected [(#'search/postprocess-search-result dashboard)]]
                 (is (= expected results)))))
 
           (testing "search combines term and semantic queries using RRF"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -147,6 +147,23 @@
                     :created_at "2024-01-02"}]
       (is (= expected (#'search/postprocess-search-result result)))))
 
+  (testing "transform result postprocessing"
+    (let [result {:model "transform"
+                  :id 3
+                  :name "User Transform"
+                  :description "Transform for users"
+                  :database_id 44
+                  :updated_at "2024-01-03"
+                  :created_at "2024-01-03"}
+          expected {:id 3
+                    :type "transform"
+                    :name "User Transform"
+                    :description "Transform for users"
+                    :database_id 44
+                    :updated_at "2024-01-03"
+                    :created_at "2024-01-03"}]
+      (is (= expected (#'search/postprocess-search-result result)))))
+
   (testing "dashboard result postprocessing"
     (let [result {:model "dashboard"
                   :id 3

--- a/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
-   [metabase-enterprise.serialization.v2.ingest :as ingest]
    [metabase.app-db.core :as mdb]
    [metabase.search.appdb.index :as search.index]
    [metabase.search.engine :as search.engine]
@@ -138,14 +137,14 @@
                                          :name "Test python transform"}]
         (let [ingested-transform (ingest-then-fetch! "transform" "Test python transform")]
           (is (= "'import':7B 'panda':8B 'pd':10B 'python':2A,5B 'test':1A,4B 'transform':3A,6B"
-                 (.getValue ^PGobject (:with_native_query_vector ingested-transform)))))))
+                 (.getValue ^PGobject (:with_native_query_vector ingested-transform))))))
 
-    (testing "MBQL queries are not indexed in with_native_query_vector"
-      (mt/with-temp [:model/Transform _ {:target {:database (mt/id)
-                                                  :table "test_mbql_table"}
-                                         :name "Test MBQL transform"
-                                         :source {:type "query"
-                                                  :query (mt/mbql-query venues {:limit 10})}}]
-        (let [ingested-transform (ingest-then-fetch! "transform" "Test MBQL transform")]
-          (is (= "'mbql':2A,5B 'test':1A,4B 'transform':3A,6B"
-                 (.getValue ^PGobject (:with_native_query_vector ingested-transform)))))))))
+      (testing "MBQL queries are not indexed in with_native_query_vector"
+        (mt/with-temp [:model/Transform _ {:target {:database (mt/id)
+                                                    :table "test_mbql_table"}
+                                           :name "Test MBQL transform"
+                                           :source {:type "query"
+                                                    :query (mt/mbql-query venues {:limit 10})}}]
+          (let [ingested-transform (ingest-then-fetch! "transform" "Test MBQL transform")]
+            (is (= "'mbql':2A,5B 'test':1A,4B 'transform':3A,6B"
+                   (.getValue ^PGobject (:with_native_query_vector ingested-transform))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
@@ -2,13 +2,17 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase-enterprise.serialization.v2.ingest :as ingest]
+   [metabase.app-db.core :as mdb]
    [metabase.search.appdb.index :as search.index]
    [metabase.search.engine :as search.engine]
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (org.postgresql.util PGobject)))
 
 (set! *warn-on-reflection* true)
 
@@ -52,10 +56,9 @@
 
 (deftest transform-ingestion-test
   (search.tu/with-temp-index-table
-    (testing "A simple transform gets properly ingested & indexed for search"
-      (let [transform-name (mt/random-name)
-            now            (t/truncate-to (t/offset-date-time) :millis)]
-        (mt/with-temp [:model/Transform {transform-id :id} {:name        transform-name
+    (testing "A simple SQL transform gets properly ingested & indexed for search"
+      (let [now (t/truncate-to (t/offset-date-time) :millis)]
+        (mt/with-temp [:model/Transform {transform-id :id} {:name        "Test transform"
                                                             :description "A test transform"
                                                             :source      {:type "query"
                                                                           :query {:database (mt/id)
@@ -64,11 +67,85 @@
                                                                           :table "test_table"}
                                                             :created_at  now
                                                             :updated_at  now}]
-          (is (=? (index-entity
-                   {:model            "transform"
-                    :model_id         (str transform-id)
-                    :name             transform-name
-                    :database_id      (mt/id)
-                    :model_created_at now
-                    :model_updated_at now})
-                  (ingest-then-fetch! "transform" transform-name))))))))
+          (let [ingested-transform (ingest-then-fetch! "transform" "Test transform")]
+            (is (=? (index-entity
+                     {:model            "transform"
+                      :model_id         (str transform-id)
+                      :name             "Test transform"
+                      :database_id      (mt/id)
+                      :model_created_at now
+                      :model_updated_at now})
+                    ingested-transform))))))
+
+    (testing "A simple Python transform gets properly ingested & indexed for search"
+      (let [now (t/truncate-to (t/offset-date-time) :millis)]
+        (mt/with-temp [:model/Transform {transform-id :id} {:name        "Test Python transform"
+                                                            :description "A Python test transform"
+                                                            :source      {:type "python"
+                                                                          :source-database (mt/id)
+                                                                          :body "import pandas as pd\n"}
+                                                            :target      {:database (mt/id)}
+                                                            :created_at  now
+                                                            :updated_at  now}]
+          (let [ingested-transform (ingest-then-fetch! "transform" "Test Python transform")]
+            (is (=? (index-entity
+                     {:model            "transform"
+                      :model_id         (str transform-id)
+                      :name             "Test Python transform"
+                      :database_id      (mt/id)
+                      :model_created_at now
+                      :model_updated_at now})
+                    ingested-transform))))))
+
+    (testing "A simple MBQL transform gets properly ingested & indexed for search"
+      (let [now (t/truncate-to (t/offset-date-time) :millis)]
+        (mt/with-temp [:model/Transform {transform-id :id} {:name        "Test MBQL transform"
+                                                            :description "An MBQL test transform"
+                                                            :source      {:type "query"
+                                                                          :query (mt/mbql-query venues {:limit 10})}
+                                                            :target      {:database (mt/id)
+                                                                          :table "test_mbql_table"}
+                                                            :created_at  now
+                                                            :updated_at  now}]
+          (let [ingested-transform (ingest-then-fetch! "transform" "Test MBQL transform")]
+            (is (=? (index-entity
+                     {:model            "transform"
+                      :model_id         (str transform-id)
+                      :name             "Test MBQL transform"
+                      :database_id      (mt/id)
+                      :model_created_at now
+                      :model_updated_at now})
+                    ingested-transform))))))))
+
+(deftest transform-query-ingestion-test
+  (testing "Contents of SQL and Python transform sources are extracted and indexed for full-text search"
+    (when (= (mdb/db-type) :postgres)
+      (mt/with-temp [:model/Transform _ {:target {:database (mt/id)
+                                                  :table "test_table"}
+                                         :name "Test SQL transform"
+                                         :source {:type "query"
+                                                  :query {:database (mt/id)
+                                                          :native {:query "SELECT 1"}}}}]
+
+        (let [ingested-transform (ingest-then-fetch! "transform" "Test SQL transform")]
+          (is (= "'1':8B 'select':7B 'sql':2A,5B 'test':1A,4B 'transform':3A,6B"
+                 (.getValue ^PGobject (:with_native_query_vector ingested-transform))))))
+
+      (mt/with-temp [:model/Transform _ {:target {:database (mt/id)}
+                                         :source {:type "python"
+                                                  :source-database (mt/id)
+                                                  :body "import pandas as pd\n"}
+                                         :name "Test python transform"}]
+        (let [ingested-transform (ingest-then-fetch! "transform" "Test python transform")]
+          (is (= "'import':7B 'panda':8B 'pd':10B 'python':2A,5B 'test':1A,4B 'transform':3A,6B"
+                 (.getValue ^PGobject (:with_native_query_vector ingested-transform)))))))
+
+    (testing "MBQL queries are not indexed in with_native_query_vector"
+      (mt/with-temp [:model/Transform _ {:target {:database (mt/id)
+                                                  :table "test_mbql_table"}
+                                         :name "Test MBQL transform"
+                                         :source {:type "query"
+                                                  :query (mt/mbql-query venues {:limit 10})}}]
+        (let [ingested-transform (ingest-then-fetch! "transform" "Test MBQL transform")]
+          (is (= "'mbql':2A,5B 'test':1A,4B 'transform':3A,6B"
+                 (.getValue ^PGobject (:with_native_query_vector ingested-transform)))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
@@ -1,0 +1,74 @@
+(ns metabase-enterprise.transforms.search-test
+  (:require
+   [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase.search.appdb.index :as search.index]
+   [metabase.search.engine :as search.engine]
+   [metabase.search.ingestion :as search.ingestion]
+   [metabase.search.test-util :as search.tu]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
+
+(defn- ingest!
+  [model where-clause]
+  (#'search.engine/update!
+   :search.engine/appdb
+   (#'search.ingestion/query->documents
+    (#'search.ingestion/spec-index-reducible model where-clause))))
+
+(defn- fetch-one [model & clauses]
+  (apply t2/select-one (search.index/active-table) :model model clauses))
+
+(defn- ingest-then-fetch!
+  [model entity-name]
+  (ingest! model [:= :this.name entity-name])
+  (fetch-one model :name entity-name))
+
+(def ^:private default-index-entity
+  {:model               nil
+   :model_id            nil
+   :name                nil
+   :official_collection nil
+   :database_id         nil
+   :pinned              nil
+   :view_count          nil
+   :collection_id       nil
+   :last_viewed_at      nil
+   :model_created_at    nil
+   :model_updated_at    nil
+   :dashboardcard_count nil
+   :last_edited_at      nil
+   :last_editor_id      nil
+   :verified            nil})
+
+(defn- index-entity
+  [entity]
+  (merge default-index-entity entity))
+
+(deftest transform-ingestion-test
+  (search.tu/with-temp-index-table
+    (testing "A simple transform gets properly ingested & indexed for search"
+      (let [transform-name (mt/random-name)
+            now            (t/truncate-to (t/offset-date-time) :millis)]
+        (mt/with-temp [:model/Transform {transform-id :id} {:name        transform-name
+                                                            :description "A test transform"
+                                                            :source      {:type "query"
+                                                                          :query {:database (mt/id)
+                                                                                  :native {:query "SELECT 1"}}}
+                                                            :target      {:database (mt/id)
+                                                                          :table "test_table"}
+                                                            :created_at  now
+                                                            :updated_at  now}]
+          (is (=? (index-entity
+                   {:model            "transform"
+                    :model_id         (str transform-id)
+                    :name             transform-name
+                    :database_id      (mt/id)
+                    :model_created_at now
+                    :model_updated_at now})
+                  (ingest-then-fetch! "transform" transform-name))))))))

--- a/src/metabase/native_query_snippets/api.clj
+++ b/src/metabase/native_query_snippets/api.clj
@@ -32,6 +32,7 @@
   (list-native-query-snippets (boolean archived)))
 
 (mu/defn get-native-query-snippet :- [:maybe (ms/InstanceOf :model/NativeQuerySnippet)]
+  "Fetch native query snippet with ID and hydrate creator."
   [id :- ms/PositiveInt]
   (-> (api/read-check (t2/select-one :model/NativeQuerySnippet :id id))
       (t2/hydrate :creator)))

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -184,7 +184,7 @@
        [:last_edited_by                      {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
        [:model_ancestors                     {:default false} [:maybe :boolean]]
        [:search_engine                       {:optional true} [:maybe string?]]
-       [:search_native_query                 {:optional true} [:maybe true?]]
+       [:search_native_query                 {:optional true} [:maybe :boolean]]
        [:verified                            {:optional true} [:maybe true?]]
        [:ids                                 {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
        [:calculate_available_models          {:optional true} [:maybe true?]]

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -259,7 +259,7 @@
    [:last-edited-by                      {:optional true} [:set {:min 1} ms/PositiveInt]]
    [:limit-int                           {:optional true} ms/Int]
    [:offset-int                          {:optional true} ms/Int]
-   [:search-native-query                 {:optional true} true?]
+   [:search-native-query                 {:optional true} :boolean]
    [:table-db-id                         {:optional true} ms/PositiveInt]
    ;; true to search for verified items only, nil will return all items
    [:verified                            {:optional true} true?]

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -3,13 +3,10 @@
   (:require
    [metabase.analytics.core :as analytics]
    [metabase.analytics.prometheus :as prometheus]
-   [metabase.search.appdb.core :as search.engines.appdb]
    [metabase.search.config :as search.config]
    [metabase.search.engine :as search.engine]
    [metabase.search.impl :as search.impl]
-   [metabase.search.in-place.legacy :as search.legacy]
    [metabase.search.ingestion :as search.ingestion]
-   [metabase.search.semantic.core :as search.engines.semantic]
    [metabase.search.spec :as search.spec]
    [metabase.search.util :as search.util]
    [metabase.util :as u]
@@ -19,14 +16,7 @@
 (set! *warn-on-reflection* true)
 
 (comment
-  ;; Make sure to import all the engine implementations. In future this can happen automatically, as per drivers.
-  ;;
-  ;; TODO -- maybe engine loading should be moved to [[metabase.search.init]] instead
   search.engine/keep-me
-  search.engines.appdb/keep-me
-  search.engines.semantic/keep-me
-  search.legacy/keep-me
-
   search.config/keep-me
   search.impl/keep-me)
 

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -267,7 +267,7 @@
    [:offset                              {:optional true} [:maybe ms/Int]]
    [:table-db-id                         {:optional true} [:maybe ms/PositiveInt]]
    [:search-engine                       {:optional true} [:maybe string?]]
-   [:search-native-query                 {:optional true} [:maybe true?]]
+   [:search-native-query                 {:optional true} [:maybe boolean?]]
    [:model-ancestors?                    {:optional true} [:maybe boolean?]]
    [:verified                            {:optional true} [:maybe true?]]
    [:ids                                 {:optional true} [:maybe [:set ms/PositiveInt]]]

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -197,7 +197,9 @@
          :collection_type
          :archived_directly
          :display_name
-         :effective_parent))))
+         :effective_parent
+         :source
+         :target))))
 
 (defn- bit->boolean
   "Coerce a bit returned by some MySQL/MariaDB versions in some situations to Boolean."

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -197,9 +197,9 @@
          :collection_type
          :archived_directly
          :display_name
-         :effective_parent
-         :source
-         :target))))
+         :effective_parent)
+        (cond-> (= model "transform")
+          (dissoc :source :target)))))
 
 (defn- bit->boolean
   "Coerce a bit returned by some MySQL/MariaDB versions in some situations to Boolean."

--- a/src/metabase/search/in_place/filter.clj
+++ b/src/metabase/search/in_place/filter.clj
@@ -50,6 +50,13 @@
     false-clause
     true-clause))
 
+;; Transforms can't be archived
+(defmethod archived-clause "transform"
+  [_model archived?]
+  (if archived?
+    false-clause
+    true-clause))
+
 (defmethod archived-clause "indexed-entity"
   [_model archived?]
   (if-not archived?

--- a/src/metabase/search/in_place/filter.clj
+++ b/src/metabase/search/in_place/filter.clj
@@ -68,7 +68,7 @@
 (mu/defn- search-string-clause-for-model
   [model                :- SearchableModel
    search-context       :- SearchContext
-   search-native-query  :- [:maybe true?]]
+   search-native-query  :- [:maybe :boolean]]
   (when-let [query (:search-string search-context)]
     (into
      [:or]

--- a/src/metabase/search/in_place/filter.clj
+++ b/src/metabase/search/in_place/filter.clj
@@ -297,6 +297,7 @@
   [search-context]
   (let [{:keys [created-at
                 created-by
+                context
                 last-edited-at
                 last-edited-by
                 models
@@ -307,15 +308,16 @@
                 display-type]} search-context
         feature->supported-models (feature->supported-models)]
     (cond-> models
-      (some? created-at)               (set/intersection (:created-at feature->supported-models))
-      (some? created-by)               (set/intersection (:created-by feature->supported-models))
-      (some? last-edited-at)           (set/intersection (:last-edited-at feature->supported-models))
-      (some? last-edited-by)           (set/intersection (:last-edited-by feature->supported-models))
-      (true? search-native-query)      (set/intersection (:search-native-query feature->supported-models))
-      (true? verified)                 (set/intersection (:verified feature->supported-models))
-      (some? non-temporal-dim-ids)     (set/intersection (:non-temporal-dim-ids feature->supported-models))
-      (some? has-temporal-dim)         (set/intersection (:has-temporal-dim feature->supported-models))
-      (seq   display-type)             (set/intersection (:display-type feature->supported-models)))))
+      (some? created-at)                   (set/intersection (:created-at feature->supported-models))
+      (some? created-by)                   (set/intersection (:created-by feature->supported-models))
+      (some? last-edited-at)               (set/intersection (:last-edited-at feature->supported-models))
+      (some? last-edited-by)               (set/intersection (:last-edited-by feature->supported-models))
+      (true? search-native-query)          (set/intersection (:search-native-query feature->supported-models))
+      (true? verified)                     (set/intersection (:verified feature->supported-models))
+      (some? non-temporal-dim-ids)         (set/intersection (:non-temporal-dim-ids feature->supported-models))
+      (some? has-temporal-dim)             (set/intersection (:has-temporal-dim feature->supported-models))
+      (seq   display-type)                 (set/intersection (:display-type feature->supported-models))
+      (not (#{:metabot :unknown} context)) (disj "transform"))))
 
 (mu/defn build-filters :- :map
   "Build the search filters for a model."

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -310,6 +310,11 @@
    :display_name
    :description])
 
+(defmethod searchable-columns "transform"
+  [_ _]
+  [:name
+   :description])
+
 (defmethod searchable-columns "indexed-entity"
   [_ _]
   [:name])
@@ -429,6 +434,10 @@
    [:table.description :table_description]
    [:metabase_database.name :database_name]])
 
+(defmethod columns-for-model "transform"
+  [_]
+  [:id :name :description :created_at :updated_at])
+
 (mu/defn- select-clause-for-model :- [:sequential HoneySQLColumn]
   "The search query uses a `union-all` which requires that there be the same number of columns in each of the segments
   of the query. This function will take the columns for `model` and will inject constant `nil` values for any column
@@ -529,6 +538,10 @@
   [model search-ctx]
   (-> (base-query-for-model model search-ctx)
       (sql.helpers/where [:= :router_database_id nil])))
+
+(defmethod search-query-for-model "transform"
+  [model search-ctx]
+  (base-query-for-model model search-ctx))
 
 (defmethod search-query-for-model "dashboard"
   [model search-ctx]

--- a/src/metabase/search/init.clj
+++ b/src/metabase/search/init.clj
@@ -1,6 +1,9 @@
 (ns metabase.search.init
   "This is loaded for side effects on system launch."
   (:require
+   [metabase.search.appdb.core]
+   [metabase.search.in-place.legacy]
    [metabase.search.models]
+   [metabase.search.semantic.core]
    [metabase.search.settings]
    [metabase.search.task.search-index]))

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
    [metabase.app-db.core :as mdb]
+   [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.search.config :as search.config]))
 
 (def ^:private seconds-in-a-day 86400)
@@ -65,22 +66,23 @@
 (defn user-recency-expr
   "Expression to select the `:user-recency` timestamp for the `current-user-id`."
   [{:keys [current-user-id]}]
-  {:select [[[:case
-              ;; Transforms get a hardcoded 15-day last_viewed_at because we don't track views on them
-              [:= :search_index.model [:inline "transform"]]
-              [:- [:now] [:interval "15 days"]]
-              :else
-              [:max :recent_views.timestamp]]
-             :last_viewed_at]]
-   :from   [:recent_views]
-   :where  [:and
-            [:= :recent_views.user_id current-user-id]
-            [:= (cast-to-text :recent_views.model_id) :search_index.model_id]
-            [:= :recent_views.model
-             [:case
-              [:= :search_index.model [:inline "dataset"]] [:inline "card"]
-              [:= :search_index.model [:inline "metric"]] [:inline "card"]
-              :else :search_index.model]]]})
+  (let [one-day-ago (sql.qp/add-interval-honeysql-form (mdb/db-type) :%now -1 :day)]
+    {:select [[[:case
+                ;; Transforms get a hardcoded 1-day last_viewed_at because we don't track views on them
+                [:= :search_index.model [:inline "transform"]]
+                one-day-ago
+                :else
+                [:max :recent_views.timestamp]]
+               :last_viewed_at]]
+     :from   [:recent_views]
+     :where  [:and
+              [:= :recent_views.user_id current-user-id]
+              [:= (cast-to-text :recent_views.model_id) :search_index.model_id]
+              [:= :recent_views.model
+               [:case
+                [:= :search_index.model [:inline "dataset"]] [:inline "card"]
+                [:= :search_index.model [:inline "metric"]] [:inline "card"]
+                :else :search_index.model]]]}))
 
 (defn model-rank-expr
   "Score an item based on its :model type."

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [honey.sql.helpers :as sql.helpers]
    [metabase.app-db.core :as mdb]
+   [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.search.config :as search.config]))
 
 (def ^:private seconds-in-a-day 86400)
@@ -65,22 +66,23 @@
 (defn user-recency-expr
   "Expression to select the `:user-recency` timestamp for the `current-user-id`."
   [{:keys [current-user-id]}]
-  {:select [[[:case
-              ;; Transforms get a hardcoded 15-day last_viewed_at because we don't track views on them
-              [:= :search_index.model [:inline "transform"]]
-              [:- [:now] [:interval "15 days"]]
-              :else
-              [:max :recent_views.timestamp]]
-             :last_viewed_at]]
-   :from   [:recent_views]
-   :where  [:and
-            [:= :recent_views.user_id current-user-id]
-            [:= (cast-to-text :recent_views.model_id) :search_index.model_id]
-            [:= :recent_views.model
-             [:case
-              [:= :search_index.model [:inline "dataset"]] [:inline "card"]
-              [:= :search_index.model [:inline "metric"]] [:inline "card"]
-              :else :search_index.model]]]})
+  (let [fifteen-days-ago (sql.qp/add-interval-honeysql-form (mdb/db-type) :%now -15 :day)]
+    {:select [[[:case
+                ;; Transforms get a hardcoded 15-day last_viewed_at because we don't track views on them
+                [:= :search_index.model [:inline "transform"]]
+                fifteen-days-ago
+                :else
+                [:max :recent_views.timestamp]]
+               :last_viewed_at]]
+     :from   [:recent_views]
+     :where  [:and
+              [:= :recent_views.user_id current-user-id]
+              [:= (cast-to-text :recent_views.model_id) :search_index.model_id]
+              [:= :recent_views.model
+               [:case
+                [:= :search_index.model [:inline "dataset"]] [:inline "card"]
+                [:= :search_index.model [:inline "metric"]] [:inline "card"]
+                :else :search_index.model]]]}))
 
 (defn model-rank-expr
   "Score an item based on its :model type."

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -304,34 +304,6 @@
                   ["dataset" c3 "card unseen"]]
                  (search-results :user-recency "card" {:current-user-id user-id}))))))))
 
-(deftest ^:parallel transforms-user-recency-test
-  (mt/with-premium-features #{:transforms}
-    (let [user-id     (mt/user->id :crowberto)
-          right-now   (Instant/now)
-          recent-view (fn [model-id timestamp]
-                        {:model     "card"
-                         :model_id  model-id
-                         :user_id   user-id
-                         :timestamp timestamp})]
-      (mt/with-temp [:model/Card        {c1 :id} {}
-                     :model/Card        {c2 :id} {}
-                     :model/Transform   {t1 :id} {:name "test transform"
-                                                  :source {:type "query"
-                                                           :query (mt/native-query {:query "SELECT 1"})}
-                                                  :target {:type "table"
-                                                           :name "test_table"}}
-                     :model/RecentViews _ (recent-view c1 right-now)]
-        (with-index-contents
-          [{:model "card"      :id c1 :name "test card recent"}
-           {:model "card"      :id c2 :name "test card unseen"}
-           {:model "transform" :id t1 :name "test transform"}]
-          (testing "Transforms get a hardcoded 1-day recency (between recently viewed card and never viewed card)"
-            (is (= [["card"      c1 "test card recent"]
-                    ["transform" t1 "test transform"]
-                    ["card"      c2 "test card unseen"]]
-                   (search-results :user-recency "test" {:current-user-id user-id
-                                                         :context :metabot})))))))))
-
 (deftest ^:parallel mine-test
   (let [crowberto (mt/user->id :crowberto)
         rasta     (mt/user->id :rasta)]

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -48,8 +48,8 @@
                 active-filters)))
 
 (deftest search-context->applicable-models-test
-  (testing "All models are relevant if we're not looking in the trash"
-    (is (= search.config/all-models
+  (testing "All models except transforms are relevant if we're not looking in the trash"
+    (is (= (disj search.config/all-models "transform")
            (search.filter/search-context->applicable-models (with-all-models-and-regular-user {:archived? false})))))
 
   (testing "We only search for certain models in the trash"
@@ -58,7 +58,7 @@
            (search.filter/search-context->applicable-models (with-all-models-and-regular-user {:archived? true})))))
 
   (testing "Indexed entities are not visible for sandboxed users"
-    (is (= (disj search.config/all-models "indexed-entity")
+    (is (= (disj search.config/all-models "indexed-entity" "transform")
            (search.filter/search-context->applicable-models (with-all-models-and-sandboxed-user {:archived? false})))))
 
   (doseq [active-filters (active-filter-combinations)]

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -107,7 +107,7 @@
             ;; This :where clause is a set to avoid flakes, since the clause order will be non-deterministic.
             :where  #{:and
                       [:in :search_index.model (cond-> #{"dashboard" "table" "segment" "collection" "database" "action" "indexed-entity" "metric" "card"}
-                                                 config/ee-available? (conj "document"))]
+                                                 config/ee-available? (conj "document" "transform"))]
                       [:in :search_index.model_id ["1" "2" "3" "4"]]
                       [:in :search_index.model ["card" "dataset" "metric" "dashboard" "action"]]
                       [:= :search_index.archived true]

--- a/test/metabase/search/in_place/filter_test.clj
+++ b/test/metabase/search/in_place/filter_test.clj
@@ -24,16 +24,23 @@
 (deftest ^:parallel ->applicable-models-test
   (testing "without optional filters"
     (testing "return :models as is"
-      (is (= search.config/all-models
+      (is (= (disj search.config/all-models "transform")
              (search.filter/search-context->applicable-models
               default-search-ctx)))
       (is (= #{}
              (search.filter/search-context->applicable-models
               (assoc default-search-ctx :models #{}))))
-      (is (= search.config/all-models
+      (is (= (disj search.config/all-models "transform")
              (search.filter/search-context->applicable-models
               (merge default-search-ctx
-                     {:archived? true})))))))
+                     {:archived? true}))))))
+
+  (testing "metabot search context includes transforms"
+    (is (= search.config/all-models
+           (search.filter/search-context->applicable-models
+            (merge default-search-ctx
+                   {:models  search.config/all-models
+                    :context :metabot}))))))
 
 (deftest ^:parallel ->applicable-models-test-2
   (testing "optional filters will return intersection of support models and provided models\n"


### PR DESCRIPTION
* Adds support for searching for transforms in the metabot search tool API. Normal search API calls pass in a model set, so won't get transforms by default for now
* Fixes up the in-place search backend to support transforms
* Indexes transform query text using a `maybe-extract-transform-query-text` ingestion fn. Similar process for DB IDs since they're only stored in a transform's `:source`
* Hard-codes a `last_viewed_at` for transforms to one day in the past for the user-recency scorer to account for a lack of view tracking for transforms
* Adds a number of unit tests, particularly around transform ingestion and ranking

Paired with https://github.com/metabase/ai-service/pull/374, this gives Metabot the ability to issue hybrid search queries over transforms, including transform content