### PR TITLE
More tests for transform search + transform dependencies tool, and some new future-proofing read checks

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -49,18 +49,19 @@
   suitable for Metabot. Takes a map with :id and :source keys."
   [{:keys [id source]}]
   (try
-    (let [result (if (= (keyword (:type source)) :query)
-                   (let [database-id   (-> source :query :database)
-                         base-provider (lib-be/application-database-metadata-provider database-id)
-                         original      (lib.metadata/transform base-provider id)
-                         _             (api/read-check original)
-                         transform     (cond-> original
-                                         source (assoc :source source))
-                         edits         {:transform [transform]}
-                         breakages     (dependencies/errors-from-proposed-edits base-provider edits)]
-                     (format-broken-transforms id breakages))
-                   ;; If this is a non-SQL query, we don't do any checks yet, so just return success
-                   {:success true :bad_transforms []})]
-      {:structured_output result})
+    (let [transform-to-check (api/check-404 (t2/select-one :model/Transform :id id))]
+      (api/read-check transform-to-check)
+      (let [result (if (= (keyword (:type source)) :query)
+                     (let [database-id       (-> source :query :database)
+                           base-provider     (lib-be/application-database-metadata-provider database-id)
+                           metadata          (lib-be/instance->metadata transform-to-check :metadata/transform)
+                           updated-metadata  (cond-> metadata
+                                               source (assoc :source source))
+                           edits             {:transform [updated-metadata]}
+                           breakages         (dependencies/errors-from-proposed-edits base-provider edits)]
+                       (format-broken-transforms id breakages))
+                     ;; If this is a non-SQL query, we don't do any checks yet, so just return success
+                     {:success true :bad_transforms []})]
+        {:structured_output result}))
     (catch Exception e
       (metabot-v3.tools.u/handle-agent-error e))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -2,8 +2,10 @@
   (:require
    [metabase-enterprise.dependencies.core :as dependencies]
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
+   [metabase.api.common :as api]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.models.interface :as mi]
    [toucan2.core :as t2]))
 
 (def ^:private ^:dynamic *max-reported-broken-transforms* 10)
