### PR TITLE
propagate original card title and description to visualizer cards

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -469,7 +469,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
       H.popover().findByText("Quarter").click();
       H.getDashboardCard().within(() => {
         cy.findByText("Q1 2023").should("be.visible");
-        cy.findByText("Question 1").click();
+        cy.findAllByTestId("legend-item").contains("Question 1").click();
       });
       H.appBar()
         .should("contain.text", "Started from")
@@ -481,7 +481,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
 
       H.getDashboardCard().within(() => {
         cy.findByText("Q1 2023").should("be.visible");
-        cy.findByText("Question 2").click();
+        cy.findAllByTestId("legend-item").contains("Question 2").click();
       });
       H.appBar()
         .should("contain.text", "Started from")

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -367,6 +367,40 @@ describe("scenarios > dashboard > visualizer > basics", () => {
     H.tooltip().findByText("My description").should("exist");
   });
 
+  it("should allow drilling into the underlying question by clicking on the title (metabase#64340)", () => {
+    H.createQuestion(ORDERS_COUNT_BY_CREATED_AT, {
+      wrapId: true,
+      idAlias: "questionId",
+    });
+
+    H.createDashboard().then(({ body: { id: dashboardId } }) => {
+      cy.get("@questionId").then((questionId) => {
+        H.addQuestionToDashboard({
+          dashboardId,
+          cardId: questionId as any,
+        });
+        H.visitDashboard(dashboardId);
+      });
+    });
+
+    H.editDashboard();
+    H.findDashCardAction(
+      H.getDashboardCard(0),
+      "Visualize another way",
+    ).click();
+
+    H.modal().within(() => {
+      H.selectVisualization("bar");
+    });
+    H.saveDashcardVisualizerModal();
+    H.saveDashboard();
+    H.getDashboardCard(0).within(() => {
+      cy.findByText("Orders by Created At (Month)").click();
+    });
+
+    cy.url().should("match", /\/question\/\d+/);
+  });
+
   it("should propagate original card title and description to visualizer cards (metabase#63863)", () => {
     const questionWithDescription = {
       ...ORDERS_COUNT_BY_CREATED_AT,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -313,8 +313,8 @@ export function DashCardVisualization({
     );
     const card = extendCardWithDashcardSettings(
       {
+        ...dashcard.card,
         display,
-        name: settings["card.title"],
         visualization_settings: settings,
       } as Card,
       _.omit(dashcard.visualization_settings, "visualization"),
@@ -326,15 +326,7 @@ export function DashCardVisualization({
 
     const series: RawSeries = [
       {
-        card: extendCardWithDashcardSettings(
-          {
-            display,
-            name: settings["card.title"],
-            visualization_settings: settings,
-          } as Card,
-          _.omit(dashcard.visualization_settings, "visualization"),
-        ) as Card,
-
+        card,
         data: mergeVisualizerData({
           columns,
           columnValuesMapping,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -313,7 +313,9 @@ export function DashCardVisualization({
     );
     const card = extendCardWithDashcardSettings(
       {
-        ...dashcard.card,
+        // Visualizer click handling code expect visualizer cards not to have card.id
+        name: dashcard.card.name,
+        description: dashcard.card.description,
         display,
         visualization_settings: settings,
       } as Card,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -162,7 +162,7 @@ function _CartesianChart(props: VisualizationProps) {
     <CartesianChartRoot isQueryBuilder={isQueryBuilder}>
       {showTitle && (
         <LegendCaption
-          title={settings["card.title"]}
+          title={settings["card.title"] ?? card.name}
           description={description}
           icon={headerIcon}
           actionButtons={actionButtons}

--- a/frontend/src/metabase/visualizer/selectors.ts
+++ b/frontend/src/metabase/visualizer/selectors.ts
@@ -52,7 +52,8 @@ export const getVisualizerRawSettings = (state: State) =>
 export const getCards = (state: State) => getCurrentHistoryItem(state).cards;
 
 export function getVisualizationTitle(state: State) {
-  const settings = getVisualizerRawSettings(state);
+  // Using computed settings to capture computed default "card.title" value if was not explicitly saved
+  const settings = getVisualizerComputedSettings(state);
   return settings["card.title"];
 }
 
@@ -145,8 +146,13 @@ export const getVisualizerDatasetColumns = createSelector(
 );
 
 const getVisualizerFlatRawSeries = createSelector(
-  [getVisualizationType, getVisualizerRawSettings, getVisualizerDatasetData],
-  (display, settings, data): RawSeries => {
+  [
+    getVisualizationType,
+    getVisualizerRawSettings,
+    getVisualizerDatasetData,
+    getCards,
+  ],
+  (display, settings, data, cards): RawSeries => {
     if (!display) {
       return [];
     }
@@ -156,6 +162,8 @@ const getVisualizerFlatRawSeries = createSelector(
         card: {
           display,
           dataset_query: {},
+          name: cards[0].name,
+          description: cards[0].description,
           visualization_settings: settings,
         } as Card,
 

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.ts
@@ -107,15 +107,9 @@ export function getInitialStateForCardDataSource(
       : DEFAULT_VISUALIZER_DISPLAY,
     columns: [],
     columnValuesMapping: {},
-    settings: {
-      "card.title": card.name,
-    },
+    settings: {},
     datasetFallbacks: { [card.id]: dataset },
   };
-
-  if (card.description != null) {
-    state.settings["card.description"] = card.description;
-  }
 
   const dataSource = createDataSource("card", card.id, card.name);
 
@@ -226,12 +220,7 @@ export function getInitialStateForCardDataSource(
   state.settings = {
     ...updateVizSettingsWithRefs(card.visualization_settings, columnsToRefs),
     ...Object.fromEntries(entries),
-    "card.title": card.name,
   };
-
-  if (card.description != null) {
-    state.settings["card.description"] = card.description;
-  }
 
   return state;
 }

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-card-data-source.unit.spec.ts
@@ -97,24 +97,9 @@ describe("getInitialStateForCardDataSource", () => {
     });
 
     expect(state.settings).toEqual({
-      "card.title": "TablyMcTableface",
       "graph.dimensions": ["COLUMN_1"],
       "graph.metrics": ["COLUMN_2"],
     });
-  });
-
-  it("should include card description in settings (metabase#63863)", () => {
-    const card = createMockCard({
-      display: "table",
-      name: "Test Card",
-      description: "This is a test description",
-    });
-
-    const state = getInitialStateForCardDataSource(card, dataset);
-
-    expect(state.settings["card.description"]).toEqual(
-      "This is a test description",
-    );
   });
 
   it("should ignore superfluous columns when the original card is a combo chart", () => {
@@ -187,7 +172,6 @@ describe("getInitialStateForCardDataSource", () => {
     });
 
     expect(state.settings).toEqual({
-      "card.title": "ComboMcComboface",
       "graph.dimensions": ["COLUMN_1"],
       "graph.metrics": ["COLUMN_2", "COLUMN_3"],
     });
@@ -234,7 +218,6 @@ describe("getInitialStateForCardDataSource", () => {
     });
 
     expect(state.settings).toEqual({
-      "card.title": "ScalarMcSmartface",
       "graph.dimensions": ["COLUMN_1"],
       "graph.metrics": ["COLUMN_2"],
       "scalar.compact_primary_number": true,
@@ -282,7 +265,6 @@ describe("getInitialStateForCardDataSource", () => {
           DIMENSION: ["$_card:1_name"],
         },
         settings: {
-          "card.title": card.name,
           "funnel.metric": "METRIC",
           "funnel.dimension": "DIMENSION",
         },

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.ts
@@ -167,12 +167,7 @@ export function getInitialStateForMultipleSeries(rawSeries: RawSeries) {
       columnsToRefs,
     ),
     ...mergedSettings,
-    "card.title": mainCard.name,
   };
-
-  if (mainCard.description != null) {
-    state.settings["card.description"] = mainCard.description;
-  }
 
   return state;
 }

--- a/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/get-initial-state-for-multiple-series.unit.spec.ts
@@ -94,37 +94,6 @@ describe("getInitialVisualizerStateForMultipleSeries", () => {
     expect(initialState.settings).toMatchObject({
       "graph.metrics": ["COLUMN_2", "COLUMN_4"],
       "graph.dimensions": ["COLUMN_1", "COLUMN_3"],
-      "card.title": "First Series",
     });
-  });
-
-  it("should include card description in settings (metabase#63863)", () => {
-    const firstCard = createMockCard({
-      id: 1,
-      name: "Test Series",
-      description: "Test description",
-      display: "line",
-      visualization_settings: {
-        "graph.metrics": ["Revenue"],
-        "graph.dimensions": ["Date"],
-      },
-    });
-
-    const rawSeries = [
-      createMockSingleSeries(firstCard, {
-        data: createMockDatasetData({
-          cols: [
-            createMockColumn({ name: "Date" }),
-            createMockColumn({ name: "Revenue" }),
-          ],
-        }),
-      }),
-    ];
-
-    const initialState = getInitialStateForMultipleSeries(rawSeries);
-
-    expect(initialState.settings["card.description"]).toEqual(
-      "Test description",
-    );
   });
 });


### PR DESCRIPTION
### Description

[Slack thread](https://metaboat.slack.com/archives/C052ZBWRG3W/p1759431946078209?thread_ts=1759159406.182739&cid=C052ZBWRG3W)

Fixes the following case:
- A question with title and description is added to a dashboard
- Then it is edited in the visualizer, for example by changing the display type - no title or description editing
- Original question title and description change -> it does not propagate to the dashcard as the visualizer copied both title and description to viz settings `card.title` and `card.description` of the visualizer entity which overrides the propagation of changes from the original question

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
