### PR TITLE
Simplify and unify M2 and node-modules caches

### DIFF
--- a/.github/actions/cross-branch-migration-test/action.yml
+++ b/.github/actions/cross-branch-migration-test/action.yml
@@ -17,8 +17,6 @@ runs:
 
     - name: Prepare backend environment
       uses: ./.github/actions/prepare-backend
-      with:
-        m2-cache-key: cross-branch-migrations
 
     - name: Run backend on base branch
       run: |

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -1,7 +1,7 @@
 name: Prepare back-end environment
 description: |
-  Prepare the backend. Installs jdk, Clojure, and fetches the cache for m2. The CI config fetchs `ci-test-config.json`
-  from master and lets us ignore tests at the var level if they are flaking.
+  Prepare the backend. Installs jdk, Clojure, and fetches the cache for m2.
+  The CI config fetches `ci-test-config.json` from master and lets us ignore tests at the var level if they are flaking.
 inputs:
   java-version:
     required: true
@@ -9,10 +9,6 @@ inputs:
   clojure-version:
     required: true
     default: '1.12.0.1488'
-  m2-cache-key:
-    description: 'Key to cache M2 packages from Maven Central'
-    required: true
-    default: 'm2'
 
 runs:
   using: "composite"
@@ -28,16 +24,20 @@ runs:
       run: |
         curl -O https://download.clojure.org/install/linux-install-${{ inputs.clojure-version }}.sh &&
         sudo bash ./linux-install-${{ inputs.clojure-version }}.sh
+
     - name: Fetch CI config
       shell: bash
       run: |
         curl -o ci-test-config.json https://raw.githubusercontent.com/metabase/metabase/refs/heads/master/ci-test-config.json
-    - name: Get M2 cache
-      uses: actions/cache@v4
+
+    - name: Get M2 cache key
+      uses: ./.github/actions/get-cache-keys
+      id: get-cache-keys
+
+    - name: Restore M2 cache
+      uses: actions/cache/restore@v4
       with:
         path: |
           ~/.m2
           ~/.gitlibs
-        key: ${{ runner.os }}-${{ inputs.m2-cache-key }}-${{ hashFiles('**/deps.edn') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ inputs.m2-cache-key }}-
+        key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -12,18 +12,24 @@ runs:
         node-version: ${{ inputs.node-version }} # this overrides, if present
         node-version-file: ".nvmrc"
 
-    - name: Get M2 cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-cljs-${{ hashFiles('**/shadow-cljs.edn') }}
+    - name: Get cache keys
+      uses: ./.github/actions/get-cache-keys
+      id: get-cache-keys
 
