### PR TITLE
63585: Pie chart legend does not respect query's sort order

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -686,9 +686,12 @@ function ensurePieChartRendered(rows, middleRows, outerRows, totalValue) {
     H.pieSlices().should("have.length", rowCount);
 
     // legend
-    rows.forEach((name, i) => {
-      cy.findAllByTestId("legend-item").contains(name).should("be.visible");
-    });
+    cy.findByTestId("chart-legend")
+      .find("li")
+      .should("have.length", rows.length)
+      .each(($el, i) => {
+        cy.wrap($el).should("contain.text", rows[i]).and("be.visible");
+      });
   });
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/63585

### Description

Rows were always being sorted by count regardless if setting `pie.sort_rows` was `false` which end up overriding query result order.
Modified behavior:
- Without custom order -> rows will follow query result order
- With custom order -> rows will follow custom order and new rows will follow query result order

Note: I had to update existing tests to reflect new ordering (you'll notice that I had to change drag&drop, renaming and color change to keep test meaningful, e.g. change color of a row that is hidden when adding limit)

### How to verify

1. New question -> Sample Database -> Products
2. Summarize `Count` by `Category`
3. Change visualization to `Pie`, view order
4. Sort by `Category` descend -> note that order is different
5. Click on settings (right side of visualization) and set a custom order -> note that it follows custom order now

### Demo


https://github.com/user-attachments/assets/0b9f5c6e-305d-460a-b185-8bdafb9d3f92



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
