### PR TITLE
Collections are delete-able

### DIFF
--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -47,14 +47,12 @@ describe("scenarios > collections > trash", () => {
       cy.findByText("Deleted at");
     });
 
-    cy.log(
-      "trashed items in collection should not have option to move to trash",
-    );
+    cy.log("trashed items in collection should have option to move to trash");
     toggleEllipsisMenuFor("Collection A");
     H.popover().within(() => {
       cy.findByText("Move to trash").should("not.exist");
       cy.findByText("Restore").should("exist");
-      cy.findByText("Delete permanently").should("not.exist");
+      cy.findByText("Delete permanently").should("exist");
     });
     toggleEllipsisMenuFor("Collection A");
 
@@ -431,15 +429,15 @@ describe("scenarios > collections > trash", () => {
 
     cy.log("can delete from trash list");
     toggleEllipsisMenuFor("Collection A");
-    // FUTURE: replace following two lines with commented out code when collections can be deleted
-    H.popover().findByText("Delete permanently").should("not.exist");
-    toggleEllipsisMenuFor("Collection A");
-    // popover().findByText("Delete permanently").click();
-    // modal().findByText("Delete Collection A permanently?").should("exist");
-    // modal().findByText("Delete permanently").click();
-    // collectionTable().within(() => {
-    //   cy.findByText("Collection A").should("not.exist");
-    // });
+    H.popover()
+      .should("contain", "Delete permanently")
+      .findByText("Delete permanently")
+      .click();
+    H.modal().findByText("Delete Collection A permanently?").should("exist");
+    H.modal().findByText("Delete permanently").click();
+    collectionTable().within(() => {
+      cy.findByText("Collection A").should("not.exist");
+    });
 
     toggleEllipsisMenuFor("Dashboard A");
     H.popover()
@@ -468,14 +466,12 @@ describe("scenarios > collections > trash", () => {
       cy.findByText("Collection B").click();
     });
     // FUTURE: replace following two lines with commented out code when collections can be deleted
-    archiveBanner().findByText("Delete permanently").should("not.exist");
-    cy.visit("/trash");
-    // archiveBanner().findByText("Delete permanently").click();
-    // modal().findByText("Delete Collection B permanently?").should("exist");
-    // modal().findByText("Delete permanently").click();
-    // collectionTable().within(() => {
-    //   cy.findByText("Collection B").should("not.exist");
-    // });
+    archiveBanner().findByText("Delete permanently").click();
+    H.modal().findByText("Delete Collection B permanently?").should("exist");
+    H.modal().findByText("Delete permanently").click();
+    collectionTable().within(() => {
+      cy.findByText("Collection B").should("not.exist");
+    });
 
     collectionTable().within(() => {
       cy.findByText("Dashboard B").click();

--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -1779,8 +1779,9 @@
   (when (seq items)
     (for [item items]
       (assoc item :can_delete (boolean (and
-                                        (not (or (= :model/Collection (t2/model item))
-                                                 (collection.root/is-root-collection? item)))
+                                        (not (collection.root/is-root-collection? item))
+                                        (or (not (= :model/Collection (t2/model item)))
+                                            api/*is-superuser?*)
                                         (:archived item)
                                         (mi/can-write? item)))))))
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #2783
The `can_delete` flag for collections was the only missing bit to have collections be deletable, since I added an API endpoint to delete collections a while ago! I thought FE work was required, doh.

Fixes UXW-1090