### PR TITLE
Visualizer cards ignore card description

### DIFF
--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -109,6 +109,7 @@ export function getInitialStateForCardDataSource(
     columnValuesMapping: {},
     settings: {
       "card.title": card.name,
+      "card.description": card.description,
     },
     datasetFallbacks: { [card.id]: dataset },
   };
@@ -223,6 +224,7 @@ export function getInitialStateForCardDataSource(
     ...updateVizSettingsWithRefs(card.visualization_settings, columnsToRefs),
     ...Object.fromEntries(entries),
     "card.title": card.name,
+    "card.description": card.description,
   };
 
   return state;

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -109,10 +109,13 @@ export function getInitialStateForCardDataSource(
     columnValuesMapping: {},
     settings: {
       "card.title": card.name,
-      "card.description": card.description,
     },
     datasetFallbacks: { [card.id]: dataset },
   };
+
+  if (card.description != null) {
+    state.settings["card.description"] = card.description;
+  }
 
   const dataSource = createDataSource("card", card.id, card.name);
 
@@ -224,8 +227,11 @@ export function getInitialStateForCardDataSource(
     ...updateVizSettingsWithRefs(card.visualization_settings, columnsToRefs),
     ...Object.fromEntries(entries),
     "card.title": card.name,
-    "card.description": card.description,
   };
