### PR TITLE
Do not pick unsupported databases automatically in transforms

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
@@ -1569,12 +1569,6 @@ LIMIT
         H.PythonEditor.value().should("contain", "import common");
 
         cy.findByTestId("python-data-picker")
-          .findByText("Select a database")
-          .click();
-
-        H.popover().findByText(DB_NAME).click();
-
-        cy.findByTestId("python-data-picker")
           .findByText("Select a table…")
           .click();
 
@@ -2317,7 +2311,7 @@ describe("scenarios > admin > transforms > runs", () => {
   });
 });
 
-H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
+describe("scenarios > admin > transforms", () => {
   beforeEach(() => {
     H.restore();
     H.resetSnowplow();
@@ -2332,7 +2326,7 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
   it("should not pick the only database when it is disabled in SQL editor", () => {
     cy.log("create a new transform");
     visitTransformListPage();
-    getTransformListPage().button("Create a transform").click();
+    cy.button("Create a transform").click();
     H.popover().findByText("SQL query").click();
 
     cy.findByTestId("gui-builder-data")
@@ -2343,7 +2337,7 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
   it("should not pick the only database when it is disabled in Python editor", () => {
     cy.log("create a new transform");
     visitTransformListPage();
-    getTransformListPage().button("Create a transform").click();
+    cy.button("Create a transform").click();
     H.popover().findByText("Python script").click();
 
     getPythonDataPicker().findByText("Select a database").should("be.visible");
@@ -2352,10 +2346,6 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
 
 function getTransformsNavLink() {
   return H.DataStudio.nav().findByRole("link", { name: "Transforms" });
-}
-
-function getTransformListPage() {
-  return cy.findByTestId("transform-list-page");
 }
 
 function getRunsNavLink() {

--- a/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms.cy.spec.ts
@@ -2317,8 +2317,45 @@ describe("scenarios > admin > transforms > runs", () => {
   });
 });
 
+H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
+  beforeEach(() => {
+    H.restore();
+    H.resetSnowplow();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
+
+  it("should not pick the only database when it is disabled in SQL editor", () => {
+    cy.log("create a new transform");
+    visitTransformListPage();
+    getTransformListPage().button("Create a transform").click();
+    H.popover().findByText("SQL query").click();
+
+    cy.findByTestId("gui-builder-data")
+      .findByText("Select a database")
+      .should("be.visible");
+  });
+
+  it("should not pick the only database when it is disabled in Python editor", () => {
+    cy.log("create a new transform");
+    visitTransformListPage();
+    getTransformListPage().button("Create a transform").click();
+    H.popover().findByText("Python script").click();
+
+    getPythonDataPicker().findByText("Select a database").should("be.visible");
+  });
+});
+
 function getTransformsNavLink() {
   return H.DataStudio.nav().findByRole("link", { name: "Transforms" });
+}
+
+function getTransformListPage() {
+  return cy.findByTestId("transform-list-page");
 }
 
 function getRunsNavLink() {

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/PythonDataPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonDataPicker/PythonDataPicker.tsx
@@ -10,6 +10,7 @@ import {
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { DatabaseDataSelector } from "metabase/query_builder/components/DataSelector";
 import { Box, Button, Icon, Stack, Text } from "metabase/ui";
+import { doesDatabaseSupportTransforms } from "metabase-enterprise/transforms/utils";
 import type {
   Database,
   DatabaseId,
@@ -162,6 +163,7 @@ export function PythonDataPicker({
           setDatabaseFn={handleDatabaseChange}
           databases={databases?.data ?? []}
           databaseIsDisabled={(database: Database) =>
+            !doesDatabaseSupportTransforms(database) ||
             !hasFeature(database, "transforms/python")
           }
         />

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -550,7 +550,12 @@ export class UnconnectedDataSelector extends Component {
       this.props.selectedDatabaseId == null
     ) {
       const databases = this.getDatabases();
-      if (databases && databases.length === 1) {
+      if (
+        databases &&
+        databases.length === 1 &&
+        (!this.props.databaseIsDisabled ||
+          !this.props.databaseIsDisabled(databases[0]))
+      ) {
         this.onChangeDatabase(databases[0]);
       }
     }

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -623,7 +623,7 @@ export class UnconnectedDataSelector extends Component {
     if (!nextStep) {
       await this.setStateWithComputedState({
         ...stateChange,
-        isPopoverOpen: !this.state.isPopoverOpen,
+        isPopoverOpen: false,
       });
     } else {
       await this.switchToStep(nextStep, stateChange, skipSteps);

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -537,7 +537,7 @@ export class UnconnectedDataSelector extends Component {
   // for steps where there's a single option sometimes we want to automatically select it
   // if `useOnlyAvailable*` prop is provided
   skipSteps() {
-    const { readOnly } = this.props;
+    const { readOnly, databaseIsDisabled } = this.props;
     const { activeStep } = this.state;
 
     if (readOnly) {
@@ -550,13 +550,11 @@ export class UnconnectedDataSelector extends Component {
       this.props.selectedDatabaseId == null
     ) {
       const databases = this.getDatabases();
-      if (
-        databases &&
-        databases.length === 1 &&
-        (!this.props.databaseIsDisabled ||
-          !this.props.databaseIsDisabled(databases[0]))
-      ) {
-        this.onChangeDatabase(databases[0]);
+      const enabledDatabases = databases.filter(
+        (db) => !databaseIsDisabled?.(db),
+      );
+      if (enabledDatabases.length >= 1) {
+        this.onChangeDatabase(enabledDatabases[0]);
       }
     }
     if (


### PR DESCRIPTION
Closes QUE-2615
Closes GDGT-1071

The native and Python datapickers automatically select the database if there is only one database available. 

This PR makes it so that they don't do that when the database being auto-selected does not support transforms.

<img width="1474" height="906" alt="Screenshot 2025-10-06 at 16 02 14" src="https://github.com/user-attachments/assets/4d29ca8c-2d8c-40a0-9cb2-846862b3eca2" />
