### PR TITLE
Connection string placeholder improvements

### DIFF
--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/engines-config.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/engines-config.ts
@@ -24,9 +24,9 @@ export const enginesConfig: Record<EngineKey, Placeholder> = {
     "redshift://examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com:5439/dev",
   snowflake:
     "snowflake://example.snowflakecomputing.com/?db=maindb&warehouse=mainwarehouse",
-  sparksql: "sparksql:Server=127.0.0.1;",
+  sparksql: "sparksql:Server=sparksql.example.com",
   sqlite: "sqlite:///C:/path/to/database.db",
-  sqlserver: "sqlserver://mydbhost:1433;databaseName=mydb",
+  sqlserver: "sqlserver://mssql.example.com:1433;databaseName=mydb",
   starburst:
     "trino://starburst.example.com:43011/hive/sales?user=test&password=secret&SSL=true&roles=system:myrole",
   vertica: "vertica://vertica.example.com:1234/databaseName?user=jane",

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/engines-config.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/engines-config.ts
@@ -3,31 +3,31 @@ import type { EngineKey } from "metabase-types/api/settings";
 type Placeholder = string | undefined;
 
 export const enginesConfig: Record<EngineKey, Placeholder> = {
-  athena: "jdbc:athena://WorkGroup=primary;Region=us-east-1;",
+  athena: "athena://WorkGroup=primary;Region=us-east-1;",
   "bigquery-cloud-sdk":
-    "jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;ProjectId=MyBigQueryProject;OAuthType=1;",
-  clickhouse: "jdbc:clickhouse:https://localhost:8443?ssl=true",
+    "bigquery://https://www.googleapis.com/bigquery/v2:443;ProjectId=MyBigQueryProject;OAuthType=1;",
+  clickhouse: "clickhouse:http://clickhouse.example.com:8443?ssl=true",
   druid:
-    "jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnection=true",
+    "avatica:remote:url=http://druid.example.com:8888/druid/v2/sql/avatica/;transparent_reconnection=true",
   "druid-jdbc":
-    "jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnection=true",
+    "avatica:remote:url=http://druid.example.com:8888/druid/v2/sql/avatica/;transparent_reconnection=true",
   databricks:
-    "jdbc:databricks://127.0.0.1:8123;httpPath=/sql/1.0/endpoints/abc;OAuthSecret=1234567890;OAuth2ClientId=xyz",
+    "databricks://databricks.example.com:8123;httpPath=/sql/1.0/endpoints/abc;OAuthSecret=1234567890;OAuth2ClientId=xyz",
   mongo: undefined,
-  mysql: "jdbc:mysql://user:pass@host:3306/dbname?ssl=true",
+  mysql: "mysql://user@pass@mysql.example.com:3306/dbname?ssl=true",
   oracle:
-    "jdbc:oracle:thin:@mydbhost:1521/mydbservice?ssl_server_cert_dn=ServerDN",
-  postgres: "jdbc:postgresql://localhost:5432/mydb",
+    "oracle:thin:@oracle.example.com:1521/mydbservice?ssl_server_cert_dn=ServerDN",
+  postgres: "postgresql://user@pass:pg.example.com:5432/mydb",
   "presto-jdbc":
-    "jdbc:presto://host:1234/sample-catalog/sample-schema?SSL=true&SSLTrustStorePassword=1234",
+    "presto://presto.example.com:1234/sample-catalog/sample-schema?SSL=true&SSLTrustStorePassword=1234",
   redshift:
-    "jdbc:redshift://examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com:5439/dev",
+    "redshift://examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com:5439/dev",
   snowflake:
     "snowflake://example.snowflakecomputing.com/?db=maindb&warehouse=mainwarehouse",
-  sparksql: "jdbc:sparksql:Server=127.0.0.1;",
-  sqlite: "jdbc:sqlite:///C:/path/to/database.db",
-  sqlserver: "jdbc:sqlserver://mydbhost:1433;databaseName=mydb",
+  sparksql: "sparksql:Server=127.0.0.1;",
+  sqlite: "sqlite:///C:/path/to/database.db",
+  sqlserver: "sqlserver://mydbhost:1433;databaseName=mydb",
   starburst:
-    "jdbc:trino://starburst.example.com:43011/hive/sales?user=test&password=secret&SSL=true&roles=system:myrole",
-  vertica: "jdbc:vertica://vertica.example.com:1234/databaseName?user=jane",
+    "trino://starburst.example.com:43011/hive/sales?user=test&password=secret&SSL=true&roles=system:myrole",
+  vertica: "vertica://vertica.example.com:1234/databaseName?user=jane",
 } as const;

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/engines-config.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/engines-config.ts
@@ -14,10 +14,10 @@ export const enginesConfig: Record<EngineKey, Placeholder> = {
   databricks:
     "databricks://databricks.example.com:8123;httpPath=/sql/1.0/endpoints/abc;OAuthSecret=1234567890;OAuth2ClientId=xyz",
   mongo: undefined,
-  mysql: "mysql://user@pass@mysql.example.com:3306/dbname?ssl=true",
+  mysql: "mysql://user:pass@mysql.example.com:3306/dbname?ssl=true",
   oracle:
     "oracle:thin:@oracle.example.com:1521/mydbservice?ssl_server_cert_dn=ServerDN",
-  postgres: "postgresql://user@pass:pg.example.com:5432/mydb",
+  postgres: "postgresql://user:pass:pg.example.com:5432/mydb",
   "presto-jdbc":
     "presto://presto.example.com:1234/sample-catalog/sample-schema?SSL=true&SSLTrustStorePassword=1234",
   redshift:

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.unit.spec.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.unit.spec.ts
@@ -92,7 +92,7 @@ describe("parseConnectionUriRegex - Amazon Athena", () => {
         protocol: "awsathena",
         host: "athena.us-east-1.amazonaws.com",
         port: "443",
-        hasJdbcPrefix: true,
+        hasJdbcPrefix: false,
         params: {
           User: "EXAMPLEKEY",
           Password: "EXAMPLESECRETKEY",
@@ -113,7 +113,7 @@ describe("parseConnectionUriRegex - Amazon Redshift", () => {
         host: "examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com",
         port: "5439",
         database: "dev",
-        hasJdbcPrefix: true,
+        hasJdbcPrefix: false,
       }),
     );
   });
@@ -166,7 +166,7 @@ describe("parseConnectionUriRegex - Clickhouse", () => {
         protocol: "clickhouse",
         host: "localhost",
         port: "8443",
-        hasJdbcPrefix: true,
+        hasJdbcPrefix: false,
         params: {
           ssl: "true",
         },
@@ -184,7 +184,7 @@ describe("parseConnectionUriRegex - Databricks", () => {
         protocol: "databricks",
         host: "127.0.0.1",
         port: "8123",
-        hasJdbcPrefix: true,
+        hasJdbcPrefix: false,
         params: {
           httpPath: "/sql/1.0/endpoints/abc",
           OAuthSecret: "1234567890",
@@ -223,7 +223,7 @@ describe("parseConnectionUriRegex - Druid", () => {
         host: "localhost",
         port: "8888",
         path: "/druid/v2/sql/avatica/",
-        hasJdbcPrefix: true,
+        hasJdbcPrefix: false,
         params: {
           transparent_reconnection: "true",
         },
@@ -246,7 +246,7 @@ describe("parseConnectionUriRegex - MySQL", () => {
         ssl: "true",
       },
       protocol: "mysql",
-      hasJdbcPrefix: true,
+      hasJdbcPrefix: false,
     });
   });
 });
@@ -264,7 +264,7 @@ describe("parseConnectionUriRegex - Oracle", () => {
           ssl_server_cert_dn: "ServerDN",
         },
         protocol: "oracle",
-        hasJdbcPrefix: true,
+        hasJdbcPrefix: false,
       }),
     );
   });
