### PR TITLE
[QP] Don't remap FKs to their human-readable column if it's hidden

### DIFF
--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -648,6 +648,7 @@
             :let   [remapped (lib.metadata/remapped-field query column)]
             :when  (and remapped
                         (not (false? (:active remapped)))
+                        (not= (:visibility-type remapped) :sensitive)
                         (not (existing-ids (:id remapped))))]
         (merge
          remapped

--- a/src/metabase/query_processor/middleware/add_remaps.clj
+++ b/src/metabase/query_processor/middleware/add_remaps.clj
@@ -92,12 +92,13 @@
   (let [col (lib.metadata/field metadata-providerable field-id)]
     (when-let [{remap-id :id, remap-name :name, remap-field-id :field-id} (:lib/external-remap col)]
       (when-let [remap-field (lib.metadata/field metadata-providerable remap-field-id)]
-        {:id                        remap-id
-         :name                      remap-name
-         :field-id                  (:id col)
-         :field-name                (:name col)
-         :human-readable-field-id   remap-field-id
-         :human-readable-field-name (:name remap-field)}))))
+        (when (not= (:visibility-type remap-field) :sensitive)
+          {:id                        remap-id
+           :name                      remap-name
+           :field-id                  (:id col)
+           :field-name                (:name col)
+           :human-readable-field-id   remap-field-id
+           :human-readable-field-name (:name remap-field)})))))
 
 (mr/def ::remap-info
   [:and

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -433,6 +433,23 @@
                {:name  "SUBTOTAL"}]
               (lib/returned-columns query -1 -1 {:include-remaps? true}))))))
 
+(deftest ^:parallel skip-hidden-remapped-columns-test
+  (testing "remaps to hidden (`:visibility-type :sensitive`) columns are ignored"
+    (let [mp (-> meta/metadata-provider
+                 (lib.tu/merged-mock-metadata-provider
+                  {:fields [{:id              (meta/id :categories :name)
+                             :visibility-type :sensitive}]})
+                 (lib.tu/remap-metadata-provider (meta/id :venues :category-id) (meta/id :categories :name)))
+          query (-> (lib/query mp (meta/table-metadata :venues))
+                    (lib/with-fields [(meta/field-metadata :venues :id)
+                                      (meta/field-metadata :venues :category-id)]))]
+      (is (=? [{:name  "ID"}
+               {:name  "CATEGORY_ID"}]
+              (lib/returned-columns query)))
+      (is (=? [{:name  "ID"}
+               {:name  "CATEGORY_ID"}]
+              (lib/returned-columns query -1 -1 {:include-remaps? true}))))))
+
 (deftest ^:parallel remapped-columns-test-2-remapping-in-joins
   (testing "explicitly joined columns with remaps are added after their join"
     (let [mp         (-> meta/metadata-provider

--- a/test/metabase/query_processor/middleware/add_remaps_test.clj
+++ b/test/metabase/query_processor/middleware/add_remaps_test.clj
@@ -47,7 +47,14 @@
              (lib/query
               category-id-remap-metadata-provider
               (meta/table-metadata :venues))
-             [:stages 0])))))
+             [:stages 0])))
+    (testing "but ignore remaps to `:visibility-type :sensitive` columns"
+      (is (nil? (-> category-id-remap-metadata-provider
+                    (lib.tu/merged-mock-metadata-provider
+                     {:fields [{:id               (meta/id :categories :name)
+                                :visibility-type :sensitive}]})
+                    (lib/query (meta/table-metadata :venues))
+                    (#'qp.add-remaps/remap-column-infos [:stages 0])))))))
 
 (deftest ^:parallel add-fk-remaps-add-fields-test
   (testing "make sure FK remaps add an entry for the FK field to `:fields`, and returns a pair of [dimension-info updated-query]"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63917
Fixes QUE-2561

### Description

For example, in our Sample Database, `Orders.PRODUCT_ID` is remapped to
`Products.TITLE` by default. If you go to the **Table Metadata** in admin
and set `Products.TITLE` to "Do not include"
(which is `:visibility-type :sensitive` internally) it should not be
used for remapping.

### How to verify

Mark the target of a remap (`Products.TITLE`) as hidden in Table Metadata.

Queries will throw before this change, and work fine with this change.
The columns (`Orders.PRODUCT_ID`) will be rendered as ordinary numeric FKs,
rather than being remapped.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
