### PR TITLE
Extend db connection timeout in tests

### DIFF
--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.ts
@@ -326,6 +326,9 @@ H.describeWithSnowplowEE("scenarios > browse (EE)", () => {
     cy.log("Visit Model 1");
     cy.findByRole("heading", { name: "Model 1" }).click();
 
+    cy.log("make sure data is loaded");
+    H.tableInteractive().findByText("Rustic Paper Wallet").should("be.visible");
+
     browseModels();
 
     cy.log("The filter toggle is not visible");

--- a/src/metabase/driver/settings.clj
+++ b/src/metabase/driver/settings.clj
@@ -72,12 +72,12 @@
   :visibility :internal
   :export?    false
   :type       :integer
-  ;; for TESTS use a timeout time of 3 seconds. This is because we have some tests that check whether
+  ;; for TESTS use a timeout time of 5 seconds. This is because we have some tests that check whether
   ;; [[driver/can-connect?]] is failing when it should, and we don't want them waiting 10 seconds to fail.
   ;;
   ;; Don't set the timeout too low -- I've had Circle fail when the timeout was 1000ms on *one* occasion.
   :default    (if config/is-test?
-                3000
+                5000
                 10000)
   :doc "Timeout in milliseconds for connecting to databases, both Metabase application database and data connections.
   In case you're connecting via an SSH tunnel and run into a timeout, you might consider increasing this value as the


### PR DESCRIPTION
We allow for 10 seconds in the app, and 3 seconds in test. I extend that 3 seconds to 5 seconds. This should really only affect bigquery.

In bigquery, we test if you "can connect" by connecting to the project and then attmepting to find any datasets that you are able to see. This is important because each test run connects to the same project but is scoped down to fewer datsets. It's possible we could change this behavior and return if you can list datasets at all, but it is nice if you can see at least one dataset based on your inclusion and exclusion filters.

For reference, the filters for my current CI run are:

```clojure
bigquery-cloud-sdk=> (update details :service-account-json (constantly "<<redacted>>"))
{:project-id nil,
 :service-account-json "<<redacted>>",
 :dataset-filters-type "inclusion",
 :dataset-filters-patterns "sha_4c3ca6238018e2b60025297f3e5c39671588adf2_QLGKZKIAOSQXOGGDURQY",
 :include-user-id-and-hash true,
 :project-id-from-credentials "metabase-bigquery-driver"}
```

In my repl, i'm seeing the following behavior:

```clojure
bigquery-cloud-sdk=> (time (let [client (database-details->client details)
                            project-id (get-project-id details)
                            datasets (.listDatasets client project-id (u/varargs BigQuery$DatasetListOption))
                            ]
                        (vec (for [^Dataset dataset (.iterateAll datasets)
                               :let [dataset-id (.. dataset getDatasetId getDataset)]
                               ]
                           dataset-id))))
"Elapsed time: 2692.292292 msecs"
["BQ_tupac_sightings"
 "Shakespeare"
 ...
 "v6_sample_dataset"]
bigquery-cloud-sdk=> (count *1)
273
```

So just enumerating all datasets takes ~2.7 seconds so we are flirting with the fail limit of 3 seconds.

I extend this to 5 seconds and this should only give a bit of breathing room to bigquery and everything else remains the same.
