### PR TITLE
Fix flaky dashboard-filters-boolean tests

### DIFF
--- a/e2e/support/helpers/e2e-bi-basics-helpers.js
+++ b/e2e/support/helpers/e2e-bi-basics-helpers.js
@@ -64,7 +64,10 @@ function getIcon(actionType) {
 export function assertQueryBuilderRowCount(count) {
   const message =
     count === 1 ? "Showing 1 row" : `Showing ${count.toLocaleString()} rows`;
-  cy.findByTestId("question-row-count").should("contain.text", message);
+  cy.findByTestId("question-row-count", { timeout: 10000 }).should(
+    "contain.text",
+    message,
+  );
 }
 
 /**

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-boolean.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-boolean.cy.spec.ts
@@ -164,6 +164,7 @@ describe(
         H.filterWidget().click();
         H.popover().button("Add filter").click();
         H.getDashboardCard().findByText(QUESTION_NAME).click();
+        H.queryBuilderHeader().findByText(QUESTION_NAME).should("be.visible");
         H.assertQueryBuilderRowCount(1);
         H.filterWidget().findByText("true").should("be.visible");
       });
@@ -250,6 +251,7 @@ describe(
         H.filterWidget().click();
         H.popover().button("Add filter").click();
         H.getDashboardCard().findByText(QUESTION_NAME).click();
+        H.queryBuilderHeader().findByText(QUESTION_NAME).should("be.visible");
         H.assertQueryBuilderRowCount(53);
         H.filterWidget().findByText("true").should("be.visible");
       });


### PR DESCRIPTION
Example failure: https://github.com/metabase/metabase/actions/runs/18488111892/job/52676186343?pr=64617

Stress tests (interestingly stress test job does not detect the issue in `master`):
- 1st test: [master](https://github.com/metabase/metabase/actions/runs/18492323663) vs [this branch](https://github.com/metabase/metabase/actions/runs/18492338229)
- 2nd test: [master](https://github.com/metabase/metabase/actions/runs/18492328103) vs [this branch](https://github.com/metabase/metabase/actions/runs/18492345799)