### PR TITLE
Move CodeMirror cursor fix in darkmode to shared CodeMirror module

### DIFF
--- a/frontend/src/metabase/common/components/CodeMirror/CodeMirror.module.css
+++ b/frontend/src/metabase/common/components/CodeMirror/CodeMirror.module.css
@@ -59,6 +59,7 @@
 
     .cm-cursor {
       border-left-width: 1.6px;
+      border-left-color: var(--mb-color-text-secondary);
     }
 
     .cm-tooltip:not(.cm-tooltip-autocomplete) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/CodeMirrorEditor/CodeMirrorEditor.module.css
@@ -8,10 +8,6 @@
   background-color: var(--mb-color-bg-light);
 
   :global {
-    .cm-cursor {
-      border-left-color: var(--mb-color-text-secondary);
-    }
-
     .cm-tooltip-autocomplete {
       box-shadow: 0 5px 14px rgba(0, 0, 0, 0.08);
       border-radius: 4px;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/64760

The case for the native/SQL editor was fixed in https://github.com/metabase/metabase/pull/64549, this PR generalises the fix to all CodeMirror editors.