### PR TITLE
Hide the python runner settings for cloud instances

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/pages/PythonRunnerSettingsPage/PythonRunnerSettingsPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/pages/PythonRunnerSettingsPage/PythonRunnerSettingsPage.tsx
@@ -5,8 +5,16 @@ import {
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
 import { AdminSettingInput } from "metabase/admin/settings/components/widgets/AdminSettingInput";
+import { useSetting } from "metabase/common/hooks";
 
 export function PythonRunnerSettingsPage() {
+  const isHosted = useSetting("is-hosted?");
+
+  // Python Runner settings are managed by Metabase Cloud for hosted instances
+  if (isHosted) {
+    return null;
+  }
+
   return (
     <SettingsPageWrapper title={t`Python Runner`}>
       <SettingsSection title={t`Service Configuration`}>

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -8,7 +8,7 @@ import {
   AdminNavWrapper,
 } from "metabase/admin/components/AdminNav";
 import { UpsellGem } from "metabase/admin/upsells/components/UpsellGem";
-import { useHasTokenFeature } from "metabase/common/hooks";
+import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { getLocation } from "metabase/selectors/routing";
 import { Divider, Flex } from "metabase/ui";
@@ -24,6 +24,7 @@ export function SettingsNav() {
   const hasJwt = useHasTokenFeature("sso_jwt");
   const hasScim = useHasTokenFeature("scim");
   const hasPythonTransforms = useHasTokenFeature("transforms-python");
+  const isHosted = useSetting("is-hosted?");
 
   return (
     <AdminNavWrapper>
@@ -88,7 +89,8 @@ export function SettingsNav() {
       </SettingsNavItem>
       <NavDivider />
       <SettingsNavItem path="uploads" label={t`Uploads`} icon="upload" />
-      {hasPythonTransforms && (
+      {/* Python Runner settings are managed by Metabase Cloud for hosted instances */}
+      {hasPythonTransforms && !isHosted && (
         <SettingsNavItem
           path="python-runner"
           label={t`Python Runner`}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/QUE-2607/ensure-runners3-settings-are-hidden-for-cloud-instances

This section is hidden for cloud instances, and even if they go to it, it'll be a blank page.
<img width="245" height="152" alt="Screenshot 2025-09-30 at 19 05 01" src="https://github.com/user-attachments/assets/2477bd57-f7d5-4cd5-997c-e80161829cc5" />
