### PR TITLE
Fix two backend test flakes

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1672,14 +1672,15 @@
                    :model/DashboardCard       dc3 {:dashboard_id (:id d2) :card_id (:id c3)}
                    :model/DashboardCardSeries s   {:dashboardcard_id (:id dc1) :card_id (:id c2)}]
       (t2/with-call-count [qc]
-        (is (=? [(assoc d1
-                        :dashcards [(assoc dc1 :series [s])]
-                        :tabs nil)
-                 (assoc d2
-                        :dashcards [(assoc dc2 :series nil)
-                                    (assoc dc3 :series nil)]
-                        :tabs nil)]
-                (into [] (serdes/extract-query "Dashboard" {:where [:in :id [(:id d1) (:id d2)]]}))))
+        ;; Use sets to ensure order independence of `extract-query` result.
+        (is (=? #{(assoc d1
+                         :dashcards [(assoc dc1 :series [s])]
+                         :tabs nil)
+                  (assoc d2
+                         :dashcards [(assoc dc2 :series nil)
+                                     (assoc dc3 :series nil)]
+                         :tabs nil)}
+                (set (serdes/extract-query "Dashboard" {:where [:in :id [(:id d1) (:id d2)]]}))))
         ;; 1 per dashboard/dashcard/series/tabs
         (is (= 4 (qc)))))))
 

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -108,7 +108,7 @@
 
         (testing "failures for timeout"
           (mt/with-prometheus-system! [_ system]
-            (mt/with-temporary-setting-values [db-connection-timeout-ms 0]
+            (mt/with-temporary-setting-values [db-connection-timeout-ms -1] ;; setting to -1 because 0 sometimes flakes
               (database/health-check-database! (mt/db))
               (is (== 0 (mt/metric-value system :metabase-database/status {:driver driver/*driver* :healthy true})) "healthy")
               (is (== 0 (mt/metric-value system :metabase-database/status {:driver driver/*driver* :healthy false :reason "user-input"})) "unhealthy user-input")


### PR DESCRIPTION
First one is caused by `serdes/extract-query` returning two dashboards in the wrong order.
Second one happens on H2 because the query sometimes goes through even with the timeout of 0 ms. Setting it to -1 ms hopefully helps, at least it seems to work.