### PR TITLE
Fix flaky sanboxing-via-ui test

### DIFF
--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -78,16 +78,17 @@ describe(
       H.restore("sandboxing-snapshot" as any);
     });
 
-    it(
-      "shows all data before sandboxing policy is applied",
-      { tags: "@flaky" },
-      () => {
-        signInAs(gizmoViewer);
-        assertNoResultsOrValuesAreSandboxed(dashboard, sandboxableQuestions);
-        signInAs(widgetViewer);
-        assertNoResultsOrValuesAreSandboxed(dashboard, sandboxableQuestions);
-      },
-    );
+    it("shows all data before sandboxing policy is applied - gizmoViewer", () => {
+      signInAs(gizmoViewer);
+      assertNoResultsOrValuesAreSandboxed(dashboard, sandboxableQuestions);
+    });
+
+    // this test looks like it could be merged with the previous one,
+    // but then it flakes at a very high rate
+    it("shows all data before sandboxing policy is applied - widgetViewer", () => {
+      signInAs(widgetViewer);
+      assertNoResultsOrValuesAreSandboxed(dashboard, sandboxableQuestions);
+    });
 
     describe("we can apply a sandbox policy", () => {
       beforeEach(() => {


### PR DESCRIPTION
Example failure: https://github.com/metabase/metabase/actions/runs/18384084043?pr=64218

Stress test: [master](https://github.com/metabase/metabase/actions/runs/18469086446/job/52618296299) vs [this branch](https://github.com/metabase/metabase/actions/runs/18469095975/job/52618289876)

### Description

Despite lengthy investigation I haven't figured out the exact cause (I suspect it's something about request aliases and/or cypress chaining).
It's one of the most complex and long-running e2e tests we have.
I tried splitting it in two and it gets the job done. At least for now.