### PR TITLE
Add Store API endpoints

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1218,9 +1218,11 @@
 
   store-api
   {:team "Cloud"
-   :api  #{metabase.store-api.core
+   :api  #{metabase.store-api.api
+           metabase.store-api.core
            metabase.store-api.init}
-   :uses #{config
+   :uses #{api
+           config
            settings
            util}}
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -202,6 +202,7 @@ module.exports = {
         "*.unit.spec.*",
         "frontend/src/metabase/admin/**/*",
         "frontend/src/metabase/setup/**/*",
+        "frontend/src/metabase-types/**/*",
         "enterprise/frontend/src/metabase-enterprise/whitelabel/**/*",
         "enterprise/frontend/src/metabase-enterprise/embedding/**/*",
         "frontend/lint/**/*",

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -163,7 +163,6 @@ export const createMockColumnRangeFormattingSetting = (
 });
 
 export const createMockPieRow = (opts?: Partial<PieRow>): PieRow => ({
-  // eslint-disable-next-line no-color-literals
   color: "#7172AD",
   defaultColor: false,
   enabled: true,

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -167,7 +167,6 @@ export const createMockSettings = (
   "application-colors": {},
   "application-font": "Lato",
   "application-font-files": [],
-  // eslint-disable-next-line no-literal-metabase-strings -- This is a mock
   "application-name": "Metabase",
   "application-favicon-url": "",
   "available-fonts": [],

--- a/frontend/src/metabase-types/api/store.ts
+++ b/frontend/src/metabase-types/api/store.ts
@@ -1,3 +1,5 @@
+import type { TokenFeature } from "./settings";
+
 export interface StoreTokenStatus {
   status?: string;
   valid: boolean;
@@ -37,3 +39,128 @@ export type BillingInfo = {
   version: string;
   content: BillingInfoLineItem[] | null;
 };
+
+export interface MetabasePlan {
+  id: number;
+  name: MetabasePlanName;
+  description: string;
+  alias: MetabasePlanAlias;
+  product: string;
+  can_purchase: boolean;
+  billing_period_months: BillingPeriodMonths;
+  trial_days: number;
+  users_included: number;
+  per_user_price: string;
+  price: string;
+
+  hosting_features: MetabasePlanHostingFeature[];
+  token_features: TokenFeature[];
+
+  addon_price?: string;
+  base_price?: string;
+}
+
+export type MetabasePlansResponse = MetabasePlan[];
+
+export type MetabasePlanHostingFeature =
+  | "can-have-dev-subscription"
+  | "clickhouse-dwh"
+  | "custom-domain"
+  | "dedicated-node"
+  | "invoiceable"
+  | "invoicing-eligibility"
+  | "is-dev-subscription"
+  | "metabase-api-key"
+  | "trial-up";
+
+export type MetabasePlanName =
+  | "Metabase Cloud Starter Plan (Yearly, with Storage)"
+  | "Metabase Dev Instance Cloud (Monthly)"
+  | "Metabase Cloud Starter Plan"
+  | "Metabase Pro Cloud (Yearly)"
+  | "Metabase Cloud Starter Plan (with Storage)"
+  | "Metabase Cloud Starter Plan (Yearly)"
+  | "Metabase Dev Instance Cloud (Yearly)"
+  | "Metabase Cloud - Business"
+  | "Metabase Pro Self-Hosted (Yearly)"
+  | "Metabase Dev Instance Self-Hosted (Monthly)"
+  | "Metabase Pro Self-Hosted"
+  | "Metabase Pro Cloud (with Storage)"
+  | "Metabase Pro Cloud"
+  | "Metabase Pro Cloud (Yearly, with Storage)"
+  | "Metabase Dev Instance Self-Hosted (Yearly)";
+
+export type MetabasePlanAlias =
+  | "business"
+  | "pro-cloud"
+  | "pro-cloud-dev"
+  | "pro-cloud-dev-yearly"
+  | "pro-cloud-with-dwh"
+  | "pro-cloud-with-dwh-yearly"
+  | "pro-cloud-yearly"
+  | "pro-self-hosted"
+  | "pro-self-hosted-dev"
+  | "pro-self-hosted-dev-yearly"
+  | "pro-self-hosted-yearly"
+  | "starter"
+  | "starter-with-dwh"
+  | "starter-with-dwh-yearly"
+  | "starter-yearly";
+
+export type BillingPeriodMonths = 1 | 12;
+
+export interface MetabaseAddon {
+  id: number;
+  name: string;
+  short_name: string;
+  description: string | null;
+  alias: MetabaseAddonAlias;
+  product_type: MetabaseAddonProductType;
+  deployment: string;
+  billing_period_months: BillingPeriodMonths;
+  active: boolean;
+  self_service: boolean;
+
+  hosting_features: MetabaseAddonHostingFeature[];
+  token_features: TokenFeature[];
+
+  trialup_to_product_id: string | null;
+  invoiceable_counterpart: string | null;
+  trial_days: number | null;
+  is_metered: boolean | null;
+
+  default_total_units: number;
+  default_included_units: number;
+  default_prepaid_units: number;
+  default_price_per_unit: number;
+  default_base_fee: number;
+}
+
+export type MetabaseAddonsResponse = MetabaseAddon[];
+
+export type MetabaseAddonAlias =
+  | "metabase-ai"
+  | "metabase-ai-yearly"
+  | "etl-connections"
+  | "etl-connections-yearly"
+  | "dwh"
+  | "dwh-yearly"
+  | "python-execution"
+  | "python-execution-yearly"
+  | "metabase-ai-tiered"
+  | "metabase-ai-tiered-yearly";
+
+export type MetabaseAddonProductType =
+  | "metabase-ai"
+  | "etl-connections"
+  | "dwh"
+  | "python-execution"
+  | "metabase-ai-tiered";
+
+export type MetabaseAddonHostingFeature =
+  | "metabase-ai"
+  | "semantic-search-db"
+  | "etl-connections"
+  | "metabase-api-key"
+  | "clickhouse-dwh"
+  | "python-runner";

--- a/frontend/src/metabase-types/api/store.ts
+++ b/frontend/src/metabase-types/api/store.ts
@@ -42,7 +42,7 @@ export type BillingInfo = {
 
 export interface MetabasePlan {
   id: number;
-  name: MetabasePlanName;
+  name: string;
   description: string;
   alias: MetabasePlanAlias;
   product: string;
@@ -53,7 +53,7 @@ export interface MetabasePlan {
   per_user_price: string;
   price: string;
 
-  hosting_features: MetabasePlanHostingFeature[];
+  hosting_features: string[];
   token_features: TokenFeature[];
 
   addon_price?: string;
@@ -61,34 +61,6 @@ export interface MetabasePlan {
 }
 
 export type MetabasePlansResponse = MetabasePlan[];
-
-export type MetabasePlanHostingFeature =
-  | "can-have-dev-subscription"
-  | "clickhouse-dwh"
-  | "custom-domain"
-  | "dedicated-node"
-  | "invoiceable"
-  | "invoicing-eligibility"
-  | "is-dev-subscription"
-  | "metabase-api-key"
-  | "trial-up";
-
-export type MetabasePlanName =
-  | "Metabase Cloud Starter Plan (Yearly, with Storage)"
-  | "Metabase Dev Instance Cloud (Monthly)"
-  | "Metabase Cloud Starter Plan"
-  | "Metabase Pro Cloud (Yearly)"
-  | "Metabase Cloud Starter Plan (with Storage)"
-  | "Metabase Cloud Starter Plan (Yearly)"
-  | "Metabase Dev Instance Cloud (Yearly)"
-  | "Metabase Cloud - Business"
-  | "Metabase Pro Self-Hosted (Yearly)"
-  | "Metabase Dev Instance Self-Hosted (Monthly)"
-  | "Metabase Pro Self-Hosted"
-  | "Metabase Pro Cloud (with Storage)"
-  | "Metabase Pro Cloud"
-  | "Metabase Pro Cloud (Yearly, with Storage)"
-  | "Metabase Dev Instance Self-Hosted (Yearly)";
 
 export type MetabasePlanAlias =
   | "business"
@@ -114,14 +86,14 @@ export interface MetabaseAddon {
   name: string;
   short_name: string;
   description: string | null;
-  alias: MetabaseAddonAlias;
+  alias: string;
   product_type: MetabaseAddonProductType;
   deployment: string;
   billing_period_months: BillingPeriodMonths;
   active: boolean;
   self_service: boolean;
 
-  hosting_features: MetabaseAddonHostingFeature[];
+  hosting_features: string[];
   token_features: TokenFeature[];
 
   trialup_to_product_id: string | null;
@@ -138,29 +110,9 @@ export interface MetabaseAddon {
 
 export type MetabaseAddonsResponse = MetabaseAddon[];
 
-export type MetabaseAddonAlias =
-  | "metabase-ai"
-  | "metabase-ai-yearly"
-  | "etl-connections"
-  | "etl-connections-yearly"
-  | "dwh"
-  | "dwh-yearly"
-  | "python-execution"
-  | "python-execution-yearly"
-  | "metabase-ai-tiered"
-  | "metabase-ai-tiered-yearly";
-
 export type MetabaseAddonProductType =
   | "metabase-ai"
   | "etl-connections"
   | "dwh"
   | "python-execution"
   | "metabase-ai-tiered";
-
-export type MetabaseAddonHostingFeature =
-  | "metabase-ai"
-  | "semantic-search-db"
-  | "etl-connections"
-  | "metabase-api-key"
-  | "clickhouse-dwh"
-  | "python-runner";

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -32,6 +32,7 @@ export * from "./session";
 export * from "./settings";
 export * from "./slack";
 export * from "./snippet";
+export * from "./store-api";
 export * from "./subscription";
 export * from "./table";
 export * from "./task";

--- a/frontend/src/metabase/api/store-api.ts
+++ b/frontend/src/metabase/api/store-api.ts
@@ -1,0 +1,20 @@
+import { Api } from "./api";
+
+export const storeApi = Api.injectEndpoints({
+  endpoints: (builder) => ({
+    listPlans: builder.query<unknown, void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/store-api/plan",
+      }),
+    }),
+    listAddons: builder.query<unknown, void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/store-api/addons",
+      }),
+    }),
+  }),
+});
+
+export const { useListPlansQuery, useListAddonsQuery } = storeApi;

--- a/frontend/src/metabase/api/store-api.ts
+++ b/frontend/src/metabase/api/store-api.ts
@@ -1,14 +1,19 @@
+import type {
+  MetabaseAddonsResponse,
+  MetabasePlansResponse,
+} from "metabase-types/api";
+
 import { Api } from "./api";
 
 export const storeApi = Api.injectEndpoints({
   endpoints: (builder) => ({
-    listPlans: builder.query<unknown, void>({
+    listPlans: builder.query<MetabasePlansResponse, void>({
       query: () => ({
         method: "GET",
         url: "/api/store-api/plan",
       }),
     }),
-    listAddons: builder.query<unknown, void>({
+    listAddons: builder.query<MetabaseAddonsResponse, void>({
       query: () => ({
         method: "GET",
         url: "/api/store-api/addons",

--- a/frontend/src/metabase/api/store-api.ts
+++ b/frontend/src/metabase/api/store-api.ts
@@ -10,7 +10,7 @@ export const storeApi = Api.injectEndpoints({
     listPlans: builder.query<MetabasePlansResponse, void>({
       query: () => ({
         method: "GET",
-        url: "/api/store-api/plan",
+        url: "/api/store-api/plans",
       }),
     }),
     listAddons: builder.query<MetabaseAddonsResponse, void>({

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -43,6 +43,7 @@
    [metabase.settings.api]
    [metabase.setup.api]
    [metabase.sso.api]
+   [metabase.store-api.api]
    [metabase.sync.api]
    [metabase.task-history.api]
    [metabase.testing-api.api]
@@ -84,6 +85,7 @@
          metabase.segments.api/keep-me
          metabase.settings.api/keep-me
          metabase.setup.api/keep-me
+         metabase.store-api.api/keep-me
          metabase.task-history.api/keep-me
          metabase.testing-api.api/keep-me
          metabase.tiles.api/keep-me
@@ -174,6 +176,7 @@
    "/setting"              (+auth 'metabase.settings.api)
    "/setup"                'metabase.setup.api
    "/slack"                (+auth metabase.channel.api/slack-routes)
+   "/store-api"            'metabase.store-api.api
    "/table"                (+auth metabase.warehouse-schema.api/table-routes)
    "/task"                 (+auth 'metabase.task-history.api)
    "/testing"              (if metabase.testing-api.core/enable-testing-routes? 'metabase.testing-api.api pass-thru-handler)

--- a/src/metabase/store_api/api.clj
+++ b/src/metabase/store_api/api.clj
@@ -4,64 +4,22 @@
    [clj-http.client :as http]
    [metabase.api.macros :as api.macros]
    [metabase.store-api.core :as store-api]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.store-api.schema :as store-api.schema]))
 
 (set! *warn-on-reflection* true)
 
 (defn- make-store-request
-  "Make a GET request to the Metabase Store API endpoint."
+  "Make a GET request to fetch infrom from public Metabase Store API endpoints."
   [endpoint]
   (let [url (str (store-api/store-api-url) "/api/v2" endpoint)]
     (:body (http/get url {:as :json}))))
 
-(mr/def ::Plan
-  [:map
-   [:id pos-int?]
-   [:name :string]
-   [:description :string]
-   [:alias :string]
-   [:product :string] ;; product id
-   [:can_purchase :boolean]
-   [:billing_period_months [:enum 1 12]]
-   [:trial_days pos-int?]
-   [:users_included pos-int?]
-   [:per_user_price :string]
-   [:price :string]
-   [:hosting_features [:sequential :string]]
-   [:token_features [:sequential :string]]
-   [:addon_price {:optional true} :string]
-   [:base_price {:optional true} :string]])
-
-(mr/def ::Addon
-  [:map
-   [:id pos-int?]
-   [:name :string]
-   [:short_name :string]
-   [:description [:maybe :string]]
-   [:alias :string]
-   [:product_type :string] ;; the actual add-on
-   [:deployment :string]
-   [:billing_period_months [:enum 1 12]]
-   [:active :boolean]
-   [:self_service :boolean]
-   [:hosting_features [:sequential :string]]
-   [:token_features [:sequential :string]]
-   [:trialup_to_product_id [:maybe :string]]
-   [:invoiceable_counterpart [:maybe :string]]
-   [:trial_days [:maybe number?]]
-   [:is_metered [:maybe :boolean]]
-   [:default_total_units number?]
-   [:default_included_units number?]
-   [:default_prepaid_units number?]
-   [:default_price_per_unit number?]
-   [:default_base_fee number?]])
-
-(api.macros/defendpoint :get "/plans" :- [:sequential ::Plan]
-  "Fetch information about available plans from the Metabase Store API."
+(api.macros/defendpoint :get "/plans" :- [:sequential ::store-api.schema/Plan]
+  "Fetch information about currently supported Metabase plans from the Metabase Store API."
   []
   (make-store-request "/plan"))
 
-(api.macros/defendpoint :get "/addons" :- [:sequential ::Addon]
-  "Fetch add-on information from the Metabase Store API."
+(api.macros/defendpoint :get "/addons" :- [:sequential ::store-api.schema/Addon]
+  "Fetch the add-on information from the Metabase Store API."
   []
   (make-store-request "/addons"))

--- a/src/metabase/store_api/api.clj
+++ b/src/metabase/store_api/api.clj
@@ -4,7 +4,6 @@
    [clj-http.client :as http]
    [metabase.api.macros :as api.macros]
    [metabase.store-api.core :as store-api]
-   [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]))
 
 (set! *warn-on-reflection* true)
@@ -12,23 +11,8 @@
 (defn- make-store-request
   "Make a GET request to the Metabase Store API endpoint."
   [endpoint]
-  (try
-    (let [url (str (store-api/store-api-url) "/api/v2" endpoint)
-          response (http/get url {:as :json
-                                  :throw-exceptions false
-                                  :timeout 30000})]
-      (if (= 200 (:status response))
-        (:body response)
-        (do
-          (log/warn "Store API request failed" {:endpoint endpoint
-                                                :status (:status response)
-                                                :url url})
-          {:error "Store API request failed"
-           :status (:status response)})))
-    (catch Exception e
-      (log/error e "Error making Store API request" {:endpoint endpoint})
-      {:error "Store API request failed"
-       :message (.getMessage e)})))
+  (let [url (str (store-api/store-api-url) "/api/v2" endpoint)]
+    (:body (http/get url {:as :json}))))
 
 (mr/def ::Plan
   [:map
@@ -64,13 +48,13 @@
    [:token_features [:sequential :string]]
    [:trialup_to_product_id [:maybe :string]]
    [:invoiceable_counterpart [:maybe :string]]
-   [:trial_days [:maybe pos-int?]]
+   [:trial_days [:maybe number?]]
    [:is_metered [:maybe :boolean]]
-   [:default_total_units :int]
-   [:default_included_units :int]
-   [:default_prepaid_units :int]
-   [:default_price_per_unit :int]
-   [:default_base_fee :int]])
+   [:default_total_units number?]
+   [:default_included_units number?]
+   [:default_prepaid_units number?]
+   [:default_price_per_unit number?]
+   [:default_base_fee number?]])
 
 (api.macros/defendpoint :get "/plan" :- [:sequential ::Plan]
   "Fetch information about available plans from the Metabase Store API."

--- a/src/metabase/store_api/api.clj
+++ b/src/metabase/store_api/api.clj
@@ -62,7 +62,7 @@
    [:self_service :boolean]
    [:hosting_features [:sequential :string]]
    [:token_features [:sequential :string]]
-   [:trial_to_product_id [:maybe :string]]
+   [:trialup_to_product_id [:maybe :string]]
    [:invoiceable_counterpart [:maybe :string]]
    [:trial_days [:maybe pos-int?]]
    [:is_metered [:maybe :boolean]]

--- a/src/metabase/store_api/api.clj
+++ b/src/metabase/store_api/api.clj
@@ -56,7 +56,7 @@
    [:default_price_per_unit number?]
    [:default_base_fee number?]])
 
-(api.macros/defendpoint :get "/plan" :- [:sequential ::Plan]
+(api.macros/defendpoint :get "/plans" :- [:sequential ::Plan]
   "Fetch information about available plans from the Metabase Store API."
   []
   (make-store-request "/plan"))

--- a/src/metabase/store_api/api.clj
+++ b/src/metabase/store_api/api.clj
@@ -66,11 +66,11 @@
    [:invoiceable_counterpart [:maybe :string]]
    [:trial_days [:maybe pos-int?]]
    [:is_metered [:maybe :boolean]]
-   [:default_total_units :number]
-   [:default_included_units :number]
-   [:default_prepaid_units :number]
-   [:default_price_per_unit :number]
-   [:default_base_fee :number]])
+   [:default_total_units]
+   [:default_included_units :int]
+   [:default_prepaid_units :int]
+   [:default_price_per_unit :int]
+   [:default_base_fee :int]])
 
 (api.macros/defendpoint :get "/plan" :- [:sequential ::Plan]
   "Fetch information about available plans from the Metabase Store API."

--- a/src/metabase/store_api/api.clj
+++ b/src/metabase/store_api/api.clj
@@ -1,0 +1,40 @@
+(ns metabase.store-api.api
+  "Public, unauthenticated API endpoints for fetching various information from the Metabase Store API."
+  (:require
+   [clj-http.client :as http]
+   [metabase.api.macros :as api.macros]
+   [metabase.store-api.core :as store-api]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(defn- make-store-request
+  "Make a GET request to the Metabase Store API endpoint."
+  [endpoint]
+  (try
+    (let [url (str (store-api/store-api-url) "/api/v2" endpoint)
+          response (http/get url {:as :json
+                                  :throw-exceptions false
+                                  :timeout 30000})]
+      (if (= 200 (:status response))
+        (:body response)
+        (do
+          (log/warn "Store API request failed" {:endpoint endpoint
+                                                :status (:status response)
+                                                :url url})
+          {:error "Store API request failed"
+           :status (:status response)})))
+    (catch Exception e
+      (log/error e "Error making Store API request" {:endpoint endpoint})
+      {:error "Store API request failed"
+       :message (.getMessage e)})))
+
+(api.macros/defendpoint :get "/plan"
+  "Fetch information about available plans from the Metabase Store API."
+  []
+  (make-store-request "/plan"))
+
+(api.macros/defendpoint :get "/addons"
+  "Fetch add-on information from the Metabase Store API."
+  []
+  (make-store-request "/addons"))

--- a/src/metabase/store_api/api.clj
+++ b/src/metabase/store_api/api.clj
@@ -66,7 +66,7 @@
    [:invoiceable_counterpart [:maybe :string]]
    [:trial_days [:maybe pos-int?]]
    [:is_metered [:maybe :boolean]]
-   [:default_total_units]
+   [:default_total_units :int]
    [:default_included_units :int]
    [:default_prepaid_units :int]
    [:default_price_per_unit :int]

--- a/src/metabase/store_api/api.clj
+++ b/src/metabase/store_api/api.clj
@@ -7,8 +7,8 @@
    [metabase.store-api.schema :as store-api.schema]
    [metabase.util.i18n :as i18n]))
 
-(defn- make-store-request
-  "Make a GET request to fetch infrom from public Metabase Store API endpoints."
+(defn- make-public-store-request!
+  "Make a GET request to fetch publicly available info from Metabase Store API endpoints."
   [endpoint]
   (if-let [url (store-api/store-api-url)]
     (:body (http/get (str url "/api/v2" endpoint) {:as :json}))
@@ -17,9 +17,9 @@
 (api.macros/defendpoint :get "/plans" :- [:sequential ::store-api.schema/Plan]
   "Fetch information about currently supported Metabase plans from the Metabase Store API."
   []
-  (make-store-request "/plan"))
+  (make-public-store-request! "/plan"))
 
 (api.macros/defendpoint :get "/addons" :- [:sequential ::store-api.schema/Addon]
   "Fetch the add-on information from the Metabase Store API."
   []
-  (make-store-request "/addons"))
+  (make-public-store-request! "/addons"))

--- a/src/metabase/store_api/api.clj
+++ b/src/metabase/store_api/api.clj
@@ -4,15 +4,15 @@
    [clj-http.client :as http]
    [metabase.api.macros :as api.macros]
    [metabase.store-api.core :as store-api]
-   [metabase.store-api.schema :as store-api.schema]))
-
-(set! *warn-on-reflection* true)
+   [metabase.store-api.schema :as store-api.schema]
+   [metabase.util.i18n :as i18n]))
 
 (defn- make-store-request
   "Make a GET request to fetch infrom from public Metabase Store API endpoints."
   [endpoint]
-  (let [url (str (store-api/store-api-url) "/api/v2" endpoint)]
-    (:body (http/get url {:as :json}))))
+  (if-let [url (store-api/store-api-url)]
+    (:body (http/get (str url "/api/v2" endpoint) {:as :json}))
+    (throw (ex-info (i18n/tru "Please configure store-api-url") {:status-code 400}))))
 
 (api.macros/defendpoint :get "/plans" :- [:sequential ::store-api.schema/Plan]
   "Fetch information about currently supported Metabase plans from the Metabase Store API."

--- a/src/metabase/store_api/schema.clj
+++ b/src/metabase/store_api/schema.clj
@@ -1,0 +1,45 @@
+(ns metabase.store-api.schema
+  (:require
+   [metabase.util.malli.registry :as mr]))
+
+(mr/def ::Plan
+  [:map
+   [:id pos-int?]
+   [:name :string]
+   [:description :string]
+   [:alias :string]
+   [:product :string] ; product id
+   [:can_purchase :boolean]
+   [:billing_period_months [:enum 1 12]]
+   [:trial_days pos-int?]
+   [:users_included pos-int?]
+   [:per_user_price :string]
+   [:price :string]
+   [:hosting_features [:sequential :string]]
+   [:token_features [:sequential :string]]
+   [:addon_price {:optional true} :string]
+   [:base_price {:optional true} :string]])
+
+(mr/def ::Addon
+  [:map
+   [:id pos-int?]
+   [:name :string]
+   [:short_name :string]
+   [:description [:maybe :string]]
+   [:alias :string]
+   [:product_type :string] ; the actual add-on
+   [:deployment :string]
+   [:billing_period_months [:enum 1 12]]
+   [:active :boolean]
+   [:self_service :boolean]
+   [:hosting_features [:sequential :string]]
+   [:token_features [:sequential :string]]
+   [:trialup_to_product_id [:maybe :string]]
+   [:invoiceable_counterpart [:maybe :string]]
+   [:trial_days [:maybe number?]]
+   [:is_metered [:maybe :boolean]]
+   [:default_total_units number?]
+   [:default_included_units number?]
+   [:default_prepaid_units number?]
+   [:default_price_per_unit number?]
+   [:default_base_fee number?]])

--- a/src/metabase/store_api/schema.clj
+++ b/src/metabase/store_api/schema.clj
@@ -1,4 +1,5 @@
 (ns metabase.store-api.schema
+  "Malli schemas for Store API requests and responses."
   (:require
    [metabase.util.malli.registry :as mr]))
 

--- a/src/metabase/store_api/schema.clj
+++ b/src/metabase/store_api/schema.clj
@@ -4,6 +4,7 @@
    [metabase.util.malli.registry :as mr]))
 
 (mr/def ::Plan
+  "Specification for the Plan entity used in the Store API."
   [:map
    [:id pos-int?]
    [:name :string]
@@ -22,6 +23,7 @@
    [:base_price {:optional true} :string]])
 
 (mr/def ::Addon
+  "Specification for the Addon entity used in the Store API."
   [:map
    [:id pos-int?]
    [:name :string]

--- a/test/metabase/store_api/api_test.clj
+++ b/test/metabase/store_api/api_test.clj
@@ -98,34 +98,32 @@
        ~@body)))
 
 (deftest ^:parallel plans-endpoint-test
-  (with-store-api-mocks
-    (testing "GET /api/store-api/plans"
+  (testing "GET /api/store-api/plans"
+    (with-store-api-mocks
       (testing "should return a list of plans"
         (let [response (mt/user-http-request :rasta :get 200 "store-api/plans")]
           (is (sequential? response))
           (is (= 2 (count response)))
           (is (= "Open Source" (-> response first :name)))
-          (is (= "Pro" (-> response second :name))))))
-    (testing "accessible without authentication"
-      (let [response (mt/client :get 200 "store-api/plans")]
-        (is (sequential? response))
-        (is (pos? (count response)))))))
-
+          (is (= "Pro" (-> response second :name)))))
+      (testing "accessible without authentication"
+        (let [response (mt/client :get 200 "store-api/plans")]
+          (is (sequential? response))
+          (is (pos? (count response))))))))
 (deftest ^:parallel addons-endpoint-test
-  (with-store-api-mocks
-    (testing "GET /api/store-api/addons"
+  (testing "GET /api/store-api/addons"
+    (with-store-api-mocks
       (testing "should return a list of add-ons"
         (let [response (mt/user-http-request :rasta :get 200 "store-api/addons")]
           (is (sequential? response))
           (is (= 2 (count response)))
           (is (= "Add-on 1" (-> response first :name)))
-          (is (= "Add-on 2" (-> response second :name)))))))
-  (testing "accessible without authentication"
-    (with-store-api-mocks
-      (let [response (mt/client :get 200 "store-api/addons")]
-        (is (sequential? response))
-        (is (pos? (count response)))))))
-
+          (is (= "Add-on 2" (-> response second :name)))))
+      (testing "accessible without authentication"
+        (with-store-api-mocks
+          (let [response (mt/client :get 200 "store-api/addons")]
+            (is (sequential? response))
+            (is (pos? (count response)))))))))
 (deftest ^:parallel error-if-store-api-url-is-not-configured
   (testing "GET /api/store-api/ without store-api-url configured will throw an error with nice message"
     (mt/with-dynamic-fn-redefs [store-api/store-api-url (constantly nil)]

--- a/test/metabase/store_api/api_test.clj
+++ b/test/metabase/store_api/api_test.clj
@@ -120,15 +120,13 @@
           (is (= "Add-on 1" (-> response first :name)))
           (is (= "Add-on 2" (-> response second :name)))))
       (testing "accessible without authentication"
-        (with-store-api-mocks
-          (let [response (mt/client :get 200 "store-api/addons")]
-            (is (sequential? response))
-            (is (pos? (count response)))))))))
+        (let [response (mt/client :get 200 "store-api/addons")]
+          (is (sequential? response))
+          (is (pos? (count response))))))))
 (deftest ^:parallel error-if-store-api-url-is-not-configured
   (testing "GET /api/store-api/ without store-api-url configured will throw an error with nice message"
     (mt/with-dynamic-fn-redefs [store-api/store-api-url (constantly nil)]
       (is (= "Please configure store-api-url"
              (mt/user-http-request :rasta :get 400 "store-api/plans")))
-
       (is (= "Please configure store-api-url"
              (mt/user-http-request :rasta :get 400 "store-api/addons"))))))

