### PR TITLE
Password reset should show confirmation toast

### DIFF
--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -336,12 +336,23 @@ describe("scenarios > admin > people", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`Reset ${normalUserName}'s password?`);
         clickButton("Reset password");
+
+        H.undoToast().within(() => {
+          cy.findByText(
+            `Password reset email sent to ${normalUserName}`,
+          ).should("be.visible");
+        });
+
+        cy.log("Should not show temporary password modal");
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`${normalUserName}'s password has been reset`).should(
           "not.exist",
         );
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(/^temporary password$/i).should("not.exist");
+
+        cy.log("Should close the modal");
+        H.modal().should("not.exist");
       },
     );
 

--- a/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.tsx
@@ -1,6 +1,6 @@
 import { goBack } from "react-router-redux";
 import { useUnmount } from "react-use";
-import { t } from "ttag";
+import { c, t } from "ttag";
 
 import {
   useForgotPasswordMutation,
@@ -10,6 +10,7 @@ import {
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import PasswordReveal from "metabase/common/components/PasswordReveal";
+import { useToast } from "metabase/common/hooks/use-toast";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { generatePassword } from "metabase/lib/security";
 import MetabaseSettings from "metabase/lib/settings";
@@ -38,12 +39,20 @@ const UserPasswordResetModalInner = ({
     clearTemporaryPassword();
   });
 
+  const [sendToast] = useToast();
   const [updatePassword] = useUpdatePasswordMutation();
   const [resetPasswordEmail] = useForgotPasswordMutation();
 
   const handleResetConfirm = async () => {
     if (emailConfigured) {
       await resetPasswordEmail(user.email).unwrap();
+
+      sendToast({
+        message: c("{0} is the name of the user")
+          .t`Password reset email sent to ${user.common_name}`,
+      });
+
+      onClose();
     } else {
       const password = generatePassword();
       await updatePassword({ id: user.id, password }).unwrap();


### PR DESCRIPTION
Closes UXW-318
Closes https://github.com/metabase/metabase/issues/60305

### How to verify

- Enable SMTP in email settings
- Go to "Admin settings > People"
- Click on a person > three dots > reset password
- The toast should show up
- The modal should be closed

### Demo

<img width="2142" height="1580" alt="CleanShot 2568-10-08 at 22 29 45@2x" src="https://github.com/user-attachments/assets/a229d70f-2d11-48d8-ab18-534cdcddd88e" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
