### PR TITLE
Update the list of source tables in Python editor when metabot changes it

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/PythonDataPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/PythonDataPicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { hasFeature } from "metabase/admin/databases/utils";
@@ -46,6 +46,10 @@ export function PythonDataPicker({
   const [tableSelections, setTableSelections] = useState<TableSelection[]>(
     getInitialTableSelections(tables),
   );
+
+  useEffect(() => {
+    setTableSelections(getInitialTableSelections(tables));
+  }, [tables]);
 
   const {
     data: databases,

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -96,7 +96,8 @@ export function PythonTransformEditor({
   const handleAcceptProposed =
     proposedSource && onAcceptProposed
       ? () => {
-          handleScriptChange(proposedSource.body);
+          setSource(proposedSource);
+          setIsSourceDirty(true);
           onAcceptProposed(proposedSource);
         }
       : undefined;


### PR DESCRIPTION
Closes BOT-442

### Description

If metabot proposes changes to the list of input tables for a Python transform, update the `PythonDataPicker` component to keep it in sync with the text of the transform source.

### How to verify

* Create a python transform
* Ask metabot to add or remove tables to the list of inputs
* Accept changes
* List of tables in the data picker on the right should update

### Demo

**Before proposing changes**

<img width="822" height="398" alt="Screenshot 2025-09-30 at 6 10 13 PM" src="https://github.com/user-attachments/assets/449e7996-b9a4-43b6-b814-fb92f4b01072" />

**Prompt**

<img width="451" height="325" alt="Screenshot 2025-09-30 at 6 11 20 PM" src="https://github.com/user-attachments/assets/fa2b91e6-6511-48c1-b9a8-57f568b4a83e" />

**After accepting changes**

<img width="1008" height="347" alt="Screenshot 2025-09-30 at 6 12 12 PM" src="https://github.com/user-attachments/assets/551616d2-80fe-405d-882d-43b7f277d4f5" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
