### PR TITLE
Match deduplicated column to field-ref if desired col name fails

### DIFF
--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -331,10 +331,14 @@
             (when-let [col (m/find-first (fn [col]
                                            (= (:lib/deduplicated-name col) id-or-name))
                                          source-metadata)]
-              (when-let [desired-column-alias (:lib/desired-column-alias col)]
-                (m/find-first (fn [[_tag _id-or-name opts]]
-                                (= (::desired-alias opts) desired-column-alias))
-                              all-exports)))))
+              (or (when-let [desired-column-alias (:lib/desired-column-alias col)]
+                    (m/find-first (fn [[_tag _id-or-name opts]]
+                                    (= (::desired-alias opts) desired-column-alias))
+                                  all-exports))
+                  (when-let [field-id-or-name (-> col :field_ref second)]
+                    (m/find-first (fn [[_tag id-or-name _opts]]
+                                    (= id-or-name field-id-or-name))
+                                  all-exports))))))
         ;; otherwise we failed to find a match! This is expected for native queries but if the source query was MBQL
         ;; there's probably something wrong.
         (when-not (:native source-query)


### PR DESCRIPTION
Closes #64058

### Description

The problem reported in #64058 is the result of field reference by a name created in v55 which in v56 gets resolved differently. Instead of the deduplicated name, the reference is expected to contain the join alias (i.e., `Products__CREATED_AT` (v56) instead of `CREATED_AT_2` (v55)).

This PR just adds yet another fallback if the standard resolution methods don't work. This is fixed on master properly, thanks to the the ref work done by @camsaul.

### How to verify

The repro from #64058 should now work.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
