### PR TITLE
fix placeholder in documents

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/Editor.module.css
@@ -178,7 +178,8 @@
   outline: none;
 }
 
-.editorContent :global(p.is-empty:first-child:before) {
+.editorContent :global(.is-empty:first-child:before),
+.editorContent :global(.node-paragraph.is-empty:first-child:before) {
   color: var(--mb-color-text-light);
   content: attr(data-placeholder);
   float: left;


### PR DESCRIPTION
The "Start writing" placeholder wasn't showing up. This PR fixes it:

<img width="629" height="201" alt="image" src="https://github.com/user-attachments/assets/35dab4f6-4b70-44db-a459-8cbfbec1a71c" />
