### PR TITLE
Set min width for DashCardActionsPanelContainer to fit content

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.module.css
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.module.css
@@ -7,6 +7,7 @@
 }
 
 .DashCardActionsPanelContainer {
+  min-width: fit-content;
   padding: 0.125em 0.25em;
   background: var(--mb-color-bg-dashboard-card);
   transform: translateY(-50%);


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64492
Set min width for DashCardActionsPanelContainer to fit content

<img width="744" height="856" alt="image" src="https://github.com/user-attachments/assets/dc192684-fa4a-4e66-8ee5-a7e18b91a5e8" />
