### PR TITLE
Consistently use lib utility functions to check for native stages

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -739,7 +739,7 @@
                              (select-keys query [:info]))
           parameters  (:parameters base)
           inner-query (chain-stages base)
-          query-type  (if (-> query :stages last :lib/type (= :mbql.stage/native))
+          query-type  (if (-> query :stages last lib.util/native-stage?)
                         :native
                         :query)]
       (merge (dissoc base :stages :parameters :lib.convert/converted?)

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -402,6 +402,7 @@
   can-run
   can-save
   check-card-overwrite
+  native?
   preview-query
   query
   query-from-legacy-inner-query

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -460,6 +460,7 @@
   query-stage
   source-table-id
   source-card-id
+  stage-type
   update-query-stage]
  [lib.validate
   find-bad-refs]

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -839,7 +839,7 @@
      (when (pos? database-id)
        [{:type :database, :id database-id}
         {:type :schema, :id database-id}])
-     (when (= (:lib/type base-stage) :mbql.stage/native)
+     (when (lib.util/native-stage? base-stage)
        (concat
         ;; Extract field dependencies from dimension template tags
         (for [{tag-type :type, [dim-tag _opts id] :dimension} (vals (:template-tags base-stage))

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -553,7 +553,7 @@
     (m/find-first #(= (:name %) id-or-name)
                   (lib.metadata.calculation/returned-columns query (lib.metadata/table query source-table-id)))
 
-    (= (:lib/type stage) :mbql.stage/native)
+    (lib.util/native-stage? stage)
     (when-some [col (resolve-in-current-stage-metadata query stage-number id-or-name)]
       (-> col
           (assoc :lib/source :source/native)

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -190,7 +190,7 @@
                   (or (and source-table (table query source-table))
                       (and source-card  (card  query source-card))
                       (and
-                       (= (:lib/type stage0) :mbql.stage/native)
+                       (lib.util/native-stage? stage0)
                        ;; Couldn't import and use `lib.native/has-write-permissions` here due to a circular dependency
                        ;; TODO Find a way to unify has-write-permissions and this function?
                        (= :write (:native-permissions (database query)))))

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -297,7 +297,7 @@
   "Name you might want to use for a query when saving an previously-unsaved query. This is the same
   as [[describe-query]] except for native queries, where we don't describe anything."
   [query]
-  (when-not (lib.util/native-stage? (lib.util/query-stage query -1))
+  (when-not (lib.util/native-stage? query -1)
     (try
       (describe-query query)
       (catch #?(:clj Throwable :cljs js/Error) e

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -297,7 +297,7 @@
   "Name you might want to use for a query when saving an previously-unsaved query. This is the same
   as [[describe-query]] except for native queries, where we don't describe anything."
   [query]
-  (when-not (= (:lib/type (lib.util/query-stage query -1)) :mbql.stage/native)
+  (when-not (lib.util/native-stage? (lib.util/query-stage query -1))
     (try
       (describe-query query)
       (catch #?(:clj Throwable :cljs js/Error) e

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -49,8 +49,7 @@
 (mu/defn native? :- :boolean
   "Given a query, return whether it is a native query."
   [query :- ::lib.schema/query]
-  (let [stage (lib.util/query-stage query 0)]
-    (= (:lib/type stage) :mbql.stage/native)))
+  (lib.util/native-stage? query 0))
 
 (defmethod lib.metadata.calculation/display-info-method :mbql/query
   [_query _stage-number query]
@@ -464,7 +463,7 @@
       (mapcat stage-seq* query-fragment))
 
     (map? query-fragment)
-    (if (= (:lib/type query-fragment) :mbql.stage/native)
+    (if (lib.util/native-stage? query-fragment)
       (-> query-fragment :template-tags template-tag-stages)
       (concat (:stages query-fragment) (mapcat stage-seq* (vals query-fragment))))
 

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -50,11 +50,11 @@
   probably wrong; we can recalculate the correct metadata anyway."
   [query        :- ::lib.schema/query
    stage-number :- :int]
-  (let [{stage-type :lib/type, :keys [source-card] :as stage} (lib.util/query-stage query stage-number)]
+  (let [{:keys [source-card] :as stage} (lib.util/query-stage query stage-number)]
     (when-let [metadata (:lib/stage-metadata stage)]
       (when (or (lib.util/native-stage? stage)
                 source-card)
-        (let [source-type (case stage-type
+        (let [source-type (case (lib.util/stage-type stage)
                             :mbql.stage/native :source/native
                             :mbql.stage/mbql   :source/card)]
           (not-empty

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -52,7 +52,7 @@
    stage-number :- :int]
   (let [{stage-type :lib/type, :keys [source-card] :as stage} (lib.util/query-stage query stage-number)]
     (when-let [metadata (:lib/stage-metadata stage)]
-      (when (or (= stage-type :mbql.stage/native)
+      (when (or (lib.util/native-stage? stage)
                 source-card)
         (let [source-type (case stage-type
                             :mbql.stage/native :source/native

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -495,16 +495,6 @@
   [query]
   (-> query :stages first :source-card))
 
-(mu/defn first-stage-type :- [:maybe [:enum :mbql.stage/mbql :mbql.stage/native]]
-  "Type of the first query stage."
-  [query :- :map]
-  (:lib/type (query-stage query 0)))
-
-(mu/defn first-stage-is-native? :- :boolean
-  "Whether the first stage of the query is a native query stage."
-  [query :- :map]
-  (= (first-stage-type query) :mbql.stage/native))
-
 (mu/defn- unique-alias :- :string
   [original :- :string
    suffix   :- :string]

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -389,17 +389,25 @@
     (not (last-stage? query stage-number))
     (update :stages #(take (inc (canonical-stage-index query stage-number)) %))))
 
+(mu/defn stage-type :- ::lib.schema/stage.type
+  "Returns the type of a query stage."
+  ([stage        :- ::lib.schema/stage]
+   (:lib/type stage))
+  ([query        :- ::lib.schema/query
+    stage-number :- int]
+   (stage-type (query-stage query stage-number))))
+
 (defn native-stage?
   "Is this query stage a native stage?"
   ([stage]
-   (= (:lib/type stage) :mbql.stage/native))
+   (= (stage-type stage) :mbql.stage/native))
   ([query stage-number]
    (native-stage? (query-stage query stage-number))))
 
 (defn mbql-stage?
   "Is this query stage an MBQL stage?"
   ([stage]
-   (= (:lib/type stage) :mbql.stage/mbql))
+   (= (stage-type stage) :mbql.stage/mbql))
   ([query stage-number]
    (mbql-stage? (query-stage query stage-number))))
 

--- a/src/metabase/lib/walk/util.cljc
+++ b/src/metabase/lib/walk/util.cljc
@@ -4,6 +4,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
+   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.util.malli :as mu]))
@@ -41,8 +42,7 @@
   "Return a combined template tags map for all native stages of a `query`."
   [query :- ::lib.schema/query]
   (transduce-stages
-   (comp (filter (fn [stage]
-                   (= (:lib/type stage) :mbql.stage/native)))
+   (comp (filter lib.util/native-stage?)
          (mapcat :template-tags))
    (fn rf
      ([m]
@@ -77,7 +77,7 @@
      query
      (fn [_query _path stage]
        (when (and (not @has-native-stage?)
-                  (= (:lib/type stage) :mbql.stage/native))
+                  (lib.util/native-stage? stage))
          (vreset! has-native-stage? true))
        nil))
     @has-native-stage?))

--- a/src/metabase/queries/models/query.clj
+++ b/src/metabase/queries/models/query.clj
@@ -180,5 +180,5 @@
     :query      false
     :native     true
     :mbql/query (let [query (mi/maybe-normalize-query :out query)]
-                  (lib.util/first-stage-is-native? query))
+                  (lib/native? query))
     false))

--- a/src/metabase/query_processor/compile.clj
+++ b/src/metabase/query_processor/compile.clj
@@ -43,7 +43,7 @@
   stages can only be the first stage, so if the last stage is native it means we have only one stage and this query is
   native-only."
   [query]
-  (= (:lib/type (lib/query-stage query -1)) :mbql.stage/native))
+  (lib/native-stage? query -1))
 
 (mu/defn- compile* :- ::compiled
   [query :- ::lib.schema/query]

--- a/src/metabase/query_processor/middleware/add_remaps.clj
+++ b/src/metabase/query_processor/middleware/add_remaps.clj
@@ -343,7 +343,7 @@
   [{{:keys [disable-remaps?]} :middleware, :as query} :- ::lib.schema/query]
   (if (or disable-remaps?
           ;; last stage (only stage) is native
-          (= (:lib/type (lib/query-stage query -1)) :mbql.stage/native))
+          (lib/native-stage? query -1))
     query
     (let [{:keys [remaps query]} (add-fk-remaps query)]
       (cond-> query

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -119,7 +119,7 @@
 (mu/defn- needs-type-inference?
   [query                                       :- ::lib.schema/query
    {initial-cols :cols, :as _initial-metadata} :- ::metadata]
-  (and (= (:lib/type (lib/query-stage query 0)) :mbql.stage/native)
+  (and (lib/native? query)
        (or (empty? initial-cols)
            (every? (fn [col]
                      (let [base-type ((some-fn :base-type :base_type) col)]

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -5,6 +5,7 @@
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.card :as lib.card]
+   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.query :as lib.query]
    [metabase.lib.schema :as lib.schema]
@@ -32,7 +33,7 @@
   [[first-stage & more]]
   (let [first-stage (cond-> first-stage
                       (and (= driver/*driver* :mongo)
-                           (= (:lib/type first-stage) :mbql.stage/native))
+                           (lib/native-stage? first-stage))
                       (update :native (fn [x]
                                         (if (map? x)
                                           x

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -355,9 +355,8 @@
       idx
       (let [new-stages (update-metric-transition-stages query path expanded-stages idx metric-metadata)]
         (recur (assoc-in query (conj path :stages) new-stages) path new-stages))
-
-      (or (= (:lib/type first-stage) :mbql.stage/mbql)
-          (and (= (:lib/type first-stage) :mbql.stage/native)
+      (or (lib/mbql-stage? first-stage)
+          (and (lib/native-stage? first-stage)
                (:qp/stage-is-from-source-card first-stage)))
       (splice-compatible-metrics query path expanded-stages)
 

--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -23,10 +23,10 @@
    stage :- ::lib.schema/stage]
   (if-not ((some-fn :parameters :template-tags) stage)
     stage
-    (let [f        (cond
-                     (lib/mbql-stage? stage)   qp.mbql/expand
-                     (lib/native-stage? stage) (fn [query _path stage]
-                                                 (qp.native/expand-stage query stage)))
+    (let [f        (case (lib/stage-type stage)
+                     :mbql.stage/mbql   qp.mbql/expand
+                     :mbql.stage/native (fn [query _path stage]
+                                          (qp.native/expand-stage query stage)))
           expanded (f query path stage)]
       (dissoc expanded :parameters :template-tags))))
 

--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -23,10 +23,10 @@
    stage :- ::lib.schema/stage]
   (if-not ((some-fn :parameters :template-tags) stage)
     stage
-    (let [f        (case (:lib/type stage)
-                     :mbql.stage/mbql   qp.mbql/expand
-                     :mbql.stage/native (fn [query _path stage]
-                                          (qp.native/expand-stage query stage)))
+    (let [f        (cond
+                     (lib/mbql-stage? stage)   qp.mbql/expand
+                     (lib/native-stage? stage) (fn [query _path stage]
+                                                 (qp.native/expand-stage query stage)))
           expanded (f query path stage)]
       (dissoc expanded :parameters :template-tags))))
 

--- a/src/metabase/query_processor/util/add_alias_info.clj
+++ b/src/metabase/query_processor/util/add_alias_info.clj
@@ -161,21 +161,22 @@
   earlier."
   [query stage-path desired-column-alias]
   (when desired-column-alias
-    (case (:lib/type (get-in query stage-path))
-      ;; for native stages just return desired-column-alias without escaping (see comment
-      ;; in [[add-escaped-desired-aliases]] for more info)
-      :mbql.stage/native
-      desired-column-alias
+    (let [stage (get-in query stage-path)]
+      (cond
+        ;; for native stages just return desired-column-alias without escaping (see comment
+        ;; in [[add-escaped-desired-aliases]] for more info)
+        (lib/native-stage? stage)
+        desired-column-alias
 
-      :mbql.stage/mbql
-      (let [desired-alias->escaped (or (::desired-alias->escaped (get-in query stage-path))
-                                       (throw (ex-info "Stage is missing ::desired-alias->escaped"
-                                                       {:stage-path stage-path})))]
-        (or (get desired-alias->escaped desired-column-alias)
-            (throw (ex-info (format "Missing ::desired-alias->escaped for %s" (pr-str desired-column-alias))
-                            {:path                   stage-path
-                             :desired-alias          desired-column-alias
-                             :desired-alias->escaped desired-alias->escaped})))))))
+        (lib/mbql-stage? stage)
+        (let [desired-alias->escaped (or (::desired-alias->escaped (get-in query stage-path))
+                                         (throw (ex-info "Stage is missing ::desired-alias->escaped"
+                                                         {:stage-path stage-path})))]
+          (or (get desired-alias->escaped desired-column-alias)
+              (throw (ex-info (format "Missing ::desired-alias->escaped for %s" (pr-str desired-column-alias))
+                              {:path                   stage-path
+                               :desired-alias          desired-column-alias
+                               :desired-alias->escaped desired-alias->escaped}))))))))
 
 (defn- escaped-join-alias [query stage-path join-alias]
   (when join-alias
@@ -319,11 +320,11 @@
   [query      :- ::lib.schema/query
    stage-path :- ::lib.walk/path
    stage      :- ::lib.schema/stage]
-  (case (:lib/type stage)
-    :mbql.stage/native
+  (cond
+    (lib/native-stage? stage)
     stage
 
-    :mbql.stage/mbql
+    (lib/mbql-stage? stage)
     (try
       (->> stage
            (add-source-aliases query stage-path)


### PR DESCRIPTION
### Description

We have a set of utility functions to check whether a stage is a native stage.  However, lib doesn't actually call those functions consistently.  We end up repeating the same logic in a lot of places, and this also makes it harder for devs to figure out the correct way to check for a native stage outside of lib.  This converts most of those checks into calls to lib's utility functions.  There are still a few "weird" checks with slightly different logic where I played it safe and kept the original code, but a lot of checks were swapped over.

This should be an entirely internal refactor that has no user-visible or test-visible effect.

### How to verify

Tests still pass

### Checklist

- n/a Tests have been added/updated to cover changes in this PR
