### PR TITLE
unstemmed words should still appear in search

### DIFF
--- a/src/metabase/search/appdb/specialization/postgres.clj
+++ b/src/metabase/search/appdb/specialization/postgres.clj
@@ -79,7 +79,10 @@
 ;; 32 divides the rank by itself + 1
 (def ^:private ts-rank-normalization 0)
 
-;; The order here is {D, C, B, A} - but just see the link to docs up there ^
+;; The order here is {D, C, B, A} - but see the link to the docs up there ^
+;; A is the entity title
+;; B is all searchable text
+;; D is backup text with 'simple' stemmer, so it's not used in scoring, but mostly for completion
 (def ^:private ts-rank-weights "{0, 0.2, 0.4, 1.0}")
 
 (defmethod specialization/text-score :postgres

--- a/src/metabase/search/appdb/specialization/postgres.clj
+++ b/src/metabase/search/appdb/specialization/postgres.clj
@@ -60,14 +60,14 @@
      ;; if stemming is not in a 'simple' mode, let's include non-stemmed words so that when your partially typed word
      ;; is not matching any stem you still have something to match; see tests for #60649
      (not= (search.util/tsv-language) "simple")
-     (conj (search.util/weighted-tsvector "C" (or (:searchable_text entity) "") "simple")))
+     (conj (search.util/weighted-tsvector "D" (or (:searchable_text entity) "") "simple")))
 
    :with_native_query_vector
    (cond-> [:||
             (search.util/weighted-tsvector "A" (or (:name entity) ""))
             (search.util/weighted-tsvector "B" (str/join " " (keep entity [:searchable_text :native_query])))]
      (not= (search.util/tsv-language) "simple")
-     (conj (search.util/weighted-tsvector "C" (or (:searchable_text entity) "") "simple")))})
+     (conj (search.util/weighted-tsvector "D" (or (:searchable_text entity) "") "simple")))})
 
 ;; See https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-RANKING
 ;;  0 (the default) ignores the document length
@@ -79,9 +79,12 @@
 ;; 32 divides the rank by itself + 1
 (def ^:private ts-rank-normalization 0)
 
+;; The order here is {D, C, B, A} - but just see the link to docs up there ^
+(def ^:private ts-rank-weights "{0, 0.2, 0.4, 1.0}")
+
 (defmethod specialization/text-score :postgres
   []
-  [:ts_rank :search_vector :query [:inline ts-rank-normalization]])
+  [:ts_rank [:inline ts-rank-weights] :search_vector :query [:inline ts-rank-normalization]])
 
 (defmethod specialization/view-count-percentile-query :postgres
   [index-table p-value]

--- a/src/metabase/search/util.clj
+++ b/src/metabase/search/util.clj
@@ -153,6 +153,8 @@
 
 (defn weighted-tsvector
   "Create a weighted tsvector for Postgres full-text search with the given weight and text."
-  [weight text]
-  ;; tsvector has a max value size of 1048575 bytes, limit to less than that because the multiple values get concatenated together
-  [:setweight [:to_tsvector [:inline (tsv-language)] [:cast (u.str/limit-bytes text search.ingestion/max-searchable-value-length) :text]] [:inline weight]])
+  ([weight text]
+   (weighted-tsvector weight text (tsv-language)))
+  ([weight text lang]
+   ;; tsvector has a max value size of 1048575 bytes, limit to less than that because the multiple values get concatenated together
+   [:setweight [:to_tsvector [:inline lang] [:cast (u.str/limit-bytes text search.ingestion/max-searchable-value-length) :text]] [:inline weight]]))

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -57,6 +57,7 @@
                         :model/Card       {}            {:name "Projected Revenue"              :collection_id col-id#}
                         :model/Card       {}            {:name "Employee Satisfaction"          :collection_id col-id#}
                         :model/Card       {}            {:name "Projected Satisfaction"         :collection_id col-id#}
+                        :model/Card       {}            {:name "Organization Reference"         :collection_id col-id#}
                         :model/Database   {db-id# :id}  {:name "Indexed Database"}
                         :model/Table      {}            {:name "Indexed Table", :db_id db-id#}]
            (search.engine/reindex! :search.engine/appdb {:in-place? true})
@@ -153,6 +154,9 @@
       (is (= #_2 3 (index-hits "projected")))
       (is (= 2 (index-hits "revenue")))
       (is (= #_1 2 (index-hits "projected revenue")))
+      (testing "Simple dictionary allows searching for unstemmed words #60649"
+        (is (= 1 (index-hits "organ")))
+        (is (= 1 (index-hits "organi"))))
       (testing "only sometimes do these occur sequentially in a phrase"
         (is (= 1 (index-hits "\"projected revenue\"")))))))
 

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -101,10 +101,10 @@
           ;; Note that, ceteris paribus, the ordering in the database is currently stable - this might change!
           ;; Due to stemming, we do not distinguish between exact matches and those that differ slightly.
         (is (= [["card" 1 "orders"]
+                ["card" 4 "order"]
                 ;; We do not currently normalize the score based on the number of words in the vector / the coverage.
                 ["card" 5 "orders, invoices, other stuff"]
                 ["card" 6 "ordering"]
-                ["card" 4 "order"]
                 ;; If the match is only in a secondary field, it is less preferred.
                 ["card" 3 "classified"]]
                (search-results :text "order"))))

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -101,11 +101,11 @@
           ;; Note that, ceteris paribus, the ordering in the database is currently stable - this might change!
           ;; Due to stemming, we do not distinguish between exact matches and those that differ slightly.
         (is (= [["card" 1 "orders"]
-                ["card" 4 "order"]
-                  ;; We do not currently normalize the score based on the number of words in the vector / the coverage.
+                ;; We do not currently normalize the score based on the number of words in the vector / the coverage.
                 ["card" 5 "orders, invoices, other stuff"]
                 ["card" 6 "ordering"]
-                  ;; If the match is only in a secondary field, it is less preferred.
+                ["card" 4 "order"]
+                ;; If the match is only in a secondary field, it is less preferred.
                 ["card" 3 "classified"]]
                (search-results :text "order"))))
       :h2


### PR DESCRIPTION
This is done by putting them in the full-text index using a 'simple' stemmer, just with a lower priority than a normal stemmed words are.

Fixes #60649
