### PR TITLE
[malli] Use optimized postwalk when calculating schema-cache-key

### DIFF
--- a/src/metabase/util/malli/registry.cljc
+++ b/src/metabase/util/malli/registry.cljc
@@ -5,10 +5,10 @@
    #?@(:clj ([malli.experimental.time :as malli.time]
              [metabase.util.malli.registry.validator-cache :as mr.validator-cache]
              [net.cgrand.macrovich :as macros]))
-   [clojure.walk :as walk]
    [malli.core :as mc]
    [malli.registry]
-   [malli.util :as mut])
+   [malli.util :as mut]
+   [metabase.util.performance :refer [postwalk]])
   #?(:cljs (:require-macros [metabase.util.malli.registry])))
 
 (defonce ^:private cache (atom {}))
@@ -21,7 +21,7 @@
 
   work correctly as cache keys instead of creating new entries every time the code is evaluated."
   [x]
-  (walk/postwalk
+  (postwalk
    (fn [form]
      (cond-> form
        (instance? #?(:clj java.util.regex.Pattern :cljs js/RegExp) form)

--- a/src/metabase/util/performance.cljc
+++ b/src/metabase/util/performance.cljc
@@ -341,7 +341,7 @@
           (add-original-meta form)
           outer))
 
-    (vector? form)
+    (and (vector? form) (not (map-entry? form)))
     (-> (reduce-kv (fn [v idx el]
                      (let [el' (inner el)]
                        (if (identical? el' el)


### PR DESCRIPTION
I managed to overlook this before because I keep Malli validation disabled locally, but this should somewhat improve testing times.