### PR TITLE
fix internal queries, but not amazing way

### DIFF
--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1710,10 +1710,11 @@
     (complement (every-pred :native :query))]
    [:fn
     {:error/message "Native queries must not specify `:query`; MBQL queries must not specify `:native`."}
-    (fn [{native :native, mbql :query, query-type :type}]
+    (fn [{native :native, mbql :query, query-type :type :as outer}]
       (core/case query-type
         :native (core/not mbql)
         :query  (core/not native)
+        :internal (and (core/not mbql) (core/not native) (:args outer))
         false))]])
 
 (mr/def ::check-query-does-not-have-source-metadata
@@ -1741,7 +1742,7 @@
     [:type
      [:enum
       {:description "Type of query. `:query` = MBQL; `:native` = native."}
-      :query :native]]
+      :query :native :internal]]
 
     [:native     {:optional true} NativeQuery]
     [:query      {:optional true} MBQLQuery]

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -205,6 +205,10 @@
   [metadata-providerable query]
   (query-method metadata-providerable (assoc (lib.convert/->pMBQL query) :lib/type :mbql/query)))
 
+(defmethod query-method :internal
+  [metadata-providerable internal-query]
+  (query-from-legacy-query metadata-providerable internal-query))
+
 ;;; this should already be a query in the shape we want but:
 ;; - let's make sure it has the database metadata that was passed in
 ;; - fill in field refs with metadata (#33680)

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -287,7 +287,7 @@
 (mr/def ::legacy-query
   [:map
    {:error/message "legacy query"}
-   [:type [:enum :native :query]]])
+   [:type [:enum :native :query :internal]]])
 
 (mr/def ::mbql5-query
   [:map
@@ -308,7 +308,8 @@
     query
     (case (:type query)
       :native (native-query->pipeline query)
-      :query  (mbql-query->pipeline query))))
+      :query  (mbql-query->pipeline query)
+      :internal (mbql-query->pipeline query))))
 
 (mu/defn canonical-stage-index :- [:int {:min 0}]
   "If `stage-number` index is a negative number e.g. `-1` convert it to a positive index so we can use `nth` on

--- a/src/metabase/lib_be/models/transforms.clj
+++ b/src/metabase/lib_be/models/transforms.clj
@@ -26,6 +26,9 @@
        (lib/cached-metadata-provider-with-cache? (:lib/metadata query))
        query
 
+       (#{:internal "internal"} (:type query))
+       query
+
        :else
        (->> query
             (lib-be.bootstrap/resolve-database (when (lib/metadata-provider? metadata-providerable)


### PR DESCRIPTION
internal queries are kinda not a thing, but they still work.

for instance, this is repl'd into stats in its "broken" state:

```clojure
api=> (metabase.request.core/as-admin
        (qp/process-query {:limit 1,
                           :type :internal,
                           :fn "metabase-enterprise.audit-app.pages.queries/bad-table",
                           :args [nil nil nil "last_run_at" "desc"],
                           :offset 0,
                           :parameters []}))
{:data
 {:cols
  ({:display_name "Card ID", :base_type :type/Integer, :remapped_to :card_name, :name "card_id"}
   {:display_name "Question", :base_type :type/Text, :remapped_from :card_id, :name "card_name"}
   {:display_name "Error", :base_type :type/Text, :code true, :name "error_substr"}
   {:display_name "Collection ID", :base_type :type/Integer, :remapped_to :collection_name, :name "collection_id"}
   {:display_name "Collection", :base_type :type/Text, :remapped_from :collection_id, :name "collection_name"}
   {:display_name "Database ID", :base_type :type/Integer, :remapped_to :database_name, :name "database_id"}
   {:display_name "Database", :base_type :type/Text, :remapped_from :database_id, :name "database_name"}
   {:display_name "Schema", :base_type :type/Text, :name "schema_name"}
   {:display_name "Table ID", :base_type :type/Integer, :remapped_to :table_name, :name "table_id"}
   {:display_name "Table", :base_type :type/Text, :remapped_from :table_id, :name "table_name"}
   {:display_name "Last run at", :base_type :type/DateTime, :name "last_run_at"}
   {:display_name "Total runs", :base_type :type/Integer, :name "total_runs"}
   {:display_name "Dashboards it's in", :base_type :type/Integer, :name "num_dashboards"}
   {:display_name "Created By ID", :base_type :type/Integer, :remapped_to :user_name, :name "user_id"}
   {:display_name "Created By", :base_type :type/Text, :remapped_from :user_id, :name "user_name"}
   {:display_name "Updated At", :base_type :type/DateTime, :name "updated_at"}),
  :rows
  [[17146
    "question name"
    "ERROR: column source.<column_name> does not exist\n  Position: 2..."
    1537
    "some name"
    26
    "some database"
    "some model"
    52728
    "some name"
    #t "2025-10-03T15:12:38.409359Z"
    251
    1
    231
    "some name"
    #t "2025-10-03T12:19:41.851458Z"]]},
 :row_count 1,
 :status :completed}
```

So the annoying thing here is really just doing enough work for the lib normalization code to not choke or complain about the shape.

The other bits are just letting it flow through the normalization, frankly because

```clojure
(defn- query->source-card-id
  "Return the ID of the Card used as the \"source\" query of this query, if applicable; otherwise return `nil`. Used so
  `:card-id` context can be passed along with the query so Collections perms checking is done if appropriate. This fn
  is a wrapper for the function of the same name in the QP util namespace; it adds additional permissions checking as
  well."
  [query]
  (when-let [source-card-id (some-> query not-empty lib-be/normalize-query lib/source-card-id)]
    (log/infof "Source query for this query is Card %s" (pr-str source-card-id))
    (api/read-check :model/Card source-card-id)
    source-card-id))
```

throws an error otherwise.

I'll prepare an even simpler version that avoids this and we can discuss the relative merits
