### PR TITLE
fix: make popular tables clickable

### DIFF
--- a/src/metabase/activity_feed/models/recent_views.clj
+++ b/src/metabase/activity_feed/models/recent_views.clj
@@ -438,7 +438,7 @@
              {:select [:t.id :t.name :t.description
                        :t.display_name :t.active :t.visibility_type :t.schema
                        [:db.name :database-name]
-                       [:db.id :database-id]
+                       [:db.id :db_id]
                        [:db.initial_sync_status :initial-sync-status]]
               :from [[:metabase_table :t]]
               :where (let [base-condition [:or
@@ -472,7 +472,7 @@
        :can_write (mi/can-write? table)
        :timestamp (str timestamp)
        :table_schema (:schema table)
-       :database {:id (:database-id table)
+       :database {:id (:db_id table)
                   :name (:database-name table)
                   :initial_sync_status (:initial-sync-status table)}})))
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60060
Fixes UXW-651.

Very silly bug, we were just populating the ID with the wrong thing (`(:database-id table)` instead of `(:db_id table)`), so the FE couldn't build links correctly.