### PR TITLE
Subtract a pixel when computing metabot chat filler height to avoid scrollbar flicker

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/hooks.ts
@@ -23,7 +23,8 @@ function calculateFillerHeight(
     parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
   const contentHeight = containerHeight - paddingAdjustment;
 
-  return Math.max(0, Math.floor(contentHeight - nonFillerElsHeight));
+  // subtract 1px to prevent a scrollbar appearing due to rounding issues
+  return Math.max(0, Math.floor(contentHeight - nonFillerElsHeight - 1));
 }
 
 function resizeFillerArea(


### PR DESCRIPTION
I don't 100% understand why this works, but it seems to reliably fix the scrollbar flicker issue I was seeing as I've been working on https://github.com/metabase/metabase/pull/64542. 

My theory is that `clientHeight()` is rounded to the nearest pixel with a certain amount of error, and these errors compound when summed to `nonFillerElsHeight` on L15. This sometimes results in a small amount of overflow from the filler component, which triggers a scroll bar in the chat window, which triggers the ResizeObserver and recomputes the filler height to somehow not trigger the overflow.