### PR TITLE
feat(sdk-bundle): use existing tooltip configuration for dark mode 

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-bundle/lib/theme/get-embedding-theme.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/lib/theme/get-embedding-theme.ts
@@ -6,6 +6,7 @@ import type {
   MetabaseColor,
   MetabaseComponentTheme,
   MetabaseTheme,
+  MetabaseTooltipComponentTheme,
 } from "metabase/embedding-sdk/theme";
 import {
   DEFAULT_EMBEDDED_COMPONENT_THEME,
@@ -13,7 +14,10 @@ import {
   getEmbeddingComponentOverrides,
 } from "metabase/embedding-sdk/theme";
 import type { MappableSdkColor } from "metabase/embedding-sdk/theme/embedding-color-palette";
-import { SDK_TO_MAIN_APP_COLORS_MAPPING } from "metabase/embedding-sdk/theme/embedding-color-palette";
+import {
+  SDK_TO_MAIN_APP_COLORS_MAPPING,
+  SDK_TO_MAIN_APP_TOOLTIP_COLORS_MAPPING,
+} from "metabase/embedding-sdk/theme/embedding-color-palette";
 import type { MantineThemeOverride } from "metabase/ui";
 
 import { colorTuple } from "./color-tuple";
@@ -77,6 +81,22 @@ export function getEmbeddingThemeOverride(
         for (const themeColorName of themeColorNames) {
           override.colors[themeColorName] = colorTuple(color);
         }
+      }
+    }
+  }
+
+  if (theme.components?.tooltip) {
+    if (!override.colors) {
+      override.colors = {};
+    }
+
+    for (const _tooltipKey in SDK_TO_MAIN_APP_TOOLTIP_COLORS_MAPPING) {
+      const tooltipKey = _tooltipKey as keyof MetabaseTooltipComponentTheme;
+      const colorKey = SDK_TO_MAIN_APP_TOOLTIP_COLORS_MAPPING[tooltipKey];
+      const tooltipColor = theme.components.tooltip[tooltipKey];
+
+      if (tooltipColor && colorKey) {
+        override.colors[colorKey] = colorTuple(tooltipColor);
       }
     }
   }

--- a/frontend/src/metabase/embedding-sdk/theme/MetabaseTheme.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/MetabaseTheme.ts
@@ -221,19 +221,7 @@ export type MetabaseComponentTheme = {
   };
 
   /** Tooltip */
-  tooltip?: {
-    /** Tooltip text color. */
-    textColor?: string;
-
-    /** Secondary text color shown in the tooltip, e.g. for tooltip headers and percentage changes. */
-    secondaryTextColor?: string;
-
-    /** Tooltip background color. */
-    backgroundColor?: string;
-
-    /** Tooltip background color for focused rows. */
-    focusedBackgroundColor?: string;
-  };
+  tooltip?: MetabaseTooltipComponentTheme;
 
   /** Popover */
   popover: {
@@ -265,6 +253,23 @@ export type MetabaseComponentTheme = {
     };
   };
 };
