### PR TITLE
Adjust e2e runner options

### DIFF
--- a/e2e/runner/run_cypress_local.ts
+++ b/e2e/runner/run_cypress_local.ts
@@ -22,13 +22,16 @@ const userOptions = {
   GENERATE_SNAPSHOTS: true,
   QUIET: false,
   TZ: "UTC",
+  QA_DB_ENABLED: undefined,
+  BUILD_JAR: undefined,
+  START_BACKEND: undefined,
   ...booleanify(process.env),
 };
 
 const derivedOptions = {
-  QA_DB_ENABLED: userOptions.START_CONTAINERS,
-  BUILD_JAR: userOptions.BACKEND_PORT === 4000,
-  START_BACKEND: userOptions.BACKEND_PORT === 4000,
+  QA_DB_ENABLED: userOptions.QA_DB_ENABLED ?? userOptions.START_CONTAINERS,
+  BUILD_JAR: userOptions.BUILD_JAR ?? userOptions.BACKEND_PORT === 4000,
+  START_BACKEND: userOptions.START_BACKEND ?? userOptions.BACKEND_PORT === 4000,
   CYPRESS_IS_EMBEDDING_SDK: String(userOptions.TEST_SUITE === "component"),
   MB_SNOWPLOW_AVAILABLE: userOptions.START_CONTAINERS,
   MB_SNOWPLOW_URL: "http://localhost:9090",


### PR DESCRIPTION
This PR modifies how cypress runner's arguments are handled. It provides a way of overriding `QA_DB_ENABLED`, `BUILD_JAR` and `START_BACKEND`.

Ideally I'd like to start cypress only once with _custom backed_, generating snapshots, and not starting containers. And backend should run on port 4000 as we have some helpers / tests that hardcode that.

- `QA_DB_ENABLED`: If containers are already running it makes sense to set `START_CONTAINERS` to `false`. I'd still like to have ability to start qa dbs tets however.
- `BUILD_JAR`: I want to avoid building the jar when I have custom BE on port 4000.
- `START_BACKED`: I don't want to start BE when custom one is running on 4000.