### PR TITLE
Closes EMB-612 no more source map for SDK in prod

### DIFF
--- a/rspack.embedding-sdk-bundle.config.js
+++ b/rspack.embedding-sdk-bundle.config.js
@@ -130,12 +130,15 @@ const config = {
         ],
       },
 
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: ["source-map-loader"],
-      },
+      // Only include source-map-loader in development mode to avoid warnings in production builds
+      ...(IS_DEV_MODE
+        ? {
+            test: /\.js$/,
+            exclude: /node_modules/,
+            enforce: "pre",
+            use: ["source-map-loader"],
+          }
+        : undefined),
 
       {
         test: /\.svg/,

--- a/rspack.embedding-sdk-cli.config.js
+++ b/rspack.embedding-sdk-cli.config.js
@@ -27,6 +27,7 @@ const config = {
   entry: `${SDK_CLI_PATH}/cli.ts`,
   target: "node",
   context: SDK_CLI_PATH,
+  devtool: false,
   output: {
     path: SDK_CLI_DIST_PATH,
     filename: "cli.js",


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #60960
Closes [EMB-612: \[SDK\] Disable source maps for production SDK builds](https://linear.app/metabase/issue/EMB-612/sdk-disable-source-maps-for-production-sdk-builds)

### Description

Disables source map for both bundle (conditionnally based on dev mode or not) and the CLI.