### PR TITLE
[util] Implement Seqable for rconcat to avoid crashing CIDER

### DIFF
--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -1229,7 +1229,11 @@
        (coll-reduce [_ f init]
          (let [acc1 (reduce f init r1)
                acc2 (reduce f acc1 r2)]
-           acc2)))
+           acc2))
+
+       ;; The only reason to implement Seqable is to make it properly renderable by CIDER (and other IDEs, probably).
+       clojure.lang.Seqable
+       (seq [_] (concat (seq r1) (seq r2))))
      :cljs
      (reify IReduce
        (-reduce [_ f]


### PR DESCRIPTION
Small QoL fix for when reified `rconcat` object (or an Eduction that contains it) is inspected or printed, make it not crash CIDER and possibly other IDEs.