### PR TITLE
remote sync: a few bugfixes and improvements from my bugbash

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/documents/models/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/documents/models/document.clj
@@ -187,7 +187,7 @@
         (when collection_id #{[{:model "Collection" :id collection_id}]}))))
 
 (defmethod serdes/descendants "Document"
-  [_model-name id]
+  [_model-name id _opts]
   (when-let [document (t2/select-one :model/Document :id id)]
     (when (= prose-mirror/prose-mirror-content-type (:content_type document))
       (merge

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -141,7 +141,8 @@
                                                :no-transforms            true
                                                :include-field-values     false
                                                :include-database-secrets false
-                                               :continue-on-error        false})]
+                                               :continue-on-error        false
+                                               :skip-archived            true})]
             (remote-sync.task/update-progress! task-id 0.3)
             (source/store! models source task-id message)
             (remote-sync.task/set-version! task-id (source.p/version source))

--- a/enterprise/backend/test/metabase_enterprise/documents/models/document_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/documents/models/document_test.clj
@@ -610,7 +610,7 @@
                                                                            {:type "cardEmbed"
                                                                             :attrs {:id 789}}]}
                                                       :content_type "application/json+vnd.prose-mirror"}]
-      (let [descendants (serdes/descendants "Document" document-id)]
+      (let [descendants (serdes/descendants "Document" document-id {})]
         (is (= {["Card" 456] {"Document" document-id}
                 ["Card" 789] {"Document" document-id}}
                descendants))))))
@@ -625,7 +625,7 @@
                                                                             :attrs {:id 789
                                                                                     :model "dashboard"}}]}
                                                       :content_type "application/json+vnd.prose-mirror"}]
-      (let [descendants (serdes/descendants "Document" document-id)]
+      (let [descendants (serdes/descendants "Document" document-id {})]
         (is (= {["Card" 456] {"Document" document-id}
                 ["Dashboard" 789] {"Document" document-id}}
                descendants))))))
@@ -642,7 +642,7 @@
                                                                             :attrs {:id 333
                                                                                     :model "table"}}]}
                                                       :content_type "application/json+vnd.prose-mirror"}]
-      (let [descendants (serdes/descendants "Document" document-id)]
+      (let [descendants (serdes/descendants "Document" document-id {})]
         (is (= {["Card" 111] {"Document" document-id}
                 ["Card" 222] {"Document" document-id}
                 ["Table" 333] {"Document" document-id}}
@@ -654,12 +654,12 @@
                                                                  :content [{:type "paragraph"
                                                                             :content [{:type "text" :text "Plain text only"}]}]}
                                                       :content_type "application/json+vnd.prose-mirror"}]
-      (let [descendants (serdes/descendants "Document" document-id)]
+      (let [descendants (serdes/descendants "Document" document-id {})]
         (is (= {} descendants))))))
 
 (deftest document-serdes-descendants-nonexistent-document-test
   (testing "Document descendants returns nil for non-existent document"
-    (let [descendants (serdes/descendants "Document" 99999999)]
+    (let [descendants (serdes/descendants "Document" 99999999 {})]
       (is (nil? descendants)))))
 
 (deftest document-serdes-descendants-unknown-smart-link-model-test
@@ -672,7 +672,7 @@
                                                                             :attrs {:id 789
                                                                                     :model "unknown-model"}}]}
                                                       :content_type "application/json+vnd.prose-mirror"}]
-      (let [descendants (serdes/descendants "Document" document-id)]
+      (let [descendants (serdes/descendants "Document" document-id {})]
         ;; Should only include the known model type
         (is (= {["Card" 456] {"Document" document-id}}
                descendants))
@@ -688,7 +688,7 @@
                                                                             :attrs {:id 456
                                                                                     :model "card"}}]}
                                                       :content_type "application/json+vnd.prose-mirror"}]
