### PR TITLE
Avoid setting up python transforms in every e2e test

### DIFF
--- a/.github/scripts/build-e2e-matrix.js
+++ b/.github/scripts/build-e2e-matrix.js
@@ -18,6 +18,7 @@ const specialTestConfigs = [
     specs: DEFAULT_SPEC_PATTERN,
   },
   { name: "mongo", tags: "@mongo", specs: DEFAULT_SPEC_PATTERN },
+  { name: "python", tags: "@python", specs: DEFAULT_SPEC_PATTERN },
 ];
 
 /**

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -65,6 +65,7 @@ jobs:
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Setup python-runner
+        if: ${{ inputs.name == python }}
         env:
           METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         run: ./.github/scripts/setup-python-runner.sh

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           echo "Running tests with specs: $SPEC_PATH"
           node e2e/runner/run_cypress_ci.js e2e \
-            --env grepTags="-@mongo+-@flaky+-@OSS+-@skip",grepOmitFiltered=true \
+            --env grepTags="-@mongo+-@python+-@flaky+-@OSS+-@skip",grepOmitFiltered=true \
             --spec "$SPEC_PATH" \
             --browser ${{ steps.cypress-prep.outputs.chrome-path }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -65,7 +65,7 @@ jobs:
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Setup python-runner
-        if: ${{ inputs.name == python }}
+        if: ${{ inputs.name == 'python' }}
         env:
           METABASE_AUTOMATION_USER_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         run: ./.github/scripts/setup-python-runner.sh

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -1400,7 +1400,7 @@ LIMIT
       H.assertQueryBuilderRowCount(1);
     });
 
-    it("should be able to update a Python query", () => {
+    it("should be able to update a Python query", { tags: ["@python"] }, () => {
       setPythonRunnerSettings();
       cy.log("create a new transform");
       H.getTableId({ name: "Animals", databaseId: WRITABLE_DB_ID }).then(

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -191,7 +191,7 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
 
     it(
       "should be possible to create and run a Python transform",
-      { tags: ["@transforms-python"] },
+      { tags: ["@python"] },
       () => {
         setPythonRunnerSettings();
         cy.log("create a new transform");
@@ -1675,7 +1675,7 @@ LIMIT
   describe("python > common library", () => {
     it(
       "should be possible to edit and save the common library",
-      { tags: ["@transforms-python"] },
+      { tags: ["@python"] },
       () => {
         visitCommonLibrary();
 
@@ -1713,7 +1713,7 @@ LIMIT
 
     it(
       "should be possible to use the common library",
-      { tags: ["@transforms-python"] },
+      { tags: ["@python"] },
       () => {
         setPythonRunnerSettings();
         createPythonLibrary(


### PR DESCRIPTION
Resolves https://linear.app/metabase/issue/GDGT-1032/avoid-setting-up-python-transforms-in-every-e2e-test

This PR saves 45 - 50 seconds from each of the e2e test groups.