### PR TITLE
remove extra pg driver tests

### DIFF
--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -255,12 +255,6 @@ jobs:
             env:
               enable-ssl-tests: 'true'
         job:
-          - name: Driver Tests
-            build-static-viz: false
-            test-args: >-
-              :only-tags [:mb/driver-tests]
-              :exclude-tags [:mb/transforms-python-test]
-            exclude-tag: ':mb/transforms-python-test'
           - name: Enterprise Tests
             build-static-viz: false
             test-args: >-


### PR DESCRIPTION
it is already covered in

```yaml
  be-tests-postgres:
    if: ${{ !inputs.skip }}
    runs-on: ubuntu-22.04
    timeout-minutes: 60
    strategy:
      fail-fast: false
      matrix:
        version:
          - name: Postgres 12.x
            junit-name: postgres-ee
            docker-image: postgres:12-alpine
            env:
              enable-ssl-tests: 'false'
          - name: Postgres Latest
            junit-name: postgres-latest-ee
            docker-image: postgres:latest
            env:
              enable-ssl-tests: 'true'
        job:
          - name: Driver Tests
            test-args: >-
              :only-tags [:mb/driver-tests]
            exclude-tag: ':mb/transforms-python-test'
```
.github/workflows/drivers.yml

> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.
