### PR TITLE
pivot download: use source alias name for matching columns

### DIFF
--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -391,16 +391,12 @@
         aggregations       (filter #(= (:lib/source %) :source/aggregations)
                                    returned-columns)
         breakouts          (filter :lib/breakout? returned-columns)
-        column-alias->index (into {}
-                                  (map-indexed (fn [i column] [(:lib/desired-column-alias column) i]))
-                                  (concat breakouts aggregations))
         column-name->index (into {}
-                                 (map-indexed (fn [i column] [(:name column) i]))
+                                 (map-indexed (fn [i column] [(:lib/deduplicated-name column) i]))
                                  (concat breakouts aggregations))
         process-columns    (fn process-columns [column-names]
                              (when (seq column-names)
-                               (into [] (keep (fn [n] (or (column-alias->index n)
-                                                          (column-name->index n)))) column-names)))
+                               (into [] (keep column-name->index) column-names)))
         pivot-opts         {:pivot-rows         (process-columns rows)
                             :pivot-cols         (process-columns columns)
                             :pivot-measures     (process-columns values)


### PR DESCRIPTION
fixes #63858 

Why this change makes sense: `column-alias->index` was added in 18bfb2052304a5a2e6204fe2d07328d980147e3c where apparently using `:name` was not enough to uniquefy column names. It seems like what's stored in `:name` got changed over time, because `pivot-long-column-names-download-test` (introduced in that commit) is passing.

But we cannot just change `desired-column-alias` to `source-column-alias`, because we'll get two `sum` in that test and there is an override happening in that map. But we still need `source-column-alias` that has not been shortened, so we use this as a backup.

I haven't been able (by reading the code) to confirm what FE is doing for this though - somehow it gets full-length names in `:name`. :\