### PR TITLE
Allow the run-query overlay when query result has the missing-required-parameter error

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -630,3 +630,11 @@ export function waitForLoaderToBeRemoved() {
 export function leaveConfirmationModal() {
   return cy.findByTestId("leave-confirmation");
 }
+
+export function ensureParameterColumnValue({ columnName, columnValue }) {
+  tableInteractiveBody().within(() => {
+    cy.get(`[data-column-id="${columnName}"]`).each((cell) => {
+      cy.wrap(cell).should("have.text", columnValue);
+    });
+  });
+}

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
@@ -18,6 +18,7 @@ import { Box, Button } from "metabase/ui";
 import type { DatasetColumn } from "metabase-types/api";
 import { createMockParameter } from "metabase-types/api/mocks";
 
+const { H } = cy;
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 const setup = ({ question }: { question: NativeQuestionDetails }) => {
@@ -27,20 +28,6 @@ const setup = ({ question }: { question: NativeQuestionDetails }) => {
 
   cy.signOut();
   mockAuthProviderAndJwtSignIn();
-};
-
-const ensureParameterColumnValue = ({
-  columnName,
-  columnValue,
-}: {
-  columnName: string;
-  columnValue: string;
-}) => {
-  tableInteractiveBody().within(() => {
-    cy.get(`[data-column-id="${columnName}"]`).each((cell) => {
-      cy.wrap(cell).should("have.text", columnValue);
-    });
-  });
 };
 
 describe("scenarios > embedding-sdk > interactive-question > native", () => {
@@ -238,7 +225,7 @@ describe("scenarios > embedding-sdk > interactive-question > native", () => {
           cy.findByPlaceholderText("State").clear().type("NY{enter}");
         });
 
-        ensureParameterColumnValue({
+        H.ensureParameterColumnValue({
           columnName: "STATE",
           columnValue: "NY",
         });
@@ -247,7 +234,7 @@ describe("scenarios > embedding-sdk > interactive-question > native", () => {
           cy.findByPlaceholderText("State").clear().type("AR{enter}");
         });
 
-        ensureParameterColumnValue({
+        H.ensureParameterColumnValue({
           columnName: "STATE",
           columnValue: "AR",
         });
@@ -256,7 +243,7 @@ describe("scenarios > embedding-sdk > interactive-question > native", () => {
           cy.findByPlaceholderText("City").type("El Paso{enter}");
         });
 
-        ensureParameterColumnValue({
+        H.ensureParameterColumnValue({
           columnName: "CITY",
           columnValue: "El Paso",
         });
@@ -277,7 +264,7 @@ describe("scenarios > embedding-sdk > interactive-question > native", () => {
 
         cy.wait("@cardQuery");
 
-        ensureParameterColumnValue({
+        H.ensureParameterColumnValue({
           columnName: "STATE",
           columnValue: "AR",
         });
@@ -286,7 +273,7 @@ describe("scenarios > embedding-sdk > interactive-question > native", () => {
           cy.findByPlaceholderText("City").type("El Paso{enter}");
         });
 
-        ensureParameterColumnValue({
+        H.ensureParameterColumnValue({
           columnName: "CITY",
           columnValue: "El Paso",
         });

--- a/frontend/src/metabase/lib/errors/server-error-types.ts
+++ b/frontend/src/metabase/lib/errors/server-error-types.ts
@@ -1,3 +1,4 @@
 export const SERVER_ERROR_TYPES = {
+  missingRequiredParameter: "missing-required-parameter",
   missingPermissions: "missing-required-permissions",
 };

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -9,6 +9,7 @@ import LoadingSpinner from "metabase/common/components/LoadingSpinner";
 import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
 import { isMac } from "metabase/lib/browser";
+import { SERVER_ERROR_TYPES } from "metabase/lib/errors";
 import { useSelector } from "metabase/lib/redux";
 import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
 import { Box, Flex, Stack, Text, Title } from "metabase/ui";
@@ -53,7 +54,9 @@ export default function QueryVisualization(props) {
           !isRunnable ||
           isRunning ||
           isNativeEditorOpen ||
-          result?.error
+          (result?.error &&
+            // This error should not prevent showing a dirty-state overlay with the `run` button
+            result.error_type !== SERVER_ERROR_TYPES.missingRequiredParameter)
         }
         className={cx(CS.spread, CS.z2)}
       />


### PR DESCRIPTION
Allow the run-query overlay when query result has the missing-required-parameter error

Fixes https://github.com/metabase/metabase/issues/64293

To Reproduce
- create sql question with 1-2 params, in my example i have state and city params, no default values, use text widget for params.
- save it
- reload a page, so parameter inputs are empty
- enter something into a parameter input, press enter - nothing happens.

Video with the bug:

https://github.com/user-attachments/assets/01f74998-f6d9-4a3c-94ad-53117f41416e


The `run query` overlay is not shown because it's not shown where there's a `missing required parameter` error for a previous query result. 
As the fix i check the error type and for the `missing required parameter` error i still show the overlay