### PR TITLE
ci: allow running stress tests on sdk tests

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -80,8 +80,6 @@ jobs:
     timeout-minutes: 60
     name: Stress test E2E flake fix
     env:
-      CYPRESS_CI: true
-      CYPRESS_IS_EMBEDDING_SDK: ${{ needs.determine-suite.outputs.suite == 'component' }}
       DISPLAY: ""
       QA_DB_ENABLED: ${{ contains(fromJSON('["sql", "mongo"]'), inputs.qa_db) }}
       CYPRESS_QA_DB_MONGO: ${{ inputs.qa_db == 'mongo' }}

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -109,6 +109,16 @@ jobs:
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+
+      - name: Prepare back-end environment
+        if: ${{ inputs.test_suite == 'component' }}
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: "cljs"
+      - name: Build Embedding SDK package
+        if: ${{ inputs.test_suite == 'component' }}
+        run: yarn build-embedding-sdk-package
+
       - name: Prepare JDK 21
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -110,6 +110,11 @@ jobs:
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
 
+      - name: Prepare back-end environment
+        if: ${{ inputs.test_suite == 'component' }}
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: "cljs"
       - name: Build Embedding SDK package
         if: ${{ inputs.test_suite == 'component' }}
         run: yarn build-embedding-sdk-package

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       test_suite:
         description: "The test suite to run"
-        type: string
+        type: choice
         required: true
         default: "e2e"
         options:

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -137,6 +137,7 @@ jobs:
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         env:
           GREP: ${{ github.event.inputs.grep }}
+          CYPRESS_IS_EMBEDDING_SDK: ${{ github.event.inputs.test_suite == 'component' }}
         run: |
           node e2e/runner/run_cypress_ci.js ${{ github.event.inputs.test_suite }} \
           --spec '${{ github.event.inputs.spec }}' \

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -37,24 +37,36 @@ on:
         default: true
 
 jobs:
