### PR TITLE
Ensure transforms get deleted synchronously from the search index

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -6,6 +6,7 @@
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
+   [metabase.search.core :as search.core]
    [metabase.search.ingestion :as search]
    [metabase.search.spec :as search.spec]
    [metabase.util :as u]
@@ -79,6 +80,7 @@
 
 (t2/define-before-delete :model/Transform [transform]
   (events/publish-event! :event/delete-transform {:id (:id transform)})
+  (search.core/delete! :model/Transform [(str (:id transform))])
   transform)
 
 (defn update-transform-tags!

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -1141,9 +1141,9 @@
                                        {:request-options {:headers {"x-metabase-session" rasta-ai-token}}}
                                        {:conversation_id conversation-id}))))
         (testing "With superuser permissions"
-          (is (=? {:structured_output [(select-keys t1 [:id :entity_id :name :description :source])
+          (is (=? {:structured_output [(mt/obj->json->obj (select-keys t1 [:id :entity_id :name :description :source]))
                                        ;; note: t2 not included because it's a (non-native) MBQL query
-                                       (select-keys t3 [:id :entity_id :name :description :source])]
+                                       (mt/obj->json->obj (select-keys t3 [:id :entity_id :name :description :source]))]
                    :conversation_id conversation-id}
                   (-> (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-transforms"
                                             {:request-options {:headers {"x-metabase-session" crowberto-ai-token}}}
@@ -1185,7 +1185,7 @@
         (testing "With superuser permissions"
           (doseq [transform [t1 t2]]
             (testing (:name transform)
-              (is (=? {:structured_output transform
+              (is (=? {:structured_output (mt/obj->json->obj (select-keys transform [:id :entity_id :name :description :source :target]))
                        :conversation_id conversation-id}
                       (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-transform-details"
                                             {:request-options {:headers {"x-metabase-session" crowberto-ai-token}}}

--- a/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
@@ -162,11 +162,10 @@
   (search.tu/with-temp-index-table
     (testing "Transform is removed from search index when deleted"
       (binding [search.ingestion/*force-sync* true]
-        (let [now (t/truncate-to (t/offset-date-time) :millis)]
-          (mt/with-temp [:model/Transform {transform-id :id} {:name "Transform to delete"}]
-            (ingest! "transform" [:= :this.id transform-id])
-            (is (some? (fetch-one "transform" :model_id (str transform-id)))
-                "Transform should be in the search index after ingestion")
-            (t2/delete! :model/Transform :id transform-id)
-            (is (nil? (fetch-one "transform" :model_id (str transform-id)))
-                "Transform should be removed from the search index after deletion")))))))
+        (mt/with-temp [:model/Transform {transform-id :id} {:name "Transform to delete"}]
+          (ingest! "transform" [:= :this.id transform-id])
+          (is (some? (fetch-one "transform" :model_id (str transform-id)))
+              "Transform should be in the search index after ingestion")
+          (t2/delete! :model/Transform :id transform-id)
+          (is (nil? (fetch-one "transform" :model_id (str transform-id)))
+              "Transform should be removed from the search index after deletion"))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
@@ -157,3 +157,16 @@
             ;; Ensure that the actual MQBL query isn't indexed
             (is (not (re-find #"source" vector-value)))
             (is (not (re-find #"table" vector-value)))))))))
+
+(deftest transform-deletion-test
+  (search.tu/with-temp-index-table
+    (testing "Transform is removed from search index when deleted"
+      (binding [search.ingestion/*force-sync* true]
+        (let [now (t/truncate-to (t/offset-date-time) :millis)]
+          (mt/with-temp [:model/Transform {transform-id :id} {:name "Transform to delete"}]
+            (ingest! "transform" [:= :this.id transform-id])
+            (is (some? (fetch-one "transform" :model_id (str transform-id)))
+                "Transform should be in the search index after ingestion")
+            (t2/delete! :model/Transform :id transform-id)
+            (is (nil? (fetch-one "transform" :model_id (str transform-id)))
+                "Transform should be removed from the search index after deletion")))))))

--- a/src/metabase/search/models.clj
+++ b/src/metabase/search/models.clj
@@ -15,7 +15,6 @@
 
 (t2/define-after-update :hook/search-index
   [instance]
-
   (search/update! instance)
   nil)
 


### PR DESCRIPTION
Deletes transforms from the search index from within `t2/define-before-delete`. See [this explanation](https://metaboat.slack.com/archives/C09CR3MT1KR/p1759518220703059?thread_ts=1759515497.737129&cid=C09CR3MT1KR) for why this wasn't working. Essentially, this doesn't work synchronously for most entity types, but it's a more visible issue for transforms because we don't support archiving them.