### PR TITLE
Show audit links for non-admins with perms

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/InsightsLink.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/InsightsLink.tsx
@@ -2,10 +2,8 @@ import { t } from "ttag";
 
 import Link from "metabase/common/components/Link";
 import SidesheetS from "metabase/common/components/Sidesheet/sidesheet.module.css";
-import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import type { InsightsLinkProps } from "metabase/plugins";
-import { getUserIsAdmin } from "metabase/selectors/user";
 import { Flex, Icon } from "metabase/ui";
 import { useGetAuditInfoQuery } from "metabase-enterprise/api";
 import type { Collection } from "metabase-types/api";
@@ -19,8 +17,6 @@ export const InsightsLink = ({
 }: InsightsLinkProps) => {
   const { data: auditInfo, error, isLoading } = useGetAuditInfoQuery();
 
-  const isUserAdmin = useSelector(getUserIsAdmin);
-
   const collection = dashboard
     ? dashboard.collection
     : (question.collection() as Collection);
@@ -29,21 +25,25 @@ export const InsightsLink = ({
     return <div data-testid="loading-indicator" />;
   }
 
-  if (!isUserAdmin) {
-    return null;
-  }
-
   if (collection?.type === "instance-analytics") {
     return null;
   }
 
-  if (error || !auditInfo) {
+  if (
+    error ||
+    !auditInfo ||
+    (!auditInfo.dashboard_overview && !auditInfo.question_overview)
+  ) {
     return null;
   }
 
   const entityId = dashboard
     ? auditInfo.dashboard_overview
     : auditInfo.question_overview;
+
+  if (!entityId) {
+    return null;
+  }
 
   const linkQueryParams = new URLSearchParams(
     dashboard

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/types/state.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/types/state.ts
@@ -1,7 +1,7 @@
 import type { CardId, CollectionId, DashboardId } from "metabase-types/api";
 
 export interface AuditInfo {
-  dashboard_overview: DashboardId;
-  question_overview: CardId;
-  custom_reports: CollectionId;
+  dashboard_overview?: DashboardId;
+  question_overview?: CardId;
+  custom_reports?: CollectionId;
 }

--- a/frontend/src/metabase/common/components/Sidesheet/components/InsightsTabOrLink/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Sidesheet/components/InsightsTabOrLink/tests/premium.unit.spec.tsx
@@ -47,10 +47,29 @@ describe("InsightsTabOrLink (EE with token)", () => {
   });
 
   describe("for non-admins", () => {
-    it("renders nothing", async () => {
+    it("renders a link if they have permission to view Usage Analytics", async () => {
+      const { history } = await setup({
+        isForADashboard: true,
+        isUserAdmin: false,
+        hasUsageAnalyticsPermission: true,
+      });
+      expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+      const routerLink = await screen.findByText("Insights");
+      await userEvent.click(routerLink);
+      expect(history?.getCurrentLocation().pathname).toBe("/dashboard/201");
+      expect(history?.getCurrentLocation().query).toEqual({
+        dashboard_id: "1",
+      });
+      expect(
+        await screen.findByTestId("usage-analytics-dashboard"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders nothing if they don't have permission", async () => {
       await setup({
         isForADashboard: true,
         isUserAdmin: false,
+        hasUsageAnalyticsPermission: false,
       });
       expect(screen.queryByRole("tab")).not.toBeInTheDocument();
       expect(screen.queryByRole("link")).not.toBeInTheDocument();

--- a/frontend/src/metabase/common/components/Sidesheet/components/InsightsTabOrLink/tests/setup.tsx
+++ b/frontend/src/metabase/common/components/Sidesheet/components/InsightsTabOrLink/tests/setup.tsx
@@ -21,12 +21,14 @@ export type SetupOpts = {
   isForADashboard?: boolean;
   enableAuditAppPlugin?: boolean;
   isUserAdmin?: boolean;
+  hasUsageAnalyticsPermission?: boolean;
 };
 
 export const setup = async ({
   isForADashboard = false,
   enableAuditAppPlugin = false,
   isUserAdmin = false,
+  hasUsageAnalyticsPermission = true,
 }: SetupOpts = {}) => {
   const storeInitialState = createMockState({
     currentUser: createMockUser({ is_superuser: isUserAdmin }),
@@ -40,7 +42,11 @@ export const setup = async ({
     ),
   });
 
-  setupAuditInfoEndpoint();
+  if (hasUsageAnalyticsPermission) {
+    setupAuditInfoEndpoint();
+  } else {
+    setupAuditInfoEndpoint({ auditInfo: {} as any });
+  }
   setupEnterprisePlugins();
 
   const mockDashboard = createMockDashboard();


### PR DESCRIPTION
If a user isn't an admin but has permission to view the Usage Analytics collection they should see links in the card sidebar.
