### PR TITLE
Do not reset collection selection after canceling action

### DIFF
--- a/e2e/test/scenarios/collections/trash.cy.spec.js
+++ b/e2e/test/scenarios/collections/trash.cy.spec.js
@@ -4,6 +4,7 @@ const { H } = cy;
 import {
   FIRST_COLLECTION_ID,
   ORDERS_COUNT_QUESTION_ID,
+  ORDERS_MODEL_ID,
   ORDERS_QUESTION_ID,
   READ_ONLY_PERSONAL_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
@@ -864,6 +865,47 @@ describe("scenarios > collections > trash", () => {
       .and("contain", "Restore")
       .and("contain", "Delete permanently");
   });
+
+  it("should not deselect items when aborting operations (metabase#44911)", () => {
+    cy.request("PUT", `/api/card/${ORDERS_QUESTION_ID}`, { archived: true });
+    cy.request("PUT", `/api/card/${ORDERS_COUNT_QUESTION_ID}`, {
+      archived: true,
+    });
+    cy.request("PUT", `/api/card/${ORDERS_MODEL_ID}`, { archived: true });
+    cy.visit("/trash");
+
+    selectItem("Orders");
+    selectItem("Orders Model");
+
+    cy.findByTestId("toast-card")
+      .should("be.visible")
+      .findByText("Delete permanently")
+      .click();
+
+    H.modal().findByText("Cancel").click();
+
+    assertChecked("Orders");
+    assertChecked("Orders Model");
+
+    cy.findByTestId("toast-card")
+      .should("be.visible")
+      .findByText("Move")
+      .click();
+
+    H.entityPickerModal().findByText("Cancel").click();
+
+    assertChecked("Orders");
+    assertChecked("Orders Model");
+
+    cy.log("Going through with action should reset selection");
+    cy.findByTestId("toast-card")
+      .should("be.visible")
+      .findByText("Delete permanently")
+      .click();
+
+    H.modal().findByText("Delete permanently").click();
+    assertChecked("Orders, Count", false);
+  });
 });
 
 function toggleEllipsisMenuFor(item) {
@@ -937,9 +979,14 @@ function ensureCanRestoreFromPage(name) {
 }
 
 function selectItem(name) {
+  cy.findByText(name).closest("tr").findByRole("checkbox").check();
+}
+
+function assertChecked(name, checked = true) {
   cy.findByText(name)
     .closest("tr")
-    .within(() => cy.findByRole("checkbox").click());
+    .findByRole("checkbox")
+    .should(checked ? "have.attr" : "not.have.attr", "checked");
 }
 
 function assertTrashSelectedInNavigationSidebar() {

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/ArchivedBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/ArchivedBulkActions.tsx
@@ -43,6 +43,11 @@ export const ArchivedBulkActions = ({
   const handleCloseModal = () => {
     setSelectedItems(null);
     setSelectedAction(null);
+  };
+
+  const unselect = () => {
+    setSelectedItems(null);
+    setSelectedAction(null);
     clearSelected();
   };
 
@@ -55,7 +60,7 @@ export const ArchivedBulkActions = ({
 
   const handleBulkRestore = () => {
     const actions = selected.map((item) => item.setArchived(false));
-    Promise.all(actions).finally(() => clearSelected());
+    Promise.all(actions).finally(unselect);
   };
 
   // delete
@@ -70,7 +75,7 @@ export const ArchivedBulkActions = ({
 
   const handleBulkDeletePermanently = async () => {
     const actions = selected.map((item) => item.delete());
-    Promise.all(actions).finally(() => clearSelected());
+    Promise.all(actions).finally(unselect);
     dispatch(
       addUndo({
         message: ngettext(

--- a/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.tsx
+++ b/frontend/src/metabase/collections/components/CollectionBulkActions/CollectionBulkActions.tsx
@@ -54,6 +54,12 @@ export const CollectionBulkActions = memo(
       clearSelected();
     };
 
+    const handleCancelModal = () => {
+      setSelectedItems(null);
+      setSelectedAction(null);
+      setRememberedDestination(null);
+    };
+
     const tryOrClear = (promise: Promise<any>) =>
       promise.finally(() => clearSelected());
 
@@ -157,7 +163,7 @@ export const CollectionBulkActions = memo(
         {selectedItems && hasSelectedItems && selectedAction === "move" && (
           <BulkMoveModal
             selectedItems={selectedItems}
-            onClose={handleCloseModal}
+            onClose={handleCancelModal}
             onMove={handleBulkMove}
             initialCollectionId={
               isTrashedCollection(collection) ? "root" : collection.id


### PR DESCRIPTION
Closes #44911

# To verify

1. Trash some items
2. Open the Trash Collection
3. Select one or a couple of items
4. Click "Delete permanently" or "Move" in the toast
5. In the resulting modal, click "Cancel"
    - The selection should not be reset