### PR TITLE
Fix `u/slugify` function's max-length option

### DIFF
--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -2584,7 +2584,7 @@
 
 (deftest unique-long-column-names-test
   (let [original ["αbcdεf_αbcdεf"     "αbcdεfg_αbcdεf"   "αbc_2_etc_αbcdεf" "αbc_3_xyz_αbcdεf"]
-        expected [:%ce%b1bcd%  :%_b59bccce :%ce%b1bc_2 :%ce%b1bc_3]
+        expected [:%ce%b1bcd  :%_a2ba0330 :%ce%b1bc_2 :%ce%b1bc_3]
         displays ["αbcdεf" "αbcdεfg" "αbc 2 etc" "αbc 3 xyz"]]
     (is (= expected (#'upload/derive-column-names ::short-column-test-driver original)))
     (mt/with-dynamic-fn-redefs [upload/max-bytes (constantly 10)]

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -133,7 +133,9 @@
       (doseq [[s expected] s->expected]
         (testing (list 'u/slugify s)
           (is (= expected
-                 (u/slugify s))))))))
+                 (u/slugify s)))))))
+  (testing "non-ASCII characters are not truncated in the middle"
+    (is (= "%E5%8B%87" (u/slugify "勇士" {:max-length 10})))))
 
 (deftest ^:parallel slugify-unicode-test
   (doseq [[group s->expected]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63234
`u/slugify` url-encoded non-ASCII characters, then took `max-length` chars off the result.

Both make sense in isolation - but if we're slugifying, e.g., the string 勇士, with max-length 10, this results in:

- first, url encode non-ASCII characters => "%E5%8B%87%E5%A3%AB"
- then, take 10 characters => "%E5%8B%87%"

But a bare `%` character, as in the trailing character above, is not valid URI syntax.

Discovered in [UXW-666: Users can't download results for questions with long cyrillic names, error "URL
malformed"](https://linear.app/metabase/issue/UXW-666/users-cant-download-results-for-questions-with-long-cyrillic-names) but there are probably more cases where this has caused mischief.