### PR TITLE
Delete skipped e2e download test that has BE tests

### DIFF
--- a/e2e/test/scenarios/sharing/downloads/sharing-download-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/sharing-download-reproductions.cy.spec.js
@@ -65,62 +65,6 @@ describe("issue 10803", () => {
   });
 });
 
-describe("issue 18219", { tags: "@skip" }, () => {
-  const questionDetails = {
-    name: "18219",
-    query: {
-      "source-table": ORDERS_ID,
-      aggregation: [["count"]],
-      breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
-    },
-  };
-
-  const testCases = ["csv", "xlsx"];
-
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsAdmin();
-  });
-
-  testCases.forEach((fileType) => {
-    it("should format temporal units on export (metabase#18219)", () => {
-      H.createQuestion(questionDetails).then(({ body: { id: questionId } }) => {
-        H.visitQuestion(questionId);
-
-        cy.findByText("Created At: Year");
-        cy.findByText("2022");
-        cy.findByText("744");
-
-        H.downloadAndAssert({ fileType, questionId, raw: true }, assertion);
-      });
-    });
-
-    function assertion(sheet) {
-      expect(sheet["A1"].v).to.eq("Created At: Year");
-
-      if (fileType === "csv") {
-        expect(sheet["A2"].v).to.eq("2022");
-      }
-
-      if (fileType === "xlsx") {
-        /**
-         * Depending on how we end up solving this issue,
-         * the following assertion on the cell type might not be correct.
-         * It's very likely we'll format temporal breakouts as strings.
-         * I.e. we have to take into account Q1, Q2, etc.
-         */
-        // expect(A2.t).to.eq("n");
-
-        /**
-         * Because of the excel date format, we cannot assert on the raw value `v`.
-         * Rather, we have to do it on the parsed value `w`.
-         */
-        expect(sheet["A2"].w).to.eq("2022");
-      }
-    }
-  });
-});
-
 describe("issue 18382", () => {
   /**
    * This question might seem a bit overwhelming at the first sight.


### PR DESCRIPTION
The e2e test was added [before the fix here](https://github.com/metabase/metabase/pull/18436). The actual fix was BE only [changes that included BE tests](https://github.com/metabase/metabase/pull/22383/files).

Lets just delete this test as it's skipped an already covered by BE tests