### PR TITLE
Fix flaky onboarding/command-palette test

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -31,6 +31,13 @@ const TAB_4 = {
   name: "Tab 4",
 };
 
+/**
+ * When keys are pressed too fast redux won't have enough time to update the state,
+ * so conditions in subsequently called event handlers may not have been updated yet.
+ * Give it some time to do so.
+ */
+const REAL_PRESS_DELAY = 1;
+
 describe("command palette", () => {
   beforeEach(() => {
     H.restore();
@@ -680,12 +687,14 @@ H.describeWithSnowplow("shortcuts", { tags: ["@actions"] }, () => {
     // Sidesheet
     cy.realPress("]");
     cy.findByRole("dialog", { name: "Info" }).should("exist");
+    cy.wait(REAL_PRESS_DELAY);
     cy.realPress("]");
     cy.findByRole("dialog", { name: "Info" }).should("not.exist");
 
     // Viz Settings
     cy.realPress("y");
     cy.findByTestId("chartsettings-sidebar").should("exist");
+    cy.wait(REAL_PRESS_DELAY);
     cy.realPress("y");
     cy.findByTestId("chartsettings-sidebar").should("not.exist");
 

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -34,7 +34,6 @@ const TAB_4 = {
 /**
  * When keys are pressed too fast redux won't have enough time to update the state,
  * so conditions in subsequently called event handlers may not have been updated yet.
- * Give it some time to do so.
  */
 const REAL_PRESS_DELAY = 1;
 


### PR DESCRIPTION
It's top 2 failing e2e test rn: https://app.trunk.io/metabase/flaky-tests/test/1546b786-eb39-5916-97c0-e9394dbe8a51?repo=metabase/metabase

Example failure: https://github.com/metabase/metabase/actions/runs/18458403443/job/52585168799?pr=64617

Stress test: [master](https://github.com/metabase/metabase/actions/runs/18463933255) vs [this branch](https://github.com/metabase/metabase/actions/runs/18463942678)
