### PR TITLE
Fix: cannot interact with DashCard actions panel while in edit mode

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.tsx
@@ -338,6 +338,7 @@ function DashCardActionsPanelInner({
       top={0}
       right="20px"
       data-testid="dashboardcard-actions-panel"
+      data-dontdrag // allows to interact with the actions panel while in the edit mode
       onMouseDown={onMouseDown}
     >
       <Box className={S.DashCardActionButtonsContainer} component="span">

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.tsx
@@ -234,6 +234,7 @@ export function GridLayout<T extends { id: number | null }>(
       onDragStop={enableTextSelection}
       onResizeStart={disableTextSelection}
       onResizeStop={enableTextSelection}
+      draggableCancel="[data-dontdrag]"
     >
       {children}
     </ReactGridLayout>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> 
closes #62225 https://linear.app/metabase/issue/UXW-559/buttons-for-editing-dashboard-cards-not-working-in-ios-on-wide-screens

### Description

Describe the overall approach and the problem being solved.

### How to verify

- Use iOS device or on iOS simulator
- Open any dashboard
- Go to edit mode
- Make sure you can both drag widgets around and interact with action buttons.

### Demo


https://github.com/user-attachments/assets/74d70011-e36b-42e8-b83b-566ea6d20cde


