### PR TITLE
Fix #58552: Prevents "Show values for this series" switch from getting hidden by the default value of graph.show_stack_values

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -189,7 +189,8 @@ export function seriesSetting({ readDependencies = [], def } = {}) {
       getHidden: (single, seriesSettings, { settings, series }) =>
         series.length <= 1 || // no need to show series-level control if there's only one series
         !settings["graph.show_values"] || // don't show it unless this chart has a global setting
-        settings["graph.show_stack_values"] === "total",
+        (settings["stackable.stack_type"] &&
+          settings["graph.show_stack_values"] === "total"),
       getDefault: (single, seriesSettings, { settings }) =>
         getSeriesDefaultShowSeriesValues(settings),
       readDependencies: ["graph.show_values", "stackable.stack_type"],


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/58552
Closes UXW-88

### Description

Prevents "Show values for this series" switch from getting hidden because of the default value for `graph.show_stack_values`.

### How to verify

See https://github.com/metabase/metabase/issues/58552 for repro steps.

Verify questions created via workaround still have the switch as well.

### Demo

**BEFORE**

https://github.com/user-attachments/assets/49856081-37b7-46f6-baab-6cd1709417ba

**AFTER**

https://github.com/user-attachments/assets/951a9e1c-3bd8-4563-a210-1669e9539338

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
