### PR TITLE
Log errors in downgrades

### DIFF
--- a/src/metabase/app_db/liquibase.clj
+++ b/src/metabase/app_db/liquibase.clj
@@ -530,8 +530,8 @@
              (format "target version must be a number between 44 and the previous major version (%d), inclusive"
                      (config/current-major-version)))))
    (with-scope-locked liquibase
-    ;; count and rollback only the applied change set ids which come after the target version (only the "v..." IDs need
-    ;; to be considered)
+     ;; count and rollback only the applied change set ids which come after the target version (only the "v..." IDs need
+     ;; to be considered)
      (let [changeset-query (format "SELECT id FROM %s WHERE id LIKE 'v%%'" (changelog-table-name liquibase))
            changeset-ids   (map :id (jdbc/query {:connection conn} [changeset-query]))
            ;; IDs in changesets do not include the leading 0/1 digit, so the major version is the first number
@@ -556,7 +556,8 @@
                                                      [(AlreadyRanChangeSetFilter. ran-changesets)
                                                       (IgnoreChangeSetFilter.)
                                                       (DbmsChangeSetFilter. lb-db)
-                                                      changeset-filter])))]
+                                                      changeset-filter])))
+           error-ids (atom [])]
        (when (and (not force) (> latest-applied latest-available))
          (throw (ex-info
                  (format "Cannot downgrade a database at version %d from Metabase version %d. You must run 'migrate down' from Metabase version >= %d."
@@ -568,11 +569,25 @@
        (if (empty? ids-to-drop)
          (log/info "No changesets to roll back")
          (do
-           (AbstractRollbackCommandStep/doRollback lb-db changelog-file nil changelog-iterator (.getChangeLogParameters liquibase) changelog nil nil)
+           (let [change-listener (proxy [liquibase.changelog.visitor.AbstractChangeExecListener] []
+                                   (rollbackFailed [^ChangeSet change-set _dbchangelog _db ^Exception e]
+                                     (swap! error-ids conj (.getId change-set))
+                                     (log/errorf e "Error rolling back migration %s" (.getId change-set))))]
+             (AbstractRollbackCommandStep/doRollback lb-db
+                                                     changelog-file
+                                                     nil
+                                                     changelog-iterator
+                                                     (.getChangeLogParameters liquibase)
+                                                     changelog
+                                                     change-listener))
            (let [remaining-query (-> (sql.helpers/select :id)
                                      (sql.helpers/from (keyword (changelog-table-name liquibase)))
                                      (sql.helpers/where [:in :id ids-to-drop]))
                  formatted-sql (sql/format remaining-query)
                  remaining-ids   (map :id (t2/query conn formatted-sql))]
              (when (seq remaining-ids)
-               (log/warnf "The following changesets were not rolled back. Likely because they are not in the changelog file: %s" (str/join ", " remaining-ids))))))))))
+               (log/warnf "The following changesets were not rolled back. Likely because %s: %s"
+                          (if (seq @error-ids)
+                            (format "there were errors in rollback (%s)" (str/join ", " @error-ids))
+                            "they are not in the changelog file")
+                          (str/join ", " remaining-ids))))))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/62179

Before (and bad) (wordwrap introduced for clarity): (note this migration down FAILS because `v56.2025-07-17T20:11:56` attempts to use `jwt_attributes` which i manually removed to create an error (as per #62179)
```
2025-08-14 16:17:36,662 WARN app-db.liquibase :: The following
changesets were not rolled back. Likely because they are not in the
changelog file: v56.2025-06-05T16:48:48, v56.2025-06-06T20:11:53,
v56.2025-06-06T20:11:54, v56.2025-06-06T20:11:55,
v56.2025-06-06T20:11:56, v56.2025-06-06T20:11:58,
v56.2025-06-13T15:00:00, v56.2025-07-07T08:02:43,
v56.2025-07-17T20:11:55, v56.2025-07-17T20:11:56 2025-08-14 16:17:36,662
INFO liquibase.logging :: Successfully released change log lock ```
```

And now:

```
2025-10-01 16:00:19,326 INFO app-db.liquibase :: Rolling back app database schema to version 55
2025-10-01 16:00:19,326 INFO app-db.liquibase :: Going to roll back changeset v56.2025-07-17T20:11:56
Rolling Back Changeset: migrations/056_update_migrations.yaml::v56.2025-07-17T20:11:56::edpaget
2025-10-01 16:00:19,328 ERROR app-db.liquibase :: Error rolling back migration v56.2025-07-17T20:11:56
liquibase.exception.RollbackFailedException: liquibase.exception.DatabaseException: ERROR: column "jwt_attributes" does not exist
  Position: 41 [Failed SQL: (0) UPDATE core_user SET login_attributes = jwt_attributes WHERE sso_source = 'jwt']
  	at liquibase.changelog.ChangeSet.rollback(ChangeSet.java:1041)
        ...
Caused by: liquibase.exception.DatabaseException: ERROR: column "jwt_attributes" does not exist
  Position: 41 [Failed SQL: (0) UPDATE core_user SET login_attributes = jwt_attributes WHERE sso_source = 'jwt']
	at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:520)
       ... omitted
       ... 65 more
Caused by: org.postgresql.util.PSQLException: ERROR: column "jwt_attributes" does not exist
  Position: 41
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2734)
	... 70 more

2025-10-01 16:00:19,330 WARN app-db.liquibase :: The following
changesets were not rolled back. Likely because there were errors in
rollback (v56.2025-07-17T20:11:56): v56.2025-06-06T20:11:53,
v56.2025-06-06T20:11:54, v56.2025-06-06T20:11:55,
v56.2025-06-06T20:11:56, v56.2025-06-06T20:11:58,
v56.2025-06-13T15:00:00, v56.2025-07-07T08:02:43,
v56.2025-07-17T20:11:55, v56.2025-07-17T20:11:56 2025-10-01 16:00:19,330
INFO liquibase.logging :: Successfully released change log lock
```

How i recreated:
connected to a jar:
```
MB_DB_CONNECTION_URI="postgres://dan:password@localhost:5432/downgrade-checks" MB_JETTY_PORT=2999 java "$(socket-repl 6000)" -jar $JARS/1.56.6.2.jar
```

```sql
downgrade-checks=# alter table core_user drop column jwt_attributes;
ALTER TABLE
```

this will make a downgrade fail:
```yaml
  - changeSet:
      id: v56.2025-07-17T20:11:56
      author: edpaget
      comment: |
        Add sync login_attributes with jwt_attributes, we need to replace jwt_attributes
        with login attributes for users with sso_source jwt so that they will get the new
        behavior where login_attributes can override jwt_attributes
      changes:
        - sql: >-
           UPDATE core_user
           SET jwt_attributes = login_attributes, login_attributes = '{}'
           WHERE sso_source = 'jwt';
      rollback:
        - sql: >-
           UPDATE core_user
           SET login_attributes = jwt_attributes
           WHERE sso_source = 'jwt';
```

This will fail as the `jwt_attributes` column has been removed.

```
Error rolling back migration v56.2025-07-17T20:11:56
liquibase.exception.RollbackFailedException: liquibase.exception.DatabaseException: ERROR: column "jwt_attributes" does not exist
  Position: 41 [Failed SQL: (0) UPDATE core_user SET login_attributes = jwt_attributes WHERE sso_source = 'jwt']
```

And then connect to the jar again, redefine the changes here, and run

```clojure
  (let [data-source (metabase.app-db.core/data-source)]
    (with-open [conn (.getConnection ^javax.sql.DataSource data-source)]
      (with-liquibase [liquibase conn]
        (rollback-major-version! conn liquibase false))))
```