@@ -20,11 +22,15 @@
                                              (disj broken-transform-ids edited-transform-id)))
                                (take *max-reported-broken-transforms* broken-transform-ids))
         broken-transforms    (when (seq transforms-to-report)
-                               (t2/select [:model/Transform :id :name] :id [:in transforms-to-report]))
+                               (->> (t2/select :model/Transform :id [:in transforms-to-report])
+                                    (filter mi/can-read?)
+                                    (map #(select-keys % [:id :name]))))
         broken-card-ids      (set (keys card-errors))
         cards-to-report      (take *max-reported-broken-transforms* broken-card-ids)
         broken-cards         (when (seq cards-to-report)
-                               (t2/select [:model/Card :id :name] :id [:in cards-to-report]))]
+                               (->> (t2/select :model/Card :id [:in cards-to-report])
+                                    (filter mi/can-read?)
+                                    (map #(select-keys % [:id :name]))))]
     {:success             (empty? broken-transform-ids)
      :bad_transform_count (count broken-transform-ids)
      :bad_transforms      (mapv
@@ -43,17 +49,19 @@
   suitable for Metabot. Takes a map with :id and :source keys."
   [{:keys [id source]}]
   (try
-    (let [result (if (= (keyword (:type source)) :query)
-                   (let [database-id   (-> source :query :database)
-                         base-provider (lib-be/application-database-metadata-provider database-id)
-                         original      (lib.metadata/transform base-provider id)
-                         transform     (cond-> original
-                                         source (assoc :source source))
-                         edits         {:transform [transform]}
-                         breakages     (dependencies/errors-from-proposed-edits base-provider edits)]
-                     (format-broken-transforms id breakages))
-                   ;; If this is a non-SQL query, we don't do any checks yet, so just return success
-                   {:success true :bad_transforms []})]
-      {:structured_output result})
+    (let [transform-to-check (api/check-404 (t2/select-one :model/Transform :id id))]
+      (api/read-check transform-to-check)
+      (let [result (if (= (keyword (:type source)) :query)
+                     (let [database-id   (-> source :query :database)
+                           base-provider (lib-be/application-database-metadata-provider database-id)
+                           original      (lib.metadata/transform base-provider id)
+                           transform     (cond-> original
+                                           source (assoc :source source))
+                           edits         {:transform [transform]}
+                           breakages     (dependencies/errors-from-proposed-edits base-provider edits)]
+                       (format-broken-transforms id breakages))
+                     ;; If this is a non-SQL query, we don't do any checks yet, so just return success
+                     {:success true :bad_transforms []})]
+        {:structured_output result}))
     (catch Exception e
       (metabot-v3.tools.u/handle-agent-error e))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/dependencies.clj
@@ -4,7 +4,6 @@
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.api.common :as api]
    [metabase.lib-be.core :as lib-be]
-   [metabase.lib.metadata :as lib.metadata]
    [metabase.models.interface :as mi]
    [toucan2.core :as t2]))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
@@ -3,7 +3,12 @@
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.tools.dependencies :as metabot.dependencies]
    [metabase.lib.core :as lib]
-   [metabase.test :as mt]))
+   [metabase.models.interface :as mi]
+   [metabase.permissions.models.permissions :as perms]
+   [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 (defmacro with-dependent-transforms!
   "Creates two dependent SQL transforms for testing:
@@ -40,110 +45,212 @@
 
 (deftest check-transform-dependencies-test
   (testing "removing total field from transform1 breaks transform2"
-    (with-dependent-transforms! [transform1-id transform2-id]
-      (let [modified-source {:type "query"
-                             :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}
-            result (metabot.dependencies/check-transform-dependencies
-                    {:id transform1-id
-                     :source modified-source})]
-        (is (false? (get-in result [:structured_output :success])))
-        (is (= 1 (get-in result [:structured_output :bad_transform_count])))
-        (let [bad-transforms (get-in result [:structured_output :bad_transforms])]
-          (is (= 1 (count bad-transforms)))
-          (is (= transform2-id (get-in (first bad-transforms) [:transform :id])))
-          (is (= "Transform 2" (get-in (first bad-transforms) [:transform :name]))))))))
-
-(deftest check-transform-dependencies-limit-test
-  (testing "max-reported-broken-transforms limit"
-    (with-dependent-transforms! [transform1-id _]
-      (mt/with-temp
-        [:model/Transform {transform3-id :id}
-         {:name "Transform 3"
-          :source {:type "query"
-                   :query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
-          :target {:type "table"
-                   :schema "public"
-                   :name "orders_transform_3"}}
-         :model/Dependency {}
-         {:from_entity_type "transform"
-          :from_entity_id   transform3-id
-          :to_entity_type   "transform"
-          :to_entity_id     transform1-id}]
-        (testing "when limit is 1, only one broken transform is reported"
-          (binding [metabot.dependencies/*max-reported-broken-transforms* 1]
-            (let [modified-source {:type "query"
-                                   :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}
-                  result (metabot.dependencies/check-transform-dependencies
-                          {:id transform1-id
-                           :source modified-source})
-                  bad-transforms (get-in result [:structured_output :bad_transforms])]
-              ;; Two downstream transforms should be broken (transform2 + transform3)...
-              (is (false? (get-in result [:structured_output :success])))
-              (is (= 2 (get-in result [:structured_output :bad_transform_count])))
-              ;; ...but only one should be reported due to the limit.
-              (is (= 1 (count bad-transforms))))))))))
-
-(deftest check-transform-dependencies-with-cards-test
-  (testing "removing field from transform breaks dependent card"
-    (with-dependent-transforms! [transform1-id _]
-      (mt/with-temp
-        [:model/Card {card-id :id}
-         {:name "Card using Transform 1"
-          :database_id (mt/id)
-          :table_id (mt/id :orders)
-          :dataset_query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
-         :model/Dependency {}
-         {:from_entity_type "card"
-          :from_entity_id card-id
-          :to_entity_type "transform"
-          :to_entity_id transform1-id}]
+    (mt/as-admin
+      (with-dependent-transforms! [transform1-id transform2-id]
         (let [modified-source {:type "query"
                                :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}
               result (metabot.dependencies/check-transform-dependencies
                       {:id transform1-id
                        :source modified-source})]
           (is (false? (get-in result [:structured_output :success])))
-          (is (= 1 (get-in result [:structured_output :bad_question_count])))
-          (let [bad-questions (get-in result [:structured_output :bad_questions])]
-            (is (= 1 (count bad-questions)))
-            (is (= card-id (get-in (first bad-questions) [:question :id])))
-            (is (= "Card using Transform 1" (get-in (first bad-questions) [:question :name])))
-            (is (some? (:errors (first bad-questions))))))))))
+          (is (= 1 (get-in result [:structured_output :bad_transform_count])))
+          (let [bad-transforms (get-in result [:structured_output :bad_transforms])]
+            (is (= 1 (count bad-transforms)))
+            (is (= transform2-id (get-in (first bad-transforms) [:transform :id])))
+            (is (= "Transform 2" (get-in (first bad-transforms) [:transform :name])))))))))
+
+(deftest check-transform-dependencies-limit-test
+  (testing "max-reported-broken-transforms limit"
+    (mt/as-admin
+      (with-dependent-transforms! [transform1-id _]
+        (mt/with-temp
+          [:model/Transform {transform3-id :id}
+           {:name "Transform 3"
+            :source {:type "query"
+                     :query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
+            :target {:type "table"
+                     :schema "public"
+                     :name "orders_transform_3"}}
+           :model/Dependency {}
+           {:from_entity_type "transform"
+            :from_entity_id   transform3-id
+            :to_entity_type   "transform"
+            :to_entity_id     transform1-id}]
+          (testing "when limit is 1, only one broken transform is reported"
+            (binding [metabot.dependencies/*max-reported-broken-transforms* 1]
+              (let [modified-source {:type "query"
+                                     :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}
+                    result (metabot.dependencies/check-transform-dependencies
+                            {:id transform1-id
+                             :source modified-source})
+                    bad-transforms (get-in result [:structured_output :bad_transforms])]
+                ;; Two downstream transforms should be broken (transform2 + transform3)...
+                (is (false? (get-in result [:structured_output :success])))
+                (is (= 2 (get-in result [:structured_output :bad_transform_count])))
+                ;; ...but only one should be reported due to the limit.
+                (is (= 1 (count bad-transforms)))))))))))
+
+(deftest check-transform-dependencies-with-cards-test
+  (testing "removing field from transform breaks dependent card"
+    (mt/as-admin
+      (with-dependent-transforms! [transform1-id _]
+        (mt/with-temp
+          [:model/Card {card-id :id}
+           {:name "Card using Transform 1"
+            :database_id (mt/id)
+            :table_id (mt/id :orders)
+            :dataset_query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
+           :model/Dependency {}
+           {:from_entity_type "card"
+            :from_entity_id card-id
+            :to_entity_type "transform"
+            :to_entity_id transform1-id}]
+          (let [modified-source {:type "query"
+                                 :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}
+                result (metabot.dependencies/check-transform-dependencies
+                        {:id transform1-id
+                         :source modified-source})]
+            (is (false? (get-in result [:structured_output :success])))
+            (is (= 1 (get-in result [:structured_output :bad_question_count])))
+            (let [bad-questions (get-in result [:structured_output :bad_questions])]
+              (is (= 1 (count bad-questions)))
+              (is (= card-id (get-in (first bad-questions) [:question :id])))
+              (is (= "Card using Transform 1" (get-in (first bad-questions) [:question :name])))
+              (is (some? (:errors (first bad-questions)))))))))))
 
 (deftest check-transform-dependencies-card-limit-test
   (testing "max-reported-broken-transforms limit applies to cards"
+    (mt/as-admin
+      (with-dependent-transforms! [transform1-id _]
+        (mt/with-temp
+          [:model/Card {card1-id :id}
+           {:name "Card 1 using Transform 1"
+            :database_id (mt/id)
+            :table_id (mt/id :orders)
+            :dataset_query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
+           :model/Dependency {}
+           {:from_entity_type "card"
+            :from_entity_id card1-id
+            :to_entity_type "transform"
+            :to_entity_id transform1-id}
+           :model/Card {card2-id :id}
+           {:name "Card 2 using Transform 1"
+            :database_id (mt/id)
+            :table_id (mt/id :orders)
+            :dataset_query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
+           :model/Dependency {}
+           {:from_entity_type "card"
+            :from_entity_id card2-id
+            :to_entity_type "transform"
+            :to_entity_id transform1-id}]
+          (testing "when limit is 1, only one broken card is reported"
+            (binding [metabot.dependencies/*max-reported-broken-transforms* 1]
+              (let [modified-source {:type "query"
+                                     :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}
+                    result (metabot.dependencies/check-transform-dependencies
+                            {:id transform1-id
+                             :source modified-source})
+                    bad-cards (get-in result [:structured_output :bad_questions])]
+               ;; Two cards should be broken...
+                (is (false? (get-in result [:structured_output :success])))
+                (is (= 2 (get-in result [:structured_output :bad_question_count])))
+               ;; ...but only one should be reported due to the limit.
+                (is (= 1 (count bad-cards)))))))))))
+
+(deftest check-transform-dependencies-permission-check-test
+  (testing "Permission check on transform being edited"
+    (with-dependent-transforms! [transform1-id _]
+      (testing "Non-superuser cannot check transform dependencies"
+        (mt/with-test-user :rasta
+          (let [modified-source {:type "query"
+                                 :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}]
+            (is (thrown-with-msg?
+                 Exception
+                 #"You don't have permissions to do that"
+                 (metabot.dependencies/check-transform-dependencies
+                  {:id transform1-id
+                   :source modified-source})))))))))
+
+(deftest check-transform-dependencies-permission-filtering-test
+  (testing "Broken cards in inaccessible collections are filtered from results"
     (with-dependent-transforms! [transform1-id _]
       (mt/with-temp
-        [:model/Card {card1-id :id}
-         {:name "Card 1 using Transform 1"
+        [:model/Collection {restricted-collection-id :id} {:name "Restricted Collection"}
+         :model/Collection {public-collection-id :id} {:name "Public Collection"}
+         :model/Card {public-card-id :id}
+         {:name "Public Card"
+          :collection_id public-collection-id
           :database_id (mt/id)
           :table_id (mt/id :orders)
           :dataset_query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
          :model/Dependency {}
          {:from_entity_type "card"
-          :from_entity_id card1-id
+          :from_entity_id public-card-id
           :to_entity_type "transform"
           :to_entity_id transform1-id}
-         :model/Card {card2-id :id}
-         {:name "Card 2 using Transform 1"
+         :model/Card {restricted-card-id :id}
+         {:name "Restricted Card"
+          :collection_id restricted-collection-id
           :database_id (mt/id)
           :table_id (mt/id :orders)
           :dataset_query (lib/native-query (mt/metadata-provider) "SELECT total FROM orders_transform_1")}
          :model/Dependency {}
          {:from_entity_type "card"
-          :from_entity_id card2-id
+          :from_entity_id restricted-card-id
           :to_entity_type "transform"
           :to_entity_id transform1-id}]
-        (testing "when limit is 1, only one broken card is reported"
-          (binding [metabot.dependencies/*max-reported-broken-transforms* 1]
+        (testing "Superuser sees all broken cards regardless of collection permissions"
+          (mt/with-test-user :crowberto
             (let [modified-source {:type "query"
                                    :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}
                   result (metabot.dependencies/check-transform-dependencies
                           {:id transform1-id
                            :source modified-source})
-                  bad-cards (get-in result [:structured_output :bad_questions])]
-              ;; Two cards should be broken...
-              (is (false? (get-in result [:structured_output :success])))
-              (is (= 2 (get-in result [:structured_output :bad_question_count])))
-              ;; ...but only one should be reported due to the limit.
-              (is (= 1 (count bad-cards))))))))))
+                  broken-question-ids (set (map #(get-in % [:question :id])
+                                                (get-in result [:structured_output :bad_questions])))]
+              ;; Both cards should appear in results for superuser
+              (is (contains? broken-question-ids public-card-id))
+              (is (contains? broken-question-ids restricted-card-id)))))
+        (testing "User with restricted collection access only sees cards they can read"
+          (perms/revoke-collection-permissions! (perms-group/all-users) (u/the-id restricted-collection-id))
+          (perms/grant-collection-read-permissions! (perms-group/all-users) (u/the-id public-collection-id))
+          (mt/with-test-user :rasta
+            (let [original-can-read? mi/can-read?]
+              ;; Temporarily allow rasta to read transforms (but preserve normal card permission checking)
+              ;; Non-superusers can't currently read transforms, but this will change, and until then
+              ;; we can test that broken cards are filtered correctly by read access.
+              (with-redefs [mi/can-read? (fn [instance]
+                                           (if (t2/instance-of? :model/Transform instance)
+                                             true
+                                             (original-can-read? instance)))]
+                (let [modified-source {:type "query"
+                                       :query (lib/native-query (mt/metadata-provider) "SELECT id FROM orders")}
+                      result (metabot.dependencies/check-transform-dependencies
+                              {:id transform1-id
+                               :source modified-source})
+                      broken-question-ids (set (map #(get-in % [:question :id])
+                                                    (get-in result [:structured_output :bad_questions])))]
+                  ;; Rasta should only see the public card, not the restricted one
+                  (is (contains? broken-question-ids public-card-id))
+                  (is (not (contains? broken-question-ids restricted-card-id))))))))))))
+
+(deftest check-transform-dependencies-python-bypass-test
+  (testing "Python transforms bypass dependency checking"
+    (mt/with-test-user :crowberto
+      (mt/with-temp [:model/Transform {python-transform-id :id}
+                     {:name "Python Transform"
+                      :source {:type "python"
+                               :body "print('hello')"
+                               :source-tables {}}
+                      :target {:type "table"
+                               :schema "public"
+                               :name "python_transform_table"}}]
+        (let [modified-source {:type "python"
+                               :body "print('modified')"
+                               :source-tables {}}
+              result (metabot.dependencies/check-transform-dependencies
+                      {:id python-transform-id
+                       :source modified-source})]
+          (is (= {:success true
+                  :bad_transforms []}
+                 (result :structured_output))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
@@ -167,3 +167,44 @@
           (t2/delete! :model/Transform :id transform-id)
           (is (nil? (fetch-one "transform" :model_id (str transform-id)))
               "Transform should be removed from the search index after deletion"))))))
+
+(deftest transform-search-test
+  (mt/with-premium-features #{:transforms}
+    (search.tu/with-temp-index-table
+      (testing "Transforms can be indexed and subsequently searched for"
+        (binding [search.ingestion/*force-sync* true]
+          (mt/with-temp [:model/Transform {transform-id :id}
+                         {:name "Customer Revenue Analysis"
+                          :description "Analyzes revenue by customer segment"
+                          :source {:type "query"
+                                   :query (mt/native-query {:query "SELECT customer_id, SUM(revenue) FROM orders GROUP BY customer_id"})}
+                          :target {:database (mt/id)
+                                   :table "customer_revenue"}}]
+            (ingest! "transform" [:= :this.id transform-id])
+            (testing "Can search by transform name"
+              (let [results (search.tu/search-results "Customer Revenue" {:context :metabot})]
+                (is (seq results) "Search should return results")
+                (is (some #(and (= "transform" (:model %))
+                                (= transform-id (:id %)))
+                          results)
+                    "Results should include the transform")))
+            (testing "Can search by transform description"
+              (let [results (search.tu/search-results "customer segment" {:context :metabot})]
+                (is (some #(and (= "transform" (:model %))
+                                (= transform-id (:id %)))
+                          results)
+                    "Should find transform by description text")))
+            (testing "Can filter search results to transforms only"
+              (mt/with-temp [:model/Card _ {:name "Customer Revenue Card"
+                                            :database_id (mt/id)
+                                            :table_id (mt/id :orders)
+                                            :dataset_query (mt/native-query {:query "SELECT 1"})}]
+                (ingest! "card" [:like :this.name "%Customer Revenue%"])
+                (let [transform-only-results (search.tu/search-results "Customer Revenue" {:models #{"transform"}
+                                                                                           :context :metabot})]
+                  (is (every? #(= "transform" (:model %)) transform-only-results)
+                      "All results should be transforms when filtered"))))
+            (testing "Should not return results for non-metabot contexts"
+              (let [results (search.tu/search-results "Customer Revenue" {:context :command-palette})]
+                (is (not (some #(= "transform" (:model %)) results))
+                    "Results should not include transform")))))))))


### PR DESCRIPTION
* Adds some extra `can-read?` checks to the transform dependency checking API for Metabot so that we silently elide broken cards/transforms that aren't readable by the current user. This should future-proof us for when we open up transforms to be written by more than just superusers.
* Adds another test for transforms search that actually tests fetching a transform via the search endpoint, with some edge cases