### PR TITLE
Fix wrong timezone in "exclude hours" filters

### DIFF
--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -298,7 +298,7 @@
   (let [year (t/year date)]
     (case unit
       :hour (when-let [hour (parse-int-in-range exclusion 0 23)]
-              (format "%sT%02d:00:00Z" date hour))
+              (format "%sT%02d:00:00" date hour))
       :day (when-let [day (short-day->day exclusion)]
              (str (t/adjust date :next-or-same-day-of-week day)))
       :month (when-let [month (short-month->month exclusion)]

--- a/src/metabase/query_processor/parameters/dates.clj
+++ b/src/metabase/query_processor/parameters/dates.clj
@@ -303,7 +303,7 @@
   (let [year (t/year date)]
     (case unit
       :hour (when-let [hour (parse-int-in-range exclusion 0 23)]
-              (format "%sT%02d:00:00Z" date hour))
+              (format "%sT%02d:00:00" date hour))
       :day (when-let [day (short-day->day exclusion)]
              (str (t/adjust date :next-or-same-day-of-week day)))
       :month (when-let [month (short-month->month exclusion)]

--- a/test/metabase/driver/common/parameters/dates_test.clj
+++ b/test/metabase/driver/common/parameters/dates_test.clj
@@ -97,12 +97,12 @@
       (testing "hours"
         (is (= [:!=
                 [:field "field" {:base-type :type/DateTime, :temporal-unit :hour-of-day}]
-                "2016-06-07T00:00:00Z"]
+                "2016-06-07T00:00:00"]
                (params.dates/date-string->filter "exclude-hours-0" [:field "field" {:base-type :type/DateTime}])))
         (is (= [:!=
                 [:field "field" {:base-type :type/DateTime, :temporal-unit :hour-of-day}]
-                "2016-06-07T00:00:00Z"
-                "2016-06-07T23:00:00Z"]
+                "2016-06-07T00:00:00"
+                "2016-06-07T23:00:00"]
                (params.dates/date-string->filter "exclude-hours-0-23" [:field "field" {:base-type :type/DateTime}])))
         (is (thrown? clojure.lang.ExceptionInfo #"Don't know how to parse date string \"exclude-hours-\""
                      (params.dates/date-string->filter "exclude-hours-" [:field "field" {:base-type :type/DateTime}])))

--- a/test/metabase/query_processor/parameters/dates_test.clj
+++ b/test/metabase/query_processor/parameters/dates_test.clj
@@ -196,15 +196,15 @@
         (is (=? [:!=
                  {}
                  [:field {:base-type :type/DateTime, :temporal-unit :hour-of-day} "field"]
-                 "2016-06-07T00:00:00Z"]
+                 "2016-06-07T00:00:00"]
                 (params.dates/date-string->filter
                  "exclude-hours-0"
                  [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"])))
         (is (=? [:!=
                  {}
                  [:field {:base-type :type/DateTime, :temporal-unit :hour-of-day} "field"]
-                 "2016-06-07T00:00:00Z"
-                 "2016-06-07T23:00:00Z"]
+                 "2016-06-07T00:00:00"
+                 "2016-06-07T23:00:00"]
                 (params.dates/date-string->filter
                  "exclude-hours-0-23"
                  [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/DateTime} "field"])))


### PR DESCRIPTION
Draft solution to https://github.com/metabase/metabase/issues/64271

### Description

Starting from the situation of the [issue repro](https://github.com/metabase/metabase/issues/64271), we are indicating "exclude hour-of-day 4 PM" but it ends up being 6 PM in the DB because we are using a zoned UTC date time in the MBQL which ends up being adjusted by the connection's timezone by the DB (report timezone).

Breakdown:

1. First we call something like `/api/dashboard/2/dashcard/36/card/39/query`

```json
{"parameters":[{"type":"date/all-options","value":"exclude-hours-16","id":"7d1ad241","target":["dimension",["field",85,{"base-type":"type/DateTimeWithLocalTZ"}],{"stage-number":0}]}],"dashboard_id":2,"dashboard_load_id":"bd08fbce-ec82-899c-656e-8509d9cb8d50"}
```

2. During preprocessing, at the `substitute-parameters` middleware, we call this:
https://github.com/metabase/metabase/blob/3aed5bfd731185fc7ff81fb062b5ffafd5cb4927/src/metabase/driver/common/parameters/dates.clj#L561

3. We convert “exclude-hours-16” to `2025-10-01T16:00:00Z` (which is zoned, in UTC!)
https://github.com/metabase/metabase/blob/3aed5bfd731185fc7ff81fb062b5ffafd5cb4927/src/metabase/query_processor/parameters/dates.clj#L306

4. On `wrap-value-literals`, we enter the [first clause](https://github.com/metabase/metabase/blob/4fb30455270c2e75fb2cf2edacf6ee259c9705f7/src/metabase/query_processor/middleware/wrap_value_literals.clj#L283-L286), onto `parse-temporal-string-literal :type/DateTimeWithTZ` which in turn calls `parse-temporal-string-literal-to-class s OffsetDateTime` with `2025-10-01T16:00:00Z`.

6. If we print what it's trying to do and what it returns:
```
going to coerce  #t "2025-10-01T16:00Z[UTC]"  with class  java.time.ZonedDateTime  to  java.time.OffsetDateTime

parse-temporal-string-literal returns:  #t "2025-10-01T16:00Z"  
returned class:  java.time.OffsetDateTime 
returned offset:  #object[java.time.ZoneOffset 0x5924b76e Z
```
7. This is then passed on to postgres, and ends up being converted to the connection's timezone by the DB because we set it to be the report timezone (+02:00)
https://github.com/metabase/metabase/blob/607768cd8c453e64fe3d257e7ff877e68375b076/src/metabase/driver/sql_jdbc/execute.clj#L467
8. From postgres you get this
<img width="2712" height="242" alt="Image" src="https://github.com/user-attachments/assets/0736a2c1-6190-4050-94cf-8de2c066bf18" />


However, if you didn’t have the Z on the generated string from step 2 so it was just `2025-10-01T16:00:00`, it becomes a LocalDateTime so it works correctly:
```
going to coerce  #t "2025-10-01T16:00"  with class  java.time.LocalDateTime  to  java.time.OffsetDateTime

parse-temporal-string-literal returns:  #t "2025-10-01T16:00+02:00"  
returned class:  java.time.OffsetDateTime  
returned offset:  #object[java.time.ZoneOffset 0x54415d35 +02:00]
```

Similar issue happens with Field Filters, but goes through the other changed file in drivers/common/parameters/dates instead

### How to verify

Follow issue repro steps