### PR TITLE
Add transforms dependency check API for metabot

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -519,6 +519,7 @@
    metabase-enterprise.advanced-permissions.models.permissions.application-permissions-test/with-new-group-and-current-graph hooks.common/with-two-top-level-bindings
    metabase-enterprise.audit-app.pages-test/with-temp-objects                                                                hooks.common/with-one-binding
    metabase-enterprise.cache.config-test/with-temp-persist-models                                                            hooks.common/with-seven-bindings
+   metabase-enterprise.metabot-v3.tools.dependencies-test/with-dependent-transforms!                                         hooks.common/with-two-bindings
    metabase-enterprise.semantic-search.db.connection/with-migrate-tx                                                         hooks.common/let-one-with-optional-value
    metabase-enterprise.serialization.test-util/with-temp-dpc                                                                 hooks.toucan2.tools.with-temp/with-temp
    metabase-enterprise.transforms-python.drivers-test/with-test-table                                                        hooks.common/with-two-bindings

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1856,6 +1856,7 @@
            util
            warehouse-schema
            warehouses
+           enterprise/dependencies
            enterprise/documents
            enterprise/transforms
            enterprise/transforms-python}}

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1711,7 +1711,7 @@
   enterprise/dependencies
   {:team "Querying"
    :api  #{metabase-enterprise.dependencies.api
-           #_metabase-enterprise.dependencies.core
+           metabase-enterprise.dependencies.core
            metabase-enterprise.dependencies.init}
    :uses #{analyze
            api

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -80,11 +80,10 @@
                                        [:query {:optional true} ::queries.schema/query]]]]
    [:target {:optional true}  [:maybe ms/Map]]])
 
