### PR TITLE
Remove `api/*current-user-id*` for public dashboard requests

### DIFF
--- a/src/metabase/public_sharing/api.clj
+++ b/src/metabase/public_sharing/api.clj
@@ -285,7 +285,12 @@
     ;; current user perms; if this Dashcard is public you're by definition allowed to run it without a perms check
     ;; anyway
     (request/as-admin
-      (m/mapply qp.dashboard/process-query-for-dashcard options))))
+      ;; Even if we have a current user, we don't want this request associated with a particular user because it's
+      ;; public. This also prevents setting user-specific parameters (for example, if a logged in user is visiting a
+      ;; page that has locked parameters, we don't want them to get those same parameters next time they visit this
+      ;; dashboard in Metabase proper.)
+      (binding [api/*current-user-id* nil]
+        (m/mapply qp.dashboard/process-query-for-dashcard options)))))
 
 (api.macros/defendpoint :get "/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id"
   "Fetch the results for a Card in a publicly-accessible Dashboard. Does not require auth credentials. Public

--- a/test/metabase/embedding/api/embed_test.clj
+++ b/test/metabase/embedding/api/embed_test.clj
@@ -10,6 +10,7 @@
    [crypto.random :as crypto-random]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
    [java-time.api :as t]
+   [metabase.api.common :as api]
    [metabase.config.core :as config]
    [metabase.dashboards.api-test :as api.dashboard-test]
    [metabase.embedding.api.common :as api.embed.common]
@@ -762,6 +763,17 @@
         (test-query-results (client/client :get 202 (dashcard-url dashcard)))
         #_{:clj-kondo/ignore [:deprecated-var]}
         (test-query-results (client/client :get 202 (dashcard-url dashcard {} (dashcard->dash-eid dashcard))))))))
+
+(deftest running-card-as-logged-in-user-does-not-set-last-used-param-values
+  (testing "running the card does not set last used param values"
+    (with-embedding-enabled-and-new-secret-key!
+      (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:venue_id "locked"}}}]
+        (is (=? {:status   "completed"
+                 :data     {:rows [[1]]}}
+                (mt/user-http-request :rasta :get 202 (dashcard-url dashcard {:params {:venue_id 100}}))))
+        (is (= {}
+               (binding [api/*current-user-id* (mt/user->id :rasta)]
+                 (:last_used_param_values (t2/hydrate (t2/select-one :model/Dashboard (:dashboard_id dashcard)) :last_used_param_values)))))))))
 
 (deftest downloading-csv-json-xlsx-results-from-the-dashcard-endpoint-shouldn-t-be-subject-to-the-default-query-constraints
   (testing (str "Downloading CSV/JSON/XLSX results from the dashcard endpoint shouldn't be subject to the default "


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57765

When processing a query for a *public* dashboard endpoint, unbind `api/*current-user-id*`. We don't want or need to associate the user here, and it can cause issues, e.g. when a public dashboard with a locked parameter is visited it causes  the user to get new `last_used_param_values`.