### PR TITLE
[perf] Use cached MetadataProvider on FE; reuse MP in `/query_metadata`

### DIFF
--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -7,6 +7,7 @@
    [goog.object :as gobject]
    [medley.core :as m]
    [metabase.lib.cache :as lib.cache]
+   [metabase.lib.metadata.cached-provider :as lib.metadata.cached-provider]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.util :as lib.util]
@@ -545,24 +546,25 @@
   #_{:pre [(pos-int? database-id)]}
   (let [metadata (parse-metadata unparsed-metadata)]
     (log/debug "Created metadata provider for metadata")
-    (reify lib.metadata.protocols/MetadataProvider
-      (database [_this]
-        (database metadata database-id))
-      (metadatas [_this metadata-spec]
-        (metadatas metadata database-id metadata-spec))
-      (setting [_this setting-key]
-        (setting unparsed-metadata setting-key))
+    (lib.metadata.cached-provider/cached-metadata-provider
+     (reify lib.metadata.protocols/MetadataProvider
+       (database [_this]
+         (database metadata database-id))
+       (metadatas [_this metadata-spec]
+         (metadatas metadata database-id metadata-spec))
+       (setting [_this setting-key]
+         (setting unparsed-metadata setting-key))
 
       ;; for debugging: call [[clojure.datafy/datafy]] on one of these to parse all of our metadata and see the whole
       ;; thing at once.
-      clojure.core.protocols/Datafiable
-      (datafy [_this]
-        (perf/postwalk
-         (fn [form]
-           (if (delay? form)
-             (deref form)
-             form))
-         metadata)))))
+       clojure.core.protocols/Datafiable
+       (datafy [_this]
+         (perf/postwalk
+          (fn [form]
+            (if (delay? form)
+              (deref form)
+              form))
+          metadata))))))
 
 (defn metadata-provider
   "Use a `metabase-lib/metadata/Metadata` as a [[metabase.lib.metadata.protocols/MetadataProvider]]."

--- a/src/metabase/lib/metadata/cache.cljc
+++ b/src/metabase/lib/metadata/cache.cljc
@@ -96,14 +96,16 @@
    not-found]
   (if-let [metadata-provider (->cached-metadata-provider metadata-providerable)]
     (lib.metadata.protocols/cached-value metadata-provider k not-found)
-    not-found))
+    (do (log/warn "Not a cached-metadata-provider")
+        not-found)))
 
 (mu/defn- cache-value! :- :nil
   [metadata-providerable :- ::lib.metadata.protocols/metadata-providerable
    k                     :- ::cache-key
    v]
-  (when-let [metadata-provider (->cached-metadata-provider metadata-providerable)]
-    (lib.metadata.protocols/cache-value! metadata-provider k v))
+  (if-let [metadata-provider (->cached-metadata-provider metadata-providerable)]
+    (lib.metadata.protocols/cache-value! metadata-provider k v)
+    (log/warn "Not a cached-metadata-provider"))
   nil)
 
 (defn ^:dynamic *cache-hit-hook*

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -486,7 +486,11 @@
     ;;
     ;; Added by [[metabase.lib.metadata.result-metadata]] primarily for legacy/backward-compatibility purposes with
     ;; legacy viz settings. This should not be used for anything other than that.
-    [:field-ref {:optional true} [:maybe [:ref :metabase.legacy-mbql.schema/Reference]]]
+    [:field-ref {:optional true} [:maybe #?(:cljs [:or
+                                                   [:ref :metabase.legacy-mbql.schema/Reference]
+                                                   [:fn {:error/message "JS array"}
+                                                    array?]]
+                                            :clj  [:ref :metabase.legacy-mbql.schema/Reference])]]
     ;;
     [:source {:optional true} [:maybe [:ref ::column.legacy-source]]]
     ;;

--- a/src/metabase/queries/api/card.clj
+++ b/src/metabase/queries/api/card.clj
@@ -702,8 +702,9 @@
   "Get all of the required query metadata for a card."
   [{:keys [id]} :- [:map
                     [:id [:or ms/PositiveInt ms/NanoIdString]]]]
-  (let [resolved-id (eid-translation/->id-or-404 :card id)]
-    (queries.metadata/batch-fetch-card-metadata [(get-card resolved-id)])))
+  (lib-be/with-metadata-provider-cache
+    (let [resolved-id (eid-translation/->id-or-404 :card id)]
+      (queries.metadata/batch-fetch-card-metadata [(get-card resolved-id)]))))
 
 ;;; ------------------------------------------------- Deleting Cards -------------------------------------------------
 

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -170,7 +170,8 @@
    _query-params
    query :- [:map
              [:database ms/PositiveInt]]]
-  (queries/batch-fetch-query-metadata [query]))
+  (lib-be/with-metadata-provider-cache
+    (queries/batch-fetch-query-metadata [query])))
 
 (api.macros/defendpoint :post "/native"
   "Fetch a native version of an MBQL query."


### PR DESCRIPTION
This addresses most of QUE-2686 #64774 but a second PR is required to fix a
56-specific issue that doesn't apply to `master`.

### Description

The FE was not using the new
`lib.metadata.cached-provider/cached-metadata-provider` except where
it gets added by `lib/query`. Previously, the FE constructed the
*uncached* MP once (ish) and then passed it to `lib/query` many times.
Each of those queries got its MP wrapped with `cached-metadata-provider`
but the next time the query got converted via `lib/query` its cached
values (eg. `visible-columns`, `returned-columns`) were lost.

This PR wraps the `lib.js.metadata/metadata-provider*` with
`cached-metadata-provider` from the start, so the cached values have
the same lifespan as the `MetadataProvider`, rather than each individual
query.

I also noticed that `/query_metadata` requests don't use
`lib-be.metadata.jvm/with-metadata-provider-cache`, so they end up
recreating `MetadataProvider`s for the same underlying database over and
over. That increases AppDB traffic and CPU usage to recompute
`returned-columns` etc. repeatedly. Both of those scale fast with the
complexity of the query.


### How to verify

Perf improvements; nothing really to test.

Removing the `lib.metadata.cached-provider/cached-metadata-provider` wrapper from
`lib.js.metadata/metadata-provider*` will start spewing warnings about trying to
use `lib.metadata.cache/cached-value` et al on an uncached MP. And it will be slower,
since a lot more recomputation of `returned-columns` et al will result.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
  - Nothing to test, since the true change is performance gain.
