### PR TITLE
Netty Vulnerability Fix - CVE-2025-55163

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -16,5 +16,5 @@
   org.apache.arrow/arrow-memory-netty    {:mvn/version "17.0.0"}
   org.apache.arrow/arrow-vector          {:mvn/version "17.0.0"}
   ;; matches those in athena
-  io.netty/netty-common                  {:mvn/version "4.1.118.Final"}
-  io.netty/netty-buffer                  {:mvn/version "4.1.118.Final"}}}
+  io.netty/netty-common                  {:mvn/version "4.1.124.Final"}
+  io.netty/netty-buffer                  {:mvn/version "4.1.124.Final"}}}


### PR DESCRIPTION
CVE ID: CVE-2025-55163
Description: Netty is vulnerable to MadeYouReset DDoS attack using malformed HTTP/2 control frames
Affected Versions: Prior to 4.1.124.Final and 4.2.4.Final
Severity: High - Can cause resource exhaustion and distributed denial of service

> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
