### PR TITLE
fix: test log names need to be unique

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -51,11 +51,13 @@ jobs:
         job:
           - name: Enterprise Tests
             edition: ee
+            test-group-name: ee
             build-static-viz: 'false'
             test-args: >-
               :only '"enterprise/backend/test"'
           - name: EE App DB Tests (Part 1)
             edition: ee
+            test-group-name: ee-app-db-1
             build-static-viz: 'true'
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
@@ -63,6 +65,7 @@ jobs:
               :partition/index 0
           - name: EE App DB Tests (Part 2)
             edition: ee
+            test-group-name: ee-app-db-2
             build-static-viz: 'true'
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
@@ -70,6 +73,7 @@ jobs:
               :partition/index 1
           - name: OSS App DB Tests (Part 1)
             edition: oss
+            test-group-name: oss-app-db-1
             build-static-viz: 'true'
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
@@ -77,6 +81,7 @@ jobs:
               :partition/index 0
           - name: OSS App DB Tests (Part 2)
             edition: oss
+            test-group-name: oss-app-db-2
             build-static-viz: 'true'
             test-args: >-
               :only '["test" ".clj-kondo/test"]'
@@ -157,7 +162,7 @@ jobs:
         if: always() && !success()
         uses: actions/upload-artifact@v4
         with:
-          name: test-logs-${{ matrix.java-version }}-${{ matrix.job.edition }}-${{ github.job }}
+          name: test-logs-${{ matrix.java-version }}-${{ matrix.job.edition }}-${{ github.job }}-${{ matrix.job.job-group-name }}
           path: logs/test-log.json
           retention-days: 1
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -162,7 +162,7 @@ jobs:
         if: always() && !success()
         uses: actions/upload-artifact@v4
         with:
-          name: test-logs-${{ matrix.java-version }}-${{ matrix.job.edition }}-${{ github.job }}-${{ matrix.job.job-group-name }}
+          name: test-logs-${{ matrix.java-version }}-${{ matrix.job.edition }}-${{ github.job }}-${{ matrix.job.test-group-name }}
           path: logs/test-log.json
           retention-days: 1
 


### PR DESCRIPTION
### Description

We're not generating unique names for the log artifacts that get uploaded on failing runs. This means if more than one maria db run fails we don't get logs for all of them. 