### PR TITLE
refactor(sdk): Properly reinitialize metabaseConfig watcher for EmbedJS wizard

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/constants.ts
@@ -81,3 +81,5 @@ export const DISABLE_UPDATE_FOR_KEYS = [
   "useExistingUserSession",
   "fetchRequestToken",
 ] as const satisfies AllowedEmbedSettingKey[];
+
+export const METABASE_CONFIG_IS_PROXY_FIELD_NAME = "__isProxy";

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/embed.unit.spec.ts
@@ -11,7 +11,6 @@ describe("embed.js script tag for sdk iframe embedding", () => {
 
   beforeEach(() => {
     jest.resetModules();
-    // @ts-expect-error -- test cleanup
     delete window.metabaseConfig;
     require("./embed"); // we do things when the script is loaded
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -13,9 +13,9 @@ import { useSetting } from "metabase/common/hooks";
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { colors as defaultMetabaseColors } from "metabase/lib/colors";
 import { Card } from "metabase/ui";
+import { METABASE_CONFIG_IS_PROXY_FIELD_NAME } from "metabase-enterprise/embedding_iframe_sdk/constants";
 // we import the equivalent of embed.js so that we don't add extra loading time
 // by appending the script
-import { METABASE_CONFIG_IS_PROXY_FIELD_NAME } from "metabase-enterprise/embedding_iframe_sdk/constants";
 import { setupConfigWatcher } from "metabase-enterprise/embedding_iframe_sdk/embed";
 import type { SdkIframeEmbedBaseSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SdkIframeEmbedPreview.tsx
@@ -13,6 +13,10 @@ import { useSetting } from "metabase/common/hooks";
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { colors as defaultMetabaseColors } from "metabase/lib/colors";
 import { Card } from "metabase/ui";
+// we import the equivalent of embed.js so that we don't add extra loading time
+// by appending the script
+import { METABASE_CONFIG_IS_PROXY_FIELD_NAME } from "metabase-enterprise/embedding_iframe_sdk/constants";
+import { setupConfigWatcher } from "metabase-enterprise/embedding_iframe_sdk/embed";
 import type { SdkIframeEmbedBaseSettings } from "metabase-enterprise/embedding_iframe_sdk/types/embed";
 
 import { useSdkIframeEmbedSetupContext } from "../context";
@@ -22,13 +26,11 @@ import { getConfigurableThemeColors } from "../utils/theme-colors";
 import { EmbedPreviewLoadingOverlay } from "./EmbedPreviewLoadingOverlay";
 import S from "./SdkIframeEmbedPreview.module.css";
 
-// we import the equivalent of embed.js so that we don't add extra loading time
-// by appending the script
-import "metabase-enterprise/embedding_iframe_sdk/embed";
-
 declare global {
   interface Window {
-    metabaseConfig: Partial<SdkIframeEmbedBaseSettings>;
+    metabaseConfig?: Partial<SdkIframeEmbedBaseSettings> & {
+      [METABASE_CONFIG_IS_PROXY_FIELD_NAME]?: boolean;
+    };
   }
 }
 
@@ -46,9 +48,18 @@ export const SdkIframeEmbedPreview = () => {
   const defineMetabaseConfig = useCallback(
     (metabaseConfig: SdkIframeEmbedBaseSettings) => {
       window.metabaseConfig = metabaseConfig;
+
+      if (!window.metabaseConfig[METABASE_CONFIG_IS_PROXY_FIELD_NAME]) {
+        setupConfigWatcher();
+      }
     },
     [],
   );
+  const cleanupMetabaseConfig = useCallback(() => {
+    if (window.metabaseConfig) {
+      delete window.metabaseConfig;
+    }
+  }, []);
 
   const derivedTheme = useMemo(() => {
     // TODO(EMB-696): There is a bug in the SDK where if we set the theme back to undefined,
@@ -81,13 +92,20 @@ export const SdkIframeEmbedPreview = () => {
   );
 
   // initial configuration, needed so that the element finds the config on first render
-  if (!window.metabaseConfig.instanceUrl) {
+  if (!window.metabaseConfig?.instanceUrl) {
     defineMetabaseConfig(metabaseConfig);
   }
 
   useEffect(() => {
     defineMetabaseConfig(metabaseConfig);
   }, [metabaseConfig, defineMetabaseConfig]);
+
+  useEffect(
+    () => () => {
+      cleanupMetabaseConfig();
+    },
+    [cleanupMetabaseConfig],
+  );
 
   // Show a "fake" loading indicator when componentName changes.
   // Embed JS has its own loading indicator, but it shows up after the iframe loads.


### PR DESCRIPTION
Properly reinitialize metabaseConfig watcher for EmbedJS wizard

Context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1759231785368609

How to test:
- open EmbedJS wizard
- check `window.metabaseConfig` - it should be a proxy object
- click the `Metabase` icon in a header to go to the main Metabase Page
- check `window.metabaseConfig` - it should be `undefined`
- open EmbedJS wizard again
- check `window.metabaseConfig` - it should be a proxy object again