### PR TITLE
Fix value between optional parameters without values not visible

### DIFF
--- a/src/metabase/parameters/shared.cljc
+++ b/src/metabase/parameters/shared.cljc
@@ -280,7 +280,7 @@
    split-text))
 
 (def ^:private optional-block-regex
-  #"\[\[.+\]\]")
+  #"\[\[.+?\]\]")
 
 (def ^:private non-optional-block-regex
   #"\[\[(.+?)\]\]")

--- a/test/metabase/parameters/shared_test.cljc
+++ b/test/metabase/parameters/shared_test.cljc
@@ -344,6 +344,11 @@
       {"foo" {:type :string/= :value "foo"}}
       "foofoo"
 
+      ;; Make sure we handle multiple optional blocks without values correctly. This has to do with regex greediness.
+      "[[{{foo}}]] between [[{{bar}}]]"
+      {}
+      " between "
+
       "[[{{foo}}]] [[{{bar}}]]"
       {"foo" {:type :string/= :value 1} "bar" {:type :string/= :value 2}}
       "1 2"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63866
Closes UXW-1763

### Backport reason
double backporting this since the change looks pretty safe. That line has been there for 3 years.

### Description

Fix invisible values in markdown between 2 optional parameters with missing values.

### How to verify

Follow the repro in https://github.com/metabase/metabase/issues/63866

### Demo
<img width="633" height="250" alt="image" src="https://github.com/user-attachments/assets/8c9c2891-d3eb-45cb-8d62-a0a149803ee3" />

<img width="485" height="299" alt="image" src="https://github.com/user-attachments/assets/6a467a1c-d70e-4c39-9740-08224970f326" />

<img width="612" height="151" alt="image" src="https://github.com/user-attachments/assets/c3c48a12-16a7-42be-a5ca-be0679ee9eea" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
