### PR TITLE
Metabot /debug mode to show tool calls

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
@@ -1,0 +1,119 @@
+import { useClipboard, useDisclosure } from "@mantine/hooks";
+import { t } from "ttag";
+
+import { CodeEditor } from "metabase/common/components/CodeEditor";
+import {
+  ActionIcon,
+  Badge,
+  Box,
+  Button,
+  Flex,
+  Icon,
+  Modal,
+  Stack,
+  Text,
+} from "metabase/ui";
+import type { MetabotDebugToolCallMessage } from "metabase-enterprise/metabot/state";
+
+const ToolCallDetailsModal = ({
+  message,
+  onClose,
+}: {
+  message: MetabotDebugToolCallMessage;
+  onClose: () => void;
+}) => {
+  const clipboard = useClipboard();
+  const copy = (value: any) => clipboard.copy(JSON.stringify(value, null, 2));
+
+  return (
+    <Modal
+      opened
+      onClose={onClose}
+      size="lg"
+      title={
+        <Flex align="center">
+          {t`Tool Call: ${message.name}`}
+          <Badge ml="sm" color="text-dark">
+            {message.id}
+          </Badge>
+        </Flex>
+      }
+      data-testid="tool-call-details-modal"
+    >
+      <Stack gap="md">
+        {message.args && (
+          <Stack gap="xs">
+            <Flex gap="xs">
+              <Text fw="bold">{t`Request`}</Text>
+              <ActionIcon h="sm" onClick={() => copy(message.args)}>
+                <Icon name="copy" size="1rem" />
+              </ActionIcon>
+            </Flex>
+            <Box mx="-1.5rem">
+              <CodeEditor
+                value={JSON.stringify(message.args, null, 2)}
+                language="json"
+                readOnly
+              />
+            </Box>
+          </Stack>
+        )}
+
+        {message.result && (
+          <Stack gap="xs">
+            <Flex gap="xs">
+              <Text fw="bold">{t`Response`}</Text>
+              <ActionIcon h="sm" onClick={() => copy(message.args)}>
+                <Icon name="copy" size="1rem" />
+              </ActionIcon>
+            </Flex>
+            <Box mx="-1.5rem">
+              <CodeEditor value={message.result} readOnly />
+            </Box>
+          </Stack>
+        )}
+      </Stack>
+    </Modal>
+  );
+};
+
+export const AgentToolCallMessage = ({
+  message,
+}: {
+  message: MetabotDebugToolCallMessage;
+}) => {
+  const [modalOpen, { open, close }] = useDisclosure(false);
+  const clipboard = useClipboard();
+  const handleCopy = () => clipboard.copy(JSON.stringify(message, null, 2));
+
+  return (
+    <>
+      <Flex
+        p="sm"
+        pl="md"
+        bg="bg-light"
+        bd="1px solid var(--mb-color-border)"
+        bdrs="sm"
+        direction="row"
+        align="center"
+        justify="space-between"
+      >
+        <Flex>
+          <Text mr="sm">🔧</Text>
+          <Text fw="bold">{message.name}</Text>
+        </Flex>
+        <Flex align="center" gap="xs">
+          <Button
+            variant="light"
+            size="compact-xs"
+            onClick={open}
+          >{t`View`}</Button>
+          <ActionIcon h="sm" onClick={handleCopy}>
+            <Icon name="copy" size="1rem" />
+          </ActionIcon>
+        </Flex>
+      </Flex>
+      {modalOpen && <ToolCallDetailsModal message={message} onClose={close} />}
+    </>
+  );
+};

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
@@ -1,4 +1,5 @@
 import { useClipboard, useDisclosure } from "@mantine/hooks";
+import { useMemo } from "react";
 import { t } from "ttag";
 
 import { CodeEditor } from "metabase/common/components/CodeEditor";
