### PR TITLE
Start utilizing the Trunk Quarantine for E2E tests

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -55,4 +55,3 @@ runs:
         variant: ${{ inputs.variant || inputs.output-name }}
         org-slug: metabase
         token: ${{ inputs.trunk-api-token }}
-      continue-on-error: true

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -171,12 +171,14 @@ jobs:
         if: always()
         with:
           input-path: ./target/junit
+          # Related to our custom upload to S3
           output-name: e2e-${{ inputs.name }}
-          variant: e2e-tests
           bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
           aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
+          # Related to Trunk uploader
+          variant: e2e-tests
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
       - name: Upload Cypress Artifacts upon failure

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -143,6 +143,7 @@ jobs:
             --env grepTags="-@mongo+-@python+-@flaky+-@OSS+-@skip",grepOmitFiltered=true \
             --spec "$SPEC_PATH" \
             --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+        continue-on-error: true
 
       - name: Run Tagged EE Cypress tests on ${{ inputs.name }}
         if: ${{ inputs.specs }}
@@ -155,6 +156,7 @@ jobs:
           --env grepTags="${{inputs.tags && format('{0}+-@skip', inputs.tags) || '-@skip'}}",grepOmitFiltered=true \
           --spec "$SPEC_PATH" \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+        continue-on-error: true
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -143,7 +143,11 @@ jobs:
             --env grepTags="-@mongo+-@python+-@flaky+-@OSS+-@skip",grepOmitFiltered=true \
             --spec "$SPEC_PATH" \
             --browser ${{ steps.cypress-prep.outputs.chrome-path }}
-        continue-on-error: true
+        # Trunk Quarantine controls the final state of the run in the CI!
+        # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
+        # pass the whole job, based on the quarantine list.
+        # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
+        continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
 
       - name: Run Tagged EE Cypress tests on ${{ inputs.name }}
         if: ${{ inputs.specs }}
@@ -156,7 +160,11 @@ jobs:
           --env grepTags="${{inputs.tags && format('{0}+-@skip', inputs.tags) || '-@skip'}}",grepOmitFiltered=true \
           --spec "$SPEC_PATH" \
           --browser ${{ steps.cypress-prep.outputs.chrome-path }}
-        continue-on-error: true
+        # Trunk Quarantine controls the final state of the run in the CI!
+        # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
+        # pass the whole job, based on the quarantine list.
+        # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
+        continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
 
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -1402,6 +1402,7 @@ LIMIT
 
     it("should be able to update a Python query", { tags: ["@python"] }, () => {
       expect(2).to.eq(42);
+
       setPythonRunnerSettings();
       cy.log("create a new transform");
       H.getTableId({ name: "Animals", databaseId: WRITABLE_DB_ID }).then(

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -378,7 +378,7 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
 FROM
   "Schema Q"."Animals"
 LIMIT
-  5`;
+  59086703127`;
 
       createMbqlTransform({ visitTransform: true });
       getTransformPage().findByText("Edit query").click();

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -1401,6 +1401,7 @@ LIMIT
     });
 
     it("should be able to update a Python query", { tags: ["@python"] }, () => {
+      expect(2).to.eq(42);
       setPythonRunnerSettings();
       cy.log("create a new transform");
       H.getTableId({ name: "Animals", databaseId: WRITABLE_DB_ID }).then(

--- a/e2e/test/scenarios/admin/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/admin/transforms.cy.spec.ts
@@ -378,7 +378,7 @@ H.describeWithSnowplowEE("scenarios > admin > transforms", () => {
 FROM
   "Schema Q"."Animals"
 LIMIT
-  59086703127`;
+  5`;
 
       createMbqlTransform({ visitTransform: true });
       getTransformPage().findByText("Edit query").click();
@@ -1401,8 +1401,6 @@ LIMIT
     });
 
     it("should be able to update a Python query", { tags: ["@python"] }, () => {
-      expect(2).to.eq(42);
-
       setPythonRunnerSettings();
       cy.log("create a new transform");
       H.getTableId({ name: "Animals", databaseId: WRITABLE_DB_ID }).then(


### PR DESCRIPTION
Resolves DEV-991

https://docs.trunk.io/flaky-tests/quarantining

This PR sets up e2e workflows to utilize the Trunk Quarantine feature. In order for the Trunk upload action to be able to control the failed/passed state of the whole job, we needed to set the `continue-on-error` to true for steps that run Cypress e2e tests.
