### PR TITLE
Removed unneeded liquibase preconditions

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6,11 +6,6 @@ databaseChangeLog:
       validCheckSum: 8:a59595109e74e7a2678a1b0dfd25f74a
       author: qnkhuat
       comment: Initialze metabase
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - tableExists:
-              tableName: core_user
       changes:
         - sqlFile:
             dbms: postgresql
@@ -2362,11 +2357,6 @@ databaseChangeLog:
       validCheckSum: 8:963c0cd3a7bd2858e4dbfd4d4aad95cb
       author: noahmoss
       comment: Add foreign key constraint on sandboxes.permission_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - foreignKeyConstraintExists:
-                - foreignKeyName: fk_sandboxes_ref_permissions
       changes:
         - addForeignKeyConstraint:
             baseTableName: sandboxes
@@ -3216,11 +3206,6 @@ databaseChangeLog:
       validCheckSum: 8:05731b3e62deb09c64b60bc10031d206
       author: qnkhuat
       comment: 'Drop parameter_card.entity_id'
-      preConditions:
-        - onFail: MARK_RAN
-        - columnExists:
-            tableName: parameter_card
-            columnName: entity_id
       changes:
         - dropColumn:
             tableName: parameter_card
@@ -3281,10 +3266,6 @@ databaseChangeLog:
       validCheckSum: 8:da33cde0f1f93eed56c0f6d9ac2007df
       author: qnkhuat
       comment: Added 0.48.0 - drop computation_job_result table
-      preConditions:
-        - onFail: MARK_RAN
-        - tableExists:
-            tableName: computation_job_result
       changes:
           - dropTable:
               tableName: computation_job_result
@@ -3295,10 +3276,6 @@ databaseChangeLog:
       validCheckSum: 8:d0b1d7cc179c332b7e31f065325b7275
       author: qnkhuat
       comment: Added 0.48.0 - drop computation_job table
-      preConditions:
-        - onFail: MARK_RAN
-        - tableExists:
-            tableName: computation_job
       changes:
           - dropTable:
               tableName: computation_job
@@ -3442,7 +3419,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: Remove ON UPDATE for revision.timestamp on mysql, mariadb
       preConditions:
-          # If preconditions fail (i.e., dbms is not mysql or mariadb) then mark this migration as 'ran'
           - onFail: MARK_RAN
           - dbms:
               type: mysql,mariadb
@@ -3769,7 +3745,7 @@ databaseChangeLog:
       comment: 'No op migration'
       changes:
         - sql:
-          sql: SELECT 1;
+            sql: SELECT 1;
       rollback:
 
   - changeSet:
@@ -6566,28 +6542,6 @@ databaseChangeLog:
       id: v49.2024-06-27T00:00:05
       author: calherries
       comment: Remove idx_uniq_field_table_id_parent_id_name because it is redundant with idx_unique_field
-      preConditions:
-        - onFail: MARK_RAN
-        - or:
-            - and:
-                - dbms:
-                    type: h2,postgresql
-                - uniqueConstraintExists:
-                    tableName: metabase_field
-                    constraintName: idx_uniq_field_table_id_parent_id_name
-            - and:
-                - dbms:
-                    type: mysql,mariadb
-                - sqlCheck:
-                    expectedResult: 1
-                    sql: >-
-                      SELECT EXISTS (
-                        SELECT *
-                        FROM information_schema.statistics
-                        WHERE table_schema = DATABASE()
-                          AND table_name = 'metabase_field'
-                          AND index_name = 'idx_uniq_field_table_id_parent_id_name'
-                      )
       changes:
         - dropUniqueConstraint:
             tableName: metabase_field
@@ -6687,12 +6641,6 @@ databaseChangeLog:
       id: v49.2024-08-21T08:33:06
       author: johnswanson
       comment: Add permissions.perm_value
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: permissions
-                columnName: perm_value
       changes:
         - addColumn:
             columns:
@@ -6708,12 +6656,6 @@ databaseChangeLog:
       id: v49.2024-08-21T08:33:07
       author: johnswanson
       comment: Add permissions.perm_type
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: permissions
-                columnName: perm_type
       changes:
         - addColumn:
             columns:
@@ -6729,12 +6671,6 @@ databaseChangeLog:
       id: v49.2024-08-21T08:33:08
       author: johnswanson
       comment: Add permissions.collection_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: permissions
-                columnName: collection_id
       changes:
         - addColumn:
             tableName: permissions
@@ -6751,11 +6687,6 @@ databaseChangeLog:
       id: v49.2024-08-21T08:33:09
       author: johnswanson
       comment: Add `permissions.collection_id` foreign key constraint
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - foreignKeyConstraintExists:
-                - foreignKeyName: fk_permissions_ref_collection_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: permissions
@@ -6789,12 +6720,6 @@ databaseChangeLog:
       author: johnswanson
       comment: Create index on `permissions.collection_id`
       rollback: # deleted with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: permissions
-                indexName: idx_permissions_collection_id
       changes:
         - createIndex:
             tableName: permissions
@@ -6809,12 +6734,6 @@ databaseChangeLog:
       author: johnswanson
       comment: Index on `permissions.perm_type`
       rollback: # deleted with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: permissions
-                indexName: idx_permissions_perm_type
       changes:
         - createIndex:
             tableName: permissions
@@ -6828,12 +6747,6 @@ databaseChangeLog:
       author: johnswanson
       comment: Index on `permissions.perm_value`
       rollback: # deleted with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: permissions
