### PR TITLE
Fix card duplication on move to before flexcontainer

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/HandleEditorDrop/HandleEditorDrop.tsx
@@ -60,7 +60,7 @@ export const HandleEditorDrop = Extension.create({
                 dropToParent.type.name !== "cardEmbed" &&
                 dropToParent.type.name !== "resizeNode"
               ) {
-                handleCardDropOnDocument(cardEmbedInitialData);
+                return handleCardDropOnDocument(cardEmbedInitialData);
               }
             }
 


### PR DESCRIPTION
Closes issue with Document Layout mentioned in https://www.loom.com/share/7baa8b1ff7fb41fca83c52870286f412?t=60&sid=434c6d2e-65df-4b74-8092-69547fdccd9d

### Description

There was no return preventing default behavior in a case when we drop a card on a document, plus issue with insert position calculation after initial card delete.

### Demo

https://github.com/user-attachments/assets/5bfc6e26-8453-4cbf-a1b9-333b26c737a5


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
