### PR TITLE
Embedding hub's checklist endpoint fails due to sample database changes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -41,14 +41,15 @@
       (and (premium-features/has-feature? :sso-saml) (sso-settings/saml-enabled) (sso-settings/saml-configured))))
 
 (defn- has-user-created-models? []
-  (t2/exists? :model/Card {:where [:and
-                                   [:= :type "model"]
-                                   [:= :archived false]
-                                   [:or
-                                    [:not-in :collection_id [(:id (audit/default-audit-collection)) {:select :id
-                                                                                                     :from   [(t2/table-name :model/Collection)]
-                                                                                                     :where  [:= :is_sample true]}]]
-                                    [:is :collection_id nil]]]}))
+  (let [sample-collection-ids (t2/select-pks-set :model/Collection :is_sample true)
+        audit-collection-id (:id (audit/default-audit-collection))
+        excluded-ids (not-empty (filter some? (conj sample-collection-ids audit-collection-id)))]
+    (t2/exists? :model/Card {:where (cond-> [:and
+                                             [:= :type "model"]
+                                             [:= :archived false]]
+                                      excluded-ids (conj [:or
+                                                          [:is :collection_id nil]
+                                                          [:not-in :collection_id excluded-ids]]))})))
 
 (defn- embedding-hub-checklist []
   {"add-data"                      (has-user-added-database?)

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -43,7 +43,7 @@
 (defn- has-user-created-models? []
   (let [sample-collection-ids (t2/select-pks-set :model/Collection :is_sample true)
         audit-collection-id (:id (audit/default-audit-collection))
-        excluded-ids (not-empty (filter some? (conj sample-collection-ids audit-collection-id)))]
+        excluded-ids (not-empty (vec (filter some? (conj sample-collection-ids audit-collection-id))))]
     (t2/exists? :model/Card {:where (cond-> [:and
                                              [:= :type "model"]
                                              [:= :archived false]]

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -41,15 +41,16 @@
       (and (premium-features/has-feature? :sso-saml) (sso-settings/saml-enabled) (sso-settings/saml-configured))))
 
 (defn- has-user-created-models? []
-  (let [sample-collection-ids (t2/select-pks-set :model/Collection :is_sample true)
-        audit-collection-id (:id (audit/default-audit-collection))
-        excluded-ids (not-empty (vec (filter some? (conj sample-collection-ids audit-collection-id))))]
-    (t2/exists? :model/Card {:where (cond-> [:and
-                                             [:= :type "model"]
-                                             [:= :archived false]]
-                                      excluded-ids (conj [:or
-                                                          [:is :collection_id nil]
-                                                          [:not-in :collection_id excluded-ids]]))})))
+  (t2/exists? :model/Card {:where [:and
+                                   [:= :type "model"]
+                                   [:= :archived false]
+                                   [:or
+                                    [:and
+                                     [:!= :collection_id (:id (audit/default-audit-collection))]
+                                     [:not-in :collection_id {:select :id
+                                                              :from   [(t2/table-name :model/Collection)]
+                                                              :where  [:= :is_sample true]}]]
+                                    [:is :collection_id nil]]]}))
 
 (defn- embedding-hub-checklist []
   {"add-data"                      (has-user-added-database?)

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -41,15 +41,16 @@
       (and (premium-features/has-feature? :sso-saml) (sso-settings/saml-enabled) (sso-settings/saml-configured))))
 
 (defn- has-user-created-models? []
-  (let [sample-collection-ids (t2/select-pks-set :model/Collection :is_sample true)
-        audit-collection-id (:id (audit/default-audit-collection))
-        excluded-ids (not-empty (vec (filter some? (conj sample-collection-ids audit-collection-id))))]
-    (t2/exists? :model/Card {:where (cond-> [:and
-                                             [:= :type "model"]
-                                             [:= :archived false]]
-                                      excluded-ids (conj [:or
-                                                          [:is :collection_id nil]
-                                                          [:not-in :collection_id excluded-ids]]))})))
+  (t2/exists? :model/Card {:where [:and
+                                   [:= :type "model"]
+                                   [:= :archived false]
+                                   [:or
+                                    [:and
+                                     [:!= :collection_id (:id (audit/default-custom-reports-collection))]
+                                     [:not-in :collection_id {:select :id
+                                                              :from   [(t2/table-name :model/Collection)]
+                                                              :where  [:= :is_sample true]}]]
+                                    [:is :collection_id nil]]]}))
 
 (defn- embedding-hub-checklist []
   {"add-data"                      (has-user-added-database?)

--- a/enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj
@@ -1,0 +1,41 @@
+(ns metabase-enterprise.embedding-hub.api-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]))
+
+(deftest has-user-created-models-test
+  (testing "has-user-created-models? correctly handles multiple sample collections (metabase#64627)"
+    (mt/with-premium-features #{:embedding}
+      (mt/with-temp [:model/Collection sample-collection-1 {:name "Sample Collection 1" :is_sample true}
+                     :model/Collection sample-collection-2 {:name "Sample Collection 2" :is_sample true}
+                     :model/Card user-model {:name "User Model"
+                                             :type "model"
+                                             :archived false
+                                             :collection_id nil
+                                             :dataset_query {:database (mt/id)
+                                                             :type :query
+                                                             :query {:source-table (mt/id :venues)}}}
+                     :model/Card _sample-model-1 {:name "Sample Model 1"
+                                                  :type "model"
+                                                  :archived false
+                                                  :collection_id (:id sample-collection-1)
+                                                  :dataset_query {:database (mt/id)
+                                                                  :type :query
+                                                                  :query {:source-table (mt/id :venues)}}}
+                     :model/Card _sample-model-2 {:name "Sample Model 2"
+                                                  :type "model"
+                                                  :archived false
+                                                  :collection_id (:id sample-collection-2)
+                                                  :dataset_query {:database (mt/id)
+                                                                  :type :query
+                                                                  :query {:source-table (mt/id :venues)}}}]
+        (testing "returns true when user-created models exist"
+          (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
+            (is (true? (:create-models response))
+                "Should detect models created by users")))
+
+        (testing "returns false when only sample models exist"
+          (mt/with-temp-vals-in-db :model/Card (:id user-model) {:archived true}
+            (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
+              (is (false? (:create-models response))
+                  "Should not detect models in sample collections"))))))))

--- a/enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj
@@ -29,13 +29,14 @@
                                                   :dataset_query {:database (mt/id)
                                                                   :type :query
                                                                   :query {:source-table (mt/id :venues)}}}]
