### PR TITLE
Fix devcontainer deprecated apt-keys call

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,6 @@ FROM mcr.microsoft.com/vscode/devcontainers/java:21
 
 RUN ( curl -fsSL https://deb.nodesource.com/setup_22.x | bash ) \
   && export DEBIAN_FRONTEND=noninteractive \
-  && apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com \
   && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig
 
 # install Clojure


### PR DESCRIPTION
Presto kerboros tests are failing because the devcontainer Dockerfile calls `apt-key`, which is deprecated. I guess the base image must have been updated recently. This is causing tests on release branches to fail (or branches that touch presto).

My understanding is we can remove the call: NodeSource should handle its own keys.

Cherry picked from a branch where made I had made a presto chang and was forced to run tests, worked. https://github.com/metabase/metabase/actions/runs/18686209797/job/53279459984?pr=60263