-                indexName: idx_permissions_perm_value
       changes:
         - createIndex:
             tableName: permissions
@@ -7174,12 +7087,6 @@ databaseChangeLog:
       id: v50.2024-02-26T22:15:52
       author: noahmoss
       comment: Add index on data_permissions(group_id, db_id, perm_value)
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: data_permissions
-                indexName: idx_data_permissions_group_id_db_id_perm_value
       changes:
         - createIndex:
             tableName: data_permissions
@@ -7197,12 +7104,6 @@ databaseChangeLog:
       id: v50.2024-02-26T22:15:53
       author: noahmoss
       comment: Add index on data_permissions(group_id, db_id, table_id, perm_value)
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: data_permissions
-                indexName: idx_data_permissions_group_id_db_id_table_id_perm_value
       changes:
         - createIndex:
             tableName: data_permissions
@@ -8310,12 +8211,6 @@ databaseChangeLog:
                   defaultValue: "view"
                   constraints:
                     nullable: false
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: recent_views
-              columnName: context
 
   - changeSet:
       id: v50.2024-06-12T12:33:07
@@ -8455,7 +8350,6 @@ databaseChangeLog:
       id: v50.2024-07-09T20:04:02
       author: calherries
       comment: Add not null constraint for report_card.last_used_at
-      preConditions:
       changes:
         - addNotNullConstraint:
             tableName: report_card
@@ -8467,7 +8361,6 @@ databaseChangeLog:
       id: v50.2024-07-09T20:04:03
       author: calherries
       comment: Set default for report_card.last_used_at
-      preConditions:
       changes:
         - sql:
             dbms: postgresql,h2
@@ -8500,12 +8393,6 @@ databaseChangeLog:
       id: v50.2024-08-27T00:00:00
       author: devurandom
       comment: Add is_attached_dwh to metabase_database
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_database
-                columnName: is_attached_dwh
       changes:
         - addColumn:
             tableName: metabase_database
@@ -8530,7 +8417,6 @@ databaseChangeLog:
                   name: dataset_query_metrics_v2_migration_backup
                   remarks: The copy of dataset_query before the metrics v2 migration
                   type: ${text.type}
-      preConditions:
 
   - changeSet:
       id: v51.2024-05-13T16:00:00
@@ -8569,7 +8455,6 @@ databaseChangeLog:
                   name: session_id
               - column:
                   name: device_id
-      preConditions:
 
   - changeSet:
       id: v51.2024-06-12T18:53:03
@@ -8588,17 +8473,11 @@ databaseChangeLog:
         - dropIndex:
             tableName: login_history
             indexName: idx_user_id_device_id
-      preConditions:
 
   - changeSet:
       id: v51.2024-07-08T10:00:00
       author: qnkhuat
       comment: Create channel table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: channel
       changes:
         - createTable:
             tableName: channel
@@ -8661,12 +8540,6 @@ databaseChangeLog:
       id: v51.2024-07-08T10:00:01
       author: qnkhuat
       comment: Create pulse_channel.channel_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: pulse_channel
-                columnName: channel_id
       changes:
         - addColumn:
             tableName: pulse_channel
@@ -8680,13 +8553,6 @@ databaseChangeLog:
       id: v51.2024-07-08T10:00:02
       author: qnkhuat
       comment: Add fk constraint to pulse_channel.channel_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_pulse_channel_channel_id
-                foreignKeyTableName: pulse_channel
-
       changes:
         - addForeignKeyConstraint:
             baseTableName: pulse_channel
@@ -8712,12 +8578,6 @@ databaseChangeLog:
       id: v51.2024-07-10T12:28:10
       author: johnswanson
       comment: Add `last_viewed_at` to dashboards
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: report_dashboard
-              columnName: last_viewed_at
       changes:
         - addColumn:
             tableName: report_dashboard
@@ -8734,12 +8594,6 @@ databaseChangeLog:
       id: v51.2024-07-22T15:49:37
       author: escherize
       comment: Add embedding_client column to query_execution for metabase embedding SDK analytics
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: query_execution
-              columnName: embedding_client
       changes:
         - addColumn:
             tableName: query_execution
@@ -8755,12 +8609,6 @@ databaseChangeLog:
       id: v51.2024-07-22T15:49:38
       author: escherize
       comment: Add embedding_version column to query_execution for metabase embedding SDK analytics
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: query_execution
-              columnName: embedding_version
       changes:
         - addColumn:
             tableName: query_execution
@@ -8776,12 +8624,6 @@ databaseChangeLog:
       id: v51.2024-07-22T15:49:39
       author: escherize
       comment: Add embedding_client column to view_log for metabase embedding SDK analytics
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: view_log
-              columnName: embedding_client
       changes:
         - addColumn:
             tableName: view_log
@@ -8797,12 +8639,6 @@ databaseChangeLog:
       id: v51.2024-07-22T15:49:40
       author: escherize
       comment: Add embedding_version column to view_log for metabase embedding SDK analytics
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: view_log
-              columnName: embedding_version
       changes:
         - addColumn:
             tableName: view_log
@@ -8828,11 +8664,6 @@ databaseChangeLog:
       id: v51.2024-07-25T11:57:27
       author: crisptrutski
       comment: Add `column` column to query fields
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: query_field
-              columnName: column
       changes:
         - addColumn:
             tableName: query_field
@@ -8848,11 +8679,6 @@ databaseChangeLog:
       id: v51.2024-07-25T11:58:27
       author: crisptrutski
       comment: Add `table` column to query fields
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: query_field
-              columnName: table
       changes:
         - addColumn:
             tableName: query_field
