### PR TITLE
Closes EMB-854 actually escape the single quote

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.ts
@@ -87,7 +87,7 @@ const toDashCase = (str: string): string =>
 export const formatAttributeValue = (value: unknown): string => {
   if (Array.isArray(value) || typeof value === "object") {
     const jsonString = JSON.stringify(value);
-    const escapedString = jsonString.replace(/'/g, "&39;");
+    const escapedString = jsonString.replace(/'/g, "&#39;");
     return `'${escapedString}'`;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/utils/embed-snippet.unit.spec.ts
@@ -23,19 +23,19 @@ describe("formatAttributeValue", () => {
 
   it("should HTML escape single quotes in array and objects", () => {
     expect(formatAttributeValue(["O'Reilly", "D'Angelo"])).toBe(
-      `'["O&39;Reilly","D&39;Angelo"]'`,
+      `'["O&#39;Reilly","D&#39;Angelo"]'`,
     );
     expect(formatAttributeValue({ quote: "It's a test" })).toBe(
-      `'{"quote":"It&39;s a test"}'`,
+      `'{"quote":"It&#39;s a test"}'`,
     );
   });
 
   it("should HTML escape single quotes in nested arrays and objects", () => {
     expect(
       formatAttributeValue([{ name: "O'Reilly" }, { name: "D'Angelo" }]),
-    ).toBe(`'[{"name":"O&39;Reilly"},{"name":"D&39;Angelo"}]'`);
+    ).toBe(`'[{"name":"O&#39;Reilly"},{"name":"D&#39;Angelo"}]'`);
     expect(formatAttributeValue({ nested: { quote: "It's a test" } })).toBe(
-      `'{"nested":{"quote":"It&39;s a test"}}'`,
+      `'{"nested":{"quote":"It&#39;s a test"}}'`,
     );
   });
 


### PR DESCRIPTION
Closes [EMB-854: Escape single quotes in embed flow code snippets](https://linear.app/metabase/issue/EMB-854/escape-single-quotes-in-embed-flow-code-snippets)

In #64242 the HTML entity used to replace single quotes misses a `#` and therefore is invalid, defeating the whole fix's purpose. This is now correct.

No backport, I'll update https://github.com/metabase/metabase/pull/64322 directly.