### PR TITLE
Cancel sql transform preview

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -1618,6 +1618,19 @@ LIMIT
         "This run succeeded before it had a chance to cancel.",
       );
     });
+
+    it("should be possible to cancel a SQL transform from the preview (metabase#64474)", () => {
+      createSlowTransform(500);
+      getTransformPage().findByText("Edit query").click();
+
+      getQueryEditor().within(() => {
+        cy.findAllByTestId("run-button").eq(0).click();
+        cy.findByTestId("loading-indicator").should("be.visible");
+
+        cy.findAllByTestId("run-button").eq(0).click();
+        cy.findByTestId("loading-indicator").should("not.exist");
+      });
+    });
   });
 
   describe("dependencies", () => {
@@ -2686,7 +2699,7 @@ function getQueryEditor() {
 }
 
 function getRunButton(options: { timeout?: number } = {}) {
-  return cy.findByTestId("run-button", options);
+  return cy.findAllByTestId("run-button", options).eq(0);
 }
 
 function getCancelButton() {


### PR DESCRIPTION
Closes #64474

Fixes the cancel functionality for the SQL transform editor.

#### To verify
1.  Create a new transform that takes some time to run (i.e. select pg_sleep(60))
2.  Run the transform from the editor
3.  See that the button turns into an X icon
4.  Click it again
    - This should cancel the query 
