### PR TITLE
Enable copying of iframe cards

### DIFF
--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -442,8 +442,7 @@
               (:action_id dashboard-card)
               nil
 
-              ;; iframe cards need no manipulation
-              (some-> dashboard-card :visualization_settings :iframe)
+              (some-> dashboard-card :visualization_settings :virtual_card :display #{"iframe"})
               dashboard-card
 
               ;; text cards need no manipulation

--- a/src/metabase/dashboards/api.clj
+++ b/src/metabase/dashboards/api.clj
@@ -442,6 +442,10 @@
               (:action_id dashboard-card)
               nil
 
+              ;; iframe cards need no manipulation
+              (some-> dashboard-card :visualization_settings :iframe)
+              dashboard-card
+
               ;; text cards need no manipulation
               (some-> dashboard-card :visualization_settings :virtual_card :display #{"text" "heading"})
               dashboard-card

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -1682,6 +1682,16 @@
                (api.dashboard/update-cards-for-copy dashcards
                                                     {1 {:id 1}}
                                                     nil
+                                                    nil)))))
+    (testing "Copies iframe cards"
+      (let [dashcards [{:card_id 1 :card {:id 1}}
+                       {:visualization_settings
+                        {:virtual_card {:display "iframe"}
+                         :iframe "<iframe src=\"https://www.youtube.com/embed/dQw4w9WgXcQ\" />"}}]]
+        (is (= dashcards
+               (api.dashboard/update-cards-for-copy dashcards
+                                                    {1 {:id 1}}
+                                                    nil
                                                     nil)))))))
 
 (deftest copy-dashboard-cards-test


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/63525

Iframe cards were filtered out from copying. With this PR in also the iframe cards are copied with a dashboard.