### PR TITLE
[serdes] do not say "Loading ..." if entity is not being loaded

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/storage.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/storage.clj
@@ -47,7 +47,8 @@
   [stream root-dir]
   (let [settings (atom [])
         report   (atom {:seen [] :errors []})
-        opts     (merge {:root-dir root-dir} (serdes/storage-base-context))]
+        opts     (-> (serdes/storage-base-context)
+                     (assoc :root-dir root-dir))]
     (doseq [entity stream]
       (cond
         (instance? Exception entity)

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -251,7 +251,7 @@
                              "count"         0
                              "success"       false
                              ;; t2/with-transactions re-wraps errors with data about toucan connections
-                             "error_message" #"(?s)Failed to read file for Collection DoesNotExist.*"}
+                             "error_message" "Failed to read file {:path \"Collection DoesNotExist\"}"}
                             (-> (snowplow-test/pop-event-data-and-user-id!) first :data)))))))))))))
 
 (deftest entity-id-dump&load-test

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -42,9 +42,7 @@
       (ingest-list [_]
         (keys mapped))
       (ingest-one [_ path]
-        (or (get mapped (no-labels path))
-            (throw (ex-info (format "Unknown ingestion target: %s" path)
-                            {:path path :world mapped})))))))
+        (get mapped (no-labels path))))))
 
 ;;; WARNING for test authors: [[extract/extract]] returns a lazy reducible value. To make sure you don't
 ;;; confound your tests with data from your dev appdb, remember to eagerly
@@ -1324,8 +1322,8 @@
               (let [report (serdes.load/load-metabase! (ingestion-in-memory changed) {:continue-on-error true})]
                 (is (= 1 (count (:errors report))))
                 (is (= 3 (count (:seen report)))))
-              (is (= [["Failed to read file for Collection does-not-exist"]]
-                     (logs-extract #"Skipping deserialization error: (.*) \{.*\}\n"
+              (is (= [["Failed to read file {:path \"Collection does-not-exist\"}"]]
+                     (logs-extract #"Skipping deserialization error: (.*)"
                                    (messages)))))))))))
 
 (deftest with-dbs-works-as-expected-test


### PR DESCRIPTION
We'd previously report "Loading..." even for entities that were not provided in the export, but were read from the DB locally. This does not make sense as no changes are happening - so we are lowering a number of noise we produce.
