### PR TITLE
Pass column settings number formatter

### DIFF
--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -40,7 +40,15 @@ const MARKDOWN_RENDERERS = {
 };
 
 export function formatValue(value: unknown, _options: OptionsType = {}) {
+  if (_options.column) {
+    _options = {
+      ..._options.column.settings,
+      ..._options,
+    };
+  }
+
   let { prefix, suffix, ...options } = _options;
+
   // avoid rendering <ExternalLink> if we have click_behavior set
   if (
     options.click_behavior &&

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -13,6 +13,7 @@ import {
   serializeNumberParameterValue,
 } from "metabase/querying/parameters/utils/parsing";
 import { Box, type ComboboxItem, MultiAutocomplete } from "metabase/ui";
+import { getFields } from "metabase-lib/v1/parameters/utils/parameter-fields";
 import { hasValue } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {
   Parameter,
@@ -100,7 +101,7 @@ export function NumberInputWidget({
     return (
       <Value
         value={value}
-        column={parameter.fields[0]}
+        column={getFields(parameter)[0]}
         parameter={parameter}
         maximumFractionDigits={20}
       />

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -20,6 +20,7 @@ import type {
   ParameterValueOrArray,
 } from "metabase-types/api";
 
+import { Value } from "../ParameterFieldWidget/Value";
 import { Footer, TokenFieldWrapper, WidgetLabel } from "../Widget";
 import { COMBOBOX_PROPS, WIDTH } from "../constants";
 
@@ -92,6 +93,20 @@ export function NumberInputWidget({
     }
   };
 
+  function renderValue({ value }: { value: string }) {
+    if (value in labelByValue) {
+      return labelByValue[value];
+    }
+    return (
+      <Value
+        value={value}
+        column={parameter.fields[0]}
+        parameter={parameter}
+        maximumFractionDigits={20}
+      />
+    );
+  }
+
   return (
     <Box
       component="form"
@@ -109,7 +124,7 @@ export function NumberInputWidget({
             autoFocus={autoFocus}
             comboboxProps={COMBOBOX_PROPS}
             parseValue={parseValue}
-            renderValue={({ value }) => labelByValue[value] ?? value}
+            renderValue={renderValue}
             onChange={handleChange}
           />
         </TokenFieldWrapper>

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 import {
+  type ReactNode,
   type StyleHTMLAttributes,
   forwardRef,
   useEffect,
@@ -124,7 +125,7 @@ export interface IFieldValuesWidgetProps {
   placeholder?: string;
   checkedColor?: string;
 
-  valueRenderer?: (value: string | number) => JSX.Element;
+  valueRenderer?: (value: RowValue) => JSX.Element;
   optionRenderer?: (option: FieldValue) => JSX.Element;
   layoutRenderer?: (props: LayoutRendererArgs) => JSX.Element;
 }
@@ -319,7 +320,7 @@ export const FieldValuesWidgetInner = forwardRef<
   };
 
   if (!valueRenderer) {
-    valueRenderer = (value: string | number) => {
+    valueRenderer = (value: RowValue) => {
       const option = options.find((option) => getValue(option) === value);
       return renderValue({
         fields,
@@ -487,6 +488,7 @@ export const FieldValuesWidgetInner = forwardRef<
                 dashboardId={dashboardId}
                 cardId={cardId}
                 value={isNumericParameter ? parseNumericValue(value) : value}
+                renderValue={valueRenderer}
                 tc={tc}
               />
             )}
@@ -715,6 +717,7 @@ type RemappedValueProps = {
   value: ParameterValueOrArray | null;
   dashboardId?: DashboardId;
   cardId?: CardId;
+  renderValue: (value: RowValue | null) => ReactNode;
   tc: ContentTranslationFunction;
 };
 
@@ -724,6 +727,7 @@ function RemappedValue({
   value,
   dashboardId,
   cardId,
+  renderValue = (value) => String(value),
   tc,
 }: RemappedValueProps) {
   const isRemapped =
@@ -762,18 +766,18 @@ function RemappedValue({
 
   const remappedData = dashboardData ?? cardData ?? parameterData;
   if (remappedData == null) {
-    return tc(value);
+    return renderValue(value);
   }
 
   const remappedValue = getValue(remappedData);
   const remappedLabel = getLabel(remappedData);
   if (remappedLabel == null) {
-    return tc(value);
+    return renderValue(value);
   }
 
   return (
     <MultiAutocompleteValue
-      value={String(remappedValue)}
+      value={renderValue(remappedValue)}
       label={tc(String(remappedLabel ?? remappedValue))}
     />
   );
@@ -782,16 +786,25 @@ function RemappedValue({
 type RemappedOptionProps = {
   option: ComboboxItem;
   fields: Field[];
+  renderValue: (value: RowValue | null) => ReactNode;
   tc: ContentTranslationFunction;
 };
 
-function RemappedOption({ option, fields, tc }: RemappedOptionProps) {
+function RemappedOption({
+  option,
+  fields,
+  renderValue,
+  tc,
+}: RemappedOptionProps) {
   const isRemapped = Field.remappedField(fields) != null;
   if (!isRemapped) {
     return tc(option.label);
   }
 
   return (
-    <MultiAutocompleteOption value={option.value} label={tc(option.label)} />
+    <MultiAutocompleteOption
+      value={renderValue(option.value)}
+      label={tc(option.label)}
+    />
   );
 }

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -28,6 +28,7 @@ import CS from "metabase/css/core/index.css";
 import Fields from "metabase/entities/fields";
 import { useTranslateContent } from "metabase/i18n/hooks";
 import type { ContentTranslationFunction } from "metabase/i18n/types";
+import type { OptionsType } from "metabase/lib/formatting";
 import { parseNumber } from "metabase/lib/number";
 import { connect, useDispatch } from "metabase/lib/redux";
 import { isNotNull } from "metabase/lib/types";
@@ -320,11 +321,14 @@ export const FieldValuesWidgetInner = forwardRef<
   };
 
   if (!valueRenderer) {
-    valueRenderer = (value: RowValue) => {
+    valueRenderer = (value: RowValue, extraOptions?: OptionsType) => {
       const option = options.find((option) => getValue(option) === value);
       return renderValue({
         fields,
-        formatOptions,
+        formatOptions: {
+          ...formatOptions,
+          ...extraOptions,
+        },
         value,
         parameter,
         cardId,
@@ -722,7 +726,7 @@ type RemappedValueProps = {
   value: ParameterValueOrArray | null;
   dashboardId?: DashboardId;
   cardId?: CardId;
-  renderValue: (value: RowValue | null) => ReactNode;
+  renderValue: (value: RowValue | null, options?: OptionsType) => ReactNode;
   tc: ContentTranslationFunction;
 };
 
@@ -782,7 +786,7 @@ function RemappedValue({
 
   return (
     <MultiAutocompleteValue
-      value={renderValue(remappedValue)}
+      value={renderValue(remappedValue, { remap: false })}
       label={tc(String(remappedLabel ?? remappedValue))}
     />
   );
@@ -791,15 +795,15 @@ function RemappedValue({
 type RemappedOptionProps = {
   option: ComboboxItem;
   fields: Field[];
-  renderValue: (value: RowValue | null) => ReactNode;
   tc: ContentTranslationFunction;
+  renderValue: (value: RowValue | null, options?: OptionsType) => ReactNode;
 };
 
 function RemappedOption({
   option,
   fields,
-  renderValue,
   tc,
+  renderValue,
 }: RemappedOptionProps) {
   const isRemapped = Field.remappedField(fields) != null;
   if (!isRemapped) {
@@ -808,7 +812,7 @@ function RemappedOption({
 
   return (
     <MultiAutocompleteOption
-      value={renderValue(option.value)}
+      value={renderValue(option.value, { remap: false })}
       label={tc(option.label)}
     />
   );

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -493,7 +493,12 @@ export const FieldValuesWidgetInner = forwardRef<
               />
             )}
             renderOption={({ option }) => (
-              <RemappedOption option={option} fields={fields} tc={tc} />
+              <RemappedOption
+                option={option}
+                fields={fields}
+                tc={tc}
+                renderValue={valueRenderer}
+              />
             )}
             onChange={(values) => {
               if (isNumericParameter) {

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.unit.spec.js
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.unit.spec.js
@@ -1,7 +1,7 @@
 import { waitForElementToBeRemoved } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { render, screen } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 
 import { Value as ValueComponent } from "../../Value";
 
@@ -35,7 +35,7 @@ function setup(opts = {}) {
   const onChange = jest.fn();
   const onSearchChange = jest.fn();
 
-  render(
+  renderWithProviders(
     <SingleSelectListField
       onChange={onChange}
       onSearchChange={onSearchChange}

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidgetValue/ParameterFieldWidgetValue.unit.spec.js
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidgetValue/ParameterFieldWidgetValue.unit.spec.js
@@ -1,4 +1,4 @@
-import { render, screen } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 
 import { ParameterFieldWidgetValue } from "./ParameterFieldWidgetValue";
 
@@ -6,12 +6,16 @@ const value = "A value";
 
 describe("when fields is empty array", () => {
   it("renders value if it is a single item", () => {
-    render(<ParameterFieldWidgetValue value={[value]} fields={[]} />);
+    renderWithProviders(
+      <ParameterFieldWidgetValue value={[value]} fields={[]} />,
+    );
     expect(screen.getByText(value)).toBeInTheDocument();
   });
 
   it("renders number of selections if multiple items", () => {
-    render(<ParameterFieldWidgetValue value={[value, value]} fields={[]} />);
+    renderWithProviders(
+      <ParameterFieldWidgetValue value={[value, value]} fields={[]} />,
+    );
     expect(screen.getByText("2 selections")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/Value/Value.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/Value/Value.tsx
@@ -9,6 +9,7 @@ import RemappedValue from "./RemappedValue";
 
 export const Value = ({
   value: rawValue,
+  column,
   ...rawOptions
 }: {
   value: unknown;
@@ -29,6 +30,8 @@ export const Value = ({
 
   const options = {
     ...rawOptions,
+    ...column?.settings,
+    column,
     displayValue: tc(rawOptions.displayValue),
   };
 

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/Value/Value.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/Value/Value.tsx
@@ -1,5 +1,6 @@
 import { isValidElement } from "react";
 
+import { useSetting } from "metabase/common/hooks";
 import { useTranslateContent } from "metabase/i18n/hooks";
 import { formatValue } from "metabase/lib/formatting";
 import type { OptionsType } from "metabase/lib/formatting/types";
@@ -19,8 +20,10 @@ export const Value = ({
   parameter?: Parameter;
   cardId?: number;
   dashboardId?: DashboardId;
+  ignoreInstanceSettings?: boolean;
 } & OptionsType) => {
   const tc = useTranslateContent<unknown>();
+  const formattingSettings = useSetting("custom-formatting");
 
   if (rawOptions.hide) {
     return null;
@@ -28,11 +31,24 @@ export const Value = ({
 
   const value = tc(rawValue);
 
-  const options = {
+  let options = {
     ...rawOptions,
-    ...column?.settings,
     column,
     displayValue: tc(rawOptions.displayValue),
+  };
+
+  if (!options.ignoreInstanceSettings) {
+    options = {
+      ...options,
+      ...formattingSettings?.["type/Number"],
+      ...formattingSettings?.["type/Temporal"],
+      ...formattingSettings?.["type/Currency"],
+    };
+  }
+
+  options = {
+    ...options,
+    ...column?.settings,
   };
 
   if (rawOptions.remap) {

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteOption/MultiAutocompleteOption.tsx
@@ -1,7 +1,9 @@
+import type { ReactNode } from "react";
+
 import { Box } from "metabase/ui";
 
 export type MultiAutocompleteOptionProps = {
-  value: string;
+  value: ReactNode;
   label?: string;
 };
 

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react-markdown/lib/react-markdown";
+import type { ReactNode } from "react";
 
 import { Box } from "metabase/ui";
 

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocompleteValue/MultiAutocompleteValue.tsx
@@ -1,7 +1,9 @@
+import type { ReactNode } from "react-markdown/lib/react-markdown";
+
 import { Box } from "metabase/ui";
 
 export type MultiAutocompleteValueProps = {
-  value: string;
+  value: ReactNode;
   label?: string;
 };
 


### PR DESCRIPTION
Closes #62107

We are passing the column to the formatter, but not correctly using the formatting options.
This PR fixes that.

This change makes filter components correctly format numbers as expected by the instance or column settings.

<img width="399" height="173" alt="Screenshot 2025-10-17 at 09 11 43" src="https://github.com/user-attachments/assets/2fe878da-c28e-43d7-afeb-64c53105b7dc" />
<img width="336" height="475" alt="Screenshot 2025-10-17 at 09 11 39" src="https://github.com/user-attachments/assets/f9e74641-e77b-44cb-9912-618d8f941230" />