-        (testing "returns true when user-created models exist"
+        (testing "returns true when there is a model not in any sample collection"
           (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
             (is (true? (:create-models response))
-                "Should detect models created by users")))
+                "Should detect the user model with nil collection_id")))
 
-        (testing "returns false when only sample models exist"
+        (testing "returns false when all models are in sample collections"
+          ;; Temporarily archive the user model so only sample collection models remain active
           (mt/with-temp-vals-in-db :model/Card (:id user-model) {:archived true}
             (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
               (is (false? (:create-models response))
-                  "Should not detect models in sample collections"))))))))
+                  "Should exclude models in both sample collections"))))))))


### PR DESCRIPTION
Closes EMB-902
Closes #64627

Since the sample database changes in https://github.com/metabase/metabase/pull/64065 was merged, the embedding hub endpoint is now failing because of this sub-query:

```clojure
[:not-in
  :collection_id [(:id (audit/default-audit-collection))
  {:select :id
   :from   [(t2/table-name :model/Collection)]
   :where  [:= :is_sample true]}]]
```

This subquery was expecting only a single collection id for sample databases, but 64065 adds this to `sample-content.edn` so now there are **two** sample collections.

```edn
  {:authority_level nil,
   :description "Questions and metrics used for the parent dashboard",
   :archived true,
   :slug "e_commerce",
   :archive_operation_id "1e52f2e4-1304-4e09-9e0e-1dce5ea843af",
   :name "E-commerce",
   :personal_owner_id nil,
   :type nil,
   :is_sample true,
   :id 3,
   :archived_directly true,
   :entity_id "54O0IbgCzm290Nnxf1wRH",
   :location "/2/",
   :namespace nil,
   :created_at #t "2024-12-02T19:06:53.806147Z"}),
```

This causes the above sub-query to error. The Cypress end-to-end test does not use `sample-content.edn` so it did not catch that.

### How to verify

- Delete your Metabase database first, or use `MB_DB_FILE` to specify a new one.
- Create a new Metabase EE instance from scratch on the master branch
- Select the "Embedding" setup intent, so the embedding hub shows up on the embedding checklist
- Complete the setup step
- Once you arrive at the embedding homepage, you should not see an error on the `GET embedding-hub/checklist` endpoint in your console.
- Check the network request. `GET embedding-hub/checklist` should return **200**.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
