### PR TITLE
Remove parallel annotation from tests

### DIFF
--- a/test/metabase/models/resolution_test.clj
+++ b/test/metabase/models/resolution_test.clj
@@ -22,7 +22,7 @@
     ;; classloader/require for thread safety
     (classloader/require nspace)))
 
-(deftest ^:parallel all-models-are-accounted-for-test
+(deftest all-models-are-accounted-for-test
   (load-every-metabase-namespace)
   (doseq [model (descendants :metabase/model)
           :when (= (namespace model) "model")]
@@ -30,7 +30,7 @@
       (is (models.resolution/model->namespace model)
           (format "%s should have a mapping for %s" `models.resolution/model->namespace model)))))
 
-(deftest ^:parallel all-entries-are-valid-test
+(deftest all-entries-are-valid-test
   (doseq [[model nspace] models.resolution/model->namespace
           :when (or config/ee-available?
                     (not (str/starts-with? nspace "metabase-enterprise")))]


### PR DESCRIPTION
### Description

Make these tests run synchronously because a race condition causing us to fail to check :model/QueryField isa? :metabase/model.

See slack: https://metaboat.slack.com/archives/CKZEMT1MJ/p1759420592339559?thread_ts=1759412299.193049&cid=CKZEMT1MJ
And a failure instance: https://github.com/metabase/metabase/actions/runs/18231952847/job/51919285868 