### PR TITLE
Extract SDK bundle error handling tests into a separate test suite

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/sdk-bundle-error-handling.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-bundle-error-handling.cy.spec.tsx
@@ -1,0 +1,82 @@
+import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
+
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  getSdkBundleScriptElement,
+  mountSdkContent,
+} from "e2e/support/helpers/embedding-sdk-component-testing";
+import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
+import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+import { deleteConflictingCljsGlobals } from "metabase/embedding-sdk/test/delete-conflicting-cljs-globals";
+
+const { H } = cy;
+
+const sdkBundleCleanup = () => {
+  getSdkBundleScriptElement()?.remove();
+  delete window.METABASE_EMBEDDING_SDK_BUNDLE;
+  delete window.METABASE_PROVIDER_PROPS_STORE;
+  deleteConflictingCljsGlobals();
+};
+
+describe(
+  "scenarios > embedding-sdk > sdk-bundle-error-handling",
+  {
+    tags: ["@skip-backward-compatibility"],
+    // These test in some cases load a new SDK Bundle that in combination with the Component Testing is memory-consuming
+    numTestsKeptInMemory: 1,
+  },
+  () => {
+    beforeEach(() => {
+      signInAsAdminAndEnableEmbeddingSdk();
+
+      cy.signOut();
+
+      mockAuthProviderAndJwtSignIn();
+    });
+
+    beforeEach(() => {
+      H.clearBrowserCache();
+
+      sdkBundleCleanup();
+
+      cy.intercept("GET", "**/app/embedding-sdk.js", {
+        statusCode: 404,
+      });
+    });
+
+    describe("when the SDK bundle can't be loaded", () => {
+      it("should show an error", () => {
+        mountSdkContent(
+          <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />,
+          {
+            waitForUser: false,
+          },
+        );
+
+        cy.findByTestId("sdk-error-container").should(
+          "contain.text",
+          "Error loading the Embedded Analytics SDK",
+        );
+      });
+
+      it("should show a custom error", () => {
+        mountSdkContent(
+          <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />,
+          {
+            sdkProviderProps: {
+              errorComponent: ({ message }: { message: string }) => (
+                <div>Custom error: {message}</div>
+              ),
+            },
+            waitForUser: false,
+          },
+        );
+
+        cy.findByTestId("sdk-error-container").should(
+          "contain.text",
+          "Custom error: Error loading the Embedded Analytics SDK",
+        );
+      });
+    });
+  },
+);

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-bundle.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-bundle.cy.spec.tsx
@@ -15,8 +15,6 @@ import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embeddin
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
 import { deleteConflictingCljsGlobals } from "metabase/embedding-sdk/test/delete-conflicting-cljs-globals";
 
-const { H } = cy;
-
 const sdkBundleCleanup = () => {
   getSdkBundleScriptElement()?.remove();
   delete window.METABASE_EMBEDDING_SDK_BUNDLE;
@@ -354,53 +352,6 @@ describe(
           "be.calledWithMatch",
           "this property is required by the component",
         );
-      });
-    });
-
-    describe("Error handling", { retries: 3 }, () => {
-      beforeEach(() => {
-        H.clearBrowserCache();
-
-        sdkBundleCleanup();
-
-        cy.intercept("GET", "**/app/embedding-sdk.js", {
-          statusCode: 404,
-        });
-      });
-
-      describe("when the SDK bundle can't be loaded", () => {
-        it("should show an error", () => {
-          mountSdkContent(
-            <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />,
-            {
-              waitForUser: false,
-            },
-          );
-
-          cy.findByTestId("sdk-error-container").should(
-            "contain.text",
-            "Error loading the Embedded Analytics SDK",
-          );
-        });
-
-        it("should show a custom error", () => {
-          mountSdkContent(
-            <InteractiveQuestion questionId={ORDERS_QUESTION_ID} />,
-            {
-              sdkProviderProps: {
-                errorComponent: ({ message }: { message: string }) => (
-                  <div>Custom error: {message}</div>
-                ),
-              },
-              waitForUser: false,
-            },
-          );
-
-          cy.findByTestId("sdk-error-container").should(
-            "contain.text",
-            "Custom error: Error loading the Embedded Analytics SDK",
-          );
-        });
       });
     });
   },

--- a/enterprise/frontend/src/embedding-sdk-bundle/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/index.ts
@@ -73,4 +73,5 @@ const sdkBundleExports: MetabaseEmbeddingSdkBundleExports = {
   validateFunctionSchema,
 };
 
+// Define a global export METABASE_EMBEDDING_SDK_BUNDLE for SDK package
 window.METABASE_EMBEDDING_SDK_BUNDLE = sdkBundleExports;


### PR DESCRIPTION
Extract SDK bundle error handling tests into a separate test suite to avoid flakyness.

CI should pass