### PR TITLE
Fix flaky transforms test

### DIFF
--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -2699,7 +2699,7 @@ function getQueryEditor() {
 }
 
 function getRunButton(options: { timeout?: number } = {}) {
-  return cy.findAllByTestId("run-button", options).eq(0);
+  return cy.findAllByTestId("run-button").eq(0, options);
 }
 
 function getCancelButton() {


### PR DESCRIPTION
Fixes a transform test that was broken due the the increased timeout being applied to the wrong assertion.

This was breaking almost 100% of the time.

[Stress test](https://github.com/metabase/metabase/actions/runs/18585142330)
