### PR TITLE
Compute param values from card results

### DIFF
--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -94,6 +94,10 @@ export function downloadAndAssert(
 
   cy.log(`Downloading ${fileType} file`);
 
+  // For _some_ reason wait is necessary for dashcard menu to stay open after
+  // the click. I assume card needs to finish loading.
+  cy.wait(200);
+
   if (isDashboard) {
     if (isEmbed) {
       getDashboardCard().realHover();

--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -768,7 +768,6 @@ describe("scenarios > content translation > static embedding > dashboards", () =
           H.filterWidget().findByText("Multi").click();
           // Search matches against untranslated text, hence "Fran" matching these names
           cy.findByPlaceholderText("Recherche dans la liste").type("Fran");
-          cy.wait("@searchQuery");
           cy.findByTestId("parameter-value-dropdown").within(() => {
             cy.findByText(/Glacia Froskeon/).click();
             cy.button(/Ajouter un filtre/).click();

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -185,7 +185,8 @@
   pivot-types]
  [lib.equality
   find-column-for-legacy-ref
-  find-matching-column]
+  find-matching-column
+  matching-column-by-source-uuid]
  [lib.expression
   expression
   expressions

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -473,8 +473,11 @@
   temporal-bucket
   with-temporal-bucket]
  [lib.util
+  canonical-stage-index
   clause?
   clause-of-type?
+  drop-limit-clause
+  drop-summary-clauses
   fresh-uuids
   mbql-stage?
   native-stage?

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -185,8 +185,7 @@
   pivot-types]
  [lib.equality
   find-column-for-legacy-ref
-  find-matching-column
-  matching-column-by-source-uuid]
+  find-matching-column]
  [lib.expression
   expression
   expressions
@@ -476,7 +475,6 @@
   canonical-stage-index
   clause?
   clause-of-type?
-  drop-limit-clause
   drop-summary-clauses
   fresh-uuids
   mbql-stage?

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -201,7 +201,7 @@
                       source-field-join-alias]} _ref-id] :- ::lib.schema.ref/ref
    column                                                :- ::lib.schema.metadata/column]
   (if source-field
-    (and (clojure.core/= source-field (:fk-field-id column))
+    (and (clojure.core/= source-field ((some-fn :fk-field-id :lib/original-fk-field-id) column))
          ;; `source-field-name` is not available on old refs
          (or (nil? source-field-name) (clojure.core/= source-field-name (:fk-field-name column)))
          (clojure.core/= source-field-join-alias (:fk-join-alias column)))

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -620,3 +620,9 @@
          (and (not (contains? matching nil))
               (clojure.core/= (count matching) (count columns))
               (every? #(clojure.core/= (count %) 1) (vals matching))))))
+
+(defn matching-column-by-source-uuid
+  "Find column in `cols`, that corresponds to `col` based on `:lib/source-uuid` equality."
+  [col cols]
+  (let [searched-uuid (:lib/source-uuid col)]
+    (m/find-first (comp #{searched-uuid} :lib/source-uuid) cols)))

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -620,9 +620,3 @@
          (and (not (contains? matching nil))
               (clojure.core/= (count matching) (count columns))
               (every? #(clojure.core/= (count %) 1) (vals matching))))))
-
-(defn matching-column-by-source-uuid
-  "Find column in `cols`, that corresponds to `col` based on `:lib/source-uuid` equality."
-  [col cols]
-  (let [searched-uuid (:lib/source-uuid col)]
-    (m/find-first (comp #{searched-uuid} :lib/source-uuid) cols)))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -60,7 +60,10 @@
                             :mbql.stage/mbql   :source/card)]
           (not-empty
            (into []
-                 (comp (map #(assoc % :lib/source source-type))
+                 (comp (map (fn [col]
+                              (cond-> (assoc col :lib/source source-type)
+                                (= :source/card source-type) (-> (assoc :lib/card-id source-card)
+                                                                 (dissoc :lib/expression-name)))))
                        ;; do not truncate the desired column aliases coming back from a native query, because if a
                        ;; native query returns a 'crazy long' column name then we need to use that in the next stage.
                        ;; See [[metabase.lib.stage-test/propagate-crazy-long-native-identifiers-test]]

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -531,7 +531,7 @@
     nil))
 
 (defn drop-summary-clauses
-  "Remove :aggregation and :breakout from stage stage-number of a query."
+  "Remove :aggregation and :breakout from the stage at `stage-number` of a `query`."
   ([query]
    (drop-summary-clauses query -1))
   ([query stage-number]

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -531,15 +531,8 @@
     nil))
 
 (defn drop-summary-clauses
-  "TBD"
+  "Remove :aggregation and :breakout from stage stage-number of a query."
   ([query]
    (drop-summary-clauses query -1))
   ([query stage-number]
    (update-query-stage query stage-number dissoc :aggregation :breakout)))
-
-(defn drop-limit-clause
-  "TBD"
-  ([query]
-   (drop-limit-clause query -1))
-  ([query stage-number]
-   (update-query-stage query stage-number dissoc :limit)))

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -529,3 +529,17 @@
     (:query :native) :mbql-version/legacy
     ;; otherwise, this is not a valid MBQL query.
     nil))
+
+(defn drop-summary-clauses
+  "TBD"
+  ([query]
+   (drop-summary-clauses query -1))
+  ([query stage-number]
+   (update-query-stage query stage-number dissoc :aggregation :breakout)))
+
+(defn drop-limit-clause
+  "TBD"
+  ([query]
+   (drop-limit-clause query -1))
+  ([query stage-number]
+   (update-query-stage query stage-number dissoc :limit)))

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -125,8 +125,8 @@
               (lib/filter nonempty)
               (cond-> #_query query-filter (lib/filter query-filter))
               (lib/breakout value-column)
-                ;; TODO(Braden, 07/04/2025): This should probably become a lib helper? I suspect this isn't the only
-                ;; "internal" query in the BE.
+              ;; TODO(Braden, 07/04/2025): This should probably become a lib helper? I suspect this isn't the only
+              ;; "internal" query in the BE.
               (assoc-in [:middleware :disable-remaps?] true)))))))
 
 (mu/defn values-from-card

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -76,8 +76,8 @@
           full-query (lib/card->underlying-query mp card)]
       (loop [stage-number (lib/canonical-stage-index full-query -1)
              query full-query]
-        ;; (1) Append stage. The searched column may be part of summaries. Further transformations will add 
-        ;; filters and breakouts. A new stage ensures those are not conflated.
+        ;; (1) Append stage. The searched column may be part of summaries. Further transformations will add
+        ;; filters and breakouts. A new stage ensures those operations are not conflated with existing summaries.
         ;; (2) visible-columns. Visible columns are used because ref may come from implicit join.
         (let [query (lib/append-stage query)]
           (or

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -66,18 +66,18 @@
   removing the later stages. Returns map as
   {:query ...
    :value-column ...}.
-  Query contains stages where last one is empty, having the matching column avaialble.
+  Query contains stages where last one is empty, having the matching column available.
   Value column contains that column.
   Callers can use column to build something beautiful on the last empty stage (see [[values-from-card-query]]).
-  Return nil if column is not found."
+  Returns nil if column is not found."
   [card value-field-ref]
   (when-some [mp (-> card :dataset_query :lib/metadata)]
     (let [card (lib.metadata/card mp (:id card))
           full-query (lib/card->underlying-query mp card)]
       (loop [stage-number (lib/canonical-stage-index full-query -1)
              query full-query]
-        ;; Append stage. Searched column can be part of summaries. Further transformation in add filters and breakout.
-        ;; New stage ensures those are not conflated.
+        ;; Append stage. The searched column may be part of summaries. Further transformations will add 
+        ;; filters and breakouts. A new stage ensures those are not conflated.
         (let [query (lib/append-stage query)]
           (or
            ;; Examine the query with summaries first.
@@ -86,14 +86,14 @@
                                      value-field-ref (lib/visible-columns query))]
              {:query query
               :value-column value-column})
-           ;; If column was not found, remove the aggregations. value-field-ref can be implicitly joined.
+           ;; If column was not found, remove the summaries.
            (let [query (lib/drop-summary-clauses query stage-number)]
              (when-some [value-column (lib/find-matching-column
                                        query -1
                                        value-field-ref (lib/visible-columns query))]
                {:query query
                 :value-column value-column}))
-           ;; If not found drop the newly added stage, examined stage and continue searching.
+           ;; If not found, drop the newly added stage and examined stage, then continue searching.
            (when (pos-int? stage-number)
              (recur (-> query lib/drop-stage lib/drop-stage)
                     (dec stage-number)))))))))

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -62,31 +62,40 @@
   1000)
 
 (defn- query-and-value-column
+  "Searches stages of card's dataset query for column matching value-field-ref. Searching from -1 to 0th stage,
+  removing the later stages. Returns map as
+  {:query ...
+   :value-column ...}.
+  Query contains stages where last one is empty, having the matching column avaialble.
+  Value column contains that column.
+  Callers can use column to build something beautiful on the last empty stage (see [[values-from-card-query]]).
+  Return nil if column is not found."
   [card value-field-ref]
   (when-some [mp (-> card :dataset_query :lib/metadata)]
     (let [card (lib.metadata/card mp (:id card))
           full-query (lib/card->underlying-query mp card)]
       (loop [stage-number (lib/canonical-stage-index full-query -1)
              query full-query]
+        ;; Append stage. Searched column can be part of summaries. Further transformation in add filters and breakout.
+        ;; New stage ensures those are not conflated.
         (let [query (lib/append-stage query)]
           (or
-           ;; Exaine returned columns first
+           ;; Examine the query with summaries first.
            (when-some [value-column (lib/find-matching-column
                                      query -1
                                      value-field-ref (lib/visible-columns query))]
              {:query query
               :value-column value-column})
-           ;; Try removing summaries
+           ;; If column was not found, remove the aggregations. value-field-ref can be implicitly joined.
+           (let [query (lib/drop-summary-clauses query stage-number)]
+             (when-some [value-column (lib/find-matching-column
+                                       query -1
+                                       value-field-ref (lib/visible-columns query))]
+               {:query query
+                :value-column value-column}))
+           ;; If not found drop the newly added stage, examined stage and continue searching.
            (when (pos-int? stage-number)
-             (let [query (lib/drop-summary-clauses query stage-number)]
-               (when-some [value-column (lib/find-matching-column
-                                         query -1
-                                         value-field-ref (lib/returned-columns query))]
-                 {:query query
-                  :value-column value-column})))
-           ;; Peel off the last stage
-           (when (pos-int? stage-number)
-             (recur (-> query lib/drop-stage)
+             (recur (-> query lib/drop-stage lib/drop-stage)
                     (dec stage-number)))))))))
 
 (mr/def ::values-from-card-query.options

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -72,7 +72,7 @@
   The `:query` key contains card's query with stages -1..n+1 removed, where n is the stage containing the column.
   The `:value-column` key contains the column."
   [card* value-field-ref]
-  (let [mp (lib-be.metadata.jvm/application-database-metadata-provider (:database_id card*))
+  (let [mp (lib-be/application-database-metadata-provider (:database_id card*))
         card (lib.metadata/card mp (:id card*))
         full-query (lib/card->underlying-query mp card)
         drop-clauses #(lib/update-query-stage % -1 dissoc :aggregation :breakout)]

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -76,8 +76,9 @@
           full-query (lib/card->underlying-query mp card)]
       (loop [stage-number (lib/canonical-stage-index full-query -1)
              query full-query]
-        ;; Append stage. The searched column may be part of summaries. Further transformations will add 
+        ;; (1) Append stage. The searched column may be part of summaries. Further transformations will add 
         ;; filters and breakouts. A new stage ensures those are not conflated.
+        ;; (2) visible-columns. Visible columns are used because ref may come from implicit join.
         (let [query (lib/append-stage query)]
           (or
            ;; Examine the query with summaries first.

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -20,7 +20,6 @@
    [metabase.query-processor.util :as qp.util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]

--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -68,9 +68,7 @@
           full-query (lib/card->underlying-query mp card)]
       (loop [stage-number (lib/canonical-stage-index full-query -1)
              query full-query]
-        (let [query (-> query
-                        (lib/drop-limit-clause stage-number)
-                        (lib/append-stage))]
+        (let [query (lib/append-stage query)]
           (or
            ;; Exaine returned columns first
            (when-some [value-column (lib/find-matching-column

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -91,7 +91,7 @@
   Dashboard is expected to have hydrated `:resolved-params`."
   [dashboard param-key]
   (for [mapping (get-in dashboard [:resolved-params param-key :mappings])
-        :let [database-id (get-in mapping [:dashcard :card :database_id])
+        :let [database-id (get-in mapping [:dashcard :card :dataset_query :database])
               card-id (get-in mapping [:dashcard :card :id])
               mp (lib-be/application-database-metadata-provider database-id)
               card (lib.metadata/card mp card-id)

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -97,8 +97,8 @@
               card (lib.metadata/card mp card-id)
               query (lib/card->underlying-query mp card)]
         :when (and (not-empty query)
-                (m/find-first (partial lib/filters query)
-                              (range (lib/stage-count query))))]
+                   (m/find-first (partial lib/filters query)
+                                 (range (lib/stage-count query))))]
     card))
 
 (defn- cards-with-filters?

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -102,7 +102,7 @@
     card))
 
 (defn- cards-with-filters?
-  "Does param-key have any card with filter mapped? Dashboard is expected to have hydrate `:resolved-params`."
+  "Does param-key have any card with filter mapped? Dashboard is expected to have hydrated `:resolved-params`."
   [dashboard param-key]
   (boolean (seq (cards-with-filters dashboard param-key))))
 

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -2,7 +2,11 @@
   (:require
    [medley.core :as m]
    [metabase.api.common :as api]
+   [metabase.legacy-mbql.normalize :as mbql.normalize]
+   [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.parameters.chain-filter :as chain-filter]
    [metabase.parameters.custom-values :as custom-values]
@@ -83,6 +87,26 @@
                  2 second
                  1 first)))))
 
+(mu/defn- cards-with-filters :- [:sequential ::lib.schema.metadata/card]
+  "Lazy seq of cards from `dashboard` that are mapped to param `param-key` and contain some filters.
+  Dashboard is expected to have hydrated `:resolved-params`."
+  [dashboard param-key]
+  (for [mapping (get-in dashboard [:resolved-params param-key :mappings])
+        :let [database-id (get-in mapping [:dashcard :card :database_id])
+              card-id (get-in mapping [:dashcard :card :id])
+              mp (lib-be/application-database-metadata-provider database-id)
+              card (lib.metadata/card mp card-id)
+              query (lib/card->underlying-query mp card)]
+        :when (when (not-empty query)
+                (m/find-first (partial lib/filters query)
+                              (range (lib/stage-count query))))]
+    card))
+
+(defn- cards-with-filters?
+  "Does param-key have any card with filter mapped? Dashboard is expected to have hydrate `:resolved-params`."
+  [dashboard param-key]
+  (boolean (seq (cards-with-filters dashboard param-key))))
+
 (mu/defn chain-filter :- ms/FieldValuesResult
   "C H A I N filters!
 
@@ -99,7 +123,8 @@
          constraints (chain-filter-constraints dashboard constraint-param-key->value)
          param       (get-in dashboard [:resolved-params param-key])
          field-ids   (into #{} (map :field-id (param->fields param)))]
-     (if (empty? field-ids)
+     (if (or (empty? field-ids)
+             (cards-with-filters? dashboard param-key))
        (or (filter-values-from-field-refs dashboard param-key)
            (throw (ex-info (tru "Parameter {0} does not have any Fields associated with it" (pr-str param-key))
                            {:param       (get (:resolved-params dashboard) param-key)

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -2,7 +2,6 @@
   (:require
    [medley.core :as m]
    [metabase.api.common :as api]
-   [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -96,7 +96,7 @@
               mp (lib-be/application-database-metadata-provider database-id)
               card (lib.metadata/card mp card-id)
               query (lib/card->underlying-query mp card)]
-        :when (when (not-empty query)
+        :when (and (not-empty query)
                 (m/find-first (partial lib/filters query)
                               (range (lib/stage-count query))))]
     card))

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -112,7 +112,7 @@
 (mu/defn- update-breakout-unit* :- ::lib.schema/stage
   [stage         :- ::lib.schema/stage
    target-column :- [:or ::lib.schema.id/field :string]
-   temporal-unit :- ::lib.schema.temporal-bucketing/unit
+   temporal-unit :- [:maybe ::lib.schema.temporal-bucketing/unit]
    new-unit      :- ::lib.schema.temporal-bucketing/unit]
   (lib.util.match/replace stage
     [(tag :guard #{:field :expression})

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5425,7 +5425,7 @@
                    :creator_id (mt/user->id :crowberto)} response))))
 
 (deftest param-mapped-SAME-fields-filtered-cards-test
-  (testing "Values for param mapped to _same_ field in _different_ cards containing filters are compued correctly (#41684)"
+  (testing "Values for param mapped to _same_ field in _different_ cards containing filters are computed correctly (#41684)"
     ;; I.e. if there is card without a filter precomputed values
     (let [mp (mt/metadata-provider)
           param-key "p"
@@ -5488,7 +5488,7 @@
                                                                       (:id d) param-key))))))))))
 
 (deftest param-mapped-DIFFERENT-fields-filtered-cards-test
-  (testing "Values for param mapped to different fields in cards containing filters are compued correctly (#41684)"
+  (testing "Values for param mapped to different fields in cards containing filters are computed correctly (#41684)"
     (let [mp (mt/metadata-provider)
           param-key "p"]
       (mt/with-temp

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5426,7 +5426,6 @@
 
 (deftest param-mapped-SAME-fields-filtered-cards-test
   (testing "Values for param mapped to _same_ field in _different_ cards containing filters are computed correctly (#41684)"
-    ;; I.e. if there is card without a filter precomputed values
     (let [mp (mt/metadata-provider)
           param-key "p"
           base-queries [(-> (lib/query mp (lib.metadata/table mp (mt/id :categories)))
@@ -5442,7 +5441,7 @@
 
                  {:test-case "nested filters"
                   :queries (mapv (fn [query]
-                                     ;; dummy stage
+                                   ;; dummy stage
                                    (-> (lib/append-stage query)
                                        (lib/expression "e" (lib/concat (lib.metadata/field mp (mt/id :categories :name))
                                                                        "XXX"))))

--- a/test/metabase/dashboards/api_test.clj
+++ b/test/metabase/dashboards/api_test.clj
@@ -5423,3 +5423,115 @@
                                                                               })]
     (is (partial= {:name       "Test Dashboard"
                    :creator_id (mt/user->id :crowberto)} response))))
+
+(deftest param-mapped-SAME-fields-filtered-cards-test
+  (testing "Values for param mapped to _same_ field in _different_ cards containing filters are compued correctly (#41684)"
+    ;; I.e. if there is card without a filter precomputed values
+    (let [mp (mt/metadata-provider)
+          param-key "p"
+          base-queries [(-> (lib/query mp (lib.metadata/table mp (mt/id :categories)))
+                            (lib/filter (lib/in (lib.metadata/field mp (mt/id :categories :name))
+                                                "African" "Artisan" "Bakery")))
+
+                        (-> (lib/query mp (lib.metadata/table mp (mt/id :categories)))
+                            (lib/filter (lib/in (lib.metadata/field mp (mt/id :categories :name))
+                                                "African" "Artisan")))]
+          tests [{:test-case "single level queries"
+                  :queries base-queries
+                  :expectations [["African"] ["Artisan"] ["Bakery"]]}
+
+                 {:test-case "nested filters"
+                  :queries (mapv (fn [query]
+                                     ;; dummy stage
+                                   (-> (lib/append-stage query)
+                                       (lib/expression "e" (lib/concat (lib.metadata/field mp (mt/id :categories :name))
+                                                                       "XXX"))))
+                                 base-queries)
+                  :expectations [["African"] ["Artisan"] ["Bakery"]]}]]
+      (doseq [{:keys [test-case queries expectations]} tests]
+        (mt/with-temp
+          [:model/Card
+           c1
+           {:dataset_query (queries 0)}
+
+           :model/Card
+           c2
+           {:dataset_query (queries 1)}
+
+           :model/Dashboard
+           d
+           {:parameters [{:id param-key
+                          :name "filtered names filter"
+                          :slug param-key
+                          :type "string/="
+                          :sectionId "string"}]}
+
+           :model/DashboardCard
+           _
+           {:dashboard_id (:id d)
+            :card_id (:id c1)
+            :parameter_mappings [{:card_id (:id c1)
+                                  :parameter_id param-key
+                                  :target ["dimension" ["field" (mt/id :categories :name) nil]]}]}
+
+           :model/DashboardCard
+           _
+           {:dashboard_id (:id d)
+            :card_id (:id c2)
+            :parameter_mappings [{:card_id (:id c2)
+                                  :parameter_id param-key
+                                  :target ["dimension" ["field" (mt/id :categories :name) nil]]}]}]
+
+          (testing test-case
+            (is (=? {:values expectations}
+                    (mt/user-http-request :crowberto :get 200 (format "dashboard/%d/params/%s/values"
+                                                                      (:id d) param-key))))))))))
+
+(deftest param-mapped-DIFFERENT-fields-filtered-cards-test
+  (testing "Values for param mapped to different fields in cards containing filters are compued correctly (#41684)"
+    (let [mp (mt/metadata-provider)
+          param-key "p"]
+      (mt/with-temp
+        [:model/Card
+         c1
+         {:dataset_query  (-> (lib/query mp (lib.metadata/table mp (mt/id :categories)))
+                              (lib/filter (lib/in (lib.metadata/field mp (mt/id :categories :name))
+                                                  "African" "Artisan" "Bakery")))}
+
+         :model/Card
+         c2
+         {:dataset_query (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                             (lib/filter (lib/in (lib.metadata/field mp (mt/id :venues :name))
+                                                 "Red Medicine" "Krua Siri"))
+                             (lib/append-stage)
+                             (lib/expression "e" (lib/concat (lib.metadata/field mp (mt/id :categories :name))
+                                                             "XXX")))}
+
+         :model/Dashboard
+         d
+         {:parameters [{:id param-key
+                        :name "filtered names filter"
+                        :slug param-key
+                        :type "string/="
+                        :sectionId "string"}]}
+
+         :model/DashboardCard
+         _
+         {:dashboard_id (:id d)
+          :card_id (:id c1)
+          :parameter_mappings [{:card_id (:id c1)
+                                :parameter_id param-key
+                                :target ["dimension" ["field" (mt/id :categories :name) nil]]}]}
+
+         :model/DashboardCard
+         _
+         {:dashboard_id (:id d)
+          :card_id (:id c2)
+          :parameter_mappings [{:card_id (:id c2)
+                                :parameter_id param-key
+                                :target ["dimension" ["field" (mt/id :venues :name) nil]]}]}]
+
+        (testing "Param mapped to different fields with different filters"
+          (is (=? {:values [["African"] ["Artisan"] ["Bakery"] ["Krua Siri"] ["Red Medicine"]]}
+                  (mt/user-http-request :crowberto :get 200 (format "dashboard/%d/params/%s/values"
+                                                                    (:id d) param-key)))))))))

--- a/test/metabase/lib/equality_test.cljc
+++ b/test/metabase/lib/equality_test.cljc
@@ -1398,18 +1398,3 @@
                {:lib/source-column-alias "CREATED_AT",    :display-name "Created At",      :selected? false}]
               (map #(select-keys % [:lib/source-column-alias :display-name :selected?])
                    marked))))))
-
-(deftest ^:parallel matching-column-by-source-uuid-test
-  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
-                  (lib/aggregate (lib/sum (meta/field-metadata :orders :total)))
-                  (lib/breakout (lib/with-temporal-bucket
-                                  (meta/field-metadata :orders :created-at) :month)))
-        returned (lib/returned-columns query)
-        want-breakout-by (m/find-first (comp #{:source/aggregations} :lib/source) returned)
-        expected-uuid (:lib/source-uuid want-breakout-by)
-        query-next (lib/append-stage query)
-        breakoutable-next (lib/breakoutable-columns query-next)
-        {:lib/keys [source source-uuid]}
-        (lib/matching-column-by-source-uuid want-breakout-by breakoutable-next)]
-    (is (= expected-uuid source-uuid))
-    (is (= :source/previous-stage source))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41684

This PR changes the way we provide filter values for parameters mapped to fields of cards that contain filters.

Specifically, the check was added so if mapping to cards as described is present, the `filter-values-from-field-refs` code path is used instead of `chain-filter/chain-filter`ing.

That way filter values from card results are used to populate the widget.

Also, the `filter-values-from-field-refs` code path was updated so params mapped to nested stages are handled correctly.