### PR TITLE
fix: viewlog test flakes

### DIFF
--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -170,7 +170,7 @@
 (deftest ^:parallel viewlog-call-test
   (testing "no viewlog event with nil card id"
     (binding [*viewlog-call-count* (atom 0)]
-      (process-userland-query {:database 2, :type :query, :query {:source-table 26}})
+      (process-userland-query (mt/mbql-query venues))
       (is (zero? @*viewlog-call-count*)))))
 
 (deftest cancel-test


### PR DESCRIPTION
### Description

Uses mt/mbql-query to generate a query for this test which seems to resolve it flaking on a validation error about missing metadata provider. 