@@ -299,7 +299,7 @@ describe("parseConnectionUriRegex - PostgreSQL", () => {
       port: "5432",
       database: "mydb",
       protocol: "postgresql",
-      hasJdbcPrefix: true,
+      hasJdbcPrefix: false,
     });
   });
 
@@ -397,7 +397,7 @@ describe("parseConnectionUriRegex - Spark SQL", () => {
     expect(result).toEqual(
       expect.objectContaining({
         protocol: "sparksql",
-        hasJdbcPrefix: true,
+        hasJdbcPrefix: false,
         params: {
           Server: "127.0.0.1",
         },
@@ -480,7 +480,7 @@ describe("parseConnectionUriRegex - Starburst", () => {
         catalog: "hive",
         schema: "sales",
         protocol: "trino",
-        hasJdbcPrefix: true,
+        hasJdbcPrefix: false,
       }),
     );
   });
@@ -496,7 +496,7 @@ describe("parseConnectionUriRegex - Vertica", () => {
         port: "1234",
         database: "databaseName",
         protocol: "vertica",
-        hasJdbcPrefix: true,
+        hasJdbcPrefix: false,
       }),
     );
   });


### PR DESCRIPTION
Several improvements to connection string placeholders:

* Remove `jdbc:<provider>` prefix. All connection strings work (or should work) without them, so they are not necessary. Most Metabase customers are likely not JDBC users, so their existing connection strings will not start with `jdbc:`.
* Use `*.example.com` hosts whenever relevant, instead of `host`, `localhost`, `127.0.0.1`, etc. Loopback addresses are almost never relevant for Cloud
* Add username/password placeholders to Postgres

Describe the overall approach and the problem being solved.

### How to verify

Add a new database, view the connection string placeholders

### Demo

<img width="1349" height="436" alt="image" src="https://github.com/user-attachments/assets/5bc4b769-49c8-4441-910f-960458a46489" />

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
