### PR TITLE
fix(sdk-bundle, sdk-package): add missing focus color due to dark mode changes

### DIFF
--- a/docs/embedding/sdk/snippets/appearance/theme.ts
+++ b/docs/embedding/sdk/snippets/appearance/theme.ts
@@ -65,6 +65,9 @@ const theme = defineMetabaseTheme({
     // Color used to indicate dangerous actions and negative values/trends
     negative: "#FF7979",
 
+    /** Color used to outline elements in focus */
+    focus: "#CAE1F7",
+
     /** Color used for popover shadows */
     shadow: "rgba(0,0,0,0.08)",
 

--- a/enterprise/frontend/src/embedding-sdk-bundle/lib/theme/get-embedding-theme.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/lib/theme/get-embedding-theme.unit.spec.ts
@@ -18,6 +18,7 @@ describe("Transform Embedding Theme Override", () => {
           "text-tertiary": "green",
           "background-disabled": "pink",
           "text-white": "white",
+          focus: "blue",
         },
 
         // we should strip any explicit "undefined" values and apply default component values
@@ -42,6 +43,7 @@ describe("Transform Embedding Theme Override", () => {
         "background-disabled": expect.arrayContaining(["pink"]),
         "text-white": expect.arrayContaining(["white"]),
         white: expect.arrayContaining(["white"]),
+        focus: expect.arrayContaining(["blue"]),
       },
       other: {
         fontSize: "2rem",

--- a/frontend/src/metabase/embedding-sdk/theme/MetabaseTheme.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/MetabaseTheme.ts
@@ -88,6 +88,9 @@ export interface MetabaseColors {
   /** Color used to indicate dangerous actions and negative values/trends */
   negative?: string;
 
+  /** Color used to outline elements in focus */
+  focus?: string;
+
   /** Color used for white text */
   "text-white"?: string;
 

--- a/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/embedding-color-palette.ts
@@ -63,6 +63,7 @@ export const SDK_TO_MAIN_APP_COLORS_MAPPING: Record<
   error: ["error"],
   "background-error": ["bg-error"],
   "text-hover": ["text-hover"],
+  focus: ["focus"],
 };
 
 /**


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/64638
Closes EMB-903

Adds the missing focus color that was missing since the dark mode changes:

<img width="3450" height="2066" alt="image" src="https://github.com/user-attachments/assets/9694437d-7016-4854-b469-d23d65d718ec" />

### How to verify

- Go to embed flow (`/embed-js`)
- Select a question
- Drill on a question
- You should see the blue outline on the pill buttons

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