-      (let [descendants (serdes/descendants "Document" document-id)]
+      (let [descendants (serdes/descendants "Document" document-id {})]
         ;; Should merge duplicate references - same card referenced twice
         (is (= {["Card" 456] {"Document" document-id}}
                descendants))
@@ -699,7 +699,7 @@
   (testing "Document descendants handles non-prose-mirror documents"
     (mt/with-temp [:model/Document {document-id :id} {:document {:some "other format"}
                                                       :content_type "application/json"}] ; Not prose-mirror
-      (let [descendants (serdes/descendants "Document" document-id)]
+      (let [descendants (serdes/descendants "Document" document-id {})]
         (is (nil? descendants))))))
 
 (deftest document-serdes-descendants-all-model-types-test
@@ -715,7 +715,7 @@
                                                                             :attrs {:id 333
                                                                                     :model "table"}}]}
                                                       :content_type "application/json+vnd.prose-mirror"}]
-      (let [descendants (serdes/descendants "Document" document-id)]
+      (let [descendants (serdes/descendants "Document" document-id {})]
         (is (= {["Card" 111] {"Document" document-id}
                 ["Dashboard" 222] {"Document" document-id}
                 ["Table" 333] {"Document" document-id}}

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -750,7 +750,7 @@
                   ["Card" card-id]             {"Collection" coll2-id}
                   ["NativeQuerySnippet" s1-id] {"Card" card-id}
                   ["Collection" coll-id]       {"NativeQuerySnippet" s1-id}}
-                 (#'extract/resolve-targets [["Collection" coll2-id]] nil))))))))
+                 (#'extract/resolve-targets {:targets [["Collection" coll2-id]]} nil))))))))
 
 (deftest timelines-and-events-test
   (mt/with-empty-h2-app-db!

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -752,6 +752,97 @@
                   ["Collection" coll-id]       {"NativeQuerySnippet" s1-id}}
                  (#'extract/resolve-targets {:targets [["Collection" coll2-id]]} nil))))))))
 
+(deftest resolve-targets-skip-archived-test
+  (testing "resolve-targets with skip-archived: true excludes archived items from dependency graph"
+    (mt/with-empty-h2-app-db!
+      (ts/with-temp-dpc [:model/Collection {coll-id :id}       {:name "Active Collection"}
+                         :model/Card       {active-card-id :id}   {:name          "Active Card"
+                                                                   :archived      false
+                                                                   :collection_id coll-id}
+                         :model/Card       {archived-card-id :id} {:name          "Archived Card"
+                                                                   :archived      true
+                                                                   :collection_id coll-id}
+                         :model/Card       {dependent-card-id :id} {:name          "Card with archived dep"
+                                                                    :collection_id coll-id
+                                                                    :dataset_query {:database (mt/id)
+                                                                                    :type     :query
+                                                                                    :query    {:source-table (str "card__" archived-card-id)}}}]
+        (testing "archived cards are excluded from targets when skip-archived: true"
+          (let [targets-with-skip (#'extract/resolve-targets {:targets       [["Collection" coll-id]]
+                                                              :skip-archived true} nil)]
+            (is (contains? targets-with-skip ["Collection" coll-id]))
+            (is (contains? targets-with-skip ["Card" active-card-id]))
+            (is (not (contains? targets-with-skip ["Card" archived-card-id]))
+                "archived card should not be in targets")
+            (is (contains? targets-with-skip ["Card" dependent-card-id])
+                "card that depends on archived card should still be included")))
+
+        (testing "archived cards are included in targets when skip-archived: false"
+          (let [targets-without-skip (#'extract/resolve-targets {:targets       [["Collection" coll-id]]
+                                                                 :skip-archived false} nil)]
+            (is (contains? targets-without-skip ["Collection" coll-id]))
+            (is (contains? targets-without-skip ["Card" active-card-id]))
+            (is (contains? targets-without-skip ["Card" archived-card-id])
+                "archived card should be in targets for dependency checking")
+            (is (contains? targets-without-skip ["Card" dependent-card-id]))))))))
+
+(deftest resolve-targets-skip-archived-test-2
+  (testing "resolve-targets with skip-archived handles archived collections and nested items"
+    (mt/with-empty-h2-app-db!
+      (ts/with-temp-dpc [:model/Collection {parent-id :id}      {:name "Parent Collection"}
+                         :model/Collection {archived-child-id :id} {:name     "Archived Child Collection"
+                                                                    :archived true
+                                                                    :location (format "/%d/" parent-id)}
+                         :model/Collection {active-child-id :id}   {:name     "Active Child Collection"
+                                                                    :archived false
+                                                                    :location (format "/%d/" parent-id)}
+                         :model/Card       {card-in-archived-id :id} {:name          "Card in archived collection"
+                                                                      :collection_id archived-child-id}
+                         :model/Card       {card-in-active-id :id}   {:name          "Card in active collection"
+                                                                      :collection_id active-child-id}]
+        (testing "archived child collections and their contents are excluded when skip-archived: true"
+          (let [targets-with-skip (#'extract/resolve-targets {:targets       [["Collection" parent-id]]
+                                                              :skip-archived true} nil)]
+            (is (contains? targets-with-skip ["Collection" parent-id]))
+            (is (contains? targets-with-skip ["Collection" active-child-id]))
+            (is (not (contains? targets-with-skip ["Collection" archived-child-id])))
+            (is (contains? targets-with-skip ["Card" card-in-active-id]))
+            (is (not (contains? targets-with-skip ["Card" card-in-archived-id]))
+                "cards in archived collections should not be included")))
+
+        (testing "all collections and cards are included when skip-archived: false"
+          (let [targets-without-skip (#'extract/resolve-targets {:targets       [["Collection" parent-id]]
+                                                                 :skip-archived false} nil)]
+            (is (contains? targets-without-skip ["Collection" parent-id]))
+            (is (contains? targets-without-skip ["Collection" active-child-id]))
+            (is (contains? targets-without-skip ["Collection" archived-child-id]))
+            (is (contains? targets-without-skip ["Card" card-in-active-id]))
+            (is (contains? targets-without-skip ["Card" card-in-archived-id]))))))))
+
+(deftest extract-skip-archived-test
+  (testing "extract with skip-archived: true excludes archived items from final extraction"
+    (mt/with-empty-h2-app-db!
+      (ts/with-temp-dpc [:model/Collection {coll-id :id}       {:name "Test Collection"}
+                         :model/Card       {active-card-id :id}   {:name          "Active Card"
+                                                                   :archived      false
+                                                                   :collection_id coll-id}
+                         :model/Card       {archived-card-id :id} {:name          "Archived Card"
+                                                                   :archived      true
+                                                                   :collection_id coll-id}]
+        (testing "archived cards are excluded from extraction with skip-archived: true"
+          (let [extraction (extract/extract {:targets       [["Collection" coll-id]]
+                                             :skip-archived true})
+                card-ids   (into #{} (map (comp :id last :serdes/meta)) (by-model "Card" extraction))]
+            (is (contains? card-ids (:entity_id (t2/select-one :model/Card :id active-card-id))))
+            (is (not (contains? card-ids (:entity_id (t2/select-one :model/Card :id archived-card-id)))))))
+
+        (testing "archived cards are included in extraction with skip-archived: false"
+          (let [extraction (extract/extract {:targets       [["Collection" coll-id]]
+                                             :skip-archived false})
+                card-ids   (into #{} (map (comp :id last :serdes/meta)) (by-model "Card" extraction))]
+            (is (contains? card-ids (:entity_id (t2/select-one :model/Card :id active-card-id))))
+            (is (contains? card-ids (:entity_id (t2/select-one :model/Card :id archived-card-id))))))))))
+
 (deftest timelines-and-events-test
   (mt/with-empty-h2-app-db!
     (ts/with-temp-dpc [:model/User

--- a/src/metabase/collections/api.clj
+++ b/src/metabase/collections/api.clj
@@ -1457,7 +1457,7 @@
           (when (api/column-will-change? :type collection-before-update updates)
             (let [child-location (collection/children-location collection-before-update)]
               (t2/query-one {:update :collection
-                             :where [:like :location #p (str child-location "%")]
+                             :where [:like :location (str child-location "%")]
                              :set {:type (:type updates)}}))
             (when (= (:type updates) "remote-synced")
               (collection/check-non-remote-synced-dependencies (t2/select-one :model/Collection :id id)))))))

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1287,7 +1287,10 @@
                                         (collection->descendant-ids collection
                                                                     :archived [:not= true]))]
       (t2/update! :model/Collection (u/the-id collection)
-                  {:archive_operation_id archive-operation-id
+                  {:type                 (if (= (:type collection) "remote-synced")
+                                           nil
+                                           :type)
+                   :archive_operation_id archive-operation-id
                    :archived_directly    true
                    :archived             true})
       (t2/query-one
@@ -1324,6 +1327,7 @@
         new-parent              (if new-parent-id
                                   (t2/select-one :model/Collection :id new-parent-id)
                                   root-collection)
+        new-parent-type         (:type new-parent)
         new-location            (children-location new-parent)
         orig-children-location  (children-location collection)
         new-children-location   (children-location (assoc collection :location new-location))
@@ -1337,6 +1341,9 @@
     (t2/with-transaction [_conn]
       (t2/update! :model/Collection (u/the-id collection)
                   {:location             new-location
+                   :type                 (if (= new-parent-type "remote-synced")
+                                           "remote-synced"
+                                           :type)
                    :archive_operation_id nil
                    :archived_directly    nil
                    :archived             false})

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1747,8 +1747,12 @@
         cards       (into {} (for [card-id (t2/select-pks-set :model/Card {:where [:and
                                                                                    [:= :collection_id id]
                                                                                    (when skip-archived [:not :archived])]})]
-                               {["Card" card-id] {"Collection" id}}))]
-    (merge child-colls dashboards cards)))
+                               {["Card" card-id] {"Collection" id}}))
+        documents   (into {} (for [doc-id (t2/select-pks-set :model/Document {:where
+                                                                              [:and [:= :collection_id id]
+                                                                               (when skip-archived [:not :archived])]})]
+                               {["Document" doc-id] {"Collection" id}}))]
+    (merge child-colls dashboards cards documents)))
 
 (defmethod serdes/storage-path "Collection" [coll {:keys [collections]}]
   (let [parental (get collections (:entity_id coll))]

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -423,7 +423,7 @@
        (set/union (when collection_id #{[{:model "Collection" :id collection_id}]}))
        (set/union (serdes/parameters-deps parameters))))
 
-(defmethod serdes/descendants "Dashboard" [_model-name id]
+(defmethod serdes/descendants "Dashboard" [_model-name id _opts]
   (let [dashcards (t2/select [:model/DashboardCard :id :card_id :action_id :parameter_mappings :visualization_settings]
                              :dashboard_id id)
         dashboard (t2/select-one :model/Dashboard :id id)

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -579,10 +579,10 @@
    NOTE: This is called during **EXPORT**.
 
    Dispatched on model-name."
-  {:arglists '([model-name db-id])}
-  (fn [model-name _] model-name))
+  {:arglists '([model-name db-id opts])}
+  (fn [model-name _ _] model-name))
 
-(defmethod descendants :default [_ _]
+(defmethod descendants :default [_ _ _]
   nil)
 
 (defmulti required

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1247,11 +1247,10 @@
                               [(parse-long (subs source-table 6))])
         all-card-ids        (seq (concat template-tags parameters-card-ids source-card-ids))
         card-ids            (if skip-archived
-                              #p (t2/select-pks-set :model/Card {:where [:and
-                                                                         (if all-card-ids
-                                                                           [:in :id all-card-ids]
-                                                                           [:= [:inline 0] [:inline 1]])
-                                                                         [:not :archived]]})
+                              (when all-card-ids
+                                (t2/select-pks-set :model/Card {:where [:and
+                                                                        [:in :id all-card-ids]
+                                                                        [:not :archived]]}))
                               all-card-ids)]
     (into {} (concat
               (for [card-id card-ids]

--- a/test/metabase/dashboards/models/dashboard_test.clj
+++ b/test/metabase/dashboards/models/dashboard_test.clj
@@ -310,7 +310,7 @@
                                                  :values_source_config {:card_id     (:id card)
                                                                         :value_field [:field (:id field) nil]}}]}]
       (is (= {["Card" (:id card)] {"Dashboard" (:id dashboard)}}
-             (serdes/descendants "Dashboard" (:id dashboard))))))
+             (serdes/descendants "Dashboard" (:id dashboard) {})))))
 
   (testing "dashboard which has a dashcard with an action"
     (mt/with-actions [{:keys [action-id]} {}]
@@ -321,7 +321,7 @@
                                          :parameter_mappings []}]
         (is (= {["Action" action-id] {"Dashboard"     (:id dashboard)
                                       "DashboardCard" (:id dc)}}
-               (serdes/descendants "Dashboard" (:id dashboard)))))))
+               (serdes/descendants "Dashboard" (:id dashboard) {}))))))
 
   (testing "dashboard in which its dashcards has parameter_mappings to a card"
     (mt/with-temp
@@ -340,7 +340,7 @@
                                     "DashboardCard" (:id dc)}
               ["Card" (:id card2)] {"Dashboard"     (:id dashboard)
                                     "DashboardCard" (:id dc)}}
