### PR TITLE
Hide the step number circle in the setup flow when we only have one step

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -314,6 +314,19 @@ describe("scenarios > setup", () => {
       .should("be.visible");
   });
 
+  // There are only one step in the setup flow, so there is no need to show step numbers.
+  it("should not show step numbers in cloud embedding use case", () => {
+    H.mockSessionProperty("is-hosted?", true);
+    H.mockSessionProperty("token-features", { hosting: true });
+
+    cy.visit(
+      "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited&use_case=embedding",
+    );
+
+    H.main().findByText("What should we call you?").should("be.visible");
+    cy.findByTestId("step-number").should("not.exist");
+  });
+
   it("should allow localization in the 'embedding' setup flow", () => {
     cy.visit(
       "/setup?first_name=John&last_name=Doe&email=john@doe.test&site_name=Doe%20Unlimited&use_case=embedding",

--- a/frontend/src/metabase/setup/components/ActiveStep/ActiveStep.tsx
+++ b/frontend/src/metabase/setup/components/ActiveStep/ActiveStep.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from "react";
 
+import { useSelector } from "metabase/lib/redux";
+import { getShouldShowStepNumber } from "metabase/setup";
+
 import {
   StepLabel,
   StepLabelText,
@@ -20,6 +23,8 @@ export const ActiveStep = ({
   children,
   className,
 }: ActiveStepProps): JSX.Element => {
+  const shouldShowStepNumber = useSelector(getShouldShowStepNumber);
+
   return (
     <StepRoot
       role="listitem"
@@ -29,9 +34,13 @@ export const ActiveStep = ({
       className={className}
     >
       <StepTitle>{title}</StepTitle>
-      <StepLabel data-testid="step-number">
-        <StepLabelText>{label}</StepLabelText>
-      </StepLabel>
+
+      {shouldShowStepNumber && (
+        <StepLabel data-testid="step-number">
+          <StepLabelText>{label}</StepLabelText>
+        </StepLabel>
+      )}
+
       {children}
     </StepRoot>
   );

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -159,3 +159,11 @@ export const getNextStep = (state: State) => {
   const activeStepIndex = steps.findIndex((step) => step.isActiveStep);
   return steps[activeStepIndex + 1].key;
 };
+
+export const getShouldShowStepNumber = (state: State): boolean => {
+  const interactiveSteps = getSteps(state).filter(
+    (step) => step.key !== "welcome" && step.key !== "completed",
+  );
+
+  return interactiveSteps.length > 1;
+};


### PR DESCRIPTION
Closes EMB-825

When we only have one step in the setup flow, i.e. Cloud with Embedding use case, we should not show the step number per design.

### How to verify

1. Go to `setup/selectors.ts` below, and comment out all the lines with `maybeAddStep`. It should only have welcome, user_info and complete. This is to emulate cloud embedding.

https://github.com/metabase/metabase/blob/0eebe5a459299e1dd2f9f043d47bec26b6bdc63d/frontend/src/metabase/setup/selectors.ts#L137-L149

2. Start a fresh Metabase instance.

3. You should not see the step number circle.

### Demo

<img width="1556" height="990" alt="CleanShot 2568-10-02 at 00 41 58@2x" src="https://github.com/user-attachments/assets/394665bc-f375-4598-9d75-20a1b2bd480f" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
