### PR TITLE
refactor(sdk-bundle): Adjust StaticQuestion and SqlParametersList visuals

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/ResultToolbar/ResultToolbar.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/ResultToolbar/ResultToolbar.tsx
@@ -1,0 +1,22 @@
+import type { PropsWithChildren } from "react";
+
+import { Group } from "metabase/ui";
+
+type Props = {
+  "data-testid"?: string;
+};
+
+export const ResultToolbar = ({
+  children,
+  "data-testid": dataTestId,
+}: PropsWithChildren<Props>) => (
+  <Group
+    justify="space-between"
+    p="sm"
+    bg="var(--mb-color-bg-sdk-question-toolbar)"
+    style={{ borderRadius: "0.5rem" }}
+    data-testid={dataTestId}
+  >
+    {children}
+  </Group>
+);

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.module.css
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.module.css
@@ -1,4 +1,7 @@
-.SqlParametersList {
-  /* Reset ResponsiveList margins */
-  margin: 0;
+.SqlParametersListContainer {
+  background: transparent;
+
+  .SqlParametersList {
+    margin: 0;
+  }
 }

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.tsx
@@ -64,7 +64,10 @@ export const SqlParametersList = () => {
 
   return (
     <ResponsiveParametersList
-      className={SqlParametersListS.SqlParametersList}
+      classNames={{
+        container: SqlParametersListS.SqlParametersListContainer,
+        parametersList: SqlParametersListS.SqlParametersList,
+      }}
       cardId={question.id()}
       dashboardId={question.dashboardId() ?? undefined}
       parameters={parameters}

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -37,6 +37,7 @@ import { Editor } from "../SdkQuestion/components/Editor";
 import { EditorButton } from "../SdkQuestion/components/EditorButton/EditorButton";
 import { FilterDropdown } from "../SdkQuestion/components/Filter/FilterDropdown";
 import { QuestionSettingsDropdown } from "../SdkQuestion/components/QuestionSettings";
+import { ResultToolbar } from "../SdkQuestion/components/ResultToolbar/ResultToolbar";
 import {
   SaveButton,
   shouldShowSaveButton,
@@ -191,13 +192,7 @@ export const SdkQuestionDefaultView = ({
           {showSaveButton && <SaveButton onClick={openSaveModal} />}
         </Group>
         {queryResults && (
-          <Group
-            justify="space-between"
-            p="sm"
-            bg="var(--mb-color-bg-sdk-question-toolbar)"
-            style={{ borderRadius: "0.5rem" }}
-            data-testid="interactive-question-result-toolbar"
-          >
+          <ResultToolbar data-testid="interactive-question-result-toolbar">
             <Group gap="xs">
               {isEditorOpen ? (
                 <PopoverBackButton
@@ -242,7 +237,7 @@ export const SdkQuestionDefaultView = ({
               {withDownloads && <DownloadWidgetDropdown />}
               <EditorButton isOpen={isEditorOpen} onClick={toggleEditor} />
             </Group>
-          </Group>
+          </ResultToolbar>
         )}
       </Stack>
 

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.stories.tsx
@@ -7,7 +7,6 @@ import {
   questionIdArgType,
   questionIds,
 } from "embedding-sdk-bundle/test/storybook-id-args";
-import { InteractiveQuestion } from "embedding-sdk-package";
 import { Box } from "metabase/ui";
 import {
   createMockNativeCard,
@@ -99,9 +98,9 @@ export const WithEditableSqlParametersCustomLayout = {
     return (
       <Box bg="var(--mb-color-background)" mih="100vh">
         <SdkQuestion {...args}>
-          <InteractiveQuestion.Title />
-          <InteractiveQuestion.SqlParametersList />
-          <InteractiveQuestion.QuestionVisualization />
+          <SdkQuestion.Title />
+          <SdkQuestion.SqlParametersList />
+          <SdkQuestion.QuestionVisualization />
         </SdkQuestion>
       </Box>
     );

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.stories.tsx
@@ -64,3 +64,14 @@ export const WithCustomTitle = {
     withChartTypeSelector: false,
   },
 };
+
+export const WithAdditionalElements = {
+  render: Template,
+
+  args: {
+    questionId: QUESTION_ID,
+    title: "Acme Inc. Sales Report",
+    withDownloads: true,
+    withChartTypeSelector: true,
+  },
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -19,13 +19,14 @@ import {
   SummarizeDropdown,
   Title,
 } from "embedding-sdk-bundle/components/private/SdkQuestion/components";
+import { ResultToolbar } from "embedding-sdk-bundle/components/private/SdkQuestion/components/ResultToolbar/ResultToolbar";
 import { DefaultViewTitle } from "embedding-sdk-bundle/components/private/SdkQuestionDefaultView/DefaultViewTitle";
 import {
   SdkQuestion,
   type SdkQuestionProps,
 } from "embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion";
 import { StaticQuestionSdkMode } from "embedding-sdk-bundle/components/public/StaticQuestion/mode";
-import { Group, Stack } from "metabase/ui";
+import { Stack } from "metabase/ui";
 import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
 import type { ClickActionModeGetter } from "metabase/visualizations/types";
 import type Question from "metabase-lib/v1/Question";
@@ -122,10 +123,10 @@ const _StaticQuestion = ({
             {title && <DefaultViewTitle title={title} />}
 
             {(withChartTypeSelector || withDownloads) && (
-              <Group justify="space-between">
+              <ResultToolbar>
                 {withChartTypeSelector && <SdkQuestion.ChartTypeDropdown />}
                 {withDownloads && <SdkQuestion.DownloadWidgetDropdown />}
-              </Group>
+              </ResultToolbar>
             )}
 
             <SdkQuestion.QuestionVisualization

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
@@ -11,7 +11,10 @@ import ResponsiveParametersListS from "./ResponsiveParametersList.module.css";
 import { SyncedParametersList } from "./SyncedParametersList";
 
 interface ResponsiveParametersListProps {
-  className?: string;
+  classNames?: {
+    container?: string;
+    parametersList?: string;
+  };
   cardId?: CardId;
   dashboardId?: DashboardId;
   parameters: Parameter[];
@@ -23,7 +26,7 @@ interface ResponsiveParametersListProps {
 }
 
 export const ResponsiveParametersList = ({
-  className,
+  classNames,
   cardId,
   dashboardId,
   parameters,
@@ -68,10 +71,15 @@ export const ResponsiveParametersList = ({
       )}
       <Box
         py="sm"
-        className={cx(ResponsiveParametersListS.ParametersListContainer, {
-          [ResponsiveParametersListS.isSmallScreen]: isSmallScreen,
-          [ResponsiveParametersListS.isShowingMobile]: mobileShowParameterList,
-        })}
+        className={cx(
+          ResponsiveParametersListS.ParametersListContainer,
+          {
+            [ResponsiveParametersListS.isSmallScreen]: isSmallScreen,
+            [ResponsiveParametersListS.isShowingMobile]:
+              mobileShowParameterList,
+          },
+          classNames?.container,
+        )}
       >
         {parameters.length > 0 && isSmallScreen && (
           <Flex p="0.75rem 1rem" align="center" justify="space-between">
@@ -87,7 +95,7 @@ export const ResponsiveParametersList = ({
         <SyncedParametersList
           className={cx(
             ResponsiveParametersListS.StyledParametersList,
-            className,
+            classNames?.parametersList,
           )}
           cardId={cardId}
           dashboardId={dashboardId}


### PR DESCRIPTION
Add the proper styles reset of ResponsiveParametersList from SqlParametersList side

We need to reset both: a bg of a container and margins of a parameters list, so they can be customized on a custom layout level

Also with this PR the Static Question also uses the same ResultToolbar as the Interactive question

<img width="2988" height="1632" alt="image" src="https://github.com/user-attachments/assets/ee859228-302e-4457-b5ca-a5cac2ac405f" />
