### PR TITLE
Fix base-type inference in pivot queries

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -3,16 +3,20 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [medley.core :as m]
    [metabase.driver :as driver]
    [metabase.driver.mongo.query-processor :as mongo.qp]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor :as qp]
    [metabase.query-processor-test.alternative-date-test :as qp.alternative-date-test]
    [metabase.query-processor-test.date-time-zone-functions-test :as qp.datetime-test]
    [metabase.query-processor.compile :as qp.compile]
+   [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.timezone :as qp.timezone]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.json :as json]))
 
 (set! *warn-on-reflection* true)
 
@@ -713,3 +717,57 @@
                                   (-> (lib/query mp dogs)
                                       (lib/filter (lib/contains person-id "e"))
                                       qp/process-query))))))))
+
+(deftest ^:parallel pivot-query-based-on-native-card-test
+  (mt/test-driver :mongo
+    (testing "Pivot queries based on a native Mongo card return the right number of columns (#64124)"
+      (let [native-query (json/encode [{:$match {:_id 1}}
+                                       {:$project {:product_id :$product_id, :subtotal :$subtotal}}])
+            mp (lib.tu/mock-metadata-provider
+                (mt/metadata-provider)
+                {:cards [{:id              1
+                          :name            "Orders native mongo"
+                          :dataset-query   {:type     :native
+                                            :native   {:collection "orders"
+                                                       :query      native-query}
+                                            :database (mt/id)}
+                          :result_metadata [{:name         "product_id"
+                                             :base_type    :type/Integer
+                                             :display_name "product_id"}
+                                            {:name         "subtotal"
+                                             :base_type    :type/Float
+                                             :display_name "subtotal"}]}]})
+            breakout-by-column-name (fn [query col-name]
+                                      (lib/breakout query (m/find-first (comp #{col-name} :name)
+                                                                        (lib/breakoutable-columns query))))
+            query (-> (lib/query mp (lib.metadata/card mp 1))
+                      (lib/aggregate (lib/count))
+                      (breakout-by-column-name "product_id")
+                      (breakout-by-column-name "subtotal"))
+            pivot-query (assoc query
+                               :pivot_rows         [0]
+                               :pivot_cols         [1]
+                               :show_row_totals    true
+                               :show_column_totals true
+                               :info               {:context :ad-hoc})]
+        (is (=? {:data
+                 {:cols
+                  [{:lib/desired-column-alias "product_id"
+                    :field_ref                [:field "product_id" {:base-type :type/Integer}]
+                    :base_type                :type/Integer
+                    :effective_type           :type/Integer}
+                   {:lib/desired-column-alias "subtotal"
+                    :field_ref                [:field "subtotal" {:base-type :type/Float}]
+                    :base_type                :type/Float
+                    :effective_type           :type/Float}
+                   {:lib/desired-column-alias "pivot-grouping"
+                    :field_ref                [:expression "pivot-grouping"]
+                    :base_type                :type/Integer
+                    :effective_type           :type/Integer}
+                   {:lib/desired-column-alias "count"
+                    :field_ref                [:aggregation 0]
+                    :base_type                :type/Integer
+                    :semantic_type            :type/Quantity
+                    :effective_type           :type/Integer}]
+                  :rows [[14 37.65 0 1] [nil 37.65 1 1] [14 nil 2 1] [nil nil 3 1]]}}
+                (qp.pivot/run-pivot-query pivot-query)))))))

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -1181,8 +1181,8 @@
 (deftest ^:parallel pivot-query-based-on-native-card-test
   (mt/test-driver :mongo
     (testing "Pivot queries based on a native Mongo card return the right number of columns (#64124)"
-      (let [native-query (json/encode [{:$project {:product_id :$product_id, :subtotal :$subtotal}}
-                                       {:$limit 1}])
+      (let [native-query (json/encode [{:$match {:_id 1}}
+                                       {:$project {:product_id :$product_id, :subtotal :$subtotal}}])
             mp (lib.tu/mock-metadata-provider
                 (mt/metadata-provider)
                 {:cards [{:id              1

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -1197,12 +1197,13 @@
                                             {:name         "subtotal"
                                              :base_type    :type/Float
                                              :display_name "subtotal"}]}]})
-            col-breakout (fn [query col-name]
-                           (lib/breakout query (m/find-first (comp #{col-name} :name) (lib/breakoutable-columns query))))
+            breakout-by-column-name (fn [query col-name]
+                                      (lib/breakout query (m/find-first (comp #{col-name} :name)
+                                                                        (lib/breakoutable-columns query))))
             query (-> (lib/query mp (lib.metadata/card mp 1))
                       (lib/aggregate (lib/count))
-                      (col-breakout "product_id")
-                      (col-breakout "subtotal"))
+                      (breakout-by-column-name "product_id")
+                      (breakout-by-column-name "subtotal"))
             pivot-query (assoc query
                                :pivot_rows         [0]
                                :pivot_cols         [1]

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -1185,12 +1185,12 @@
       (let [native-query "[{\"$project\": {\"product_id\": \"$product_id\", \"subtotal\": \"$subtotal\"}}, {\"$limit\": 1}]"
             mp (lib.tu/mock-metadata-provider
                 (mt/metadata-provider)
-                {:cards [{:id            1
-                          :name          "Orders native mongo"
-                          :dataset-query {:type     :native
-                                          :native   {:collection "orders"
-                                                     :query      native-query}
-                                          :database (mt/id)}
+                {:cards [{:id              1
+                          :name            "Orders native mongo"
+                          :dataset-query   {:type     :native
+                                            :native   {:collection "orders"
+                                                       :query      native-query}
+                                            :database (mt/id)}
                           :result_metadata [{:name         "product_id"
                                              :base_type    :type/Integer
                                              :display_name "product_id"}

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -15,9 +15,13 @@
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.util :as driver.u]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
+   [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
@@ -1174,3 +1178,55 @@
       :type/MongoBSONID        "objectId"
       :type/MongoBinData       "binData"
       :type/IPAddress          "string")))
+
+(deftest ^:parallel pivot-query-based-on-native-card-test
+  (mt/test-driver :mongo
+    (testing "Pivot queries based on a native Mongo card return the right number of columns (#64124)"
+      (let [native-query "[{\"$project\": {\"product_id\": \"$product_id\", \"subtotal\": \"$subtotal\"}}, {\"$limit\": 1}]"
+            mp (lib.tu/mock-metadata-provider
+                (mt/metadata-provider)
+                {:cards [{:id            1
+                          :name          "Orders native mongo"
+                          :dataset-query {:type     :native
+                                          :native   {:collection "orders"
+                                                     :query      native-query}
+                                          :database (mt/id)}
+                          :result_metadata [{:name         "product_id"
+                                             :base_type    :type/Integer
+                                             :display_name "product_id"}
+                                            {:name         "subtotal"
+                                             :base_type    :type/Float
+                                             :display_name "subtotal"}]}]})
+            col-breakout (fn [query col-name]
+                           (lib/breakout query (m/find-first (comp #{col-name} :name) (lib/breakoutable-columns query))))
+            query (-> (lib/query mp (lib.metadata/card mp 1))
+                      (lib/aggregate (lib/count))
+                      (col-breakout "product_id")
+                      (col-breakout "subtotal"))
+            pivot-query (assoc query
+                               :privot_rows [0]
+                               :pivot_cols  [1]
+                               :show_row_totals true
+                               :show_column_totals true
+                               :info {:context :ad-hoc})]
+        (is (=? {:data
+                 {:cols
+                  [{:lib/desired-column-alias "product_id"
+                    :field_ref [:field "product_id" {:base-type :type/Integer}]
+                    :base_type :type/Integer
+                    :effective_type :type/Integer}
+                   {:lib/desired-column-alias "subtotal"
+                    :field_ref [:field "subtotal" {:base-type :type/Float}]
+                    :base_type :type/Float
+                    :effective_type :type/Float}
+                   {:lib/desired-column-alias "pivot-grouping"
+                    :field_ref [:expression "pivot-grouping"]
+                    :base_type :type/Integer
+                    :effective_type :type/Integer}
+                   {:lib/desired-column-alias "count"
+                    :field_ref [:aggregation 0]
+                    :base_type :type/Integer
+                    :semantic_type :type/Quantity
+                    :effective_type :type/Integer}]
+                  :rows [[14 37.65 0 1] [nil 37.65 1 1] [nil nil 3 1]]}}
+                (qp.pivot/run-pivot-query pivot-query)))))))

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -17,7 +17,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util :as lib.tu]
-   [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
@@ -1182,7 +1181,8 @@
 (deftest ^:parallel pivot-query-based-on-native-card-test
   (mt/test-driver :mongo
     (testing "Pivot queries based on a native Mongo card return the right number of columns (#64124)"
-      (let [native-query "[{\"$project\": {\"product_id\": \"$product_id\", \"subtotal\": \"$subtotal\"}}, {\"$limit\": 1}]"
+      (let [native-query (json/encode [{:$project {:product_id :$product_id, :subtotal :$subtotal}}
+                                       {:$limit 1}])
             mp (lib.tu/mock-metadata-provider
                 (mt/metadata-provider)
                 {:cards [{:id              1

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -1204,29 +1204,29 @@
                       (col-breakout "product_id")
                       (col-breakout "subtotal"))
             pivot-query (assoc query
-                               :privot_rows [0]
-                               :pivot_cols  [1]
-                               :show_row_totals true
+                               :pivot_rows         [0]
+                               :pivot_cols         [1]
+                               :show_row_totals    true
                                :show_column_totals true
-                               :info {:context :ad-hoc})]
+                               :info               {:context :ad-hoc})]
         (is (=? {:data
                  {:cols
                   [{:lib/desired-column-alias "product_id"
-                    :field_ref [:field "product_id" {:base-type :type/Integer}]
-                    :base_type :type/Integer
-                    :effective_type :type/Integer}
+                    :field_ref                [:field "product_id" {:base-type :type/Integer}]
+                    :base_type                :type/Integer
+                    :effective_type           :type/Integer}
                    {:lib/desired-column-alias "subtotal"
-                    :field_ref [:field "subtotal" {:base-type :type/Float}]
-                    :base_type :type/Float
-                    :effective_type :type/Float}
+                    :field_ref                [:field "subtotal" {:base-type :type/Float}]
+                    :base_type                :type/Float
+                    :effective_type           :type/Float}
                    {:lib/desired-column-alias "pivot-grouping"
-                    :field_ref [:expression "pivot-grouping"]
-                    :base_type :type/Integer
-                    :effective_type :type/Integer}
+                    :field_ref                [:expression "pivot-grouping"]
+                    :base_type                :type/Integer
+                    :effective_type           :type/Integer}
                    {:lib/desired-column-alias "count"
-                    :field_ref [:aggregation 0]
-                    :base_type :type/Integer
-                    :semantic_type :type/Quantity
-                    :effective_type :type/Integer}]
-                  :rows [[14 37.65 0 1] [nil 37.65 1 1] [nil nil 3 1]]}}
+                    :field_ref                [:aggregation 0]
+                    :base_type                :type/Integer
+                    :semantic_type            :type/Quantity
+                    :effective_type           :type/Integer}]
+                  :rows [[14 37.65 0 1] [nil 37.65 1 1] [14 nil 2 1] [nil nil 3 1]]}}
                 (qp.pivot/run-pivot-query pivot-query)))))))

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -662,7 +662,9 @@
                                                                   :original-ref-style/name)}])
         (as-> $col (assoc $col :display-name (lib.metadata.calculation/display-name query stage-number $col))
           (cond-> $col
-            (contains? #{nil :type/*} (:effective-type $col)) (m/assoc-some :effective-type (:base-type $col))))
+            (and (contains? #{nil :type/*} (:effective-type $col))
+                 (not (contains? #{nil :type/*} (:base-type $col))))
+            (assoc :effective-type (:base-type $col))))
         ;; `:lib/desired-column-alias` needs to be recalculated in the context of the stage where the ref
         ;; appears, go ahead and remove it so we don't accidentally try to use it when it may or may not be
         ;; accurate at all.

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -660,7 +660,9 @@
           {:lib/original-ref-style-for-result-metadata-purposes (if (pos-int? id-or-name)
                                                                   :original-ref-style/id
                                                                   :original-ref-style/name)}])
-        (as-> $col (assoc $col :display-name (lib.metadata.calculation/display-name query stage-number $col)))
+        (as-> $col (assoc $col :display-name (lib.metadata.calculation/display-name query stage-number $col))
+          (cond-> $col
+            (contains? #{nil :type/*} (:effective-type $col)) (m/assoc-some :effective-type (:base-type $col))))
         ;; `:lib/desired-column-alias` needs to be recalculated in the context of the stage where the ref
         ;; appears, go ahead and remove it so we don't accidentally try to use it when it may or may not be
         ;; accurate at all.

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -99,10 +99,13 @@
              (and (seq incoming-cols)
                   (= (count incoming-cols) (count base-types)))
              (assoc-in [:data :cols] (mapv (fn [col base-type]
-                                             (assoc col
-                                                    :base_type      base-type
-                                                    :effective_type base-type
-                                                    :field_ref      [:field (:name col) {:base-type base-type}]))
+                                             (cond-> (assoc col :base_type base-type, :effective_type base-type)
+                                               ;; if we have a field_ref for a named column, set the base_type options
+                                               (string? (get-in col [:field_ref 1]))
+                                               (update-in [:field_ref 2] assoc :base-type base-type)
+                                               ;; if there is no field_ref at all, add it
+                                               (nil? (:field_ref col))
+                                               (assoc :field_ref [:field (:name col) {:base-type base-type}])))
                                            incoming-cols
                                            base-types))))))))
 

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -96,7 +96,8 @@
      (let [incoming-cols (when (map? result)
                            (-> result :data :cols))]
        (rf (cond-> result
-             (= (count incoming-cols) (count base-types))
+             (and (seq incoming-cols)
+                  (= (count incoming-cols) (count base-types)))
              (assoc-in [:data :cols] (mapv (fn [col base-type]
                                              (assoc col
                                                     :base_type      base-type

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -83,7 +83,10 @@
              (driver.common/values->base-type)
              (analyze/constant-fingerprinter driver-base-type)))))
 
-(defn- enrich-with-inferred-type [col base-type]
+(defn- enrich-with-inferred-type
+  "Set :base_type and :effective_type to `base-type` in `col`.
+  Also set or update the :field_ref field to contain `base-type` in the field ref options."
+  [col base-type]
   (cond-> (assoc col :base_type base-type, :effective_type base-type)
     ;; if we have a field_ref for a named column, set the base_type options
     (string? (get-in col [:field_ref 1]))
@@ -106,9 +109,9 @@
                               (-> result :data :cols))]
        (rf (cond-> result
              (and (seq result-data-cols)
-                  ;; For pivot queries, when generating the summary column, row, or field, the number of
+                  ;; For pivot queries, when generating the row, column, or grand totals, the number of
                   ;; result-data-cols can be greater than the number of base-types.  In these cases, the
-                  ;; result-data-cols already have the correct type, so no calculation is necessary.
+                  ;; result-data-cols already have the correct type, so no enrichment is necessary.
                   ;; For native queries where this correction is needed, the number and position of the columns and
                   ;; the base-types should match. (#64124)
                   (= (count result-data-cols) (count base-types)))

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -83,6 +83,15 @@
              (driver.common/values->base-type)
              (analyze/constant-fingerprinter driver-base-type)))))
 
+(defn- enrich-with-inferred-type [col base-type]
+  (cond-> (assoc col :base_type base-type, :effective_type base-type)
+    ;; if we have a field_ref for a named column, set the base_type options
+    (string? (get-in col [:field_ref 1]))
+    (update-in [:field_ref 2] assoc :base-type base-type)
+    ;; if there is no field_ref at all, add it
+    (nil? (:field_ref col))
+    (assoc :field_ref [:field (:name col) {:base-type base-type}])))
+
 (mu/defn- infer-base-type-xform :- ::qp.schema/rf
   "Add an xform to `rf` that will update the final results metadata with `base_type` and an updated `field_ref` based on
   the a sample of values in result rows. This is only needed for drivers that don't return base type in initial metadata
@@ -93,25 +102,16 @@
    rf
    [(base-type-inferer metadata)]
    (fn combine [result base-types]
-     (let [incoming-cols (when (map? result)
-                           (-> result :data :cols))]
+     (let [result-data-cols (when (map? result)
+                              (-> result :data :cols))]
        (rf (cond-> result
-             (and (seq incoming-cols)
+             (and (seq result-data-cols)
                   ;; For pivot queries, the number of incoming-cols can be greater than the number of base-types
                   ;; in these cases, the incoming-cols already have the correct type, no calculation is necessary.
                   ;; For native queries where this correction is needed, the number and position of the columns
                   ;; and the base-types should match. (#64124)
-                  (= (count incoming-cols) (count base-types)))
-             (assoc-in [:data :cols] (mapv (fn [col base-type]
-                                             (cond-> (assoc col :base_type base-type, :effective_type base-type)
-                                               ;; if we have a field_ref for a named column, set the base_type options
-                                               (string? (get-in col [:field_ref 1]))
-                                               (update-in [:field_ref 2] assoc :base-type base-type)
-                                               ;; if there is no field_ref at all, add it
-                                               (nil? (:field_ref col))
-                                               (assoc :field_ref [:field (:name col) {:base-type base-type}])))
-                                           incoming-cols
-                                           base-types))))))))
+                  (= (count result-data-cols) (count base-types)))
+             (assoc-in [:data :cols] (mapv enrich-with-inferred-type result-data-cols base-types))))))))
 
 (mu/defn- add-column-info-with-type-inference :- ::qp.schema/rf
   [query            :- ::lib.schema/query

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -97,6 +97,10 @@
                            (-> result :data :cols))]
        (rf (cond-> result
              (and (seq incoming-cols)
+                  ;; For pivot queries, the number of incoming-cols can be greater than the number of base-types
+                  ;; in these cases, the incoming-cols already have the correct type, no calculation is necessary.
+                  ;; For native queries where this correction is needed, the number and position of the columns
+                  ;; and the base-types should match. (#64124)
                   (= (count incoming-cols) (count base-types)))
              (assoc-in [:data :cols] (mapv (fn [col base-type]
                                              (cond-> (assoc col :base_type base-type, :effective_type base-type)

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -93,16 +93,17 @@
    rf
    [(base-type-inferer metadata)]
    (fn combine [result base-types]
-     (let [cols' (mapv (fn [col base-type]
-                         (assoc col
-                                :base_type      base-type
-                                :effective_type base-type
-                                :field_ref      [:field (:name col) {:base-type base-type}]))
-                       (:cols metadata)
-                       base-types)]
+     (let [incoming-cols (when (map? result)
+                           (-> result :data :cols))]
        (rf (cond-> result
-             (map? result)
-             (assoc-in [:data :cols] cols')))))))
+             (= (count incoming-cols) (count base-types))
+             (assoc-in [:data :cols] (mapv (fn [col base-type]
+                                             (assoc col
+                                                    :base_type      base-type
+                                                    :effective_type base-type
+                                                    :field_ref      [:field (:name col) {:base-type base-type}]))
+                                           incoming-cols
+                                           base-types))))))))
 
 (mu/defn- add-column-info-with-type-inference :- ::qp.schema/rf
   [query            :- ::lib.schema/query

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -106,10 +106,11 @@
                               (-> result :data :cols))]
        (rf (cond-> result
              (and (seq result-data-cols)
-                  ;; For pivot queries, the number of incoming-cols can be greater than the number of base-types
-                  ;; in these cases, the incoming-cols already have the correct type, no calculation is necessary.
-                  ;; For native queries where this correction is needed, the number and position of the columns
-                  ;; and the base-types should match. (#64124)
+                  ;; For pivot queries, when generating the summary column, row, or field, the number of
+                  ;; result-data-cols can be greater than the number of base-types.  In these cases, the
+                  ;; result-data-cols already have the correct type, so no calculation is necessary.
+                  ;; For native queries where this correction is needed, the number and position of the columns and
+                  ;; the base-types should match. (#64124)
                   (= (count result-data-cols) (count base-types)))
              (assoc-in [:data :cols] (mapv enrich-with-inferred-type result-data-cols base-types))))))))
 


### PR DESCRIPTION
Fixes #64124

### Description

As described in #64344, the immediate issue is that when the annotate middleware enriches columns with base types, it assumes that the columns coming from metadata are the same as in the result :data :cols object. However, in this bug's scenario, because of the summary sub-queries of the pivot query, the metadata contains fewer columns, and so replacing the result data cols with the enriched metadata cols leads to an error.

The solution in #64344 relies on doing the enrichment based on name matching, this solution tries to determine if the enrichment is necessary at all and relies on the result :data :cols already having the correct information (with the exception of missing type info).

This PR does two things:

1. sets the `:effective-type` to the `:base-type` in field resolution when effective type is `nil` or `:type/*`, and
1. in the annotate middleware, it relies on `(-> result :data :cols)` already properly set (by `expected-cols`) and sets `:base-type`, `:effective-type`, and `:field-ref` only when the number of columns match (which should be the case for normal queries, but not for a pivot query).

For pivot queries, getting the types from the database cannot be necessary, because they are MBQL queries with summary clauses.

### How to verify

The repro steps from #64124 should not fail.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
