### PR TITLE
fix(modular): links and type/URL columns should be rendered as clickable

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
@@ -1,6 +1,7 @@
 import {
   EditableDashboard,
   InteractiveDashboard,
+  InteractiveQuestion,
 } from "@metabase/embedding-sdk-react";
 
 const { H } = cy;
@@ -24,6 +25,30 @@ describe("scenarios > embedding-sdk > dashboard-click-behavior", () => {
     // Make the PRODUCT_ID column a URL column for click behavior tests, to avoid having to create a new model
     cy.request("PUT", `/api/field/${ORDERS.PRODUCT_ID}`, {
       semantic_type: "type/URL",
+    });
+
+    // Create a question with custom column that returns a url as a string
+    H.createQuestion({
+      name: "Orders with URL Expression",
+      query: {
+        "source-table": ORDERS_ID,
+        expressions: {
+          // NOTE: this is a question, so it won't have semantic_type set as url, we'll need a model for that
+          url_column: [
+            "concat",
+            "https://example.org/",
+            ["field", ORDERS.ID, { "base-type": "type/BigInteger" }],
+          ],
+        },
+        fields: [
+          ["field", ORDERS.ID, { "base-type": "type/BigInteger" }],
+          ["expression", "url_column", { "base-type": "type/Text" }],
+          ["field", ORDERS.PRODUCT_ID, null],
+        ],
+        limit: 5,
+      },
+    }).then(({ body: question }) => {
+      cy.wrap(question.id).as("questionId");
     });
 
     H.createDashboardWithQuestions({
@@ -60,7 +85,7 @@ describe("scenarios > embedding-sdk > dashboard-click-behavior", () => {
       ],
       cards: [
         {
-          size_x: 12,
+          size_x: 24,
           col: 0,
           visualization_settings: {
             column_settings: {
@@ -77,7 +102,7 @@ describe("scenarios > embedding-sdk > dashboard-click-behavior", () => {
         },
         {
           size_x: 12,
-          col: 12,
+          col: 0,
           visualization_settings: {
             click_behavior: {
               type: "link",
@@ -191,6 +216,125 @@ describe("scenarios > embedding-sdk > dashboard-click-behavior", () => {
 
     getSdkRoot().within(() => {
       cy.findByTestId("visualization-root").should("be.visible");
+    });
+  });
+
+  it("columns that return a string url should be rendered as a link", () => {
+    cy.get<string>("@questionId").then((questionId) => {
+      mountSdkContent(<InteractiveQuestion questionId={questionId} />);
+    });
+
+    cy.intercept("GET", "/api/card/*").as("getCard");
+    cy.wait("@getCard");
+
+    cy.findByRole("link", { name: "https://example.org/448" })
+      .should("have.length", 1)
+      .should("have.attr", "href", "https://example.org/448");
+  });
+
+  it("columns that have 'type/URL' semantic type should be rendered as a link", () => {
+    cy.signIn("admin");
+
+    cy.get<string>("@questionId").then((questionId) => {
+      // Convert question to model
+      cy.request("GET", `/api/card/${questionId}`)
+        .then((response) => {
+          const questionData = response.body;
+          return cy.request("PUT", `/api/card/${questionId}`, {
+            ...questionData,
+            type: "model",
+          });
+        })
+        .then(() => {
+          // re-fetch it as model
+          return cy.request("GET", `/api/card/${questionId}`);
+        })
+        .then((modelResponse) => {
+          // Update model column semantic type for url_column to type/URL
+
+          const modelData = modelResponse.body;
+          const updatedMetadata = modelData.result_metadata.map((col: any) => {
+            if (col.name === "url_column") {
+              return { ...col, semantic_type: "type/URL" };
+            }
+            return col;
+          });
+
+          return cy.request("PUT", `/api/card/${questionId}`, {
+            ...modelData,
+            result_metadata: updatedMetadata,
+          });
+        })
+        .then(() => {
+          // Create dashboard with the model
+          H.createDashboardWithQuestions({
+            dashboardName: "URL Dashboard",
+            questions: [
+              {
+                name: "Orders with URLs",
+                query: {
+                  "source-table": `card__${questionId}`,
+                  limit: 5,
+                },
+              },
+            ],
+          }).then(({ dashboard }) => {
+            mountSdkContent(
+              <InteractiveDashboard dashboardId={dashboard.id} />,
+            );
+
+            getSdkRoot().within(() => {
+              H.getDashboardCard(0)
+                .findByRole("link", {
+                  name: "https://example.org/448",
+                })
+                .should("have.attr", "href", "https://example.org/448");
+            });
+          });
+        });
+    });
+  });
+
+  it("columns that have 'Display as Link' should be rendered as a link and use the custom rendering", () => {
+    cy.signIn("admin");
+    cy.intercept("GET", "/api/card/*").as("getCard");
+
+    cy.get<string>("@questionId").then((questionId) => {
+      H.createDashboardWithQuestions({
+        dashboardName: "URL Dashboard",
+        questions: [
+          {
+            name: "Orders with URLs",
+            query: {
+              "source-table": `card__${questionId}`,
+              limit: 5,
+            },
+          },
+        ],
+        cards: [
+          {
+            visualization_settings: {
+              column_settings: {
+                [JSON.stringify(["name", "ID"])]: {
+                  view_as: "link",
+                  link_text: "Link to {{ID}}",
+                  link_url: "https://example.org/{{ID}}",
+                },
+              },
+            },
+          },
+        ],
+      }).then(({ dashboard }) => {
+        mountSdkContent(<EditableDashboard dashboardId={dashboard.id} />);
+
+        getSdkRoot().within(() => {
+          H.getDashboardCard(0)
+            .findByRole("link", {
+              name: "Link to 448",
+            })
+            .should("have.attr", "href", "https://example.org/448");
+        });
+      });
     });
   });
 });

--- a/frontend/src/metabase/lib/formatting/url.tsx
+++ b/frontend/src/metabase/lib/formatting/url.tsx
@@ -3,7 +3,6 @@ import cx from "classnames";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import Link from "metabase/common/components/Link";
 import CS from "metabase/css/core/index.css";
-import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isSameOrSiteUrlOrigin } from "metabase/lib/dom";
 import { getDataFromClicked } from "metabase-lib/v1/parameters/utils/click-behavior";
 import { isURL } from "metabase-lib/v1/types/utils/isa";
@@ -42,11 +41,6 @@ export function formatUrl(value: string, options: OptionsType = {}) {
   if (jsx && rich && url) {
     const text = getLinkText(value, options);
     const className = cx(CS.link, CS.linkWrappable);
-
-    // (metabase#51099) prevent url from being rendered as a link when in sdk
-    if (isEmbeddingSdk()) {
-      return url;
-    }
 
     if (isSameOrSiteUrlOrigin(url)) {
       return (


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #59666



TLDR: we accidentally disabled *all links* when we wanted to disabled only "Go to dashboard/question" click behaviour, this is part of addressing it, by making links external work again

More context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1759229502716219?thread_ts=1758732884.565759&cid=C063Q3F1HPF


Note:
This only fixes "links" that come from these cases:
- columns that return a url
- columns with type/URL
- columns with visualization settings "Display as link" (see image below)
<img width="977" height="645" alt="image" src="https://github.com/user-attachments/assets/3053cf8e-8d19-4431-8426-aa9ed5c6e668" />


It does _not_ fix click behaviours, which will be fixed in other tasks part of [Improve click support in SDK and EAJS](https://linear.app/metabase/project/improve-click-support-in-sdk-and-eajs-52781e0dd1f0)


How to verify:
The easiest way is to create a calculated column that returns an url
You can create two of them, convert the question to model, change the metadata of one of them to type/URL and see that they both work in EAJS (embed-js)
For the "Display as": add it to a dashboard, click on visualization settings for the dashcard and see the screenshot above