@@ -8885,11 +8711,6 @@ databaseChangeLog:
       id: v51.2024-07-26T11:56:27
       author: crisptrutski
       comment: Add `table_id` column to query fields
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: query_field
-              columnName: table_id
       changes:
         - addColumn:
             tableName: query_field
@@ -8905,11 +8726,6 @@ databaseChangeLog:
       id: v51.2024-07-29T09:22:12
       author: crisptrutski
       comment: Add the query_analysis table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - tableExists:
-              tableName: query_analysis
       changes:
         - createTable:
             tableName: query_analysis
@@ -8953,7 +8769,6 @@ databaseChangeLog:
       author: crisptrutski
       comment: Index query_analysis.card_id
       rollback: # not necessary, will be removed with the table
-      preConditions: # linter made me add this
       changes:
         - createIndex:
             tableName: query_analysis
@@ -8966,11 +8781,6 @@ databaseChangeLog:
       id: v51.2024-07-29T09:24:13
       author: crisptrutski
       comment: Add the query_table join table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - tableExists:
-              tableName: query_table
       changes:
         - createTable:
             tableName: query_table
@@ -9032,7 +8842,6 @@ databaseChangeLog:
       author: crisptrutski
       comment: Index query_table.card_id
       rollback: # not necessary, will be removed with the table
-      preConditions: # linter made me add this
       changes:
         - createIndex:
             tableName: query_table
@@ -9046,7 +8855,6 @@ databaseChangeLog:
       author: crisptrutski
       comment: Index query_table.analysis_id
       rollback: # not necessary, will be removed with the table
-      preConditions: # linter made me add this
       changes:
         - createIndex:
             tableName: query_table
@@ -9060,7 +8868,6 @@ databaseChangeLog:
       author: crisptrutski
       comment: Index query_table.table_id
       rollback: # not necessary, will be removed with the table
-      preConditions: # linter made me add this
       changes:
         - createIndex:
             tableName: query_table
@@ -9083,11 +8890,6 @@ databaseChangeLog:
       id: v51.2024-07-29T10:04:13
       author: crisptrutski
       comment: Put Query Fields under a parent Query Analysis record
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: query_field
-              columnName: analysis_id
       changes:
         - addColumn:
             tableName: query_field
@@ -9116,7 +8918,6 @@ databaseChangeLog:
       author: crisptrutski
       comment: Index query_field.analysis_id
       rollback: # not necessary, will be removed with the table
-      preConditions: # linter made me add this
       changes:
         - createIndex:
             tableName: query_field
@@ -9129,11 +8930,6 @@ databaseChangeLog:
       id: v51.2024-08-02T11:56:27
       author: crisptrutski
       comment: Add `schema` column to query fields
-      preConditions:
-        - not:
-            - columnExists:
-                tableName: query_field
-                columnName: schema
       changes:
         - addColumn:
             tableName: query_field
@@ -9162,11 +8958,6 @@ databaseChangeLog:
       id: v51.2024-08-05T16:00:00
       author: metamben
       comment: Add source card reference to report_card to support metrics based models and questions
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: report_card
-              columnName: source_card_id
       changes:
         - addColumn:
             tableName: report_card
@@ -9180,7 +8971,6 @@ databaseChangeLog:
       id: v51.2024-08-05T16:00:01
       author: metamben
       comment: Add FK constraint to report_card.source_card_id
-      preConditions:
       changes:
         - addForeignKeyConstraint:
             baseTableName: report_card
@@ -9196,11 +8986,6 @@ databaseChangeLog:
       author: metamben
       comment: Index report_card.source_card_id
       rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: report_card
-                indexName: idx_report_card_source_card_id
       changes:
         - createIndex:
             tableName: report_card
@@ -9232,11 +9017,6 @@ databaseChangeLog:
       id: v51.2024-08-26T08:53:46
       author: crisptrutski
       comment: Add a status column to track the progress and outcome of query analysis
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: query_analysis
-              columnName: status
       changes:
         - addColumn:
             tableName: query_analysis
@@ -9250,11 +9030,6 @@ databaseChangeLog:
       id: v51.2024-09-03T16:54:18
       author: adam-james
       comment: Add pivot_results to pulse_card
-      preConditions:
-        - not:
-            - columnExists:
-                tableName: pulse_card
-                columnName: pivot_results
       changes:
         - addColumn:
             tableName: pulse_card
@@ -9269,12 +9044,6 @@ databaseChangeLog:
       id: v51.2024-09-09T15:11:16
       author: johnswanson
       comment: add an index for `collection.type`
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: collection
-                indexName: idx_collection_type
       changes:
         - createIndex:
             tableName: collection
@@ -9498,10 +9267,6 @@ databaseChangeLog:
       id: v51.2024-10-24T14:24:59
       author: noahmoss
       comment: Drop foreign key constraint on persisted_info.card_id
-      preConditions:
-        - foreignKeyConstraintExists:
-            foreignKeyName: fk_persisted_info_card_id
-            foreignKeyTableName: persisted_info
       changes:
         - dropForeignKeyConstraint:
             constraintName: fk_persisted_info_card_id
@@ -9519,11 +9284,6 @@ databaseChangeLog:
       id: v51.2024-10-24T14:25:01
       author: noahmoss
       comment: Re-add nullable foreign key constraint on persisted_info.card_id
-      preConditions:
-        - not:
-            - foreignKeyConstraintExists:
-              foreignKeyName: fk_persisted_info_card_id
-              foreignKeyTableName: persisted_info
       changes:
         - addForeignKeyConstraint:
             baseTableName: persisted_info
