### PR TITLE
Closes EMB-854 escape single quotes in embed code snippets

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
@@ -85,11 +85,7 @@ const toDashCase = (str: string): string =>
 
 // Convert values to string attributes
 export const formatAttributeValue = (value: unknown): string => {
-  if (
-    value === null ||
-    Array.isArray(value) ||
-    (typeof value === "object" && value !== null)
-  ) {
+  if (Array.isArray(value) || (typeof value === "object" && value !== null)) {
     const jsonString = JSON.stringify(value);
     const escapedString = jsonString.replace(/'/g, "&39;");
     return `'${escapedString}'`;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
@@ -85,7 +85,7 @@ const toDashCase = (str: string): string =>
 
 // Convert values to string attributes
 export const formatAttributeValue = (value: unknown): string => {
-  if (Array.isArray(value) || (typeof value === "object" && value !== null)) {
+  if (Array.isArray(value) || typeof value === "object") {
     const jsonString = JSON.stringify(value);
     const escapedString = jsonString.replace(/'/g, "&39;");
     return `'${escapedString}'`;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
@@ -84,9 +84,15 @@ const toDashCase = (str: string): string =>
   str.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
 
 // Convert values to string attributes
-const formatAttributeValue = (value: unknown): string => {
-  if (Array.isArray(value) || typeof value === "object") {
-    return `'${JSON.stringify(value)}'`;
+export const formatAttributeValue = (value: unknown): string => {
+  if (
+    value === null ||
+    Array.isArray(value) ||
+    (typeof value === "object" && value !== null)
+  ) {
+    const jsonString = JSON.stringify(value);
+    const escapedString = jsonString.replace(/'/g, "&39;");
+    return `'${escapedString}'`;
   }
 
   return `"${value}"`;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.unit.spec.ts
@@ -40,15 +40,13 @@ describe("formatAttributeValue", () => {
   });
 
   it("should format object values correctly", () => {
-    expect(formatAttributeValue({ key: "value" })).toBe('\'{"key":"value"}\'');
-    expect(formatAttributeValue({ a: 1, b: true })).toBe(
-      '\'{"a":1,"b":true}\'',
-    );
+    expect(formatAttributeValue({ key: "value" })).toBe(`'{"key":"value"}'`);
+    expect(formatAttributeValue({ a: 1, b: true })).toBe(`'{"a":1,"b":true}'`);
   });
 
   it("should handle nested arrays and objects", () => {
     expect(formatAttributeValue([{ a: 1 }, { b: 2 }])).toBe(
-      '\'[{"a":1},{"b":2}]\'',
+      `'[{"a":1},{"b":2}]'`,
     );
     expect(
       formatAttributeValue([

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.unit.spec.ts
@@ -59,7 +59,7 @@ describe("formatAttributeValue", () => {
   });
 
   it("should handle null and undefined values", () => {
-    expect(formatAttributeValue(null)).toBe("'null'");
+    expect(formatAttributeValue(null)).toBe('"null"');
     expect(formatAttributeValue(undefined)).toBe('"undefined"');
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.unit.spec.ts
@@ -1,0 +1,65 @@
+import { formatAttributeValue } from "./embed-snippet";
+
+describe("formatAttributeValue", () => {
+  it("should format string values correctly", () => {
+    expect(formatAttributeValue("hello")).toBe('"hello"');
+  });
+
+  it("should format number values correctly", () => {
+    expect(formatAttributeValue(42)).toBe('"42"');
+    expect(formatAttributeValue(3.14)).toBe('"3.14"');
+  });
+
+  it("should format boolean values correctly", () => {
+    expect(formatAttributeValue(true)).toBe('"true"');
+    expect(formatAttributeValue(false)).toBe('"false"');
+  });
+
+  it("should format array values correctly", () => {
+    expect(formatAttributeValue([1, 2, 3])).toBe("'[1,2,3]'");
+    expect(formatAttributeValue(["a", "b", "c"])).toBe('\'["a","b","c"]\'');
+    expect(formatAttributeValue([1, "b", true])).toBe("'[1,\"b\",true]'");
+  });
+
+  it("should HTML escape single quotes in array and objects", () => {
+    expect(formatAttributeValue(["O'Reilly", "D'Angelo"])).toBe(
+      `'["O&39;Reilly","D&39;Angelo"]'`,
+    );
+    expect(formatAttributeValue({ quote: "It's a test" })).toBe(
+      `'{"quote":"It&39;s a test"}'`,
+    );
+  });
+
+  it("should HTML escape single quotes in nested arrays and objects", () => {
+    expect(
+      formatAttributeValue([{ name: "O'Reilly" }, { name: "D'Angelo" }]),
+    ).toBe(`'[{"name":"O&39;Reilly"},{"name":"D&39;Angelo"}]'`);
+    expect(formatAttributeValue({ nested: { quote: "It's a test" } })).toBe(
+      `'{"nested":{"quote":"It&39;s a test"}}'`,
+    );
+  });
+
+  it("should format object values correctly", () => {
+    expect(formatAttributeValue({ key: "value" })).toBe('\'{"key":"value"}\'');
+    expect(formatAttributeValue({ a: 1, b: true })).toBe(
+      '\'{"a":1,"b":true}\'',
+    );
+  });
+
+  it("should handle nested arrays and objects", () => {
+    expect(formatAttributeValue([{ a: 1 }, { b: 2 }])).toBe(
+      '\'[{"a":1},{"b":2}]\'',
+    );
+    expect(
+      formatAttributeValue([
+        [1, 2],
+        [3, 4],
+      ]),
+    ).toBe("'[[1,2],[3,4]]'");
+  });
+
+  it("should handle null and undefined values", () => {
+    expect(formatAttributeValue(null)).toBe("'null'");
+    expect(formatAttributeValue(undefined)).toBe('"undefined"');
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.unit.spec.ts
@@ -59,7 +59,7 @@ describe("formatAttributeValue", () => {
   });
 
   it("should handle null and undefined values", () => {
-    expect(formatAttributeValue(null)).toBe('"null"');
+    expect(formatAttributeValue(null)).toBe("'null'");
     expect(formatAttributeValue(undefined)).toBe('"undefined"');
   });
 });


### PR DESCRIPTION
Closes [EMB-854: Escape single quotes in embed flow code snippets](https://linear.app/metabase/issue/EMB-854/escape-single-quotes-in-embed-flow-code-snippets)

### Description

Dead simple escape for single quotes in embed flow code snippets, to avoid generating invalid HTML. The resulting string doesn't need to be parsed, as it's valid HTML and will be properly picked up by the web-components.

### How to verify

 1. Start MB from scratch with the embedding flow (nuke the DB)
 2. Add some initial parameters with values that contain single quotes
 3. -> those should be replaced by `&39;`

### Demo

<img width="1407" height="664" alt="image" src="https://github.com/user-attachments/assets/cad81b88-b809-4ed6-b0d9-b60c0d9d0848" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
