### PR TITLE
feat(sdk)!: allow mapQuestionClickActions to run actions on click and clean the data we pass

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-bundle/stories/mapQuestionClickActions.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/stories/mapQuestionClickActions.stories.tsx
@@ -1,0 +1,189 @@
+import { useState } from "react";
+
+import { InteractiveDashboard } from "embedding-sdk-bundle/components/public/dashboard";
+import { CommonSdkStoryWrapper } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
+import type { MetabaseDataPointObject } from "embedding-sdk-package";
+
+export default {
+  title: "EmbeddingSDK/Map Question Click Actions",
+  decorators: [CommonSdkStoryWrapper],
+  parameters: { layout: "fullscreen" },
+};
+
+export const PluginOpenMenu = (_args: any) => {
+  const [modalData, setModalData] = useState<MetabaseDataPointObject | null>(
+    null,
+  );
+
+  return (
+    <div>
+      <InteractiveDashboard
+        dashboardId={1}
+        withDownloads
+        plugins={{
+          mapQuestionClickActions: (clickActions, clicked) => {
+            return [
+              ...clickActions,
+              {
+                buttonType: "horizontal",
+                name: "custom",
+                title: "Open modal",
+                onClick: () => {
+                  setModalData(clicked);
+                },
+              },
+            ];
+          },
+        }}
+      />
+      <SimpleModal open={Boolean(modalData)} onClose={() => setModalData(null)}>
+        <p>You clicked on question: {modalData?.question?.name ?? "Unknown"}</p>
+        <pre>{JSON.stringify({ ...modalData, raw: "redacted" }, null, 2)}</pre>
+      </SimpleModal>
+    </div>
+  );
+};
+
+export const PluginDoActionDirectly = (_args: any) => {
+  const [modalData, setModalData] = useState<MetabaseDataPointObject | null>(
+    null,
+  );
+
+  return (
+    <div>
+      <InteractiveDashboard
+        dashboardId={1}
+        withDownloads
+        plugins={{
+          mapQuestionClickActions: (clickActions, clicked) => {
+            return {
+              name: "custom",
+              title: "Open modal",
+              buttonType: "horizontal",
+              onClick: () => {
+                setModalData(clicked);
+              },
+            };
+          },
+        }}
+      />
+      <SimpleModal open={Boolean(modalData)} onClose={() => setModalData(null)}>
+        <p>You clicked on question: {modalData?.question?.name ?? "Unknown"}</p>
+        <pre>{JSON.stringify({ ...modalData, raw: "redacted" }, null, 2)}</pre>
+      </SimpleModal>
+    </div>
+  );
+};
+
+export const PluginDoActionDependingOnData = (_args: any) => {
+  const [modalData, setModalData] = useState<MetabaseDataPointObject | null>(
+    null,
+  );
+
+  return (
+    <div>
+      <p>
+        On the E-Commerce Insights dashboard, this should open the modal
+        directly on the first chart, and add the action to the menu on the
+        others
+      </p>
+      <InteractiveDashboard
+        dashboardId={1}
+        withDownloads
+        plugins={{
+          mapQuestionClickActions: (clickActions, clicked) => {
+            // this should be the first chart in the E-Commerce Insights dashboard
+            if (clicked.question?.id === 12) {
+              return {
+                name: "custom",
+                title: "Open modal",
+                buttonType: "horizontal",
+                onClick: () => {
+                  setModalData(clicked);
+                },
+              };
+            }
+            return [
+              ...clickActions,
+              {
+                name: "custom",
+                title: "Open modal",
+                buttonType: "horizontal",
+                onClick: () => {
+                  setModalData(clicked);
+                },
+              },
+            ];
+          },
+        }}
+      />
+      <SimpleModal open={Boolean(modalData)} onClose={() => setModalData(null)}>
+        <p>You clicked on question: {modalData?.question?.name ?? "Unknown"}</p>
+        <pre>{JSON.stringify({ ...modalData, raw: "redacted" }, null, 2)}</pre>
+      </SimpleModal>
+    </div>
+  );
+};
+
+const SimpleModal = ({
+  open,
+  onClose,
+  children,
+}: React.PropsWithChildren<{
+  open: boolean;
+  onClose: () => void;
+}>) => {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          backgroundColor: "white",
+          borderRadius: "8px",
+          padding: "24px",
+          maxWidth: "500px",
+          width: "90%",
+          maxHeight: "80vh",
+          overflow: "auto",
+          position: "relative",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={onClose}
+          style={{
+            position: "absolute",
+            top: "12px",
+            right: "12px",
+            background: "none",
+            border: "none",
+            fontSize: "24px",
+            cursor: "pointer",
+            color: "#666",
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/stories/mapQuestionClickActions.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/stories/mapQuestionClickActions.stories.tsx
@@ -57,9 +57,6 @@ export const PluginDoActionDirectly = (_args: any) => {
         plugins={{
           mapQuestionClickActions: (clickActions, clicked) => {
             return {
-              name: "custom",
-              title: "Open modal",
-              buttonType: "horizontal",
               onClick: () => {
                 setModalData(clicked);
               },
@@ -95,9 +92,6 @@ export const PluginDoActionDependingOnData = (_args: any) => {
             // this should be the first chart in the E-Commerce Insights dashboard
             if (clicked.question?.id === 12) {
               return {
-                name: "custom",
-                title: "Open modal",
-                buttonType: "horizontal",
                 onClick: () => {
                   setModalData(clicked);
                 },

--- a/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
@@ -17,7 +17,7 @@ export type MetabaseDataPointObject = {
 export type MetabaseClickActionPluginsConfig = (
   clickActions: MetabaseClickAction[],
   clickedDataPoint: MetabaseDataPointObject,
-) => MetabaseClickAction[];
+) => MetabaseClickAction[] | MetabaseClickAction;
 
 export type MetabaseDashboardPluginsConfig = {
   dashboardCardMenu?: DashboardCardMenu;

--- a/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
@@ -29,7 +29,9 @@ export type MetabaseDataPointObject = {
 export type MetabaseClickActionPluginsConfig = (
   clickActions: MetabaseClickAction[],
   clickedDataPoint: MetabaseDataPointObject,
-) => MetabaseClickAction[] | MetabaseClickAction;
+) =>
+  | MetabaseClickAction[]
+  | { onClick: (context: { closePopover: () => void }) => void };
 
 export type MetabaseDashboardPluginsConfig = {
   dashboardCardMenu?: DashboardCardMenu;

--- a/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
@@ -1,17 +1,29 @@
 import type { DashboardCardMenu } from "metabase/dashboard/components/DashCard/DashCardMenu/dashcard-menu";
 
+import type { MetabaseQuestion } from "./question";
+
 export type MetabaseClickAction = {
   name: string;
 } & Record<string, any>;
 
 export type MetabaseDataPointObject = {
-  value?: string | number | null | boolean;
-  column?: Record<string, any>;
+  value?: string | number | null | boolean | object;
+  column?: {
+    name?: string;
+    display_name?: string;
+  };
+  data?: Record<string, string | number | null | boolean | object>;
   event?: MouseEvent;
-  data?: {
-    col: Record<string, any> | null;
-    value: string | number | null | boolean;
-  }[];
+  question?: MetabaseQuestion;
+  raw?: {
+    value?: string | number | null | boolean;
+    column?: Record<string, any>;
+    event?: MouseEvent;
+    data?: {
+      col: Record<string, any> | null;
+      value: string | number | null | boolean;
+    }[];
+  };
 };
 
 export type MetabaseClickActionPluginsConfig = (

--- a/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
@@ -29,9 +29,7 @@ export type MetabaseDataPointObject = {
 export type MetabaseClickActionPluginsConfig = (
   clickActions: MetabaseClickAction[],
   clickedDataPoint: MetabaseDataPointObject,
-) =>
-  | MetabaseClickAction[]
-  | { onClick: (context: { closePopover: () => void }) => void };
+) => MetabaseClickAction[] | { onClick: () => void };
 
 export type MetabaseDashboardPluginsConfig = {
   dashboardCardMenu?: DashboardCardMenu;

--- a/frontend/src/metabase/embedding-sdk/lib/transform-clicked.ts
+++ b/frontend/src/metabase/embedding-sdk/lib/transform-clicked.ts
@@ -1,0 +1,37 @@
+import type { MetabaseDataPointObject } from "metabase/embedding-sdk/types/plugins";
+import type { ClickObject } from "metabase/visualizations/types";
+import type Question from "metabase-lib/v1/Question";
+
+import { transformSdkQuestion } from "./transform-question";
+
+/**
+ * Transforms the internal question and the `clicked` object into a simpler, less overwhelming structure.
+ * We still provide the raw object in `raw` for advanced use cases, such as needing to access
+ * mapped values.
+ */
+export function transformClickedDataPoint(
+  clicked: ClickObject,
+  question: Question,
+): MetabaseDataPointObject {
+  return {
+    raw: clicked as Record<string, unknown>,
+
+    column: clicked.column
+      ? {
+          name: clicked.column.name,
+          display_name: clicked.column.display_name,
+        }
+      : undefined,
+    value: clicked.value,
+    question: transformSdkQuestion(question),
+    data: clicked.data?.reduce(
+      (acc, curr) => {
+        if (curr.col) {
+          acc[curr.col.name] = curr.value;
+        }
+        return acc;
+      },
+      {} as Record<string, string | number | null | boolean | object>,
+    ),
+  };
+}

--- a/frontend/src/metabase/embedding-sdk/lib/transform-question.ts
+++ b/frontend/src/metabase/embedding-sdk/lib/transform-question.ts
@@ -1,5 +1,6 @@
-import type { MetabaseQuestion } from "metabase/embedding-sdk/types/question";
 import type Question from "metabase-lib/v1/Question";
+
+import type { MetabaseQuestion } from "../types/question";
 
 export function transformSdkQuestion(question: Question): MetabaseQuestion {
   const card = question.card();

--- a/frontend/src/metabase/embedding-sdk/types/plugins.ts
+++ b/frontend/src/metabase/embedding-sdk/types/plugins.ts
@@ -28,7 +28,9 @@ export type MetabaseDataPointObject = {
 export type MetabaseClickActionPluginsConfig = (
   clickActions: ClickAction[],
   clickedDataPoint: MetabaseDataPointObject,
-) => ClickAction[] | ClickAction;
+) =>
+  | ClickAction[]
+  | { onClick: (context: { closePopover: () => void }) => void };
 
 export type DashboardCardMenuCustomElement = ({
   question,

--- a/frontend/src/metabase/embedding-sdk/types/plugins.ts
+++ b/frontend/src/metabase/embedding-sdk/types/plugins.ts
@@ -13,7 +13,7 @@ export type MetabaseDataPointObject = Pick<
 export type MetabaseClickActionPluginsConfig = (
   clickActions: ClickAction[],
   clickedDataPoint: MetabaseDataPointObject,
-) => ClickAction[];
+) => ClickAction[] | ClickAction;
 
 export type DashboardCardMenuCustomElement = ({
   question,

--- a/frontend/src/metabase/embedding-sdk/types/plugins.ts
+++ b/frontend/src/metabase/embedding-sdk/types/plugins.ts
@@ -28,9 +28,7 @@ export type MetabaseDataPointObject = {
 export type MetabaseClickActionPluginsConfig = (
   clickActions: ClickAction[],
   clickedDataPoint: MetabaseDataPointObject,
-) =>
-  | ClickAction[]
-  | { onClick: (context: { closePopover: () => void }) => void };
+) => ClickAction[] | { onClick: () => void };
 
 export type DashboardCardMenuCustomElement = ({
   question,

--- a/frontend/src/metabase/embedding-sdk/types/plugins.ts
+++ b/frontend/src/metabase/embedding-sdk/types/plugins.ts
@@ -1,14 +1,29 @@
 import type { ReactNode } from "react";
 
 import type { DashCardMenuItem } from "metabase/dashboard/components/DashCard/DashCardMenu/dashcard-menu";
-import type { ClickAction, ClickObject } from "metabase/visualizations/types";
+import type { ClickAction } from "metabase/visualizations/types";
 
 import type { MetabaseQuestion } from "./question";
 
-export type MetabaseDataPointObject = Pick<
-  ClickObject,
-  "value" | "column" | "data" | "event"
->;
+export type MetabaseDataPointObject = {
+  value?: string | number | null | boolean | object;
+  column?: {
+    name?: string;
+    display_name?: string;
+  };
+  data?: Record<string, string | number | null | boolean | object>;
+  event?: MouseEvent;
+  question?: MetabaseQuestion;
+  raw?: {
+    value?: string | number | null | boolean;
+    column?: Record<string, any>;
+    event?: MouseEvent;
+    data?: {
+      col: Record<string, any> | null;
+      value: string | number | null | boolean;
+    }[];
+  };
+};
 
 export type MetabaseClickActionPluginsConfig = (
   clickActions: ClickAction[],

--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -59,13 +59,12 @@ export class Mode {
         transformClickedDataPoint(clicked, question),
       );
 
-      // If the plugin returns a single object, it means we should call that action right away without showing the popover
-      if (
-        !Array.isArray(actionsOrActionObject) &&
-        "onClick" in actionsOrActionObject
-      ) {
+      if (Array.isArray(actionsOrActionObject)) {
+        actions = actionsOrActionObject;
+      } else if ("onClick" in actionsOrActionObject) {
+        // If the plugin returns a single object, it means we should call that action right away without showing the popover
         // `performDefaultAction` checks if it only gets one action, and if it has `default: true`, it's called directly without showing the popover
-        return [
+        actions = [
           {
             // makes it run without showing the popover
             default: true,
@@ -80,7 +79,9 @@ export class Mode {
           },
         ];
       } else {
-        actions = actionsOrActionObject as ClickAction[];
+        console.warn(
+          "mapQuestionClickActions should return an array of actions, or a single object with a `onClick` property",
+        );
       }
     }
 

--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -1,3 +1,4 @@
+import { transformSdkQuestion } from "metabase/embedding-sdk/lib/transform-question";
 import type { MetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
 import { queryDrill } from "metabase/querying/drills/utils/query-drill";
 import type { DrillThruDisplayInfo } from "metabase-lib";
@@ -60,6 +61,7 @@ export class Mode {
           column: clicked.column,
           event: clicked.event,
           data: clicked.data,
+          question: transformSdkQuestion(question),
         },
       );
 

--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -1,4 +1,4 @@
-import { transformSdkQuestion } from "metabase/embedding-sdk/lib/transform-question";
+import { transformClickedDataPoint } from "metabase/embedding-sdk/lib/transform-clicked";
 import type { MetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
 import { queryDrill } from "metabase/querying/drills/utils/query-drill";
 import type { DrillThruDisplayInfo } from "metabase-lib";
@@ -56,13 +56,7 @@ export class Mode {
     if (this._plugins?.mapQuestionClickActions) {
       const actionsOrActionObject = this._plugins.mapQuestionClickActions(
         actions,
-        {
-          value: clicked.value,
-          column: clicked.column,
-          event: clicked.event,
-          data: clicked.data,
-          question: transformSdkQuestion(question),
-        },
+        transformClickedDataPoint(clicked, question),
       );
 
       // If the plugin returns a single object, it means we should call that action right away without showing the popover

--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -53,12 +53,39 @@ export class Mode {
     }
 
     if (this._plugins?.mapQuestionClickActions) {
-      actions = this._plugins.mapQuestionClickActions(actions, {
-        value: clicked.value,
-        column: clicked.column,
-        event: clicked.event,
-        data: clicked.data,
-      });
+      const actionsOrActionObject = this._plugins.mapQuestionClickActions(
+        actions,
+        {
+          value: clicked.value,
+          column: clicked.column,
+          event: clicked.event,
+          data: clicked.data,
+        },
+      );
+
+      // If the plugin returns a single object, it means we should call that action right away without showing the popover
+      if (
+        !Array.isArray(actionsOrActionObject) &&
+        "onClick" in actionsOrActionObject
+      ) {
+        // `performDefaultAction` checks if it only gets one action, and if it has `default: true`, it's called directly without showing the popover
+        return [
+          {
+            // makes it run without showing the popover
+            default: true,
+
+            // fallback values in case they just return `{ onClick: () => {})`}
+            section: "auto",
+            type: "custom",
+            buttonType: "horizontal",
+            name: "default",
+
+            ...(actionsOrActionObject as Partial<ClickAction>),
+          },
+        ];
+      } else {
+        actions = actionsOrActionObject as ClickAction[];
+      }
     }
 
     return actions;

--- a/frontend/src/metabase/visualizations/lib/action.js
+++ b/frontend/src/metabase/visualizations/lib/action.js
@@ -8,6 +8,11 @@ export function performAction(
   action,
   { dispatch, onChangeCardAndRun, onUpdateQuestion },
 ) {
+  if (action.onClick) {
+    action.onClick();
+    return true;
+  }
+
   let didPerform = false;
   if (action.action) {
     const reduxAction = action.action();


### PR DESCRIPTION
**Note: this is a breaking change as it changes the api of `mapQuestionClickActions`**

<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #51970 closes #63344
Technical doc: https://www.notion.so/metabase/Improve-click-support-in-SDK-and-EAJS-28469354c901807db752dd332cdb0283

I suggest reviewing this PR [commit by commit](https://github.com/metabase/metabase/pull/64425/commits)

# Description
Closes [EMB-796: Improve mapQuestionClickActions by including useful context instead of context of MB internals](https://linear.app/metabase/issue/EMB-796/improve-mapquestionclickactions-by-including-useful-context-instead-of)
Closes [EMB-77: Customize visualization click actions in the sdk via onVisualizationClick prop](https://linear.app/metabase/issue/EMB-77/customize-visualization-click-actions-in-the-sdk-via) (even though not with that function name)

This PR allows SDK users to run actions on visualization clicks, without having to push the action in the click actions menu.
To do that, they'll have to return a single object with the shape of `{ onClick: () => {... } }` instead of the array of actions, see the tech doc for more details as to why.
It also cleans the data we pass, to make it less overwhelming and simpler to parse.


# How to verify
You can use the stories added in this story

# Missing things from this PR:
https://linear.app/metabase/issue/EMB-890/allow-mapquestionclickactions-to-override-links-cells is still not fixed
Tests are also missing, I'll start working on those today together with the bug above