### PR TITLE
[flake] Increase test timeout in metabase.app-db.liquibase-test

### DIFF
--- a/test/metabase/app_db/liquibase_test.clj
+++ b/test/metabase/app_db/liquibase_test.clj
@@ -89,7 +89,7 @@
               (is (= :timed-out (liquibase/wait-for-all-locks sleep-ms timeout-ms)))))
           (testing "Will return successfully if the lock is released while we are waiting"
             (let [migrate-ms 100
-                  timeout-ms 200
+                  timeout-ms 500
                   locked     (promise)]
               (future
                 (liquibase/with-scope-locked liquibase


### PR DESCRIPTION
This occasionally fails on CI, most likely because noisy neighbours and overall CI agents being not very stable to guarantee assertion completion in under 200 ms.
