### PR TITLE
Handful of fixes for transforms search

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/context.clj
@@ -46,7 +46,9 @@
   [:set :string])
 
 (defn backend-metabot-capabilities
-  "Set of backend capabilities available to the AI service. Those are determined by the endpoints available to ai-service. When an endpoint would change in a non-backward compatible way, we should create a new version of this capability."
+  "Set of backend capabilities available to the AI service. Those are determined by the endpoints available to
+  ai-service. When an endpoint would change in a non-backward compatible way, we should create a new version of this
+  capability."
   []
   ;; 20 ns per call, safe to keep unmemoized
   (for [[[_method url _params] _spec] (-> (the-ns 'metabase-enterprise.metabot-v3.tools.api)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -1079,6 +1079,7 @@
    [:map [:output :string]]])
 
 (defn- search
+  "Shared handler for the /search and /search_v2 endpoints."
   [arguments conversation_id request]
   (try
     (let [options (mc/encode ::search-arguments

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -1078,15 +1078,8 @@
                          [:total_count :int]]]]
    [:map [:output :string]]])
 
-(api.macros/defendpoint :post "/search" :- [:merge ::search-result ::tool-request]
-  "Enhanced search with term and semantic queries using Reciprocal Rank Fusion."
-  [_route-params
-   _query-params
-   {:keys [arguments conversation_id] :as body} :- [:merge
-                                                    [:map [:arguments {:optional true} ::search-arguments]]
-                                                    ::tool-request]
-   request]
-  (metabot-v3.context/log (assoc body :api :search) :llm.log/llm->be)
+(defn- search
+  [arguments conversation_id request]
   (try
     (let [options (mc/encode ::search-arguments
                              arguments (mtx/transformer {:name :tool-api-request}))
@@ -1105,6 +1098,30 @@
       (doto (-> {:output (str "Search failed: " (or (ex-message e) "Unknown error"))}
                 (assoc :conversation_id conversation_id))
         (metabot-v3.context/log :llm.log/be->llm)))))
+
+(api.macros/defendpoint :post "/search" :- [:merge ::search-result ::tool-request]
+  "Enhanced search with term and semantic queries using Reciprocal Rank Fusion."
+  [_route-params
+   _query-params
+   {:keys [arguments conversation_id] :as body} :- [:merge
+                                                    [:map [:arguments {:optional true} ::search-arguments]]
+                                                    ::tool-request]
+   request]
+  (metabot-v3.context/log (assoc body :api :search) :llm.log/llm->be)
+  (search arguments conversation_id request))
+
+(api.macros/defendpoint :post "/search_v2" :- [:merge ::search-result ::tool-request]
+  "Enhanced search with term and semantic queries using Reciprocal Rank Fusion. This is identical to /search, but
+  duplicated in order to add a new capability to AI service that indicates that Metabot can search transforms. The
+  /search endpoint is kept around for backward compatibility."
+  [_route-params
+   _query-params
+   {:keys [arguments conversation_id] :as body} :- [:merge
+                                                    [:map [:arguments {:optional true} ::search-arguments]]
+                                                    ::tool-request]
+   request]
+  (metabot-v3.context/log (assoc body :api :search) :llm.log/llm->be)
+  (search arguments conversation_id request))
 
 (api.macros/defendpoint :post "/get-snippets" :- [:merge ::get-snippets-result ::tool-request]
   "Get a list of all known SQL snippets."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -1056,7 +1056,7 @@
   "Unified schema for search result items."
   [:map {:decode/tool-api-response #(update-keys % metabot-v3.u/safe->snake_case_en)}
    [:id :int]
-   [:type [:enum :table :model :dashboard :question :metric :database]]
+   [:type [:enum :table :model :dashboard :question :metric :database :transform]]
    [:name :string]
    [:display_name {:optional true} [:maybe :string]]
    [:description {:optional true} [:maybe :string]]
@@ -1121,7 +1121,7 @@
                                                     [:map [:arguments {:optional true} ::search-arguments]]
                                                     ::tool-request]
    request]
-  (metabot-v3.context/log (assoc body :api :search) :llm.log/llm->be)
+  (metabot-v3.context/log (assoc body :api :search_v2) :llm.log/llm->be)
   (search arguments conversation_id request))
 
 (api.macros/defendpoint :post "/get-snippets" :- [:merge ::get-snippets-result ::tool-request]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -100,7 +100,7 @@
           (map :search-result)))))
 
 (defn search
-  "Search for data sources (tables, models, cards, dashboards, metrics) in Metabase.
+  "Search for data sources (tables, models, cards, dashboards, metrics, transforms) in Metabase.
   Abstracted from the API endpoint logic."
   [{:keys [term-queries semantic-queries database-id created-at last-edited-at
            entity-types limit metabot-id search-native-query]}]
@@ -139,8 +139,11 @@
                                             :context :metabot
                                             :archived false
                                             :limit (or limit 50)
-                                            :offset 0
-                                            :search-native-query (boolean search-native-query)}
+                                            :offset 0}
+                                           ;; Don't include search-native-query key if nil so that we don't
+                                           ;; inadvertently filter out search models that don't support it
+                                           (when search-native-query
+                                             {:search-native-query (boolean search-native-query)})
                                            (when use-verified-content?
                                              {:verified true})))
                           _ (log/infof "[METABOT-SEARCH] Search context models for query '%s': %s"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/search_test.clj
@@ -320,3 +320,27 @@
                                               :entity-types ["dashboard"]})]
                   (is (= 1 (count results)))
                   (is (= 2 (:id (first results)))))))))))))
+
+(deftest search-native-query-test
+  (mt/with-test-user :rasta
+    (with-redefs [perms/impersonated-user? (fn [] false)
+                  perms/sandboxed-user? (fn [] false)
+                  api/*current-user-id* 1]
+      (testing ":search-native-query is included in context when true"
+        (with-redefs [search-core/search (fn [context]
+                                           (is (true? (:search-native-query context)))
+                                           {:data []})]
+          (search/search {:term-queries ["test"]
+                          :entity-types ["card"]
+                          :search-native-query true})))
+
+      (testing ":search-native-query is not included in context when nil or false"
+        (with-redefs [search-core/search (fn [context]
+                                           (is (not (contains? context :search-native-query)))
+                                           {:data []})]
+          (search/search {:term-queries ["test"]
+                          :entity-types ["card"]
+                          :search-native-query false})
+          (search/search {:term-queries ["test"]
+                          :entity-types ["card"]
+                          :search-native-query nil}))))))

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/hooks.ts
@@ -23,7 +23,7 @@ function calculateFillerHeight(
     parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
   const contentHeight = containerHeight - paddingAdjustment;
 
-  return Math.max(0, contentHeight - nonFillerElsHeight);
+  return Math.max(0, Math.floor(contentHeight - nonFillerElsHeight));
 }
 
 function resizeFillerArea(


### PR DESCRIPTION
* Adds both `/search` and `/search_v2` endpoints for the metabot search tool which share an implementation. This is to provide a new capability (`search_v2`) to power a new `SearchToolv2` in AI service that includes transform search. However we still need to offer the v1 `search` capability for the non-transforms metabot and for backwards compatibility.
* Fixes a small search API usage issue — `:search-native-query` should only be set in the search context when `true`, because if you pass `:search-native-query` `false` or `nil` it'll still remove models that don't have a concept of native queries. This is definitely a footgun so I want to clean up the search API semantics here, but this is a quick fix to get things working again