### PR TITLE
[pivot] Fix pivot tables built upon Mongo native queries

### DIFF
--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -800,3 +800,33 @@
                 [nil 1 3]]
                (mt/rows
                 (qp.pivot/run-pivot-query query))))))))
+
+#_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+(deftest pivot-table-from-native-mongo-query-test
+  (testing "#64124"
+    (mt/test-drivers #{:mongo}
+      (mt/dataset test-data
+        (let [query {:database (mt/id)
+                     :type     :query
+                     :query    {:source-table "card__1"
+                                :aggregation  [[:count]]
+                                :breakout     [[:field "PRODUCT_ID" {:base-type :type/Integer}]
+                                               [:field "QUANTITY" {:base-type :type/Integer}]]}}
+              pivot-settings {:pivot_table.column_split {:rows    ["PRODUCT_ID"]
+                                                         :columns ["QUANTITY"]
+                                                         :values  ["count"]}}]
+          (mt/with-metadata-provider
+            (lib.tu/mock-metadata-provider
+             (mt/metadata-provider)
+             {:cards [{:id 1
+                       :dataset-query {:type     :native
+                                       :native   {:collection "orders"
+                                                  :query      "[{\"$project\": {\"_id\": 0, \"PRODUCT_ID\": 1, \"QUANTITY\": 1}}]"}
+                                       :database (mt/id)}
+                       :database-id (mt/id)
+                       :result-metadata [{:name "PRODUCT_ID" :base_type :type/Integer}
+                                         {:name "QUANTITY" :base_type :type/Integer}]}]})
+            (let [result (qp/process-query (assoc query :visualization_settings pivot-settings))]
+              (is (= (count (:cols (:data result)))
+                     (count (first (:rows (:data result)))))
+                  "Result must contain as many columns as there are items in each row."))))))))


### PR DESCRIPTION
This should address https://github.com/metabase/metabase/issues/64124.

The extended description of the problem is in that issue. Technically, the trouble happens because when the Annotate middleware enriches columns with base types, it assumes that the columns coming from `metadata` are the same as in the `:data` object. However, in this bug's scenario, the metadata contains fewer columns (for whatever reason, it's beyond my intelligence for now).

The proposed PR makes a careful effort to preserve all original columns and enrich them only when they match with metadata columns. What happens if we miss and don't enrich some – again, no idea, but it seems to fix the referenced issue.