### PR TITLE
Increase idle transaction timeout for with-temp in python test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms_python/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/execute_test.clj
@@ -116,6 +116,7 @@
                                               :body          long-running-code}
                                      :target (assoc target :database (mt/id))}]
                   (mt/with-temp [:model/Transform transform transform-def]
+                    (t2/query "SET LOCAL idle_in_transaction_session_timeout = 30000") ; mt/with-temp introduces a transaction which postgres might close early!
                     (let [{:keys [run_id]} (try
                                              (transforms-python.execute/execute-python-transform! transform {:run-method :manual})
                                              (catch Exception _


### PR DESCRIPTION
Timeout test flakes with 'connection closed' errors, increasing the idle time of a transaction (with-temp holds a transaction open) to try and mitigate this.