-    - name: Get node_modules cache
-      uses: actions/cache@v4
+    - name: Restore M2 cache
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.m2
+          ~/.gitlibs
+        key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
+
+    - name: Restore node_modules cache
+      uses: actions/cache/restore@v4
       id: node-modules-cache
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock', '**/patches/*.patch') }}
+        key: ${{ steps.get-cache-keys.outputs.node-cache-key }}
 
     - run: yarn install --frozen-lockfile --prefer-offline
       shell: bash

--- a/.github/actions/run-embedding-sdk-storybook/action.yml
+++ b/.github/actions/run-embedding-sdk-storybook/action.yml
@@ -7,8 +7,6 @@ runs:
 
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
-      with:
-        m2-cache-key: "cljs"
 
     - name: Compile CLJS
       run: yarn build-pure:cljs

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -15,8 +15,6 @@ runs:
   steps:
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
-      with:
-        m2-cache-key: driver
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
       if: ${{ inputs.build-static-viz == 'true' }}

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cloverage"
       - name: Build static viz frontend
         run: yarn build-static-viz
         env:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: 'kondo'
       - name: Run clj-kondo
         run: ./bin/mage kondo
 
@@ -35,8 +33,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "eastwood"
       - run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood
         name: Run Eastwood linter
 
@@ -112,7 +108,6 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
-          m2-cache-key: be-tests
           java-version: "${{ matrix.java-version }}"
       # Depending on which files changed, we might either have to build static-viz
       # from scratch or download the previously built artifact
@@ -180,8 +175,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare backend
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: be-check
       # TODO -- we should probably also check WITHOUT ee -- do a check with only OSS namespaces on the classpath
       - name: Check namespaces
         run: clojure -M:ee:drivers:check
@@ -195,8 +188,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: 'cljfmt'
       - name: Run cljfmt
         run: ./bin/mage cljfmt-all --force-check
 

--- a/.github/workflows/build-scripts.yml
+++ b/.github/workflows/build-scripts.yml
@@ -16,8 +16,6 @@ jobs:
     - name: Prepare back-end environment
       timeout-minutes: 5
       uses: ./.github/actions/prepare-backend
-      with:
-        m2-cache-key: 'build-scripts'
 
     - name: Run build and release script tests
       run: clojure -X:dev:drivers:build:build-dev:build-test:ci

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -40,8 +40,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - name: Compile CLJS
         run: NODE_ENV=development yarn build-pure:cljs
       - name: Publish to Chromatic

--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -38,7 +38,5 @@ jobs:
       uses: ./.github/actions/prepare-frontend
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
-      with:
-        m2-cache-key: 'cljs'
     - name: Run Cljs tests
       run: yarn run test-cljs

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,8 +14,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - name: Run frontend unit tests
         run: yarn run test-unit --silent --coverage
       - name: Upload coverage to codecov.io

--- a/.github/workflows/docs-generate-base.yml
+++ b/.github/workflows/docs-generate-base.yml
@@ -9,10 +9,6 @@ on:
         description: "The branch to check out and create a PR against"
         required: true
         type: string
-      m2_cache_key_suffix:
-        description: "A unique suffix for the Maven cache key"
-        required: true
-        type: string
     secrets:
       automation_token:
         description: "A token with permissions to create branches and PRs"
@@ -37,8 +33,6 @@ jobs:
 
       - name: Prepare backend environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "auto-update-docs-${{ inputs.m2_cache_key_suffix }}"
 
       - name: Generate environment variables documentation
         id: generate_env_docs

--- a/.github/workflows/docs-master-generate.yml
+++ b/.github/workflows/docs-master-generate.yml
@@ -11,6 +11,5 @@ jobs:
     uses: ./.github/workflows/docs-generate-base.yml
     with:
       target_branch: "master"
-      m2_cache_key_suffix: "master"
     secrets:
       automation_token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}

--- a/.github/workflows/docs-release-generate.yml
+++ b/.github/workflows/docs-release-generate.yml
@@ -11,6 +11,5 @@ jobs:
     uses: ./.github/workflows/docs-generate-base.yml
     with:
       target_branch: "release-x.56.x"
-      m2_cache_key_suffix: "release"
     secrets:
       automation_token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}

--- a/.github/workflows/e2e-component-tests-embedding-sdk-backward-compatibility.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk-backward-compatibility.yml
@@ -112,7 +112,6 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
-          m2-cache-key: uberjar
           java-version: "${{ needs.get-build-requirements.outputs.java_version || 21 }}"
 
       - name: Prepare front-end environment

--- a/.github/workflows/e2e-component-tests-embedding-sdk.yml
+++ b/.github/workflows/e2e-component-tests-embedding-sdk.yml
@@ -83,7 +83,6 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
-          m2-cache-key: uberjar
           java-version: "${{ needs.get-build-requirements.outputs.java_version || 21 }}"
 
       - name: Build uberjar with ./bin/build.sh
@@ -144,8 +143,6 @@ jobs:
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
 
       - name: Retrieve Embedding SDK dist artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
+++ b/.github/workflows/e2e-embedding-sdk-compatibility-tests.yml
@@ -167,7 +167,6 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
-          m2-cache-key: uberjar
           java-version: "${{ needs.get-build-requirements.outputs.java_version || 21 }}"
 
       - name: Build uberjar with ./bin/build.sh

--- a/.github/workflows/embedding-sdk.yml
+++ b/.github/workflows/embedding-sdk.yml
@@ -40,8 +40,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - name: Build Embedding SDK package
         run: |
           # Remove the matchers to not report false positives on every PR

--- a/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
+++ b/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
@@ -43,8 +43,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - name: Build cljs
         run: yarn build:cljs
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -35,8 +35,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - name: Restore ESLint cache
         uses: actions/cache@v4
         with:
@@ -65,8 +63,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - run: yarn build-pure:cljs
         name: Compile CLJS
       - run: yarn type-check-pure
@@ -90,8 +86,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - name: Run frontend unit tests
         run: yarn run test-unit --silent --shard=${{ matrix.shard }}/${{ env.SHARDS }}
       - name: Upload Test Results
@@ -116,8 +110,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - name: Run frontend timezones tests
         run: yarn run test-timezones
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -22,8 +22,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - run: yarn test-unit frontend/src/metabase/querying/expressions/pratt/fuzz.lexifier.unit.spec.ts
         env:
           MB_FUZZ: 1
@@ -38,8 +36,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - run: yarn test-unit frontend/src/metabase/querying/expressions/fuzz.compiler.unit.spec.ts
         env:
           MB_FUZZ: 1
@@ -54,8 +50,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - run: yarn test-unit frontend/src/metabase/querying/expressions/fuzz.string.unit.spec.ts
         env:
           MB_FUZZ: 1

--- a/.github/workflows/generative-query-test.yml
+++ b/.github/workflows/generative-query-test.yml
@@ -40,8 +40,6 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: generative-query-test
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
 

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -38,8 +38,6 @@ jobs:
       uses: ./.github/actions/prepare-frontend
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
-      with:
-        m2-cache-key: 'i18n'
     - name: Install xgettext if necessary
       run: |
         if ! command -v xgettext > /dev/null; then

--- a/.github/workflows/loki-update.yml
+++ b/.github/workflows/loki-update.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
 
       - name: Compile CLJS
         run: yarn build-pure:cljs

--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
 
       - name: Compile CLJS
         run: NODE_ENV=development yarn build-pure:cljs

--- a/.github/workflows/mage.yml
+++ b/.github/workflows/mage.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: 'kondo'
       - name: Setup Babashka
         uses: turtlequeue/setup-babashka@v1.7.0
         with:

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -16,7 +16,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: lint-migrations
       - name: Verify Liquibase Migrations
         run: ./bin/mage lint-migrations

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -254,8 +254,6 @@ jobs:
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "release-sdk"
 
       - name: Run unit tests
         run: yarn embedding-sdk:test-unit
@@ -277,8 +275,6 @@ jobs:
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "release-sdk"
 
       - name: Bump published npm package version
         # NOTE: this should happen before "Build SDK bundle" as we inject SDK version into the code during build step

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,8 +49,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "files-changed"
       - name: Build static-viz frontend
         run: yarn build-static-viz
         env:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: 'snyk'
       - name: Generate all pom.xml
         run: .github/scripts/write-poms.sh
       - name: Upload pom files

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -29,8 +29,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: manage-translations
       - name: install gettext
         run: sudo apt-get install gettext
 

--- a/.github/workflows/tusk-sanity-check.yml
+++ b/.github/workflows/tusk-sanity-check.yml
@@ -46,8 +46,6 @@ jobs:
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: "cljs"
       - run: yarn build-pure:cljs
         name: Compile CLJS
 

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -134,7 +134,6 @@ jobs:
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
-          m2-cache-key: uberjar
           java-version: "${{ needs.get-build-requirements.outputs.java_version || 21 }}"
       - name: Build
         run: ./bin/build.sh

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -27,8 +27,6 @@ jobs:
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
-        with:
-          m2-cache-key: 'update-be-deps'
       - name: Open PRs to Upgrade Backend Deps
         uses: ./.github/actions/upgrade-backend-deps
         with:

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -16,7 +16,5 @@ jobs:
     - uses: actions/checkout@v4
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
-      with:
-        m2-cache-key: 'whitespace-linter'
     - run: clojure -T:whitespace-linter lint
       name: Run Whitespace Linter


### PR DESCRIPTION
Resolves DEV-996
Resolves DEV-1000

<img width="650" height="366" alt="image" src="https://github.com/user-attachments/assets/54315d97-289b-4b2c-a23d-624861af3c1c" />

## What does this PR accomplish?

It applies the unified caching strategy (see #64988) across all backend and frontend workflows. After this PR is merged, only a handful of smaller standalone caches will still operate based on hashFiles, rather than on a week of the year (our caching strategy).

> [!IMPORTANT]
> The caching logic is now contained within the `prepare-backend` and `prepare-frontend` actions. Workflows that call them are no longer able to alter the cache key.

This PR is a part of a [larger initiative](https://linear.app/metabase/project/sane-ci-caches-988905f7dcb8/overview) to take control over the CI caches. We've had a lot of different names for something that is basically M2 cache under the hood. Here's the list of different keys we used:
- auto-update-docs-master,
- auto-update-docs-release,
- cross-branch-migrations,
- cljs, 
- driver, 
- cloverage, 
- kondo, 
- eastwood, 
- be-tests, 
- be-check, 
- cljfmt, 
- build-scripts, 
- uberjar, 
- generative-query-test, 
- i18n, 
- lint-migrations, 
- release-sdk, 
- files-changed, 
- snyk, 
- manage-translations, 
- whitespace-linter, 
- update-be-deps

## Testing

Apart from the CI being green, we can confirm the caching strategy is working by looking at the logs. As you can see [here](https://github.com/metabase/metabase/actions/runs/18782856176/job/53596763432#step:3:192), the jobs are already using the new, unified cache.

<img width="485" height="166" alt="image" src="https://github.com/user-attachments/assets/b8648898-494f-4942-a697-d982874530e8" />
