### PR TITLE
fix: skip join in stats handler test

### DIFF
--- a/test/metabase/server/statistics_handler_test.clj
+++ b/test/metabase/server/statistics_handler_test.clj
@@ -80,8 +80,7 @@
     (.start connector)
     (thunk connector chan-start-handle chan-finish-handle chan-done-request)
     (.stop connector)
-    (.stop server)
-    (.join server)))
+    (.stop server)))
 
 (defmacro with-server
   [status-code async arguments & body]


### PR DESCRIPTION
Avoid test cleanup locking up by not joining back to the jetty server if it fails to shutdown.