-(api.macros/defendpoint :post "/check_transform"
-  "Check a proposed edit to a transform, and return the card, transform, etc. IDs for things that will break."
-  [_route-params
-   _query-params
-   {:keys [id source target] :as _body} :- ::transform-body]
+(defn check-transform-dependencies
+  "Check a proposed edit to a transform, and return the card, transform, etc. IDs for things that will break.
+  Takes a map with :id (required), :source (optional), and :target (optional) keys."
+  [{:keys [id source target]}]
   (if (= (keyword (:type source))
          :query)
     (let [database-id   (-> source :query :database)
@@ -98,6 +97,13 @@
       (broken-cards-response breakages))
     ;; if this isn't a sql query, just claim it works
     {:success true}))
+
+(api.macros/defendpoint :post "/check_transform"
+  "Check a proposed edit to a transform, and return the card, transform, etc. IDs for things that will break."
+  [_route-params
+   _query-params
+   body :- ::transform-body]
+  (check-transform-dependencies body))
 
 (api.macros/defendpoint :post "/check_snippet"
   "Check a proposed edit to a native snippet, and return the cards, etc. which will be broken."

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -84,8 +84,7 @@
   "Check a proposed edit to a transform, and return the card, transform, etc. IDs for things that will break.
   Takes a map with :id (required), :source (optional), and :target (optional) keys."
   [{:keys [id source target]}]
-  (if (= (keyword (:type source))
-         :query)
+  (if (= (keyword (:type source)) :query)
     (let [database-id   (-> source :query :database)
           base-provider (lib-be/application-database-metadata-provider database-id)
           original      (lib.metadata/transform base-provider id)

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -80,10 +80,11 @@
                                        [:query {:optional true} ::queries.schema/query]]]]
    [:target {:optional true}  [:maybe ms/Map]]])
 
-(defn check-transform-dependencies
-  "Check a proposed edit to a transform, and return the card, transform, etc. IDs for things that will break.
-  Takes a map with :id (required), :source (optional), and :target (optional) keys."
-  [{:keys [id source target]}]
+(api.macros/defendpoint :post "/check_transform"
+  "Check a proposed edit to a transform, and return the card, transform, etc. IDs for things that will break."
+  [_route-params
+   _query-params
+   {:keys [id source target]} :- ::transform-body]
   (if (= (keyword (:type source)) :query)
     (let [database-id   (-> source :query :database)
           base-provider (lib-be/application-database-metadata-provider database-id)
@@ -96,13 +97,6 @@
       (broken-cards-response breakages))
     ;; if this isn't a sql query, just claim it works
     {:success true}))
-
-(api.macros/defendpoint :post "/check_transform"
-  "Check a proposed edit to a transform, and return the card, transform, etc. IDs for things that will break."
-  [_route-params
-   _query-params
-   body :- ::transform-body]
-  (check-transform-dependencies body))
 
 (api.macros/defendpoint :post "/check_snippet"
   "Check a proposed edit to a native snippet, and return the cards, etc. which will be broken."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -1,16 +1,44 @@
 (ns metabase-enterprise.metabot-v3.tools.dependencies
   (:require
-   [metabase-enterprise.dependencies.api :as dependencies.api]
-   [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]))
+   [metabase-enterprise.dependencies.core :as dependencies]
+   [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
+   [metabase.lib-be.metadata.jvm :as lib-be.metadata.jvm]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(defn- format-broken-transforms
+  "Format the breakages into a response suitable for Metabot."
+  [{:keys [transform]}]
+  (let [broken-transform-ids (keys transform)
+        broken-transforms    (when (seq broken-transform-ids)
+                               (t2/select [:model/Transform :id :name] :id [:in broken-transform-ids]))
+        transforms-by-id     (u/index-by :id broken-transforms)]
+    {:success        (empty? broken-transform-ids)
+     :bad_transforms (reduce
+                      (fn [acc [transform-id errors]]
+                        (let [transform (get transforms-by-id transform-id)]
+                          (conj acc {:transform transform :errors errors})))
+                      []
+                      transform)}))
 
 (defn check-transform-dependencies
-  "Check a proposed edit to a transform, and return the card, transform, etc. IDs for things that will break.
+  "Check a proposed edit to a SQL transform, and return transforms that will break.
   Takes a map with :id (required), :source (optional), and :target (optional) keys."
-  [args]
+  [{:keys [id source]}]
   (try
-    {:structured_output
-     (select-keys
-      (dependencies.api/check-transform-dependencies args)
-      [:success :bad_transforms])}
+    (let [result (if (= (keyword (:type source))
+                        :query)
+                   (let [database-id   (-> source :query :database)
+                         base-provider (lib-be.metadata.jvm/application-database-metadata-provider database-id)
+                         original      (lib.metadata/transform base-provider id)
+                         transform     (cond-> original
+                                         source (assoc :source source))
+                         edits         {:transform [transform]}
+                         breakages     (dependencies/errors-from-proposed-edits base-provider edits)]
+                     (format-broken-transforms breakages))
+                   ;; If this is a non-SQL query, we don't do any checks yet, so just return success
+                   {:success true :bad_transforms []})]
+      {:structured_output result})
     (catch Exception e
       (metabot-v3.tools.u/handle-agent-error e))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -2,7 +2,7 @@
   (:require
    [metabase-enterprise.dependencies.core :as dependencies]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
-   [metabase.lib-be.metadata.jvm :as lib-be.metadata.jvm]
+   [metabase.lib-be.core :as lib-be]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -36,7 +36,7 @@
   (try
     (let [result (if (= (keyword (:type source)) :query)
                    (let [database-id   (-> source :query :database)
-                         base-provider (lib-be.metadata.jvm/application-database-metadata-provider database-id)
+                         base-provider (lib-be/application-database-metadata-provider database-id)
                          original      (lib.metadata/transform base-provider id)
                          transform     (cond-> original
                                          source (assoc :source source))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -8,6 +8,9 @@
   Takes a map with :id (required), :source (optional), and :target (optional) keys."
   [args]
   (try
-    {:structured_output (dependencies.api/check-transform-dependencies args)}
+    {:structured_output
+     (select-keys
+      (dependencies.api/check-transform-dependencies args)
+      [:success :bad_transforms])}
     (catch Exception e
       (metabot-v3.tools.u/handle-agent-error e))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -1,0 +1,13 @@
+(ns metabase-enterprise.metabot-v3.tools.dependencies
+  (:require
+   [metabase-enterprise.dependencies.api :as dependencies.api]
+   [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]))
+
+(defn check-transform-dependencies
+  "Check a proposed edit to a transform, and return the card, transform, etc. IDs for things that will break.
+  Takes a map with :id (required), :source (optional), and :target (optional) keys."
+  [args]
+  (try
+    {:structured_output (dependencies.api/check-transform-dependencies args)}
+    (catch Exception e
+      (metabot-v3.tools.u/handle-agent-error e))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -32,7 +32,7 @@
 (defn check-transform-dependencies
   "Check a proposed edit to a SQL transform, and return transforms that will break in a format
   suitable for Metabot. Takes a map with :id and :source keys."
-  [base-provider {:keys [id source]}]
+  [{:keys [id source]}]
   (try
     (let [result (if (= (keyword (:type source)) :query)
                    (let [database-id   (-> source :query :database)

--- a/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/models/transform.clj
@@ -190,10 +190,10 @@
   "Return the query text (truncated to `max-searchable-value-length`) from transform source; else nil.
   Extracts SQL from query-type transforms and Python code from python-type transforms."
   [{:keys [source]}]
-  (let [source-data ((:out mi/transform-json) source)
+  (let [source-data (transform-source-out source)
         query-text (case (:type source-data)
-                     "query" (get-in source-data [:query :native :query])
-                     "python" (:body source-data)
+                     :query (lib/raw-native-query (:query source-data))
+                     :python (:body source-data)
                      nil)]
     (when query-text
       (subs query-text 0 (min (count query-text) search/max-searchable-value-length)))))

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -7,7 +7,7 @@
    [metabase-enterprise.transforms.models.transform-run :as transform-run]
    [metabase-enterprise.transforms.settings :as transforms.settings]
    [metabase.driver :as driver]
-   [metabase.lib.core :as lib]
+   [metabase.lib.query :as lib.query]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
@@ -46,8 +46,10 @@
 (defn native-query-transform?
   "Check if this is a native query transform"
   [transform]
-  (and (query-transform? transform)
-       (= :native (lib/normalized-query-type (-> transform :source :query)))))
+  (def transform transform)
+  (when (query-transform? transform)
+    (let [query (-> transform :source :query)]
+      (lib.query/native? query))))
 
 (defn python-transform?
   "Check if this is a Python transform."

--- a/enterprise/backend/src/metabase_enterprise/transforms/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/util.clj
@@ -46,7 +46,6 @@
 (defn native-query-transform?
   "Check if this is a native query transform"
   [transform]
-  (def transform transform)
   (when (query-transform? transform)
     (let [query (-> transform :source :query)]
       (lib.query/native? query))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -1194,7 +1194,7 @@
       (mt/with-temp [:model/Transform t1 {:name "People Transform"
                                           :description "Simple select on People table"
                                           :source {:type "query"
-                                                   :query (mt/native-query {:query "SELECT * FROM PEOPLE"})}
+                                                   :query (lib/native-query (mt/metadata-provider) "SELECT * FROM PEOPLE")}
                                           :target {:type "table"
                                                    :name "t1_table"}}
                      :model/Transform t2 {:name "MBQL Transform"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.tools.dependencies :as metabot.dependencies]
+   [metabase.lib.core :as lib]
    [metabase.test :as mt]))
 
 (defmacro with-dependent-transforms!
@@ -18,14 +19,14 @@
       :model/Transform {transform1-id# :id}
       {:name "Transform 1"
        :source {:type "query"
-                :query (mt/native-query {:query "SELECT id, total FROM orders"})}
+                :query (lib/native-query (mt/metadata-provider) "SELECT id, total FROM orders")}
        :target {:type "table"
                 :schema "public"
                 :name "orders_transform_1"}}
       :model/Transform {transform2-id# :id}
       {:name "Transform 2"
        :source {:type "query"
-                :query (mt/native-query {:query "SELECT id, total FROM orders_transform_1"})}
+                :query (lib/native-query (mt/metadata-provider) "SELECT id, total FROM orders_transform_1")}
        :target {:type "table"
                 :schema "public"
                 :name "orders_transform_2"}}
@@ -41,7 +42,7 @@
   (testing "removing total field from transform1 breaks transform2"
     (with-dependent-transforms! [transform1-id transform2-id]
       (let [modified-source {:type "query"
-                             :query (mt/native-query {:query "SELECT id FROM orders"})}
+                             :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}
             result (metabot.dependencies/check-transform-dependencies
                     {:id transform1-id
                      :source modified-source})]
@@ -59,7 +60,7 @@
         [:model/Transform {transform3-id :id}
          {:name "Transform 3"
           :source {:type "query"
-                   :query (mt/native-query {:query "SELECT total FROM orders_transform_1"})}
+                   :query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
           :target {:type "table"
                    :schema "public"
                    :name "orders_transform_3"}}
@@ -71,7 +72,7 @@
         (testing "when limit is 1, only one broken transform is reported"
           (binding [metabot.dependencies/*max-reported-broken-transforms* 1]
             (let [modified-source {:type "query"
-                                   :query (mt/native-query {:query "SELECT id FROM orders"})}
+                                   :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}
                   result (metabot.dependencies/check-transform-dependencies
                           {:id transform1-id
                            :source modified-source})

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
@@ -18,20 +18,14 @@
       :model/Transform {transform1-id# :id}
       {:name "Transform 1"
        :source {:type "query"
-                :query {:database (mt/id)
-                        :type "native"
-                        :native {:query "SELECT id, total FROM orders"
-                                 :template-tags {}}}}
+                :query (mt/native-query {:query "SELECT id, total FROM orders"})}
        :target {:type "table"
                 :schema "public"
                 :name "orders_transform_1"}}
       :model/Transform {transform2-id# :id}
       {:name "Transform 2"
        :source {:type "query"
-                :query {:database (mt/id)
-                        :type "native"
-                        :native {:query "SELECT id, total FROM orders_transform_1"
-                                 :template-tags {}}}}
+                :query (mt/native-query {:query "SELECT id, total FROM orders_transform_1"})}
        :target {:type "table"
                 :schema "public"
                 :name "orders_transform_2"}}
@@ -47,10 +41,7 @@
   (testing "removing total field from transform1 breaks transform2"
     (with-dependent-transforms! [transform1-id transform2-id]
       (let [modified-source {:type "query"
-                             :query {:database (mt/id)
-                                     :type "native"
-                                     :native {:query "SELECT id FROM orders"
-                                              :template-tags {}}}}
+                             :query (mt/native-query {:query "SELECT id FROM orders"})}
             result (metabot.dependencies/check-transform-dependencies
                     {:id transform1-id
                      :source modified-source})]
@@ -68,10 +59,7 @@
         [:model/Transform {transform3-id :id}
          {:name "Transform 3"
           :source {:type "query"
-                   :query {:database (mt/id)
-                           :type "native"
-                           :native {:query "SELECT total FROM orders_transform_1"
-                                    :template-tags {}}}}
+                   :query (mt/native-query {:query "SELECT total FROM orders_transform_1"})}
           :target {:type "table"
                    :schema "public"
                    :name "orders_transform_3"}}
@@ -83,10 +71,7 @@
         (testing "when limit is 1, only one broken transform is reported"
           (binding [metabot.dependencies/*max-reported-broken-transforms* 1]
             (let [modified-source {:type "query"
-                                   :query {:database (mt/id)
-                                           :type "native"
-                                           :native {:query "SELECT id FROM orders"
-                                                    :template-tags {}}}}
+                                   :query (mt/native-query {:query "SELECT id FROM orders"})}
                   result (metabot.dependencies/check-transform-dependencies
                           {:id transform1-id
                            :source modified-source})

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
@@ -1,0 +1,98 @@
+(ns metabase-enterprise.metabot-v3.tools.dependencies-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.tools.dependencies :as metabot.dependencies]
+   [metabase.test :as mt]))
+
+(defmacro with-dependent-transforms!
+  "Creates two dependent SQL transforms for testing:
+  - transform1: selects id and total from orders
+  - transform2: selects total from transform1's output table
+
+  Binds symbols transform1-id and transform2-id."
+  [[transform1-binding transform2-binding] & body]
+  `(mt/with-temp
+     [:model/Table {table1-id# :id} {:db_id (mt/id)
+                                     :schema "public"
+                                     :name "orders_transform_1"}
+      :model/Transform {transform1-id# :id}
+      {:name "Transform 1"
+       :source {:type "query"
+                :query {:database (mt/id)
+                        :type "native"
+                        :native {:query "SELECT id, total FROM orders"
+                                 :template-tags {}}}}
+       :target {:type "table"
+                :schema "public"
+                :name "orders_transform_1"}}
+      :model/Transform {transform2-id# :id}
+      {:name "Transform 2"
+       :source {:type "query"
+                :query {:database (mt/id)
+                        :type "native"
+                        :native {:query "SELECT id, total FROM orders_transform_1"
+                                 :template-tags {}}}}
+       :target {:type "table"
+                :schema "public"
+                :name "orders_transform_2"}}
+      :model/Dependency {} {:from_entity_type "transform"
+                            :from_entity_id transform2-id#
+                            :to_entity_type "transform"
+                            :to_entity_id transform1-id#}]
+     (let [~transform1-binding transform1-id#
+           ~transform2-binding transform2-id#]
+       ~@body)))
+
+(deftest check-transform-dependencies-test
+  (testing "removing total field from transform1 breaks transform2"
+    (with-dependent-transforms! [transform1-id transform2-id]
+      (let [modified-source {:type "query"
+                             :query {:database (mt/id)
+                                     :type "native"
+                                     :native {:query "SELECT id FROM orders"
+                                              :template-tags {}}}}
+            result (metabot.dependencies/check-transform-dependencies
+                    {:id transform1-id
+                     :source modified-source})]
+        (is (false? (get-in result [:structured_output :success])))
+        (is (= 1 (get-in result [:structured_output :bad_transform_count])))
+        (let [bad-transforms (get-in result [:structured_output :bad_transforms])]
+          (is (= 1 (count bad-transforms)))
+          (is (= transform2-id (get-in (first bad-transforms) [:transform :id])))
+          (is (= "Transform 2" (get-in (first bad-transforms) [:transform :name]))))))))
+
+(deftest check-transform-dependencies-limit-test
+  (testing "max-reported-broken-transforms limit"
+    (with-dependent-transforms! [transform1-id _]
+      (mt/with-temp
+        [:model/Transform {transform3-id :id}
+         {:name "Transform 3"
+          :source {:type "query"
+                   :query {:database (mt/id)
+                           :type "native"
+                           :native {:query "SELECT total FROM orders_transform_1"
+                                    :template-tags {}}}}
+          :target {:type "table"
+                   :schema "public"
+                   :name "orders_transform_3"}}
+         :model/Dependency {}
+         {:from_entity_type "transform"
+          :from_entity_id   transform3-id
+          :to_entity_type   "transform"
+          :to_entity_id     transform1-id}]
+        (testing "when limit is 1, only one broken transform is reported"
+          (binding [metabot.dependencies/*max-reported-broken-transforms* 1]
+            (let [modified-source {:type "query"
+                                   :query {:database (mt/id)
+                                           :type "native"
+                                           :native {:query "SELECT id FROM orders"
+                                                    :template-tags {}}}}
+                  result (metabot.dependencies/check-transform-dependencies
+                          {:id transform1-id
+                           :source modified-source})
+                  bad-transforms (get-in result [:structured_output :bad_transforms])]
+              ;; Two downstream transforms should be broken (transform2 + transform3)...
+              (is (false? (get-in result [:structured_output :success])))
+              (is (= 2 (get-in result [:structured_output :bad_transform_count])))
+              ;; ...but only one should be reported due to the limit.
+              (is (= 1 (count bad-transforms))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.app-db.core :as mdb]
+   [metabase.lib.core :as lib]
    [metabase.search.appdb.index :as search.index]
    [metabase.search.engine :as search.engine]
    [metabase.search.ingestion :as search.ingestion]
@@ -122,9 +123,7 @@
                                                   :table "test_table"}
                                          :name "Test SQL transform"
                                          :source {:type "query"
-                                                  :query {:database (mt/id)
-                                                          :native {:query "SELECT 1"}}}}]
-
+                                                  :query (lib/native-query (mt/metadata-provider) "SELECT 1")}}]
         (let [ingested-transform (ingest-then-fetch! "transform" "Test SQL transform")
               vector-value (.getValue ^PGobject (:with_native_query_vector ingested-transform))]
           (is (string? vector-value))

--- a/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
@@ -60,8 +60,7 @@
         (mt/with-temp [:model/Transform {transform-id :id} {:name        "Test transform"
                                                             :description "A test transform"
                                                             :source      {:type "query"
-                                                                          :query {:database (mt/id)
-                                                                                  :native {:query "SELECT 1"}}}
+                                                                          :query (mt/native-query {:query "SELECT 1"})}
                                                             :target      {:database (mt/id)
                                                                           :table "test_table"}
                                                             :created_at  now

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/hooks.ts
@@ -23,7 +23,7 @@ function calculateFillerHeight(
     parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
   const contentHeight = containerHeight - paddingAdjustment;
 
-  return Math.max(0, Math.floor(contentHeight - nonFillerElsHeight));
+  return Math.max(0, Math.floor(contentHeight - nonFillerElsHeight - 1));
 }
 
 function resizeFillerArea(

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/hooks.ts
@@ -23,7 +23,7 @@ function calculateFillerHeight(
     parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
   const contentHeight = containerHeight - paddingAdjustment;
 
-  return Math.max(0, Math.floor(contentHeight - nonFillerElsHeight - 1));
+  return Math.max(0, Math.floor(contentHeight - nonFillerElsHeight));
 }
 
 function resizeFillerArea(


### PR DESCRIPTION
Adds a dependency checking API for metabot that essentially shares the same implementation as the existing `check_transform` dependencies API for now, except returning a slightly different shape and limiting the number of returned transforms to 10. In this PR I've also restricted dependency checking only to other transforms; a future change will be to return broken cards as well.

I have an open question about backwards comparability here: if AI service hits an older version of metabase, this API may not exist and the call will error. Would this warrant a new capability so that we only call the API if the capability is present?