### PR TITLE
Fix localization number separators

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
@@ -158,7 +158,7 @@ export function FormattingWidget() {
                 { label: "100 000,00", value: ", " },
                 { label: "100.000,00", value: ",." },
                 { label: "100000.00", value: "." },
-                { label: "100'000.00", value: ".'" },
+                { label: "100’000.00", value: ".’" },
               ]}
               onChange={(newValue) =>
                 handleChange({

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
@@ -165,7 +165,7 @@ describe("FormattingWidget", () => {
     });
   });
 
-  it("should proivde expected number separators (#61854)", async () => {
+  it("should provide expected number separators (#61854)", async () => {
     await setup();
 
     const seperatorStyleInput = await screen.findByLabelText("Separator style");

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
@@ -164,4 +164,21 @@ describe("FormattingWidget", () => {
       expect(toasts).toHaveLength(6);
     });
   });
+
+  it("should proivde expected number separators (#61854)", async () => {
+    await setup();
+
+    const seperatorStyleInput = await screen.findByLabelText("Separator style");
+    await userEvent.click(seperatorStyleInput);
+
+    const [item] = screen.getAllByRole("listbox");
+    const children = within(item).getAllByRole("option");
+    expect(children.length).toBe(5);
+
+    expect(within(item).getByText("100,000.00")).toBeInTheDocument();
+    expect(within(item).getByText("100 000,00")).toBeInTheDocument();
+    expect(within(item).getByText("100.000,00")).toBeInTheDocument();
+    expect(within(item).getByText("100000.00")).toBeInTheDocument();
+    expect(within(item).getByText("100’000.00")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
@@ -171,14 +171,14 @@ describe("FormattingWidget", () => {
     const seperatorStyleInput = await screen.findByLabelText("Separator style");
     await userEvent.click(seperatorStyleInput);
 
-    const [item] = screen.getAllByRole("listbox");
-    const children = within(item).getAllByRole("option");
+    const [dropdown] = screen.getAllByRole("listbox");
+    const children = within(dropdown).getAllByRole("option");
     expect(children.length).toBe(5);
 
-    expect(within(item).getByText("100,000.00")).toBeInTheDocument();
-    expect(within(item).getByText("100 000,00")).toBeInTheDocument();
-    expect(within(item).getByText("100.000,00")).toBeInTheDocument();
-    expect(within(item).getByText("100000.00")).toBeInTheDocument();
-    expect(within(item).getByText("100’000.00")).toBeInTheDocument();
+    expect(within(dropdown).getByText("100,000.00")).toBeInTheDocument();
+    expect(within(dropdown).getByText("100 000,00")).toBeInTheDocument();
+    expect(within(dropdown).getByText("100.000,00")).toBeInTheDocument();
+    expect(within(dropdown).getByText("100000.00")).toBeInTheDocument();
+    expect(within(dropdown).getByText("100’000.00")).toBeInTheDocument();
   });
 });

--- a/src/metabase/appearance/settings.clj
+++ b/src/metabase/appearance/settings.clj
@@ -341,6 +341,23 @@ See [fonts](../configuring-metabase/fonts.md).")
   :audit      :getter
   :feature    :whitelabel)
 
+(def avaialable-number-separators
+  "Number separators that are available to use in uploads csv parsing. Values match what is implemented
+  `metabase.upload.types` namespace, specifically e.g. [[metabase.upload.types/int-regex]]."
+  #{"."
+    ".,"
+    ",."
+    ", "
+    ".’"})
+
+(defn- validate-custom-formatting!
+  [new-value]
+  (let [separators (some-> new-value :type/Number :number_separators)]
+    (when-not (avaialable-number-separators separators)
+      (throw (ex-info (tru "Invalid number separators.")
+                      {:separators separators
+                       :available-separators avaialable-number-separators})))))
+
 (defsetting custom-formatting
   (deferred-tru "Object keyed by type, containing formatting settings")
   :encryption :no
@@ -348,7 +365,10 @@ See [fonts](../configuring-metabase/fonts.md).")
   :export?    true
   :default    {}
   :visibility :public
-  :audit      :getter)
+  :audit      :getter
+  :setter     (fn [new-value]
+                (validate-custom-formatting! new-value)
+                (setting/set-value-of-type! :json :custom-formatting new-value)))
 
 (defsetting show-homepage-data
   (deferred-tru

--- a/src/metabase/appearance/settings.clj
+++ b/src/metabase/appearance/settings.clj
@@ -352,7 +352,7 @@ See [fonts](../configuring-metabase/fonts.md).")
 
 (defn- validate-custom-formatting!
   [new-value]
-  (let [separators (some-> new-value :type/Number :number_separators)]
+  (when-some [separators (some-> new-value :type/Number :number_separators)]
     (when-not (avaialable-number-separators separators)
       (throw (ex-info (tru "Invalid number separators.")
                       {:separators separators

--- a/test/metabase/appearance/settings_test.clj
+++ b/test/metabase/appearance/settings_test.clj
@@ -178,3 +178,15 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"Loading message set to an unsupported value"
                             (appearance.settings/loading-message! :unsupported-value))))))
+
+(deftest custom-formatting-number-separators-test
+  (testing "Only valid values can be set as number separators (#61854)"
+    (let [violating-separators ".'"]
+      (is (thrown-with-msg?
+           Exception #"Invalid number separators."
+           (appearance.settings/custom-formatting!
+            #:type{:Temporal {:date_style "MMMM D, YYYY"
+                              :time_style "h:mm A"
+                              :date_abbreviate false}
+                   :Number {:number_separators violating-separators}
+                   :Currency {:currency "USD" :currency_style "symbol"}}))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/61854

Frontend has been modified recently so `.'` (apostrophe; utf8 0x27) separator is used for localization settings instead of `.’` (right single quotation mark; utf8 0xe28099).

This PR fixes the FE, updates the setter of the corresponding setting to avoid similar errors and adds test that ensures only correct values can be set.