+  determine-suite:
+    name: Determine test suite
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      suite: ${{ steps.detect.outputs.name }}
+    steps:
+      - name: Detect suite from spec path
+        id: detect
+        run: |
+          SPEC='${{ inputs.spec }}'
+          if [[ "$SPEC" == e2e/test-component/scenarios/embedding-sdk/* ]]; then
+            echo "name=component" >> $GITHUB_OUTPUT
+          else
+            echo "name=e2e" >> $GITHUB_OUTPUT
+          fi
+
   workflow-summary:
     name: Stress test inputs
+    needs: [determine-suite]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - name: Generate workflow summary
         run: |
-          SPEC='${{ inputs.spec }}'
-          if [[ "$SPEC" == e2e/test-component/scenarios/embedding-sdk/* ]]; then
-            SUITE="component"
-          else
-            SUITE="e2e"
-          fi
           echo '**Inputs:**' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '- `branch`: ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
           echo '- `spec`: ${{ inputs.spec }}' >> $GITHUB_STEP_SUMMARY
-          echo '- `test_suite` (inferred): '"$SUITE" >> $GITHUB_STEP_SUMMARY
+          echo '- `test_suite` (inferred): ${{ needs.determine-suite.outputs.suite }}' >> $GITHUB_STEP_SUMMARY
           echo '- `burn_in`: ${{ inputs.burn_in }}' >> $GITHUB_STEP_SUMMARY
           echo '- `grep`: "${{ inputs.grep }}"' >> $GITHUB_STEP_SUMMARY
           echo '- `qa_db`: "${{ inputs.qa_db }}"' >> $GITHUB_STEP_SUMMARY
@@ -63,6 +75,7 @@ jobs:
           echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
 
   stress-test-flake-fix:
+    needs: [determine-suite]
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     name: Stress test E2E flake fix
@@ -108,22 +121,13 @@ jobs:
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
 
-      - name: Determine test suite
-        id: suite
-        run: |
-          SPEC='${{ inputs.spec }}'
-          if [[ "$SPEC" == e2e/test-component/scenarios/embedding-sdk/* ]]; then
-            echo "name=component" >> $GITHUB_OUTPUT
-          else
-            echo "name=e2e" >> $GITHUB_OUTPUT
-          fi
       - name: Prepare back-end environment
-        if: ${{ steps.suite.outputs.name == 'component' }}
+        if: ${{ needs.determine-suite.outputs.suite == 'component' }}
         uses: ./.github/actions/prepare-backend
         with:
           m2-cache-key: "cljs"
       - name: Build Embedding SDK package
-        if: ${{ steps.suite.outputs.name == 'component' }}
+        if: ${{ needs.determine-suite.outputs.suite == 'component' }}
         run: yarn build-embedding-sdk-package
 
       - name: Prepare JDK 21
@@ -144,9 +148,9 @@ jobs:
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         env:
           GREP: ${{ github.event.inputs.grep }}
-          CYPRESS_IS_EMBEDDING_SDK: ${{ steps.suite.outputs.name == 'component' }}
+          CYPRESS_IS_EMBEDDING_SDK: ${{ needs.determine-suite.outputs.suite == 'component' }}
         run: |
-          node e2e/runner/run_cypress_ci.js ${{ steps.suite.outputs.name }} \
+          node e2e/runner/run_cypress_ci.js ${{ needs.determine-suite.outputs.suite }} \
           --spec '${{ github.event.inputs.spec }}' \
           --env burn=${{ github.event.inputs.burn_in }} \
           --config-file e2e/support/cypress-stress-test.config.js \

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -3,14 +3,6 @@ name: E2E Stress Test Flake Fix
 on:
   workflow_dispatch:
     inputs:
-      test_suite:
-        description: "The test suite to run"
-        type: choice
-        required: true
-        default: "e2e"
-        options:
-          - e2e
-          - component
       spec:
         description: "Relative path of the target spec"
         type: string
@@ -52,11 +44,17 @@ jobs:
     steps:
       - name: Generate workflow summary
         run: |
+          SPEC='${{ inputs.spec }}'
+          if [[ "$SPEC" == e2e/test-component/scenarios/embedding-sdk/* ]]; then
+            SUITE="component"
+          else
+            SUITE="e2e"
+          fi
           echo '**Inputs:**' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
-          echo '- `test_suite`: ${{ inputs.test_suite }}' >> $GITHUB_STEP_SUMMARY
           echo '- `branch`: ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
           echo '- `spec`: ${{ inputs.spec }}' >> $GITHUB_STEP_SUMMARY
+          echo '- `test_suite` (inferred): '"$SUITE" >> $GITHUB_STEP_SUMMARY
           echo '- `burn_in`: ${{ inputs.burn_in }}' >> $GITHUB_STEP_SUMMARY
           echo '- `grep`: "${{ inputs.grep }}"' >> $GITHUB_STEP_SUMMARY
           echo '- `qa_db`: "${{ inputs.qa_db }}"' >> $GITHUB_STEP_SUMMARY
@@ -110,13 +108,22 @@ jobs:
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
 
+      - name: Determine test suite
+        id: suite
+        run: |
+          SPEC='${{ inputs.spec }}'
+          if [[ "$SPEC" == e2e/test-component/scenarios/embedding-sdk/* ]]; then
+            echo "name=component" >> $GITHUB_OUTPUT
+          else
+            echo "name=e2e" >> $GITHUB_OUTPUT
+          fi
       - name: Prepare back-end environment
-        if: ${{ inputs.test_suite == 'component' }}
+        if: ${{ steps.suite.outputs.name == 'component' }}
         uses: ./.github/actions/prepare-backend
         with:
           m2-cache-key: "cljs"
       - name: Build Embedding SDK package
-        if: ${{ inputs.test_suite == 'component' }}
+        if: ${{ steps.suite.outputs.name == 'component' }}
         run: yarn build-embedding-sdk-package
 
       - name: Prepare JDK 21
@@ -137,9 +144,9 @@ jobs:
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         env:
           GREP: ${{ github.event.inputs.grep }}
-          CYPRESS_IS_EMBEDDING_SDK: ${{ github.event.inputs.test_suite == 'component' }}
+          CYPRESS_IS_EMBEDDING_SDK: ${{ steps.suite.outputs.name == 'component' }}
         run: |
-          node e2e/runner/run_cypress_ci.js ${{ github.event.inputs.test_suite }} \
+          node e2e/runner/run_cypress_ci.js ${{ steps.suite.outputs.name }} \
           --spec '${{ github.event.inputs.spec }}' \
           --env burn=${{ github.event.inputs.burn_in }} \
           --config-file e2e/support/cypress-stress-test.config.js \

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -3,6 +3,14 @@ name: E2E Stress Test Flake Fix
 on:
   workflow_dispatch:
     inputs:
+      test_suite:
+        description: "The test suite to run"
+        type: string
+        required: true
+        default: "e2e"
+        options:
+          - e2e
+          - component
       spec:
         description: "Relative path of the target spec"
         type: string
@@ -119,7 +127,7 @@ jobs:
         env:
           GREP: ${{ github.event.inputs.grep }}
         run: |
-          node e2e/runner/run_cypress_ci.js e2e \
+          node e2e/runner/run_cypress_ci.js ${{ github.event.inputs.test_suite }} \
           --spec '${{ github.event.inputs.spec }}' \
           --env burn=${{ github.event.inputs.burn_in }} \
           --config-file e2e/support/cypress-stress-test.config.js \

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           echo '**Inputs:**' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
+          echo '- `test_suite`: ${{ inputs.test_suite }}' >> $GITHUB_STEP_SUMMARY
           echo '- `branch`: ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
           echo '- `spec`: ${{ inputs.spec }}' >> $GITHUB_STEP_SUMMARY
           echo '- `burn_in`: ${{ inputs.burn_in }}' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -110,11 +110,6 @@ jobs:
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
 
-      - name: Prepare back-end environment
-        if: ${{ inputs.test_suite == 'component' }}
-        uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - name: Build Embedding SDK package
         if: ${{ inputs.test_suite == 'component' }}
         run: yarn build-embedding-sdk-package

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -80,6 +80,8 @@ jobs:
     timeout-minutes: 60
     name: Stress test E2E flake fix
     env:
+      CYPRESS_CI: true
+      CYPRESS_IS_EMBEDDING_SDK: ${{ needs.determine-suite.outputs.suite == 'component' }}
       DISPLAY: ""
       QA_DB_ENABLED: ${{ contains(fromJSON('["sql", "mongo"]'), inputs.qa_db) }}
       CYPRESS_QA_DB_MONGO: ${{ inputs.qa_db == 'mongo' }}

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -42,16 +42,16 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
-      suite: ${{ steps.detect.outputs.name }}
+      suite: ${{ steps.detect.outputs.suite }}
     steps:
       - name: Detect suite from spec path
         id: detect
         run: |
           SPEC='${{ inputs.spec }}'
           if [[ "$SPEC" == e2e/test-component/scenarios/embedding-sdk/* ]]; then
-            echo "name=component" >> $GITHUB_OUTPUT
+            echo "suite=component" >> $GITHUB_OUTPUT
           else
-            echo "name=e2e" >> $GITHUB_OUTPUT
+            echo "suite=e2e" >> $GITHUB_OUTPUT
           fi
 
   workflow-summary:

--- a/e2e/support/cypress-stress-test.config.js
+++ b/e2e/support/cypress-stress-test.config.js
@@ -1,5 +1,11 @@
 const { defineConfig } = require("cypress");
 
-const { stressTestConfig } = require("./config");
+const {
+  stressTestConfig,
+  embeddingSdkComponentTestConfig,
+} = require("./config");
 
-module.exports = defineConfig({ e2e: stressTestConfig });
+module.exports = defineConfig({
+  e2e: stressTestConfig,
+  component: { ...embeddingSdkComponentTestConfig, retries: 0 },
+});

--- a/e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers.tsx
+++ b/e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers.tsx
@@ -61,7 +61,9 @@ export function mountSdkContent(
   }
 
   if (waitForUser) {
-    cy.wait("@getUser", { timeout: 15000 }).then(({ response }) => {
+    // When running stress tests with network throttling, the request can take longer to complete
+    // as it first needs to fetch the bundle from the server
+    cy.wait("@getUser", { timeout: 20_000 }).then(({ response }) => {
       expect(response?.statusCode).to.equal(200);
     });
   }

--- a/e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers.tsx
+++ b/e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers.tsx
@@ -61,7 +61,7 @@ export function mountSdkContent(
   }
 
   if (waitForUser) {
-    cy.wait("@getUser").then(({ response }) => {
+    cy.wait("@getUser", { timeout: 15000 }).then(({ response }) => {
       expect(response?.statusCode).to.equal(200);
     });
   }


### PR DESCRIPTION
Closes [EMB-884: make it possible to stress test sdk e2e tests](https://linear.app/metabase/issue/EMB-884/make-it-possible-to-stress-test-sdk-e2e-tests)


This PR adds an extra step that checks for the path of the test we want to run and determines which suite to run ("e2e" for normal test or "component" for sdk test).
It then uses the suite to determine if it should build the sdk and passes some envs to make the sdk tests run correctly.


Example runs:
on an non-sdk spec: https://github.com/metabase/metabase/actions/runs/19043051922
(a test failed but not my fault 🤷 )
<img width="827" height="851" alt="image" src="https://github.com/user-attachments/assets/787152a6-2d8e-4a80-986a-87a266fc82e7" />

on an sdk spec: https://github.com/metabase/metabase/actions/runs/19043024465
<img width="787" height="833" alt="image" src="https://github.com/user-attachments/assets/cc119407-9626-42f6-9ce6-ba8240a2a7b9" />
