### PR TITLE
Make db removal somewhat more efficient

### DIFF
--- a/dev/src/dev/toucan2_monitor.clj
+++ b/dev/src/dev/toucan2_monitor.clj
@@ -57,7 +57,7 @@
                      (stacktrace/print-stack-trace (Exception. "tracker")))
                    str/split-lines)]
     (some-> (u/seek #(and (re-find #"^\s*metabase\." %)
-                          (not (re-find #"^\s*metabase\.db" %))) trace)
+                          (not (re-find #"^\s*metabase\.(db|app_db\.connection)" %))) trace)
             str/trim)))
 
 (defn- track-query-execution-fn

--- a/src/metabase/warehouses/api.clj
+++ b/src/metabase/warehouses/api.clj
@@ -1010,12 +1010,13 @@
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
   (api/check-superuser)
-  (api/let-404 [db (t2/select-one :model/Database :id id)]
-    (api/check-403 (mi/can-write? db))
-    (t2/delete! :model/Database :router_database_id id)
-    (database-routing/delete-associated-database-router! id)
-    (t2/delete! :model/Database :id id)
-    (events/publish-event! :event/database-delete {:object db :user-id api/*current-user-id*}))
+  (t2/with-transaction [_conn]
+    (api/let-404 [db (t2/select-one :model/Database :id id)]
+      (api/check-403 (mi/can-write? db))
+      (t2/delete! :model/Database :router_database_id id)
+      (database-routing/delete-associated-database-router! id)
+      (t2/delete! :model/Database :id id)
+      (events/publish-event! :event/database-delete {:object db :user-id api/*current-user-id*})))
   api/generic-204-no-content)
 
 ;;; ------------------------------------------ POST /api/database/:id/sync_schema -------------------------------------------

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -306,39 +306,54 @@
       normalize-details)))
 
 (mu/defn- delete-database-fields!
-  "We need to use toucan to delete the fields instead of cascading deletes because MySQL doesn't support columns with
-  cascade delete foreign key constraints in generated columns. #44866
-
-  Use a join to do this so we don't end up with a mega query with > 64k parameters (#58491)
-
-  TODO -- this is an absolutely horrible way to deal with deleting Fields belonging to a Database, there can be
-  literally hundreds of thousands of fields and we do an individual follow-on DELETE in :model/Field before-delete for
-  each one. I really think we should have kept the FK as an ON DELETE CASCADE. -- Cam"
   [database-id :- ::lib.schema.id/database]
   {:pre [(pos-int? database-id)]}
-  (t2/delete! :model/Field (case (mdb/db-type)
-                             (:postgres :h2)
-                             {:where  [:in :id {:select    [[:field.id :id]]
-                                                :from      [[(t2/table-name :model/Field) :field]]
-                                                :left-join [[(t2/table-name :model/Table) :table]
-                                                            [:= :field.table_id :table.id]]
-                                                :where     [:= :table.db_id [:inline database-id]]}]}
-
-                             :mysql
-                             {:delete    [:field]
-                              :from      [[(t2/table-name :model/Field) :field]]
-                              :left-join [[(t2/table-name :model/Table) :table]
-                                          [:= :field.table_id :table.id]]
-                              :where     [:= :table.db_id [:inline database-id]]})))
+  ;; Field has `define-before-delete` deleting children, but we'll delete them all at once because they refer same
+  ;; database - iteratively, deleting those that no one depends on first
+  (loop []
+    (let [deleted (t2/query-one
+                   {:delete-from (t2/table-name :model/Field)
+                    :where
+                    [:and
+                     [:in :table_id {:from   [(t2/table-name :model/Table)]
+                                     :select [:id]
+                                     :where  [:= :db_id database-id]}]
+                     ;; Double-wrapped subquery to work around MySQL limitation
+                     [:not-in :id {:select [:parent_id]
+                                   :from   [[{:select [:parent_id]
+                                              :from   [(t2/table-name :model/Field)]
+                                              :where  [:and
+                                                       [:not= :parent_id nil]
+                                                       [:in :table_id {:from   [(t2/table-name :model/Table)]
+                                                                       :select [:id]
+                                                                       :where  [:= :db_id database-id]}]]}
+                                             :parent_fields]]}]]})]
+      (when (pos? deleted)
+        (recur)))))
 
 (t2/define-before-delete :model/Database
   [{id :id, driver :engine, :as database}]
   (unschedule-tasks! database)
   (secret/delete-orphaned-secrets! database)
   (delete-database-fields! id)
-  ;; This is a temporary hack to hide these cards from most searches.
-  ;; Once search supports deletion, we should revisit this.
-  (t2/update! :model/Card :database_id id {:archived true})
+  (->> (eduction
+        (map t2.realize/realize)
+        (partition-all 1000)
+        ;; mysql and h2 both do not support `returning`, so we do the correct thing for postgres and
+        ;; then some sad version for those two
+        (t2/reducible-query (if (= :postgres (mdb/db-type))
+                              {:delete-from (t2/table-name :model/Card)
+                               :where       [:= :database_id id]
+                               :returning   [:id]}
+                              {:from   [(t2/table-name :model/Card)]
+                               :select [:id]
+                               :where  [:= :database_id id]})))
+       (run! (fn [batch]
+               ;; damn circular deps
+               ((requiring-resolve 'metabase.search.core/delete!) :model/Card (map (comp str :id) batch)))))
+  (when (not= :postgres (mdb/db-type))
+    (t2/query {:delete-from (t2/table-name :model/Card)
+               :where       [:= :database_id id]}))
   (try
     (driver/notify-database-updated driver database)
     (catch Throwable e

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -1875,5 +1875,6 @@
           (t2/delete! :model/Database :id db-id)
           (is (not (t2/exists? :model/Card :id card-id)))
           (let [search-results (mt/user-http-request :crowberto :get 200 "search" :q card-name)]
-            (is (not (some #(= (:id %) card-id) (:data search-results)))
+            (is (not (some #{card-id}
+                           (mapv :id (:data search-results))))
                 "Card should not be found in search results after database deletion")))))))


### PR DESCRIPTION
Tries to not load data in memory if possible:

- fields were being deleted one-by-one to execute `define-before-delete` in `field.clj`; but we're removing all fields for the db, so we can just just remove everything that exists.
- cards were deleted one-by-one to cause reindexing, but we can just grab their ids and delete them from the search index.

fixes #52729