### PR TITLE
Surface broken cards from Metabot dependencies check API

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2021,6 +2021,7 @@
            lib-be
            models
            premium-features
+           queries
            query-processor
            request
            search

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1843,7 +1843,6 @@
            permissions
            premium-features
            pulse
-           queries
            query-processor
            request
            search

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1843,6 +1843,7 @@
            permissions
            premium-features
            pulse
+           queries
            query-processor
            request
            search

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -1155,9 +1155,7 @@
   [:and
    [:map
     [:transform_id :int]
-    [:source {:optional true} [:maybe [:map
-                                       [:type {:optional true} :keyword]
-                                       [:query {:optional true} ::queries.schema/query]]]]]
+    [:source ::metabot-v3.tools.transforms/transform-source]]
    [:map {:encode/tool-api-request
           #(set/rename-keys % {:transform_id :id})}]])
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -28,7 +28,6 @@
    [metabase.api.routes.common :as api.routes.common]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
-   [metabase.queries.schema :as queries.schema]
    [metabase.request.core :as request]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -1161,18 +1161,25 @@
    [:map {:encode/tool-api-request
           #(set/rename-keys % {:transform_id :id})}]])
 
+(mr/def ::broken-question
+  [:map {:decode/tool-api-response #(update-keys % metabot-v3.u/safe->snake_case_en)}
+   [:id :int]
+   [:name :string]])
+
 (mr/def ::broken-transform
   [:map {:decode/tool-api-response #(update-keys % metabot-v3.u/safe->snake_case_en)}
    [:id :int]
-   [:name :string]
-   [:description {:optional true} [:maybe :string]]])
+   [:name :string]])
 
 (mr/def ::check-transform-dependencies-result
   [:or
    [:map {:decode/tool-api-response #(update-keys % metabot-v3.u/safe->snake_case_en)}
     [:structured_output [:map
                          [:success :boolean]
-                         [:bad_transforms [:sequential ::broken-transform]]]]]
+                         [:bad_transform_count :int]
+                         [:bad_transforms [:sequential ::broken-transform]]
+                         [:bad_question_count :int]
+                         [:bad_questions [:sequential ::broken-question]]]]]
    [:map [:output :string]]])
 
 (api.macros/defendpoint :post "/check-transform-dependencies" :- [:merge ::check-transform-dependencies-result ::tool-request]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -28,6 +28,7 @@
    [metabase.api.routes.common :as api.routes.common]
    [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
+   [metabase.queries.schema :as queries.schema]
    [metabase.request.core :as request]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
@@ -1154,7 +1155,9 @@
   [:and
    [:map
     [:transform_id :int]
-    [:source {:optional true} [:maybe ms/Map]]]
+    [:source {:optional true} [:maybe [:map
+                                       [:type {:optional true} :keyword]
+                                       [:query {:optional true} ::queries.schema/query]]]]]
    [:map {:encode/tool-api-request
           #(set/rename-keys % {:transform_id :id})}]])
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -4,7 +4,6 @@
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (def ^:private ^:dynamic *max-reported-broken-transforms* 10)
@@ -22,7 +21,6 @@
                                (take *max-reported-broken-transforms* broken-transform-ids))
         broken-transforms    (when (seq broken-transform-ids)
                                (t2/select [:model/Transform :id :name] :id [:in transforms-to-report]))
-        ; transforms-by-id     (u/index-by :id broken-transforms)
         broken-card-ids      (set (keys card-errors))
         cards-to-report      (take *max-reported-broken-transforms* broken-card-ids)
         broken-cards         (when (seq broken-card-ids)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -31,11 +31,12 @@
                            (fn [transform]
                              {:transform transform :errors (get transform-errors (:id transform))})
                            broken-transforms)
-     :bad_card_count     (count broken-card-ids)
-     :bad_cards          (when (seq broken-card-ids)
-                           (mapv (fn [card]
-                                   {:card card :errors (get card-errors (:id card))})
-                                 broken-cards))}))
+     ;; Use "question" terminology rather than "card" to avoid confusing Metabot
+     :bad_question_count  (count broken-card-ids)
+     :bad_questions       (when (seq broken-card-ids)
+                            (mapv (fn [card]
+                                    {:question card :errors (get card-errors (:id card))})
+                                  broken-cards))}))
 
 (defn check-transform-dependencies
   "Check a proposed edit to a SQL transform, and return transforms that will break in a format

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -19,11 +19,11 @@
                                        (take (dec *max-reported-broken-transforms*)
                                              (disj broken-transform-ids edited-transform-id)))
                                (take *max-reported-broken-transforms* broken-transform-ids))
