### PR TITLE
Update "Create an alert" onboarding video

### DIFF
--- a/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
+++ b/frontend/src/metabase/home/components/Onboarding/Onboarding.tsx
@@ -569,8 +569,8 @@ export const Onboarding = () => {
               <Accordion.Panel>
                 <Stack gap="lg">
                   <VideoTutorial
-                    id="pbkECx-1Cos"
-                    si="r1KRkR0CJ3BmHOOE"
+                    id="MPw5__mVg58"
+                    si="jaUgne1VDg6VXprJ"
                     title="How to create an alert?"
                   />
                   {shouldConfigureCommunicationChannels && (


### PR DESCRIPTION
### Description

We moved the "Create an alert" button from question's sharing menu to question's "..." menu ([PR](https://github.com/metabase/metabase/pull/64510)), so one of the onboarding videos needs to be updated.

Slack: https://metaboat.slack.com/archives/C01LQQ2UW03/p1760089043052449

### How to verify

1. Open sidebar
2. Click "How to use Metabase"
3. Scroll down to "Get alerts when metrics behave unexpectedly" and click it

New video should be there.