### PR TITLE
WRK 905 Allow commenting on unsaved documents

### DIFF
--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -615,14 +615,14 @@ H.describeWithSnowplowEE("document comments", () => {
       getParagraph("Lorem ipsum dolor sit amet.xyz").realHover();
 
       cy.findByLabelText("Comments")
-        .should("be.disabled")
+        .should("not.be.disabled")
         .click({ force: true });
-      Comments.getSidebar().should("not.exist");
+      Comments.getSidebar().should("be.visible");
 
       cy.findByLabelText("Show all comments")
-        .should("be.disabled")
+        .should("not.be.disabled")
         .click({ force: true });
-      Comments.getSidebar().should("not.exist");
+      Comments.getSidebar().should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -614,14 +614,10 @@ H.describeWithSnowplowEE("document comments", () => {
 
       getParagraph("Lorem ipsum dolor sit amet.xyz").realHover();
 
-      cy.findByLabelText("Comments")
-        .should("not.be.disabled")
-        .click();
+      cy.findByLabelText("Comments").should("not.be.disabled").click();
       Comments.getSidebar().should("be.visible");
 
-      cy.findByLabelText("Show all comments")
-        .should("not.be.disabled")
-        .click();
+      cy.findByLabelText("Show all comments").should("not.be.disabled").click();
       Comments.getSidebar().should("be.visible");
     });
   });

--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -570,7 +570,7 @@ H.describeWithSnowplowEE("document comments", () => {
     });
   });
 
