### PR TITLE
turn off some more tests [ci skip]

### DIFF
--- a/ci-test-config.json
+++ b/ci-test-config.json
@@ -3,7 +3,10 @@
   "ignored": {
     "vars": [
       "metabase.session.models.session-test/send-email-on-first-login-from-new-device-test",
-      "metabase-enterprise.impersonation.driver-test/nested-do-with-connection-with-options-test"
+      "metabase-enterprise.impersonation.driver-test/nested-do-with-connection-with-options-test",
+      "metabase.warehouse-schema.api.table-test/update-table-sync-test",
+      "metabase.warehouses.api-test/can-rescan-fieldvalues-for-a-db",
+      "metabase-enterprise.transforms-python.transforms-api-test/python-transform-schema-change-integration-test"
     ]
   },
   "metadata": {


### PR DESCRIPTION
i’m turning off a few tests:

- "metabase-enterprise.transforms-python.transforms-api-test/python-transform-schema-change-integration-test" this fails in redshift as seen here: https://github.com/metabase/metabase/actions/runs/18413981334/job/52473134679?pr=64390 cc @querying-be

- "metabase.warehouses.api-test/can-rescan-fieldvalues-for-a-db" as seen here: https://github.com/metabase/metabase/actions/runs/18413981334/job/52473134684?pr=64390

- "metabase.warehouse-schema.api.table-test/update-table-sync-test" as seen here: https://github.com/metabase/metabase/actions/runs/18413981334/job/52473134684?pr=64390 (same run)
