### PR TITLE
Fix build-e2e-matrix.unit.spec.js tests

### DIFF
--- a/.github/scripts/build-e2e-matrix.unit.spec.js
+++ b/.github/scripts/build-e2e-matrix.unit.spec.js
@@ -11,7 +11,7 @@ describe("buildMatrix", () => {
   it("should calculate correct regular chunks with default parameters", () => {
     const result = testBuildMatrix("./e2e/test/scenarios/**/*.cy.spec.*", 30);
 
-    expect(result.regularChunks).toBe(27);
+    expect(result.regularChunks).toBe(26);
   });
 
   it("should create correct number of configuration objects", () => {
@@ -21,10 +21,10 @@ describe("buildMatrix", () => {
   });
 
   it("should apply default specs path when empty entry is provided", () => {
-    const result = testBuildMatrix("", 5);
+    const result = testBuildMatrix("", 6);
 
     expect(result.regularChunks).toBe(2);
-    expect(result.config.length).toBe(5);
+    expect(result.config.length).toBe(6);
   });
 
   it("should name regular test groups sequentially", () => {
@@ -39,13 +39,14 @@ describe("buildMatrix", () => {
   });
 
   it("should handle case when input chunks equals special tests count", () => {
-    const result = testBuildMatrix("./e2e/test/scenarios/**/*.cy.spec.*", 3);
+    const result = testBuildMatrix("./e2e/test/scenarios/**/*.cy.spec.*", 4);
 
     expect(result.regularChunks).toBe(0);
-    expect(result.config.length).toBe(3);
+    expect(result.config.length).toBe(4);
     expect(result.config[0].name).toBe("embedding-sdk");
     expect(result.config[1].name).toBe("oss-subset");
     expect(result.config[2].name).toBe("mongo");
+    expect(result.config[3].name).toBe("python");
   });
 
   it("should correctly calculate regularChunks for non-default spec pattern", () => {
@@ -83,9 +84,10 @@ describe("buildMatrix", () => {
   it("should return special test configs when default spec pattern is provided", () => {
     const result = testBuildMatrix("./e2e/test/scenarios/**/*.cy.spec.*", 50);
 
-    expect(result.config[47].name).toBe("embedding-sdk");
-    expect(result.config[48].name).toBe("oss-subset");
-    expect(result.config[49].name).toBe("mongo");
+    expect(result.config[46].name).toBe("embedding-sdk");
+    expect(result.config[47].name).toBe("oss-subset");
+    expect(result.config[48].name).toBe("mongo");
+    expect(result.config[49].name).toBe("python");
   });
 
   it("should not return special test configs when non-default spec pattern is provided", () => {


### PR DESCRIPTION
Fix build-e2e-matrix.unit.spec.js tests after https://github.com/metabase/metabase/pull/64749