### PR TITLE
Add missing import

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.transforms.util
   (:require
    [clojure.core.async :as a]
+   [clojure.string :as str]
    [java-time.api :as t]
    [metabase-enterprise.transforms.canceling :as canceling]
    [metabase-enterprise.transforms.models.transform-run :as transform-run]


### PR DESCRIPTION
It seems like https://github.com/metabase/metabase/pull/64037 introduced a missing import of `str`, causing builds to fail on `master`.

This PR fixes that.