### PR TITLE
Add a missing require

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.transforms.util
   (:require
    [clojure.core.async :as a]
+   [clojure.string :as str]
    [java-time.api :as t]
    [metabase-enterprise.transforms.canceling :as canceling]
    [metabase-enterprise.transforms.models.transform-run :as transform-run]


### PR DESCRIPTION
Fixes broken CI pipeline on master due to a missing namespace.

Props to @WiNloSt for spotting the missing require first.