### PR TITLE
[MBQL lib + QP] Ban `:unit` on columns, prefer `:temporal-unit`

### DIFF
--- a/src/metabase/lib/convert/metadata_to_legacy.cljc
+++ b/src/metabase/lib/convert/metadata_to_legacy.cljc
@@ -1,14 +1,17 @@
 (ns metabase.lib.convert.metadata-to-legacy
   (:require
    [medley.core :as m]
+   [metabase.lib.metadata.result-metadata :as-alias lib.result-metadata]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.memoize :as u.memo]))
 
 (let [f (u.memo/fast-memo
          (fn [k]
-           (cond-> k
-             (simple-keyword? k) u/->snake_case_en)))]
+           (case k
+             ::lib.result-metadata/unit :unit
+             #_else (cond-> k
+                      (simple-keyword? k) u/->snake_case_en))))]
   (defn lib-metadata-column-key->legacy-metadata-column-key
     "Convert unnamespaced keys to snake case for traditional reasons; `:lib/` keys and the like can stay in kebab case
   because you can't consume them in JS without using bracket notation anyway (and you probably shouldn't be doing it

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -421,7 +421,7 @@
    ;; formatting to display values of the column" according
    ;; to [[metabase.query-processor-test.nested-queries-test/breakout-year-test]]
    (when-let [temporal-unit ((some-fn :metabase.lib.field/temporal-unit :inherited-temporal-unit) col)]
-     {:unit temporal-unit})
+     {::unit temporal-unit})
    col))
 
 (defn- add-binning-info [col]

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -185,7 +185,9 @@
                   (and (:id m) (not (pos-int? (:id m))))
                   (dissoc :id)))
         ;; remove deprecated `:ident` and `:model/inner_ident` keys (normalized to `:model/inner-ident`)
-        (dissoc :ident :model/inner-ident))))
+        (dissoc :ident :model/inner-ident)
+        ;; Remove deprecated :unit; prefer :temporal-unit.
+        (dissoc :unit))))
 
 (def ^:private column-validate-for-source-specs
   "Schemas to use to validate columns with a given `:lib/source`. Since a lot of these schemas are applicable to
@@ -509,7 +511,9 @@
    ;; Additional constraints
    ;;
    ::lib.schema.common/kebab-cased-map
-   [:ref ::column.validate-for-source]])
+   [:ref ::column.validate-for-source]
+   (lib.schema.common/disallowed-keys
+    {:unit "Use :temporal-unit in Lib"})])
 
 (mr/def ::persisted-info.definition
   "Definition spec for a cached table."

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -43,7 +43,8 @@
   (u.memo/fast-memo u/->kebab-case-en))
 
 (def ^:private metadata-type->schema
-  {:metadata/card ::lib.schema.metadata/card})
+  {:metadata/card   ::lib.schema.metadata/card
+   :metadata/column ::lib.schema.metadata/column})
 
 (defn instance->metadata
   "Convert a (presumably) Toucan 2 instance of an application database model with `snake_case` keys to a MLv2 style


### PR DESCRIPTION
### Description

A small step in cleaning up the column metadata inside lib.

### How to verify

No visible changes.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
