### PR TITLE
disable excessive spam in the prs caused by sdk build

### DIFF
--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -180,9 +180,9 @@ jobs:
 
       - name: Build Embedding SDK package
         run: |
+          # Remove the matchers to not report false positives on every PR
+          # unrelated to embedding (EMB-765)
           echo "::remove-matcher owner=tsc::"
-          echo "::remove-matcher owner=eslint-compact::"
-          echo "::remove-matcher owner=eslint-stylish::"
           yarn build-embedding-sdk-package
 
       - name: Prepare Embedding SDK artifact

--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -179,7 +179,11 @@ jobs:
           name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
 
       - name: Build Embedding SDK package
-        run: yarn build-embedding-sdk-package
+        run: |
+          echo "::remove-matcher owner=tsc::"
+          echo "::remove-matcher owner=eslint-compact::"
+          echo "::remove-matcher owner=eslint-stylish::"
+          yarn build-embedding-sdk-package
 
       - name: Prepare Embedding SDK artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -44,9 +44,9 @@ jobs:
           m2-cache-key: "cljs"
       - name: Build Embedding SDK package
         run: |
+          # Remove the matchers to not report false positives on every PR
+          # unrelated to embedding (EMB-765)
           echo "::remove-matcher owner=tsc::"
-          echo "::remove-matcher owner=eslint-compact::"
-          echo "::remove-matcher owner=eslint-stylish::"
           yarn build-embedding-sdk-package
       - name: Prepare Embedding SDK artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -38,14 +38,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
-      - name: Disable TypeScript annotations
-        run: echo "::remove-matcher owner=tsc::"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
           m2-cache-key: "cljs"
       - name: Build Embedding SDK package
-        run: yarn build-embedding-sdk-package
+        run: |
+          echo "::remove-matcher owner=tsc::"
+          echo "::remove-matcher owner=eslint-compact::"
+          echo "::remove-matcher owner=eslint-stylish::"
+          yarn build-embedding-sdk-package
       - name: Prepare Embedding SDK artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+      - name: Disable TypeScript annotations
+        run: echo "::remove-matcher owner=tsc::"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -131,3 +131,6 @@ export type { EmbeddingEntityType } from "metabase-types/store/embedding-data-pi
 
 export type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 export type { IconName } from "metabase/embedding-sdk/types/icon";
+
+// eslint-disable-next-line no-console
+console.log("triggering the builds");

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -131,6 +131,3 @@ export type { EmbeddingEntityType } from "metabase-types/store/embedding-data-pi
 
 export type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 export type { IconName } from "metabase/embedding-sdk/types/icon";
-
-// eslint-disable-next-line no-console
-console.log("triggering the builds");


### PR DESCRIPTION
It disables this excessive spam until we actually make tsc not output those errors (with https://linear.app/metabase/issue/EMB-765/fix-tsc-errors-on-sdk-build)

This seems to only show up in the "old view" for reviewing prs, but it's still annoying. It works by disabling the problem matchers for tsc (that are setup by default by setup-node) so that github won't add those comments for the build step.


Before:
<img width="1228" height="844" alt="image" src="https://github.com/user-attachments/assets/fd650a74-f7c4-487f-af3e-d7194fc08fcb" />

After:
see https://github.com/metabase/metabase/pull/64742/files *WITH THE OLD GITHUB PR VIEW*


