### PR TITLE
Fix #63904: Corrects dashcard selector usage

### DIFF
--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -37,11 +37,11 @@ import {
 } from "../analytics";
 import type { SectionLayout } from "../sections";
 import {
+  getCurrentDashcards,
   getDashCardById,
   getDashboard,
   getDashboardId,
   getDashboards,
-  getDashcardList,
   getDashcards,
   getSelectedTabId,
 } from "../selectors";
@@ -471,7 +471,7 @@ export const removeCardFromDashboard = createThunkAction(
   }) =>
     (dispatch, getState) => {
       const dashboard = checkNotNull(getDashboard(getState()));
-      const dashcards = getDashcardList(getState());
+      const dashcards = getCurrentDashcards(getState());
       const dashcard = getDashCardById(getState(), dashcardId);
 
       const originalParameters = dashboard.parameters

--- a/frontend/src/metabase/dashboard/actions/parameters.tsx
+++ b/frontend/src/metabase/dashboard/actions/parameters.tsx
@@ -51,13 +51,13 @@ import {
 } from "../analytics";
 import {
   getAutoApplyFiltersToastId,
+  getCurrentDashcards,
   getDashCardById,
   getDashboard,
   getDashboardBeforeEditing,
   getDashboardComplete,
   getDashboardHeaderParameters,
   getDashboardId,
-  getDashcardList,
   getDashcards,
   getDraftParameterValues,
   getFiltersToReset,
@@ -274,7 +274,7 @@ export const setEditingParameter =
     const currentTabId = getSelectedTabId(getState());
     const parameterDashcard = findDashCardForInlineParameter(
       parameterId,
-      getDashcardList(getState()),
+      getCurrentDashcards(getState()),
     );
 
     if (

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -170,10 +170,6 @@ export const getDashboard = createSelector(
 
 export const getDashcards = (state: State) => state.dashboard.dashcards;
 
-export const getDashcardList = createSelector([getDashcards], (dashcards) =>
-  Object.values(dashcards),
-);
-
 export const getDashCardById = (state: State, dashcardId: DashCardId) => {
   const dashcards = getDashcards(state);
   return dashcards[dashcardId];
@@ -221,6 +217,11 @@ export const getDashboardComplete = createSelector(
       }
     );
   },
+);
+
+export const getCurrentDashcards = createSelector(
+  [getDashboardComplete],
+  (dashboard) => dashboard?.dashcards || [],
 );
 
 export const getDashcardHref = createSelector(
@@ -443,9 +444,8 @@ export const getParameters = createSelector(
 );
 
 export const getDashboardHeaderParameters = createSelector(
-  [getDashcards, getParameters],
-  (dashcards, parameters) => {
-    const dashcardList = Object.values(dashcards);
+  [getCurrentDashcards, getParameters],
+  (dashcardList, parameters) => {
     return parameters.filter(
       (parameter) => !isDashcardInlineParameter(parameter.id, dashcardList),
     );

--- a/frontend/src/metabase/dashboard/selectors.unit.spec.js
+++ b/frontend/src/metabase/dashboard/selectors.unit.spec.js
@@ -4,6 +4,7 @@ import { createMockEntitiesState } from "__support__/store";
 import {
   getClickBehaviorSidebarDashcard,
   getDashboardComplete,
+  getDashboardHeaderParameters,
   getEditingParameterId,
   getIsEditingParameter,
   getIsSharing,
@@ -219,6 +220,39 @@ describe("dashboard/selectors", () => {
           hasVariableTemplateTagTarget: false,
         },
       ]);
+    });
+  });
+
+  describe("getDashboardHeaderParameters", () => {
+    it("should ignore dashcards that don't belong to the current dashboard", () => {
+      const parameterId = "_parameterId_";
+      const state = {
+        ...STATE,
+        dashboard: {
+          ...STATE.dashboard,
+          dashboards: {
+            0: {
+              ...STATE.dashboard.dashboards[0],
+              dashcards: [1],
+              parameters: [{ id: parameterId }],
+            },
+          },
+          dashcards: {
+            0: {
+              ...STATE.dashboard.dashcards[0],
+              inline_parameters: [parameterId],
+              dashboard_id: 1,
+            },
+            1: {
+              ...STATE.dashboard.dashcards[1],
+              dashboard_id: 0,
+            },
+          },
+        },
+      };
+      const headerParameters = getDashboardHeaderParameters(state);
+      expect(headerParameters).toHaveLength(1);
+      expect(headerParameters[0].id).toBe(parameterId);
     });
   });
 

--- a/frontend/src/metabase/parameters/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.tsx
@@ -5,7 +5,7 @@ import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
 import { moveParameter } from "metabase/dashboard/actions";
-import { getDashcardList, getTabs } from "metabase/dashboard/selectors";
+import { getCurrentDashcards, getTabs } from "metabase/dashboard/selectors";
 import {
   findDashCardForInlineParameter,
   isHeadingDashCard,
@@ -29,13 +29,13 @@ export function MoveParameterMenu({ parameterId }: MoveParameterMenuProps) {
   const ref = useRef<HTMLInputElement>(null);
 
   const dashcards = useSelector((state) =>
-    getDashcardList(state).filter(
+    getCurrentDashcards(state).filter(
       (dashcard) => isHeadingDashCard(dashcard) || isQuestionDashCard(dashcard),
     ),
   );
 
   const parameterDashcard = useSelector((state) => {
-    const dashcards = getDashcardList(state);
+    const dashcards = getCurrentDashcards(state);
     return findDashCardForInlineParameter(parameterId, dashcards);
   });
 

--- a/frontend/src/metabase/parameters/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/MoveParameterMenu/MoveParameterMenu.unit.spec.tsx
@@ -50,6 +50,9 @@ async function setup({ tabs = [], dashcards }: SetupOpts) {
     dashcards,
     parameters: [TEST_PARAMETER],
   });
+  const otherDashboardDashcards: DashboardCard[] = [
+    { ...TEST_DASHCARD, id: 1001, dashboard_id: 1001 },
+  ];
 
   renderWithProviders(<MoveParameterMenu parameterId={TEST_PARAMETER.id} />, {
     storeInitialState: createMockState({
@@ -61,7 +64,10 @@ async function setup({ tabs = [], dashcards }: SetupOpts) {
             dashcards: dashcards.map((dc) => dc.id),
           },
         },
-        dashcards: _.indexBy(dashcards, "id"),
+        dashcards: {
+          ..._.indexBy(dashcards, "id"),
+          ..._.indexBy(otherDashboardDashcards, "id"),
+        },
       }),
     }),
   });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63904
Closes UXW-1766

### Description

* Fixes issue where `getDashboardHeaderParameters` looks at all cached dashcards rather than just the ones from the currently viewed dashboard.
* Renames `getDashcardList` -> `getCurrentDashcards` and makes it only return dashcards for the current dashboard.

Includes related fix for https://github.com/metabase/metabase/issues/63983.

### How to verify

See https://github.com/metabase/metabase/issues/63904 for repro steps

### Demo

**BEFORE AND AFTER**
("after" starts at the halfway point)

https://github.com/user-attachments/assets/ab22182e-cb88-4b5f-b6f9-55baae51778d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
