### PR TITLE
Remove deprecated `Lib.displayName`

### DIFF
--- a/frontend/src/metabase-lib/breakout.unit.spec.ts
+++ b/frontend/src/metabase-lib/breakout.unit.spec.ts
@@ -21,7 +21,9 @@ describe("breakout", () => {
       const breakouts = Lib.breakouts(nextQuery, 0);
 
       expect(breakouts).toHaveLength(1);
-      expect(Lib.displayName(nextQuery, breakouts[0])).toBe("Title");
+      expect(Lib.displayInfo(nextQuery, 0, breakouts[0]).displayName).toBe(
+        "Title",
+      );
     });
 
     it("should preserve breakout positions between v1-v2 roundtrip", () => {
@@ -117,7 +119,9 @@ describe("breakout", () => {
         productCategory,
       );
       const nextBreakouts = Lib.breakouts(nextQuery, 0);
-      expect(Lib.displayName(nextQuery, nextBreakouts[0])).toBe("Category");
+      expect(Lib.displayInfo(nextQuery, 0, nextBreakouts[0]).displayName).toBe(
+        "Category",
+      );
       expect(breakouts[0]).not.toEqual(nextBreakouts[0]);
     });
   });

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -1,5 +1,4 @@
 import * as ML from "cljs/metabase.lib.js";
-import * as ML_MetadataCalculation from "cljs/metabase.lib.metadata.calculation";
 import type {
   Field as ApiField,
   CardId,
@@ -55,13 +54,6 @@ export function metadataProvider(
   metadata: Metadata,
 ): MetadataProvider {
   return ML.metadataProvider(databaseId, metadata);
-}
-
-/**
- * @deprecated use displayInfo instead
- */
-export function displayName(query: Query, clause: Clause): string {
-  return ML_MetadataCalculation.display_name(query, clause);
 }
 
 declare function DisplayInfoFn(

--- a/frontend/src/metabase-lib/order_by.unit.spec.ts
+++ b/frontend/src/metabase-lib/order_by.unit.spec.ts
@@ -160,7 +160,9 @@ describe("order by", () => {
       const orderBys = Lib.orderBys(nextQuery, 0);
 
       expect(orderBys).toHaveLength(1);
-      expect(Lib.displayName(nextQuery, orderBys[0])).toBe("Title ascending");
+      const displayInfo = Lib.displayInfo(nextQuery, 0, orderBys[0]);
+      expect(displayInfo.displayName).toBe("Title");
+      expect(displayInfo.direction).toBe("asc");
     });
   });
 
@@ -186,9 +188,10 @@ describe("order by", () => {
         Lib.orderByClause(productCategory, "desc"),
       );
       const nextOrderBys = Lib.orderBys(nextQuery, 0);
-      expect(Lib.displayName(nextQuery, nextOrderBys[0])).toBe(
-        "Category descending",
-      );
+      const displayInfo = Lib.displayInfo(nextQuery, 0, nextOrderBys[0]);
+      expect(displayInfo.displayName).toBe("Category");
+      expect(displayInfo.direction).toBe("desc");
+
       expect(orderBys[0]).not.toEqual(nextOrderBys[0]);
     });
   });


### PR DESCRIPTION
It was only used in two unit tests that needed updating.