### PR TITLE
Use non-whitelabeled blue color for Metabase logo

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemBanner.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemBanner.tsx
@@ -8,7 +8,7 @@ import { useSdkDispatch } from "embedding-sdk-bundle/store";
 import { setUsageProblem } from "embedding-sdk-bundle/store/reducer";
 import type { SdkUsageProblem } from "embedding-sdk-bundle/types/usage-problem";
 import ExternalLink from "metabase/common/components/ExternalLink";
-import LogoIcon from "metabase/common/components/LogoIcon";
+import DefaultLogoIcon from "metabase/common/components/LogoIcon";
 import { originalColors } from "metabase/lib/colors";
 import { Button, Card, Flex, Icon, Popover, Stack, Text } from "metabase/ui";
 
@@ -20,7 +20,6 @@ export interface SdkUsageProblemBannerProps {
 
 // Prevent the usage problem banner from inheriting the theme colors,
 // so they remain legible even when the theme is changed.
-const unthemedBrand = originalColors["brand"];
 const unthemedTextDark = originalColors["text-dark"];
 
 export const SdkUsageProblemBanner = ({
@@ -60,7 +59,7 @@ export const SdkUsageProblemBanner = ({
           i-should-be-flex="true"
         >
           <Flex bg="white" px="sm" className={S.Logo} align="center">
-            <LogoIcon height={24} fill={unthemedBrand} />
+            <DefaultLogoIcon height={24} />
           </Flex>
 
           <Flex justify="center" align="center" className={S.Content}>

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemBanner.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemBanner.tsx
@@ -8,7 +8,7 @@ import { useSdkDispatch } from "embedding-sdk-bundle/store";
 import { setUsageProblem } from "embedding-sdk-bundle/store/reducer";
 import type { SdkUsageProblem } from "embedding-sdk-bundle/types/usage-problem";
 import ExternalLink from "metabase/common/components/ExternalLink";
-import DefaultLogoIcon from "metabase/common/components/LogoIcon";
+import MetabaseLogo from "metabase/common/components/LogoIcon";
 import { originalColors } from "metabase/lib/colors";
 import { Button, Card, Flex, Icon, Popover, Stack, Text } from "metabase/ui";
 
@@ -59,7 +59,7 @@ export const SdkUsageProblemBanner = ({
           i-should-be-flex="true"
         >
           <Flex bg="white" px="sm" className={S.Logo} align="center">
-            <DefaultLogoIcon height={24} />
+            <MetabaseLogo height={24} />
           </Flex>
 
           <Flex justify="center" align="center" className={S.Content}>

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
@@ -23,6 +23,9 @@ const getCustomLogoUrl = (settingValues: EnterpriseSettings) => {
 export const getLogoUrl = (state: EnterpriseState) =>
   getCustomLogoUrl(getSettings(state));
 
+export const getIsDefaultMetabaseLogo = (state: EnterpriseState) =>
+  getLogoUrl(state) === DEFAULT_LOGO_URL;
+
 export const getLoadingMessage = (state: EnterpriseState) => {
   const setting = getSetting(state, "loading-message");
   // default to empty string to account for a historical bug where the

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
@@ -6,10 +6,14 @@ import { Component } from "react";
 import CS from "metabase/css/core/index.css";
 import { parseDataUri, removeAllChildren } from "metabase/lib/dom";
 import { connect } from "metabase/lib/redux";
-import { getLogoUrl } from "metabase-enterprise/settings/selectors";
+import {
+  getIsDefaultMetabaseLogo,
+  getLogoUrl,
+} from "metabase-enterprise/settings/selectors";
 
 const mapStateToProps = (state) => ({
   url: getLogoUrl(state),
+  isDefaultMetabaseLogo: getIsDefaultMetabaseLogo(state),
 });
 
 class LogoIcon extends Component {
@@ -74,7 +78,7 @@ class LogoIcon extends Component {
         const svg =
           xhr.responseXML && xhr.responseXML.getElementsByTagName("svg")[0];
         if (svg) {
-          svg.setAttribute("fill", "currentcolor");
+          svg.setAttribute("fill", "#ff0000");
           this.updateSize(svg);
 
           removeAllChildren(this._container);
@@ -120,7 +124,13 @@ class LogoIcon extends Component {
   }
 
   render() {
-    const { dark, style = {}, height, className } = this.props;
+    const {
+      dark,
+      style = {},
+      height,
+      className,
+      isDefaultMetabaseLogo,
+    } = this.props;
 
     return (
       <span
@@ -128,7 +138,11 @@ class LogoIcon extends Component {
         className={cx(
           "Icon",
           CS.textCentered,
-          { [CS.textBrand]: !dark },
+          // If using the Metabase logo, use the non-whitelabeled Metabase brand color.
+          {
+            [isDefaultMetabaseLogo ? CS.textMetabaseBrand : CS.textBrand]:
+              !dark,
+          },
           { [CS.textWhite]: dark },
           className,
         )}

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
@@ -78,7 +78,7 @@ class LogoIcon extends Component {
         const svg =
           xhr.responseXML && xhr.responseXML.getElementsByTagName("svg")[0];
         if (svg) {
-          svg.setAttribute("fill", "#ff0000");
+          svg.setAttribute("fill", "currentcolor");
           this.updateSize(svg);
 
           removeAllChildren(this._container);

--- a/frontend/src/metabase/common/components/LogoIcon/LogoIcon.jsx
+++ b/frontend/src/metabase/common/components/LogoIcon/LogoIcon.jsx
@@ -22,7 +22,7 @@ export class DefaultLogoIcon extends Component {
       <svg
         className={cx(
           "Icon",
-          { [CS.textBrand]: !dark },
+          { [CS.textMetabaseBrand]: !dark },
           { [CS.textWhite]: dark },
         )}
         viewBox="0 0 212 256"

--- a/frontend/src/metabase/css/core/colors.module.css
+++ b/frontend/src/metabase/css/core/colors.module.css
@@ -29,6 +29,11 @@
   color: var(--mb-color-brand);
 }
 
+/** Non-whitelabeled Metabase brand color */
+.textMetabaseBrand {
+  color: var(--mb-color-metabase-brand);
+}
+
 .textSuccess {
   color: var(--mb-color-success);
 }

--- a/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
@@ -65,6 +65,14 @@ export const SDK_TO_MAIN_APP_COLORS_MAPPING: Record<
   "text-hover": ["text-hover"],
 };
 
+/**
+ * These colors must never be changed.
+ * For example, the blue Metabase brand color.
+ **/
+export const SDK_UNCHANGEABLE_COLORS: (ColorName | SemanticColorKey)[] = [
+  "metabase-brand",
+];
+
 export const SDK_TO_MAIN_APP_TOOLTIP_COLORS_MAPPING: Record<
   keyof NonNullable<MetabaseComponentTheme["tooltip"]>,
   ColorName

--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -7,6 +7,7 @@ import { getDynamicCssVariables } from "metabase/embedding-sdk/theme/dynamic-css
 import {
   SDK_TO_MAIN_APP_COLORS_MAPPING,
   SDK_TO_MAIN_APP_TOOLTIP_COLORS_MAPPING,
+  SDK_UNCHANGEABLE_COLORS,
 } from "metabase/embedding-sdk/theme/embedding-color-palette";
 import { colorConfig } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
@@ -80,6 +81,9 @@ function getSdkDesignSystemCssVariables(theme: MantineTheme) {
     ${Object.entries(SDK_TO_MAIN_APP_TOOLTIP_COLORS_MAPPING).flatMap(
       ([, colorName]) => createSdkColorVars(colorName),
     )}
+
+    /* Colors that cannot be changed. */
+    ${SDK_UNCHANGEABLE_COLORS.map((colorName) => createSdkColorVars(colorName))}
   `;
 }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58349
Closes UXW-296

Makes the default Metabase logo color always use the blue logo color. See this [comment](https://metaboat.slack.com/archives/C057WD5L0JG/p1747917852670589?thread_ts=1747917649.491319&cid=C057WD5L0JG) from Bruno.

### How to verify

- Change the colors in admin settings > branding to purple
- Go to homepage
- The Metabase logo should be blue, not purple

For the Embedding SDK / EAJS, use this HTML snippet and turn off embedding in admin settings:

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>Title</title>

  <style>
  body {
    margin: 0;
  }

  metabase-metabot {
    height: 100vh;
  }
  </style>
</head>
<body>
<script defer src="http://localhost:3000/app/embed.js"></script>

<script>
  function defineMetabaseConfig(config) {
    window.metabaseConfig = config;
  }
</script>

<script>
  defineMetabaseConfig({
    "instanceUrl": "http://localhost:3000/",
    "useExistingUserSession": true,
    "theme": {
      "colors": {
        "brand": "#e74c3c"
      }
    }
  });
</script>

<div>
  <metabase-metabot></metabase-metabot>
</div>
</body>
</html>
```

### Demo

Homepage

<img width="1854" height="1776" alt="CleanShot 2568-10-08 at 22 53 54@2x" src="https://github.com/user-attachments/assets/f2472114-1d75-47dd-a778-6fefad26420f" />

Login Page

<img width="2546" height="1772" alt="CleanShot 2568-10-08 at 22 54 53@2x" src="https://github.com/user-attachments/assets/64fcc052-f1d4-4afb-8916-2397ae614d84" />

React SDK & Embedded Analytics JS - UsageProblemBanner

<img width="708" height="502" alt="CleanShot 2568-10-08 at 23 19 14@2x" src="https://github.com/user-attachments/assets/c2337c45-6f5a-4bb2-85d1-2bc73a068623" />
