### PR TITLE
Add tests for metabot tools snippets and check-transform-dependencies endpoints

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -1427,4 +1427,3 @@
                                         {:arguments {:transform_id transform1-id
                                                      :source modified-source}
                                          :conversation_id conversation-id}))))))))
-


### PR DESCRIPTION
### Description

* Add tests for metabot tools snippets API endpoints
* Add `api/check-404` in `check-transform-dependencies`
* Add test for metabot tools `check-transform-dependencies` endpoint

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
