### PR TITLE
Adjust parameter_mappings for a text dashcard when its variable is removed

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1424,7 +1424,7 @@ describe("scenarios > dashboard > parameters", () => {
 
     it("should not display a parameter widget if there are no linked with it cards after a text card variable is removed (UXW-751)", () => {
       H.createDashboard({
-        parameters: [categoryParameter],
+        parameters: [categoryParameter, countParameter],
       }).then(({ body: dashboard }) => {
         const virtualCard = createMockVirtualCard({
           display: "text",
@@ -1435,14 +1435,19 @@ describe("scenarios > dashboard > parameters", () => {
           cards: [
             createMockTextDashboardCard({
               card: virtualCard,
-              text: "Value {{VAR}}",
+              text: "Value {{VAR1}} and {{VAR2}}",
               size_x: 3,
               size_y: 3,
               parameter_mappings: [
                 {
                   parameter_id: categoryParameter.id,
                   card_id: virtualCard.id,
-                  target: ["text-tag", "VAR"],
+                  target: ["text-tag", "VAR1"],
+                },
+                {
+                  parameter_id: countParameter.id,
+                  card_id: virtualCard.id,
+                  target: ["text-tag", "VAR2"],
                 },
               ],
             }),
@@ -1451,13 +1456,28 @@ describe("scenarios > dashboard > parameters", () => {
         H.visitDashboard(dashboard.id);
       });
 
-      cy.findByTestId("parameter-widget").contains("Category").should("exist");
+      H.filterWidget({ isEditing: false }).contains("Category").should("exist");
+      H.filterWidget({ isEditing: false }).contains("Category").should("exist");
 
       H.editDashboard();
+
       H.getDashboardCard(0).click();
       H.getDashboardCard(0).within(() => {
         cy.get("textarea").clear();
-        cy.get("textarea").type("Foo");
+        cy.get("textarea").type("Value {{}{{}VAR1}}");
+      });
+
+      H.saveDashboard();
+
+      H.filterWidget({ isEditing: false }).contains("Category").should("exist");
+      cy.findByTestId("parameter-widget").contains("Count").should("not.exist");
+
+      H.editDashboard();
+
+      H.getDashboardCard(0).click();
+      H.getDashboardCard(0).within(() => {
+        cy.get("textarea").clear();
+        cy.get("textarea").type("Value null");
       });
 
       H.saveDashboard();

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.ts
@@ -42,6 +42,14 @@ export function getTemplateTagFromTarget(target: ParameterTarget) {
   return type === "template-tag" ? tag : null;
 }
 
+export function getTextTagFromTarget(target: ParameterTarget) {
+  if (!target?.[1] || target?.[0] !== "text-tag") {
+    return null;
+  }
+
+  return target[1];
+}
+
 /**
  * Returns only real DB fields and not all mapped columns.
  * Use getMappingOptionByTarget for columns.

--- a/frontend/src/metabase-lib/v1/parameters/utils/targets.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/targets.unit.spec.ts
@@ -15,6 +15,7 @@ import {
   getParameterColumns,
   getParameterTargetField,
   getTemplateTagFromTarget,
+  getTextTagFromTarget,
   isParameterVariableTarget,
 } from "metabase-lib/v1/parameters/utils/targets";
 import type {
@@ -207,6 +208,18 @@ describe("parameters/utils/targets", () => {
       expect(
         getTemplateTagFromTarget(["dimension", ["field", 123, null]]),
       ).toBe(null);
+    });
+  });
+
+  describe("getTextTagFromTarget", () => {
+    it("should return the tag of a text tag target", () => {
+      expect(getTextTagFromTarget(["text-tag", "foo"])).toBe("foo");
+    });
+
+    it("should return null for targets that are not text tags", () => {
+      expect(getTextTagFromTarget(["dimension", ["field", 123, null]])).toBe(
+        null,
+      );
     });
   });
 

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -1,5 +1,6 @@
 import _ from "underscore";
 
+import { tag_names } from "cljs/metabase.parameters.shared";
 import { isQuestionCard, isQuestionDashCard } from "metabase/dashboard/utils";
 import { slugify } from "metabase/lib/formatting";
 import { isNotNull } from "metabase/lib/types";
@@ -13,6 +14,7 @@ import type {
 import { isFieldFilterParameter } from "metabase-lib/v1/parameters/utils/parameter-type";
 import {
   getParameterTargetField,
+  getTextTagFromTarget,
   isParameterVariableTarget,
 } from "metabase-lib/v1/parameters/utils/targets";
 import type {
@@ -324,3 +326,27 @@ export function getFilteringParameterValuesMap(
 
   return filteringParameterValues;
 }
+
+export const getFilteredParameterMappingsForDashcardText = (
+  parameterMappings: DashboardCard["parameter_mappings"],
+  dashcardText: string,
+) => {
+  if (!parameterMappings) {
+    return parameterMappings;
+  }
+
+  const tagNames = tag_names(dashcardText);
+
+  return parameterMappings.filter((mapping) => {
+    const target = mapping.target;
+
+    const textTag = getTextTagFromTarget(target);
+
+    // A different tag type (not a text-tag) or no tag at all means we keep the mapping
+    if (!textTag) {
+      return true;
+    }
+
+    return tagNames.includes(textTag);
+  });
+};

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -78,8 +78,12 @@ export function Text({
   );
 
   const updateParameterMappings = useCallback(() => {
-    dispatch(updateParameterMappingsForDashcardText(dashcard.id));
-  }, [dashcard.id, dispatch]);
+    if (!dashcard.id) {
+      return;
+    }
+
+    dispatch(updateParameterMappingsForDashcardText(dashcard?.id));
+  }, [dashcard?.id, dispatch]);
 
   const hasContent = !isEmpty(settings.text);
   const placeholder = t`You can use Markdown here, and include variables {{like_this}}`;

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeExternalLinks from "rehype-external-links";
 import remarkGfm from "remark-gfm";
@@ -8,9 +8,10 @@ import { t } from "ttag";
 
 import { useToggle } from "metabase/common/hooks/use-toggle";
 import CS from "metabase/css/core/index.css";
+import { updateParameterMappingsForDashcardText } from "metabase/dashboard/actions";
 import { getParameterValues } from "metabase/dashboard/selectors";
 import { useTranslateContent } from "metabase/i18n/hooks";
-import { useSelector } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import { isEmpty } from "metabase/lib/validate";
 import { fillParametersInText } from "metabase/visualizations/shared/utils/parameter-substitution";
 
@@ -43,6 +44,7 @@ export function Text({
   isEditing,
   isMobile,
 }) {
+  const dispatch = useDispatch();
   const parameterValues = useSelector(getParameterValues);
   const justAdded = useMemo(() => dashcard?.justAdded || false, [dashcard]);
   const [textValue, setTextValue] = useState(settings.text);
@@ -74,6 +76,10 @@ export function Text({
       }),
     [dashcard, dashboard, parameterValues, translatedText],
   );
+
+  const updateParameterMappings = useCallback(() => {
+    dispatch(updateParameterMappingsForDashcardText(dashcard.id));
+  }, [dashcard.id, dispatch]);
 
   const hasContent = !isEmpty(settings.text);
   const placeholder = t`You can use Markdown here, and include variables {{like_this}}`;
@@ -126,6 +132,7 @@ export function Text({
 
               if (settings.text !== textValue) {
                 onUpdateVisualizationSettings({ text: textValue });
+                updateParameterMappings();
               }
             }}
             isMobile={isMobile}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63717
Adjust parameter_mappings for a text dashcard when its variable is removed

How to validate:
- check green CI
- check code
- follow reproduction steps below and be sure that now the issue is fixed

How to reproduce:
1. Create a new dashboard.
2. Add a text parameter "PARAM" with an input box.
3. Add a text card with the text: "Value = {{VAR}}"
4. Connect the PARAM parameter to VAR in the text box.
5. Save the dashboard.
6. Confirm that the PARAM parameter is present and that entered values display in the text card.
7. Edit the dashboard.
8. Delete the {{VAR}} variable from the text card.
9. Save the dashboard.

- Expected behavior: The PARAM parameter is not present.
- Observed behavior:
    - The PARAM parameter is still present.
    - Entered values do not display in the text card. (Confirms the connection no longer works.)
    - Editing the dashboard and clicking in the PARAM parameter shows "You can connect widgets to {{variables}} in text cards" in the text card. (Confirms that some logic in the code has determined that the connection does not exist.)
    - Re-adding the {{VAR}} variable to the text card and clicking in the PARAM parameter now shows the connection dropdown in the text card and it is populated with "VAR". (Indicates that the mapping still existed somewhere.)
