### PR TITLE
Fix the `fixup-viz-settings` hack

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/notification/payload/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/notification/payload/execute_test.clj
@@ -8,42 +8,69 @@
 (deftest viz-settings-is-correctly-returned
   (testing (str "2 questions with the same query but different viz-settings on a dashboard "
                 "with caching enabled should returns the correct viz-settings #57793")
-    (let [query (mt/mbql-query orders {:limit 1})
-          viz-settings-for-dashcard (fn [dashboard-id dashcard-id card-id]
-                                      (-> (mt/as-admin
-                                            (notification.payload.execute/execute-dashboard-subscription-card
-                                             {:dashboard_id dashboard-id
-                                              :card_id      card-id
-                                              :id           dashcard-id}
-                                             []))
-                                          :result
-                                          :data
-                                          :viz-settings :ver))
-          viz-settings-for-card (fn [card-id]
-                                  (-> (notification.payload.execute/execute-card
-                                       (mt/user->id :crowberto)
-                                       card-id)
-                                      :result
-                                      :data
-                                      :viz-settings :ver))]
+    (let [query (mt/mbql-query orders {:aggregation [[:count]
+                                                     [:sum $total]]})
+          result-for-dashcard (fn [dashboard-id dashcard-id card-id]
+                                (-> (mt/as-admin
+                                      (notification.payload.execute/execute-dashboard-subscription-card
+                                       {:dashboard_id dashboard-id
+                                        :card_id      card-id
+                                        :id           dashcard-id}
+                                       []))
+                                    :result))
+          result-for-card (fn [card-id]
+                            (-> (notification.payload.execute/execute-card
+                                 (mt/user->id :crowberto)
+                                 card-id)
+                                :result))]
       (t2/delete! :model/QueryCache)
-      (mt/with-temp
-        [:model/Card {card-1 :id}              {:dataset_query query
-                                                :visualization_settings {:ver 1}}
-         :model/Card {card-2 :id}              {:dataset_query query
-                                                :visualization_settings {:ver 2}}
-         :model/Dashboard {dashboard-id :id}   {}
-         :model/DashboardCard {dashcard-1 :id} {:dashboard_id dashboard-id
-                                                :card_id     card-1}
-         :model/DashboardCard {dashcard-2 :id} {:dashboard_id dashboard-id
-                                                :card_id     card-2}
-         :model/CacheConfig _                  {:model    "dashboard"
-                                                :model_id dashboard-id
-                                                :strategy :duration
-                                                :config   {:unit    :hours
-                                                           :duration 1}}]
-        (is (= 1 (viz-settings-for-dashcard dashboard-id dashcard-1 card-1)))
-        (is (= 1 (viz-settings-for-card card-1)))
-        (testing "card 2 should have viz-settings is 2"
-          (is (= 2 (viz-settings-for-card card-2)))
-          (is (= 2 (viz-settings-for-dashcard dashboard-id dashcard-2 card-2))))))))
+      (mt/with-premium-features #{:cache-granular-controls}
+        (mt/with-temp
+          ;; Card 1 has count hidden, sum visible
+          [:model/Card {card-1 :id}              {:dataset_query query
+                                                  :visualization_settings
+                                                  {:table.cell_column "count", :table.columns [{:name "count", :enabled false} {:name "sum", :enabled true}]}}
+           ;; Card 2 has count visible, sum hidden
+           :model/Card {card-2 :id}              {:dataset_query query
+                                                  :visualization_settings
+                                                  {:table.cell_column "count", :table.columns [{:name "count", :enabled true} {:name "sum", :enabled false}]}}
+           :model/Dashboard {dashboard-id :id}   {}
+           :model/DashboardCard {dashcard-1 :id} {:dashboard_id dashboard-id
+                                                  :card_id     card-1}
+           :model/DashboardCard {dashcard-2 :id} {:dashboard_id dashboard-id
+                                                  :card_id     card-2}
+           :model/CacheConfig _                  {:model    "database"
+                                                  :model_id (mt/id)
+                                                  :strategy :duration
+                                                  :config   {:unit    :hours
+                                                             :duration 1}}]
+          (testing "Card 1 has count hidden and sum visible"
+            (is (=? {:cached nil?
+                     :data {:viz-settings {:metabase.models.visualization-settings/table-columns
+                                           [{:metabase.models.visualization-settings/table-column-enabled false
+                                             :metabase.models.visualization-settings/table-column-name "count"}
+                                            {:metabase.models.visualization-settings/table-column-enabled true
+                                             :metabase.models.visualization-settings/table-column-name "sum"}]}}}
+                    (result-for-dashcard dashboard-id dashcard-1 card-1)))
+            (is (=? {:cached some?
+                     :data {:viz-settings {:metabase.models.visualization-settings/table-columns
+                                           [{:metabase.models.visualization-settings/table-column-enabled true
+                                             :metabase.models.visualization-settings/table-column-name "count"}
+                                            {:metabase.models.visualization-settings/table-column-enabled false
+                                             :metabase.models.visualization-settings/table-column-name "sum"}]}}}
+                    (result-for-dashcard dashboard-id dashcard-2 card-2))))
+          (testing "Card 2 has count visible and sum hidden"
+            (is (=? {:cached some?
+                     :data {:viz-settings {:metabase.models.visualization-settings/table-columns
+                                           [{:metabase.models.visualization-settings/table-column-enabled false
+                                             :metabase.models.visualization-settings/table-column-name "count"}
+                                            {:metabase.models.visualization-settings/table-column-enabled true
+                                             :metabase.models.visualization-settings/table-column-name "sum"}]}}}
+                    (result-for-card card-1)))
+            (is (=? {:cached some?
+                     :data {:viz-settings {:metabase.models.visualization-settings/table-columns
+                                           [{:metabase.models.visualization-settings/table-column-enabled true
+                                             :metabase.models.visualization-settings/table-column-name "count"}
+                                            {:metabase.models.visualization-settings/table-column-enabled false
+                                             :metabase.models.visualization-settings/table-column-name "sum"}]}}}
+                    (result-for-card card-2)))))))))

