### PR TITLE
Opt python logging test out of slower drivers

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -267,7 +267,9 @@
                       :expect-status :failed
                       :expected ["42" "is the answer" "Failed to create the resulting table"]
                       :writeback-ex (Exception. "Boom!")}]]
-      (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+      (mt/test-drivers (-> (mt/normal-drivers-with-feature :transforms/table)
+                           ;; certain drivers are slow/unpredictable enough that the generous timings in this test are not enough
+                           (disj :snowflake :redshift :bigquery-cloud-sdk))
         (mt/with-premium-features #{:transforms :transforms-python}
           (mt/dataset transforms-dataset/transforms-test
             (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]


### PR DESCRIPTION
Known slow (cloud) drivers cannot always meet the generous 'event should occur within' type timing assertions.

For now opting the python transforms logging test out of those drivers to avoid flakes.