### PR TITLE
Fix MetabotAgentSuggestionMessage only show "create" for new transforms

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentSuggestionMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentSuggestionMessage.tsx
@@ -114,7 +114,7 @@ export const AgentSuggestionMessage = ({
   );
 
   const canApply = !isViewing || !isActive;
-  const isNew = !isViewing && !editorTransform;
+  const isNew = !isViewing && !editorTransform && suggestedTransform.id == null;
 
   const {
     data: originalTransform,


### PR DESCRIPTION
### Description

If the user asks metabot to edit an existing transform, but isn't currently viewing the transform, we should still display an "apply" message rather than a "create" message.

https://metaboat.slack.com/archives/C09CR3MT1KR/p1760034396345789


### How to verify

* Go to the transform page, but don't click on any particular transform
* Ask metabot to edit an existing tranform

### Demo

**before**
<img width="420" height="204" alt="Screenshot 2025-10-09 at 7 09 09 PM" src="https://github.com/user-attachments/assets/ba15e8b5-34a3-4f70-813d-da35284a31c9" />

**after**
<img width="419" height="212" alt="Screenshot 2025-10-09 at 7 07 33 PM" src="https://github.com/user-attachments/assets/c9e6be04-ae40-4d60-8fdd-4c84f74c1480" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
