### PR TITLE
[QP] Allow multiple dashboard/card params to exist, if only one is set

### DIFF
--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -135,6 +135,15 @@
                 param-display-name)
            {:type qp.error-type/missing-required-parameter}))
 
+(defn- multiple-conflicting-param-values-exception [param-display-name]
+  (ex-info (tru "Multiple conflicting values were given for ''{0}''" param-display-name)
+           {:type qp.error-type/multiple-conflicting-parameter-values}))
+
+(defn- multiple-conflicting-default-values-exception [param-display-name]
+  (ex-info (tru "No value was given for ''{0}'' and multiple filters have conflicting default values"
+                param-display-name)
+           {:type qp.error-type/multiple-conflicting-default-values}))
+
 (mu/defn- dimension->field-id :- ::lib.schema.id/field
   [dimension]
   (second dimension))
@@ -303,27 +312,31 @@
   "Get the value that should be used for a raw value (i.e., non-Field filter) template tag from `params`."
   [tag    :- ::mbql.s/TemplateTag
    params :- [:maybe [:sequential ::lib.schema.parameter/parameter]]]
-  (let [matching-param (when-let [matching-params (not-empty (tag-params tag params))]
-                         ;; double-check and make sure we didn't end up with multiple mappings or something crazy like that.
-                         (when (> (count matching-params) 1)
-                           (throw (ex-info (tru "Error: multiple values specified for parameter; non-Field Filter parameters can only have one value.")
-                                           {:type                qp.error-type/invalid-parameter
-                                            :template-tag        tag
-                                            :matching-parameters params})))
-                         (first matching-params))
-        nil-value?       (and matching-param
-                              (nil? (:value matching-param)))]
-    ;; But if the param is present in `params` and its value is nil, don't use the default.
-    ;; If the param is not present in `params` use a default from either the tag or the Dashboard parameter.
-    ;; If both the tag and Dashboard parameter specify a default value, prefer the default value from the tag.
-    (or (:value matching-param)
-        (when (and nil-value? (not (:required tag)))
-          params/no-value)
-        (:default tag)
-        (:default matching-param)
-        (if (:required tag)
-          (throw (missing-required-param-exception (:display-name tag)))
-          params/no-value))))
+  (let [matching-params (tag-params tag params)
+        real-values     (into #{} (keep :value)   matching-params)
+        defaults        (into #{} (keep :default) matching-params)]
+    (cond
+      ;; Multiple parameters with different values set does not make sense.
+      (> (count real-values) 1)
+      (throw (multiple-conflicting-param-values-exception (:display-name tag)))
+
+      ;; A single real value wins.
+      (= (count real-values) 1)   (first real-values)
+      ;; If some parameters matched, but none have values, AND this tag is not required, then return a blank value.
+      (and (seq matching-params)
+           (not (:required tag))) params/no-value
+
+      ;; Prefer the default value of the tag over those of the parameters.
+      (:default tag)              (:default tag)
+      ;; If there are conflicting default values among the parameters, throw.
+      (> (count defaults) 1)
+      (throw (multiple-conflicting-default-values-exception (:display-name tag)))
+      ;; If there is exactly one (distinct) default value among the matching parameters, use it.
+      (= (count defaults) 1)      (first defaults)
+      ;; No value at all - throw if this tag was required.
+      (:required tag)             (throw (missing-required-param-exception (:display-name tag)))
+      ;; Fall back to no value.
+      :else                       params/no-value)))
 
 (defmethod parse-tag :number
   [tag params]

--- a/src/metabase/query_processor/error_type.clj
+++ b/src/metabase/query_processor/error_type.clj
@@ -58,6 +58,16 @@
   :parent invalid-query
   :show-in-embeds? true)
 
+(deferror multiple-conflicting-parameter-values
+  "The query is parameterized, and multiple filters provided conflicting values."
+  :parent invalid-query
+  :show-in-embeds? true)
+
+(deferror multiple-conflicting-default-values
+  "The query is parameterized, no value was supplied, and multiple filters have conflicting default values."
+  :parent invalid-query
+  :show-in-embeds? true)
+
 (deferror invalid-parameter
   "The query is parameterized, and a supplied parameter has an invalid value."
   :parent invalid-query


### PR DESCRIPTION
Fixes #64135.

### Description

Previously this code would throw if multiple dashboard and/or card
params were bound to the same SQL variable. Now multiple links are
allowed, provided that only one is actually given a value.

Actually, this logic de-duplicates the values, so if multiple filters
all set the same value, that also works.

### How to verify

1. Create a SQL question with a variable, eg.
   `SELECT * FROM ORDERS [[WHERE product_id = {{product}}]]`.
2. Add that card to a dashboard.
3. Add a dashboard filter (type Number) linked to `product`.
4. Add a card filter (type Number) linked to `product`.

Previously, the card would fail to run. Now the QP will accept it.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