@@ -9541,10 +9301,6 @@ databaseChangeLog:
       id: v52.2024-09-05T08:00:00
       author: qnkhuat
       comment: Create the notification table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification
       changes:
         - createTable:
             tableName: notification
@@ -9587,10 +9343,6 @@ databaseChangeLog:
       id: v52.2024-09-05T08:00:01
       author: qnkhuat
       comment: Create the notification_subscription table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification_subscription
       changes:
         - createTable:
             remarks: which type of trigger a notification is subscribed to
@@ -9637,11 +9389,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: index on notification_subscription.notification_id
       rollback: # no need, will be dropped with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_subscription
-                indexName: idx_notification_subscription_notification_id
       changes:
         - createIndex:
             tableName: notification_subscription
@@ -9654,10 +9401,6 @@ databaseChangeLog:
       id: v52.2024-09-05T08:00:03
       author: qnkhuat
       comment: Create the channel_template table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: channel_template
       changes:
         - createTable:
             tableName: channel_template
@@ -9713,10 +9456,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: Create the notification_handler table
       validCheckSum: ANY
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification_handler
       changes:
         - createTable:
             tableName: notification_handler
@@ -9787,11 +9526,6 @@ databaseChangeLog:
       id: v52.2024-09-05T08:00:05
       author: qnkhuat
       comment: Add fk constraint to notification_handler.template_id
-      preConditions:
-        - not:
-          - foreignKeyConstraintExists:
-              foreignKeyName: fk_notification_handler_template_id
-              foreignKeyTableName: notification_handler
       changes:
         - addForeignKeyConstraint:
             baseTableName: notification_handler
@@ -9806,11 +9540,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: index on notification_handler.notification_id
       rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_handler
-                indexName: idx_notification_handler_notification_id
       changes:
         - createIndex:
             tableName: notification_handler
@@ -9824,11 +9553,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: index on notification_handler.channel_id
       rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_handler
-                indexName: idx_notification_handler_channel_id
       changes:
         - createIndex:
             tableName: notification_handler
@@ -9842,11 +9566,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: index on notification_handler.template_id
       rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_handler
-                indexName: idx_notification_handler_template_id
       changes:
         - createIndex:
             tableName: notification_handler
@@ -9859,10 +9578,6 @@ databaseChangeLog:
       id: v52.2024-09-05T08:00:09
       author: qnkhuat
       comment: Create the notification_recipient table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification_recipient
       changes:
         - createTable:
             tableName: notification_recipient
@@ -9937,11 +9652,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: index on notification_recipient.notification_handler_id
       rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_recipient
-                indexName: idx_notification_recipient_notification_handler_id
       changes:
         - createIndex:
             tableName: notification_recipient
@@ -9955,11 +9665,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: index on notification_recipient.user_id
       rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_recipient
-                indexName: idx_notification_recipient_user_id
       changes:
         - createIndex:
             tableName: notification_recipient
@@ -9973,11 +9678,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: index on notification_recipient.permissions_group_id
       rollback: # not necessary, will be removed with the table
-      preConditions:
-        - not:
-            - indexExists:
-                tableName: notification_recipient
-                indexName: idx_notification_recipient_permissions_group_id
       changes:
         - createIndex:
             tableName: notification_recipient
@@ -9990,11 +9690,6 @@ databaseChangeLog:
       id: v52.2024-09-05T08:00:13
       author: qnkhuat
       comment: Drop the channel_template.entity_id column
-      preConditions:
-        - onFail: MARK_RAN
-        - columnExists:
-            tableName: metabase_database
-            columnName: is_attached_dwh
       changes:
         - dropColumn:
             tableName: channel_template
@@ -10005,11 +9700,6 @@ databaseChangeLog:
       id: v52.2024-10-15T08:00:00
       author: qnkhuat
       comment: add notification_subscription.cron_schedule
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: notification_subscription
-              columnName: cron_schedule
       changes:
         - addColumn:
             tableName: notification_subscription
@@ -10055,12 +9745,6 @@ databaseChangeLog:
       id: v52.2024-12-10T10:28:16
       author: johnswanson
       comment: Add `report_card.dashboard_id`
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: report_card
-              columnName: dashboard_id
       changes:
         - addColumn:
             tableName: report_card
@@ -10076,11 +9760,6 @@ databaseChangeLog:
       id: v52.2024-12-10T10:28:21
       author: johnswanson
       comment: Make `report_card.dashboard_id` a foreign key
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - foreignKeyConstraintExists:
-            - foreignKeyName: fk_report_card_ref_dashboard_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: report_card
@@ -10095,12 +9774,6 @@ databaseChangeLog:
       author: johnswanson
       comment: Add an index for `report_card.dashboard_id`
       rollback: # will be removed with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: report_card
-                indexName: idx_report_card_dashboard_id
       changes:
         - createIndex:
             indexName: idx_report_card_dashboard_id
@@ -10113,11 +9786,6 @@ databaseChangeLog:
       id: v52.2024-12-16T09:19:00
       author: crisptrutski
       comment: Metadata about search indexes
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: search_index_metadata
       changes:
         - createTable:
             tableName: search_index_metadata
@@ -10175,12 +9843,6 @@ databaseChangeLog:
       author: crisptrutski
       comment: 'Protection against concurrent creation or promotion of indexes.'
       rollback: # will be removed with the table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: search_index_metadata
