### PR TITLE
[METABOT] Use `limit` in final search response

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -123,7 +123,7 @@
                                             :current-user-perms @api/*current-user-permissions-set*
                                             :context :metabot
                                             :archived false
-                                            :limit (or limit 50)
+                                            :limit limit
                                             :offset 0}
                                            (when use-verified-content?
                                              {:verified true})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/search.clj
@@ -107,6 +107,7 @@
         use-verified-content? (if metabot-id
                                 (:use_verified_content metabot)
                                 false)
+        limit (or limit 50)
         search-fn (fn [query]
                     (let [search-context (search/search-context
                                           (merge
@@ -131,5 +132,5 @@
         ;; Create futures for parallel execution
         futures (mapv #(future (search-fn %)) all-queries)
         result-lists (mapv deref futures)
-        fused-results (reciprocal-rank-fusion result-lists)]
+        fused-results (take limit (reciprocal-rank-fusion result-lists))]
     (map transform-search-result fused-results)))


### PR DESCRIPTION
Currently the `limit` in the metabot search endpoint:
- Is used only for the intermediate search invocations, not the final result set we respond with
- Has no default

This PR uses `limit` to also truncate the final result set, defaulting to 50 if no `limit` was provided

Inspired by seeing search tool responses on stats include 125+ result entities, consuming 6,500+ tokens for just the formatted search result in the agent context (per `tiktoken.encoding_for_model('gpt-4o')`)