### PR TITLE
Fix long snippet names overflow

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionRow.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/CollectionRow.jsx
@@ -2,6 +2,7 @@
 import cx from "classnames";
 import { Component } from "react";
 
+import { Ellipsified } from "metabase/common/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
 import SnippetCollections from "metabase/entities/snippet-collections";
 import { Icon } from "metabase/ui";
@@ -30,11 +31,20 @@ class CollectionRow extends Component {
         )}
         {...(collection.archived ? undefined : { onClick: onSelectCollection })}
       >
-        <Icon name="folder" size={ICON_SIZE} style={{ opacity: 0.25 }} />
-        <span className={cx(CS.flexFull, CS.ml1, CS.textBold)}>
+        <Icon
+          name="folder"
+          size={ICON_SIZE}
+          style={{ opacity: 0.25 }}
+          className={CS.flexNoShrink}
+        />
+        <Ellipsified className={cx(CS.flexFull, CS.ml1, CS.textBold)} flex={1}>
           {collection.name}
-        </span>
-        <CollectionOptionsButton {...this.props} collection={collection} />
+        </Ellipsified>
+        <CollectionOptionsButton
+          {...this.props}
+          collection={collection}
+          className={CS.flexNoShrink}
+        />
       </div>
     );
   }

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorSidebar/EditorSidebar.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorSidebar/EditorSidebar.module.css
@@ -1,3 +1,4 @@
 .sidebar {
   border-left: 1px solid var(--mb-color-border);
+  max-width: 400px;
 }

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.jsx
@@ -4,6 +4,7 @@ import { Component } from "react";
 import { t } from "ttag";
 
 import Button from "metabase/common/components/Button";
+import { Ellipsified } from "metabase/common/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
 import Snippets from "metabase/entities/snippets";
 import { Flex, Icon } from "metabase/ui";
@@ -63,7 +64,9 @@ class SnippetRowInner extends Component {
               name={insertSnippet ? "arrow_left_to_line" : "snippet"}
               className={CS.hoverChild}
             />
-            <span className={cx(CS.flexFull, CS.ml1)}>{snippet.name}</span>
+            <Ellipsified style={{ maxWidth: 270 }} className={cx(CS.ml1)}>
+              {snippet.name}
+            </Ellipsified>
           </Flex>
           <Icon
             name={isOpen ? "chevronup" : "chevrondown"}

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.jsx
@@ -55,6 +55,7 @@ class SnippetRowInner extends Component {
                     insertSnippet(snippet);
                   }
             }
+            style={{ maxWidth: "90%" }}
           >
             <Icon
               name="snippet"
@@ -64,7 +65,7 @@ class SnippetRowInner extends Component {
               name={insertSnippet ? "arrow_left_to_line" : "snippet"}
               className={CS.hoverChild}
             />
-            <Ellipsified style={{ maxWidth: 270 }} className={cx(CS.ml1)}>
+            <Ellipsified style={{ maxWidth: "90%" }} className={cx(CS.ml1)}>
               {snippet.name}
             </Ellipsified>
           </Flex>

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.jsx
@@ -55,19 +55,22 @@ class SnippetRowInner extends Component {
                     insertSnippet(snippet);
                   }
             }
-            style={{ maxWidth: "90%" }}
+            flex={1}
+            miw={0}
           >
             <Icon
               name="snippet"
-              className={cx(CS.hoverChildHidden, CS.textLight)}
+              className={cx(
+                CS.hoverChildHidden,
+                CS.textLight,
+                SnippetRowS.SnippetIcon,
+              )}
             />
             <Icon
               name={insertSnippet ? "arrow_left_to_line" : "snippet"}
-              className={CS.hoverChild}
+              className={cx(CS.hoverChild, SnippetRowS.SnippetIcon)}
             />
-            <Ellipsified style={{ maxWidth: "90%" }} className={cx(CS.ml1)}>
-              {snippet.name}
-            </Ellipsified>
+            <Ellipsified className={cx(CS.ml1)}>{snippet.name}</Ellipsified>
           </Flex>
           <Icon
             name={isOpen ? "chevronup" : "chevrondown"}

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.jsx
@@ -43,6 +43,7 @@ class SnippetRowInner extends Component {
             CS.hoverParent,
             CS.hoverDisplay,
           )}
+          style={{ minWidth: 0 }}
           onClick={() => this.setState({ isOpen: !isOpen })}
         >
           <Flex
@@ -55,7 +56,6 @@ class SnippetRowInner extends Component {
                     insertSnippet(snippet);
                   }
             }
-            flex={1}
             miw={0}
           >
             <Icon
@@ -74,7 +74,10 @@ class SnippetRowInner extends Component {
           </Flex>
           <Icon
             name={isOpen ? "chevronup" : "chevrondown"}
-            className={cx({ [CS.hoverChild]: !isOpen })}
+            className={cx(
+              { [CS.hoverChild]: !isOpen },
+              SnippetRowS.SnippetIcon,
+            )}
           />
         </div>
         {isOpen && (

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.module.css
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetRow/SnippetRow.module.css
@@ -14,3 +14,7 @@
     color: var(--mb-color-brand);
   }
 }
+
+.SnippetIcon {
+  flex-shrink: 0;
+}


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/61070#top

### Description
Use Ellipsified to truncate long snippet names

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
