### PR TITLE
[METABOT] Fix 404 in `get-table-details` helper

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -264,9 +264,10 @@
     (let [options (cond-> arguments
                     (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
           details (cond
-                    (int? model-id)    (u/prog1 (card-details model-id (assoc options :only-model true))
-                                         (api/check (= :model (:type <>)) 404
-                                                    (format "ID %s is not a valid model id, it's a question" model-id)))
+                    (int? model-id)    (let [card (card-details model-id (assoc options :only-model true))]
+                                         (if (= :model (:type card))
+                                           card
+                                           (format "ID %s is not a valid model id, it's a question" model-id)))
                     (int? table-id)    (table-details table-id options)
                     (string? table-id) (if-let [[_ card-id] (re-matches #"card__(\d+)" table-id)]
                                          (card-details (parse-long card-id) options)


### PR DESCRIPTION
If Metabot makes a mistake and passes a question ID as `model-id` to the `get-table-details` handler we throw a 404 which I believe is getting intercepted in our endpoint middleware because ai-service then sees the error below.

This PR:
- Does not throw a 404, but instead follows the existing pattern of short circuiting with the intended error message which is then passed as the response

```html
ai_service.metabase.exceptions.MetabaseApiError: API request failed: 404, <html>
  <head>
      <link rel='stylesheet' href='https://www.metabase.com/css/main.css'>
      <title>Metabase instance not found</title>
      <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato">
  </head>
<body>
  <div class="MB-Error">
    <div class="relative mt4 py4 pb5">
      <div class="container sm-text-centered z6">
        <img width="128" height="128" src="https://s3.amazonaws.com/static.metabase.com/plug.png">
        <h1>Metabase instance not found</h1>
        <p>The instance or URL path you tried to reach does not exist. Please check the URL in the address bar, or create a new instance in the <a href="https://store.metabase.com/">store</a>.</p>
        <p id="datetime" class="text-italic text-light"></p>
      </div>
    </div>
  </div>
  <script type="text/javascript">
    function updateDateTime() {
      const now = new Date();
      const currentDateTime = now.toUTCString();
      document.getElementById('datetime').innerText = currentDateTime;
    }
    updateDateTime();
  </script>
</body>
</html>
```