### PR TITLE
Fix downloading tables grouped by datetime->int

### DIFF
--- a/src/metabase/types/core.cljc
+++ b/src/metabase/types/core.cljc
@@ -389,7 +389,9 @@
   {:deprecated "0.57.0"}
   [tyype                                                  :- :keyword
    {base-type :base_type, effective-type :effective_type} :- ::snake-cased-type-info]
-  (some #(isa? % tyype) [base-type effective-type]))
+  (if (nil? effective-type)
+    (isa? base-type tyype)
+    (isa? effective-type tyype)))
 
 (mu/defn temporal-field?
   "True if a Metabase `Field` instance has a temporal base or semantic type, i.e. if this Field represents a value


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63196
The Linear task has a slightly more involved setup. I found that I could replicate the issue with a slightly simpler setup:

- set up a simple query:
  - select COUNT from ORDERS
  - group by the day of the month
- log in as the sandboxed user
- try to download the card results (as CSV, XLSX, etc)
- see the error

Why does this happen? I found that, for a sandboxed user, the query results show the "day of the month" column as having

```
         :base_type :type/DateTime,
         :database_type "TIMESTAMP",
         :effective_type :type/Integer,
```

while an admin user sees the same column as having

```
         :base_type :type/Integer,
         :database_type "INTEGER",
         :effective_type :type/Integer,
```

This seems bizarre and worth looking more into, but honestly shouldn't really matter - if the effective type is an integer, we certainly shouldn't be formatting it as a datetime.

`field-is-type?` is only used for checking whether a field is temporal for formatting purposes, so I think this is a relatively low risk change, and note that `metabase.lib.types.isa/temporal?` (the replacement suggested by the deprecation notice for `metabase.types.core/temporal-field?`) returns `false` for both cases.

[UXW-660: Pivot tables with integer breakout columns fail to download as formatted XLSX for sandboxed tables](https://linear.app/metabase/issue/UXW-660/pivot-tables-with-integer-breakout-columns-fail-to-download-as)