-             (serdes/descendants "Dashboard" (:id dashboard))))))
+             (serdes/descendants "Dashboard" (:id dashboard) {})))))
 
   (testing "dashboard in which its dashcards have series"
     (mt/with-temp
@@ -358,7 +358,7 @@
                         [["Card" (:id card)] (cond-> {"Dashboard"           (:id dashboard)
                                                       "DashboardCard"       (:id dashcard)}
                                                series (assoc "DashboardCardSeries" (:id series)))]))
-             (serdes/descendants "Dashboard" (:id dashboard)))))))
+             (serdes/descendants "Dashboard" (:id dashboard) {}))))))
 
 (deftest ^:parallel hydrate-tabs-test
   (mt/with-temp

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -619,7 +619,7 @@
 (deftest ^:parallel descendants-test
   (testing "regular cards don't depend on anything"
     (mt/with-temp [:model/Card card {:name "some card"}]
-      (is (empty? (serdes/descendants "Card" (:id card)))))))
+      (is (empty? (serdes/descendants "Card" (:id card) {}))))))
 
 (deftest ^:parallel descendants-test-2
   (testing "cards which have another card as the source depend on that card"
@@ -628,9 +628,9 @@
                                       :dataset_query {:database (mt/id)
                                                       :type     :query
                                                       :query    {:source-table (str "card__" (:id card1))}}}]