-  it("prevents editing the document when comments are open", () => {
+  it("allows editing the document when comments are open", () => {
     create1ParagraphDocument();
 
     cy.get<DocumentId>("@documentId").then((documentId) => {
@@ -580,17 +580,17 @@ H.describeWithSnowplowEE("document comments", () => {
         H.documentContent().click();
 
         cy.realType("test");
-        cy.findByRole("button", { name: "Save" }).should("not.exist");
+        cy.findByRole("button", { name: "Save" }).should("exist");
 
         H.documentContent()
-          .get('[contenteditable="false"]')
+          .get('[contenteditable="true"]')
           .should("be.visible");
         H.documentFormattingMenu().should("not.exist");
       });
     });
   });
 
-  it("prevents opening comments when document has changes", () => {
+  it("allows opening comments when document has changes", () => {
     create1ParagraphDocument();
 
     cy.get<DocumentId>("@documentId").then((documentId) => {

--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -616,12 +616,12 @@ H.describeWithSnowplowEE("document comments", () => {
 
       cy.findByLabelText("Comments")
         .should("not.be.disabled")
-        .click({ force: true });
+        .click();
       Comments.getSidebar().should("be.visible");
 
       cy.findByLabelText("Show all comments")
         .should("not.be.disabled")
-        .click({ force: true });
+        .click();
       Comments.getSidebar().should("be.visible");
     });
   });

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentHeader.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentHeader.tsx
@@ -134,20 +134,7 @@ export const DocumentHeader = ({
         {!isNewDocument && hasComments && (
           <Tooltip label={t`Show all comments`}>
             <Box>
-              {showSaveButton && (
-                <ActionIcon
-                  className={S.commentsIcon}
-                  disabled
-                  variant="subtle"
-                  size="md"
-                  aria-label={t`Show all comments`}
-                  data-hide-on-print
-                >
-                  <Icon name="comment" />
-                </ActionIcon>
-              )}
-
-              {!showSaveButton && document && (
+              {document && (
                 <ActionIcon
                   className={S.commentsIcon}
                   component={Link}

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -138,8 +138,7 @@ export const DocumentPage = ({
   const hasComments =
     !!commentsData?.comments && commentsData.comments.length > 0;
 
-  const canWrite =
-    (isNewDocument || documentData?.can_write);
+  const canWrite = isNewDocument || documentData?.can_write;
 
   useEffect(() => {
     if (error) {

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/DocumentPage.tsx
@@ -58,7 +58,6 @@ import {
 import { useDocumentState } from "../hooks/use-document-state";
 import { useRegisterDocumentMetabotContext } from "../hooks/use-register-document-metabot-context";
 import {
-  getCommentSidebarOpen,
   getDraftCards,
   getHasUnsavedChanges,
   getSelectedEmbedIndex,
@@ -92,7 +91,6 @@ export const DocumentPage = ({
   const dispatch = useDispatch();
   const selectedQuestionId = useSelector(getSelectedQuestionId);
   const selectedEmbedIndex = useSelector(getSelectedEmbedIndex);
-  const commentSidebarOpen = useSelector(getCommentSidebarOpen);
   const draftCards = useSelector(getDraftCards);
   const [editorInstance, setEditorInstance] = useState<TiptapEditor | null>(
     null,
@@ -141,7 +139,7 @@ export const DocumentPage = ({
     !!commentsData?.comments && commentsData.comments.length > 0;
 
   const canWrite =
-    (isNewDocument || documentData?.can_write) && !commentSidebarOpen;
+    (isNewDocument || documentData?.can_write);
 
   useEffect(() => {
     if (error) {

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/CommentsMenu/CommentsMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/CommentsMenu/CommentsMenu.tsx
@@ -29,10 +29,7 @@ export const getUnresolvedComments = (
 };
 
 export const CommentsMenu = forwardRef<HTMLDivElement, Props>(
-  function CommentsMenu(
-    { active, href, show, style, threads }: Props,
-    ref,
-  ) {
+  function CommentsMenu({ active, href, show, style, threads }: Props, ref) {
     const unresolvedCommentsCount = useMemo(
       () => getUnresolvedComments(threads).length,
       [threads],

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/CommentsMenu/CommentsMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/CommentsMenu/CommentsMenu.tsx
@@ -30,7 +30,7 @@ export const getUnresolvedComments = (
 
 export const CommentsMenu = forwardRef<HTMLDivElement, Props>(
   function CommentsMenu(
-    { active, disabled, href, show, style, threads }: Props,
+    { active, href, show, style, threads }: Props,
     ref,
   ) {
     const unresolvedCommentsCount = useMemo(
@@ -42,9 +42,7 @@ export const CommentsMenu = forwardRef<HTMLDivElement, Props>(
     return createPortal(
       <Box
         className={cx(S.commentsMenu, {
-          [S.visible]: disabled
-            ? hasUnresolvedComments
-            : show || hasUnresolvedComments,
+          [S.visible]: show || hasUnresolvedComments,
         })}
         contentEditable={false}
         draggable={false}
@@ -54,16 +52,10 @@ export const CommentsMenu = forwardRef<HTMLDivElement, Props>(
         style={style}
       >
         <CommentsButton
-          disabled={disabled}
           variant={active ? "filled" : "default"}
           unresolvedCommentsCount={unresolvedCommentsCount}
-          {...(disabled
-            ? undefined
-            : {
-                component: ForwardRefLink,
-                // If no existing unresolved comments comments, add query param to auto-open new comment form
-                to: unresolvedCommentsCount > 0 ? href : `${href}?new=true`,
-              })}
+          component={ForwardRefLink}
+          to={unresolvedCommentsCount > 0 ? href : `${href}?new=true`}
         />
       </Box>,
       document.body,

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/CommentsMenu/CommentsMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/CommentsMenu/CommentsMenu.tsx
@@ -48,7 +48,7 @@ export const CommentsMenu = forwardRef<HTMLDivElement, Props>(
         ref={ref}
         style={style}
       >
-        <CommentsButton
+        <CommentsButton<typeof ForwardRefLink>
           variant={active ? "filled" : "default"}
           unresolvedCommentsCount={unresolvedCommentsCount}
           component={ForwardRefLink}

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/CommentsMenu/CommentsMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/CommentsMenu/CommentsMenu.tsx
@@ -11,7 +11,7 @@ import S from "./CommentsMenu.module.css";
 
 interface Props {
   active: boolean;
-  disabled: boolean;
+  disabled?: boolean;
   href: string;
   show: boolean;
   style: CSSProperties;

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/components/CommentsButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/components/CommentsButton.tsx
@@ -6,7 +6,7 @@ import { Button, type ButtonProps, Icon } from "metabase/ui";
 interface Props extends ButtonProps {
   unresolvedCommentsCount: number;
   component?: React.ElementType<any, any>;
-  to: string;
+  to?: string;
 }
 
 export const CommentsButton = ({

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/components/CommentsButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/components/CommentsButton.tsx
@@ -1,9 +1,12 @@
+import type React from "react";
 import { t } from "ttag";
 
 import { Button, type ButtonProps, Icon } from "metabase/ui";
 
 interface Props extends ButtonProps {
   unresolvedCommentsCount: number;
+  component?: React.ElementType<any, any>;
+  to: string;
 }
 
 export const CommentsButton = ({

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/components/CommentsButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/components/CommentsButton.tsx
@@ -1,18 +1,17 @@
-import type React from "react";
+import type { ComponentPropsWithoutRef, ElementType } from "react";
 import { t } from "ttag";
 
 import { Button, type ButtonProps, Icon } from "metabase/ui";
 
-interface Props extends ButtonProps {
+type Props<C extends ElementType = "button"> = ButtonProps & {
   unresolvedCommentsCount: number;
-  component?: React.ElementType<any, any>;
-  to?: string;
-}
+  component?: C;
+} & Omit<ComponentPropsWithoutRef<C>, keyof ButtonProps | "component">;
 
-export const CommentsButton = ({
+export const CommentsButton = <C extends ElementType = "button">({
   unresolvedCommentsCount,
   ...props
-}: Props) => {
+}: Props<C>) => {
   return (
     <Button
       aria-label={t`Comments`}
@@ -22,7 +21,7 @@ export const CommentsButton = ({
       }
       px="sm"
       size="xs"
-      {...props}
+      {...(props as ButtonProps)}
     >
       {unresolvedCommentsCount > 0 ? unresolvedCommentsCount : null}
     </Button>

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Blockquote/Blockquote.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Blockquote/Blockquote.tsx
@@ -16,7 +16,6 @@ import { CommentsMenu } from "metabase-enterprise/documents/components/Editor/Co
 import {
   getChildTargetId,
   getCurrentDocument,
-  getHasUnsavedChanges,
   getHoveredChildTargetId,
 } from "metabase-enterprise/documents/selectors";
 import { getListCommentsQuery } from "metabase-enterprise/documents/utils/api";
@@ -52,7 +51,6 @@ export const BlockquoteNodeView = ({ node }: NodeViewProps) => {
     getListCommentsQuery(document),
   );
   const comments = commentsData?.comments;
-  const hasUnsavedChanges = useSelector(getHasUnsavedChanges);
   const [hovered, setHovered] = useState(false);
   const [rendered, setRendered] = useState(false); // floating ui wrongly positions things without this
   const { _id } = node.attrs;
@@ -92,7 +90,6 @@ export const BlockquoteNodeView = ({ node }: NodeViewProps) => {
       {document && rendered && (
         <CommentsMenu
           active={isOpen}
-          disabled={hasUnsavedChanges}
           href={`/document/${document.id}/comments/${_id}`}
           ref={refs.setFloating}
           show={isOpen || hovered}

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/BulletList/BulletList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/BulletList/BulletList.tsx
@@ -16,7 +16,6 @@ import { CommentsMenu } from "metabase-enterprise/documents/components/Editor/Co
 import {
   getChildTargetId,
   getCurrentDocument,
-  getHasUnsavedChanges,
   getHoveredChildTargetId,
 } from "metabase-enterprise/documents/selectors";
 import { getListCommentsQuery } from "metabase-enterprise/documents/utils/api";
@@ -49,7 +48,6 @@ export const BulletListNodeView = ({ node, editor, getPos }: NodeViewProps) => {
     getListCommentsQuery(document),
   );
   const comments = commentsData?.comments;
-  const hasUnsavedChanges = useSelector(getHasUnsavedChanges);
   const [hovered, setHovered] = useState(false);
   const [rendered, setRendered] = useState(false); // floating ui wrongly positions things without this
   const { _id } = node.attrs;
@@ -90,7 +88,6 @@ export const BulletListNodeView = ({ node, editor, getPos }: NodeViewProps) => {
       {document && rendered && isTopLevel({ editor, getPos }) && (
         <CommentsMenu
           active={isOpen}
-          disabled={hasUnsavedChanges}
           href={`/document/${document.id}/comments/${_id}`}
           ref={refs.setFloating}
           show={isOpen || hovered}

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CodeBlock/CodeBlock.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/CodeBlock/CodeBlock.tsx
@@ -17,7 +17,6 @@ import { CommentsMenu } from "metabase-enterprise/documents/components/Editor/Co
 import {
   getChildTargetId,
   getCurrentDocument,
-  getHasUnsavedChanges,
   getHoveredChildTargetId,
 } from "metabase-enterprise/documents/selectors";
 import { getListCommentsQuery } from "metabase-enterprise/documents/utils/api";
@@ -128,7 +127,6 @@ export const CodeBlockNodeView = ({ node }: NodeViewProps) => {
     getListCommentsQuery(document),
   );
   const comments = commentsData?.comments;
-  const hasUnsavedChanges = useSelector(getHasUnsavedChanges);
   const [hovered, setHovered] = useState(false);
   const [rendered, setRendered] = useState(false); // floating ui wrongly positions things without this
   const { _id } = node.attrs;
@@ -177,7 +175,6 @@ export const CodeBlockNodeView = ({ node }: NodeViewProps) => {
       {document && rendered && (
         <CommentsMenu
           active={isOpen}
-          disabled={hasUnsavedChanges}
           href={`/document/${document.id}/comments/${_id}`}
           ref={refs.setFloating}
           show={isOpen || hovered}

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/FlexContainer/FlexContainer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/FlexContainer/FlexContainer.tsx
@@ -9,9 +9,7 @@ import cx from "classnames";
 import type React from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
 
-import { useSelector } from "metabase/lib/redux";
 import { Box } from "metabase/ui";
-import { getCommentSidebarOpen } from "metabase-enterprise/documents/selectors";
 
 import styles from "./FlexContainer.module.css";
 
@@ -87,8 +85,6 @@ const FlexContainerComponent: React.FC<NodeViewProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isResizing, setIsResizing] = useState(false);
-
-  const shouldDisableResizing = useSelector(getCommentSidebarOpen);
 
   // Get column count and current widths
   const columnCount = node.content.childCount;
@@ -196,7 +192,7 @@ const FlexContainerComponent: React.FC<NodeViewProps> = ({
   );
 
   const renderResizeHandles = () => {
-    if (columnCount <= 1 || shouldDisableResizing) {
+    if (columnCount <= 1) {
       return null;
     }
 

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Heading/Heading.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Heading/Heading.tsx
@@ -16,7 +16,6 @@ import { CommentsMenu } from "metabase-enterprise/documents/components/Editor/Co
 import {
   getChildTargetId,
   getCurrentDocument,
-  getHasUnsavedChanges,
   getHoveredChildTargetId,
 } from "metabase-enterprise/documents/selectors";
 import { getListCommentsQuery } from "metabase-enterprise/documents/utils/api";
@@ -65,7 +64,6 @@ export const HeadingNodeView = ({ node }: NodeViewProps) => {
     getListCommentsQuery(document),
   );
   const comments = commentsData?.comments;
-  const hasUnsavedChanges = useSelector(getHasUnsavedChanges);
   const [hovered, setHovered] = useState(false);
   const [rendered, setRendered] = useState(false); // floating ui wrongly positions things without this
   const { _id, level } = node.attrs;
@@ -107,7 +105,6 @@ export const HeadingNodeView = ({ node }: NodeViewProps) => {
       {document && rendered && (
         <CommentsMenu
           active={isOpen}
-          disabled={hasUnsavedChanges}
           href={`/document/${document.id}/comments/${_id}`}
           ref={refs.setFloating}
           show={isOpen || hovered}

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/OrderedList/OrderedList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/OrderedList/OrderedList.tsx
@@ -16,7 +16,6 @@ import { CommentsMenu } from "metabase-enterprise/documents/components/Editor/Co
 import {
   getChildTargetId,
   getCurrentDocument,
-  getHasUnsavedChanges,
   getHoveredChildTargetId,
 } from "metabase-enterprise/documents/selectors";
 import { getListCommentsQuery } from "metabase-enterprise/documents/utils/api";
@@ -65,7 +64,6 @@ export const OrderedListNodeView = ({
     getListCommentsQuery(document),
   );
   const comments = commentsData?.comments;
-  const hasUnsavedChanges = useSelector(getHasUnsavedChanges);
   const [hovered, setHovered] = useState(false);
   const [rendered, setRendered] = useState(false); // floating ui wrongly positions things without this
   const { _id } = node.attrs;
@@ -106,7 +104,6 @@ export const OrderedListNodeView = ({
       {document && rendered && isTopLevel({ editor, getPos }) && (
         <CommentsMenu
           active={isOpen}
-          disabled={hasUnsavedChanges}
           href={`/document/${document.id}/comments/${_id}`}
           ref={refs.setFloating}
           show={isOpen || hovered}

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Paragraph/Paragraph.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Paragraph/Paragraph.tsx
@@ -16,7 +16,6 @@ import { CommentsMenu } from "metabase-enterprise/documents/components/Editor/Co
 import {
   getChildTargetId,
   getCurrentDocument,
-  getHasUnsavedChanges,
   getHoveredChildTargetId,
 } from "metabase-enterprise/documents/selectors";
 import { getListCommentsQuery } from "metabase-enterprise/documents/utils/api";
@@ -56,7 +55,6 @@ export const ParagraphNodeView = ({
     getListCommentsQuery(document),
   );
   const comments = commentsData?.comments;
-  const hasUnsavedChanges = useSelector(getHasUnsavedChanges);
   const [hovered, setHovered] = useState(false);
   const [rendered, setRendered] = useState(false); // floating ui wrongly positions things without this
   const { _id } = node.attrs;
@@ -99,7 +97,6 @@ export const ParagraphNodeView = ({
         isTopLevel({ editor, getPos }) && (
           <CommentsMenu
             active={isOpen}
-            disabled={hasUnsavedChanges}
             href={`/document/${document.id}/comments/${_id}`}
             ref={refs.setFloating}
             show={isOpen || hovered}

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/ResizeNode/ResizeNode.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/ResizeNode/ResizeNode.tsx
@@ -7,9 +7,7 @@ import {
 import type React from "react";
 import { useRef, useState } from "react";
 
-import { useSelector } from "metabase/lib/redux";
 import { Box, Flex } from "metabase/ui";
-import { getCommentSidebarOpen } from "metabase-enterprise/documents/selectors";
 
 import S from "./ResizeNode.module.css";
 
@@ -86,8 +84,6 @@ const ResizeNodeView = ({
   const [height, setHeight] = useState(attrs.height);
   const _height = useRef(attrs.height);
 
-  const shouldDisableResizing = useSelector(getCommentSidebarOpen);
-
   const computeHeight = (delta: number) => {
     const newHeight = _height.current + delta;
 
@@ -114,9 +110,7 @@ const ResizeNodeView = ({
       data-type="resizeNode"
     >
       <NodeViewContent className={S.content} />
-      {!shouldDisableResizing && (
-        <DragHandle onDrag={handleDrag} onDragEnd={handleDragEnd} />
-      )}
+      <DragHandle onDrag={handleDrag} onDragEnd={handleDragEnd} />
     </NodeViewWrapper>
   );
 };


### PR DESCRIPTION
Closes [WRK-905](https://linear.app/metabase/issue/WRK-905/allow-commenting-on-unsaved-documents)

### Description

Allow commenting on existing but unsaved documents.

### How to verify

1. Create a new document, save it.
2. Start editing a document by creating a new paragraph.
3. Hover over the paragraph, see comment icon on the right.
4. Click the icon to leave a comment.

### Demo


https://github.com/user-attachments/assets/a244fb99-5a14-45e3-84ea-8c0ad424a93b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
