### PR TITLE
Fix zoom and hover on map while editing

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -2204,3 +2204,60 @@ describe("issue 63176", () => {
     });
   });
 });
+
+describe("issue 64138", () => {
+  const MAP_QUESTION = {
+    query: {
+      "source-table": PEOPLE_ID,
+    },
+
+    display: "map",
+    displayIsLocked: true,
+    visualization_settings: {
+      "map.type": "pin",
+      "map.pin_type": "markers",
+    },
+  };
+
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+
+    H.createQuestionAndDashboard({
+      questionDetails: MAP_QUESTION,
+    }).then(({ body: { dashboard_id } }) => {
+      H.visitDashboard(dashboard_id);
+    });
+  });
+
+  it("should hide map controls when editing dashboard (metabase#64138)", () => {
+    H.editDashboard();
+
+    cy.log("hovering the map should not show the zoom controls");
+    H.getDashboardCard(0)
+      .realHover({
+        position: "center",
+      })
+      .within(() => {
+        cy.findByLabelText("Zoom in").should("not.exist");
+        cy.findByText("Set as default view").should("be.visible").click();
+      });
+
+    cy.log("hovering marker icons should not open their tooltips");
+    getMarkerIcon(0).realHover();
+    H.popover({ skipVisibilityCheck: true }).should("not.exist");
+
+    cy.log("clicking marker icons should not navigate to the question");
+    getMarkerIcon(0).click({ force: true });
+    cy.location("pathname").should("match", /^\/dashboard\/[0-9]+$/);
+    H.modal().should("not.exist");
+  });
+
+  function getMarkerIcon(index) {
+    // pick the last one so it will be on top
+    return H.getDashboardCard(index)
+      .get(".leaflet-marker-icon")
+      .should("have.length.gt", 0)
+      .last();
+  }
+});

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.transforms.util
   (:require
    [clojure.core.async :as a]
+   [clojure.string :as str]
    [java-time.api :as t]
    [metabase-enterprise.transforms.canceling :as canceling]
    [metabase-enterprise.transforms.models.transform-run :as transform-run]

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -84,7 +84,14 @@ export default class LeafletMap extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { bounds, settings } = this.props;
+    const { bounds, settings, zoomControl } = this.props;
+
+    if (zoomControl === false) {
+      this.map.removeControl(this.map.zoomControl);
+    } else {
+      this.map.addControl(this.map.zoomControl);
+    }
+
     if (
       !prevProps ||
       prevProps.points !== this.props.points ||

--- a/frontend/src/metabase/visualizations/components/LeafletMarkerPinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMarkerPinMap.jsx
@@ -98,57 +98,64 @@ export default class LeafletMarkerPinMap extends LeafletMap {
 
   _createMarker = (rowIndex) => {
     const marker = L.marker([0, 0], { icon: this.pinMarkerIcon });
-    const { onHoverChange, onVisualizationClick, settings } = this.props;
-    if (onHoverChange) {
-      marker.on("mousemove", (e) => {
-        const {
-          series: [
-            {
-              data: { cols, rows },
-            },
-          ],
-        } = this.props;
-        const hover = {
-          dimensions: cols.map((col, colIndex) => ({
-            value: rows[rowIndex][colIndex],
-            column: col,
-          })),
-          element: marker._icon,
-        };
-        onHoverChange(hover);
-      });
-      marker.on("mouseout", () => {
-        onHoverChange(null);
-      });
-    }
-    if (onVisualizationClick) {
-      marker.on("click", () => {
-        const {
-          series: [
-            {
-              data: { cols, rows },
-            },
-          ],
-        } = this.props;
-        // if there is a primary key then associate a pin with it
-        const pkIndex = _.findIndex(cols, isPK);
-        const hasPk = pkIndex >= 0;
+    marker.on("mousemove", () => {
+      const { onHoverChange } = this.props;
+      if (!onHoverChange) {
+        return;
+      }
+      const {
+        series: [
+          {
+            data: { cols, rows },
+          },
+        ],
+      } = this.props;
+      const hover = {
+        dimensions: cols.map((col, colIndex) => ({
+          value: rows[rowIndex][colIndex],
+          column: col,
+        })),
+        element: marker._icon,
+      };
+      onHoverChange(hover);
+    });
 
-        const data = cols.map((col, index) => ({
-          col,
-          value: rows[rowIndex][index],
-        }));
+    marker.on("mouseout", () => {
+      const { onHoverChange } = this.props;
+      onHoverChange?.(null);
+    });
 
-        onVisualizationClick({
-          value: hasPk ? rows[rowIndex][pkIndex] : null,
-          column: hasPk ? cols[pkIndex] : null,
-          element: marker._icon,
-          origin: { row: rows[rowIndex], cols },
-          settings,
-          data,
-        });
+    marker.on("click", () => {
+      const { onVisualizationClick, settings } = this.props;
+      if (!onVisualizationClick) {
+        return;
+      }
+      const {
+        series: [
+          {
+            data: { cols, rows },
+          },
+        ],
+      } = this.props;
+      // if there is a primary key then associate a pin with it
+      const pkIndex = _.findIndex(cols, isPK);
+      const hasPk = pkIndex >= 0;
+
+      const data = cols.map((col, index) => ({
+        col,
+        value: rows[rowIndex][index],
+      }));
+
+      onVisualizationClick({
+        value: hasPk ? rows[rowIndex][pkIndex] : null,
+        column: hasPk ? cols[pkIndex] : null,
+        element: marker._icon,
+        origin: { row: rows[rowIndex], cols },
+        settings,
+        data,
       });
-    }
+    });
+
     return marker;
   };
 }

--- a/frontend/src/metabase/visualizations/components/PinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.jsx
@@ -226,6 +226,11 @@ export default class PinMap extends Component {
             binWidth={binWidth}
             binHeight={binHeight}
             onFiltering={(filtering) => this.setState({ filtering })}
+            zoomControl={!isEditing}
+            onHoverChange={isEditing ? null : mapProps.onHoverChange}
+            onVisualizationClick={
+              isEditing ? null : mapProps.onVisualizationClick
+            }
           />
         ) : null}
         <div

--- a/frontend/src/metabase/visualizations/components/PinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.jsx
@@ -227,9 +227,11 @@ export default class PinMap extends Component {
             binHeight={binHeight}
             onFiltering={(filtering) => this.setState({ filtering })}
             zoomControl={!isEditing}
-            onHoverChange={isEditing ? null : mapProps.onHoverChange}
+            onHoverChange={
+              isDashboard && isEditing ? null : mapProps.onHoverChange
+            }
             onVisualizationClick={
-              isEditing ? null : mapProps.onVisualizationClick
+              isDashboard && isEditing ? null : mapProps.onVisualizationClick
             }
           />
         ) : null}

--- a/frontend/src/metabase/visualizations/components/PinMap.module.css
+++ b/frontend/src/metabase/visualizations/components/PinMap.module.css
@@ -1,4 +1,5 @@
 .pinMapButton {
   opacity: 0.9;
   margin-bottom: 0.5rem;
+  pointer-events: all;
 }

--- a/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
@@ -309,7 +309,8 @@ export class Map extends Component {
       this.props.width === nextProps.width &&
       this.props.height === nextProps.height;
     const sameSeries = isSameSeries(this.props.series, nextProps.series);
-    return !(sameSize && sameSeries);
+    const sameIsEditing = this.props.isEditing === nextProps.isEditing;
+    return !(sameSize && sameSeries && sameIsEditing);
   }
 
   render() {


### PR DESCRIPTION
Closes #64138 

This PR fixes the issue by:
- disabling the zoom controls when in editing mode
- disabling the pin hover and click events in editing mode
- it also fixes the `Set as default view`

### To verify

1. New -> Question -> People
2. Visualize
3. Change viz to Map -> Pin Map -> Pin type: Markers
4. Save the question and add it to a dashboard
5. Edit the dashboard
6. Hover the dashboard card with the map in it
  - No tooltips should be shown
  - No zoom controls should be shown
  - Click the `Set as default view` - this should work