### PR TITLE
tests: wait for data in a flaky test

### DIFF
--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -436,6 +436,8 @@ describe("issue 28106", () => {
           .findByTestId("scroll-container")
           .as("schemasList");
 
+        H.entityPickerModalLevel(2).should("contain", "Animals");
+
         cy.get("@schemasList").scrollTo("bottom");
 
         // assert scrolling worked and the last item is visible


### PR DESCRIPTION
closes QUE-2608

if we start scrolling when the data from third tab is still in processing, scroll doesn't happen, so we need to wait for js stack to become empty

stress test
- ❌ [master 20/30](https://github.com/metabase/metabase/actions/runs/18155278957/job/51673614023)
- ✅ [fix 50/50](https://github.com/metabase/metabase/actions/runs/18155286221/job/51673636805)

we triggered scroll before "Animals" appeared in the last column 
<img width="1246" height="664" alt="image" src="https://github.com/user-attachments/assets/a92c10ce-fcf0-4b73-996a-558258103215" />