-                indexName: idx_search_index_metadata_unique_status
       changes:
         - addUniqueConstraint:
             remarks: Unique entry for each status, from any given metabase instance's perspective.
@@ -10232,7 +9894,6 @@ databaseChangeLog:
       id: v52.2025-05-28T00:00:01
       author: edpaget
       comment: set perms/download-results to no when a table has perms/view-data blocked
-      preConditions: # change is safe to run regardless
       changes:
          - sql:
             dbms: postgresql,h2
@@ -10267,11 +9928,6 @@ databaseChangeLog:
       id: v53.2024-12-02T16:21:15
       author: noahmoss
       comment: Add cache_config.refresh_automatically column
-      preConditions:
-        - not:
-            - columnExists:
-                tableName: cache_config
-                columnName: refresh_automatically
       changes:
         - addColumn:
             tableName: cache_config
@@ -10291,11 +9947,6 @@ databaseChangeLog:
         - 9:8adcf08936200cc74153d0c306452e0c
       author: noahmoss
       comment: Add query_execution.parameterized column
-      preConditions:
-        - not:
-            - columnExists:
-                tableName: query_execution
-                columnName: parameterized
       changes:
         - addColumn:
             tableName: query_execution
@@ -10311,12 +9962,6 @@ databaseChangeLog:
       id: v53.2024-12-10T10:00:00
       author: qnkhuat
       comment: add notification.internal_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - columnExists:
-              tableName: notification
-              columnName: internal_id
       changes:
         - addColumn:
             tableName: notification
@@ -10381,11 +10026,6 @@ databaseChangeLog:
       comment: >
         add a table for user-level KV. This is intended for use as a lightweight mechanism for the frontend to be able
         to mark things as seen, unseen, dismissed, etc
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: user_key_value
       changes:
         - createTable:
             tableName: user_key_value
@@ -10501,12 +10141,6 @@ databaseChangeLog:
       id: v53.2025-01-03T19:07:39
       author: noahmoss
       comment: Add `deactivated_at` column to the `core_user` table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: core_user
-                columnName: deactivated_at
       changes:
         - addColumn:
             tableName: core_user
@@ -10541,11 +10175,6 @@ databaseChangeLog:
       id: v53.2025-04-02T15:25:04
       author: edpaget
       comment: create new cluster lock table for instance coordination
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: metabase_cluster_lock
       changes:
         - createTable:
             tableName: metabase_cluster_lock
@@ -10563,7 +10192,6 @@ databaseChangeLog:
       id: v53.2025-05-06T16:03:19
       author: nvoxland
       comment: Support indexing of values with bigint ids
-      preConditions:
       changes:
         - modifyDataType:
             tableName: model_index_value
@@ -10579,12 +10207,6 @@ databaseChangeLog:
       id: v54.2025-01-30T16:10:55
       author: bshepherdson
       comment: Add `entity_id` column to the `metabase_database` table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_database
-                columnName: entity_id
       changes:
         - addColumn:
             tableName: metabase_database
@@ -10601,12 +10223,6 @@ databaseChangeLog:
       id: v54.2025-01-30T16:13:20
       author: bshepherdson
       comment: Add `entity_id` column to the `metabase_table` table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_table
-                columnName: entity_id
       changes:
         - addColumn:
             tableName: metabase_table
@@ -10623,12 +10239,6 @@ databaseChangeLog:
       id: v54.2025-01-30T16:14:02
       author: bshepherdson
       comment: Add `entity_id` column to the `metabase_field` table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_field
-                columnName: entity_id
       changes:
         - addColumn:
             tableName: metabase_field
@@ -10645,11 +10255,6 @@ databaseChangeLog:
       id: v54.2025-02-14T08:00:00
       author: qnkhuat
       comment: add notification.payload_id
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: notification
-              columnName: payload_id
       changes:
         - addColumn:
             tableName: notification
@@ -10665,10 +10270,6 @@ databaseChangeLog:
       id: v54.2025-02-14T08:01:00
       author: qnkhuat
       comment: create the notification_card table
-      preConditions:
-        - not:
-          - tableExists:
-              tableName: notification_card
       changes:
         - createTable:
             tableName: notification_card
@@ -10723,11 +10324,6 @@ databaseChangeLog:
       id: v54.2025-02-14T08:03:00
       author: qnkhuat
       comment: add notification.creator_id
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: notification
-              columnName: creator_id
       changes:
         - addColumn:
             tableName: notification
@@ -10743,11 +10339,6 @@ databaseChangeLog:
       id: v54.2025-02-14T08:04:00
       author: qnkhuat
       comment: add fk constraint to notification.creator_id
-      preConditions:
-        - not:
-          - foreignKeyConstraintExists:
-              foreignKeyName: fk_notification_creator_id
-              foreignKeyTableName: notification
       changes:
         - addForeignKeyConstraint:
             baseTableName: notification
@@ -10763,12 +10354,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: Add an index for `notification.creator_id`
       rollback: # will be removed with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: notification
-                indexName: idx_notification_creator_id
       changes:
         - createIndex:
             indexName: idx_notification_creator_id
@@ -10782,12 +10367,6 @@ databaseChangeLog:
       author: qnkhuat
       comment: Add an index for `notification_card.card_id`
       rollback: # will be removed with the column
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: notification_card
-                indexName: idx_notification_card_card_id
       changes:
         - createIndex:
             indexName: idx_notification_card_card_id
@@ -10853,7 +10432,6 @@ databaseChangeLog:
       id: v54.2025-03-06T16:55:15
       author: nvoxland
       comment: Replacing storing the session key in the "id" column in favor of storing a new hashed version
