### PR TITLE
Add color-scheme meta tag for light and dark modes

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -16,6 +16,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="base-href" content="{{{baseHref}}}" />
     <meta name="uri" content="{{{uri}}}" />
+    <meta name="color-scheme" content="light dark" />
 
     {{{embedCode}}}
 


### PR DESCRIPTION
## Description

When static embedding without background and with dark mode (`background=false&theme=night`), the iframe is still showing a white background. 

Full explanation resource article: https://fvsch.com/transparent-iframes

Historically the color scheme was set through css, see #54918 

## How to verify

1. Embed a dashboard in an iframe with and url ending with `#background=false&theme=night`, preferably on a dark parent page
2. You still see a white background even though `background: transparent` style is set around in the child document

## Demo

### Before

<img width="864" height="196" alt="image" src="https://github.com/user-attachments/assets/199e4ae9-7b49-48e6-8b0c-f90ec037cd6e" />

### After adding `<meta name="color-scheme" content="light dark" />`

<img width="864" height="196" alt="image" src="https://github.com/user-attachments/assets/db9ed040-2a41-4609-a461-c48e76f99658" />