### PR TITLE
Token grace period

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
@@ -44,7 +44,7 @@
       (let [add-on {:product-type product-type}]
         (events/publish-event! :event/cloud-add-on-purchase {:details {:add-on add-on}, :user-id api/*current-user-id*})
         (hm.client/call :change-add-ons :upsert-add-ons [add-on]))
-      (premium-features/clear-cache)
+      (premium-features/clear-cache!)
       {:status 200 :body {}}
       (catch Exception e
         (log/warnf e "Error adding purchasing add-on '%s'" product-type)

--- a/enterprise/backend/src/metabase_enterprise/premium_features/airgap.clj
+++ b/enterprise/backend/src/metabase_enterprise/premium_features/airgap.clj
@@ -46,7 +46,3 @@
 (defenterprise decode-airgap-token
   "Decodes the airgap token and returns the decoded token."
   :feature :none [token] (decode-token token))
-
-(defenterprise token-valid-now?
-  "Check that the decoded token is still valid and returns the decoded token."
-  :feature :none [token-status] (valid-now? token-status))

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -55,9 +55,9 @@
                                               {:terms_of_service true})))))
             (testing "succeeds"
               (let [{store-api-proxy :proxy store-api-calls :calls} (semantic.tu/spy (constantly nil))
-                    {clear-token-cache-proxy :proxy clear-token-cache-calls :calls} (semantic.tu/spy premium-features/clear-cache)]
-                (with-redefs [hm.client/call               store-api-proxy
-                              premium-features/clear-cache clear-token-cache-proxy]
+                    {clear-token-cache-proxy :proxy clear-token-cache-calls :calls} (semantic.tu/spy premium-features/clear-cache!)]
+                (with-redefs [hm.client/call                store-api-proxy
+                              premium-features/clear-cache! clear-token-cache-proxy]
                   (is (=? {}
                           (mt/user-http-request user :post 200 "ee/cloud-add-ons/metabase-ai"
                                                 {:terms_of_service true})))

--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -30,7 +30,7 @@
   plan-alias
   quotas
   TokenStatus
-  clear-cache]
+  clear-cache!]
 
  (metabase.premium-features.settings
   active-users-count

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -200,7 +200,7 @@
   (retrieve [_ token] "Attempt to retrieve features associated with a token. This is best effort, perhaps never set,
   perhaps has timed out. Possible this is nil."))
 
-(mu/defn- fetch-token-status* :- TokenStatus
+(mu/defn- decode-token* :- TokenStatus
   "Decode a token. If you get a positive response about the token, even if it is not valid, return that. Errors will
   be caught further up with appropriate fall backs, retry strategies, and grace periods for features."
   [token :- TokenStr]
@@ -228,7 +228,7 @@
 
 (def ^{:arglists '([token])} decode-token
   "Decode a token. Memoized for 12 hours."
-  (memoize/ttl fetch-token-status* :ttl/threshold token-status-cache-ttl))
+  (memoize/ttl decode-token* :ttl/threshold token-status-cache-ttl))
 
 (defn clear-cache!
   "Clear the token cache so that [[fetch-token-and-parse-body]] will return the latest data."

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -327,9 +327,10 @@
     (reify GracePeriod
       (save! [_ token features] (.put guava-cache token features))
       (retrieve [_ token]
-        (let [value (.get guava-cache token (constantly ::not-present))]
-          (when-not (identical? value ::not-present)
-            value))))))
+        (when token
+          (let [value (.get guava-cache token (constantly ::not-present))]
+            (when-not (identical? value ::not-present)
+              value)))))))
 
 (defonce ^{:doc "A grace period of 36 hours means that token features would be good for 24 hours after the last
   successful token check happens, since we cache those features for 12 hours. Note this records the entire response

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -15,7 +15,9 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util.json :as json]
    [metabase.util.malli.registry :as mr]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (java.util.concurrent TimeUnit)))
 
 (set! *warn-on-reflection* true)
 
@@ -36,15 +38,23 @@
 (use-fixtures :once (fixtures/initialize :db))
 (use-fixtures :each reset-circuit-breaker-fixture)
 
+(def no-op-grace
+  "Grace period that does nothing"
+  (reify token-check/GracePeriod
+    (save! [_ _token _features] nil)
+    (retrieve [_ _token] nil)))
+
 (defn- token-status-response
-  [token token-check-response]
-  (http-fake/with-fake-routes-in-isolation
-    {{:address      (#'token-check/token-status-url token @#'token-check/token-check-url)
-      :query-params (merge (#'token-check/stats-for-token-request)
-                           {:site-uuid  (premium-features.settings/site-uuid-for-premium-features-token-checks)
-                            :mb-version (:tag config/mb-version-info)})}
-     (constantly token-check-response)}
-    (#'token-check/fetch-token-status* token)))
+  ([token token-check-response]
+   (token-status-response token token-check-response no-op-grace))
+  ([token token-check-response grace-period]
+   (http-fake/with-fake-routes-in-isolation
+     {{:address      (#'token-check/token-status-url token @#'token-check/token-check-url)
+       :query-params (merge (#'token-check/stats-for-token-request)
+                            {:site-uuid  (premium-features.settings/site-uuid-for-premium-features-token-checks)
+                             :mb-version (:tag config/mb-version-info)})}
+      (constantly token-check-response)}
+     (#'token-check/fetch-token-status* token grace-period))))
 
 (def ^:private token-response-fixture
   (json/encode {:valid    true
@@ -57,7 +67,7 @@
         print-token (apply str (concat (take 4 token) "..." (take-last 4 token)))]
     (testing "Do not log the token (#18249)"
       (mt/with-log-messages-for-level [messages :info]
-        (#'token-check/fetch-token-status* token)
+        (#'token-check/fetch-token-status* token no-op-grace)
         (let [logs (mapv :message (messages))]
           (is (every? (complement #(re-find (re-pattern token) %)) logs))
           (is (= 1 (count (filter #(re-find (re-pattern print-token) %) logs)))))))))
@@ -76,7 +86,7 @@
       (is (= {:valid         false
               :status        "Unable to validate token"
               :error-details "network issues"}
-             (#'token-check/fetch-token-status (apply str (repeat 64 "b"))))))))
+             (#'token-check/fetch-token-status (apply str (repeat 64 "b")) no-op-grace))))))
 
 (deftest fetch-token-caches-successful-responses
   (testing "For successful responses, the result is cached"
@@ -85,7 +95,7 @@
       (binding [http/request (fn [& _]
                                (swap! call-count inc)
                                {:status 200 :body "{\"valid\": true, \"status\": \"fake\"}"})]
-        (dotimes [_ 10] (#'token-check/fetch-token-status token))
+        (dotimes [_ 10] (#'token-check/fetch-token-status token no-op-grace))
         (is (= 1 @call-count))))))
 
 (deftest fetch-token-caches-invalid-responses
@@ -95,7 +105,7 @@
       (binding [http/request (fn [& _]
                                (swap! call-count inc)
                                {:status 400 :body "{\"valid\": false, \"status\": \"fake\"}"})]
-        (dotimes [_ 10] (#'token-check/fetch-token-status token))
+        (dotimes [_ 10] (#'token-check/fetch-token-status token no-op-grace))
         (is (= 1 @call-count))))))
 
 (deftest fetch-token-does-not-cache-exceptions
@@ -105,10 +115,10 @@
       (binding [http/request (fn [& _]
                                (swap! call-count inc)
                                (throw (ex-info "oh, fiddlesticks" {})))]
-        (dotimes [_ 5] (#'token-check/fetch-token-status token))
+        (dotimes [_ 5] (#'token-check/fetch-token-status token no-op-grace))
         ;; Note that we have a fallback URL that gets hit in this case (see
         ;; https://github.com/metabase/metabase/issues/27036) and 2x5=10
-        (is (= 10 @call-count))))))
+        (is (= 5 @call-count))))))
 
 (deftest fetch-token-does-not-cache-5XX-responses
   (let [call-count (atom 0)
@@ -116,7 +126,7 @@
     (binding [http/request (fn [& _]
                              (swap! call-count inc)
                              {:status 500})]
-      (dotimes [_ 10] (#'token-check/fetch-token-status token))
+      (dotimes [_ 10] (#'token-check/fetch-token-status token no-op-grace))
       ;; Same as above, we have a fallback URL that gets hit in this case (see
       ;; https://github.com/metabase/metabase/issues/27036) and 2x10=20
       (is (= 10 @call-count)))))
@@ -128,7 +138,7 @@
         (is (= {:valid false
                 :status "Unable to validate token"
                 :error-details "Token validation is currently unavailable."}
-               (#'token-check/fetch-token-status (tu/random-token))))
+               (#'token-check/fetch-token-status (tu/random-token) no-op-grace)))
         (is (= 0 @call-count))))))
 
 (deftest ^:parallel fetch-token-status-test-4
@@ -144,26 +154,57 @@
     ;; upstream in Cloud could break this. We probably want to catch that stuff anyway tho in tests rather than waiting
     ;; for bug reports to come in
     (is (partial= {:valid false, :status "Token does not exist."}
-                  (#'token-check/fetch-token-status* (tu/random-token))))))
+                  (#'token-check/fetch-token-status* (tu/random-token) no-op-grace)))))
 
 (deftest fetch-token-does-not-call-db-when-cached
   (testing "No DB calls are made when checking token status if the status is cached"
     (let [token (tu/random-token)
-          _ (#'token-check/fetch-token-status token)
+          _ (#'token-check/fetch-token-status token no-op-grace)
           ;; Sigh. This is really quite horrific. But we need some wiggle room here: any endpoint that gets some setting
           ;; inside it is going to check to see whether it's time for an update check. If it is, it'll hit the DB to see
           ;; when settings were last updated, and the count will be incremented. Therefore, let's do this a few times...
           call-counts (repeatedly 3 (fn []
                                       (t2/with-call-count [call-count]
-                                        (#'token-check/fetch-token-status token)
+                                        (#'token-check/fetch-token-status token no-op-grace)
                                         (call-count))))]
       ;; ... and then make sure that *some* of the times, we didn't hit the DB again.
       (is (some zero? call-counts)))))
 
+(deftest grace-period-test
+  (testing "implementation check"
+    (let [token (tu/random-token)
+          grace (token-check/make-grace-period 20 TimeUnit/MILLISECONDS)]
+      (token-check/save! grace token {:saved :features})
+      (is (= {:saved :features} (token-check/retrieve grace token)))
+      (is (nil? (token-check/retrieve grace (tu/random-token))))
+      (Thread/sleep 50)
+      (testing "Expires tokens after grace period elapses"
+        (is (nil? (token-check/retrieve grace token))))))
+  (testing "Falls back last known value"
+    (let [token (tu/random-token)]
+      (mt/with-temporary-setting-values [premium-embedding-token token]
+        (testing "Initially gets good stuff"
+          (binding [http/request (fn [& _] {:status 200
+                                            :body "{\"valid\":true,\"status\":\"fake\",\"features\":[\"fake\",\"features\"]}"})]
+            (is (= #{"fake" "features"} (token-check/*token-features*)))))
+        (testing "When service goes down, continue in grace period"
+          (let [called? (atom false)]
+           (binding [http/request (fn [& _]
+                                    (reset! called? true)
+                                    {:status 500})]
+             (is (= #{"fake" "features"} (token-check/*token-features*)))
+             (is (not @called?) "We should memoize token values")
+             ;; simulate cache expiration after 12 hours
+             (token-check/clear-cache)
+             (is (= #{"fake" "features"} (token-check/*token-features*)))
+             (is @called? "Did not hit the network!")
+             (is (= {:valid true :status "fake" :features ["fake" "features"]}
+                    (token-check/retrieve token-check/grace-period token))))))))))
+
 (deftest token-status-setting-test
   (testing "If a `premium-embedding-token` has been set, the `token-status` setting should return the response
             from the store.metabase.com endpoint for that token."
-    (mt/with-temporary-raw-setting-values [premium-embedding-token (tu/random-token)]
+    (mt/with-temporary-setting-values [premium-embedding-token (tu/random-token)]
       (is (= {:valid false, :status "Token does not exist."}
              (premium-features/token-status)))))
   (testing "If premium-embedding-token is nil, the token-status setting should also be nil."

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -233,16 +233,6 @@
                (#'token-check/token-information token grace)))
         (is (= 3 @call-count))))))
 
-(comment
-  (-> (first (ns-publics *ns*)) second meta :test)
-  (let [tests (->> (ns-publics *ns*)
-                   (filter (fn [[_s v]] (-> v meta :test))))]
-    (doseq [[ts tv] tests]
-      (println "testing: " ts)
-      (time (clojure.test/run-test-var tv))
-      (dotimes [_ 2] (println "***"))))
-  )
-
 (deftest token-status-setting-test
   (testing "If a `premium-embedding-token` has been set, the `token-status` setting should return the response
             from the store.metabase.com endpoint for that token."

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -199,16 +199,7 @@
               (is (= #{"fake" "features"} (token-check/*token-features*)))
               (is @called? "Did not hit the network!")
               (is (= {:valid true :status "fake" :features ["fake" "features"]}
-                     (token-check/retrieve token-check/grace-period token)))))))))
-  (testing "Setting a new value populates the grace period cache"
-    (let [new-token (tu/random-token)]
-      (binding [http/request (fn [& _] {:status 200
-                                        :body "{\"valid\":true,\"status\":\"fake\",\"features\":[\"fake\",\"features\"]}"})]
-        (mt/discard-setting-changes [premium-embedding-token]
-          (premium-features.settings/premium-embedding-token! new-token)
-          (is (= #{"fake" "features"} (token-check/*token-features*)))
-          (is (= {:valid true :status "fake" :features ["fake" "features"]}
-                 (token-check/retrieve token-check/grace-period new-token))))))))
+                     (token-check/retrieve token-check/grace-period token))))))))))
 
 (deftest token-status-setting-test
   (testing "If a `premium-embedding-token` has been set, the `token-status` setting should return the response

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -81,7 +81,7 @@
       ;; ... and then make sure that *some* of the times, we didn't hit the DB again.
       (is (some zero? call-counts)))))
 
-(deftest tower-test
+(deftest token-checker-test
   (let [token          (tu/random-token)
         behavior       (atom :success)
         call-count     (atom 0)

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -196,8 +196,7 @@
 (deftest e2e
   (testing "token check hits the network"
     (let [storage               (atom {})
-          grace                 #_(token-check/make-grace-period 200 TimeUnit/MILLISECONDS)
-                                (reify token-check/GracePeriod
+          grace                 (reify token-check/GracePeriod
                                   (save! [_ token features] (swap! storage assoc token features))
                                   (retrieve [_ token] (get @storage token)))
           token                 (tu/random-token)

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -600,7 +600,7 @@
   The token-value binding will contain the random token that was set."
   [[token-value] & body]
   `(let [~token-value (premium-features.test-util/random-token)]
-     (with-redefs [metabase.premium-features.token-check/fetch-token-status
+     (with-redefs [metabase.premium-features.token-check/token-information
                    (constantly {:valid    true
                                 :status   "fake"
                                 :features ["test" "fixture"]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -600,7 +600,7 @@
   The token-value binding will contain the random token that was set."
   [[token-value] & body]
   `(let [~token-value (premium-features.test-util/random-token)]
-     (with-redefs [metabase.premium-features.token-check/token-information
+     (with-redefs [metabase.premium-features.token-check/check-token
                    (constantly {:valid    true
                                 :status   "fake"
                                 :features ["test" "fixture"]


### PR DESCRIPTION
Add a grace period to token checks

The gist: create a grace period by which we allow previous token responses to remain in effect when the token checks error.
To achieve this, a new protocol GracePeriod with functions `save! token repsonse` and `retrieve token`. Current implementation is on top of a guava cache that lets us expire keys at 36 hours. It's completely up to the grace period for when retrieve works; the caller doesn't care, it just asks if there is a value in the grace period.

There's a function `decode-token` that will decode an airgapped token or hit our token check service with the token. This function is memoized at 12 hours. This function must return a response `{:valid ... :features}` or throw an error if its unable to decode the token.

Ther function `harness` invokes the above decode token, catches errors, hooks up the rate limiting, saves successful responses into the grace period and provides the grace period value in the case that the `decode-token` function errors.

```
 (*token-features*) ;; call this function to simulate the check of features
Checking with the MetaStore to see whether token 'f325...d01a' is valid...
Reporting Metabase stats: {... user counts etc}
 -> #{"features come back"}
 ;; meanwhile clear cache to simulate elapsing of 12 hours

 (*token-features*) ;; call function again to simulate check of features
2025-10-22 21:30:26,620 INFO premium-features.token-check :: Checking with the MetaStore to see whether token 'f325...d01a' is valid...
2025-10-22 21:30:26,622 ERROR premium-features.token-check :: Error fetching token status from https://token-check.metabase.com:
clojure.lang.ExceptionInfo: network issues ;; hit network issue

2025-10-22 21:30:26,632 INFO premium-features.token-check :: Using token from grace period
->> #{graceperiod network features}
...

;; here after 5 seconds (in real life will be 36 hours)
2025-10-22 21:31:00,064 WARN premium-features.token-check :: Removing token: f325...d01a from grace period cache {mb-quartz-job-type=Cache}
```

Everything else is trying to remove a bunch of complexity down to a single function that takes a token and returns information, clear area where all the caching, retry strategies, and grace periods exist in one lexical scope.


```clojure
metabase.premium-features.token-check=> (-token-status)
{:valid true, :status "Token is valid." :features [...]}
metabase.premium-features.token-check=> ;; turned off wifi
metabase.premium-features.token-check=> (clear-cache!) ;; clears the ttl, simulating expiration
nil
metabase.premium-features.token-check=> (-token-status)
{:valid true, :status "Token is valid." :features [...]}
metabase.premium-features.token-check=> ;; reenabled wifi
metabase.premium-features.token-check=> (-token-status)
{:valid true, :status "Token is valid." :features [...]}
```

And associated logs at the time:

```
;; intial real check
INFO premium-features.token-check :: Checking with the MetaStore to see whether token 'f325...d01a' is valid...
INFO premium-features.token-check :: Reporting Metabase stats: {...}
INFO premium-features.token-check :: Checking with the MetaStore to see whether token 'f325...d01a' is valid...
;; when wifi is off we hit the grace period
INFO premium-features.token-check :: Reporting Metabase stats: {...}
INFO premium-features.token-check :: Using token from grace period
;; wifi is reenabled we try again to hit store
INFO premium-features.token-check :: Checking with the MetaStore to see whether token 'f325...d01a' is valid...
INFO premium-features.token-check :: Reporting Metabase stats: {...}
```