-      preConditions:
       changes:
         - addColumn:
             tableName: core_session
@@ -10870,7 +10448,6 @@ databaseChangeLog:
       id: v54.2025-03-06T16:55:16
       author: nvoxland
       comment: Creating index on the hashed session key
-      preConditions:
       changes:
         - createIndex:
             tableName: core_session
@@ -10883,11 +10460,6 @@ databaseChangeLog:
       id: v54.2025-03-11T16:00:00
       author: qnkhuat
       comment: add notification_subscription.ui_display_type
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: notification_subscription
-              columnName: ui_display_type
       changes:
         - addColumn:
             tableName: notification_subscription
@@ -10903,7 +10475,6 @@ databaseChangeLog:
       id: v54.2025-03-17T18:52:44
       author: noahmoss
       comment: Migrating zh site locales to zh_CN
-      preConditions:
       changes:
         - sql:
             dbms: postgresql
@@ -10923,7 +10494,6 @@ databaseChangeLog:
       id: v54.2025-03-17T18:52:59
       author: noahmoss
       comment: Migrating zh user locales to zh_CN
-      preConditions:
       changes:
         - sql:
             sql: >-
@@ -10935,12 +10505,6 @@ databaseChangeLog:
       author: edpaget
       comment: Add index to field_usage query_execution_id column to support faster deletes
       rollback: # cannot rollback an index on a fk in mysql
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: field_usage
-                indexName: idx_field_usage_query_execution_id
       changes:
         - createIndex:
             tableName: field_usage
@@ -11015,7 +10579,6 @@ databaseChangeLog:
       id: v54.2025-05-13T21:46:53
       author: nvoxland
       comment: Add language to index metadata
-      preConditions:
       changes:
         - addColumn:
             tableName: search_index_metadata
@@ -11033,7 +10596,6 @@ databaseChangeLog:
       id: v54.2025-05-13T21:46:54
       author: nvoxland
       comment: Preparing to replace index
-      preConditions:
       changes:
         - dropUniqueConstraint:
             tableName: search_index_metadata
@@ -11049,12 +10611,6 @@ databaseChangeLog:
       id: v54.2025-05-13T21:46:55
       author: nvoxland
       comment: 'Protection against concurrent creation or promotion of indexes.'
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: search_index_metadata
-                indexName: idx_search_index_metadata_unique_status
       changes:
         - addUniqueConstraint:
             remarks: Unique entry for each status, from any given metabase instance's perspective.
@@ -11097,11 +10653,6 @@ databaseChangeLog:
       id: v55.2025-03-24T16:28:41
       author: bshepherdson
       comment: Add report_card.card_schema
-      preConditions:
-        - not:
-          - columnExists:
-              tableName: report_card
-              columnName: card_schema
       changes:
         - addColumn:
             tableName: report_card
@@ -11118,7 +10669,6 @@ databaseChangeLog:
       id: v55.2025-03-24T16:36:19
       author: bshepherdson
       comment: Creating index on the card_schema
-      preConditions:
       changes:
         - createIndex:
             tableName: report_card
@@ -11131,11 +10681,6 @@ databaseChangeLog:
       id: v55.2025-04-01T07:17:52
       author: johnswanson
       comment: Add `db_router` table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: db_router
       changes:
         - createTable:
             tableName: db_router
@@ -11172,12 +10717,6 @@ databaseChangeLog:
       id: v55.2025-04-01T07:18:02
       author: johnswanson
       comment: Add self-referential foreign key `router_database_id` to metabase_database
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_database
-                columnName: router_database_id
       changes:
         - addColumn:
             tableName: metabase_database
@@ -11194,12 +10733,6 @@ databaseChangeLog:
       id: v55.2025-04-01T07:18:47
       author: johnswanson
       comment: add an index for `metabase_database.router_database_id`
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: metabase_database
-                indexName: idx_unique_metabase_database_router_database_id_name
       changes:
         - addUniqueConstraint:
             tableName: metabase_database
@@ -11210,11 +10743,6 @@ databaseChangeLog:
       id: v55.2025-04-01T07:18:52
       author: johnswanson
       comment: Add foreign key for `router_database_id`
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-          - foreignKeyConstraintExists:
-            - foreignKeyName: fk_metabase_database_metabase_database_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: metabase_database
@@ -11229,7 +10757,6 @@ databaseChangeLog:
       id: v55.2025-04-17T08:44:39
       author: johnswanson
       comment: Add permissions_group.magic_group_type
-      preConditions: # Not required
       changes:
         - addColumn:
             tableName: permissions_group
@@ -11257,7 +10784,6 @@ databaseChangeLog:
       id: v55.2025-04-22T05:42:48
       author: johnswanson
       comment: Add `permissions_group.is_tenant_group`
-      preConditions: # Not required
       changes:
         - addColumn:
             tableName: permissions_group
@@ -11274,7 +10800,6 @@ databaseChangeLog:
       id: v55.2025-04-22T05:54:51
       author: johnswanson
       comment: Add `core_user.tenant_id`
-      preConditions: #
       changes:
         - addColumn:
             tableName: core_user
@@ -11392,12 +10917,6 @@ databaseChangeLog:
       validCheckSum: 9:85e9ad7b60db0cd795254ca52d6dd5a7
       author: ranquild
       comment: Add metabase_table.is_defective_duplicate
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_table
-                columnName: is_defective_duplicate
       changes:
         - addColumn:
             tableName: metabase_table
