### PR TITLE
Ignore BE exception when checking dependencies

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-card-dependencies/use-check-card-dependencies.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-card-dependencies/use-check-card-dependencies.ts
@@ -14,7 +14,6 @@ import { useCheckDependencies } from "../use-check-dependencies";
 
 export function useCheckCardDependencies({
   onSave,
-  onError,
 }: UseCheckDependenciesProps<Question>): UseCheckDependenciesResult<Question> {
   const store = useStore();
 
@@ -35,6 +34,5 @@ export function useCheckCardDependencies({
     getCheckDependenciesRequest,
     useLazyCheckDependenciesQuery: useLazyCheckCardDependenciesQuery,
     onSave,
-    onError,
   });
 }

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-dependencies/use-check-dependencies.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-dependencies/use-check-dependencies.ts
@@ -23,14 +23,12 @@ type UseCheckDependenciesProps<TChange, TRequest> = {
   getCheckDependenciesRequest: (change: TChange) => TRequest;
   useLazyCheckDependenciesQuery: () => UseCheckDependenciesQueryResult<TRequest>;
   onSave: (change: TChange) => Promise<void>;
-  onError: (error: unknown) => void;
 };
 
 export function useCheckDependencies<TChange, TRequest>({
   getCheckDependenciesRequest,
   useLazyCheckDependenciesQuery,
   onSave,
-  onError,
 }: UseCheckDependenciesProps<
   TChange,
   TRequest
@@ -46,7 +44,8 @@ export function useCheckDependencies<TChange, TRequest>({
         getCheckDependenciesRequest(change),
       );
       if (error != null) {
-        onError(error);
+        console.error("Error when checking dependencies.", error);
+        await onSave(change);
       } else if (data != null && !data.success) {
         setChange(change);
         setIsConfirmationShown(true);
@@ -54,7 +53,7 @@ export function useCheckDependencies<TChange, TRequest>({
         await onSave(change);
       }
     },
-    [getCheckDependenciesRequest, checkDependencies, onSave, onError],
+    [getCheckDependenciesRequest, checkDependencies, onSave],
   );
 
   const handleCloseConfirmation = useCallback(() => {

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-snippet-dependencies/use-check-snippet-dependencies.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-snippet-dependencies/use-check-snippet-dependencies.ts
@@ -12,13 +12,11 @@ import { useCheckDependencies } from "../use-check-dependencies";
 
 export function useCheckSnippetDependencies({
   onSave,
-  onError,
 }: UseCheckDependenciesProps<UpdateSnippetRequest>): UseCheckDependenciesResult<UpdateSnippetRequest> {
   return useCheckDependencies({
     getCheckDependenciesRequest,
     useLazyCheckDependenciesQuery: useLazyCheckSnippetDependenciesQuery,
     onSave,
-    onError,
   });
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-snippet-dependencies/use-check-snippet-dependencies.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-snippet-dependencies/use-check-snippet-dependencies.unit.spec.ts
@@ -18,13 +18,12 @@ function setup({
   setupCheckSnippetDependenciesEndpoint(response);
 
   const onSave = jest.fn();
-  const onError = jest.fn();
   const { result } = renderHookWithProviders(
-    () => useCheckSnippetDependencies({ onSave, onError }),
+    () => useCheckSnippetDependencies({ onSave }),
     {},
   );
 
-  return { result, onSave, onError };
+  return { result, onSave };
 }
 
 describe("useCheckSnippetDependencies", () => {

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-transform-dependencies/use-check-transform-dependencies.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-transform-dependencies/use-check-transform-dependencies.ts
@@ -12,13 +12,11 @@ import { useCheckDependencies } from "../use-check-dependencies";
 
 export function useCheckTransformDependencies({
   onSave,
-  onError,
 }: UseCheckDependenciesProps<UpdateTransformRequest>): UseCheckDependenciesResult<UpdateTransformRequest> {
   return useCheckDependencies({
     getCheckDependenciesRequest,
     useLazyCheckDependenciesQuery: useLazyCheckTransformDependenciesQuery,
     onSave,
-    onError,
   });
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-transform-dependencies/use-check-transform-dependencies.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/hooks/use-check-transform-dependencies/use-check-transform-dependencies.unit.spec.ts
@@ -18,13 +18,12 @@ function setup({
   setupCheckTransformDependenciesEndpoint(response);
 
   const onSave = jest.fn();
-  const onError = jest.fn();
   const { result } = renderHookWithProviders(
-    () => useCheckTransformDependencies({ onSave, onError }),
+    () => useCheckTransformDependencies({ onSave }),
     {},
   );
 
-  return { result, onSave, onError };
+  return { result, onSave };
 }
 
 describe("useCheckTransformDependencies", () => {

--- a/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
@@ -75,9 +75,6 @@ export function TransformQueryPageBody({
         dispatch(push(getTransformUrl(transform.id)));
       }
     },
-    onError: () => {
-      sendErrorToast(t`Failed to update transform query`);
-    },
   });
 
   const handleSaveSource = async (source: TransformSource) => {

--- a/frontend/src/metabase/common/components/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/common/components/SaveQuestionModal/SaveQuestionModal.tsx
@@ -30,9 +30,6 @@ export const SaveQuestionModal = ({
     handleSaveAfterConfirmation,
   } = PLUGIN_DEPENDENCIES.useCheckCardDependencies({
     onSave,
-    onError: (error) => {
-      throw error;
-    },
   });
   useEscapeToCloseModal(onClose);
 

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -916,7 +916,6 @@ export type CheckDependenciesModalProps = {
 
 export type UseCheckDependenciesProps<TChange> = {
   onSave: (change: TChange) => Promise<void>;
-  onError: (error: unknown) => void;
 };
 
 export type UseCheckDependenciesResult<TChange> = {

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
@@ -492,9 +492,6 @@ const _DatasetEditorInner = (props: DatasetEditorInnerProps) => {
       await setQueryBuilderMode("view");
       runQuestionQuery();
     },
-    onError: (error) => {
-      throw error;
-    },
   });
 
   useLayoutEffect(() => {

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.tsx
@@ -75,9 +75,6 @@ export function SnippetFormModal({
     handleCloseConfirmation,
   } = PLUGIN_DEPENDENCIES.useCheckSnippetDependencies({
     onSave: handleUpdate,
-    onError: (error) => {
-      throw error;
-    },
   });
 
   const handleSubmit = useCallback(

--- a/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditor.tsx
+++ b/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditor.tsx
@@ -58,9 +58,6 @@ export const MetricEditor = forwardRef<HTMLDivElement, MetricEditorProps>(
       handleCloseConfirmation,
     } = PLUGIN_DEPENDENCIES.useCheckCardDependencies({
       onSave,
-      onError: (error) => {
-        throw error;
-      },
     });
 
     const handleCreate = (question: Question) => {

--- a/frontend/test/__support__/server-mocks/dependencies.ts
+++ b/frontend/test/__support__/server-mocks/dependencies.ts
@@ -8,6 +8,10 @@ export function setupCheckCardDependenciesEndpoint(
   fetchMock.post("path:/api/ee/dependencies/check_card", response);
 }
 
+export function setupCheckCardDependenciesEndpointError() {
+  fetchMock.post("path:/api/ee/dependencies/check_card", { status: 500 });
+}
+
 export function setupCheckSnippetDependenciesEndpoint(
   response: CheckDependenciesResponse,
 ) {


### PR DESCRIPTION
The endpoint has limitations and sometimes can throw an error. We should proceed as normal in this case.

There is no easy way to verify it in the app. Please take a look at the unit test.