### PR TITLE
Better @mentions

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/shared/MenuComponents.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/shared/MenuComponents.tsx
@@ -10,8 +10,7 @@ import {
   Text,
   UnstyledButton,
 } from "metabase/ui";
-
-import type { SuggestionModel } from "../types";
+import type { SuggestionModel } from "metabase-enterprise/rich_text_editing/tiptap/extensions/shared/types";
 
 import S from "./MenuItems.module.css";
 
@@ -29,6 +28,7 @@ export interface MenuItem {
   model?: SuggestionModel;
   id?: number | string;
   href?: string;
+  hasSubmenu?: boolean;
 }
 
 export const MenuItemComponent = ({
@@ -65,6 +65,10 @@ export const MenuItemComponent = ({
           </Text>
         )}
       </Stack>
+
+      {item.hasSubmenu && (
+        <Icon name="chevronright" size=".75rem" color="text-light" />
+      )}
     </Group>
   </UnstyledButton>
 );

--- a/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/documents/components/Editor/types.ts
@@ -1,8 +1,4 @@
-import type { SearchModel } from "metabase-types/api";
-
 export interface CardEmbedRef {
   id: number;
   name?: string;
 }
-
-export type SuggestionModel = SearchModel | "user";

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Command/CommandSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Command/CommandSuggestion.tsx
@@ -231,6 +231,7 @@ export const CommandSuggestion = forwardRef<
     onSelectEntity: onSelectLinkEntity,
     enabled: true,
     searchModels: showLinkSearch ? LINK_SEARCH_MODELS : EMBED_SEARCH_MODELS,
+    canBrowseAll: true,
   });
 
   const {
@@ -397,6 +398,7 @@ export const CommandSuggestion = forwardRef<
           modal={entityModal}
           onModalSelect={entityHandlers.handleModalSelect}
           onModalClose={entityHandlers.handleModalClose}
+          canBrowseAll
         />
       ) : (
         <>

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Mention/MentionSuggestion.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Mention/MentionSuggestion.tsx
@@ -7,22 +7,23 @@ import {
   LoadingSuggestionPaper,
   SuggestionPaper,
 } from "metabase-enterprise/documents/components/Editor/shared/SuggestionPaper";
-import type { SuggestionModel } from "metabase-enterprise/documents/components/Editor/types";
 import { getCurrentDocument } from "metabase-enterprise/documents/selectors";
 import type { SearchResult } from "metabase-types/api";
 
 import { EntitySearchSection } from "../shared/EntitySearchSection";
+import type { SuggestionModel } from "../shared/types";
 import { useEntitySuggestions } from "../shared/useEntitySuggestions";
 
 import type { MentionCommandProps } from "./MentionExtension";
 
-interface MentionSuggestionProps {
+export interface MentionSuggestionProps {
   items: SearchResult[];
   command: (item: MentionCommandProps) => void;
   editor: Editor;
   range: Range;
   query: string;
   searchModels?: SuggestionModel[];
+  canBrowseAll?: boolean;
 }
 
 interface SuggestionRef {
@@ -33,7 +34,15 @@ const MentionSuggestionComponent = forwardRef<
   SuggestionRef,
   MentionSuggestionProps
 >(function MentionSuggestionComponent(
-  { items: _items, command, editor, range: _range, query, searchModels },
+  {
+    items: _items,
+    command,
+    editor,
+    range,
+    query,
+    searchModels,
+    canBrowseAll = true,
+  },
   ref,
 ) {
   const document = useSelector(getCurrentDocument);
@@ -49,7 +58,7 @@ const MentionSuggestionComponent = forwardRef<
         model: item.model,
         label: item.label,
         href: item.href,
-        document,
+        document, // currently only used for analytics tracking purposes
       });
     },
     [command, document],
@@ -61,12 +70,15 @@ const MentionSuggestionComponent = forwardRef<
     searchResults,
     selectedIndex,
     modal,
+    selectedSearchModelName,
     handlers,
   } = useEntitySuggestions({
     query,
     editor,
+    range,
     searchModels,
     onSelectEntity,
+    canBrowseAll,
   });
 
   useImperativeHandle(ref, () => ({
@@ -78,7 +90,10 @@ const MentionSuggestionComponent = forwardRef<
   }
 
   return (
-    <SuggestionPaper aria-label={t`Mention Dialog`}>
+    <SuggestionPaper
+      aria-label={t`Mention Dialog`}
+      key={selectedSearchModelName}
+    >
       <EntitySearchSection
         menuItems={menuItems}
         selectedIndex={selectedIndex}
@@ -90,6 +105,8 @@ const MentionSuggestionComponent = forwardRef<
         onModalSelect={handlers.handleModalSelect}
         onModalClose={handlers.handleModalClose}
         onItemHover={handlers.hoverHandler}
+        selectedSearchModelName={selectedSearchModelName}
+        canBrowseAll={canBrowseAll}
       />
     </SuggestionPaper>
   );
@@ -99,15 +116,22 @@ export const MentionSuggestion = MentionSuggestionComponent;
 
 export const createMentionSuggestion = ({
   searchModels,
+  canBrowseAll,
 }: {
   searchModels: SuggestionModel[];
+  canBrowseAll?: boolean;
 }) => {
   return forwardRef<
     SuggestionRef,
     Omit<MentionSuggestionProps, "searchModels">
   >(function MentionSuggestionWrapper(props, ref) {
     return (
-      <MentionSuggestion {...props} ref={ref} searchModels={searchModels} />
+      <MentionSuggestion
+        {...props}
+        ref={ref}
+        searchModels={searchModels}
+        canBrowseAll={canBrowseAll}
+      />
     );
   });
 };

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Mention/MentionSuggestion.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Mention/MentionSuggestion.unit.spec.tsx
@@ -1,0 +1,205 @@
+import userEvent from "@testing-library/user-event";
+import type { Editor } from "@tiptap/core";
+import fetchMock from "fetch-mock";
+
+import {
+  setupRecentViewsEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import { checkNotNull } from "metabase/lib/types";
+import {
+  createMockRecentCollectionItem,
+  createMockSearchResult,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import type { MentionSuggestionProps } from "./MentionSuggestion";
+import { MentionSuggestion } from "./MentionSuggestion";
+
+const expectOptionToBePresent = async (name: string | RegExp) => {
+  expect(await screen.findByRole("option", { name })).toBeInTheDocument();
+};
+
+const expectOptionNotToBePresent = (name: string | RegExp) => {
+  expect(screen.queryByRole("option", { name })).not.toBeInTheDocument();
+};
+
+const SEARCH_ITEMS = [
+  createMockSearchResult({
+    name: "Orders question",
+    model: "card",
+    id: 1,
+  }),
+];
+
+const RECENT_ITEMS = [
+  createMockRecentCollectionItem({
+    id: 4,
+    name: "Recent Card",
+    model: "card",
+  }),
+];
+
+interface SetupProps extends Partial<MentionSuggestionProps> {
+  query?: string;
+  searchItems?: typeof SEARCH_ITEMS;
+  recentItems?: typeof RECENT_ITEMS;
+}
+
+const setup = (props: SetupProps = {}) => {
+  const command = jest.fn();
+
+  const mockChain = {
+    focus: jest.fn().mockReturnThis(),
+    deleteRange: jest.fn().mockReturnThis(),
+    insertContent: jest.fn().mockReturnThis(),
+    run: jest.fn().mockReturnThis(),
+  };
+
+  const editor = {
+    commands: {
+      focus: jest.fn(),
+      deleteRange: jest.fn().mockReturnThis(),
+      insertContent: jest.fn().mockReturnThis(),
+      run: jest.fn(),
+    },
+    chain: jest.fn().mockReturnValue(mockChain),
+  } as unknown as Editor;
+
+  setupSearchEndpoints(props.searchItems ?? SEARCH_ITEMS);
+  setupRecentViewsEndpoints(props.recentItems ?? RECENT_ITEMS);
+
+  const defaultProps: MentionSuggestionProps = {
+    items: [],
+    command,
+    editor,
+    range: { from: 0, to: 0 },
+    query: props.query || "",
+    ...props,
+  };
+
+  renderWithProviders(<MentionSuggestion {...defaultProps} />, {
+    storeInitialState: createMockState({}),
+  });
+
+  return { command, editor };
+};
+
+describe("MentionSuggestion", () => {
+  it("shows recent items for empty query", async () => {
+    setup({ query: "" });
+    await expectOptionToBePresent(/Recent Card/);
+  });
+
+  it("shows 'Browse all' when canBrowseAll=true", async () => {
+    setup({ query: "", canBrowseAll: true });
+    await expectOptionToBePresent(/Recent Card/);
+    expect(screen.getByText("Browse all")).toBeInTheDocument();
+  });
+
+  it("hides 'Browse all' when canBrowseAll=false", async () => {
+    setup({ query: "", canBrowseAll: false });
+    await expectOptionToBePresent(/Recent Card/);
+    expect(screen.queryByText("Browse all")).not.toBeInTheDocument();
+  });
+
+  it("searches without model filtering when none provided", async () => {
+    setup({ query: "ord" });
+    await expectOptionToBePresent(/Orders question/);
+    expectOptionNotToBePresent(/Recent Card/);
+  });
+
+  it("shows model selector for empty query with searchModels", async () => {
+    setup({ query: "", searchModels: ["card", "dashboard", "table"] });
+    await expectOptionToBePresent(/Question/);
+    await expectOptionToBePresent(/Dashboard/);
+    await expectOptionToBePresent(/Table/);
+  });
+
+  it("filters search by selected model and shows model name", async () => {
+    const { editor } = setup({
+      query: "",
+      searchModels: ["card", "dashboard", "table"],
+      searchItems: [
+        createMockSearchResult({
+          name: "Sales Dashboard",
+          model: "dashboard",
+          id: 10,
+        }),
+      ],
+    });
+
+    // click option
+    await userEvent.click(
+      await screen.findByRole("option", {
+        name: /Dashboard/,
+      }),
+    );
+    expect(editor.chain).toHaveBeenCalled();
+    const chainMethods = editor.chain();
+    expect(chainMethods.focus).toHaveBeenCalled();
+    expect(chainMethods.deleteRange).toHaveBeenCalled();
+    expect(chainMethods.insertContent).toHaveBeenCalledWith("@");
+    expect(chainMethods.run).toHaveBeenCalled();
+
+    // Now the component should re-render with "Dashboard" shown at the top
+    // This happens because selectedSearchModelName is passed as a key to SuggestionPaper
+    expect(await screen.findByText("Dashboard")).toBeInTheDocument();
+
+    // Verify that only dashboard results are shown when searching
+    await expectOptionToBePresent(/Sales Dashboard/);
+
+    const call = fetchMock.callHistory.lastCall("path:/api/search");
+    const urlObject = new URL(checkNotNull(call?.request?.url));
+    expect(urlObject.searchParams.get("models")).toEqual("dashboard");
+  });
+
+  it("filters model selector by query text", async () => {
+    setup({
+      query: "que",
+      searchModels: ["card", "dashboard", "table"],
+    });
+
+    await expectOptionToBePresent(/Question/);
+    expectOptionNotToBePresent(/Dashboard/);
+    expectOptionNotToBePresent(/Table/);
+  });
+
+  it("behaves as standard mention without searchModels", async () => {
+    setup({ query: "" });
+
+    await expectOptionToBePresent(/Recent Card/);
+    expect(screen.getByText("Browse all")).toBeInTheDocument();
+    expectOptionNotToBePresent(/Question/);
+    expectOptionNotToBePresent(/Dashboard/);
+  });
+
+  it("searches all models when query doesn't match any model name", async () => {
+    setup({
+      query: "Sales", // Doesn't match any model name
+      searchModels: ["card", "dashboard", "table"],
+      searchItems: [
+        createMockSearchResult({ name: "Sales Card", model: "card", id: 11 }),
+        createMockSearchResult({
+          name: "Sales Dashboard",
+          model: "dashboard",
+          id: 12,
+        }),
+        createMockSearchResult({
+          name: "Sales Table",
+          model: "table",
+          id: 13,
+        }),
+      ],
+    });
+
+    expect(
+      await screen.findAllByRole("option", { name: /Sales/ }),
+    ).toHaveLength(3);
+    const call = fetchMock.callHistory.lastCall("path:/api/search");
+    const urlObject = new URL(checkNotNull(call?.request?.url));
+    const models = urlObject.searchParams.getAll("models").sort();
+    expect(models).toEqual(["card", "dashboard", "table"]);
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Mention/MentionSuggestion.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/Mention/MentionSuggestion.unit.spec.tsx
@@ -130,7 +130,6 @@ describe("MentionSuggestion", () => {
       ],
     });
 
-    // click option
     await userEvent.click(
       await screen.findByRole("option", {
         name: /Dashboard/,
@@ -143,11 +142,7 @@ describe("MentionSuggestion", () => {
     expect(chainMethods.insertContent).toHaveBeenCalledWith("@");
     expect(chainMethods.run).toHaveBeenCalled();
 
-    // Now the component should re-render with "Dashboard" shown at the top
-    // This happens because selectedSearchModelName is passed as a key to SuggestionPaper
     expect(await screen.findByText("Dashboard")).toBeInTheDocument();
-
-    // Verify that only dashboard results are shown when searching
     await expectOptionToBePresent(/Sales Dashboard/);
 
     const call = fetchMock.callHistory.lastCall("path:/api/search");

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/MetabotMention/MetabotMentionExtension.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/MetabotMention/MetabotMentionExtension.tsx
@@ -16,6 +16,7 @@ interface MentionProps {
   type?: string;
   id?: number | string;
   model?: string;
+  label?: string;
 }
 
 export const MetabotMentionPluginKey = new PluginKey("metabot-mention");
@@ -53,8 +54,10 @@ export const MetabotMentionExtension = Extension.create<MentionOptions>({
                 attrs: {
                   entityId: props.id,
                   model: props.model,
+                  label: props.label,
                 },
               })
+              .insertContent(" ") // Add space after mention
               .run();
           }
         },

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
@@ -27,7 +27,6 @@ import {
   useGetDocumentQuery,
   useListMentionsQuery,
 } from "metabase-enterprise/api";
-import type { SuggestionModel } from "metabase-enterprise/documents/components/Editor/types";
 import { updateMentionsCache } from "metabase-enterprise/documents/documents.slice";
 import type {
   Card,
@@ -44,6 +43,7 @@ import {
   entityToUrlableModel,
   isMentionableUser,
 } from "../shared/suggestionUtils";
+import type { SuggestionModel } from "../shared/types";
 
 import styles from "./SmartLinkNode.module.css";
 
@@ -229,7 +229,7 @@ export const SmartLink = Node.create<{
   },
 });
 
-const useEntityData = (
+export const useEntityData = (
   entityId: number | null,
   model: SuggestionModel | null,
 ) => {
@@ -335,17 +335,27 @@ const useEntityData = (
 
 export const SmartLinkComponent = memo(
   ({ node }: NodeViewProps) => {
-    const { entityId, model } = node.attrs;
-    const { entity, isLoading, error } = useEntityData(entityId, model);
+    const { entityId, model, label } = node.attrs;
+
+    const {
+      entity: networkEntity,
+      isLoading,
+      error,
+    } = useEntityData(entityId, model);
+    const cachedEntity = { id: parseInt(entityId, 10), model, name: label };
+    const entity = networkEntity || cachedEntity;
 
     const dispatch = useDispatch();
     useEffect(() => {
-      if (entity?.name) {
-        dispatch(updateMentionsCache({ entityId, model, name: entity.name }));
+      if (entity) {
+        const name =
+          "display_name" in entity ? entity.display_name : entity?.name;
+        dispatch(updateMentionsCache({ entityId, model, name }));
       }
-    }, [dispatch, entity?.name, entityId, model]);
+    }, [dispatch, entity, entityId, model]);
 
-    if (isLoading) {
+    const showLoading = isLoading && !entity;
+    if (showLoading) {
       return (
         <NodeViewWrapper as="span">
           <span className={styles.smartLink}>
@@ -382,7 +392,15 @@ export const SmartLinkComponent = memo(
     const entityUrlableModel = entityToUrlableModel(entity, model);
     const entityUrl = modelToUrl(entityUrlableModel);
 
-    const iconData = getIcon(entityToObjectWithModel(entity, model));
+    const iconData =
+      entity === cachedEntity
+        ? getIcon(cachedEntity)
+        : getIcon(
+            entityToObjectWithModel(
+              entity as NonNullable<typeof networkEntity>,
+              model,
+            ),
+          );
 
     return (
       <NodeViewWrapper as="span">
@@ -428,7 +446,7 @@ function entityToObjectWithModel(
   };
 }
 
-function getName(entity: SmartLinkEntity) {
+function getName(entity: { name?: string; display_name?: string }) {
   if ("display_name" in entity && entity.display_name !== "") {
     return entity.display_name;
   }

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.unit.spec.tsx
@@ -9,7 +9,6 @@ import {
   setupTableEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
-import type { SuggestionModel } from "metabase-enterprise/documents/components/Editor/types";
 import {
   createMockCard,
   createMockCollection,
@@ -19,25 +18,49 @@ import {
   createMockTable,
 } from "metabase-types/api/mocks";
 
+import type { SuggestionModel } from "../shared/types";
+
 import { SmartLinkComponent, type SmartLinkEntity } from "./SmartLinkNode";
 
-function createProps(model: SuggestionModel, entity: SmartLinkEntity) {
-  const node = { attrs: { entityId: entity.id, model } };
+function createProps(
+  model: SuggestionModel,
+  entity: SmartLinkEntity | { id: number; label?: string },
+  label?: string,
+) {
+  const node = { attrs: { entityId: entity.id, model, label } };
   return { node } as unknown as NodeViewProps;
 }
 
 function setup({
   entity,
   model,
+  label,
 }: {
   model: SuggestionModel;
   entity: SmartLinkEntity;
+  label?: string;
 }) {
-  const props = createProps(model, entity);
+  const props = createProps(model, entity, label);
   renderWithProviders(<SmartLinkComponent {...props} />);
 }
 
 describe("SmartLink", () => {
+  describe("general", () => {
+    it("renders cached label immediately while loading network data", async () => {
+      const card = createMockCard({ name: "Network Card Name" });
+      setupCardEndpoints(card);
+      setup({ model: "card", entity: card, label: "Cached Card Name" });
+
+      expect(screen.getByText("Cached Card Name")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("img", { name: /hourglass/ }),
+      ).not.toBeInTheDocument();
+      // Eventually updates to network data
+      expect(await screen.findByText("Network Card Name")).toBeInTheDocument();
+      expect(screen.queryByText("Cached Card Name")).not.toBeInTheDocument();
+    });
+  });
+
   describe("for Card", () => {
     it("should render the name of a card", async () => {
       const card = createMockCard({

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/EntitySearchSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/EntitySearchSection.tsx
@@ -21,6 +21,8 @@ interface EntitySearchSectionProps {
   onModalSelect: (item: QuestionPickerValueItem) => void;
   onModalClose: () => void;
   onItemHover: (index: number) => void;
+  canBrowseAll?: boolean;
+  selectedSearchModelName?: string;
 }
 
 export function EntitySearchSection({
@@ -34,9 +36,18 @@ export function EntitySearchSection({
   onModalSelect,
   onModalClose,
   onItemHover,
+  selectedSearchModelName,
+  canBrowseAll,
 }: EntitySearchSectionProps) {
   return (
     <>
+      {selectedSearchModelName && (
+        <Box py="xs">
+          <Text size="sm" c="text-light" fw="bold">
+            {selectedSearchModelName}
+          </Text>
+        </Box>
+      )}
       {menuItems.map((item, index) => (
         <MenuItemComponent
           key={index}
@@ -46,20 +57,30 @@ export function EntitySearchSection({
           onMouseEnter={() => onItemHover(index)}
         />
       ))}
-      {query.length > 0 && searchResults.length === 0 ? (
+      {query.length > 0 &&
+      menuItems.length === 0 &&
+      searchResults.length === 0 ? (
         <Box p="sm" ta="center">
           <Text size="md" c="text-medium">{t`No results found`}</Text>
         </Box>
       ) : null}
-      {menuItems.length > 0 && <Divider my="sm" mx="sm" />}
-      <SearchResultsFooter
-        isSelected={selectedIndex === menuItems.length}
-        onClick={onFooterClick}
-        onMouseEnter={() => onItemHover(menuItems.length)}
-      />
+      {canBrowseAll && (
+        <>
+          {menuItems.length > 0 && <Divider my="sm" mx="sm" />}
 
-      {modal === "question-picker" && (
-        <QuestionPickerModal onChange={onModalSelect} onClose={onModalClose} />
+          <SearchResultsFooter
+            isSelected={selectedIndex === menuItems.length}
+            onClick={onFooterClick}
+            onMouseEnter={() => onItemHover(menuItems.length)}
+          />
+
+          {modal === "question-picker" && (
+            <QuestionPickerModal
+              onChange={onModalSelect}
+              onClose={onModalClose}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/constants.ts
@@ -1,4 +1,4 @@
-import type { SuggestionModel } from "metabase-enterprise/documents/components/Editor/types";
+import type { SuggestionModel } from "./types";
 
 export const LINK_SEARCH_MODELS: SuggestionModel[] = [
   "card",

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/suggestionUtils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/suggestionUtils.ts
@@ -1,8 +1,8 @@
+import { getTranslatedEntityName } from "metabase/common/utils/model-names";
 import { getIcon } from "metabase/lib/icon";
 import { getName } from "metabase/lib/name";
 import type { UrlableModel } from "metabase/lib/urls/modelToUrl";
 import type { MenuItem } from "metabase-enterprise/documents/components/Editor/shared/MenuComponents";
-import type { SuggestionModel } from "metabase-enterprise/documents/components/Editor/types";
 import type {
   Database,
   MentionableUser,
@@ -10,6 +10,8 @@ import type {
   SearchResult,
 } from "metabase-types/api";
 import { isObject } from "metabase-types/guards";
+
+import type { SuggestionModel } from "./types";
 
 export const filterRecents = (item: RecentItem, models: SuggestionModel[]) =>
   models.includes(item.model);
@@ -76,6 +78,21 @@ export function buildUserMenuItems(
       id: user.id,
       model: "user",
       action: () => onSelect(user),
+    };
+  });
+}
+
+export function buildSearchModelMenuItems(
+  searchModels: SuggestionModel[],
+  onSelect: (model: SuggestionModel) => void,
+): MenuItem[] {
+  return searchModels.map((model) => {
+    return {
+      icon: getIcon({ model }).name,
+      label: getTranslatedEntityName(model) || model,
+      model,
+      action: () => onSelect(model),
+      hasSubmenu: true,
     };
   });
 }

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/types.ts
@@ -1,0 +1,3 @@
+import type { SearchModel } from "metabase-types/api";
+
+export type SuggestionModel = SearchModel | "transform" | "user";

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/useEntitySuggestions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/shared/useEntitySuggestions.ts
@@ -131,15 +131,12 @@ export function useEntitySuggestions({
     if (selectedSearchModel) {
       return [selectedSearchModel];
     }
-    // If we have searchModels but no matches, use all searchModels
     if (searchModels && filteredSearchModels?.length === 0) {
       return searchModels;
     }
-    // Otherwise use the filtered models (or undefined if no searchModels provided)
     return filteredSearchModels;
   }, [selectedSearchModel, filteredSearchModels, searchModels]);
 
-  // Determine if we're in model selection mode
   const searchModelMenuItems = useMemo(() => {
     return selectedSearchModel || filteredSearchModels === undefined
       ? []
@@ -149,7 +146,6 @@ export function useEntitySuggestions({
         );
   }, [filteredSearchModels, selectedSearchModel, handleSearchModelSelect]);
 
-  // Check if we have any matching search models
   const hasSearchModels = (searchModels?.length ?? 0) > 0;
   const hasMatchingFilteredModels = (filteredSearchModels?.length ?? 0) > 0;
   const isInModelSelectionMode =
@@ -173,7 +169,6 @@ export function useEntitySuggestions({
     searchModels: effectiveSearchModels,
   });
 
-  // Combine menu items based on current mode
   const menuItems = useMemo(() => {
     if (isInModelSelectionMode) {
       return searchModelMenuItems;
@@ -262,7 +257,7 @@ export function useEntitySuggestions({
     setSelectedIndex(0);
   }, [menuItems.length]);
 
-  // Get the translated name for the selected search modelAdd a comment on lines R256 to R257Add diff commentMarkdown input:  edit mode selected.WritePreviewAdd a suggestionHeadingBoldItalicQuoteCodeLinkUnordered listNumbered listTask listMentionReferenceSaved repliesAdd FilesPaste, drop, or click to add filesCancelCommentStart a reviewReturn to code
+  // Get the translated name for the selected search modelAdd a comment on lines
   const selectedSearchModelName = selectedSearchModel
     ? getTranslatedEntityName(selectedSearchModel) || selectedSearchModel
     : undefined;

--- a/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/suggestionRenderer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/rich_text_editing/tiptap/extensions/suggestionRenderer.tsx
@@ -1,4 +1,5 @@
 import {
+  type Placement,
   type VirtualElement,
   autoUpdate,
   computePosition,
@@ -11,11 +12,33 @@ import type {
   SuggestionKeyDownProps,
   SuggestionProps,
 } from "@tiptap/suggestion";
+import { merge } from "icepick";
 import type React from "react";
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+interface SuggestionRendererOptions {
+  positionOptions: {
+    placement: Placement;
+    fallbackPlacements: Placement[];
+  };
+}
+
+const defaultRendererOptions: SuggestionRendererOptions = {
+  positionOptions: {
+    placement: "bottom-start",
+    fallbackPlacements: ["top-start", "bottom-end", "top-end"],
+  },
+};
 
 export const createSuggestionRenderer = <I = unknown, TSelected = unknown>(
   SuggestionComponent: React.ComponentType<SuggestionProps<I, TSelected>>,
+  options?: DeepPartial<SuggestionRendererOptions>,
 ) => {
+  const config = merge(defaultRendererOptions, options);
+
   return () => {
     let component: ReactRenderer | undefined;
     let currentClientRect: (() => DOMRect | null) | null | undefined;
@@ -42,11 +65,11 @@ export const createSuggestionRenderer = <I = unknown, TSelected = unknown>(
       };
 
       computePosition(virtualElement, element, {
-        placement: "bottom-start",
+        placement: config.positionOptions.placement,
         strategy: "fixed",
         middleware: [
           flip({
-            fallbackPlacements: ["top-start", "bottom-end", "top-end"],
+            fallbackPlacements: config.positionOptions.fallbackPlacements,
             padding: 4,
           }),
           shift({


### PR DESCRIPTION
### Description

Pulls out `@mentions` updates from #63313 and adds test coverage. The existing functionality should be preserved for all uses of mentions right now but with new params you're able to control it to look like this:

<img width="662" height="616" alt="CleanShot 2025-10-06 at 09 33 28@2x" src="https://github.com/user-attachments/assets/36b1dd86-c82f-4d78-a34a-0b9e831b84cb" />
<img width="938" height="478" alt="image (13)" src="https://github.com/user-attachments/assets/a69cbf3b-0577-4f14-ac5b-5e0ecd4bff17" />

Or you can maintain the original option
<img width="748" height="648" alt="CleanShot 2025-10-06 at 15 06 16@2x" src="https://github.com/user-attachments/assets/331fb43e-c6ab-4387-9835-17523b92200d" />

### How to verify

Should preserve existing behavior. You can change values like in the unit tests or check out #63313 and use the metabot chat's input to test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
