### PR TITLE
Remove high cardinality run-id labels

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/instrumentation.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/instrumentation.clj
@@ -36,8 +36,7 @@
   (let [stage-type (label-to-stage stage-label)]
     (log/infof "Transform stage started: run-id=%d type=%s label=%s" job-run-id (name stage-type) (name stage-label))
     (prometheus/inc! :metabase-transforms/stage-started
-                     {:job-run-id (str job-run-id)
-                      :stage-type (name stage-type)
+                     {:stage-type (name stage-type)
                       :stage-label (name stage-label)})))
 
 (mu/defn record-stage-completion!
@@ -47,8 +46,7 @@
    duration-ms :- int?]
   (let [stage-type (label-to-stage stage-label)]
     (log/infof "Transform stage completed: run-id=%d type=%s label=%s duration=%dms" job-run-id (name stage-type) (name stage-label) duration-ms)
-    (let [labels {:job-run-id (str job-run-id)
-                  :stage-type (name stage-type)
+    (let [labels {:stage-type (name stage-type)
                   :stage-label (name stage-label)}]
       (prometheus/inc! :metabase-transforms/stage-completed labels)
       (prometheus/observe! :metabase-transforms/stage-duration-ms labels duration-ms))))
@@ -60,8 +58,7 @@
    duration-ms :- int?]
   (let [stage-type (label-to-stage stage-label)]
     (log/warnf "Transform stage failed: run-id=%d type=%s label=%s duration=%s" job-run-id (name stage-type) (name stage-label) (str duration-ms "ms"))
-    (let [labels {:job-run-id (str job-run-id)
-                  :stage-type (name stage-type)
+    (let [labels {:stage-type (name stage-type)
                   :stage-label (name stage-label)}]
       (prometheus/inc! :metabase-transforms/stage-failed labels)
       (when duration-ms
@@ -124,8 +121,7 @@
                (name stage-label)
                (if bytes (str " bytes=" bytes) "")
                (if rows (str " rows=" rows) "")))
-  (let [labels {:job-run-id (str job-run-id)
-                :stage-label (name stage-label)}]
+  (let [labels {:stage-label (name stage-label)}]
     (when bytes
       (prometheus/observe! :metabase-transforms/data-transfer-bytes labels bytes))
     (when rows
@@ -136,15 +132,13 @@
   [job-id run-method]
   (log/infof "Transform job started: job-id=%d run-method=%s" job-id (name run-method))
   (prometheus/inc! :metabase-transforms/job-runs-total
-                   {:job-id (str job-id)
-                    :run-method (name run-method)}))
+                   {:run-method (name run-method)}))
 
 (defn record-job-completion!
   "Record the successful completion of a transform job run."
   [job-id run-method duration-ms]
   (log/infof "Transform job completed: job-id=%d run-method=%s duration=%dms" job-id (name run-method) duration-ms)
-  (let [labels {:job-id (str job-id)
-                :run-method (name run-method)}]
+  (let [labels {:run-method (name run-method)}]
     (prometheus/inc! :metabase-transforms/job-runs-completed labels)
     (prometheus/observe! :metabase-transforms/job-run-duration-ms labels duration-ms)))
 
@@ -152,8 +146,7 @@
   "Record the failure of a transform job run."
   [job-id run-method duration-ms]
   (log/warnf "Transform job failed: job-id=%d run-method=%s duration=%dms" job-id (name run-method) duration-ms)
-  (let [labels {:job-id (str job-id)
-                :run-method (name run-method)}]
+  (let [labels {:run-method (name run-method)}]
     (prometheus/inc! :metabase-transforms/job-runs-failed labels)
     (prometheus/observe! :metabase-transforms/job-run-duration-ms labels duration-ms)))
 
@@ -177,10 +170,8 @@
    duration-ms :- int?
    status :- [:enum :success :error :timeout]]
   (log/infof "Python API call %s: run-id=%d duration=%dms" (name status) job-run-id duration-ms)
-  (let [labels {:job-run-id (str job-run-id)}]
-    (prometheus/inc! :metabase-transforms/python-api-calls-total
-                     (assoc labels :status (name status)))
-    (prometheus/observe! :metabase-transforms/python-api-call-duration-ms labels duration-ms)))
+  (prometheus/inc! :metabase-transforms/python-api-calls-total {:status (name status)})
+  (prometheus/observe! :metabase-transforms/python-api-call-duration-ms {} duration-ms))
 
 (defmacro with-python-api-timing
   "Execute body while timing a Python API call."

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -406,51 +406,51 @@
    ;; transform metrics
    (prometheus/counter :metabase-transforms/job-runs-total
                        {:description "Total number of transform job runs started."
-                        :labels [:job-id :run-method]})
+                        :labels [:run-method]})
    (prometheus/counter :metabase-transforms/job-runs-completed
                        {:description "Number of transform job runs that completed successfully."
-                        :labels [:job-id :run-method]})
+                        :labels [:run-method]})
    (prometheus/counter :metabase-transforms/job-runs-failed
                        {:description "Number of transform job runs that failed."
-                        :labels [:job-id :run-method]})
+                        :labels [:run-method]})
    (prometheus/histogram :metabase-transforms/job-run-duration-ms
                          {:description "Duration in milliseconds of transform job runs."
-                          :labels [:job-id :run-method]
+                          :labels [:run-method]
                           ;; 100ms -> 6 hours
                           :buckets [100 500 1000 5000 10000 30000 60000 300000 1800000 7200000 14400000 21600000]})
    (prometheus/counter :metabase-transforms/stage-started
                        {:description "Number of transform stages started."
-                        :labels [:job-run-id :stage-type :stage-label]})
+                        :labels [:stage-type :stage-label]})
    (prometheus/counter :metabase-transforms/stage-completed
                        {:description "Number of transform stages completed successfully."
-                        :labels [:job-run-id :stage-type :stage-label]})
+                        :labels [:stage-type :stage-label]})
    (prometheus/counter :metabase-transforms/stage-failed
                        {:description "Number of transform stages that failed."
-                        :labels [:job-run-id :stage-type :stage-label]})
+                        :labels [:stage-type :stage-label]})
    (prometheus/histogram :metabase-transforms/stage-duration-ms
                          {:description "Duration in milliseconds of individual transform stages."
-                          :labels [:job-run-id :stage-type :stage-label]
+                          :labels [:stage-type :stage-label]
                           ;; 10ms -> 10 minutes
                           :buckets [10 100 500 1000 5000 10000 30000 60000 300000 600000]})
    (prometheus/histogram :metabase-transforms/data-transfer-bytes
                          {:description "Size in bytes of data transferred during transform stages."
-                          :labels [:job-run-id :stage-label]
+                          :labels [:stage-label]
                           ;; 1KB -> 10GB
                           :buckets [1000 10000 100000 1000000 10000000 100000000 1000000000 10000000000]})
    (prometheus/histogram :metabase-transforms/data-transfer-rows
                          {:description "Number of rows transferred during transform stages."
-                          :labels [:job-run-id :stage-label]
+                          :labels [:stage-label]
                           ;; 10 -> 10M rows
                           :buckets [10 100 1000 10000 100000 1000000 10000000]})
    ;; Python-transform specific metrics
    (prometheus/histogram :metabase-transforms/python-api-call-duration-ms
                          {:description "Duration of Python runner API calls."
-                          :labels [:job-run-id]
+                          :labels []
                           ;; 100ms -> 6 hours
                           :buckets [100 500 1000 5000 10000 30000 60000 300000 1800000 7200000 14400000 21600000]})
    (prometheus/counter :metabase-transforms/python-api-calls-total
                        {:description "Total number of Python runner API calls."
-                        :labels [:job-run-id :status]})])
+                        :labels [:status]})])
 
 (defn- quartz-collectors
   []


### PR DESCRIPTION
We expect to see many unique run ids, this is not a good fit for a label which should have a low cardinality. We do not want to cause memory/performance issues for prometheus.