-      (is (empty? (serdes/descendants "Card" (:id card1))))
+      (is (empty? (serdes/descendants "Card" (:id card1) {})))
       (is (= {["Card" (:id card1)] {"Card" (:id card2)}}
-             (serdes/descendants "Card" (:id card2)))))))
+             (serdes/descendants "Card" (:id card2) {}))))))
 
 (deftest ^:parallel descendants-test-3
   (testing "cards that has a native template tag"
@@ -646,7 +646,7 @@
                                                                          :snippet-id   (:id snippet)}}
                                                :query         "select * from products where {{snippet}}"}}}]
       (is (= {["NativeQuerySnippet" (:id snippet)] {"Card" (:id card)}}
-             (serdes/descendants "Card" (:id card)))))))
+             (serdes/descendants "Card" (:id card) {}))))))
 
 (deftest ^:parallel descendants-test-4
   (testing "cards which have parameter's source is another card"
@@ -657,7 +657,7 @@
                                                     :values_source_type   "card"
                                                     :values_source_config {:card_id (:id card1)}}]}]
       (is (= {["Card" (:id card1)] {"Card" (:id card2)}}
-             (serdes/descendants "Card" (:id card2)))))))
+             (serdes/descendants "Card" (:id card2) {}))))))
 
 (deftest ^:parallel extract-test
   (let [metadata (qp.preprocess/query->expected-cols (mt/mbql-query venues))

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -659,6 +659,54 @@
       (is (= {["Card" (:id card1)] {"Card" (:id card2)}}
              (serdes/descendants "Card" (:id card2) {}))))))
 
