### PR TITLE
Fix metrics-collection e2e flake

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-collection.cy.spec.js
@@ -225,14 +225,14 @@ describe("scenarios > metrics > collection", () => {
     H.createQuestion({
       ...ORDERS_SCALAR_MODEL_METRIC,
       collection_id: FIRST_COLLECTION_ID,
-    }).then(({ body: card }) => {
+    }).then(() => {
       cy.signIn("nocollection");
       H.visitCollection(FIRST_COLLECTION_ID);
     });
     H.getPinnedSection()
-      .findByTestId("scalar-container")
-      .findByText("18,760")
-      .should("be.visible");
+      .findByTestId("scalar-value")
+      .should("not.be.empty")
+      .and("be.visible");
   });
 });
 


### PR DESCRIPTION
We're making the assertion a bit more flexible without losing the confidence that this test was supposed to give us when it was created.

## Stress-test x50
https://github.com/metabase/metabase/actions/runs/18107561588

## Local run
<img width="1749" height="1042" alt="image" src="https://github.com/user-attachments/assets/8229231d-30aa-4659-96e2-74b904c8243d" />
