### PR TITLE
Add "Local symbol" option in "Currency label style" visualization setting

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -507,6 +507,17 @@ describe("scenarios > visualizations > table", () => {
     H.popover().findByText("In every table cell").click();
     H.tableHeaderColumn("Discount").should("be.visible");
     H.tableInteractive().findByText("$6.42").should("be.visible");
+
+    cy.log(
+      "should still show the option if it's already selected but currency does not support it",
+    );
+    cy.findByLabelText("Unit of currency").click();
+    cy.findByRole("option", { name: "US Dollar" }).click();
+    H.popover().findByText("Local symbol ($)").should("be.visible");
+
+    cy.log("but should hide it once a valid option is selected");
+    H.popover().findByText("Symbol ($)").click();
+    H.popover().findByText("Local symbol ($)").should("not.exist");
   });
 });
 

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -489,6 +489,25 @@ describe("scenarios > visualizations > table", () => {
     cy.tick(5000);
     cy.findByTestId("query-builder-main").findByText("Waiting for results...");
   });
+
+  it("should support 'Local symbol' in 'Currency label style' viz setting", () => {
+    H.openOrdersTable();
+
+    H.tableHeaderClick("Discount ($)");
+    H.popover().icon("gear").click();
+    cy.findByLabelText("Unit of currency").click();
+    cy.findByRole("option", { name: "New Zealand Dollar" }).click();
+    H.tableHeaderColumn("Discount (NZ$)").should("be.visible");
+    H.tableInteractive().findByText("6.42").should("be.visible");
+
+    H.popover().findByText("Local symbol ($)").should("be.visible").click();
+    H.tableHeaderColumn("Discount ($)").should("be.visible");
+    H.tableInteractive().findByText("6.42").should("be.visible");
+
+    H.popover().findByText("In every table cell").click();
+    H.tableHeaderColumn("Discount").should("be.visible");
+    H.tableInteractive().findByText("$6.42").should("be.visible");
+  });
 });
 
 describe("scenarios > visualizations > table > dashboards context", () => {

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import type { CurrencyStyle } from "metabase/lib/formatting";
 import type { SdkIframeEmbedSetupSettings } from "metabase-enterprise/embedding_iframe_sdk_setup/types";
 
 import type { InputSettingType } from "./actions";
@@ -27,7 +28,7 @@ export interface NumberFormattingSettings {
 
 export interface CurrencyFormattingSettings {
   currency?: string;
-  currency_style?: string;
+  currency_style?: CurrencyStyle;
   currency_in_header?: boolean;
 }
 

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.tsx
@@ -5,6 +5,7 @@ import _ from "underscore";
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { useAdminSetting } from "metabase/api/utils";
 import {
+  type CurrencyStyle,
   getCurrencyOptions,
   getCurrencyStyleOptions,
   getDateStyleOptionsForUnit,
@@ -63,10 +64,12 @@ export function FormattingWidget() {
     const currencyOptions = (
       getCurrencyOptions() as { name: string; value: string }[]
     ).map(mapNameToLabel);
-    const currencyStyleOptions =
-      getCurrencyStyleOptions(currency).map(mapNameToLabel);
+    const currencyStyleOptions = getCurrencyStyleOptions(
+      currency,
+      currencyStyle,
+    ).map(mapNameToLabel);
     return [currencyOptions, currencyStyleOptions];
-  }, [currency]);
+  }, [currency, currencyStyle]);
 
   if (isLoading) {
     return null;
@@ -199,7 +202,7 @@ export function FormattingWidget() {
                   ...localValue,
                   "type/Currency": {
                     ...localValue?.["type/Currency"],
-                    currency_style: newValue as string,
+                    currency_style: newValue as CurrencyStyle,
                   },
                 })
               }

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
@@ -96,6 +96,10 @@ describe("FormattingWidget", () => {
     // eslint-disable-next-line jest-dom/prefer-to-have-value
     expect(nameRadio).toHaveAttribute("value", "name");
     expect(nameRadio).not.toBeChecked();
+
+    expect(
+      within(currencyStyleWidget).queryByLabelText(/Local symbol/),
+    ).not.toBeInTheDocument();
   });
 
   it("should update multiple settings", async () => {

--- a/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/FormattingWidget.unit.spec.tsx
@@ -81,9 +81,9 @@ describe("FormattingWidget", () => {
     const dateAbbreviateToggle = await screen.findByRole("switch");
     expect(dateAbbreviateToggle).not.toBeChecked();
 
-    const symbolRadio = within(currencyStyleWidget).getByLabelText(/symbol/i);
-    const codeRadio = within(currencyStyleWidget).getByLabelText(/code/i);
-    const nameRadio = within(currencyStyleWidget).getByLabelText(/name/i);
+    const symbolRadio = within(currencyStyleWidget).getByLabelText(/Symbol/);
+    const codeRadio = within(currencyStyleWidget).getByLabelText(/Code/);
+    const nameRadio = within(currencyStyleWidget).getByLabelText(/Name/);
 
     // eslint-disable-next-line jest-dom/prefer-to-have-value
     expect(symbolRadio).toHaveAttribute("value", "symbol");

--- a/frontend/src/metabase/lib/formatting/currency.ts
+++ b/frontend/src/metabase/lib/formatting/currency.ts
@@ -29,14 +29,20 @@ export interface CompactCurrencyOptions {
   currency_style: CurrencyStyle;
 }
 
-let currencyMapCache: Record<string, CurrencyInfo>;
+const getCurrencyMapCache = (() => {
+  let currencyMapCache: Record<string, CurrencyInfo>;
+
+  return () => {
+    if (!currencyMapCache) {
+      currencyMapCache = Object.fromEntries(currency);
+    }
+
+    return currencyMapCache;
+  };
+})();
 
 export function getCurrencySymbol(currencyCode: string): string {
-  if (!currencyMapCache) {
-    // only turn the array into a map if we call this function
-    currencyMapCache = Object.fromEntries(currency);
-  }
-  return currencyMapCache[currencyCode]?.symbol || currencyCode || "$";
+  return getCurrencyMapCache()[currencyCode]?.symbol || currencyCode || "$";
 }
 
 export const COMPACT_CURRENCY_OPTIONS: CompactCurrencyOptions = {

--- a/frontend/src/metabase/lib/formatting/currency.ts
+++ b/frontend/src/metabase/lib/formatting/currency.ts
@@ -45,6 +45,12 @@ export function getCurrencySymbol(currencyCode: string): string {
   return getCurrencyMapCache()[currencyCode]?.symbol || currencyCode || "$";
 }
 
+export function getCurrencySymbolNative(currencyCode: string): string {
+  return (
+    getCurrencyMapCache()[currencyCode]?.symbol_native || currencyCode || "$"
+  );
+}
+
 export const COMPACT_CURRENCY_OPTIONS: CompactCurrencyOptions = {
   // Currencies vary in how many decimals they display, so this is probably
   // wrong in some cases. Intl.NumberFormat has some of that data built-in, but

--- a/frontend/src/metabase/lib/formatting/currency.ts
+++ b/frontend/src/metabase/lib/formatting/currency.ts
@@ -61,13 +61,14 @@ export const COMPACT_CURRENCY_OPTIONS: CompactCurrencyOptions = {
 
 export function getCurrencyStyleOptions(
   currency = "USD",
+  value?: CurrencyStyle,
 ): CurrencyStyleOption[] {
   const symbol = getCurrencySymbol(currency);
   const narrowSymbol = getCurrencyNarrowSymbol(currency);
   const code = getCurrency(currency, "code");
   const name = getCurrency(currency, "name");
   return [
-    ...(symbol !== code
+    ...(symbol !== code || value === "symbol"
       ? [
           {
             name: t`Symbol` + ` ` + `(${symbol})`,
@@ -75,7 +76,8 @@ export function getCurrencyStyleOptions(
           },
         ]
       : []),
-    ...(narrowSymbol !== code && narrowSymbol !== symbol
+    ...((narrowSymbol !== code && narrowSymbol !== symbol) ||
+    value === "narrowSymbol"
       ? [
           {
             name: t`Local symbol` + ` ` + `(${narrowSymbol})`,

--- a/frontend/src/metabase/lib/formatting/currency.ts
+++ b/frontend/src/metabase/lib/formatting/currency.ts
@@ -17,7 +17,7 @@ export interface CurrencyOption {
   value: string;
 }
 
-export type CurrencyStyle = "symbol" | "code" | "name";
+export type CurrencyStyle = Intl.NumberFormatOptionsCurrencyDisplay;
 
 export interface CurrencyStyleOption {
   name: string;
@@ -45,7 +45,7 @@ export function getCurrencySymbol(currencyCode: string): string {
   return getCurrencyMapCache()[currencyCode]?.symbol || currencyCode || "$";
 }
 
-export function getCurrencySymbolNative(currencyCode: string): string {
+export function getCurrencyNarrowSymbol(currencyCode: string): string {
   return (
     getCurrencyMapCache()[currencyCode]?.symbol_native || currencyCode || "$"
   );
@@ -63,6 +63,7 @@ export function getCurrencyStyleOptions(
   currency = "USD",
 ): CurrencyStyleOption[] {
   const symbol = getCurrencySymbol(currency);
+  const narrowSymbol = getCurrencyNarrowSymbol(currency);
   const code = getCurrency(currency, "code");
   const name = getCurrency(currency, "name");
   return [
@@ -81,6 +82,10 @@ export function getCurrencyStyleOptions(
     {
       name: t`Name` + ` ` + `(${name})`,
       value: "name" as const,
+    },
+    {
+      name: t`Local symbol` + ` ` + `(${narrowSymbol})`,
+      value: "narrowSymbol" as const,
     },
   ];
 }

--- a/frontend/src/metabase/lib/formatting/currency.ts
+++ b/frontend/src/metabase/lib/formatting/currency.ts
@@ -75,6 +75,14 @@ export function getCurrencyStyleOptions(
           },
         ]
       : []),
+    ...(narrowSymbol !== code && narrowSymbol !== symbol
+      ? [
+          {
+            name: t`Local symbol` + ` ` + `(${narrowSymbol})`,
+            value: "narrowSymbol" as const,
+          },
+        ]
+      : []),
     {
       name: t`Code` + ` ` + `(${code})`,
       value: "code" as const,
@@ -82,10 +90,6 @@ export function getCurrencyStyleOptions(
     {
       name: t`Name` + ` ` + `(${name})`,
       value: "name" as const,
-    },
-    {
-      name: t`Local symbol` + ` ` + `(${narrowSymbol})`,
-      value: "narrowSymbol" as const,
     },
   ];
 }

--- a/frontend/src/metabase/lib/formatting/currency.unit.spec.ts
+++ b/frontend/src/metabase/lib/formatting/currency.unit.spec.ts
@@ -14,6 +14,7 @@ describe("getCurrencyStyleOptions", () => {
     const options = getCurrencyStyleOptions("NZD");
     expect(options).toEqual([
       { name: "Symbol (NZ$)", value: "symbol" },
+      { name: "Local symbol ($)", value: "narrowSymbol" },
       { name: "Code (NZD)", value: "code" },
       { name: "Name (New Zealand dollars)", value: "name" },
     ]);

--- a/frontend/src/metabase/lib/formatting/currency.unit.spec.ts
+++ b/frontend/src/metabase/lib/formatting/currency.unit.spec.ts
@@ -27,4 +27,14 @@ describe("getCurrencyStyleOptions", () => {
       { name: "Name (PKMN)", value: "name" },
     ]);
   });
+
+  it("should include current value even if it would normally be hidden", () => {
+    const options = getCurrencyStyleOptions("USD", "narrowSymbol");
+    expect(options).toEqual([
+      { name: "Symbol ($)", value: "symbol" },
+      { name: "Local symbol ($)", value: "narrowSymbol" },
+      { name: "Code (USD)", value: "code" },
+      { name: "Name (US dollars)", value: "name" },
+    ]);
+  });
 });

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -284,7 +284,10 @@ export const NUMBER_COLUMN_SETTINGS = {
     widget: "radio",
     getProps: (column, settings) => {
       return {
-        options: getCurrencyStyleOptions(settings["currency"] || "USD"),
+        options: getCurrencyStyleOptions(
+          settings["currency"] || "USD",
+          settings["currency_style"],
+        ),
       };
     },
     getDefault: getDefaultCurrencyStyle,

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -5,6 +5,7 @@ import { currency } from "cljs/metabase.util.currency";
 import {
   displayNameForColumn,
   getCurrency,
+  getCurrencyNarrowSymbol,
   getCurrencyStyleOptions,
   getCurrencySymbol,
   getDateFormatFromStyle,
@@ -395,6 +396,9 @@ export const NUMBER_COLUMN_SETTINGS = {
       ) {
         if (settings["currency_style"] === "symbol") {
           return getCurrencySymbol(settings["currency"]);
+        }
+        if (settings["currency_style"] === "narrowSymbol") {
+          return getCurrencyNarrowSymbol(settings["currency"]);
         }
         return getCurrency(settings["currency"], settings["currency_style"]);
       }


### PR DESCRIPTION
Closes #23786

### Description

Previous PR: #24253

### How to verify

1. Admin > Table Metadata > Sample Database > Orders > Tax
2. Change semantic type to "Currency"
3. Choose "New Zealand Dollar" as unit of currency
4. Change currency label style to "Local symbol ($)"
5. Open preview

Table header should have $ symbol.

6. Change "Where to display the unit of currency" to "In every table cell"

Every table cell should have $ symbol.

### Demo

https://github.com/user-attachments/assets/5f968fea-6b9b-41ad-85cf-3cb0c2d5d976
