### PR TITLE
Fix check for card changes

### DIFF
--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -994,9 +994,13 @@
             {:collection_id 2 :description \"diff\"})"
   [consider card-before updates]
   ;; have to ignore keyword vs strings over api. `{:type :query}` vs `{:type "query"}`
-  (let [prepare              (fn prepare [card] (walk/prewalk (fn [x] (if (keyword? x)
-                                                                        (name x)
-                                                                        x))
+  (let [prepare              (fn prepare [card] (walk/prewalk (fn [x]
+                                                                (if (keyword? x)
+                                                                  (->> [(namespace x)
+                                                                        (name x)]
+                                                                       (remove nil?)
+                                                                       (str/join "/"))
+                                                                  x))
                                                               card))
         before               (prepare (select-keys card-before consider))
         after                (prepare (select-keys updates consider))

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -724,7 +724,8 @@
   (letfn [(changed? [before after]
             (#'card/changed? @#'card/card-compare-keys before after))]
     (testing "Ignores keyword/string"
-      (is (false? (changed? {:dataset_query {:type :query}} {:dataset_query {:type "query"}}))))
+      (is (false? (changed? {:dataset_query {:type :query}} {:dataset_query {:type "query"}})))
+      (is (false? (changed? {:dataset_query {:silly/namespaced ::keywords}} {:dataset_query {"silly/namespaced" "metabase.queries.models.card-test/keywords"}}))))
     (testing "Ignores properties not in `api.card/card-compare-keys"
       (is (false? (changed? {:collection_id 1
                              :collection_position 0}

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -722,28 +722,13 @@
              (t2/select-one-fn :metabase_version :model/Card :id (:id card)))))))
 
 (deftest ^:parallel changed?-test
-  (letfn [(changed? [before after]
-            (#'card/changed? @#'card/card-compare-keys before after))]
-    (testing "Ignores properties not in `api.card/card-compare-keys"
-      (is (false? (changed? {:collection_id 1
-                             :collection_position 0}
-                            {:collection_id 2
-                             :collection_position 1}))))
-    (testing "Compares *normalized* queries"
-      (is (false? (changed? {:dataset_query {:type :query
-                                             :query (mt/query orders)}}
-                            {:dataset_query {:type :query
-                                             :query (walk/stringify-keys (mt/query orders))}}))))
-    (testing "Sees changes"
-      (is (true? (changed? {:dataset_query {:type :query
-                                            :query (mt/query orders)}}
-                           {:dataset_query {:type :query
-                                            :query (mt/query checkins)}})))
-      (testing "But only when they are different in the after, not just omitted"
-        (is (false? (changed? {:dataset_query {} :collection_id 1}
-                              {:collection_id 1})))
-        (is (true? (changed? {:dataset_query {} :collection_id 1}
-                             {:dataset_query nil :collection_id 1})))))))
+  (let [changed? (fn [a b] (#'card/changed? a b))]
+    (is (changed? {:a "a"} {:a "b"}))
+    (is (not (changed? {:a "a" :b "b"} {:b "b"})))
+    (is (not (changed? {:a "a"} {})))
+    (is (not (changed? {} {})))
+    (is (thrown? clojure.lang.ExceptionInfo (changed? {:a "a"} {:b "b"})))
+    (is (thrown? clojure.lang.ExceptionInfo (changed? {:a "a"} {:a "a" :b "b"})))))
 
 (deftest hydrate-dashboard-count-test
   (testing "cards associated with more than 1 dashboard"

--- a/test/metabase/queries/models/card_test.clj
+++ b/test/metabase/queries/models/card_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.queries.models.card-test
   (:require
    [clojure.test :refer :all]
-   [clojure.walk :as walk]
    [java-time.api :as t]
    [metabase.audit-app.impl :as audit]
    [metabase.config.core :as config]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64025
The query coming from the FE looks like:

```
{:aggregation [["count"]],
 :breakout [["field"
             42
             {:base-type "type/DateTime",
             :temporal-unit "month"}]],
 :source-table 7}
```

(note strings like `"count"` and `"month"` and, most importantly, `"type/DateTime"`.)

The card from the DB looked like:

```
{:aggregation [[:count]],
 :breakout [[:field
             42
             {:base-type :type/DateTime,
              :temporal-unit :month}]],
 :source-table 7}
```

When we compare the query to the old version to see if it's changed (and thus, we should invalidate the verified status) we walk it first, converting all keywords to strings:

```
  (let [prepare              (fn prepare [card] (walk/prewalk (fn [x] (if (keyword? x)
                                                                        (name x)
                                                                        x))
```

... but this is not the correct way to do this conversion, because `:type/DateTime` becomes `"DateTime"`. We need to include the namespace if it's present!
