### PR TITLE
Include email in forgot password links

### DIFF
--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.tsx
@@ -18,11 +18,12 @@ import { InfoBody, InfoMessage, InfoTitle } from "./ResetPassword.styled";
 
 interface ResetPasswordQueryParams {
   token: string;
+  email?: string;
 }
 
 interface ResetPasswordProps {
   params: ResetPasswordQueryParams;
-  location?: Location<{ redirect?: string }>;
+  location?: Location<{ redirect?: string; email?: string }>;
 }
 
 export const ResetPassword = ({
@@ -31,6 +32,7 @@ export const ResetPassword = ({
 }: ResetPasswordProps): JSX.Element | null => {
   const { token } = params;
   const redirectUrl = location?.query?.redirect;
+  const email = location?.query?.email;
   const dispatch = useDispatch();
   const { data: status, isLoading } =
     useGetPasswordResetTokenStatusQuery(token);
@@ -56,20 +58,30 @@ export const ResetPassword = ({
           onSubmit={handlePasswordSubmit}
         />
       ) : (
-        <ResetPasswordExpired />
+        <ResetPasswordExpired email={email} />
       )}
     </AuthLayout>
   );
 };
 
-const ResetPasswordExpired = (): JSX.Element => {
+interface ResetPasswordExpiredProps {
+  email?: string;
+}
+
+const ResetPasswordExpired = ({
+  email,
+}: ResetPasswordExpiredProps): JSX.Element => {
+  const forgotPasswordUrl = email
+    ? `/auth/forgot_password?email=${encodeURIComponent(email)}`
+    : "/auth/forgot_password";
+
   return (
     <InfoBody>
       <InfoTitle>{t`Whoops, that's an expired link`}</InfoTitle>
       <InfoMessage>
         {t`For security reasons, password reset links expire after a little while. If you still need to reset your password, you can request a new reset email.`}
       </InfoMessage>
-      <Button as={Link} primary to={"/auth/forgot_password"}>
+      <Button as={Link} primary to={forgotPasswordUrl}>
         {t`Request a new reset email`}
       </Button>
     </InfoBody>

--- a/src/metabase/notification/payload/impl/system_event.clj
+++ b/src/metabase/notification/payload/impl/system_event.clj
@@ -1,5 +1,6 @@
 (ns metabase.notification.payload.impl.system-event
   (:require
+   [clojure.string :as str]
    [metabase.appearance.core :as appearance]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.channel.email.messages :as messages]
@@ -9,19 +10,23 @@
    [metabase.system.core :as system]
    [metabase.users.models.user :as user]
    [metabase.util.i18n :refer [trs]]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [toucan2.core :as t2]))
 
 (defn- join-url
   [user-id redirect]
   ;; TODO: the reset token should come from the event-info, not generated here!
   (let [reset-token               (auth-identity/create-password-reset! user-id)
         should-link-to-login-page (and (sso/sso-enabled?)
-                                       (not (session/enable-password-login)))]
+                                       (not (session/enable-password-login)))
+        email (t2/select-one-fn :email [:model/User :email] user-id)]
     (if should-link-to-login-page
       (str (system/site-url) "/auth/login")
       ;; NOTE: the new user join url is a password reset route with an indicator that this is a first time user.
       (str (user/form-password-reset-url reset-token)
-           (when redirect (str "?redirect=" redirect))
+           "?"
+           (str/join "&" (remove nil? [(when redirect (str "redirect=" redirect))
+                                       (when email (str "email=" email))]))
            "#new"))))
 
 (defn- custom-payload

--- a/test/metabase/notification/payload/impl/system_event_test.clj
+++ b/test/metabase/notification/payload/impl/system_event_test.clj
@@ -157,7 +157,7 @@
              "You're invited to join SuperStar's Metabase"
              [#"Kratos could use your help setting up Metabase"
               #"Your Metabase is up and running, but Kratos needs you to connect your data. You'll probably need:"
-              #"<a[^>]*href=\"https?://metabase\.com/auth/reset_password/.*\?redirect(&#x3D;|=)/admin/databases/create#new\"[^>]*>"]
+              #"<a[^>]*href=\"https?://metabase\.com/auth/reset_password/.*\?redirect(&#x3D;|=)/admin/databases/create.*#new\"[^>]*>"]
              "Kratos")
 
       (testing "with invitor's first_name not defined"
@@ -165,7 +165,7 @@
                "You're invited to join SuperStar's Metabase"
                [#"You are invited to help setting up Metabase"
                 #"Your Metabase is up and running, but your help is needed to connect data. You'll probably need:"
-                #"<a[^>]*href=\"https?://metabase\.com/auth/reset_password/.*\?redirect(&#x3D;|=)/admin/databases/create#new\"[^>]*>"]
+                #"<a[^>]*href=\"https?://metabase\.com/auth/reset_password/.*\?redirect(&#x3D;|=)/admin/databases/create.*#new\"[^>]*>"]
                nil)))))
 
 (deftest notification-create-email-test

--- a/test/metabase/users/models/user_test.clj
+++ b/test/metabase/users/models/user_test.clj
@@ -34,7 +34,7 @@
   the only place to get it (the token stored in the DB is an encrypted hash)."
   [new-user-email-address]
   (when-let [[{[{invite-email :content}] :body}] (get @mt/inbox new-user-email-address)]
-    (let [[_ reset-token] (re-find #"/auth/reset_password/(\d+_[\w_-]+)#new" invite-email)]
+    (let [[_ reset-token] (re-find #"/auth/reset_password/(\d+_[\w_-]+)\?.+#new" invite-email)]
       (client/client :post 200 "session/reset_password" {:token    reset-token
                                                          :password "p@ssword1"}))))
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63146
Theoretically the BE could provide the email if you send in an expired token, but it seems slightly less controversial to just provide a link like `/auth/reset_password/the-very-long-token?email=some%40email.com`.

This way having the expired token itself can't reveal any information, but if you click on an expired link, then it's just 2 clicks to send yourself a fresh token instead of click -> type email -> click.

Fixes [UXW-658: New user invites expire quickly, adds friction to new user experience](https://linear.app/metabase/issue/UXW-658/new-user-invites-expire-quickly-adds-friction-to-new-user-experience)
