### PR TITLE
feat(sdk): plugins passed to the provider are passed down to the dashboard

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/plugins.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/plugins.cy.spec.tsx
@@ -80,7 +80,7 @@ describe("scenarios > embedding-sdk > plugins", () => {
       });
     });
 
-    it("should open a click actions popover with a custom item", () => {
+    it("should open a click actions popover with a custom item from component plugins", () => {
       cy.get<string>("@dashboardId").then((dashboardId) => {
         mountSdkContent(
           <InteractiveDashboard
@@ -93,6 +93,31 @@ describe("scenarios > embedding-sdk > plugins", () => {
             }}
           />,
         );
+      });
+
+      getSdkRoot().within(() => {
+        cy.findByText("Facebook").click();
+
+        cy.findByTestId("click-actions-popover").within(() => {
+          cy.findByText("Custom element").click();
+        });
+
+        cy.findByTestId("click-actions-popover").should("not.exist");
+      });
+    });
+
+    it("should open a click actions popover with a custom item from global plugins (EMB-894)", () => {
+      cy.get<string>("@dashboardId").then((dashboardId) => {
+        mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />, {
+          sdkProviderProps: {
+            pluginsConfig: {
+              mapQuestionClickActions: (clickActions: ClickAction[]) => [
+                ...clickActions,
+                CUSTOM_ACTION_WITH_VIEW,
+              ],
+            },
+          },
+        });
       });
 
       getSdkRoot().within(() => {

--- a/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/enterprise/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
@@ -1,5 +1,8 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
+import { useSdkSelector } from "embedding-sdk-bundle/store";
+import { getPlugins } from "embedding-sdk-bundle/store/selectors";
+import type { MetabasePluginsConfig } from "embedding-sdk-bundle/types/plugins";
 import { PublicOrEmbeddedDashCardMenu } from "metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu";
 import { DASHBOARD_ACTION } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys";
 import { isQuestionCard } from "metabase/dashboard/utils";
@@ -20,14 +23,20 @@ import { interactiveDashboardSchema } from "./InteractiveDashboard.schema";
 export type InteractiveDashboardProps = SdkDashboardProps;
 
 const InteractiveDashboardInner = (props: InteractiveDashboardProps) => {
+  const globalPlugins = useSdkSelector(getPlugins);
+
+  const plugins: MetabasePluginsConfig = useMemo(() => {
+    return { ...globalPlugins, ...props.plugins };
+  }, [globalPlugins, props.plugins]);
+
   const getClickActionMode: ClickActionModeGetter = useCallback(
     ({ question }) =>
       getEmbeddingMode({
         question,
         queryMode: EmbeddingSdkMode,
-        plugins: props.plugins as InternalMetabasePluginsConfig,
+        plugins: plugins as InternalMetabasePluginsConfig,
       }),
-    [props.plugins],
+    [plugins],
   );
 
   return (


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #63992
Closes [EMB-856: \[Modular embedding\] columns of type URL should be clickable](https://linear.app/metabase/issue/EMB-856/modular-embedding-columns-of-type-url-should-be-clickable)

It's implemented in the same way we do for the questions:
https://github.com/metabase/metabase/blob/e51ff44b26418ef06535f4154286b5b1cdd8110f/enterprise/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx#L122-L127