### PR TITLE
Split fields returned to metabot for cards/models into core fields and related_tables

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -286,9 +286,10 @@
     (let [options (cond-> arguments
                     (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
           details (cond
-                    (int? model-id)    (u/prog1 (card-details model-id (assoc options :only-model true))
-                                         (api/check (= :model (:type <>)) 404
-                                                    (format "ID %s is not a valid model id, it's a question" model-id)))
+                    (int? model-id)    (let [card (card-details model-id (assoc options :only-model true))]
+                                         (if (= :model (:type card))
+                                           card
+                                           (format "ID %s is not a valid model id, it's a question" model-id)))
                     (int? table-id)    (table-details table-id options)
                     (string? table-id) (if-let [[_ card-id] (re-matches #"card__(\d+)" table-id)]
                                          (card-details (parse-long card-id) options)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -9,7 +9,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.types.isa :as lib.types.isa]
-   [metabase.request.core :as request]
    [metabase.util :as u]
    [metabase.util.humanization :as u.humanization]
    [metabase.warehouse-schema.models.field-values :as field-values]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -192,13 +192,15 @@
    (let [id (:id base)
          card-metadata (lib.metadata/card metadata-provider id)
          dataset-query (get card-metadata :dataset-query)
+         query-needed? (or with-fields? with-related-tables? with-metrics?)
          ;; pivot questions have strange result-columns so we work with the dataset-query
          card-type (:type base)
-         card-query (lib/query metadata-provider (if (and (#{:question} card-type)
-                                                          (#{:pivot} (:display base))
-                                                          (#{:query} (:type dataset-query)))
-                                                   dataset-query
-                                                   card-metadata))
+         card-query (when query-needed?
+                      (lib/query metadata-provider (if (and (#{:question} card-type)
+                                                            (#{:pivot} (:display base))
+                                                            (#{:query} (:type dataset-query)))
+                                                     dataset-query
+                                                     card-metadata)))
          returned-fields (when with-fields?
                            (->> (lib/returned-columns card-query)
                                 field-values-fn))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/dummy_tools.clj
@@ -247,7 +247,7 @@
                             :models  (vec models)}}))))
 
 (comment
-  (binding [api/current-user-permissions-set* (delay #{"/"})
+  (binding [api/*current-user-permissions-set* (delay #{"/"})
             api/*current-user-id* 2
             api/*is-superuser?* true]
     #_(table-details 30 nil)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -598,17 +598,20 @@
                                :with_metric_default_temporal_breakout :with-default-temporal-breakout?})}]])
 
 (mr/def ::table-result
-  [:map
-   [:id :int]
-   [:type [:enum :model :table]]
-   [:name :string]
-   [:display_name :string]
-   [:database_id :int]
-   [:database_schema {:optional true} [:maybe :string]] ; Schema name, if applicable
-   [:fields ::columns]
-   [:related_tables {:optional true} [:sequential ::table-result]]
-   [:description {:optional true} [:maybe :string]]
-   [:metrics {:optional true} [:sequential ::basic-metric]]])
+  [:schema
+   {:registry {::table-result
+               [:map
+                [:id :int]
+                [:type [:enum :model :table]]
+                [:name :string]
+                [:display_name :string]
+                [:database_id :int]
+                [:database_schema {:optional true} [:maybe :string]] ; Schema name, if applicable
+                [:fields ::columns]
+                [:related_tables {:optional true} [:sequential [:ref ::table-result]]]
+                [:description {:optional true} [:maybe :string]]
+                [:metrics {:optional true} [:sequential ::basic-metric]]]}}
+   ::table-result])
 
 (mr/def ::get-table-details-result
   [:or

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -583,6 +583,7 @@
     [:table_id                              {:optional true}                [:or :int :string]]
     [:with_fields                           {:optional true, :default true} :boolean]
     [:with_field_values                     {:optional true, :default true} :boolean]
+    [:with_related_tables                   {:optional true, :default true} :boolean]
     [:with_metrics                          {:optional true, :default true} :boolean]
     [:with_metric_default_temporal_breakout {:optional true, :default true} :boolean]]
    [:fn {:error/message "Exactly one of model_id and table_id required"}
@@ -592,10 +593,11 @@
                                :table_id                              :table-id
                                :with_fields                           :with-fields?
                                :with_field_values                     :with-field-values?
+                               :with_related_tables                   :with-related-tables?
                                :with_metrics                          :with-metrics?
                                :with_metric_default_temporal_breakout :with-default-temporal-breakout?})}]])
 
-(mr/def ::basic-table
+(mr/def ::table-result
   [:map
    [:id :int]
    [:type [:enum :model :table]]
@@ -604,19 +606,14 @@
    [:database_id :int]
    [:database_schema {:optional true} [:maybe :string]] ; Schema name, if applicable
    [:fields ::columns]
+   [:related_tables {:optional true} [:sequential ::table-result]]
    [:description {:optional true} [:maybe :string]]
    [:metrics {:optional true} [:sequential ::basic-metric]]])
-
-(mr/def ::full-table
-  [:merge
-   ::basic-table
-   [:map {:decode/tool-api-response #(update-keys % metabot-v3.u/safe->snake_case_en)}
-    [:queryable_foreign_key_tables {:optional true} [:sequential ::basic-table]]]])
 
 (mr/def ::get-table-details-result
   [:or
    [:map {:decode/tool-api-response #(update-keys % metabot-v3.u/safe->snake_case_en)}
-    [:structured_output ::full-table]]
+    [:structured_output ::table-result]]
    [:map [:output :string]]])
 
 (mr/def ::answer-sources-result
@@ -625,7 +622,7 @@
     {:decode/tool-api-response #(update-keys % metabot-v3.u/safe->snake_case_en)}
     [:structured_output [:map
                          [:metrics [:sequential ::full-metric]]
-                         [:models  [:sequential ::full-table]]]]]
+                         [:models  [:sequential ::table-result]]]]]
    [:map [:output :string]]])
 
 (api.macros/defendpoint :post "/answer-sources" :- [:merge ::answer-sources-result ::tool-request]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -727,7 +727,8 @@
         metric-data {:name "Metric"
                      :description "Model based metric"
                      :type :metric}
-        expected-fields
+        ;; Core fields returned by the model (lib/returned-columns)
+        expected-core-fields
         [{:name "ID", :display_name "ID", :type "number", :semantic_type "pk"}
          {:name "USER_ID", :display_name "User ID", :type "number", :semantic_type "fk"}
          {:name "PRODUCT_ID", :display_name "Product ID", :type "number", :semantic_type "fk"}
@@ -736,47 +737,59 @@
          {:name "TOTAL", :display_name "Total", :type "number"}
          {:name "DISCOUNT", :display_name "Discount", :type "number", :semantic_type "discount"}
          {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp"}
-         {:name "QUANTITY", :display_name "Quantity", :type "number", :semantic_type "quantity", :field_values int-sequence?}
-         {:name "ID", :display_name "ID", :type "number", :semantic_type "pk", :table_reference "User"}
-         {:name "ADDRESS", :display_name "Address", :type "string", :table_reference "User"}
-         {:name "EMAIL", :display_name "Email", :type "string", :semantic_type "email", :table_reference "User"}
-         {:name "PASSWORD", :display_name "Password", :type "string", :table_reference "User"}
-         {:name "NAME", :display_name "Name", :type "string", :semantic_type "name", :table_reference "User"}
-         {:name "CITY", :display_name "City", :type "string", :semantic_type "city", :table_reference "User"}
-         {:name "LONGITUDE", :display_name "Longitude", :type "number", :semantic_type "longitude", :table_reference "User"}
-         {:name "STATE", :display_name "State", :type "string", :semantic_type "state", :table_reference "User"}
-         {:name "SOURCE", :display_name "Source", :type "string", :semantic_type "source", :table_reference "User"}
-         {:name "BIRTH_DATE", :display_name "Birth Date", :type "date", :table_reference "User"}
-         {:name "ZIP", :display_name "Zip", :type "string", :table_reference "User"}
-         {:name "LATITUDE", :display_name "Latitude", :type "number", :semantic_type "latitude", :table_reference "User"}
-         {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp", :table_reference "User"}
-         {:name "ID", :display_name "ID", :type "number", :semantic_type "pk", :table_reference "Product"}
-         {:name "EAN", :display_name "Ean", :type "string", :field_values string-sequence?, :table_reference "Product"}
-         {:name "TITLE", :display_name "Title"
-          :type "string"
-          :semantic_type "title"
-          :field_values string-sequence?
-          :table_reference "Product"}
-         {:name "CATEGORY", :display_name "Category"
-          :type "string"
-          :semantic_type "category"
-          :field_values string-sequence?
-          :table_reference "Product"}
-         {:name "VENDOR", :display_name "Vendor"
-          :type "string"
-          :semantic_type "company"
-          :field_values string-sequence?
-          :table_reference "Product"}
-         {:name "PRICE", :display_name "Price", :type "number", :table_reference "Product"}
-         {:name "RATING", :display_name "Rating", :type "number", :semantic_type "score", :table_reference "Product"}
-         {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp", :table_reference "Product"}]]
+         {:name "QUANTITY", :display_name "Quantity", :type "number", :semantic_type "quantity", :field_values int-sequence?}]
+        ;; Related tables via FK (order matches what related-tables function returns)
+        expected-related-tables
+        [{:type "table"
+          :id (mt/id :products)
+          :name "PRODUCTS"
+          :display_name "Products"
+          :database_id (mt/id)
+          :database_schema "PUBLIC"
+          :fields
+          [{:name "ID", :display_name "ID", :type "number", :semantic_type "pk"}
+           {:name "EAN", :display_name "Ean", :type "string", :field_values string-sequence?}
+           {:name "TITLE", :display_name "Title", :type "string", :semantic_type "title", :field_values string-sequence?}
+           {:name "CATEGORY", :display_name "Category", :type "string", :semantic_type "category", :field_values string-sequence?}
+           {:name "VENDOR", :display_name "Vendor", :type "string", :semantic_type "company", :field_values string-sequence?}
+           {:name "PRICE", :display_name "Price", :type "number"}
+           {:name "RATING", :display_name "Rating", :type "number", :semantic_type "score"}
+           {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp"}]}
+         {:type "table"
+          :id (mt/id :people)
+          :name "PEOPLE"
+          :display_name "People"
+          :database_id (mt/id)
+          :database_schema "PUBLIC"
+          :fields
+          [{:name "ID", :display_name "ID", :type "number", :semantic_type "pk"}
+           {:name "ADDRESS", :display_name "Address", :type "string"}
+           {:name "EMAIL", :display_name "Email", :type "string", :semantic_type "email"}
+           {:name "PASSWORD", :display_name "Password", :type "string"}
+           {:name "NAME", :display_name "Name", :type "string", :semantic_type "name"}
+           {:name "CITY", :display_name "City", :type "string", :semantic_type "city"}
+           {:name "LONGITUDE", :display_name "Longitude", :type "number", :semantic_type "longitude"}
+           {:name "STATE", :display_name "State", :type "string", :semantic_type "state"}
+           {:name "SOURCE", :display_name "Source", :type "string", :semantic_type "source"}
+           {:name "BIRTH_DATE", :display_name "Birth Date", :type "date"}
+           {:name "ZIP", :display_name "Zip", :type "string"}
+           {:name "LATITUDE", :display_name "Latitude", :type "number", :semantic_type "latitude"}
+           {:name "CREATED_AT", :display_name "Created At", :type "datetime", :semantic_type "creation_timestamp"}]}]]
     {:model-data model-data
      :metric-data metric-data
-     :expected-fields expected-fields}))
+     :expected-core-fields expected-core-fields
+     :expected-related-tables expected-related-tables}))
+
+(defn- add-field-ids
+  "Add field_id to fields using map-indexed. Optionally apply transform-fn to each field."
+  ([prefix-template fields]
+   (add-field-ids prefix-template fields identity))
+  ([prefix-template fields transform-fn]
+   (map-indexed #(transform-fn (assoc %2 :field_id (format prefix-template %1))) fields)))
 
 (deftest get-model-details-basic-test
   (mt/with-premium-features #{:metabot-v3}
-    (let [{:keys [model-data metric-data expected-fields]} (model-test-fixtures)
+    (let [{:keys [model-data metric-data expected-core-fields expected-related-tables]} (model-test-fixtures)
           conversation-id (str (random-uuid))
           ai-token (ai-session-token)]
       (mt/with-temp [:model/Card {model-id :id}  model-data
@@ -799,11 +812,12 @@
                                                 (assoc :id model-id
                                                        :type "model"
                                                        :display_name "Model Model"
-                                                       :queryable_foreign_key_tables []
                                                        :verified true
-                                                       :fields
-                                                       (map-indexed #(assoc %2 :field_id (format "c%d/%d" model-id %1))
-                                                                    expected-fields)
+                                                       :fields (add-field-ids (format "c%d/%%d" model-id) expected-core-fields)
+                                                       :related_tables
+                                                       (map #(update % :fields
+                                                                     (partial add-field-ids (format "t%d/%%d" (:id %))))
+                                                            expected-related-tables)
                                                        :metrics [(assoc metric-data
                                                                         :id metric-id
                                                                         :type "metric"
@@ -813,7 +827,7 @@
 
 (deftest get-model-details-without-field-values-test
   (mt/with-premium-features #{:metabot-v3}
-    (let [{:keys [model-data metric-data expected-fields]} (model-test-fixtures)
+    (let [{:keys [model-data metric-data expected-core-fields expected-related-tables]} (model-test-fixtures)
           conversation-id (str (random-uuid))
           ai-token (ai-session-token)]
       (mt/with-temp [:model/Card {model-id :id}  model-data
@@ -835,13 +849,16 @@
                                               (assoc :id model-id
                                                      :type "model"
                                                      :display_name "Model Model"
-                                                     :queryable_foreign_key_tables []
                                                      :verified true
                                                      :fields
-                                                     (map-indexed #(assoc %2
-                                                                          :field_id (format "c%d/%d" model-id %1)
-                                                                          :field_values missing-value)
-                                                                  expected-fields)
+                                                     (add-field-ids (format "c%d/%%d" model-id) expected-core-fields
+                                                                    #(assoc % :field_values missing-value))
+                                                     :related_tables
+                                                     (map (fn [table]
+                                                            (update table :fields
+                                                                    #(add-field-ids (format "t%d/%%d" (:id table)) %
+                                                                                    (fn [f] (assoc f :field_values missing-value)))))
+                                                          expected-related-tables)
                                                      :metrics [(assoc metric-data
                                                                       :id metric-id
                                                                       :type "metric"
@@ -851,7 +868,7 @@
 
 (deftest get-model-details-without-fields-test
   (mt/with-premium-features #{:metabot-v3}
-    (let [{:keys [model-data metric-data]} (model-test-fixtures)
+    (let [{:keys [model-data metric-data expected-related-tables]} (model-test-fixtures)
           conversation-id (str (random-uuid))
           ai-token (ai-session-token)]
       (mt/with-temp [:model/Card {model-id :id}  model-data
@@ -873,9 +890,10 @@
                                               (assoc :id model-id
                                                      :type "model"
                                                      :display_name "Model Model"
-                                                     :queryable_foreign_key_tables []
                                                      :verified true
                                                      :fields []
+                                                     :related_tables
+                                                     (map #(assoc % :fields []) expected-related-tables)
                                                      :metrics [(assoc metric-data
                                                                       :id metric-id
                                                                       :type "metric"
@@ -885,7 +903,7 @@
 
 (deftest get-model-details-without-metric-temporal-breakout-test
   (mt/with-premium-features #{:metabot-v3}
-    (let [{:keys [model-data metric-data]} (model-test-fixtures)
+    (let [{:keys [model-data metric-data expected-related-tables]} (model-test-fixtures)
           conversation-id (str (random-uuid))
           ai-token (ai-session-token)]
       (mt/with-temp [:model/Card {model-id :id}  model-data
@@ -907,9 +925,10 @@
                                               (assoc :id model-id
                                                      :type "model"
                                                      :display_name "Model Model"
-                                                     :queryable_foreign_key_tables []
                                                      :verified true
                                                      :fields []
+                                                     :related_tables
+                                                     (map #(assoc % :fields []) expected-related-tables)
                                                      :metrics [(assoc metric-data
                                                                       :id metric-id
                                                                       :type "metric"
@@ -921,7 +940,7 @@
 
 (deftest get-model-details-without-metrics-test
   (mt/with-premium-features #{:metabot-v3}
-    (let [{:keys [model-data]} (model-test-fixtures)
+    (let [{:keys [model-data expected-related-tables]} (model-test-fixtures)
           conversation-id (str (random-uuid))
           ai-token (ai-session-token)]
       (mt/with-temp [:model/Card {model-id :id}  model-data
@@ -943,9 +962,10 @@
                                               (assoc :id model-id
                                                      :type "model"
                                                      :display_name "Model Model"
-                                                     :queryable_foreign_key_tables []
                                                      :verified true
                                                      :fields []
+                                                     :related_tables
+                                                     (map #(assoc % :fields []) expected-related-tables)
                                                      :metrics missing-value))
                        :conversation_id conversation-id}
                       (request (assoc arguments


### PR DESCRIPTION
Updates the return value for models fetched via the `/get_table_details` tool API according to the [spec outlined here in Slack](https://metaboat.slack.com/archives/C09CR3MT1KR/p1758806329317279?thread_ts=1758733610.192489&cid=C09CR3MT1KR). Essentially this means that `:fields` only includes the columns returned directly by the model's query, and tables related by FK are included under `:related_tables`, which have their fields included in turn. Before, both "returned" & "visible" fields were returned under the same `:fields` key; this change should make the distinction much more clear to Metabot.

I've also added a `with_related_tables` API parameter & updated the schema accordingly