### PR TITLE
feat(sdk-bundle, embed-js): add metabase-metabot custom element for Embed JS

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -389,6 +389,32 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
     });
   });
 
+  describe("<metabase-metabot>", () => {
+    it("should use sidebar layout by default when no layout attribute is provided", () => {
+      H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-metabot />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByTestId("metabot-question-container")
+        .should("have.attr", "data-layout", "sidebar");
+    });
+
+    it("should respect the layout attribute when set to stacked", () => {
+      H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-metabot layout="stacked" />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByTestId("metabot-question-container")
+        .should("have.attr", "data-layout", "stacked");
+    });
+  });
+
   describe("common checks", () => {
     describe("should be permissive with json attributes", () => {
       // NOTE: pay attention if you use initialFilters for these tests, as when the filters are not parsed correctly

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -390,19 +390,33 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
   });
 
   describe("<metabase-metabot>", () => {
-    it("should use sidebar layout by default when no layout attribute is provided", () => {
+    it("should load the embedded Metabot component", () => {
       H.visitCustomHtmlPage(`
       ${H.getNewEmbedScriptTag()}
       ${H.getNewEmbedConfigurationScript()}
       <metabase-metabot />
       `);
 
-      H.getSimpleEmbedIframeContent()
-        .findByTestId("metabot-question-container")
-        .should("have.attr", "data-layout", "sidebar");
+      H.getSimpleEmbedIframeContent().within(() => {
+        cy.log("metabot chat should be interactive");
+        cy.findByText("Ask questions to AI.").should("be.visible");
+        cy.findByPlaceholderText("Ask AI a question...").type("Foo{enter}");
+        cy.findByText(
+          "Metabot is currently offline. Please try again later.",
+        ).should("be.visible");
+
+        cy.log(
+          "uses sidebar layout by default when no layout attribute is provided",
+        );
+        cy.findByTestId("metabot-question-container").should(
+          "have.attr",
+          "data-layout",
+          "sidebar",
+        );
+      });
     });
 
-    it("should respect the layout attribute when set to stacked", () => {
+    it("should apply the data-layout attribute when layout is set to stacked", () => {
       H.visitCustomHtmlPage(`
       ${H.getNewEmbedScriptTag()}
       ${H.getNewEmbedConfigurationScript()}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -194,7 +194,7 @@ const SdkIframeEmbedView = ({
       {
         componentName: "metabase-metabot",
       },
-      (settings) => <MetabotQuestion layout={settings.layout} />,
+      (settings) => <MetabotQuestion layout={settings.layout} height="100%" />,
     )
     .otherwise(() => null);
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -5,6 +5,7 @@ import { PublicComponentStylesWrapper } from "embedding-sdk-bundle/components/pr
 import { SdkError } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
 import { SdkBreadcrumbsProvider } from "embedding-sdk-bundle/components/private/SdkBreadcrumbs";
 import { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
+import { MetabotQuestion } from "embedding-sdk-bundle/components/public/MetabotQuestion";
 import { SdkQuestion } from "embedding-sdk-bundle/components/public/SdkQuestion";
 import { StaticQuestion } from "embedding-sdk-bundle/components/public/StaticQuestion";
 import {
@@ -188,6 +189,12 @@ const SdkIframeEmbedView = ({
           />
         );
       },
+    )
+    .with(
+      {
+        componentName: "metabase-metabot",
+      },
+      (settings) => <MetabotQuestion layout={settings.layout} />,
     )
     .otherwise(() => null);
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.ts
@@ -564,6 +564,10 @@ const MetabaseManageContentElement = createCustomElement("metabase-browser", [
   "read-only",
 ]);
 
+const MetabaseMetabotElement = createCustomElement("metabase-metabot", [
+  "layout",
+]);
+
 // Expose the old API that's still used in the tests, we'll probably remove this api unless customers prefer it
 if (typeof window !== "undefined") {
   (window as any)["metabase.embed"] = {
@@ -575,4 +579,5 @@ export {
   MetabaseDashboardElement,
   MetabaseQuestionElement,
   MetabaseManageContentElement,
+  MetabaseMetabotElement,
 };

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/types/embed.ts
@@ -131,6 +131,18 @@ export interface BrowserEmbedOptions {
   dashboardId?: never;
 }
 
+export interface MetabotEmbedOptions {
+  componentName: "metabase-metabot";
+
+  /** Layout mode for the metabot interface */
+  layout?: "auto" | "sidebar" | "stacked";
+
+  // incompatible options
+  template?: never;
+  questionId?: never;
+  dashboardId?: never;
+}
+
 type CollectionBrowserEntityTypes =
   | "collection"
   | "dashboard"
@@ -156,7 +168,8 @@ export type SdkIframeEmbedTemplateSettings =
   | DashboardEmbedOptions
   | QuestionEmbedOptions
   | ExplorationEmbedOptions
-  | BrowserEmbedOptions;
+  | BrowserEmbedOptions
+  | MetabotEmbedOptions;
 
 /** Settings used by the sdk embed route */
 export type SdkIframeEmbedSettings = Omit<

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -186,6 +186,8 @@ export const SdkIframeEmbedPreview = () => {
               : undefined,
           }),
         )
+        // TODO(EMB-869): add Metabot experience to embed flow
+        .with({ componentName: "metabase-metabot" }, () => null)
         .exhaustive()}
 
       <EmbedPreviewLoadingOverlay isVisible={isLoading} />

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/default-embed-setting.ts
@@ -79,4 +79,6 @@ export const getExperienceFromSettings = (
     .with({ componentName: "metabase-question" }, () => "chart")
     .with({ componentName: "metabase-browser" }, () => "browser")
     .with({ componentName: "metabase-dashboard" }, () => "dashboard")
+    // TODO(EMB-869): add Metabot experience to embed flow - replace this with "metabot"
+    .with({ componentName: "metabase-metabot" }, () => "chart")
     .exhaustive();


### PR DESCRIPTION
Closes EMB-858

Adds the `<metabase-metabot>` custom element to EAJS, with the `layout` property exposed.

### How to verify

Render the following `<metabase-metabot>` test snippet in your local HTML page.

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>Title</title>

  <style>
  body {
    margin: 0;
  }

  metabase-metabot {
    height: 100vh;
  }
  </style>
</head>
<body>
<script defer src="http://localhost:3000/app/embed.js"></script>

<script>
  function defineMetabaseConfig(config) {
    window.metabaseConfig = config;
  }
</script>

<script>
  defineMetabaseConfig({
    "instanceUrl": "http://localhost:3000",
    "useExistingUserSession": true,
    "theme": {
      "colors": {
        "brand": "#e74c3c"
      }
    }
  });
</script>

<div>
  <metabase-metabot layout="stacked"></metabase-metabot>
</div>
</body>
</html>
```

The embedded Metabot component should show up.

### Demo

<img width="1586" height="990" alt="CleanShot 2568-10-04 at 06 40 50@2x" src="https://github.com/user-attachments/assets/7574e294-8ccf-4a37-a28a-054f6a0556df" />

### Will be added in another PR

- Analytics for Metabot component in EAJS

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
