### PR TITLE
fix(sdk-bundle): missing hover text color in summarization/grouping menus

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-bundle/lib/theme/get-embedding-theme.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/lib/theme/get-embedding-theme.unit.spec.ts
@@ -17,6 +17,7 @@ describe("Transform Embedding Theme Override", () => {
           "text-primary": "yellow",
           "text-tertiary": "green",
           "background-disabled": "pink",
+          "text-white": "white",
         },
 
         // we should strip any explicit "undefined" values and apply default component values
@@ -39,6 +40,8 @@ describe("Transform Embedding Theme Override", () => {
         "text-light": expect.arrayContaining(["green"]),
         "text-tertiary": expect.arrayContaining(["green"]),
         "background-disabled": expect.arrayContaining(["pink"]),
+        "text-white": expect.arrayContaining(["white"]),
+        white: expect.arrayContaining(["white"]),
       },
       other: {
         fontSize: "2rem",

--- a/frontend/src/metabase/css/components/list.module.css
+++ b/frontend/src/metabase/css/components/list.module.css
@@ -95,7 +95,7 @@
 .ListItemCursor:not(.ListItemDisabled) :global(.Icon),
 .ListItem:not(.ListItemDisabled):hover :global(.Icon),
 .ListItemSelected:not(.ListItemDisabled) :global(.Icon) {
-  color: var(--mb-color-white) !important;
+  color: var(--mb-color-text-white) !important;
 }
 
 /* Moved from `query_builder.module.css` to make migration easier */

--- a/frontend/src/metabase/css/components/list.module.css
+++ b/frontend/src/metabase/css/components/list.module.css
@@ -71,7 +71,7 @@
 .ListItemCursor:not(.ListItemDisabled) .ListItemTitle,
 .ListItem:not(.ListItemDisabled):hover .ListItemTitle,
 .ListItemSelected:not(.ListItemDisabled) .ListItemTitle {
-  color: var(--mb-color-white);
+  color: var(--mb-color-text-white);
 }
 
 /* LIST ITEM DESCRIPTION */

--- a/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
@@ -59,7 +59,7 @@ export const SDK_TO_MAIN_APP_COLORS_MAPPING: Record<
   shadow: ["shadow"],
   positive: ["success"],
   negative: ["danger"],
-  "text-white": ["text-white"],
+  "text-white": ["text-white", "white"],
   error: ["error"],
   "background-error": ["bg-error"],
   "text-hover": ["text-hover"],


### PR DESCRIPTION
Closes #64477
Closes EMB-891

Fixes `white` colors not being mapped correctly.

### How to verify

- Go to Storybook > Interactive Question
- Click on an interactive question.
- Click on Summarization or Grouping
- Hover over the menus
- The white text color is still there.

### Demo

<img width="1314" height="1162" alt="CleanShot 2568-10-08 at 21 00 22@2x" src="https://github.com/user-attachments/assets/077f2e51-4d19-4c1b-8a4d-b866d2e1c048" />