--- a/test/metabase/store_api/api_test.clj
+++ b/test/metabase/store_api/api_test.clj
@@ -1,0 +1,129 @@
+(ns metabase.store-api.api-test
+  "Tests for /api/store-api endpoints."
+  (:require
+   [clj-http.fake :as fake]
+   [clojure.test :refer :all]
+   [metabase.store-api.core :as store-api]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private mock-plans-response
+  [{:id                    1
+    :name                  "Open Source"
+    :description           "The open source plan"
+    :alias                 "open-source"
+    :product               "metabase-os"
+    :can_purchase          false
+    :billing_period_months 1
+    :trial_days            14
+    :users_included        1
+    :per_user_price        "$0"
+    :price                 "$0"
+    :hosting_features      []
+    :token_features        []}
+   {:id                    2
+    :name                  "Pro"
+    :description           "The pro plan"
+    :alias                 "pro"
+    :product               "metabase-pro"
+    :can_purchase          true
+    :billing_period_months 12
+    :trial_days            14
+    :users_included        1
+    :per_user_price        "$99"
+    :price                 "$99"
+    :hosting_features      ["feature1"]
+    :token_features        ["token_feature1"]}])
+
+(def ^:private mock-addons-response
+  [{:id                            1
+    :name                          "Add-on 1"
+    :short_name                    "addon-1"
+    :description                   "Description of add-on 1"
+    :alias                         "addon-1"
+    :product_type                  "addon"
+    :deployment                    "on-prem"
+    :billing_period_months         1
+    :active                        true
+    :self_service                  true
+    :hosting_features              []
+    :token_features                []
+    :trialup_to_product_id         nil
+    :invoiceable_counterpart       nil
+    :trial_days                    nil
+    :is_metered                    false
+    :default_total_units           100.0
+    :default_included_units        0.0
+    :default_prepaid_units         0.0
+    :default_price_per_unit        10.0
+    :default_base_fee              0.0}
+   {:id                            2
+    :name                          "Add-on 2"
+    :short_name                    "addon-2"
+    :description                   "Description of add-on 2"
+    :alias                         "addon-2"
+    :product_type                  "addon"
+    :deployment                    "cloud"
+    :billing_period_months         12
+    :active                        true
+    :self_service                  false
+    :hosting_features              ["feature1"]
+    :token_features                ["token_feature1"]
+    :trialup_to_product_id         "some-product"
+    :invoiceable_counterpart       "counterpart"
+    :trial_days                    30
+    :is_metered                    true
+    :default_total_units           500.0
+    :default_included_units        100.0
+    :default_prepaid_units         200.0
+    :default_price_per_unit        5.0
+    :default_base_fee              50.0}])
+
+(defn- make-fake-routes
+  "Create fake routes for the store API."
+  [store-api-url]
+  {(str store-api-url "/api/v2/plan")
+   (constantly {:status  200
+                :headers {"content-type" "application/json"}
+                :body    mock-plans-response})
+   (str store-api-url "/api/v2/addons")
+   (constantly {:status  200
+                :headers {"content-type" "application/json"}
+                :body    mock-addons-response})})
+
+(defmacro with-store-api-mocks [& body]
+  `(let [store-url# (store-api/store-api-url)
+         routes#    (make-fake-routes store-url#)]
+     (fake/with-fake-routes routes#
+       ~@body)))
+
+(deftest ^:parallel plans-endpoint-test
+  (testing "GET /api/store-api/plans"
+    (with-store-api-mocks
+      (testing "should return a list of plans"
+        (let [response (mt/user-http-request :rasta :get 200 "store-api/plans")]
+          (is (vector? response))
+          (is (= 2 (count response)))
+          (is (= "Open Source" (-> response first :name)))
+          (is (= "Pro" (-> response second :name)))))))
+  (testing "accessible without authentication"
+    (with-store-api-mocks
+      (let [response (mt/client :get 200 "store-api/plans")]
+        (is (vector? response))
+        (is (pos? (count response)))))))
+
+(deftest ^:parallel addons-endpoint-test
+  (testing "GET /api/store-api/addons"
+    (with-store-api-mocks
+      (testing "should return a list of add-ons"
+        (let [response (mt/user-http-request :rasta :get 200 "store-api/addons")]
+          (is (vector? response))
+          (is (= 2 (count response)))
+          (is (= "Add-on 1" (-> response first :name)))
+          (is (= "Add-on 2" (-> response second :name)))))))
+  (testing "accessible without authentication"
+    (with-store-api-mocks
+      (let [response (mt/client :get 200 "store-api/addons")]
+        (is (vector? response))
+        (is (pos? (count response)))))))

--- a/test/metabase/store_api/api_test.clj
+++ b/test/metabase/store_api/api_test.clj
@@ -112,8 +112,8 @@
         (is (pos? (count response)))))))
 
 (deftest ^:parallel addons-endpoint-test
-  (testing "GET /api/store-api/addons"
-    (with-store-api-mocks
+  (with-store-api-mocks
+    (testing "GET /api/store-api/addons"
       (testing "should return a list of add-ons"
         (let [response (mt/user-http-request :rasta :get 200 "store-api/addons")]
           (is (sequential? response))


### PR DESCRIPTION
This PR adds two new endpoints that communicate with the Metabase Store through the Metabase core backend. Their purpose is to fetch information about the currently supported Metabase plans, as well as the information about the currently supported add-ons.

