### PR TITLE
[MBQL lib] Use `:between` filters for bucketed time fields

### DIFF
--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -75,7 +75,7 @@
                            (:temporal-unit (lib.options/options maybe-clause-arg)))
                 (u.time/timestamp-coercible? other-arg))))
 
-(defn- expand-temporal-expression
+(defn expand-temporal-expression
   "Modify expression in a way, that its resulting [[expression-parts]] are digestable by filter picker.
 
    Current filter picker implementation is unable to handle expression parts of expressions of a form

--- a/src/metabase/xrays/automagic_dashboards/combination.clj
+++ b/src/metabase/xrays/automagic_dashboards/combination.clj
@@ -163,8 +163,8 @@
   [{:keys [cell-query]}]
   (letfn [(collect-dimensions [[op & args]]
             (case (some-> op qp.util/normalize-token)
-              :and (mapcat collect-dimensions args)
-              :=   (magic.util/collect-field-references args)
+              :and          (mapcat collect-dimensions args)
+              (:between :=) (magic.util/collect-field-references args)
               nil))]
     (->> cell-query
          collect-dimensions

--- a/src/metabase/xrays/automagic_dashboards/filters.clj
+++ b/src/metabase/xrays/automagic_dashboards/filters.clj
@@ -11,7 +11,8 @@
 (defn- temporal?
   "Does `field` represent a temporal value, i.e. a date, time, or datetime?"
   [{base-type :base_type, effective-type :effective_type, unit :unit}]
-  ;; TODO -- not sure why we're excluding year here? Is it because we normally returned it as an integer in the past?
+  ;; Excluding :year because it's (currently) both an extraction and truncation unit.
+  ;; For the purposes of this check, :year is an interesting :unit which yields a time interval, not just a number.
   (and (not ((disj u.date/extract-units :year) unit))
        (isa? (or effective-type base-type) :type/Temporal)))
 

--- a/src/metabase/xrays/automagic_dashboards/names.clj
+++ b/src/metabase/xrays/automagic_dashboards/names.clj
@@ -204,7 +204,13 @@
 (mu/defmethod humanize-filter-value :between
   [root :- ::ads/root
    [_ field-reference min-value max-value]]
-  (tru "{0} is between {1} and {2}" (item-name root field-reference) min-value max-value))
+  (let [{:keys [item-name effective_type base_type unit]} (item-reference->field root field-reference)]
+    (or (when (isa? (or effective_type base_type) :type/Temporal)
+          (let [humanized-min (humanize-datetime min-value unit)
+                humanized-max (humanize-datetime max-value unit)]
+            (when (= humanized-min humanized-max)
+              (tru "{0} is {1}" item-name humanized-min))))
+        (tru "{0} is between {1} and {2}" item-name min-value max-value))))
 
 (mu/defmethod humanize-filter-value :inside
   [root :- ::ads/root

--- a/test/metabase/lib/drill_thru/automatic_insights_test.cljc
+++ b/test/metabase/lib/drill_thru/automatic_insights_test.cljc
@@ -82,7 +82,8 @@
             (lib/drill-thru query -1 nil drill)))))
 
 (deftest ^:parallel automatic-insights-apply-test
-  (let [filters [[:= {} [:field {} (meta/id :orders :created-at)] "2023-12-01"]]]
+  (let [filters [[:between {} [:field {} (meta/id :orders :created-at)]
+                  "2023-12-01" "2023-12-31"]]]
     (testing "breakouts are turned to filters, aggregations dropped"
       (auto-insights (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                          (lib/aggregate (lib/sum (meta/field-metadata :orders :subtotal)))
@@ -109,7 +110,7 @@
                        (lib/breakout (lib/with-temporal-bucket
                                        (meta/field-metadata :orders :created-at)
                                        :month)))
-                   [[:= {} [:field {} (meta/id :orders :created-at)] "2023-12-01"]
+                   [[:between {} [:field {} (meta/id :orders :created-at)] "2023-12-01" "2023-12-31"]
                     [:= {} [:field {} (meta/id :products :category)] "Doohickey"]])))
 
 (deftest ^:parallel automatic-insights-apply-test-3
@@ -129,7 +130,8 @@
                          (lib/breakout (lib/with-temporal-bucket
                                          (meta/field-metadata :orders :created-at)
                                          :month)))
-                     [[:= {} [:field {} (meta/id :orders :created-at)] "2023-12-01"]]))))
+                     [[:between {} [:field {} (meta/id :orders :created-at)]
+                       "2023-12-01" "2023-12-31"]]))))
 
 (deftest ^:parallel binned-column-test
   (testing "Automatic insights for a binned column should generate filters for current bin's min/max values"

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -114,28 +114,20 @@
                                  :value      "2022-12-01T00:00:00+02:00"}]}}))
 
 (def ^:private last-month
-  #?(:cljs (let [now    (js/Date.)
-                 year   (.getFullYear now)
-                 month  (.getMonth now)]
-             (-> (js/Date.UTC year (dec month))
-                 (js/Date.)
-                 (.toISOString)))
+  ;; The JS date libraries suck. Rather than working hard to get this right in both environments for a unit test,
+  ;; here's a hard-coded value. This can be any month, provided it is in the range of the Sample Database, which is
+  ;; roughly +/- 2 years. I've picked June 2026 in October 2025, so this value should be good for a few years.
+  #?(:cljs "2026-06-01"
      :clj  (let [last-month (-> (t/zoned-date-time (t/year) (t/month))
                                 (t/minus (t/months 1)))]
              (t/format :iso-offset-date-time last-month))))
 
-(let [[start end] #?(:cljs (let [now    (js/Date.)
-                                 year   (.getFullYear now)
-                                 month  (.getMonth now)]
-                             [(-> (js/Date.UTC year (dec month))
-                                  (js/Date.))
-                              (-> (js/Date.UTC year month 0) ; Sep 0 == Aug 31
-                                  (js/Date.))])
+;; See the note above under [[last-month]] about the hard-coded values in CLJS.
+(let [[start end] #?(:cljs ["2026-06-01" "2026-06-30"]
                      :clj  (let [this-month (t/local-date (t/year) (t/month))]
                              [(t/minus this-month (t/months 1))
-                              (t/minus this-month (t/days 1))]
-                             #_(t/format :iso-date last-month-end)))
-      ->str       #?(:cljs (fn [d] (str (.getYear d) "-" (inc (.getMonth d)) "-" (.getDay d)))
+                              (t/minus this-month (t/days 1))]))
+      ->str       #?(:cljs identity ; They're already just strings.
                      :clj  #(t/format :iso-date %))]
   (def ^:private last-month-start (->str start))
   (def ^:private last-month-end   (->str end)))


### PR DESCRIPTION
Closes #12496.

### Description

When using the `underlying-records` drill ("See these Orders") on a bucketed temporal value, such as a data point in
a time series, use a `:between` filter with the endpoints of the bucket, rather than `:=`.

The queries work with `:=` (because the QP expands them to `:between`) but some parts of the filter UI
render it badly. With `:between`, the filter is rendered properly as a date range.

### How to verify

1. Create a time series query, eg. `Count of Orders by Created At: Month`
2. Render it as a line chart
3. Click a data point
4. Select "See these Orders"
5. The filter widget shows eg. "May 1-31, 2025", and if you click to open it you see that range of dates selected.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
