### PR TITLE
refactor(embed-js): Refactor EmbedJS component matching pattern

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -182,7 +182,6 @@ const SdkIframeEmbedView = ({
       {
         componentName: "metabase-question",
         questionId: P.nonNullable,
-        drills: P.optional(true),
       },
       (settings) => (
         <SdkQuestion

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk/components/SdkIframeEmbedRoute.tsx
@@ -163,33 +163,41 @@ const SdkIframeEmbedView = ({
     .with(
       {
         componentName: "metabase-question",
+        questionId: P.intersection(P.nonNullable, P.not("new")),
+        drills: false,
+      },
+      (settings) => (
+        <StaticQuestion
+          key={rerenderKey}
+          questionId={settings.questionId}
+          withDownloads={settings.withDownloads}
+          height="100%"
+          initialSqlParameters={settings.initialSqlParameters}
+          hiddenParameters={settings.hiddenParameters}
+          title={settings.withTitle ?? true}
+        />
+      ),
+    )
+    .with(
+      {
+        componentName: "metabase-question",
         questionId: P.nonNullable,
+        drills: P.optional(true),
       },
-      (settings) => {
-        const commonProps = {
-          questionId: settings.questionId,
-          withDownloads: settings.withDownloads,
-          height: "100%",
-          initialSqlParameters: settings.initialSqlParameters,
-          title: settings.withTitle ?? true, // defaulting title to true even if in the sdk it defaults to false for static
-        };
-
-        // note: to create a new question we need to render InteractiveQuestion
-        if (settings.drills === false && settings.questionId !== "new") {
-          // note: this disable drills but also removes the top toolbar
-          return <StaticQuestion {...commonProps} key={rerenderKey} />;
-        }
-
-        return (
-          <SdkQuestion
-            {...commonProps}
-            isSaveEnabled={settings.isSaveEnabled ?? false}
-            key={rerenderKey}
-            targetCollection={settings.targetCollection}
-            entityTypes={settings.entityTypes}
-          />
-        );
-      },
+      (settings) => (
+        <SdkQuestion
+          key={rerenderKey}
+          questionId={settings.questionId}
+          withDownloads={settings.withDownloads}
+          height="100%"
+          initialSqlParameters={settings.initialSqlParameters}
+          hiddenParameters={settings.hiddenParameters}
+          title={settings.withTitle ?? true}
+          isSaveEnabled={settings.isSaveEnabled ?? false}
+          targetCollection={settings.targetCollection}
+          entityTypes={settings.entityTypes}
+        />
+      ),
     )
     .with(
       {


### PR DESCRIPTION
Just a refactoring to split static/interacting into 2 separate matches, because for anonymous we `have` to split them and use 2 different patterns (different combinations id + drills and token + drills)

Logic should be the same 