@@ -25,6 +26,18 @@ const ToolCallDetailsModal = ({
   const clipboard = useClipboard();
   const copy = (value: any) => clipboard.copy(JSON.stringify(value, null, 2));
 
+  const parsedArgs = useMemo(() => {
+    try {
+      return message.args
+        ? // done for formatting
+          JSON.stringify(JSON.parse(message.args), null, 2)
+        : undefined;
+    } catch {
+      console.warn("Failed to parse tool call args as JSON", message.args);
+      return message.args;
+    }
+  }, [message.args]);
+
   return (
     <Modal
       opened
@@ -45,16 +58,12 @@ const ToolCallDetailsModal = ({
           <Stack gap="xs">
             <Flex gap="xs">
               <Text fw="bold">{t`Request`}</Text>
-              <ActionIcon h="sm" onClick={() => copy(message.args)}>
+              <ActionIcon h="sm" onClick={() => copy(parsedArgs)}>
                 <Icon name="copy" size="1rem" />
               </ActionIcon>
             </Flex>
             <Box mx="-1.5rem">
-              <CodeEditor
-                value={JSON.stringify(message.args, null, 2)}
-                language="json"
-                readOnly
-              />
+              <CodeEditor value={parsedArgs} language="json" readOnly />
             </Box>
           </Stack>
         )}

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
@@ -31,10 +31,10 @@ const ToolCallDetailsModal = ({
       return message.args
         ? // done for formatting
           JSON.stringify(JSON.parse(message.args), null, 2)
-        : undefined;
+        : "{}";
     } catch {
       console.warn("Failed to parse tool call args as JSON", message.args);
-      return message.args;
+      return message.args ?? "{}";
     }
   }, [message.args]);
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotAgentToolCallMessage.tsx
@@ -63,7 +63,7 @@ const ToolCallDetailsModal = ({
           <Stack gap="xs">
             <Flex gap="xs">
               <Text fw="bold">{t`Response`}</Text>
-              <ActionIcon h="sm" onClick={() => copy(message.args)}>
+              <ActionIcon h="sm" onClick={() => copy(message.result)}>
                 <Icon name="copy" size="1rem" />
               </ActionIcon>
             </Flex>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -177,7 +177,7 @@ export const MetabotChat = ({
               />
               {/* loading */}
               {metabot.isDoingScience && (
-                <MetabotThinking toolCalls={metabot.toolCalls} />
+                <MetabotThinking toolCalls={metabot.activeToolCalls} />
               )}
               {/* filler - height gets set via ref mutation */}
               <div ref={fillerRef} data-testid="metabot-message-filler" />

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -174,7 +174,6 @@ export const MetabotChat = ({
                 onRetryMessage={handleRetryMessage}
                 isDoingScience={metabot.isDoingScience}
                 showFeedbackButtons
-                debugMode={metabot.debugMode}
               />
               {/* loading */}
               {metabot.isDoingScience && (

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChat.tsx
@@ -174,6 +174,7 @@ export const MetabotChat = ({
                 onRetryMessage={handleRetryMessage}
                 isDoingScience={metabot.isDoingScience}
                 showFeedbackButtons
+                debugMode={metabot.debugMode}
               />
               {/* loading */}
               {metabot.isDoingScience && (

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -249,7 +249,7 @@ const ToolCallDetailsModal = ({
   const resultValue = resultIsString
     ? message.result
     : JSON.stringify(message.result, null, 2);
-  const resultLanguage = resultIsString ? "text" : "json";
+  const resultLanguage = resultIsString ? undefined : "json";
 
   return (
     <Modal

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -245,12 +245,6 @@ const ToolCallDetailsModal = ({
   message: MetabotDebugToolCallMessage;
   onClose: () => void;
 }) => {
-  const resultIsString = typeof message.result === "string";
-  const resultValue = resultIsString
-    ? message.result
-    : JSON.stringify(message.result, null, 2);
-  const resultLanguage = resultIsString ? undefined : "json";
-
   return (
     <Modal
       opened
@@ -260,23 +254,21 @@ const ToolCallDetailsModal = ({
       data-testid="tool-call-details-modal"
     >
       <Stack gap="md">
-        <Stack gap="xs">
-          <Text fw="bold">{t`Request`}</Text>
-          <CodeEditor
-            value={JSON.stringify(message.message, null, 2)}
-            language="json"
-            readOnly
-          />
-        </Stack>
+        {message.args && (
+          <Stack gap="xs">
+            <Text fw="bold">{t`Request`}</Text>
+            <CodeEditor
+              value={JSON.stringify(message.args, null, 2)}
+              language="json"
+              readOnly
+            />
+          </Stack>
+        )}
 
         {message.result && (
           <Stack gap="xs">
             <Text fw="bold">{t`Response`}</Text>
-            <CodeEditor
-              value={resultValue}
-              language={resultLanguage}
-              readOnly
-            />
+            <CodeEditor value={message.result} readOnly />
           </Stack>
         )}
       </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -1,19 +1,15 @@
-import { useClipboard, useDisclosure } from "@mantine/hooks";
+import { useClipboard } from "@mantine/hooks";
 import cx from "classnames";
 import { useCallback, useState } from "react";
 import { t } from "ttag";
 
-import { CodeEditor } from "metabase/common/components/CodeEditor";
 import { useToast } from "metabase/common/hooks";
 import {
   ActionIcon,
-  Button,
   Flex,
   type FlexProps,
   Icon,
   type IconName,
-  Modal,
-  Stack,
   Text,
 } from "metabase/ui";
 import { useSubmitMetabotFeedbackMutation } from "metabase-enterprise/api/metabot";
@@ -21,7 +17,6 @@ import type {
   MetabotAgentChatMessage,
   MetabotAgentTextChatMessage,
   MetabotChatMessage,
-  MetabotDebugToolCallMessage,
   MetabotErrorMessage,
   MetabotUserChatMessage,
 } from "metabase-enterprise/metabot/state";
@@ -31,6 +26,7 @@ import { AIMarkdown } from "../AIMarkdown/AIMarkdown";
 
 import { AgentSuggestionMessage } from "./MetabotAgentSuggestionMessage";
 import { AgentTodoListMessage } from "./MetabotAgentTodoMessage";
+import { AgentToolCallMessage } from "./MetabotAgentToolCallMessage";
 import Styles from "./MetabotChat.module.css";
 import { MetabotFeedbackModal } from "./MetabotFeedbackModal";
 
@@ -240,88 +236,6 @@ export const AgentErrorMessage = ({
     )}
   </MessageContainer>
 );
-
-const ToolCallDetailsModal = ({
-  message,
-  onClose,
-}: {
-  message: MetabotDebugToolCallMessage;
-  onClose: () => void;
-}) => {
-  return (
-    <Modal
-      opened
-      onClose={onClose}
-      size="lg"
-      title={t`Tool Call: ${message.name}`}
-      data-testid="tool-call-details-modal"
-    >
-      <Stack gap="md">
-        {message.args && (
-          <Stack gap="xs">
-            <Text fw="bold">{t`Request`}</Text>
-            <CodeEditor
-              value={JSON.stringify(message.args, null, 2)}
-              language="json"
-              readOnly
-            />
-          </Stack>
-        )}
-
-        {message.result && (
-          <Stack gap="xs">
-            <Text fw="bold">{t`Response`}</Text>
-            <CodeEditor value={message.result} readOnly />
-          </Stack>
-        )}
-      </Stack>
-    </Modal>
-  );
-};
-
-export const AgentToolCallMessage = ({
-  message,
-  ...props
-}: FlexProps & {
-  message: MetabotDebugToolCallMessage;
-}) => {
-  const [modalOpen, { open, close }] = useDisclosure(false);
-  const clipboard = useClipboard();
-  const handleCopy = () => clipboard.copy(JSON.stringify(message, null, 2));
-
-  return (
-    <>
-      <MessageContainer
-        chatRole="agent"
-        {...props}
-        p="sm"
-        pl="md"
-        bg="bg-light"
-        bd="1px solid var(--mb-color-border)"
-        bdrs="sm"
-        direction="row"
-        align="center"
-        justify="space-between"
-      >
-        <Flex>
-          <Text mr="sm">🔧</Text>
-          <Text fw="bold">{message.name}</Text>
-        </Flex>
-        <Flex align="center" gap="xs">
-          <Button
-            variant="light"
-            size="compact-xs"
-            onClick={open}
-          >{t`View`}</Button>
-          <ActionIcon h="sm" onClick={handleCopy}>
-            <Icon name="copy" size="1rem" />
-          </ActionIcon>
-        </Flex>
-      </MessageContainer>
-      {modalOpen && <ToolCallDetailsModal message={message} onClose={close} />}
-    </>
-  );
-};
 
 export const getFullAgentReply = (
   messages: MetabotChatMessage[],

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -10,6 +10,7 @@ import {
   type MetabotUserChatMessage,
   getActiveToolCalls,
   getAgentErrorMessages,
+  getDebugMode,
   getIsLongMetabotConversation,
   getIsProcessing,
   getMessages,
@@ -59,6 +60,10 @@ export const useMetabotAgent = () => {
 
   const activeToolCalls = useSelector(getActiveToolCalls as any) as ReturnType<
     typeof getActiveToolCalls
+  >;
+
+  const debugMode = useSelector(getDebugMode as any) as ReturnType<
+    typeof getDebugMode
   >;
 
   const setVisible = useCallback(
@@ -176,6 +181,7 @@ export const useMetabotAgent = () => {
     submitInput,
     retryMessage,
     activeToolCalls,
+    debugMode,
     profileOverride,
     reactions,
   };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -8,6 +8,7 @@ import { trackMetabotRequestSent } from "../analytics";
 import {
   type MetabotPromptSubmissionResult,
   type MetabotUserChatMessage,
+  getActiveToolCalls,
   getAgentErrorMessages,
   getIsLongMetabotConversation,
   getIsProcessing,
@@ -17,7 +18,6 @@ import {
   getMetabotRequestId,
   getMetabotVisible,
   getProfileOverride,
-  getToolCalls,
   resetConversation as resetConversationAction,
   retryPrompt,
   setVisible as setVisibleAction,
@@ -57,8 +57,8 @@ export const useMetabotAgent = () => {
     getMetabotRequestId as any,
   ) as ReturnType<typeof getMetabotRequestId>;
 
-  const toolCalls = useSelector(getToolCalls as any) as ReturnType<
-    typeof getToolCalls
+  const activeToolCalls = useSelector(getActiveToolCalls as any) as ReturnType<
+    typeof getActiveToolCalls
   >;
 
   const setVisible = useCallback(
@@ -175,7 +175,7 @@ export const useMetabotAgent = () => {
     startNewConversation,
     submitInput,
     retryMessage,
-    toolCalls,
+    activeToolCalls,
     profileOverride,
     reactions,
   };

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -72,16 +72,13 @@ function setup(
 
   setupEnterprisePlugins();
 
-  const {
-    ui = <Metabot />,
-    currentUser = createMockUser(),
-    metabotPluginInitialState = {
-      ...getMetabotInitialState(),
-      visible: true,
-      useStreaming: true,
-    },
-    promptSuggestions = [],
-  } = options || {};
+  const ui = options?.ui ?? <Metabot />;
+  const currentUser = options?.currentUser ?? createMockUser();
+  const metabotPluginInitialState = options?.metabotPluginInitialState ?? {
+    ...getMetabotInitialState(),
+    visible: true,
+  };
+  const promptSuggestions = options?.promptSuggestions ?? [];
 
   fetchMock.get(
     `path:/api/ee/metabot-v3/metabot/${FIXED_METABOT_IDS.DEFAULT}/prompt-suggestions`,
@@ -1020,6 +1017,58 @@ describe("metabot-streaming", () => {
         ).not.toBeInTheDocument();
       });
       expect(screen.queryByText(/xxxxxxx/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("experimental", () => {
+    describe("debug mode", () => {
+      const mockResponse = () => {
+        mockAgentEndpoint(
+          {
+            textChunks: [
+              `0:"Before"`,
+              `9:{"toolCallId":"debug_test","toolName":"debug_test","args":""}`,
+              `a:{"toolCallId":"debug_test","result":""}`,
+              `0:"After"`,
+              `d:{"finishReason":"stop","usage":{"promptTokens":4916,"completionTokens":8}}`,
+            ],
+          }, // small delay to cause loading state
+        );
+      };
+
+      it("should not show tool_call messages in chat if debug mode is disabled", async () => {
+        setup();
+        mockResponse();
+
+        await enterChatMessage("Don't show me tool call messages");
+        await assertConversation([
+          ["user", "Don't show me tool call messages"],
+          ["agent", "Before"],
+          ["agent", "After"],
+        ]);
+      });
+
+      it("should show tool_call messages in chat if debug mode is enabled", async () => {
+        setup({
+          metabotPluginInitialState: {
+            ...getMetabotInitialState(),
+            visible: true,
+            experimental: {
+              ...getMetabotInitialState().experimental,
+              debugMode: true,
+            },
+          },
+        });
+        mockResponse();
+
+        await enterChatMessage("Don't show me tool call messages");
+        await assertConversation([
+          ["user", "Don't show me tool call messages"],
+          ["agent", "Before"],
+          ["agent", "debug_test"],
+          ["agent", "After"],
+        ]);
+      });
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/metabot.unit.spec.tsx
@@ -72,13 +72,16 @@ function setup(
 
   setupEnterprisePlugins();
 
-  const ui = options?.ui ?? <Metabot />;
-  const currentUser = options?.currentUser ?? createMockUser();
-  const metabotPluginInitialState = options?.metabotPluginInitialState ?? {
-    ...getMetabotInitialState(),
-    visible: true,
-  };
-  const promptSuggestions = options?.promptSuggestions ?? [];
+  const {
+    ui = <Metabot />,
+    currentUser = createMockUser(),
+    metabotPluginInitialState = {
+      ...getMetabotInitialState(),
+      visible: true,
+      useStreaming: true,
+    },
+    promptSuggestions = [],
+  } = options || {};
 
   fetchMock.get(
     `path:/api/ee/metabot-v3/metabot/${FIXED_METABOT_IDS.DEFAULT}/prompt-suggestions`,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -33,13 +33,14 @@ import {
 import {
   getAgentErrorMessages,
   getAgentRequestMetadata,
+  getDebugMode,
   getHistory,
   getIsProcessing,
   getLastMessage,
   getMetabotConversationId,
   getUserPromptForMessageId,
 } from "./selectors";
-import type { SlashCommand } from "./types";
+import type { MetabotStoreState, SlashCommand } from "./types";
 import { createMessageId, parseSlashCommand } from "./utils";
 
 export const {
@@ -54,6 +55,7 @@ export const {
   toolCallEnd,
   setProfileOverride,
   setMetabotReqIdOverride,
+  setDebugMode,
   addSuggestedTransform,
   activateSuggestedTransform,
   deactivateSuggestedTransform,
@@ -105,7 +107,7 @@ export const setVisible =
 
 export const executeSlashCommand = createAsyncThunk<void, SlashCommand>(
   "metabase-enterprise/metabot/executeSlashCommand",
-  async (slashCommand, { dispatch }) => {
+  async (slashCommand, { dispatch, getState }) => {
     match(slashCommand)
       .with({ cmd: "profile" }, ({ args }) => {
         if (args.length <= 1) {
@@ -120,6 +122,18 @@ export const executeSlashCommand = createAsyncThunk<void, SlashCommand>(
         } else {
           dispatch(addUndo({ message: "/metabot <name>" }));
         }
+      })
+      .with({ cmd: "debug" }, () => {
+        const currentDebugMode = getDebugMode(getState() as MetabotStoreState);
+        const newDebugMode = !currentDebugMode;
+        dispatch(setDebugMode(newDebugMode));
+        dispatch(
+          addUndo({
+            message: newDebugMode
+              ? "Debug mode enabled"
+              : "Debug mode disabled",
+          }),
+        );
       })
       .otherwise(() => {
         dispatch(addUndo({ message: "Unknown command" }));

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -113,6 +113,7 @@ export interface MetabotState {
   state: any;
   reactions: MetabotReactionsState;
   activeToolCalls: MetabotToolCall[];
+  debugMode: boolean;
   experimental: {
     metabotReqIdOverride: string | undefined;
     profileOverride: string | undefined;
@@ -132,6 +133,7 @@ export const getMetabotInitialState = (): MetabotState => ({
     suggestedTransforms: [],
   },
   activeToolCalls: [],
+  debugMode: false,
   experimental: {
     metabotReqIdOverride: undefined,
     profileOverride: undefined,
@@ -292,6 +294,9 @@ export const metabot = createSlice({
     },
     setProfileOverride: (state, action: PayloadAction<string | undefined>) => {
       state.experimental.profileOverride = action.payload;
+    },
+    setDebugMode: (state, action: PayloadAction<boolean>) => {
+      state.debugMode = action.payload;
     },
     addSuggestedTransform: (
       state,

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -60,9 +60,9 @@ export type MetabotDebugToolCallMessage = {
   role: "tool";
   type: "tool_call";
   name: string;
-  message: any;
+  args?: Record<string, any>;
   status: "started" | "ended";
-  result?: any;
+  result?: string;
 };
 
 export type MetabotAgentChatMessage =
@@ -200,13 +200,13 @@ export const metabot = createSlice({
       action: PayloadAction<{
         toolCallId: string;
         toolName: string;
-        args: string;
+        args?: string;
       }>,
     ) => {
       const { toolCallId, toolName, args } = action.payload;
       let parsedArgs;
       try {
-        parsedArgs = JSON.parse(args);
+        parsedArgs = args ? JSON.parse(args) : undefined;
       } catch {
         console.warn("Failed to parse tool call args as JSON", args);
         parsedArgs = undefined;
@@ -216,7 +216,7 @@ export const metabot = createSlice({
         role: "tool",
         type: "tool_call",
         name: toolName,
-        message: parsedArgs,
+        args: parsedArgs ?? null,
         status: "started",
       });
       state.activeToolCalls.push({

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -60,7 +60,7 @@ export type MetabotDebugToolCallMessage = {
   role: "agent";
   type: "tool_call";
   name: string;
-  args?: Record<string, any> | string;
+  args?: string;
   status: "started" | "ended";
   result?: string;
 };
@@ -205,19 +205,12 @@ export const metabot = createSlice({
       }>,
     ) => {
       const { toolCallId, toolName, args } = action.payload;
-      let parsedArgs;
-      try {
-        parsedArgs = args ? JSON.parse(args) : undefined;
-      } catch {
-        console.warn("Failed to parse tool call args as JSON", args);
-        parsedArgs = args;
-      }
       state.messages.push({
         id: toolCallId,
         role: "agent",
         type: "tool_call",
         name: toolName,
-        args: parsedArgs,
+        args,
         status: "started",
       });
       state.activeToolCalls.push({

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -112,7 +112,7 @@ export interface MetabotState {
   history: MetabotHistory;
   state: any;
   reactions: MetabotReactionsState;
-  toolCalls: MetabotToolCall[];
+  activeToolCalls: MetabotToolCall[];
   experimental: {
     metabotReqIdOverride: string | undefined;
     profileOverride: string | undefined;
@@ -131,7 +131,7 @@ export const getMetabotInitialState = (): MetabotState => ({
     navigateToPath: null,
     suggestedTransforms: [],
   },
-  toolCalls: [],
+  activeToolCalls: [],
   experimental: {
     metabotReqIdOverride: undefined,
     profileOverride: undefined,
@@ -156,7 +156,7 @@ export const metabot = createSlice({
       state,
       action: PayloadAction<Omit<MetabotAgentChatMessage, "id" | "role">>,
     ) => {
-      state.toolCalls = [];
+      state.activeToolCalls = [];
       state.messages.push({
         id: createMessageId(),
         role: "agent",
@@ -173,7 +173,7 @@ export const metabot = createSlice({
       state.errorMessages.push(action.payload);
     },
     addAgentTextDelta: (state, action: PayloadAction<string>) => {
-      const hasToolCalls = state.toolCalls.length > 0;
+      const hasToolCalls = state.activeToolCalls.length > 0;
       const lastMessage = _.last(state.messages);
       const canAppend =
         !hasToolCalls &&
@@ -191,7 +191,7 @@ export const metabot = createSlice({
         });
       }
 
-      state.toolCalls = hasToolCalls ? [] : state.toolCalls;
+      state.activeToolCalls = hasToolCalls ? [] : state.activeToolCalls;
     },
     toolCallStart: (
       state,
@@ -217,7 +217,7 @@ export const metabot = createSlice({
         message: parsedArgs,
         status: "started",
       });
-      state.toolCalls.push({
+      state.activeToolCalls.push({
         id: toolCallId,
         name: toolName,
         message: TOOL_CALL_MESSAGES[toolName],
@@ -228,7 +228,7 @@ export const metabot = createSlice({
       state,
       action: PayloadAction<{ toolCallId: string; result?: any }>,
     ) => {
-      state.toolCalls = state.toolCalls.map((tc) =>
+      state.activeToolCalls = state.activeToolCalls.map((tc) =>
         tc.id === action.payload.toolCallId ? { ...tc, status: "ended" } : tc,
       );
 
@@ -267,7 +267,7 @@ export const metabot = createSlice({
       state.history = [];
       state.state = {};
       state.isProcessing = false;
-      state.toolCalls = [];
+      state.activeToolCalls = [];
       state.conversationId = uuid();
       state.reactions.suggestedTransforms = [];
       state.experimental.metabotReqIdOverride = undefined;
@@ -344,11 +344,11 @@ export const metabot = createSlice({
       .addCase(sendAgentRequest.fulfilled, (state, action) => {
         state.history = action.payload?.history?.slice() ?? [];
         state.state = { ...(action.payload?.state ?? {}) };
-        state.toolCalls = [];
+        state.activeToolCalls = [];
         state.isProcessing = false;
       })
       .addCase(sendAgentRequest.rejected, (state) => {
-        state.toolCalls = [];
+        state.activeToolCalls = [];
         state.isProcessing = false;
       });
   },

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/reducer.ts
@@ -60,7 +60,7 @@ export type MetabotDebugToolCallMessage = {
   role: "tool";
   type: "tool_call";
   name: string;
-  args?: Record<string, any>;
+  args?: Record<string, any> | string;
   status: "started" | "ended";
   result?: string;
 };
@@ -209,14 +209,14 @@ export const metabot = createSlice({
         parsedArgs = args ? JSON.parse(args) : undefined;
       } catch {
         console.warn("Failed to parse tool call args as JSON", args);
-        parsedArgs = undefined;
+        parsedArgs = args;
       }
       state.messages.push({
         id: toolCallId,
         role: "tool",
         type: "tool_call",
         name: toolName,
-        args: parsedArgs ?? null,
+        args: parsedArgs,
         status: "started",
       });
       state.activeToolCalls.push({

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -29,9 +29,9 @@ export const getMessages = createSelector(
   (metabot) => metabot.messages,
 );
 
-export const getToolCalls = createSelector(
+export const getActiveToolCalls = createSelector(
   getMetabot,
-  (metabot) => metabot.toolCalls,
+  (metabot) => metabot.activeToolCalls,
 );
 
 export const getLastMessage = createSelector(getMessages, (messages) =>

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -34,6 +34,11 @@ export const getActiveToolCalls = createSelector(
   (metabot) => metabot.activeToolCalls,
 );
 
+export const getDebugMode = createSelector(
+  getMetabot,
+  (metabot) => metabot.debugMode,
+);
+
 export const getLastMessage = createSelector(getMessages, (messages) =>
   _.last(messages),
 );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/selectors.ts
@@ -24,19 +24,28 @@ export const getMetabotVisible = createSelector(
   (metabot) => metabot.visible,
 );
 
-export const getMessages = createSelector(
+export const getDebugMode = createSelector(
+  getMetabot,
+  (metabot) => metabot.experimental.debugMode,
+);
+
+const getInternalMessages = createSelector(
   getMetabot,
   (metabot) => metabot.messages,
+);
+
+export const getMessages = createSelector(
+  [getInternalMessages, getDebugMode],
+  (messages, debugMode) => {
+    return debugMode
+      ? messages
+      : messages.filter((msg) => msg.type !== "tool_call");
+  },
 );
 
 export const getActiveToolCalls = createSelector(
   getMetabot,
   (metabot) => metabot.activeToolCalls,
-);
-
-export const getDebugMode = createSelector(
-  getMetabot,
-  (metabot) => metabot.debugMode,
 );
 
 export const getLastMessage = createSelector(getMessages, (messages) =>


### PR DESCRIPTION
Adds a /debug slash command for Metabot that shows tool calls interleaved with normal chat messages. It includes a button on each call to open a modal showing the call's request and response data.

Tool calls are buffered in Metabot's `messages` state array just like normal messages, just with a different type, and are hidden when `/debug` is disabled. I've renamed `state.toolCalls` to `state.activeToolCalls` for clarity, since these are flushed after calls complete. This structure allows you to enable debug mode after chatting with Metabot and see the prior tool calls.

<img width="984" height="410" alt="CleanShot 2025-10-30 at 11 52 21@2x" src="https://github.com/user-attachments/assets/10acf0fd-1e76-4dac-9714-f3fe7ad810ee" />

<img width="1302" height="1610" alt="CleanShot 2025-10-30 at 11 52 30@2x" src="https://github.com/user-attachments/assets/2997c15e-4c84-4586-a0dd-0f076ec73b3f" />