### PR TITLE
fix transforms snippet sidebar add/edit button not opening modal

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/EditorBody/EditorBody.tsx
@@ -52,7 +52,7 @@ type EditorBodyProps = {
   onToggleDataReference: () => void;
   onToggleSnippetSidebar: () => void;
   onCancelQuery: () => void;
-
+  onInsertSnippet: (snippet: NativeQuerySnippet) => void;
   modalSnippet?: NativeQuerySnippet | null;
   onChangeModalSnippet: (snippet: NativeQuerySnippet | null) => void;
   onChangeNativeEditorSelection: (range: SelectionRange[]) => void;
@@ -77,6 +77,7 @@ export function EditorBody({
   onToggleSnippetSidebar,
   databases,
   modalSnippet,
+  onInsertSnippet,
   onChangeModalSnippet,
   onChangeNativeEditorSelection,
   nativeEditorSelectedText,
@@ -139,6 +140,7 @@ export function EditorBody({
       toggleDataReference={onToggleDataReference}
       toggleSnippetSidebar={onToggleSnippetSidebar}
       modalSnippet={modalSnippet}
+      insertSnippet={onInsertSnippet}
       closeSnippetModal={() => onChangeModalSnippet(null)}
       databaseIsDisabled={(db: Database) => {
         const database = databases.find((database) => database.id === db.id);

--- a/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/QueryEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/components/QueryEditor/QueryEditor.tsx
@@ -171,6 +171,7 @@ export function QueryEditor({
               onToggleSnippetSidebar={handleToggleSnippetSidebar}
               onOpenModal={handleOpenModal}
               modalSnippet={modalSnippet}
+              onInsertSnippet={handleInsertSnippet}
               onChangeModalSnippet={setModalSnippet}
               onChangeNativeEditorSelection={setSelectionRange}
               nativeEditorSelectedText={selectedText}


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/64567

### Description

When editing a SQL transform, the snippet sidebar's "Edit" or "Add" buttons didn't work. This was because the `<NativeQueryEditor>` component used in the transforms editor was missing the `insertSnippet` prop which has to be truthy for the modals to show up

### How to verify

In master, go to Transforms -> SQL -> Snippets -> Try to add or edit a snippet, nothing happens.

In the branch it works again