### PR TITLE
lower log level to debug for field ref issues

### DIFF
--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -513,10 +513,10 @@
     (resolve-in-card-returned-columns query source-card-id id-or-name)))
 
 (defn- fallback-metadata [id-or-name]
-  (log/warn (u/format-color :red
-                            (str "We tried every trick we could think of and still failed to resolve a field"
-                                 " ref. If the query doesn't work, this is why. Returning fallback metadata for %s")
-                            (pr-str id-or-name)))
+  (log/debug (u/format-color :red
+                             (str "We tried every trick we could think of and still failed to resolve a field"
+                                  " ref. If the query doesn't work, this is why. Returning fallback metadata for %s")
+                             (pr-str id-or-name)))
   (merge
    {:lib/type            :metadata/column
     ;; guess that the column came from the previous stage
@@ -600,11 +600,11 @@
              (not *recursive-expression-resolution?*))
     (binding [*recursive-expression-resolution?* true]
       (when-some [expr (lib.expression/maybe-resolve-expression query stage-number id-or-name)]
-        (log/warn (u/format-color :red
-                                  (str "Resolved field %s to an expression. Please remember to use :expression references"
-                                       " for expressions in the current stage -- using a :field ref is unsupported and may"
-                                       " not be allowed in the future.")
-                                  (pr-str id-or-name)))
+        (log/debug (u/format-color :red
+                                   (str "Resolved field %s to an expression. Please remember to use :expression references"
+                                        " for expressions in the current stage -- using a :field ref is unsupported and may"
+                                        " not be allowed in the future.")
+                                   (pr-str id-or-name)))
         (-> (lib.expression/expression-metadata query stage-number expr)
             (assoc :lib/source-column-alias id-or-name))))))
 

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -369,10 +369,10 @@
                                                                                                     (with-join-alias field-ref nil))]
                                                (when-not (:metabase.lib.field.resolution/fallback-metadata? resolved)
                                                  resolved))
-                                             (log/warnf "Failed to find matching column in join %s for ref %s, found:\n%s"
-                                                        (pr-str join-alias)
-                                                        (pr-str field-ref)
-                                                        (pr-str (map (juxt :id :metabase.lib.join/join-alias :lib/source-column-alias) cols))))]
+                                             (log/debugf "Failed to find matching column in join %s for ref %s, found:\n%s"
+                                                         (pr-str join-alias)
+                                                         (pr-str field-ref)
+                                                         (pr-str (map (juxt :id :metabase.lib.join/join-alias :lib/source-column-alias) cols))))]
 
                         :when     (and match
                                        (not (false? (:active match))))]

--- a/src/metabase/lib/normalize.cljc
+++ b/src/metabase/lib/normalize.cljc
@@ -46,9 +46,9 @@
   "If normalization errors somewhere, just log the error and return the partially-normalized result. Easier to debug
   this way."
   [error]
-  (log/warnf "Error normalizing MBQL 5: %s\n%s"
-             (pr-str (me/humanize (:explain error)))
-             (u/pprint-to-str (dissoc error :explain)))
+  (log/debugf "Error normalizing MBQL 5: %s\n%s"
+              (pr-str (me/humanize (:explain error)))
+              (u/pprint-to-str (dissoc error :explain)))
   (:value error))
 
 (def ^:private ^:dynamic *error-fn*


### PR DESCRIPTION
These log lines will now be debug level warnings rather warning level warnings.
```
<lib.normalize>  Error normalizing MBQL 5
<lib.field.resolution>  We tried every trick we could think
<lib.join>  Failed to find matching column in join
```

Intrepid readers will also notice that moved "Resolved field %s to an expression. ..." to debug as well.