-        broken-transforms    (when (seq broken-transform-ids)
+        broken-transforms    (when (seq transforms-to-report)
                                (t2/select [:model/Transform :id :name] :id [:in transforms-to-report]))
         broken-card-ids      (set (keys card-errors))
         cards-to-report      (take *max-reported-broken-transforms* broken-card-ids)
-        broken-cards         (when (seq broken-card-ids)
+        broken-cards         (when (seq cards-to-report)
                                (t2/select [:model/Card :id :name] :id [:in cards-to-report]))]
     {:success             (empty? broken-transform-ids)
      :bad_transform_count (count broken-transform-ids)

--- a/enterprise/backend/src/metabase_enterprise/transforms/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/api.clj
@@ -15,6 +15,7 @@
    [metabase.api.util.handlers :as handlers]
    [metabase.driver.util :as driver.u]
    [metabase.events.core :as events]
+   [metabase.queries.schema :as queries.schema]
    [metabase.request.core :as request]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru]]
@@ -35,7 +36,7 @@
    [:query
     [:map
      [:type [:= "query"]]
-     [:query [:map [:database :int]]]]]
+     [:query ::queries.schema/query]]]
    [:python
     [:map {:closed true}
      [:source-database {:optional true} :int]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
@@ -91,9 +91,7 @@
          {:name "Card using Transform 1"
           :database_id (mt/id)
           :table_id (mt/id :orders)
-          :dataset_query {:type "native"
-                          :database (mt/id)
-                          :native {:query "SELECT total FROM orders_transform_1"}}}
+          :dataset_query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
          :model/Dependency {}
          {:from_entity_type "card"
           :from_entity_id card-id
@@ -120,9 +118,7 @@
          {:name "Card 1 using Transform 1"
           :database_id (mt/id)
           :table_id (mt/id :orders)
-          :dataset_query {:type "native"
-                          :database (mt/id)
-                          :native {:query "SELECT total FROM orders_transform_1"}}}
+          :dataset_query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
          :model/Dependency {}
          {:from_entity_type "card"
           :from_entity_id card1-id
@@ -132,9 +128,7 @@
          {:name "Card 2 using Transform 1"
           :database_id (mt/id)
           :table_id (mt/id :orders)
-          :dataset_query {:type "native"
-                          :database (mt/id)
-                          :native {:query "SELECT total FROM orders_transform_1"}}}
+          :dataset_query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
          :model/Dependency {}
          {:from_entity_type "card"
           :from_entity_id card2-id

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
@@ -147,9 +147,9 @@
                   result (metabot.dependencies/check-transform-dependencies
                           {:id transform1-id
                            :source modified-source})
-                  bad-cards (get-in result [:structured_output :bad_cards])]
+                  bad-cards (get-in result [:structured_output :bad_questions])]
               ;; Two cards should be broken...
               (is (false? (get-in result [:structured_output :success])))
-              (is (= 2 (get-in result [:structured_output :bad_card_count])))
+              (is (= 2 (get-in result [:structured_output :bad_question_count])))
               ;; ...but only one should be reported due to the limit.
               (is (= 1 (count bad-cards))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
@@ -105,12 +105,12 @@
                       {:id transform1-id
                        :source modified-source})]
           (is (false? (get-in result [:structured_output :success])))
-          (is (= 1 (get-in result [:structured_output :bad_card_count])))
-          (let [bad-cards (get-in result [:structured_output :bad_cards])]
-            (is (= 1 (count bad-cards)))
-            (is (= card-id (get-in (first bad-cards) [:card :id])))
-            (is (= "Card using Transform 1" (get-in (first bad-cards) [:card :name])))
-            (is (some? (:errors (first bad-cards))))))))))
+          (is (= 1 (get-in result [:structured_output :bad_question_count])))
+          (let [bad-questions (get-in result [:structured_output :bad_questions])]
+            (is (= 1 (count bad-questions)))
+            (is (= card-id (get-in (first bad-questions) [:question :id])))
+            (is (= "Card using Transform 1" (get-in (first bad-questions) [:question :name])))
+            (is (some? (:errors (first bad-questions))))))))))
 
 (deftest check-transform-dependencies-card-limit-test
   (testing "max-reported-broken-transforms limit applies to cards"


### PR DESCRIPTION
* Surfaces broken cards from the dependencies API, to go with https://github.com/metabase/ai-service/pull/394 which gives Metabot the ability to mention them to the user
* Updates malli schema for `/check-transform-dependencies` so that transform source query gets correctly parsed as MBQL5
* Also updates `MetabotAgentSuggestionMessage.tsx` to use the Lib to fetch native query source instead of matching on query structure