### PR TITLE
Avoid use of analytics content for suggested prompts

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1855,6 +1855,7 @@
            metabase-enterprise.metabot-v3.tools.api}
    :uses #{api
            app-db
+           audit-app
            collections
            config
            driver

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.api.common :as api]
+   [metabase.audit-app.core :as audit-app]
    [metabase.collections.models.collection :as collection]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
@@ -153,6 +154,7 @@
         base-query {:select [:report_card.*]
                     :from   [[:report_card]]
                     :where [:and
+                            [:!= :report_card.database_id audit-app/audit-db-id]
                             collection-filter
                             [:in :type [:inline ["metric" "model"]]]
                             [:= :archived false]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -141,7 +141,9 @@
 
   Takes a metabot-id and returns all metric and model cards in that metabot's collection
   and its subcollections. If the metabot has use_verified_content enabled, only verified
-  content is returned."
+  content is returned.
+
+  Ignores analytics content."
   [metabot-id & {:keys [limit] :as _opts}]
   (let [metabot (t2/select-one :model/Metabot :id metabot-id)
         metabot-collection-id (:collection_id metabot)


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-461/suggested-prompts-should-not-contain-analytics-content
