### PR TITLE
Fix merge e2e timings step

### DIFF
--- a/.github/scripts/average-e2e-timings.js
+++ b/.github/scripts/average-e2e-timings.js
@@ -21,7 +21,6 @@ const collectAndAverageTimings = async ({
 
     const timingData = await downloadAndExtractArtifacts(
       artifacts,
-      token,
       github,
       context,
     );

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Extract chunk-specific changed timings
         id: extract-timings
-        if: inputs.split_index >= 0
+        if: inputs.split_index >= 0 && github.ref == 'refs/heads/master'
         continue-on-error: true
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Extract chunk-specific changed timings
         id: extract-timings
-        if: inputs.split_index >= 0 && github.ref == 'refs/heads/master'
+        if: inputs.split_index >= 0
         continue-on-error: true
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     needs: e2e-tests
-    if: always() && !cancelled()
+    if: always() && !cancelled() && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -118,8 +118,7 @@ jobs:
             const fs = require('fs');
             const path = require('path');
 
-            const globber = await glob.create('timing-files/*/chunkTimings.json');
-            const chunkFiles = await globber.glob();
+            const chunkFiles = glob.sync('timing-files/*/chunkTimings.json');
 
             const specs = new Map();
             chunkFiles.forEach(file => {

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     needs: e2e-tests
-    if: always() && !cancelled() && github.ref == 'refs/heads/master'
+    if: always() && !cancelled()
     steps:
       - uses: actions/checkout@v4
         with:
@@ -118,7 +118,8 @@ jobs:
             const fs = require('fs');
             const path = require('path');
 
-            const chunkFiles = glob.sync('timing-files/*/chunkTimings.json');
+            const globber = await glob.create('timing-files/*/chunkTimings.json');
+            const chunkFiles = await globber.glob();
 
             const specs = new Map();
             chunkFiles.forEach(file => {

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -118,7 +118,8 @@ jobs:
             const fs = require('fs');
             const path = require('path');
 
-            const chunkFiles = glob.sync('timing-files/*/chunkTimings.json');
+            const globber = await glob.create('timing-files/*/chunkTimings.json');
+            const chunkFiles = await globber.glob();
 
             const specs = new Map();
             chunkFiles.forEach(file => {


### PR DESCRIPTION
Glob works differently in an actions context. I tested on this branch and it seems to be creating the merged file correctly now.

Previously, it was failing in the ` name: Merge split timings` step