### PR TITLE
Design polishes for EAJS embed wizard

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
@@ -86,7 +86,7 @@ export const GetCodeStep = () => {
                           cursor="pointer"
                         />
                       </HoverCard.Target>
-                      <HoverCard.Dropdown bg="bg-primary">
+                      <HoverCard.Dropdown>
                         <Text lh="md" p="md" style={{ width: 300 }}>
                           {/* eslint-disable-next-line no-literal-metabase-strings -- this string is only shown for admins. */}
                           {t`This option lets you test Embedded Analytics JS locally using your existing Metabase session cookie. This only works for testing locally, using your admin account and on this browser. This may not work on Safari and Firefox. We recommend testing this in Chrome.`}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
@@ -86,7 +86,7 @@ export const GetCodeStep = () => {
                           cursor="pointer"
                         />
                       </HoverCard.Target>
-                      <HoverCard.Dropdown bg="white">
+                      <HoverCard.Dropdown bg="bg-primary">
                         <Text lh="md" p="md" style={{ width: 300 }}>
                           {/* eslint-disable-next-line no-literal-metabase-strings -- this string is only shown for admins. */}
                           {t`This option lets you test Embedded Analytics JS locally using your existing Metabase session cookie. This only works for testing locally, using your admin account and on this browser. This may not work on Safari and Firefox. We recommend testing this in Chrome.`}

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/GetCodeStep.tsx
@@ -86,8 +86,8 @@ export const GetCodeStep = () => {
                           cursor="pointer"
                         />
                       </HoverCard.Target>
-                      <HoverCard.Dropdown>
-                        <Text size="sm" p="md" style={{ width: 300 }}>
+                      <HoverCard.Dropdown bg="white">
+                        <Text lh="md" p="md" style={{ width: 300 }}>
                           {/* eslint-disable-next-line no-literal-metabase-strings -- this string is only shown for admins. */}
                           {t`This option lets you test Embedded Analytics JS locally using your existing Metabase session cookie. This only works for testing locally, using your admin account and on this browser. This may not work on Safari and Firefox. We recommend testing this in Chrome.`}
                         </Text>

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceRecentItemCard.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceRecentItemCard.module.css
@@ -1,6 +1,6 @@
 .ResourceCard {
   cursor: pointer;
-  border: 2px solid var(--mb-color-border);
+  border: 1px solid var(--mb-color-border);
   transition: border-color 0.2s ease-in-out;
   user-select: none;
 }

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceRecentItemCard.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceRecentItemCard.module.css
@@ -9,6 +9,10 @@
   border-color: var(--mb-color-brand);
 }
 
+.ResourceCard:hover {
+  background: var(--mb-color-background-hover-light);
+}
+
 @media (prefers-reduced-motion) {
   .ResourceCard {
     transition: none;

--- a/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/embedding_iframe_sdk_setup/components/SelectEmbedResourceStep.tsx
@@ -208,11 +208,12 @@ export const SelectEmbedResourceStep = () => {
           </Text>
 
           <ActionIcon
-            variant="outline"
             size="lg"
             title={browseResourceTitle}
             onClick={openPicker}
             data-testid="embed-browse-entity-button"
+            c="text-primary"
+            bd="1px solid var(--mb-color-border)"
           >
             <Icon name="search" size={16} />
           </ActionIcon>

--- a/frontend/src/metabase/lib/colors/colors.ts
+++ b/frontend/src/metabase/lib/colors/colors.ts
@@ -276,7 +276,10 @@ export const colorConfig = {
     light: `color-mix(in srgb, var(--mb-color-brand) 15%, transparent)`, //baseColors.oceanAlpha[10],
     dark: `color-mix(in srgb, var(--mb-color-brand) 15%, transparent)`, //baseColors.oceanAlpha[20],
   },
-
+  "background-hover-light": {
+    light: `color-mix(in srgb, var(--mb-color-brand) 5%, transparent)`, //baseColors.oceanAlpha[5],
+    dark: `color-mix(in srgb, var(--mb-color-brand) 5%, transparent)`, //baseColors.oceanAlpha[10],
+  },
   "background-inverse": {
     light: baseColors.orion[80],
     dark: baseColors.orion[20],


### PR DESCRIPTION
Closes EMB-915

Tiny design changes for the EAJS embed wizard per [this Figma](https://www.figma.com/design/5ZpoBYjn70prjvqDXVfT5e/Embedding-Hub?node-id=15855-994&t=Llwb6QhxoEHFsVfy-4).

### How to verify

It should match the changes from [this Figma](https://www.figma.com/design/5ZpoBYjn70prjvqDXVfT5e/Embedding-Hub?node-id=15855-994&t=Llwb6QhxoEHFsVfy-4):

- Text in the auth popover should be size 14
- Resource card border should be 1px, not 2px
- Add hover state to resource card

<img width="400" alt="CleanShot 2568-10-22 at 04 33 36@2x" src="https://github.com/user-attachments/assets/3582d014-de61-4ec4-8a2b-ac1511db0172" />

<img width="400" alt="CleanShot 2568-10-22 at 04 33 31@2x" src="https://github.com/user-attachments/assets/c88cb8dc-4b37-49d3-8d8e-4b5969de7d15" />

### Demo

<img width="400" alt="CleanShot 2568-10-22 at 04 35 26@2x" src="https://github.com/user-attachments/assets/91b53383-2087-457e-8363-8bed78929b1f" />

<img width="400" alt="CleanShot 2568-10-22 at 04 35 36@2x" src="https://github.com/user-attachments/assets/15f08922-e36e-470b-94bc-ed1d53920321" />