@@ -11446,12 +10965,6 @@ databaseChangeLog:
       validCheckSum: ANY
       author: ranquild
       comment: Add metabase_table.unique_table_helper to create an index that ignores EXISTING duplicates
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_table
-                columnName: unique_table_helper
       changes:
         - sql:
             dbms: postgresql
@@ -11480,12 +10993,6 @@ databaseChangeLog:
       validCheckSum: 9:848d1cb748064b5de423139fbbbc2876
       author: ranquild
       comment: Add unique constraint on metabase_table(db_id, name, unique_table_helper)
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - uniqueConstraintExists:
-                tableName: metabase_table
-                constraintName: idx_unique_table
       changes:
         - addUniqueConstraint:
             tableName: metabase_table
@@ -11500,11 +11007,6 @@ databaseChangeLog:
       id: v55.2025-05-19T16:46:48
       author: edpaget
       comment: Add metabot table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: metabot
       changes:
         - createTable:
             tableName: metabot
@@ -11555,11 +11057,6 @@ databaseChangeLog:
       id: v55.2025-05-19T16:47:48
       author: edpaget
       comment: Add metabot entity table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: metabot_entity
       changes:
         - createTable:
             tableName: metabot_entity
@@ -11609,12 +11106,6 @@ databaseChangeLog:
       id: v55.2025-05-19T16:48:48
       author: edpaget
       comment: Add index on metabot_entity.metabot_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: metabot_entity
-                indexName: idx_metabot_entity_metabot_id
       changes:
         - createIndex:
             tableName: metabot_entity
@@ -11627,12 +11118,6 @@ databaseChangeLog:
       id: v55.2025-05-19T16:49:49
       author: edpaget
       comment: Add foreign key constraint on metabot_entity.metabot_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_metabot_entity_metabot_id
-                foreignKeyTableName: metabot_entity
       changes:
         - addForeignKeyConstraint:
             baseTableName: metabot_entity
@@ -11691,11 +11176,6 @@ databaseChangeLog:
       validCheckSum: 9:1ed306a6b2573b7b140275e5319fae2c
       author: ranquild
       comment: Drop metabase_database.entity_id
-      preConditions:
-        - onFail: MARK_RAN
-        - columnExists:
-            tableName: metabase_database
-            columnName: entity_id
       changes:
         - dropColumn:
             tableName: metabase_database
@@ -11717,11 +11197,6 @@ databaseChangeLog:
       validCheckSum: 9:b03020b86a754abc46edca465f91eb6f
       author: ranquild
       comment: Drop metabase_table.entity_id
-      preConditions:
-        - onFail: MARK_RAN
-        - columnExists:
-            tableName: metabase_table
-            columnName: entity_id
       changes:
         - dropColumn:
             tableName: metabase_table
@@ -11743,11 +11218,6 @@ databaseChangeLog:
       validCheckSum: 9:70285cb34c7e9e4dd25f322a46e21c04
       author: ranquild
       comment: Drop metabase_field.entity_id
-      preConditions:
-        - onFail: MARK_RAN
-        - columnExists:
-            tableName: metabase_field
-            columnName: entity_id
       changes:
         - dropColumn:
             tableName: metabase_field
@@ -11768,11 +11238,6 @@ databaseChangeLog:
       id: v55.2025-06-03T16:52:38
       author: metamben
       comment: Add metabot prompt table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: metabot_prompt
       changes:
         - createTable:
             tableName: metabot_prompt
@@ -11835,12 +11300,6 @@ databaseChangeLog:
       id: v55.2025-06-03T16:52:48
       author: metamben
       comment: Add index on metabot_prompt.metabot_entity_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: metabot_prompt
-                indexName: idx_metabot_prompt_metabot_entity_id
       changes:
         - createIndex:
             tableName: metabot_prompt
@@ -11853,12 +11312,6 @@ databaseChangeLog:
       id: v55.2025-06-03T16:52:58
       author: metamben
       comment: Add foreign key constraint on metabot_prompt.metabot_entity_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_metabot_prompt_metabot_entity_id
-                foreignKeyTableName: metabot_prompt
       changes:
         - addForeignKeyConstraint:
             baseTableName: metabot_prompt
@@ -11872,12 +11325,6 @@ databaseChangeLog:
       id: v55.2025-06-03T16:53:08
       author: metamben
       comment: Add index on metabot_prompt.card_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: metabot_prompt
-                indexName: idx_metabot_prompt_card_id
       changes:
         - createIndex:
             tableName: metabot_prompt
@@ -11890,12 +11337,6 @@ databaseChangeLog:
       id: v55.2025-06-03T16:53:18
       author: metamben
       comment: Add foreign key constraint on metabot_prompt.card_id
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_metabot_prompt_card_id
-                foreignKeyTableName: metabot_prompt
       changes:
         - addForeignKeyConstraint:
             baseTableName: metabot_prompt
@@ -11909,12 +11350,6 @@ databaseChangeLog:
       id: v55.2025-06-09T01:00:00
       author: metabase-dev
       comment: Add inline_parameters to report_dashboardcard for card-level parameter display
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: report_dashboardcard
-                columnName: inline_parameters
       changes:
         - addColumn:
             tableName: report_dashboardcard

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6,6 +6,11 @@ databaseChangeLog:
       validCheckSum: 8:a59595109e74e7a2678a1b0dfd25f74a
       author: qnkhuat
       comment: Initialze metabase
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+          - tableExists: ## Have to manually check since the changest ids don't always match
+              tableName: core_user
       changes:
         - sqlFile:
             dbms: postgresql

