### PR TITLE
Move the SameSite cookie settings from interactive embedding to security tab

### DIFF
--- a/docs/embedding/interactive-embedding.md
+++ b/docs/embedding/interactive-embedding.md
@@ -34,7 +34,7 @@ Check out the [Interactive embedding quick start](./interactive-embedding-quick-
 
 If you're dealing with a [multi-tenant](https://www.metabase.com/learn/metabase-basics/embedding/multi-tenant-self-service-analytics) situation, check out our recommendations for [Configuring permissions for different customer schemas](../permissions/embedding.md).
 
-If you have your app running locally, and you're using the Pro Cloud version, or hosting Metabase and your app in different domains, you'll need to set your Metabase environment's session cookie samesite option to "none".
+If you have your app running locally, and you're using the Pro Cloud version, or hosting Metabase and your app in different domains, you'll need to set your Metabase environment's session cookie SameSite option to "none".
 
 ## Enabling interactive embedding in Metabase
 
@@ -128,13 +128,13 @@ Note that your interactive embed must be compatible with Safari to run on _any_ 
 
 If you want to embed Metabase in another domain (say, if Metabase is hosted at `metabase.yourcompany.com`, but you want to embed Metabase at `yourcompany.github.io`), you can tell Metabase to set the session cookie's SameSite value to "none".
 
-You can set session cookie's SameSite value in **Admin settings** > **Embedding** > **Interactive** > **SameSite cookie setting**.
+You can set session cookie's SameSite value in **Admin settings** > **Embedding** > **Security** > **SameSite cookie setting**.
 
 SameSite values include:
 
-- **Lax** (default): Allows cookies to be sent when someone navigates to the origin site from an external site (like when following a link).
-- **None**: Allows all cross-site requests. Incompatible with most Safari and iOS browsers, such as Chrome on iOS. If you set this environment variable to "None", you must use HTTPS in Metabase to prevent browsers from rejecting the request.
-- **Strict** (not recommended): Never allows cookies to be sent on a cross-site request. Warning: this will prevent users from following external links to Metabase.
+- **Lax** (default): Allows Metabase session cookies to be shared on the same domain. Used for production instances on the same domain.
+- **None (requires HTTPS)**: Use "None" when your app and Metabase are hosted on different domains. Incompatible with Safari and iOS-based browsers.
+- **Strict** (not recommended): Does not allow Metabase session cookies to be shared with embedded instances. Use this if you do not want to enable session sharing with embedding.
 
 You can also set the [`MB_SESSION_COOKIE_SAMESITE` environment variable](../configuring-metabase/environment-variables.md#mb_session_cookie_samesite).
 

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/EmbeddingAppSameSiteCookieDescription/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/EmbeddingAppSameSiteCookieDescription/index.ts
@@ -1,1 +1,0 @@
-export { SameSiteSelectWidget } from "./SameSiteSelectWidget";

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.tsx
@@ -17,7 +17,6 @@ import { useDocsUrl } from "metabase/common/hooks";
 import { Box, Button } from "metabase/ui";
 
 import { EmbeddingAppOriginDescription } from "./EmbeddingAppOriginDescription";
-import { SameSiteSelectWidget } from "./EmbeddingAppSameSiteCookieDescription";
 
 const utmTags = {
   utm_source: "product",
@@ -60,8 +59,6 @@ export function InteractiveEmbeddingSettings() {
           placeholder="https://*.example.com"
           inputType="text"
         />
-
-        <SameSiteSelectWidget />
       </SettingsSection>
 
       <RelatedSettingsSection

--- a/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/components/InteractiveEmbeddingSettings.unit.spec.tsx
@@ -75,21 +75,6 @@ describe("InteractiveEmbeddingSettings", () => {
     expect(body).toEqual({ value: "https://*.foo.example.com" });
   });
 
-  it("should allow changing samesite cookie setting", async () => {
-    await setup({ enabled: true });
-
-    const button = await screen.findByText("Lax (default)");
-    await userEvent.click(button);
-    const newOption = await screen.findByText("Strict (not recommended)");
-    await userEvent.click(newOption);
-
-    const puts = await findRequests("PUT");
-    expect(puts).toHaveLength(1);
-    const [{ url, body }] = puts;
-    expect(url).toContain("/setting/session-cookie-samesite");
-    expect(body).toEqual({ value: "strict" });
-  });
-
   it("should show cards with related settings", async () => {
     await setup({ enabled: true });
 

--- a/frontend/src/metabase/admin/embedding/components/EmbeddingNav.tsx
+++ b/frontend/src/metabase/admin/embedding/components/EmbeddingNav.tsx
@@ -59,6 +59,14 @@ export function EmbeddingNav() {
           label={t`Static`}
           icon="embed_static"
         />
+
+        <Divider mb="sm" />
+
+        <EmbeddingNavItem
+          path="/admin/embedding/security"
+          label={t`Security`}
+          icon="lock"
+        />
       </Stack>
     </AdminNavWrapper>
   );

--- a/frontend/src/metabase/admin/embedding/components/EmbeddingNav.tsx
+++ b/frontend/src/metabase/admin/embedding/components/EmbeddingNav.tsx
@@ -65,7 +65,7 @@ export function EmbeddingNav() {
         <EmbeddingNavItem
           path="/admin/embedding/security"
           label={t`Security`}
-          icon="lock"
+          icon="shield_outline"
         />
       </Stack>
     </AdminNavWrapper>

--- a/frontend/src/metabase/admin/routes.jsx
+++ b/frontend/src/metabase/admin/routes.jsx
@@ -23,6 +23,7 @@ import { PerformanceApp } from "metabase/admin/performance/components/Performanc
 import getAdminPermissionsRoutes from "metabase/admin/permissions/routes";
 import {
   EmbeddingSdkSettings,
+  EmbeddingSecuritySettings,
   StaticEmbeddingSettings,
 } from "metabase/admin/settings/components/EmbeddingSettings";
 import { Help } from "metabase/admin/tools/components/Help";
@@ -172,6 +173,11 @@ const getRoutes = (store, CanAccessSettings, IsAdmin) => (
             path="static"
             title={t`Static`}
             component={StaticEmbeddingSettings}
+          />
+          <Route
+            path="security"
+            title={t`Security`}
+            component={EmbeddingSecuritySettings}
           />
         </Route>
       </Route>

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingAppSameSiteCookieDescription.styled.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingAppSameSiteCookieDescription.styled.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- legacy component
 import styled from "@emotion/styled";
 
 import Alert from "metabase/common/components/Alert";

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingAppSameSiteCookieDescription.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingAppSameSiteCookieDescription.tsx
@@ -31,8 +31,7 @@ export const EmbeddingAppSameSiteCookieDescription = () => {
     <Stack gap="sm">
       {shouldDisplayNote && <AuthorizedOriginsNote />}
       {/* eslint-disable-next-line no-literal-metabase-strings -- Metabase settings */}
-      <Text>{t`Determines whether or not cookies are allowed to be sent on cross-site requests. You’ll likely need to change this to None if your embedding application is hosted under a different domain than Metabase. Otherwise, leave it set to Lax, as it's more secure.`}</Text>
-      <Text>{jt`If you set this to None, you'll have to use HTTPS, or browsers will reject the request. ${(
+      <Text>{jt`Determines whether to allow cookies for cross-site requests. ${(
         <ExternalLink key="learn-more" href={docsUrl}>
           {t`Learn more`}
         </ExternalLink>

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingAppSameSiteCookieDescription.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingAppSameSiteCookieDescription.tsx
@@ -12,7 +12,6 @@ import { SameSiteAlert } from "./EmbeddingAppSameSiteCookieDescription.styled";
 
 export const EmbeddingAppSameSiteCookieDescription = () => {
   const docsUrl = useSelector((state) =>
-    // eslint-disable-next-line no-unconditional-metabase-links-render -- Admin settings
     getDocsUrl(state, {
       page: "embedding/interactive-embedding",
       anchor: "embedding-metabase-in-a-different-domain",
@@ -30,7 +29,6 @@ export const EmbeddingAppSameSiteCookieDescription = () => {
   return (
     <Stack gap="sm">
       {shouldDisplayNote && <AuthorizedOriginsNote />}
-      {/* eslint-disable-next-line no-literal-metabase-strings -- Metabase settings */}
       <Text>{jt`Determines whether to allow cookies for cross-site requests. ${(
         <ExternalLink key="learn-more" href={docsUrl}>
           {t`Learn more`}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingSecuritySettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingSecuritySettings.tsx
@@ -1,0 +1,18 @@
+import { t } from "ttag";
+
+import {
+  SettingsPageWrapper,
+  SettingsSection,
+} from "metabase/admin/components/SettingsSection";
+
+import { SameSiteSelectWidget } from "./SameSiteSelectWidget";
+
+export function EmbeddingSecuritySettings() {
+  return (
+    <SettingsPageWrapper title={t`Security`}>
+      <SettingsSection>
+        <SameSiteSelectWidget />
+      </SettingsSection>
+    </SettingsPageWrapper>
+  );
+}

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingSecuritySettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/EmbeddingSecuritySettings.unit.spec.tsx
@@ -1,0 +1,46 @@
+import userEvent from "@testing-library/user-event";
+
+import {
+  findRequests,
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+  setupUpdateSettingEndpoint,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
+
+import { EmbeddingSecuritySettings } from "./EmbeddingSecuritySettings";
+
+const setup = async () => {
+  const settings = createMockSettings();
+
+  setupPropertiesEndpoints(settings);
+  setupSettingsEndpoints([]);
+  setupUpdateSettingEndpoint();
+
+  renderWithProviders(<EmbeddingSecuritySettings />);
+};
+
+describe("EmbeddingSecuritySettings", () => {
+  it("should allow changing samesite cookie setting", async () => {
+    await setup();
+
+    expect(await screen.findByText("Security")).toBeInTheDocument();
+
+    expect(
+      await screen.findByText("SameSite cookie setting"),
+    ).toBeInTheDocument();
+
+    const button = await screen.findByText("Lax (default)");
+    await userEvent.click(button);
+    const newOption = await screen.findByText("Strict (not recommended)");
+    await userEvent.click(newOption);
+
+    const puts = await findRequests("PUT");
+    expect(puts).toHaveLength(1);
+
+    const [{ url, body }] = puts;
+    expect(url).toContain("/setting/session-cookie-samesite");
+    expect(body).toEqual({ value: "strict" });
+  });
+});

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/SameSiteSelectWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/SameSiteSelectWidget.tsx
@@ -13,19 +13,16 @@ const getSameSiteOptions = (): Options[] => [
   {
     value: "lax",
     name: t`Lax (default)`,
-    // eslint-disable-next-line no-literal-metabase-strings -- admin settings
     description: t`Allows Metabase session cookies to be shared on the same domain. Used for production instances on the same domain.`,
   },
   {
     value: "strict",
     name: t`Strict (not recommended)`,
-    // eslint-disable-next-line no-literal-metabase-strings -- admin settings
     description: t`Does not allow Metabase session cookies to be shared with embedded instances. Use this if you do not want to enable session sharing with embedding.`,
   },
   {
     value: "none",
     name: t`None (requires HTTPS)`,
-    // eslint-disable-next-line no-literal-metabase-strings -- admin settings
     description: t`Use "None" when your app and Metabase are hosted on different domains. Incompatible with Safari and iOS-based browsers.`,
   },
 ];

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/SameSiteSelectWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/SameSiteSelectWidget.tsx
@@ -13,18 +13,20 @@ const getSameSiteOptions = (): Options[] => [
   {
     value: "lax",
     name: t`Lax (default)`,
-    description: t`Allows cookies to be sent when a user is navigating to the origin site from an external site (like when following a link).`,
+    // eslint-disable-next-line no-literal-metabase-strings -- admin settings
+    description: t`Allows Metabase session cookies to be shared on the same domain. Used for production instances on the same domain.`,
   },
   {
     value: "strict",
     name: t`Strict (not recommended)`,
     // eslint-disable-next-line no-literal-metabase-strings -- admin settings
-    description: t`Never allows cookies to be sent on a cross-site request. Warning: this will prevent users from following external links to Metabase.`,
+    description: t`Does not allow Metabase session cookies to be shared with embedded instances. Use this if you do not want to enable session sharing with embedding.`,
   },
   {
     value: "none",
-    name: t`None`,
-    description: t`Allows all cross-site requests. Incompatible with most Safari and iOS-based browsers.`,
+    name: t`None (requires HTTPS)`,
+    // eslint-disable-next-line no-literal-metabase-strings -- admin settings
+    description: t`Use "None" when your app and Metabase are hosted on different domains. Incompatible with Safari and iOS-based browsers.`,
   },
 ];
 
@@ -60,7 +62,7 @@ export function SameSiteSelectWidget() {
       settingDetails={settingDetails}
       settingKey="session-cookie-samesite"
     >
-      <Stack gap="md">
+      <Stack gap="xs">
         <SettingHeader
           id="session-cookie-samesite"
           title={t`SameSite cookie setting`}
@@ -90,7 +92,9 @@ export function SameSiteSelectWidget() {
                   maw="21rem"
                 >
                   <Text>{name}</Text>
-                  <Text c="text-light">{description}</Text>
+                  <Text c="text-secondary" size="sm" lh="lg">
+                    {description}
+                  </Text>
                 </Menu.Item>
               ))}
             </Menu.Dropdown>

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/index.ts
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/EmbeddingSecuritySettings/index.ts
@@ -1,0 +1,1 @@
+export { EmbeddingSecuritySettings } from "./EmbeddingSecuritySettings";

--- a/frontend/src/metabase/admin/settings/components/EmbeddingSettings/index.ts
+++ b/frontend/src/metabase/admin/settings/components/EmbeddingSettings/index.ts
@@ -1,2 +1,3 @@
 export { StaticEmbeddingSettings } from "./StaticEmbeddingSettings";
 export { EmbeddingSdkSettings } from "./EmbeddingSdkSettings/EmbeddingSdkSettings";
+export { EmbeddingSecuritySettings } from "./EmbeddingSecuritySettings";


### PR DESCRIPTION
Closes EMB-885
Relate to #63336

Moves the "SameSite cookie setting" into the settings UI, with an updated copy

### How to verify

- Go to "Admin settings > Embedding > Security"
- You should see the "SameSite cookie setting" in the security tab
- Go to "Admin settings > Embedding > Interactive"
- You should no longer see the "SameSite cookie setting" in the interactive tab

### Demo

<img width="2682" height="1590" alt="CleanShot 2568-10-09 at 22 40 19@2x" src="https://github.com/user-attachments/assets/d18ecc9e-acde-4efc-9417-044e48d70954" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
