### PR TITLE
Fix Pie and Cartesian charts viz settings not translated

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -150,6 +150,7 @@ type SpecificTranslationConfig = {
 const visualizationTranslationConfig: Partial<
   Record<VisualizationDisplay, SpecificTranslationConfig>
 > = {
+  // Represents all cartesian charts
   pie: {
     settingsKey: "pie.rows",
     isValueInSettings: (pieRows = [], value) => {

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -251,7 +251,6 @@ export const translateCardNames = (
 
 export const useTranslateSeries = (series: Series) => {
   const tc = useTranslateContent();
-  // const dictionary = useListContentTranslations();
   return useMemo(() => {
     if (!hasTranslations(tc)) {
       return series;

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from "react";
 import _ from "underscore";
 
 import type { ContentTranslationFunction } from "metabase/i18n/types";
+import { isCartesianChart } from "metabase/visualizations";
 import type { HoveredObject } from "metabase/visualizations/types";
 import type {
   DictionaryArray,
@@ -204,8 +205,11 @@ export const translateFieldValuesInSeries = (
 
     const translatedRows: RowValue[][] = singleSeries.data.rows.map((row) =>
       row.map((value) => {
+        const display = singleSeries.card?.display;
         const translationConfig =
-          visualizationTranslationConfig[singleSeries.card?.display];
+          visualizationTranslationConfig[
+            isCartesianChart(display) ? "bar" : display
+          ];
         if (translationConfig?.isValueInSettings) {
           const setting: any =
             singleSeries.card.visualization_settings[
@@ -276,8 +280,11 @@ function translateVizSettings(
   tc: ContentTranslationFunction,
 ): Series {
   return series.map((singleSeries) => {
+    const display = singleSeries.card?.display;
     const translationConfig =
-      visualizationTranslationConfig[singleSeries.card?.display];
+      visualizationTranslationConfig[
+        isCartesianChart(display) ? "bar" : display
+      ];
 
     if (translationConfig) {
       return I.updateIn(

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -226,7 +226,7 @@ export interface ColumnSettings {
   [key: string]: any;
 }
 
-export type VisualizationSettings = {
+type TypedVisualizationSettings = {
   "graph.show_values"?: boolean;
   "stackable.stack_type"?: StackType;
   "graph.show_stack_values"?: StackValuesDisplay;
@@ -329,15 +329,16 @@ export type VisualizationSettings = {
   // List view settings
   "list.columns"?: ListViewColumns;
   "list.entity_icon"?: string;
+};
 
-  [key: string]: any;
-} & EmbedVisualizationSettings;
+export type VisualizationSettings = TypedVisualizationSettings &
+  EmbedVisualizationSettings & { [key: string]: any };
 
 export type EmbedVisualizationSettings = {
   iframe?: string;
 };
 
-export type VisualizationSettingKey = keyof VisualizationSettings;
+export type VisualizationSettingKey = keyof TypedVisualizationSettings;
 
 export type CardId = number;
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63972
Closes EMB-853

### Description

Rationale: Adding code in the function that modifies values tie to how each visualization is processed. And it's harder to understand and fix since we need to understand how each visualization processes the settings and value altogether to result in the value/legends on the display.

Modifying only the visualization settings is far easier to understand as viz settings shape doesn't change as often.

And another important detail is that we also only translate values that are not already in the visualization settings, since those in viz settings will be replaced by one in the viz settings. Then we translate all strings found in the viz settings according to each chart type under interests. This adds a bit more logic on the value translation.
 
### How to verify

### Demo


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
