### PR TITLE
[perf] Introduce lean implementations of for and doseq

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -489,6 +489,8 @@
   metabase.util.malli/defn-                                                             schema.core/defn
   metabase.util.malli/fn                                                                schema.core/fn
   metabase.util.namespaces/import-fns                                                   potemkin/import-vars
+  metabase.util.performance/doseq                                                       clojure.core/doseq
+  metabase.util.performance/for                                                         clojure.core/for
   metabase.util/with-timer-ms                                                           clojure.core/fn
   metabuild-common.core/with-open-jar-file-system                                       clojure.core/let
   metabuild-common.files/with-open-jar-file-system                                      clojure.core/let

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -28,7 +28,7 @@
   Removing empty clauses like `{:aggregation nil}` or `{:breakout []}`.
 
   Token normalization occurs first, followed by canonicalization, followed by removing empty clauses."
-  (:refer-clojure :exclude [mapv every? some select-keys])
+  (:refer-clojure :exclude [mapv every? some select-keys #?(:clj doseq) #?(:clj for)])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -44,7 +44,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :as perf :refer [mapv every? some select-keys]]
+   [metabase.util.performance :as perf :refer [mapv every? some select-keys #?(:clj doseq) #?(:clj for)]]
    [metabase.util.time :as u.time]))
 
 (defn- mbql-clause?

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1,7 +1,7 @@
 (ns metabase.legacy-mbql.schema
   "Schema for validating a *normalized* MBQL query. This is also the definitive grammar for MBQL, wow!"
   (:refer-clojure :exclude [count distinct min max + - / * and or not not-empty = < > <= >= time case concat replace
-                            abs float every? select-keys])
+                            abs float every? select-keys #?(:clj doseq)])
   (:require
    [clojure.core :as core]
    [clojure.set :as set]
@@ -28,7 +28,7 @@
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? select-keys]]))
+   [metabase.util.performance :refer [every? select-keys #?(:clj doseq)]]))
 
 ;; A NOTE ABOUT METADATA:
 ;;

--- a/src/metabase/legacy_mbql/schema/helpers.cljc
+++ b/src/metabase/legacy_mbql/schema/helpers.cljc
@@ -1,6 +1,7 @@
 (ns metabase.legacy-mbql.schema.helpers
-  (:refer-clojure :exclude [distinct])
+  (:refer-clojure :exclude [distinct #?(:clj for)])
   (:require
+   #?(:clj [metabase.util.performance :refer [for]])
    [clojure.string :as str]
    [metabase.types.core]
    [metabase.util.malli.registry :as mr]))

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -1,6 +1,6 @@
 (ns metabase.legacy-mbql.util
   "Utilitiy functions for working with MBQL queries."
-  (:refer-clojure :exclude [replace some mapv every?])
+  (:refer-clojure :exclude [replace some mapv every? #?(:clj for)])
   (:require
    #?@(:clj
        [[metabase.legacy-mbql.jvm-util :as mbql.jvm-u]
@@ -17,7 +17,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.namespaces :as shared.ns]
-   [metabase.util.performance :refer [some mapv every?]]
+   [metabase.util.performance :refer [some mapv every? #?(:clj for)]]
    [metabase.util.time :as u.time]))
 
 (shared.ns/import-fns

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.aggregation
-  (:refer-clojure :exclude [count distinct max min var select-keys mapv])
+  (:refer-clojure :exclude [count distinct max min var select-keys mapv #?(:clj doseq) #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.common :as lib.common]
@@ -21,7 +21,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys mapv]]))
+   [metabase.util.performance :refer [select-keys mapv #?(:clj doseq) #?(:clj for)]]))
 
 (mu/defn column-metadata->aggregation-ref :- :mbql.clause/aggregation
   "Given `:metadata/column` column metadata for an aggregation, construct an `:aggregation` reference."

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.breakout
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv #?(:clj for)])
   (:require
    [clojure.string :as str]
    [metabase.lib.binning :as lib.binning]
@@ -16,7 +16,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv]]))
+   [metabase.util.performance :refer [mapv #?(:clj for)]]))
 
 (defmethod lib.metadata.calculation/describe-top-level-key-method :breakout
   [query stage-number _k]

--- a/src/metabase/lib/common.cljc
+++ b/src/metabase/lib/common.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.common
-  (:refer-clojure :exclude [mapv every?])
+  (:refer-clojure :exclude [mapv every? #?(:clj for)])
   (:require
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
@@ -8,7 +8,7 @@
    [metabase.lib.schema.common :as schema.common]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv #?@(:clj [every?])]])
+   [metabase.util.performance :refer [mapv #?@(:clj [every? for])]])
   #?(:cljs (:require-macros [metabase.lib.common])))
 
 (comment lib.options/keep-me

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.convert
-  (:refer-clojure :exclude [mapv some select-keys])
+  (:refer-clojure :exclude [mapv some select-keys #?(:clj doseq) #?(:clj for)])
   (:require
    [clojure.data :as data]
    [clojure.set :as set]
@@ -21,7 +21,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [mapv some select-keys]])
+   [metabase.util.performance :as perf :refer [mapv some select-keys #?(:clj doseq) #?(:clj for)]])
   #?@(:cljs [(:require-macros [metabase.lib.convert :refer [with-aggregation-list]])]))
 
 (def ^:private ^:dynamic *pMBQL-uuid->legacy-index*

--- a/src/metabase/lib/drill_thru.cljc
+++ b/src/metabase/lib/drill_thru.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.drill-thru
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys #?(:clj for)])
   (:require
    [metabase.lib.drill-thru.automatic-insights :as lib.drill-thru.automatic-insights]
    [metabase.lib.drill-thru.column-extract :as lib.drill-thru.column-extract]
@@ -32,7 +32,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys]]))
+   [metabase.util.performance :refer [select-keys #?(:clj for)]]))
 
 (comment
   lib.drill-thru.fk-details/keep-me

--- a/src/metabase/lib/drill_thru/fk_details.cljc
+++ b/src/metabase/lib/drill_thru/fk_details.cljc
@@ -31,7 +31,7 @@
   drills ([[metabase.lib.drill-thru.pk]], [[metabase.lib.drill-thru.fk-details]],
   or [[metabase.lib.drill-thru.zoom]]); see [[metabase.lib.drill-thru.object-details]] for the high-level logic that
   calls out to the individual implementations."
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys #?(:clj for)])
   (:require
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
    [metabase.lib.filter :as lib.filter]
@@ -42,7 +42,7 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys]]))
+   [metabase.util.performance :refer [select-keys #?(:clj for)]]))
 
 (mu/defn fk-details-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.fk-details]
   "Return an `:fk-details` 'View details' drill when clicking on the value of a FK column."

--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -41,7 +41,7 @@
   - `pivotTypes` function that return available column types for the drill - \"category\" | \"location\" | \"time\"
 
   - `pivotColumnsForType` returns the list of available columns for the drill and the selected type"
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys #?(:clj for)])
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
@@ -54,7 +54,7 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys]]))
+   [metabase.util.performance :refer [select-keys #?(:clj for)]]))
 
 (mu/defn- pivot-drill-pred :- [:sequential ::lib.schema.metadata/column]
   "Implementation for pivoting on various kinds of fields.

--- a/src/metabase/lib/drill_thru/pk.cljc
+++ b/src/metabase/lib/drill_thru/pk.cljc
@@ -33,7 +33,7 @@
   drills ([[metabase.lib.drill-thru.pk]], [[metabase.lib.drill-thru.fk-details]],
   or [[metabase.lib.drill-thru.zoom]]); see [[metabase.lib.drill-thru.object-details]] for the high-level logic that
   calls out to the individual implementations."
-  (:refer-clojure :exclude [select-keys])
+  (:refer-clojure :exclude [select-keys #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
@@ -43,7 +43,7 @@
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [select-keys]]))
+   [metabase.util.performance :refer [select-keys #?(:clj for)]]))
 
 (mu/defn pk-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.pk]
   "'View details' drill when you click on a value in a table that has MULTIPLE PKs. There are two subtypes of PK

--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -38,7 +38,7 @@
   There is a separate function `filterDrillDetails` which returns `query` and `column` used for the `FilterPicker`. It
   should automatically append a query stage and find the corresponding _filterable_ column in this stage. It is used
   for `contains` and `does-not-contain` operators."
-  (:refer-clojure :exclude [select-keys mapv])
+  (:refer-clojure :exclude [select-keys mapv #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.drill-thru.column-filter :as lib.drill-thru.column-filter]
@@ -57,7 +57,7 @@
    [metabase.lib.underlying :as lib.underlying]
    [metabase.util.malli :as mu]
    [metabase.util.number :as u.number]
-   [metabase.util.performance :refer [select-keys mapv]]))
+   [metabase.util.performance :refer [select-keys mapv #?(:clj for)]]))
 
 (defn- maybe-bigint->value-clause
   [value]

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -28,7 +28,7 @@
   Question transformation:
 
   - Set display \"table\""
-  (:refer-clojure :exclude [mapv])
+  (:refer-clojure :exclude [mapv #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.aggregation :as lib.aggregation]
@@ -50,7 +50,7 @@
    [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv]]))
+   [metabase.util.performance :refer [mapv #?(:clj for)]]))
 
 (mu/defn underlying-records-drill :- [:maybe ::lib.schema.drill-thru/drill-thru.underlying-records]
   "When clicking on a particular broken-out group, offer a look at the details of all the rows that went into this

--- a/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_timeseries.cljc
@@ -34,6 +34,7 @@
   Question transformation:
 
   - Set default display"
+  (:refer-clojure :exclude [for])
   (:require
    [metabase.lib.breakout :as lib.breakout]
    [metabase.lib.drill-thru.common :as lib.drill-thru.common]
@@ -48,7 +49,8 @@
    [metabase.lib.underlying :as lib.underlying]
    [metabase.lib.util :as lib.util]
    [metabase.util.i18n :as i18n]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [some]]))
 
 (mu/defn- valid-current-units :- [:sequential ::lib.schema.temporal-bucketing/unit.date-time.truncate]
   [query :- ::lib.schema/query
@@ -63,22 +65,25 @@
   [query        :- ::lib.schema/query
    stage-number :- :int
    dimensions   :- [:sequential ::lib.schema.drill-thru/context.row.value]]
-  (first (for [[breakout-ref breakout-col] (map vector
-                                                (lib.breakout/breakouts query stage-number)
-                                                (lib.breakout/breakouts-metadata query stage-number))
-               :when (and (lib.util/clause-of-type? breakout-ref :field)
-                          (lib.temporal-bucket/temporal-bucket breakout-ref))
-               {:keys [column] :as dimension} dimensions
-               :when (and (lib.equality/find-matching-column breakout-ref [column])
-                          (= (lib.temporal-bucket/raw-temporal-bucket breakout-ref)
-                             (or (lib.temporal-bucket/raw-temporal-bucket column)
-                                 ;; If query is multi-stage and column comes from a call
-                                 ;; to [[lib.calculation/returned-columns]], then it may have an
-                                 ;; :inherited-temporal-unit instead of a :temporal-unit.
-                                 (:inherited-temporal-unit column))))]
-           ;; If stage-number is not -1, then the column from the input dimension will be from the last stage,
-           ;; whereas breakout-col will be the corresponding breakout column from [[lib.underlying/top-level-stage]].
-           (assoc dimension :column breakout-col :column-ref breakout-ref))))
+  (some (fn [[breakout-ref breakout-col]]
+          (when (and (lib.util/clause-of-type? breakout-ref :field)
+                     (lib.temporal-bucket/temporal-bucket breakout-ref))
+            (some (fn [{:keys [column] :as dimension}]
+                    (when (and (lib.equality/find-matching-column breakout-ref [column])
+                               (= (lib.temporal-bucket/raw-temporal-bucket breakout-ref)
+                                  (or (lib.temporal-bucket/raw-temporal-bucket column)
+                                      ;; If query is multi-stage and column comes from a call
+                                      ;; to [[lib.calculation/returned-columns]], then it may have an
+                                      ;; :inherited-temporal-unit instead of a :temporal-unit.
+                                      (:inherited-temporal-unit column))))
+                      ;; If stage-number is not -1, then the column from the input dimension will be from the
+                      ;; last stage, whereas breakout-col will be the corresponding breakout column
+                      ;; from [[lib.underlying/top-level-stage]].
+                      (assoc dimension :column breakout-col :column-ref breakout-ref)))
+                  dimensions)))
+        (map vector
+             (lib.breakout/breakouts query stage-number)
+             (lib.breakout/breakouts-metadata query stage-number))))
 
 (mu/defn- next-breakout-unit :- [:maybe ::lib.schema.drill-thru/drill-thru.zoom-in.timeseries.next-unit]
   [query :- ::lib.schema/query

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.equality
   "Logic for determining whether two pMBQL queries are equal."
-  (:refer-clojure :exclude [= every? some mapv])
+  (:refer-clojure :exclude [= every? some mapv #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
@@ -21,7 +21,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every? some mapv]]))
+   [metabase.util.performance :refer [every? some mapv #?(:clj for)]]))
 
 (defmulti =
   "Determine whether two already-normalized pMBQL maps, clauses, or other sorts of expressions are equal. The basic rule

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.expression
-  (:refer-clojure :exclude [+ - * / case coalesce abs time concat replace float mapv some select-keys])
+  (:refer-clojure :exclude [+ - * / case coalesce abs time concat replace float mapv some select-keys
+                            #?(:clj doseq) #?(:clj for)])
   (:require
    [clojure.string :as str]
    [malli.core :as mc]
@@ -28,7 +29,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.number :as u.number]
-   [metabase.util.performance :refer [mapv some select-keys]]))
+   [metabase.util.performance :refer [mapv some select-keys #?(:clj doseq) #?(:clj for)]]))
 
 (mu/defn column-metadata->expression-ref :- :mbql.clause/expression
   "Given `:metadata/column` column metadata for an expression, construct an `:expression` reference."

--- a/src/metabase/lib/extraction.cljc
+++ b/src/metabase/lib/extraction.cljc
@@ -1,5 +1,7 @@
 (ns metabase.lib.extraction
+  #?(:clj (:refer-clojure :exclude [for]))
   (:require
+   #?(:clj [metabase.util.performance :refer [for]])
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
@@ -16,14 +18,14 @@
 (defn- column-extract-temporal-units [column]
   (let [time-units [:hour-of-day]
         date-units [:day-of-month :day-of-week :month-of-year :quarter-of-year :year]]
-    (vec (for [unit (concat (when-not (lib.types.isa/date-without-time? column)
-                              time-units)
-                            (when-not (lib.types.isa/time? column)
-                              date-units))]
-           {:lib/type     ::extraction
-            :tag          unit
-            :column       column
-            :display-name (lib.temporal-bucket/describe-temporal-unit unit)}))))
+    (for [unit (concat (when-not (lib.types.isa/date-without-time? column)
+                         time-units)
+                       (when-not (lib.types.isa/time? column)
+                         date-units))]
+      {:lib/type     ::extraction
+       :tag          unit
+       :column       column
+       :display-name (lib.temporal-bucket/describe-temporal-unit unit)})))
 
 (defn- regex-available? [metadata-providerable]
   (lib.metadata/database-supports? metadata-providerable :regex))

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.fe-util
-  (:refer-clojure :exclude [every? mapv select-keys some])
+  (:refer-clojure :exclude [every? mapv select-keys some #?(:clj doseq) #?(:clj for)])
   (:require
    [inflections.core :as inflections]
    [medley.core :as m]
@@ -33,7 +33,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.number :as u.number]
-   [metabase.util.performance :refer [every? mapv select-keys some]]
+   [metabase.util.performance :refer [every? mapv select-keys some #?(:clj doseq) #?(:clj for)]]
    [metabase.util.time :as u.time]))
 
 (def ^:private ExpressionArg

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.field
-  (:refer-clojure :exclude [every? select-keys mapv])
+  (:refer-clojure :exclude [every? select-keys mapv #?(:clj for)])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -32,7 +32,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? select-keys mapv]]
+   [metabase.util.performance :refer [every? select-keys mapv #?(:clj for)]]
    [metabase.util.time :as u.time]))
 
 (defn- column-metadata-effective-type

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.filter
-  (:refer-clojure :exclude [filter and or not = < <= > >= not-empty case every? some mapv])
+  (:refer-clojure :exclude [filter and or not = < <= > >= not-empty case every? some mapv #?(:clj doseq) #?(:clj for)])
   (:require
    [inflections.core :as inflections]
    [medley.core :as m]
@@ -27,7 +27,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.number :as u.number]
-   [metabase.util.performance :refer [every? some mapv]]
+   [metabase.util.performance :refer [every? some mapv #?(:clj doseq) #?(:clj for)]]
    [metabase.util.time :as u.time]))
 
 (doseq [tag [:and :or]]

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.join
   "Functions related to manipulating EXPLICIT joins in MBQL."
-  (:refer-clojure :exclude [mapv run! some])
+  (:refer-clojure :exclude [mapv run! some #?(:clj for)])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -35,7 +35,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [mapv run! some]]))
+   [metabase.util.performance :refer [mapv run! some #?(:clj for)]]))
 
 (defn- join? [x]
   (= (lib.dispatch/dispatch-value x) :mbql/join))

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.metadata
-  (:refer-clojure :exclude [every?])
+  (:refer-clojure :exclude [every? #?(:clj doseq) #?(:clj for)])
   (:require
    [medley.core :as m]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
@@ -11,7 +11,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [every?]]))
+   [metabase.util.performance :refer [every? #?(:clj doseq) #?(:clj for)]]))
 
 ;;; TODO -- deprecate all the schemas below, and just use the versions in [[lib.schema.metadata]] instead.
 

--- a/src/metabase/lib/metadata/cached_provider.cljc
+++ b/src/metabase/lib/metadata/cached_provider.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.metadata.cached-provider
-  (:refer-clojure :exclude [update-keys])
+  (:refer-clojure :exclude [update-keys #?(:clj doseq)])
   (:require
    #?@(:clj ([metabase.util.json :as json]
              [pretty.core :as pretty]))
@@ -9,7 +9,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [update-keys]]))
+   [metabase.util.performance :refer [update-keys #?(:clj doseq)]]))
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.metadata.calculation
-  (:refer-clojure :exclude [select-keys mapv])
+  (:refer-clojure :exclude [select-keys mapv #?(:clj for)])
   (:require
    #?(:clj  [metabase.config.core :as config]
       :cljs [metabase.lib.cache :as lib.cache])
@@ -24,7 +24,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [select-keys mapv]]))
+   [metabase.util.performance :refer [select-keys mapv #?(:clj for)]]))
 
 (mr/def ::display-name-style
   "Schema for valid values of `display-name-style` as passed to [[display-name-method]].

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -6,7 +6,7 @@
 
   Traditionally this code lived in the [[metabase.query-processor.middleware.annotate]] namespace, where it is still
   used today."
-  (:refer-clojure :exclude [mapv select-keys some update-keys every?])
+  (:refer-clojure :exclude [mapv select-keys some update-keys every? #?(:clj for)])
   (:require
    #?@(:clj
        ([metabase.config.core :as config]))
@@ -33,7 +33,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [mapv select-keys some update-keys every?]]))
+   [metabase.util.performance :refer [mapv select-keys some update-keys every? #?(:clj for)]]))
 
 (mr/def ::col
   ;; TODO (Cam 6/19/25) -- I think we should actually namespace all the keys added here (to make it clear where they

--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.order-by
-  (:refer-clojure :exclude [some mapv])
+  (:refer-clojure :exclude [some mapv #?(:clj for)])
   (:require
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
@@ -17,7 +17,7 @@
    [metabase.lib.util.match :as lib.util.match]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some mapv]]))
+   [metabase.util.performance :refer [some mapv #?(:clj for)]]))
 
 (lib.hierarchy/derive :asc  ::order-by-clause)
 (lib.hierarchy/derive :desc ::order-by-clause)

--- a/src/metabase/lib/parse.cljc
+++ b/src/metabase/lib/parse.cljc
@@ -1,12 +1,12 @@
 (ns metabase.lib.parse
   "Code for parsing parameters in raw SQL strings."
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some #?(:clj for)])
   (:require
    [clojure.string :as str]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
-   [metabase.util.performance :refer [some]]))
+   [metabase.util.performance :refer [some #?(:clj for)]]))
 
 (defn- combine-adjacent-strings
   "Returns any adjacent strings in coll combined together"

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.query
-  (:refer-clojure :exclude [remove some select-keys mapv])
+  (:refer-clojure :exclude [remove some select-keys mapv #?(:clj for)])
   (:require
    [medley.core :as m]
    ;; allowed since this is needed to convert legacy queries to MBQL 5
@@ -29,7 +29,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some select-keys mapv]]
+   [metabase.util.performance :refer [some select-keys mapv #?(:clj for)]]
    [weavejester.dependency :as dep]))
 
 (defmethod lib.metadata.calculation/metadata-method :mbql/query

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.remove-replace
-  (:refer-clojure :exclude [every? mapv run! some])
+  (:refer-clojure :exclude [every? mapv run! some #?(:clj for)])
   (:require
    [clojure.set :as set]
    [medley.core :as m]
@@ -22,7 +22,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [every? mapv run! some]]))
+   [metabase.util.performance :as perf :refer [every? mapv run! some #?(:clj for)]]))
 
 (defn- stage-paths
   [query stage-number]

--- a/src/metabase/lib/schema/aggregation.cljc
+++ b/src/metabase/lib/schema/aggregation.cljc
@@ -1,12 +1,12 @@
 (ns metabase.lib.schema.aggregation
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some #?(:clj doseq)])
   (:require
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.mbql-clause :as mbql-clause]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some]]))
+   [metabase.util.performance :refer [some #?(:clj doseq)]]))
 
 ;; count has an optional expression arg. This is the number of non-NULL values -- corresponds to count(<expr>) in SQL
 (mbql-clause/define-catn-mbql-clause :count :- :type/Integer

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.schema.expression
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some #?(:clj for)])
   (:require
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
@@ -10,7 +10,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some]]))
+   [metabase.util.performance :refer [some #?(:clj for)]]))
 
 (defmulti type-of-method
   "Impl for [[type-of]]. Use [[type-of]], but implement [[type-of-method]].

--- a/src/metabase/lib/schema/expression/arithmetic.cljc
+++ b/src/metabase/lib/schema/expression/arithmetic.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.schema.expression.arithmetic
   "Arithmetic expressions like `:+`."
-  (:refer-clojure :exclude [every? some])
+  (:refer-clojure :exclude [every? some #?(:clj doseq)])
   (:require
    [medley.core :as m]
    [metabase.lib.hierarchy :as lib.hierarchy]
@@ -10,7 +10,7 @@
    [metabase.lib.schema.temporal-bucketing :as temporal-bucketing]
    [metabase.types.core :as types]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? some]]))
+   [metabase.util.performance :refer [every? some #?(:clj doseq)]]))
 
 (defn- valid-interval-for-type? [[_tag _opts _n unit :as _interval] expr-type]
   (let [unit-schema (cond

--- a/src/metabase/lib/schema/expression/conditional.cljc
+++ b/src/metabase/lib/schema/expression/conditional.cljc
@@ -1,6 +1,8 @@
 (ns metabase.lib.schema.expression.conditional
   "Conditional expressions like `:case` and `:coalesce`."
+  #?(:clj (:refer-clojure :exclude [doseq]))
   (:require
+   #?(:clj [metabase.util.performance :refer [doseq]])
    [clojure.set :as set]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.mbql-clause :as mbql-clause]

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -1,5 +1,7 @@
 (ns metabase.lib.schema.expression.string
+  #?(:clj (:refer-clojure :exclude [doseq]))
   (:require
+   #?(:clj [metabase.util.performance :refer [doseq]])
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.mbql-clause :as mbql-clause]))
 

--- a/src/metabase/lib/schema/expression/temporal.cljc
+++ b/src/metabase/lib/schema/expression/temporal.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.schema.expression.temporal
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some #?(:clj doseq) #?(:clj for)])
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -11,7 +11,7 @@
    [metabase.lib.schema.temporal-bucketing :as temporal-bucketing]
    [metabase.util :as u]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some]]
+   [metabase.util.performance :refer [some #?(:clj doseq) #?(:clj for)]]
    [metabase.util.time.impl-common :as u.time.impl-common])
   #?@
    (:clj

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.stage
   "Method implementations for a stage of a query."
-  (:refer-clojure :exclude [mapv some])
+  (:refer-clojure :exclude [mapv some #?(:clj for)])
   (:require
    [clojure.string :as str]
    [metabase.lib.aggregation :as lib.aggregation]
@@ -24,7 +24,7 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.malli :as mu]
    [metabase.util.namespaces :as shared.ns]
-   [metabase.util.performance :refer [mapv some]]))
+   [metabase.util.performance :refer [mapv some #?(:clj for)]]))
 
 (comment metabase.lib.stage.util/keep-me)
 

--- a/src/metabase/lib/swap.cljc
+++ b/src/metabase/lib/swap.cljc
@@ -1,5 +1,7 @@
 (ns metabase.lib.swap
+  #?(:clj (:refer-clojure :exclude [for]))
   (:require
+   #?(:clj [metabase.util.performance :refer [for]])
    [metabase.lib.options :as lib.options]
    [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.util :as lib.util]

--- a/src/metabase/lib/underlying.cljc
+++ b/src/metabase/lib/underlying.cljc
@@ -1,7 +1,9 @@
 (ns metabase.lib.underlying
   "Helpers for getting at \"underlying\" or \"top-level\" queries and columns.
   This logic is shared by a handful of things like drill-thrus."
+  #?(:clj (:refer-clojure :exclude [for]))
   (:require
+   #?(:clj [metabase.util.performance :refer [for]])
    [clojure.set :as set]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -1,5 +1,5 @@
 (ns metabase.lib.util
-  (:refer-clojure :exclude [format every? mapv select-keys update-keys some])
+  (:refer-clojure :exclude [format every? mapv select-keys update-keys some #?(:clj doseq) #?(:clj for)])
   (:require
    #?@(:clj
        ([potemkin :as p])
@@ -26,7 +26,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [every? mapv select-keys update-keys some]]))
+   [metabase.util.performance :refer [every? mapv select-keys update-keys some #?(:clj doseq) #?(:clj for)]]))
 
 #?(:clj
    (set! *warn-on-reflection* true))

--- a/src/metabase/types/coercion_hierarchies.cljc
+++ b/src/metabase/types/coercion_hierarchies.cljc
@@ -1,5 +1,7 @@
 (ns metabase.types.coercion-hierarchies
+  #?(:clj (:refer-clojure :exclude [for]))
   (:require
+   #?(:clj [metabase.util.performance :refer [for]])
    [clojure.set :as set]))
 
 ;; these need to be defonce so we don't drop our hierarchies, but defonce doesn't support docstrings:

--- a/src/metabase/types/core.cljc
+++ b/src/metabase/types/core.cljc
@@ -49,9 +49,10 @@
   ### Entity Types -- keys starting with `:entity/`
 
   These are used to record the semantic purpose of a Table."
+  #?(:clj (:refer-clojure :exclude [for]))
   (:require
-   #?@(:cljs
-       [[metabase.util :as u]])
+   #?(:clj [metabase.util.performance :refer [for]]
+      :cljs [metabase.util :as u])
    [clojure.set :as set]
    [metabase.types.coercion-hierarchies :as coercion-hierarchies]
    [metabase.util.malli :as mu]

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1,7 +1,7 @@
 #_{:clj-kondo/ignore [:metabase/namespace-name]}
 (ns metabase.util
   "Common utility functions useful throughout the codebase."
-  (:refer-clojure :exclude [group-by last])
+  (:refer-clojure :exclude [group-by last #?(:clj for)])
   (:require
    #?@(:clj ([clojure.core.protocols]
              [clojure.math.numeric-tower :as math]
@@ -29,7 +29,7 @@
    [metabase.util.memoize :as memoize]
    [metabase.util.namespaces :as u.ns]
    [metabase.util.number :as u.number]
-   [metabase.util.performance :as perf]
+   [metabase.util.performance :as perf :refer [#?(:clj for)]]
    [metabase.util.polyfills]
    [nano-id.core :as nano-id]
    [net.cgrand.macrovich :as macros]

--- a/src/metabase/util/formatting/internal/date_builder.cljc
+++ b/src/metabase/util/formatting/internal/date_builder.cljc
@@ -13,7 +13,9 @@
   - `[:month-full-name]` gives `\"April\"`
   - `[:month-name]` gives `\"Apr\"`
   - `[:month-dd]` gives `\"04\"`"
+  #?(:clj (:refer-clojure :exclude [for]))
   (:require
+   #?(:clj [metabase.util.performance :refer [for]])
    [clojure.string :as str])
   #?(:clj (:import
            java.time.format.DateTimeFormatter)))

--- a/src/metabase/util/formatting/internal/date_formatters.cljc
+++ b/src/metabase/util/formatting/internal/date_formatters.cljc
@@ -2,7 +2,9 @@
   "The gory details of transforming date and time styles, with units and other options, into formatting functions.
 
   This namespace deals with the options only, not with specific dates, and returns reusable formatter functions."
+  #?(:clj (:refer-clojure :exclude [for]))
   (:require
+   #?(:clj [metabase.util.performance :refer [for]])
    [clojure.string :as str]
    [metabase.util.formatting.constants :as constants]
    [metabase.util.formatting.internal.date-builder :as builder]

--- a/src/metabase/util/humanization.cljc
+++ b/src/metabase/util/humanization.cljc
@@ -1,5 +1,7 @@
 (ns metabase.util.humanization
+  #?(:clj (:refer-clojure :exclude [for]))
   (:require
+   #?(:clj [metabase.util.performance :refer [for]])
    [clojure.string :as str]
    [metabase.util :as u]))
 

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -1,14 +1,14 @@
 (ns metabase.util.performance
   "Functions and utilities for faster processing. This namespace is compatible with both Clojure and ClojureScript.
   However, some functions are either not only available in CLJS, or offer passthrough non-improved functions."
-  (:refer-clojure :exclude [reduce mapv run! some every? concat select-keys update-keys empty? not-empty #?(:cljs clj->js)])
-  #?@(:clj ()
-      :cljs [(:require
-              [cljs.core :as core]
-              [goog.object :as gobject])])
-  #?@(:clj [(:import (clojure.lang Counted ITransientCollection LazilyPersistentVector RT)
-                     (java.util ArrayList HashMap Iterator List))]
-      :default ()))
+  (:refer-clojure :exclude [reduce mapv run! some every? concat select-keys update-keys empty? not-empty doseq for #?(:cljs clj->js)])
+  #?(:clj (:require
+           [net.cgrand.macrovich :as macros])
+     :cljs (:require
+            [cljs.core :as core]
+            [goog.object :as gobject]))
+  #?(:clj (:import (clojure.lang Counted ITransientCollection LazilyPersistentVector RT)
+                   (java.util ArrayList HashMap Iterator List))))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -314,6 +314,100 @@
                              m m)
                   maybe-persistent!
                   (add-original-meta m))))
+
+;; List comprehension reimplementation.
+
+#?(:clj
+   (defmacro for
+     "Like `clojure.core/for` but eager, returns a vector, more friendly to inlining, and uses iterators.
+
+  ClojureScript version delegates to `clojure.core/for` unless it the simplest one-dimensional iteration where the
+  whole macro is replaced with `mapv`."
+     {:style/indent 1}
+     [seq-exprs & body-exprs]
+     (#'clojure.core/assert-args
+      (vector? seq-exprs) "a vector for its binding"
+      (even? (count seq-exprs)) "an even number of forms in binding vector"
+      (every? #{:let :while :when} (filter keyword? (take-nth 2 seq-exprs))) "invalid 'for' keyword")
+     (macros/case
+       :clj
+       (let [groups (reduce (fn [groups [k v]]
+                              (if (#{:let :while :when} k)
+                                (conj (pop groups) (conj (peek groups) [k v]))
+                                (conj groups [k v])))
+                            [] (partition 2 seq-exprs))]
+         (letfn [(emit-action [[[k v :as pair] & rest-mods] res-sym body]
+                   (if pair
+                     (case k
+                       :let `(let ~v ~(emit-action rest-mods res-sym body))
+                       :while `(if ~v ~(emit-action rest-mods res-sym body) ~res-sym)
+                       :when `(if ~v ~(emit-action rest-mods res-sym body) (recur ~res-sym)))
+                     body))
+                 (emit-loop [[[bind expr & mod-pairs] & rest-groups] res-sym]
+                   (if bind
+                     (let [own-res-sym (gensym "res")]
+                       `(let [it# (RT/iter ~expr)]
+                          (loop [~own-res-sym ~(or res-sym `(transient []))]
+                            (if (.hasNext it#)
+                              (let [~bind (.next it#)]
+                                ~(emit-action mod-pairs own-res-sym
+                                              `(recur ~(emit-loop rest-groups own-res-sym))))
+                              ~(if (nil? res-sym) ;; Only top-level calls persistent!
+                                 `(persistent! ~own-res-sym)
+                                 own-res-sym)))))
+                     ;; Reached the end - time to emit body
+                     `(conj! ~res-sym (do ~@body-exprs))))]
+           (emit-loop groups nil)))
+
+       :cljs
+       (if (= (count seq-exprs) 2)
+         ;; Simplest case - just replace with mapv.
+         `(mapv (fn [~(first seq-exprs)] ~@body-exprs) ~(second seq-exprs))
+         `(vec (clojure.core/for ~seq-exprs (do ~@body-exprs)))))))
+
+#?(:clj
+   (defmacro doseq
+     "Like `clojure.core/doseq` but eager, more friendly to inlining, and uses iterators.
+
+  ClojureScript version delegates to `clojure.core/doseq` unless it the simplest one-dimensional iteration where the
+  whole macro is replaced with `run!`."
+     {:style/indent 1}
+     [seq-exprs & body-exprs]
+     (#'clojure.core/assert-args
+      (vector? seq-exprs) "a vector for its binding"
+      (even? (count seq-exprs)) "an even number of forms in binding vector"
+      (every? #{:let :while :when} (filter keyword? (take-nth 2 seq-exprs))) "invalid 'doseq' keyword")
+     (macros/case
+       :clj
+       (let [groups (reduce (fn [groups [k v]]
+                              (if (#{:let :while :when} k)
+                                (conj (pop groups) (conj (peek groups) [k v]))
+                                (conj groups [k v])))
+                            [] (partition 2 seq-exprs))]
+         (letfn [(emit-action [[[k v :as pair] & rest-mods] body]
+                   (if pair
+                     (case k
+                       :let `(let ~v ~(emit-action rest-mods body))
+                       :while `(when ~v ~(emit-action rest-mods body))
+                       :when `(if ~v ~(emit-action rest-mods body) (recur)))
+                     body))
+                 (emit-loop [[[bind expr & mod-pairs] & rest-groups]]
+                   (if bind
+                     `(let [it# (RT/iter ~expr)]
+                        (loop []
+                          (when (.hasNext it#)
+                            (let [~bind (.next it#)]
+                              ~(emit-action mod-pairs `(do ~(emit-loop rest-groups)
+                                                           (recur)))))))
+                     ;; Reached the end - time to emit body
+                     `(do ~@body-exprs)))]
+           (emit-loop groups)))
+
+       :cljs
+       (if (= (count seq-exprs) 2)
+         ;; Simplest case - just replace with run!.
+         `(run! (fn [~(first seq-exprs)] ~@body-exprs) ~(second seq-exprs))
+         `(clojure.core/doseq ~seq-exprs ~@body-exprs)))))
 
 ;; clojure.walk reimplementation. Partially adapted from https://github.com/tonsky/clojure-plus.
 

--- a/test/metabase/util/performance_test.cljc
+++ b/test/metabase/util/performance_test.cljc
@@ -45,6 +45,64 @@
             (perf/transpose [[1 1 1 1 1] [2 2 2 2 2] [3 3 3 3 3] [4 4 4 4 4] [5 5 5 5 5]])
             (apply mapv vector [[1 1 1 1 1] [2 2 2 2 2] [3 3 3 3 3] [4 4 4 4 4] [5 5 5 5 5]])))))
 
+#?(:clj
+   (deftest list-comprehensions-test
+     (are [i o] (= o i)
+       (perf/for [x (range 3)
+                  y (range 5)]
+         [x y])
+       #_=> [[0 0] [0 1] [0 2] [0 3] [0 4] [1 0] [1 1] [1 2] [1 3] [1 4] [2 0] [2 1] [2 2] [2 3] [2 4]]
+
+       (perf/for [x (range 3) :when (odd? x)
+                  y (range 5)] [x y])
+       #_=> [[1 0] [1 1] [1 2] [1 3] [1 4]]
+
+       (perf/for [x (range 3) :when (> x 5)
+                  y (range 5)]
+         [x y])
+       #_=> []
+
+       (perf/for [x (range 10) :when (odd? x)
+                  y (range 20) :while (< y 7)
+                  :let [z [x y]]]
+         z)
+       #_=> [[1 0] [1 1] [1 2] [1 3] [1 4] [1 5] [1 6] [3 0] [3 1] [3 2] [3 3] [3 4] [3 5] [3 6] [5 0] [5 1] [5 2] [5 3] [5 4] [5 5] [5 6] [7 0] [7 1] [7 2] [7 3] [7 4] [7 5] [7 6] [9 0] [9 1] [9 2] [9 3] [9 4] [9 5] [9 6]]
+
+       (perf/for [x (range 5)
+                  :let [x2 (* 2 x)] :when (> x2 4)
+                  y (range 20) :while (< y 7)
+                  :let [z [x2 y]]]
+         z)
+       #_=> [[6 0] [6 1] [6 2] [6 3] [6 4] [6 5] [6 6] [8 0] [8 1] [8 2] [8 3] [8 4] [8 5] [8 6]]
+
+       (perf/for [x (range 7)
+                  y (range 7) :while (< y x)]
+         [x y])
+       #_=> [[1 0] [2 0] [2 1] [3 0] [3 1] [3 2] [4 0] [4 1] [4 2] [4 3] [5 0] [5 1] [5 2] [5 3] [5 4] [6 0] [6 1] [6 2] [6 3] [6 4] [6 5]]
+
+       (perf/for [x nil
+                  y nil]
+         [x y])
+       #_=> [])
+
+     (are [i o] (= o i)
+       (with-out-str
+         (perf/doseq [x (range 3)
+                      y (range 5)]
+           (println x y)))
+       #_=> "0 0\n0 1\n0 2\n0 3\n0 4\n1 0\n1 1\n1 2\n1 3\n1 4\n2 0\n2 1\n2 2\n2 3\n2 4\n"
+       (with-out-str
+         (perf/doseq [x (range 5)
+                      :let [x2 (* 2 x)] :when (> x2 4)
+                      y (range 20) :while (< y 7)
+                      :let [z [x2 y]]] (println z)))
+       #_=> "[6 0]\n[6 1]\n[6 2]\n[6 3]\n[6 4]\n[6 5]\n[6 6]\n[8 0]\n[8 1]\n[8 2]\n[8 3]\n[8 4]\n[8 5]\n[8 6]\n"
+       (with-out-str
+         (perf/doseq [x nil
+                      y nil]
+           (println x y)))
+       #_=> "")))
+
 (deftest ^:parallel test-postwalk
   (are [before after] (= after (perf/postwalk #(cond-> %
                                                  (number? %) inc)


### PR DESCRIPTION
Two more additions to `metabase.util.performance`: `for` and `doseq`. The new versions have several benefits:

1. They are a bit more efficient computation-wise – no chunking and laziness overhead since most of the time they are not needed.
2. Less bytecode generated on the Java side.
3. Significantly smaller CLJS expansion. I've replaced `for` and `doseq` in all `.cljc` namespaces across Metabase and got 2.2% release bundle reduction (1727 KB => 1690 KB) and 3% gzipped reduction (405 KB => 393 KB). It ain't much but it's honest work.