### PR TITLE
Fix edge case in to-tsquery-expr

### DIFF
--- a/src/metabase/search/util.clj
+++ b/src/metabase/search/util.clj
@@ -147,6 +147,7 @@
             (partition-by #{"or"})
             (remove #(= (first %) "or"))
             (map process-clause)
+            (remove str/blank?)
             (str/join " | ")
             maybe-complete)))))
 

--- a/test/metabase/search/util_test.clj
+++ b/test/metabase/search/util_test.clj
@@ -40,6 +40,9 @@
   (is (= "'a' & 'b' | 'c':*"
          (search-expr "a b or c")))
 
+  (is (= "'a' | 'b':*"
+         (search-expr "a or and or b")))
+
   (is (= "'this' & !'that':*"
          (search-expr "this -that")))
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/64329

The core issue is that we remove `"and"` terms in `process-clause` but this leaves them as an empty string in the generated tsquery. So a query like `x or and or y` is interpreted as an OR of three strings: `"x"`, `""` and `"y"`, which results in invalid tsquery syntax. 

I've fixed this by adding an additional `str/blank?` filter after we call `process-clause` to remove clauses that end up being blank.