### PR TITLE
uxw-1935: mark settings as set by env var

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/AnonymousTrackingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AnonymousTrackingInput.tsx
@@ -6,10 +6,13 @@ import { Stack } from "metabase/ui";
 import { trackTrackingPermissionChanged } from "../../analytics";
 import { SettingHeader } from "../SettingHeader";
 
-import { BasicAdminSettingInput } from "./AdminSettingInput";
+import {
+  BasicAdminSettingInput,
+  SetByEnvVarWrapper,
+} from "./AdminSettingInput";
 
 export function AnonymousTrackingInput() {
-  const { value, updateSetting, description } = useAdminSetting(
+  const { value, updateSetting, description, settingDetails } = useAdminSetting(
     "anon-tracking-enabled",
   );
 
@@ -34,12 +37,17 @@ export function AnonymousTrackingInput() {
         title={t`Anonymous tracking`}
         description={description}
       />
-      <BasicAdminSettingInput
-        name="anon-tracking-enabled"
-        inputType="boolean"
-        value={value}
-        onChange={(newValue) => handleChange(Boolean(newValue))}
-      />
+      <SetByEnvVarWrapper
+        settingKey="anon-tracking-enabled"
+        settingDetails={settingDetails}
+      >
+        <BasicAdminSettingInput
+          name="anon-tracking-enabled"
+          inputType="boolean"
+          value={value}
+          onChange={(newValue) => handleChange(Boolean(newValue))}
+        />
+      </SetByEnvVarWrapper>
     </Stack>
   );
 }

--- a/frontend/src/metabase/admin/settings/components/widgets/AnonymousTrackingInput.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AnonymousTrackingInput.unit.spec.tsx
@@ -19,7 +19,13 @@ import { AnonymousTrackingInput } from "./AnonymousTrackingInput";
 
 const trackingFN = jest.spyOn(analytics, "trackTrackingPermissionChanged");
 
-const setup = ({ value }: { value: boolean }) => {
+const setup = ({
+  value,
+  isEnvSetting,
+}: {
+  value: boolean;
+  isEnvSetting?: boolean;
+}) => {
   const settings = createMockSettings({
     "anon-tracking-enabled": value,
   });
@@ -31,6 +37,8 @@ const setup = ({ value }: { value: boolean }) => {
       key: "anon-tracking-enabled",
       description: "Enable the collection of anonymous usage data",
       value: false,
+      is_env_setting: isEnvSetting,
+      env_name: isEnvSetting ? "MB_ANON_TRACKING_ENABLED" : undefined,
     }),
   ]);
 
@@ -74,5 +82,28 @@ describe("AnonymousTrackingInput", () => {
     expect(trackingFN).toHaveBeenCalledWith(true);
 
     expect(await screen.findByRole("switch")).toBeChecked();
+  });
+
+  it("should show environment variable message when anonymous tracking is set via env var", async () => {
+    setup({ value: true, isEnvSetting: true });
+    expect(
+      await screen.findByText(/This has been set by the/),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("MB_ANON_TRACKING_ENABLED"),
+    ).toBeInTheDocument();
+  });
+
+  it("should not show the switch when anonymous tracking is set via env var", async () => {
+    setup({ value: true, isEnvSetting: true });
+    await screen.findByText(/This has been set by the/);
+
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
+
+  it("should show the switch when anonymous tracking is not set via env var", async () => {
+    setup({ value: true, isEnvSetting: false });
+
+    expect(await screen.findByRole("switch")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/admin/settings/components/widgets/SiteUrlWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SiteUrlWidget.tsx
@@ -9,8 +9,10 @@ import { Box, Text } from "metabase/ui";
 
 import { SettingHeader } from "../SettingHeader";
 
+import { SetByEnvVarWrapper } from "./AdminSettingInput";
+
 export function SiteUrlWidget() {
-  const { value, updateSetting, description, isLoading } =
+  const { value, updateSetting, description, isLoading, settingDetails } =
     useAdminSetting("site-url");
   const isHosted = useHasTokenFeature("hosting");
   const [errorMessage, setErrorMessage] = useState("");
@@ -46,18 +48,20 @@ export function SiteUrlWidget() {
           </>
         }
       />
-      <InputWithSelectPrefix
-        value={value || ""}
-        onChange={(newValue: string) => handleChange(newValue)}
-        prefixes={["https://", "http://"]}
-        defaultPrefix="http://"
-        placeholder={"http://example.com"}
-      />
-      {errorMessage && (
-        <Text size="sm" color="danger" mt="sm">
-          {errorMessage}
-        </Text>
-      )}
+      <SetByEnvVarWrapper settingKey="site-url" settingDetails={settingDetails}>
+        <InputWithSelectPrefix
+          value={value || ""}
+          onChange={(newValue: string) => handleChange(newValue)}
+          prefixes={["https://", "http://"]}
+          defaultPrefix="http://"
+          placeholder={"http://example.com"}
+        />
+        {errorMessage && (
+          <Text size="sm" color="danger" mt="sm">
+            {errorMessage}
+          </Text>
+        )}
+      </SetByEnvVarWrapper>
     </Box>
   );
 }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64505
A few settings weren't wrapped with `SetByEnvVarWrapper`, so weren't marked as un-modifiable.


## Site URL
<img width="586" height="181" alt="Screenshot 2025-10-09 at 07 07 27" src="https://github.com/user-attachments/assets/6e391d8e-7009-4732-814c-9004608e7ff2" />

## Anonymous Tracking
<img width="586" height="141" alt="Screenshot 2025-10-09 at 07 07 39" src="https://github.com/user-attachments/assets/292da3bb-6079-4c7a-b281-da651e56ddf0" />

## Enable X-Ray Features
This is mentioned in the issue (#64505) but afaict, `MB_SHOW_HOMEPAGE_XRAYS` is actually unused, and the one we do actually use, `MB_ENABLE_XRAYS`, is already working as expected.