### PR TITLE
bump netty common and buffer to 4.1.124.Final

### DIFF
--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -9,4 +9,4 @@
  ;; https://github.com/metabase/metabase/actions/workflows/athena.yml
  ;; new versions of athena-jdbc appear here:
  ;; https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver.html#jdbc-v3-driver-download-uber-jar
- {com.metabase/athena-jdbc {:mvn/version "3.5.0"}}}
+ {com.metabase/athena-jdbc {:mvn/version "3.6.0"}}}

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -16,5 +16,5 @@
   org.apache.arrow/arrow-memory-netty    {:mvn/version "17.0.0"}
   org.apache.arrow/arrow-vector          {:mvn/version "17.0.0"}
   ;; matches those in athena
-  io.netty/netty-common                  {:mvn/version "4.1.118.Final"}
-  io.netty/netty-buffer                  {:mvn/version "4.1.118.Final"}}}
+  io.netty/netty-common                  {:mvn/version "4.1.124.Final"}
+  io.netty/netty-buffer                  {:mvn/version "4.1.124.Final"}}}


### PR DESCRIPTION
We had tried this previously, but the athena driver has these libraries uberjar'd into it. So we need this to be in lockstep. See https://github.com/metabase/metabase/pull/63894 for more info.

but i'll include some info here:
there are two copies on the classpath:

```clojure
user=> (enumeration-seq (.. (Thread/currentThread) getContextClassLoader (getResources "io/netty/buffer/ByteBufAllocator.class")))
(#object[java.net.URL 0x3bb34fe "jar:file:/private/tmp/fixed-athena/plugins/bigquery-cloud-sdk.metabase-driver.jar!/io/netty/buffer/ByteBufAllocator.class"]
 #object[java.net.URL 0x4ac1867d "jar:file:/private/tmp/fixed-athena/plugins/athena.metabase-driver.jar!/io/netty/buffer/ByteBufAllocator.class"])
```

one in the bigquery driver jar and one in the athena driver jar. The bigquery driver jar has an explicit dep and we can control it independently. The athena jar has it uberjar'd in and we can't control it independently. So we want to make sure that we are relying on the version that is (unfortunately) baked into athena.

For this we can see the athena 3.6.0 jar has the following pom.properties file:
`META-INF/maven/io.netty/netty-buffer/pom.properties`

```properties
artifactId=netty-buffer
groupId=io.netty
version=4.1.124.Final
```

So we will pin that version in bigquery as well so we only have a single version (but still two copies) on the classpath.

This way whichever classfile is resolved (and this can vary depending on whether an athena db or bigquery db is synced first, or health checked) it should behave the same