--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -7,6 +7,7 @@
    [metabase.dashboards.models.dashboard-card :as dashboard-card]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
+   [metabase.models.visualization-settings :as viz-settings]
    [metabase.notification.payload.temp-storage :as notification.temp-storage]
    [metabase.parameters.shared :as shared.params]
    [metabase.query-processor :as qp]
@@ -135,10 +136,11 @@
 
 (defn- fixup-viz-settings
   "The viz-settings from :data :viz-settings might be incorrect if there is a cached of the same query.
-  See #58469.
+  See #58469 and #64687.
   TODO: remove this hack when it's fixed in QP."
   [qp-result]
-  (update-in qp-result [:data :viz-settings] merge (get-in qp-result [:json_query :viz-settings])))
+  (update-in qp-result [:data :viz-settings] merge (-> (get-in qp-result [:json_query :viz-settings])
+                                                       viz-settings/db->norm)))
 
 (def rows-to-disk-threshold
   "Maximum rows to hold in memory when running notification queries. After this, query results are streamed straight to disk. See [[metabase.notification.payload.temp-storage]] for more details."


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64687
This fixup broke because QP started returning the db-shaped viz-settings (e.g. `:table.columns`) instead of the normalized viz-settings (e.g.
`:metabase.models.visualization-settings/table-columns `) under `[:json_query :viz-settings]`.

The existing test for this fix did not catch the regression because the shape of viz settings was faked out for testing, and did not get transformed like real viz settings. `{:ver 2}` stayed as `{:ver 2}`, while `{:table.columns []}` is transformed into
`{::visualization-settings/table-columns []}`

Fixes [UXW-1992: Query Cache can Cause Incorrect Subscription Visualizations](https://linear.app/metabase/issue/UXW-1992/query-cache-can-cause-incorrect-subscription-visualizations) / #64687,  which was a regression of #58469 