### PR TITLE
Fix caching with drills

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -341,15 +341,15 @@ class ChoroplethMapInner extends Component {
     const onClickFeature =
       isClickable &&
       ((click) => {
-        if (visualizationIsClickable(getFeatureClickObject(rows[0]))) {
-          const featureKey = getFeatureKey(click.feature);
-          const row = rowByFeatureKey.get(featureKey);
-          if (onVisualizationClick) {
-            onVisualizationClick({
-              ...getFeatureClickObject(row, click.feature),
-              event: click.event,
-            });
-          }
+        const featureKey = getFeatureKey(click.feature);
+        const row = rowByFeatureKey.get(featureKey);
+        const clickData = {
+          ...getFeatureClickObject(row, click.feature),
+          event: click.event,
+        };
+
+        if (onVisualizationClick && visualizationIsClickable(clickData)) {
+          onVisualizationClick(clickData);
         }
       });
     const onHoverFeature =

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -105,8 +105,9 @@ export function DetailsTableCell({
     value.startsWith("http");
 
   const handleClick = (e: MouseEvent<HTMLSpanElement>) => {
-    if (onVisualizationClick && visualizationIsClickable(clicked)) {
-      onVisualizationClick({ ...clicked, element: e.currentTarget });
+    const clickData = { ...clicked, element: e.currentTarget };
+    if (onVisualizationClick && visualizationIsClickable(clickData)) {
+      onVisualizationClick(clickData);
     }
   };
 

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -396,14 +396,67 @@ class Visualization extends PureComponent<
     }
   };
 
-  _getQuestionForCardCached(
+  private static getQuestionForCard(
     metadata: Metadata | undefined,
     card: Card | undefined,
   ) {
     return !!card && !!metadata ? new Question(card, metadata) : undefined;
   }
 
-  getMode(
+  _getClickActionsCached(
+    clickedObject: ClickObject | null | undefined,
+    mode: ClickActionModeGetter | Mode | QueryClickActionsMode | undefined,
+    computedSettings: Record<string, string>,
+    dashcard?: DashboardCard,
+    metadata?: Metadata,
+    rawSeries: (
+      | SingleSeries
+      | {
+          card: Card;
+        }
+    )[] = [],
+    visualizerRawSeries: RawSeries = [],
+    isRawTable = false,
+    getExtraDataForClick: (
+      clicked: ClickObject | null,
+    ) => Record<string, unknown> = () => ({}),
+  ) {
+    if (!clickedObject) {
+      return [];
+    }
+
+    const clicked = isVisualizerDashboardCard(dashcard)
+      ? formatVisualizerClickObject(
+          clickedObject,
+          visualizerRawSeries,
+          dashcard.visualization_settings.visualization.columnValuesMapping,
+        )
+      : clickedObject;
+
+    const card = Visualization.findCardById(
+      clicked.cardId,
+      dashcard,
+      rawSeries,
+      visualizerRawSeries,
+    );
+    const question = Visualization.getQuestionForCard(metadata, card);
+    const modeInstance = Visualization.getMode(mode, question);
+
+    return modeInstance
+      ? modeInstance.actionsForClick(
+          {
+            ...clicked,
+            extraData: {
+              ...getExtraDataForClick(clicked),
+              isRawTable,
+            },
+          },
+          computedSettings,
+        )
+      : [];
+  }
+
+  private static getMode(
     modeOrModeGetter:
       | ClickActionModeGetter
       | Mode
@@ -432,54 +485,49 @@ class Visualization extends PureComponent<
   }
 
   getClickActions(clickedObject?: ClickObject | null) {
-    if (!clickedObject) {
-      return [];
-    }
-
     const {
+      mode,
       dashcard,
       metadata,
-      visualizerRawSeries = [],
+      rawSeries,
+      visualizerRawSeries,
       isRawTable,
-      getExtraDataForClick = () => ({}),
+      getExtraDataForClick,
     } = this.props;
 
-    const clicked = isVisualizerDashboardCard(dashcard)
-      ? formatVisualizerClickObject(
-          clickedObject,
-          visualizerRawSeries,
-          dashcard.visualization_settings.visualization.columnValuesMapping,
-        )
-      : clickedObject;
+    const { computedSettings } = this.state;
 
-    const card = this.findCardById(clicked.cardId);
-
-    const question = this._getQuestionForCardCached(metadata, card);
-    const mode = this.getMode(this.props.mode, question);
-
-    return mode
-      ? mode.actionsForClick(
-          {
-            ...clicked,
-            extraData: {
-              ...getExtraDataForClick(clicked),
-              isRawTable,
-            },
-          },
-          this.state.computedSettings,
-        )
-      : [];
+    return this._getClickActionsCached(
+      clickedObject,
+      mode,
+      computedSettings,
+      dashcard,
+      metadata,
+      rawSeries,
+      visualizerRawSeries,
+      isRawTable,
+      getExtraDataForClick,
+    );
   }
 
-  findCardById = (cardId?: CardId | null) => {
-    const { dashcard, rawSeries = [], visualizerRawSeries = [] } = this.props;
+  private static findCardById(
+    cardId?: CardId | null,
+    dashcard?: DashboardCard,
+    rawSeries: (
+      | SingleSeries
+      | {
+          card: Card;
+        }
+    )[] = [],
+    visualizerRawSeries: RawSeries = [],
+  ) {
     const isVisualizerViz = isVisualizerDashboardCard(dashcard);
     const lookupSeries = isVisualizerViz ? visualizerRawSeries : rawSeries;
     return (
       lookupSeries.find((series) => series.card.id === cardId)?.card ??
       lookupSeries[0].card
     );
-  };
+  }
 
   getNormalizedSizes = () => {
     const { width, height } = this.props;
@@ -534,8 +582,16 @@ class Visualization extends PureComponent<
     nextCard,
     objectId,
   }: Pick<OnChangeCardAndRunOpts, "nextCard" | "objectId">) => {
-    this.props.onChangeCardAndRun?.({
-      previousCard: this.findCardById(nextCard?.id),
+    const { dashcard, rawSeries, visualizerRawSeries, onChangeCardAndRun } =
+      this.props;
+
+    onChangeCardAndRun?.({
+      previousCard: Visualization.findCardById(
+        nextCard?.id,
+        dashcard,
+        rawSeries,
+        visualizerRawSeries,
+      ),
       nextCard,
       objectId,
     });
@@ -937,7 +993,7 @@ class Visualization extends PureComponent<
 }
 
 const VisualizationMemoized = memoizeClass<Visualization>(
-  "_getQuestionForCardCached",
+  "_getClickActionsCached",
 )(Visualization);
 
 // eslint-disable-next-line import/no-default-export

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -412,13 +412,11 @@ export const useChartEvents = (
         cardId: seriesModel.cardId,
         dimensions,
         settings,
+        element: event.currentTarget,
       };
 
       if (hasBreakout && visualizationIsClickable(clickData)) {
-        onVisualizationClick({
-          ...clickData,
-          element: event.currentTarget,
-        });
+        onVisualizationClick(clickData);
       } else if (isDashboard) {
         onOpenQuestion(seriesModel.cardId);
       }

--- a/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge/Gauge.jsx
@@ -367,16 +367,24 @@ const GaugeArc = ({
     .outerRadius(OUTER_RADIUS)
     .innerRadius(OUTER_RADIUS * INNER_RADIUS_RATIO);
 
-  const clicked = segment && { value: segment.min, column, settings };
-  const isClickable = clicked && onVisualizationClick != null;
+  const isClickable = segment != null && onVisualizationClick != null;
   const options = column && settings?.column ? settings.column(column) : {};
   const range = segment ? [segment.min, segment.max] : [];
   const value = range.map((v) => formatValue(v, options)).join(" - ");
   const hovered = segment ? { data: [{ key: segment.label, value }] } : {};
 
   const handleClick = (e) => {
-    if (onVisualizationClick && visualizationIsClickable(clicked)) {
-      onVisualizationClick({ ...clicked, event: e.nativeEvent });
+    if (!segment) {
+      return;
+    }
+    const clickData = {
+      value: segment.min,
+      column,
+      settings,
+      event: e.nativeEvent,
+    };
+    if (onVisualizationClick && visualizationIsClickable(clickData)) {
+      onVisualizationClick(clickData);
     }
   };
 

--- a/frontend/src/metabase/visualizations/visualizations/Progress/Progress.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress/Progress.jsx
@@ -221,12 +221,12 @@ export default class Progress extends Component {
 
     const barMessage = getProgressMessage(metrics);
 
-    const clicked = { value, column, settings };
     const isClickable = onVisualizationClick != null;
 
     const handleClick = (e) => {
-      if (onVisualizationClick && visualizationIsClickable(clicked)) {
-        onVisualizationClick({ ...clicked, event: e.nativeEvent });
+      const clickData = { value, column, settings, event: e.nativeEvent };
+      if (onVisualizationClick && visualizationIsClickable(clickData)) {
+        onVisualizationClick(clickData);
       }
     };
 

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -209,12 +209,10 @@ const RowChartVisualization = ({
   };
 
   const handleSelectSeries = (event: React.MouseEvent, seriesIndex: number) => {
-    const clickData = getLegendClickData(
-      seriesIndex,
-      series,
-      settings,
-      chartColumns,
-    );
+    const clickData = {
+      ...getLegendClickData(seriesIndex, series, settings, chartColumns),
+      element: event.currentTarget,
+    };
 
     const areMultipleCards = rawMultipleSeries.length > 1;
     if (areMultipleCards) {
@@ -223,10 +221,7 @@ const RowChartVisualization = ({
     }
 
     if ("breakout" in chartColumns && visualizationIsClickable(clickData)) {
-      onVisualizationClick({
-        ...clickData,
-        element: event.currentTarget,
-      });
+      onVisualizationClick(clickData);
     } else if (isDashboard) {
       openQuestion();
     }

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.tsx
@@ -180,21 +180,27 @@ export class Scalar extends Component<
       formatOptions,
     );
 
-    const clicked = {
-      value,
-      column,
-      data: rows[0]?.map((value, index) => ({ value, col: cols[index] })),
-      settings,
-    };
     const isClickable = onVisualizationClick != null;
 
     const handleClick = () => {
+      if (this._scalar == null) {
+        return;
+      }
+
+      const clickData = {
+        value,
+        column,
+        data: rows[0]?.map((value, index) => ({ value, col: cols[index] })),
+        settings,
+        element: this._scalar,
+      };
+
       if (
         this._scalar &&
         onVisualizationClick &&
-        visualizationIsClickable(clicked)
+        visualizationIsClickable(clickData)
       ) {
-        onVisualizationClick({ ...clicked, element: this._scalar });
+        onVisualizationClick(clickData);
       }
     };
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.tsx
@@ -85,12 +85,18 @@ export function SmartScalar({
   const isClickable = onVisualizationClick != null;
 
   const handleClick = () => {
+    if (scalarRef.current == null) {
+      return;
+    }
+
+    const clickData = { ...clicked, element: scalarRef.current };
+
     if (
       scalarRef.current &&
       onVisualizationClick &&
-      visualizationIsClickable(clicked)
+      visualizationIsClickable(clickData)
     ) {
-      onVisualizationClick({ ...clicked, element: scalarRef.current });
+      onVisualizationClick(clickData);
     }
   };
 


### PR DESCRIPTION
https://metaboat.slack.com/archives/C05MPF0TM3L/p1760443512917079

Fix caching of drills in the `Visualization` component:
- Made the `getClickActions` function memoized
- All its dependents are made static to ensure that no stale props / state are used
- Individual visualizations are updated to pass the same object to `isVisualizationClickable` and `onVisualizationClick` to avoid re-computing drills 2 times on every click.

How to verify:
- Open a question like Orders, Count
- Click on the scalar. There should be one call to `Lib.availableDrillThrus`