### PR TITLE
Lib column unique key

### DIFF
--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -33,6 +33,7 @@
    [metabase.lib.limit :as lib.limit]
    [metabase.lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.metadata.column]
    [metabase.lib.metadata.composed-provider :as lib.metadata.composed-provider]
    [metabase.lib.metadata.protocols]
    [metabase.lib.metric :as lib.metric]
@@ -88,6 +89,7 @@
          lib.limit/keep-me
          metabase.lib.metadata/keep-me
          lib.metadata.calculation/keep-me
+         metabase.lib.metadata.column/keep-me
          lib.metadata.composed-provider/keep-me
          metabase.lib.metadata.protocols/keep-me
          lib.metric/keep-me
@@ -354,6 +356,9 @@
   suggested-name
   type-of
   visible-columns]
+ [metabase.lib.metadata.column
+  column-unique-key
+  column-with-unique-key]
  [lib.metadata.composed-provider
   composed-metadata-provider]
  [metabase.lib.metadata.protocols

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -455,9 +455,9 @@
     [:lib/source ::lib.schema.metadata/column.source]]])
 
 (mr/def ::returned-column
+  "Schema for a returned column as returned by [[returned-columns]]; includes all the normal metadata but is also
+  guaranteed to have `:lib/source`, `:lib/source-column-alias`, and `:lib/desired-column-alias`."
   [:merge
-   ;; visible column is just the normal column metadata schema but also requires `:lib/source` and
-   ;; `:lib/source-column-alias`
    [:ref ::visible-column]
    [:map
     [:lib/desired-column-alias ::lib.schema.metadata/desired-column-alias]]])

--- a/src/metabase/lib/metadata/column.cljc
+++ b/src/metabase/lib/metadata/column.cljc
@@ -1,0 +1,42 @@
+(ns metabase.lib.metadata.column
+  (:require
+   [medley.core :as m]
+   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]))
+
+(mr/def ::column-unique-key
+  [:re
+   #"^column-unique-key-v\d+\$.+$"])
+
+(mr/def ::column-unique-key-version
+  nat-int?)
+
+(mu/defn- pack-unique-key :- ::column-unique-key
+  [version    :- ::column-unique-key-version
+   column-key :- :string]
+  (str "column-unique-key-v" version "$" column-key))
+
+(mu/defn- unpack-unique-key :- [:tuple #_version ::column-unique-key-version #_rest :string]
+  [unique-key :- ::column-unique-key]
+  (let [[_match version-string column-key] (re-find #"^column-unique-key-v(\d+)\$(.+$)" unique-key)]
+    [(parse-long version-string) column-key]))
+
+(mu/defn column-unique-key :- ::column-unique-key
+  "Create a unique key for returned column metadata. Treat this key as opaque!"
+  [col :- ::lib.metadata.calculation/returned-column]
+  (pack-unique-key 1 (:lib/desired-column-alias col)))
+
+(mu/defn column-with-unique-key :- [:maybe ::lib.metadata.calculation/returned-column]
+  "Get metadata for the returned column with `unique-key`."
+  ([query unique-key]
+   (column-with-unique-key query -1 unique-key))
+  ([query        :- ::lib.schema/query
+    stage-number :- :int
+    unique-key   :- ::column-unique-key]
+   (let [[version column-key] (unpack-unique-key unique-key)]
+     (m/find-first
+      (case version
+        1 #(= (:lib/desired-column-alias %) column-key))
+      (lib.metadata.calculation/returned-columns query stage-number)))))

--- a/test/metabase/lib/metadata/column_test.cljc
+++ b/test/metabase/lib/metadata/column_test.cljc
@@ -22,5 +22,5 @@
   (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))]
     (is (thrown-with-msg?
          #?(:clj java.lang.IllegalArgumentException :cljs :default)
-         #"\QNo matching clause: 123456\E"
+         #"No matching clause: 123456"
          (lib.metadata.column/column-with-unique-key query "column-unique-key-v123456$Categories__NAME")))))

--- a/test/metabase/lib/metadata/column_test.cljc
+++ b/test/metabase/lib/metadata/column_test.cljc
@@ -1,0 +1,26 @@
+(ns metabase.lib.metadata.column-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata.column :as lib.metadata.column]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]))
+
+(deftest ^:parallel column-unique-key-test
+  (let [query           (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                            (lib/join (meta/table-metadata :categories)))
+        categories-name (lib.tu.notebook/find-col-with-spec query
+                                                            (lib/returned-columns query)
+                                                            {:display-name "Categories"}
+                                                            {:display-name "Name"})]
+    (is (= "column-unique-key-v1$Categories__NAME"
+           (lib.metadata.column/column-unique-key categories-name)))
+    (is (= categories-name
+           (lib.metadata.column/column-with-unique-key query "column-unique-key-v1$Categories__NAME")))))
+
+(deftest ^:parallel column-unique-key-error-on-unknown-version-test
+  (let [query (lib/query meta/metadata-provider (meta/table-metadata :venues))]
+    (is (thrown-with-msg?
+         #?(:clj java.lang.IllegalArgumentException :cljs :default)
+         #"\QNo matching clause: 123456\E"
+         (lib.metadata.column/column-with-unique-key query "column-unique-key-v123456$Categories__NAME")))))


### PR DESCRIPTION
Requested by the querying team

Adds two functions 

- `lib/column-unique-key` to generate a versions opaque unique key based on a returned column 
- `lib/column-with-unique-key` that given a query and unique key will find and return the appropriate column