### PR TITLE
Skip Claude code review on draft PRs

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   review:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-cc-review') && !contains(fromJSON(env.EXCLUDED_PR_AUTHORS), github.event.pull_request.user.login) }}
+    if: github.event.pull_request.draft == false && !contains(fromJSON(env.EXCLUDED_PR_AUTHORS), github.event.pull_request.user.login) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
This made the separate tag for skipping the workflow redundant so I removed it as well to simplify things