### PR TITLE
fix(sdk-bundle): warn on invalid layout in MetabotQuestion

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -239,6 +239,29 @@ describe("scenarios > embedding-sdk > metabot-question", () => {
       );
     });
   });
+
+  it("should fallback to sidebar layout when invalid layout prop is provided and show a warning", () => {
+    setup(metabotResponse);
+
+    cy.window().then((win) => {
+      cy.spy(win.console, "warn").as("consoleWarn");
+    });
+
+    mountSdkContent(<MetabotQuestion layout="foobar" />);
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("metabot-question-container").should(
+        "have.attr",
+        "data-layout",
+        "sidebar",
+      );
+    });
+
+    cy.get("@consoleWarn").should(
+      "have.been.calledWith",
+      'Invalid layout for MetabotQuestion: foobar. Valid values are "stacked", "sidebar", or "auto"',
+    );
+  });
 });
 
 const mockSuggestedPrompts = () => {

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion.tsx
@@ -1,6 +1,6 @@
 import { useElementSize } from "@mantine/hooks";
 import { useId, useMemo } from "react";
-import { match } from "ts-pattern";
+import { P, match } from "ts-pattern";
 
 import { FlexibleSizeComponent } from "embedding-sdk-bundle/components/private/FlexibleSizeComponent";
 import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
@@ -43,10 +43,18 @@ const MetabotQuestionInner = ({
 
   const derivedLayout = useMemo(() => {
     return match(layout)
-      .with("auto", () =>
-        containerWidth <= MAX_MOBILE_CONTAINER_WIDTH ? "stacked" : "sidebar",
-      )
-      .otherwise((layout) => layout);
+      .with(P.union("stacked", "sidebar"), (layout) => layout)
+      .otherwise((layout) => {
+        if (layout !== "auto") {
+          console.warn(
+            `Invalid layout for MetabotQuestion: ${layout}. Valid values are "stacked", "sidebar", or "auto"`,
+          );
+        }
+
+        return containerWidth <= MAX_MOBILE_CONTAINER_WIDTH
+          ? "stacked"
+          : "sidebar";
+      });
   }, [layout, containerWidth]);
 
   function renderQuestion() {


### PR DESCRIPTION
Closes EMB-886

Fallback to automatic layout if an invalid `layout` prop is provided to MetabotQuestion

### How to verify

Try rendering the `MetabotQuestion` (SDK) or `metabase-metabot` (EAJS):

For SDK:

```tsx
<MetabotQuestion layout="foobar" />
```

For EAJS:

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>Title</title>

  <style>
  body {
    margin: 0;
  }

  metabase-metabot {
    height: 100vh;
  }
  </style>
</head>
<body>
<script defer src="http://localhost:3000/app/embed.js"></script>

<script>
  function defineMetabaseConfig(config) {
    window.metabaseConfig = config;
  }
</script>

<script>
  defineMetabaseConfig({
    "instanceUrl": "http://localhost:3000",
    "useExistingUserSession": true,
    "theme": {
      "colors": {
        "brand": "#e74c3c"
      }
    }
  });
</script>

<div>
  <metabase-metabot layout="foobar"></metabase-metabot>
</div>
</body>
</html>
```

It should render the automatic layout (sidebar on big screen) by default, and show a console warning.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