+
+/**
+ * Theme for the tooltip component.
+ */
+export interface MetabaseTooltipComponentTheme {
+  /** Tooltip text color. */
+  textColor?: string;
+
+  /** Secondary text color shown in the tooltip, e.g. for tooltip headers and percentage changes. */
+  secondaryTextColor?: string;
+
+  /** Tooltip background color. */
+  backgroundColor?: string;
+
+  /** Tooltip background color for focused rows. */
+  focusedBackgroundColor?: string;
+}
 
 /**
  * @inline

--- a/frontend/src/metabase/embedding-sdk/theme/css-vars-to-sdk-theme.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/css-vars-to-sdk-theme.ts
@@ -27,12 +27,6 @@ export const CSS_VARIABLES_TO_SDK_THEME_MAP = {
   // Overlays
   "--mb-overlay-z-index": "popover.zIndex",
 
-  // Tooltips
-  "--mb-color-tooltip-text": "tooltip.textColor",
-  "--mb-color-tooltip-background": "tooltip.backgroundColor",
-  "--mb-color-tooltip-background-focused": "tooltip.focusedBackgroundColor",
-  "--mb-color-tooltip-text-secondary": "tooltip.secondaryTextColor",
-
   // Dashboards
   "--mb-color-bg-dashboard": "dashboard.backgroundColor",
   "--mb-color-bg-dashboard-card": "dashboard.card.backgroundColor",

--- a/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
@@ -1,6 +1,7 @@
 import type {
   MetabaseColor,
   MetabaseColors,
+  MetabaseTooltipComponentTheme,
 } from "metabase/embedding-sdk/theme";
 import { colors } from "metabase/lib/colors";
 import type { ColorName, ColorPalette } from "metabase/lib/colors/types";
@@ -59,13 +60,18 @@ export const SDK_TO_MAIN_APP_COLORS_MAPPING: Record<
   positive: ["success"],
   negative: ["danger"],
   "text-white": ["text-white"],
-  "tooltip-background": ["tooltip-background"],
-  "tooltip-text": ["tooltip-text"],
-  "tooltip-background-focused": ["tooltip-background-focused"],
-  "tooltip-text-secondary": ["tooltip-text-secondary"],
-
   error: ["error"],
   "background-error": ["bg-error"],
+};
+
+export const SDK_TO_MAIN_APP_TOOLTIP_COLORS_MAPPING: Record<
+  keyof MetabaseTooltipComponentTheme,
+  ColorName
+> = {
+  textColor: "tooltip-text",
+  secondaryTextColor: "tooltip-text-secondary",
+  backgroundColor: "tooltip-background",
+  focusedBackgroundColor: "tooltip-background-focused",
 };
 
 const originalColors = { ...colors };

--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -4,8 +4,12 @@ import { getIn } from "icepick";
 
 import { CSS_VARIABLES_TO_SDK_THEME_MAP } from "metabase/embedding-sdk/theme/css-vars-to-sdk-theme";
 import { getDynamicCssVariables } from "metabase/embedding-sdk/theme/dynamic-css-vars";
-import { SDK_TO_MAIN_APP_COLORS_MAPPING } from "metabase/embedding-sdk/theme/embedding-color-palette";
+import {
+  SDK_TO_MAIN_APP_COLORS_MAPPING,
+  SDK_TO_MAIN_APP_TOOLTIP_COLORS_MAPPING,
+} from "metabase/embedding-sdk/theme/embedding-color-palette";
 import { colorConfig } from "metabase/lib/colors";
+import type { ColorName } from "metabase/lib/colors/types";
 import type { MantineTheme } from "metabase/ui";
 
 const createColorVars = (colorScheme: "light" | "dark"): string =>
@@ -52,29 +56,29 @@ export function getMetabaseSdkCssVariables(theme: MantineTheme, font: string) {
  * be available globally at :root
  **/
 function getSdkDesignSystemCssVariables(theme: MantineTheme) {
+  const createSdkColorVars = (colorName: ColorName) => {
+    /**
+     * Prevent returning the primary color when color is not found,
+     * so we could add a logic to fallback to the default color ourselves.
+     *
+     * We will only create CSS custom properties for colors that are defined
+     * in the palette, and additional colors overridden by the SDK.
+     */
+    const color = theme.fn.themeColor(colorName);
+    const colorExist = color !== colorName;
+    if (colorExist) {
+      return `--mb-color-${colorName}: ${color};`;
+    }
+  };
   return css`
-    /* Semantic colors */
-    /* Dynamic colors from SDK */
-    ${Object.entries(SDK_TO_MAIN_APP_COLORS_MAPPING).flatMap(
-      ([_key, metabaseColorNames]) => {
-        return metabaseColorNames.map((metabaseColorName) => {
-          /**
-           * Prevent returning the primary color when color is not found,
-           * so we could add a logic to fallback to the default color ourselves.
-           *
-           * We will only create CSS custom properties for colors that are defined
-           * in the palette, and additional colors overridden by the SDK.
-           *
-           * @see SDK_TO_MAIN_APP_COLORS_MAPPING
-           */
-          const color = theme.fn.themeColor(metabaseColorName);
-          const colorExist = color !== metabaseColorName;
+    /* SDK colors defined via theme.colors */
+    ${Object.entries(SDK_TO_MAIN_APP_COLORS_MAPPING).flatMap(([, colorNames]) =>
+      colorNames.map(createSdkColorVars),
+    )}
 
-          if (colorExist) {
-            return `--mb-color-${metabaseColorName}: ${color};`;
-          }
-        });
-      },
+    /* SDK tooltip colors defined via theme.components.tooltip */
+    ${Object.entries(SDK_TO_MAIN_APP_TOOLTIP_COLORS_MAPPING).flatMap(
+      ([, colorName]) => createSdkColorVars(colorName),
     )}
   `;
 }


### PR DESCRIPTION
Makes the existing tooltip configuration work for dark mode.

### How to verify

Tooltip color overrides should continue to work as before.

1. Go to the` InteractiveDashboard > Default` SDK story
2. Change the theme to "Proficiency" using the theme button (the one with the brush icon that says "default")
3. Hover over a bar chart
4. You should see a themed (i.e. white) tooltip 

<img width="1782" height="918" alt="CleanShot 2568-10-02 at 21 06 34@2x" src="https://github.com/user-attachments/assets/605aad59-a530-4ab7-ab99-c48f0eb41d20" />