### PR TITLE
Ignore fn-deprecated warnings in cljs logs

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -15,7 +15,8 @@
    :dev        {:output-dir "target/cljs_dev/"
                 :compiler-options {:reader-features #{:cljs-dev}}}
    :compiler-options {:reader-features #{:cljs-release}
-                      :source-map      true}
+                      :source-map      true
+                      :warnings        {:fn-deprecated false}}
    :closure-defines {goog.debug.LOGGING_ENABLED true}
    :entries    [metabase.dashboards.constants
                 metabase.legacy-mbql.js


### PR DESCRIPTION
This should silence the fn-deprecated warnings in CLJS logs.

Kudos and props to @piranha for finding the solution. Slack thread [here](https://metaboat.slack.com/archives/C084XNEPH6K/p1760624372707829).