--- a/resources/migrations/056_update_migrations.yaml
+++ b/resources/migrations/056_update_migrations.yaml
@@ -134,11 +134,6 @@ databaseChangeLog:
       id: v56.2025-06-13T15:00:00
       author: rafpaf
       comment: Create content translation table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: content_translation
       changes:
         - createTable:
             tableName: content_translation
@@ -239,12 +234,6 @@ databaseChangeLog:
       id: v56.2025-07-30T10:35:00
       author: bronsa
       comment: Add deactivated_at column to metabase_table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_table
-                columnName: deactivated_at
       changes:
         - addColumn:
             tableName: metabase_table
@@ -260,12 +249,6 @@ databaseChangeLog:
       id: v56.2025-07-30T10:35:01
       author: bronsa
       comment: Add archived_at column to metabase_table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_table
-                columnName: archived_at
       changes:
         - addColumn:
             tableName: metabase_table
@@ -282,12 +265,6 @@ databaseChangeLog:
       author: bronsa
       comment: Add composite index on metabase_table for unarchived deactivated tables by db_id (PostgreSQL)
       dbms: postgresql
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: metabase_table
-                indexName: idx_metabase_table_db_deactivated
       changes:
         - sql:
             sql: >-
@@ -559,12 +536,6 @@ databaseChangeLog:
                   remarks: The metabot entity this prompt is associated with
                   constraints:
                     nullable: true
-            preConditions:
-              - onFail: MARK_RAN
-              - not:
-                  - columnExists:
-                      tableName: metabot_prompt
-                      columnName: metabot_entity_id
         - sql:
             comment: Restore metabot_prompt.metabot_entity_id values from metabot_prompt.metabot_id
             sql: >-

--- a/resources/migrations/057_update_migrations.yaml
+++ b/resources/migrations/057_update_migrations.yaml
@@ -4,11 +4,6 @@ databaseChangeLog:
       id: v57.2025-08-01T10:00:00
       author: qnkhuat
       comment: Add undo/redo change tracking table
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: data_edit_undo_chain
       changes:
         - createTable:
             tableName: data_edit_undo_chain
@@ -96,11 +91,6 @@ databaseChangeLog:
       id: v57.2025-08-01T10:02:00
       author: qnkhuat
       comment: A table for generating atomic sequence numbers
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: sequences
       changes:
         - createTable:
             tableName: sequences
@@ -124,12 +114,6 @@ databaseChangeLog:
       id: v57.2025-08-15T10:00:00
       author: qnkhuat
       comment: Add metabase_table.is_writable
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: metabase_table
-                columnName: is_writable
       changes:
         - addColumn:
             tableName: metabase_table
@@ -1101,11 +1085,6 @@ databaseChangeLog:
       id: v57.2025-08-24T10:00:00
       author: kulyk
       comment: Create comment table for documents feature
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: comment
       changes:
         - createTable:
             tableName: comment
@@ -1257,11 +1236,6 @@ databaseChangeLog:
       id: v57.2025-09-01T17:15:00
       author: kulyk
       comment: Create comment_reaction table for comment reactions feature
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: comment_reaction
       changes:
         - createTable:
             tableName: comment_reaction
@@ -1356,10 +1330,6 @@ databaseChangeLog:
       id: v57.2025-09-08T17:50:00
       author: metamben
       comment: Drop old dependency table
-      preConditions:
-        - onFail: MARK_RAN
-        - tableExists:
-            tableName: dependency
       changes:
         - dropTable:
             tableName: dependency
@@ -1434,12 +1404,6 @@ databaseChangeLog:
       id: v57.2025-09-08T18:00:00
       author: metamben
       comment: Create dependency table to track dependencies in a general way
-
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - tableExists:
-                tableName: dependency
       changes:
         - createTable:
             tableName: dependency
@@ -1482,12 +1446,6 @@ databaseChangeLog:
       id: v57.2025-09-08T18:10:00
       author: metamben
       comment: Unique constraint to prevent duplicate dependencies
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - uniqueConstraintExists:
-                tableName: dependency
-                constraintName: idx_unique_dependency
       changes:
         - addUniqueConstraint:
             tableName: dependency
@@ -1498,12 +1456,6 @@ databaseChangeLog:
       id: v57.2025-09-08T18:20:00
       author: metamben
       comment: Index for finding dependencies FROM a specific entity
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: dependency
-                indexName: idx_dependency_from
       changes:
         - createIndex:
             tableName: dependency
@@ -1518,12 +1470,6 @@ databaseChangeLog:
       id: v57.2025-09-08T18:30:00
       author: metamben
       comment: Index for finding dependencies TO a specific entity
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - indexExists:
-                tableName: dependency
-                indexName: idx_dependency_to
       changes:
         - createIndex:
             tableName: dependency
@@ -1629,12 +1575,6 @@ databaseChangeLog:
       id: v57.2025-09-16T12:55:00
       author: stasgavrylov
       comment: Add content_html column to comment table for storing HTML-rendered content
-      preConditions:
-        - onFail: MARK_RAN
-        - not:
-            - columnExists:
-                tableName: comment
-                columnName: content_html
       changes:
         - addColumn:
             tableName: comment


### PR DESCRIPTION
### Description

Liquibase tracks what has been applied and not, so re-checking if a changeset has ran by looking an "exists" precondition is normally only slowing things down

Comparing startup speed from an empty database:
- Local Postgres 14.5s -> 3.0s
- H2 2.1s -> 1.8s

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