+
+  if (card.description != null) {
+    state.settings["card.description"] = card.description;
+  }
 
   return state;
 }

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -98,7 +98,6 @@ describe("getInitialStateForCardDataSource", () => {
 
     expect(state.settings).toEqual({
       "card.title": "TablyMcTableface",
-      "card.description": null,
       "graph.dimensions": ["COLUMN_1"],
       "graph.metrics": ["COLUMN_2"],
     });
@@ -189,7 +188,6 @@ describe("getInitialStateForCardDataSource", () => {
 
     expect(state.settings).toEqual({
       "card.title": "ComboMcComboface",
-      "card.description": null,
       "graph.dimensions": ["COLUMN_1"],
       "graph.metrics": ["COLUMN_2", "COLUMN_3"],
     });
@@ -237,7 +235,6 @@ describe("getInitialStateForCardDataSource", () => {
 
     expect(state.settings).toEqual({
       "card.title": "ScalarMcSmartface",
-      "card.description": null,
       "graph.dimensions": ["COLUMN_1"],
       "graph.metrics": ["COLUMN_2"],
       "scalar.compact_primary_number": true,
@@ -286,7 +283,6 @@ describe("getInitialStateForCardDataSource", () => {
         },
         settings: {
           "card.title": card.name,
-          "card.description": null,
           "funnel.metric": "METRIC",
           "funnel.dimension": "DIMENSION",
         },

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -18,6 +18,7 @@ describe("getInitialStateForCardDataSource", () => {
     card: createMockCard({
       display: "smartscalar",
       name: "ScalarMcSmartface",
+      description: null,
       visualization_settings: {
         "scalar.compact_primary_number": true,
       },
@@ -72,6 +73,7 @@ describe("getInitialStateForCardDataSource", () => {
     const card = createMockCard({
       display: "table",
       name: "TablyMcTableface",
+      description: null,
       visualization_settings: {},
     });
 
@@ -96,9 +98,24 @@ describe("getInitialStateForCardDataSource", () => {
 
     expect(state.settings).toEqual({
       "card.title": "TablyMcTableface",
+      "card.description": null,
       "graph.dimensions": ["COLUMN_1"],
       "graph.metrics": ["COLUMN_2"],
     });
+  });
+
+  it("should include card description in settings (metabase#63863)", () => {
+    const card = createMockCard({
+      display: "table",
+      name: "Test Card",
+      description: "This is a test description",
+    });
+
+    const state = getInitialStateForCardDataSource(card, dataset);
+
+    expect(state.settings["card.description"]).toEqual(
+      "This is a test description",
+    );
   });
 
   it("should ignore superfluous columns when the original card is a combo chart", () => {
@@ -137,6 +154,7 @@ describe("getInitialStateForCardDataSource", () => {
     const card = createMockCard({
       display: "combo",
       name: "ComboMcComboface",
+      description: null,
       visualization_settings: {
         "graph.metrics": ["sum", "sum_2"],
         "graph.dimensions": ["CREATED_AT"],
@@ -171,6 +189,7 @@ describe("getInitialStateForCardDataSource", () => {
 
     expect(state.settings).toEqual({
       "card.title": "ComboMcComboface",
+      "card.description": null,
       "graph.dimensions": ["COLUMN_1"],
       "graph.metrics": ["COLUMN_2", "COLUMN_3"],
     });
@@ -218,6 +237,7 @@ describe("getInitialStateForCardDataSource", () => {
 
     expect(state.settings).toEqual({
       "card.title": "ScalarMcSmartface",
+      "card.description": null,
       "graph.dimensions": ["COLUMN_1"],
       "graph.metrics": ["COLUMN_2"],
       "scalar.compact_primary_number": true,
@@ -230,6 +250,7 @@ describe("getInitialStateForCardDataSource", () => {
       const card = createMockCard({
         name: `${vizType} card`,
         display: vizType,
+        description: null,
       });
       const initialState = getInitialStateForCardDataSource(card, dataset);
 
@@ -265,6 +286,7 @@ describe("getInitialStateForCardDataSource", () => {
         },
         settings: {
           "card.title": card.name,
+          "card.description": null,
           "funnel.metric": "METRIC",
           "funnel.dimension": "DIMENSION",
         },

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
@@ -168,8 +168,11 @@ export function getInitialStateForMultipleSeries(rawSeries: RawSeries) {
     ),
     ...mergedSettings,
     "card.title": mainCard.name,
-    "card.description": mainCard.description,
   };
+
+  if (mainCard.description != null) {
+    state.settings["card.description"] = mainCard.description;
+  }
 
   return state;
 }

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
@@ -168,6 +168,7 @@ export function getInitialStateForMultipleSeries(rawSeries: RawSeries) {
     ),
     ...mergedSettings,
     "card.title": mainCard.name,
+    "card.description": mainCard.description,
   };
 
   return state;

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.unit.spec.ts
@@ -18,6 +18,7 @@ describe("getInitialVisualizerStateForMultipleSeries", () => {
       id: 1,
       name: "First Series",
       display: "line",
+      description: null,
       visualization_settings: {
         "graph.metrics": ["Revenue"],
         "graph.dimensions": ["Date"],
@@ -28,6 +29,7 @@ describe("getInitialVisualizerStateForMultipleSeries", () => {
       id: 2,
       name: "Second Series",
       display: "line",
+      description: null,
       visualization_settings: {
         "graph.metrics": ["Profit"],
         "graph.dimensions": ["Date"],
@@ -93,6 +95,37 @@ describe("getInitialVisualizerStateForMultipleSeries", () => {
       "graph.metrics": ["COLUMN_2", "COLUMN_4"],
       "graph.dimensions": ["COLUMN_1", "COLUMN_3"],
       "card.title": "First Series",
+      "card.description": null,
     });
+  });
+
+  it("should include card description in settings (metabase#63863)", () => {
+    const firstCard = createMockCard({
+      id: 1,
+      name: "Test Series",
+      description: "Test description",
+      display: "line",
+      visualization_settings: {
+        "graph.metrics": ["Revenue"],
+        "graph.dimensions": ["Date"],
+      },
+    });
+
+    const rawSeries = [
+      createMockSingleSeries(firstCard, {
+        data: createMockDatasetData({
+          cols: [
+            createMockColumn({ name: "Date" }),
+            createMockColumn({ name: "Revenue" }),
+          ],
+        }),
+      }),
+    ];
+
+    const initialState = getInitialStateForMultipleSeries(rawSeries);
+
+    expect(initialState.settings["card.description"]).toEqual(
+      "Test description",
+    );
   });
 });

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.unit.spec.ts
@@ -95,7 +95,6 @@ describe("getInitialVisualizerStateForMultipleSeries", () => {
       "graph.metrics": ["COLUMN_2", "COLUMN_4"],
       "graph.dimensions": ["COLUMN_1", "COLUMN_3"],
       "card.title": "First Series",
-      "card.description": null,
     });
   });
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63863
### Description

Fixes that visualizer cards don't get underlying question description.

### How to verify

- Create a question, add description to it
- Add it on a dashboard
- Open the visualizer for the dashcard
- Change anything except for the description field and save
- Ensure the visualizer card has the description info tooltip with the original question description

### Demo

This card has been changed in the visualizer:

<img width="902" height="394" alt="Screenshot 2025-09-29 at 1 02 56 PM" src="https://github.com/user-attachments/assets/6c590627-b335-4078-ab08-69e2e334ab14" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
