### PR TITLE
Fix Firefox bug where models are not clickable until after selecting/unselecting some text

### DIFF
--- a/frontend/src/metabase/browse/models/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/models/ModelsTable.tsx
@@ -167,7 +167,7 @@ const ModelRow = ({ model }: { model?: ModelResult }) => {
 
       // do not trigger click when selecting text
       const selection = document.getSelection();
-      if (selection?.type === "Range") {
+      if (selection?.type === "Range" && selection?.toString().length > 0) {
         event.stopPropagation();
         return;
       }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/64488

I traced the weird behavior I was seeing down to this early return: we don't want to click a model if you're trying to select text instead. But for some reason on a fresh page load in Firefox, `document.getSelection()` returns a range selection of the empty string, which was preventing clicking any of the models until you select & unselect some unrelated text. A straightforward check that a non-empty string is actually selected fixes the issue.

I wasn't sure where best to test this, but I'm happy to add a test if anyone gives me a pointer.