+(deftest ^:parallel descendants-skip-archived-test
+  (testing "cards with skip-archived: true excludes archived source-table cards"
+    (mt/with-temp [:model/Card card1 {:name "base card" :archived true}
+                   :model/Card card2 {:name "derived card"
+                                      :dataset_query {:database (mt/id)
+                                                      :type     :query
+                                                      :query    {:source-table (str "card__" (:id card1))}}}]
+      (is (empty? (serdes/descendants "Card" (:id card2) {:skip-archived true}))
+          "archived card should not be in descendants when skip-archived is true")
+      (is (= {["Card" (:id card1)] {"Card" (:id card2)}}
+             (serdes/descendants "Card" (:id card2) {:skip-archived false}))
+          "archived card should be in descendants when skip-archived is false"))))
+
+(deftest ^:parallel descendants-skip-archived-test-2
+  (testing "cards with skip-archived: true excludes archived parameter source cards"
+    (mt/with-temp [:model/Card card1 {:name "base card" :archived true}
+                   :model/Card card2 {:name       "derived card"
+                                      :parameters [{:id                   "valid-id"
+                                                    :type                 "id"
+                                                    :values_source_type   "card"
+                                                    :values_source_config {:card_id (:id card1)}}]}]
+      (is (empty? (serdes/descendants "Card" (:id card2) {:skip-archived true}))
+          "archived parameter source card should not be in descendants when skip-archived is true")
+      (is (= {["Card" (:id card1)] {"Card" (:id card2)}}
+             (serdes/descendants "Card" (:id card2) {:skip-archived false}))
+          "archived parameter source card should be in descendants when skip-archived is false"))))
+
+(deftest ^:parallel descendants-skip-archived-test-3
+  (testing "cards with skip-archived: true includes non-archived cards among multiple dependencies"
+    (mt/with-temp [:model/Card card1 {:name "base card 1" :archived true}
+                   :model/Card card2 {:name "base card 2" :archived false}
+                   :model/Card card3 {:name       "derived card"
+                                      :parameters [{:id                   "param-1"
+                                                    :type                 "id"
+                                                    :values_source_type   "card"
+                                                    :values_source_config {:card_id (:id card1)}}
+                                                   {:id                   "param-2"
+                                                    :type                 "id"
+                                                    :values_source_type   "card"
+                                                    :values_source_config {:card_id (:id card2)}}]}]
+      (is (= {["Card" (:id card2)] {"Card" (:id card3)}}
+             (serdes/descendants "Card" (:id card3) {:skip-archived true}))
+          "only non-archived cards should be in descendants when skip-archived is true")
+      (is (= {["Card" (:id card1)] {"Card" (:id card3)}
+              ["Card" (:id card2)] {"Card" (:id card3)}}
+             (serdes/descendants "Card" (:id card3) {:skip-archived false}))
+          "all cards should be in descendants when skip-archived is false"))))
+
 (deftest ^:parallel extract-test
   (let [metadata (qp.preprocess/query->expected-cols (mt/mbql-query venues))
         query    (mt/mbql-query venues)]


### PR DESCRIPTION
first, set the collection type correctly on archive/unarchive.

second, allow serialization without archived items, and use it for remote sync.

third, serialize documents as the descendants of collections.