### PR TITLE
feat(sdk): adds `handleLink` to customize how links should be open

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-bundle/types/metabase-provider.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/types/metabase-provider.ts
@@ -4,7 +4,7 @@ import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 
 import type { MetabaseAuthConfig } from "./auth-config";
 import type { SdkEventHandlersConfig } from "./events";
-import type { MetabasePluginsConfig } from "./plugins";
+import type { MetabaseGlobalPluginsConfig } from "./plugins";
 import type { SdkErrorComponent } from "./ui";
 
 /**
@@ -37,7 +37,7 @@ export interface MetabaseProviderProps {
   /**
    * See [Plugins](https://www.metabase.com/docs/latest/embedding/sdk/plugins).
    */
-  pluginsConfig?: MetabasePluginsConfig;
+  pluginsConfig?: MetabaseGlobalPluginsConfig;
 
   /**
    * See [Global event handlers](https://www.metabase.com/docs/latest/embedding/sdk/config#global-event-handlers).

--- a/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
@@ -40,6 +40,6 @@ export type MetabasePluginsConfig = {
   dashboard?: MetabaseDashboardPluginsConfig;
 };
 
-export type MetabaseGlobalPluginsConfig = {
-  handleLink?: (url: string) => boolean;
-} & MetabasePluginsConfig;
+export type MetabaseGlobalPluginsConfig = MetabasePluginsConfig & {
+  handleLink?: (url: string) => { handled: boolean };
+};

--- a/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
@@ -39,3 +39,7 @@ export type MetabasePluginsConfig = {
   mapQuestionClickActions?: MetabaseClickActionPluginsConfig;
   dashboard?: MetabaseDashboardPluginsConfig;
 };
+
+export type MetabaseGlobalPluginsConfig = {
+  handleLink?: (url: string) => void;
+} & MetabasePluginsConfig;

--- a/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-bundle/types/plugins.ts
@@ -41,5 +41,5 @@ export type MetabasePluginsConfig = {
 };
 
 export type MetabaseGlobalPluginsConfig = {
-  handleLink?: (url: string) => void;
+  handleLink?: (url: string) => boolean;
 } & MetabasePluginsConfig;

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/MetabaseProvider/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/MetabaseProvider/MetabaseProvider.tsx
@@ -10,6 +10,7 @@ import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-me
 import { useSdkLoadingState } from "embedding-sdk-shared/hooks/use-sdk-loading-state";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
+import { SDK_GLOBAL_PLUGINS } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import { SdkLoadingState } from "embedding-sdk-shared/types/sdk-loading";
 
 /**
@@ -100,6 +101,10 @@ export const MetabaseProvider = memo(function MetabaseProvider({
   ...props
 }: MetabaseProviderProps) {
   const ensureSingleInstanceId = useId();
+
+  useEffect(() => {
+    SDK_GLOBAL_PLUGINS.handleLink = props.pluginsConfig?.handleLink;
+  }, [props.pluginsConfig?.handleLink]);
 
   return (
     <ClientSideOnlyWrapper ssrFallback={children}>

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/MetabaseProvider/MetabaseProvider.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/MetabaseProvider/MetabaseProvider.tsx
@@ -10,7 +10,6 @@ import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-me
 import { useSdkLoadingState } from "embedding-sdk-shared/hooks/use-sdk-loading-state";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
-import { SDK_GLOBAL_PLUGINS } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import { SdkLoadingState } from "embedding-sdk-shared/types/sdk-loading";
 
 /**
@@ -101,10 +100,6 @@ export const MetabaseProvider = memo(function MetabaseProvider({
   ...props
 }: MetabaseProviderProps) {
   const ensureSingleInstanceId = useId();
-
-  useEffect(() => {
-    SDK_GLOBAL_PLUGINS.handleLink = props.pluginsConfig?.handleLink;
-  }, [props.pluginsConfig?.handleLink]);
 
   return (
     <ClientSideOnlyWrapper ssrFallback={children}>

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/plugins/HandleLinkPlugin.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/plugins/HandleLinkPlugin.stories.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+
+import { getStorybookSdkAuthConfigForUser } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
+import { useCurrentUser } from "embedding-sdk-package/hooks/public/use-current-user";
+import { getHostedBundleStoryDecorator } from "embedding-sdk-package/test/getHostedBundleStoryDecorator";
+
+import { InteractiveQuestion } from "../InteractiveQuestion";
+import { MetabaseProvider } from "../MetabaseProvider";
+
+const config = getStorybookSdkAuthConfigForUser("admin");
+
+export default {
+  title: "EmbeddingSDK/Plugins/handleLink",
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [getHostedBundleStoryDecorator()],
+  argTypes: {
+    questionId: {
+      control: { type: "number" },
+      description: "Question ID with links to test handleLink plugin",
+    },
+  },
+  args: {
+    questionId: null,
+  } as { questionId: number | null },
+};
+
+const QuestionNotice = () => {
+  return (
+    <div
+      style={{
+        padding: "20px",
+        background: "#fff3cd",
+        border: "1px solid #ffc107",
+        marginBottom: "10px",
+      }}
+    >
+      <p style={{ margin: 0 }}>
+        <strong>Setup Instructions:</strong>{" "}
+        {
+          "This story requires a question id of a question with links. You can use "
+        }
+        <a
+          href="http://metabase.localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImxpYi90eXBlIjoibWJxbC9xdWVyeSIsInN0YWdlcyI6W3sic291cmNlLXRhYmxlIjozLCJsaWIvdHlwZSI6Im1icWwuc3RhZ2UvbWJxbCIsImV4cHJlc3Npb25zIjpbWyJjb25jYXQiLHsibGliL3V1aWQiOiJjZDRlNDM5Yy00OTYwLTRlOWMtOGFkMy1iODQ2Mjk1ZjVmOGYiLCJlZmZlY3RpdmUtdHlwZSI6InR5cGUvVGV4dCIsImxpYi9leHByZXNzaW9uLW5hbWUiOiJHb29nbGUgaXQifSwiaHR0cHM6Ly93d3cuZ29vZ2xlLmNvbS9zZWFyY2g_cT1FQU4lMjAiLFsiZmllbGQiLHsibGliL3V1aWQiOiI2ODkxODJkOS0zNGMzLTQ5NGYtODk4NC1lNmUxODNmNzlmZDAiLCJlZmZlY3RpdmUtdHlwZSI6InR5cGUvVGV4dCIsImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9LDE1XV0sWyJjb25jYXQiLHsibGliL3V1aWQiOiJhNzMzZjNkNS1mZmNkLTQyMGYtOTMwNy1kMDlhOGM0MjBlMjgiLCJsaWIvZXhwcmVzc2lvbi1uYW1lIjoiQmluZyBpdCJ9LCJodHRwczovL3d3dy5iaW5nLmNvbS9zZWFyY2g_cT1FQU4lMjAiLFsiZmllbGQiLHsiZWZmZWN0aXZlLXR5cGUiOiJ0eXBlL1RleHQiLCJsaWIvdXVpZCI6ImI3ZTc2MGY3LTI3ZTktNDZiZS04NGVhLWZhMDIwOTRlMzUzMCIsImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9LDE1XV1dfV0sImRhdGFiYXNlIjoxfSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e30sInR5cGUiOiJxdWVzdGlvbiJ9"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <strong>this question template</strong>
+        </a>
+        . Open it, save it to your Metabase instance, and then enter the
+        question ID in the controls below.
+      </p>
+    </div>
+  );
+};
+
+const AdminUserCheck = () => {
+  const user = useCurrentUser();
+  if (!(user as any)?.is_superuser) {
+    return (
+      <div
+        style={{
+          padding: "20px",
+          background: "#fff3cd",
+          border: "1px solid #ffc107",
+          marginBottom: "10px",
+        }}
+      >
+        {
+          "The storybook user is not set as admin. You may not have the permission to access the question. Go to "
+        }
+        <a
+          href="http://metabase.localhost:3000/admin/people"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          http://metabase.localhost:3000/admin/people
+        </a>
+        {" and make "}
+        <strong>admin@metabase.com</strong>
+        {" an admin."}
+      </div>
+    );
+  }
+  return null;
+};
+
+export const Default = ({ questionId }: { questionId: number }) => {
+  const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
+
+  const handleLink = (url: string) => {
+    setSelectedUrl(url);
+    return { handled: true };
+  };
+
+  if (!questionId) {
+    return <QuestionNotice />;
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+      {selectedUrl && (
+        <div
+          style={{
+            padding: "20px",
+            background: "#e8f5e9",
+            border: "1px solid #4caf50",
+          }}
+        >
+          <p>Selected URL: {selectedUrl}</p>
+        </div>
+      )}
+      <MetabaseProvider authConfig={config} pluginsConfig={{ handleLink }}>
+        <AdminUserCheck />
+
+        <InteractiveQuestion questionId={questionId} />
+      </MetabaseProvider>
+    </div>
+  );
+};

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -104,6 +104,7 @@ export type {
   MetabaseDashboard,
   MetabaseDashboardPluginsConfig,
   MetabaseFontFamily,
+  MetabaseGlobalPluginsConfig,
   MetabasePluginsConfig,
   MetabaseQuestion,
   MetabaseTheme,

--- a/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
@@ -7,7 +7,7 @@ type SdkGlobalPlugins = {
 };
 
 // `MetabaseProvider` and most of the sdk code are in two different bundles,
-// this mean we can't use an exported object as singleton to share the global
+// this means we can't use an exported object as singleton to share the global
 // plugins between them. This function uses `ensureMetabaseProviderPropsStore`
 // to access the provider props across bundles
 export const getSdkGlobalPlugins = (): SdkGlobalPlugins => {

--- a/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
@@ -1,0 +1,14 @@
+type HandleLinkFn = (url: string) => boolean | void;
+
+type SdkGlobalPlugins = {
+  handleLink?: HandleLinkFn;
+};
+
+declare global {
+  interface Window {
+    SDK_GLOBAL_PLUGINS?: SdkGlobalPlugins;
+  }
+}
+
+window.SDK_GLOBAL_PLUGINS = window.SDK_GLOBAL_PLUGINS || {};
+export const SDK_GLOBAL_PLUGINS: SdkGlobalPlugins = window.SDK_GLOBAL_PLUGINS!;

--- a/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
@@ -1,6 +1,6 @@
 import { ensureMetabaseProviderPropsStore } from "./ensure-metabase-provider-props-store";
 
-type HandleLinkFn = (url: string) => boolean;
+type HandleLinkFn = (url: string) => { handled: boolean };
 
 type SdkGlobalPlugins = {
   handleLink?: HandleLinkFn;

--- a/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
@@ -1,14 +1,17 @@
+import { ensureMetabaseProviderPropsStore } from "./ensure-metabase-provider-props-store";
+
 type HandleLinkFn = (url: string) => boolean | void;
 
 type SdkGlobalPlugins = {
   handleLink?: HandleLinkFn;
 };
 
-declare global {
-  interface Window {
-    SDK_GLOBAL_PLUGINS?: SdkGlobalPlugins;
-  }
-}
-
-window.SDK_GLOBAL_PLUGINS = window.SDK_GLOBAL_PLUGINS || {};
-export const SDK_GLOBAL_PLUGINS: SdkGlobalPlugins = window.SDK_GLOBAL_PLUGINS!;
+// `MetabaseProvider` and most of the sdk code are in two different bundles,
+// this mean we can't use an exported object as singleton to share the global
+// plugins between them. This function uses `ensureMetabaseProviderPropsStore`
+// to access the provider props across bundles
+export const getSdkGlobalPlugins = (): SdkGlobalPlugins => {
+  return (
+    ensureMetabaseProviderPropsStore().getState().props?.pluginsConfig || {}
+  );
+};

--- a/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
@@ -1,6 +1,6 @@
 import { ensureMetabaseProviderPropsStore } from "./ensure-metabase-provider-props-store";
 
-type HandleLinkFn = (url: string) => boolean | void;
+type HandleLinkFn = (url: string) => boolean;
 
 type SdkGlobalPlugins = {
   handleLink?: HandleLinkFn;

--- a/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
+++ b/enterprise/frontend/src/embedding-sdk-shared/lib/sdk-global-plugins.ts
@@ -15,3 +15,24 @@ export const getSdkGlobalPlugins = (): SdkGlobalPlugins => {
     ensureMetabaseProviderPropsStore().getState().props?.pluginsConfig || {}
   );
 };
+
+/**
+ * Invokes the handleLink plugin if configured in the host app and returns an object with a 'handled' property, indicating if the host app handled the link.
+ */
+export function handleLinkSdkPlugin(url: string): { handled: boolean } {
+  const globalPlugins = getSdkGlobalPlugins();
+
+  if (!globalPlugins?.handleLink) {
+    return { handled: false };
+  }
+
+  const result = globalPlugins.handleLink(url);
+
+  if (!result || typeof result !== "object" || !("handled" in result)) {
+    throw new Error(
+      "handleLink plugin must return an object with a 'handled' property",
+    );
+  }
+
+  return result;
+}

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -1,7 +1,7 @@
 import querystring from "querystring";
 import _ from "underscore";
 
-import { SDK_GLOBAL_PLUGINS } from "embedding-sdk-shared/lib/sdk-global-plugins";
+import { getSdkGlobalPlugins } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isCypressActive, isStorybookActive } from "metabase/env";
 import MetabaseSettings from "metabase/lib/settings";
@@ -322,9 +322,12 @@ export function open(
   url = ignoreSiteUrl ? url : getWithSiteUrl(url);
 
   // In the react sdk, we allow the host app to override how to open links
-  if (isEmbeddingSdk() && SDK_GLOBAL_PLUGINS.handleLink) {
-    SDK_GLOBAL_PLUGINS.handleLink(url);
-    return;
+  if (isEmbeddingSdk()) {
+    const globalPlugins = getSdkGlobalPlugins();
+    if (globalPlugins?.handleLink) {
+      globalPlugins.handleLink(url);
+      return;
+    }
   }
 
   if (shouldOpenInBlankWindow(url, options)) {

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -1,7 +1,7 @@
 import querystring from "querystring";
 import _ from "underscore";
 
-import { getSdkGlobalPlugins } from "embedding-sdk-shared/lib/sdk-global-plugins";
+import { handleLinkSdkPlugin } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isCypressActive, isStorybookActive } from "metabase/env";
 import MetabaseSettings from "metabase/lib/settings";
@@ -322,21 +322,9 @@ export function open(
   url = ignoreSiteUrl ? url : getWithSiteUrl(url);
 
   // In the react sdk, allow the host app to override how to open links
-  if (isEmbeddingSdk()) {
-    const globalPlugins = getSdkGlobalPlugins();
-    if (globalPlugins?.handleLink) {
-      const result = globalPlugins.handleLink(url);
-
-      if (!result || typeof result !== "object" || !("handled" in result)) {
-        throw new Error(
-          "handleLink plugin must return an object with a 'handled' property (e.g., { handled: true } or { handled: false })",
-        );
-      }
-
-      if (result.handled) {
-        return;
-      }
-    }
+  if (isEmbeddingSdk() && handleLinkSdkPlugin(url).handled) {
+    // Plugin handled the link, don't continue with default behavior
+    return;
   }
 
   if (shouldOpenInBlankWindow(url, options)) {

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -325,8 +325,9 @@ export function open(
   if (isEmbeddingSdk()) {
     const globalPlugins = getSdkGlobalPlugins();
     if (globalPlugins?.handleLink) {
-      globalPlugins.handleLink(url);
-      return;
+      if (globalPlugins.handleLink(url)) {
+        return; // the plugin should return true to prevent the default behavior
+      }
     }
   }
 

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -321,12 +321,21 @@ export function open(
 ) {
   url = ignoreSiteUrl ? url : getWithSiteUrl(url);
 
-  // In the react sdk, we allow the host app to override how to open links
+  // In the react sdk, allow the host app to override how to open links
   if (isEmbeddingSdk()) {
     const globalPlugins = getSdkGlobalPlugins();
-    if (globalPlugins?.handleLink && globalPlugins.handleLink(url)) {
-      // If the plugin returns true, it means they handled the link and we should not continue with the default behavior
-      return;
+    if (globalPlugins?.handleLink) {
+      const result = globalPlugins.handleLink(url);
+
+      if (!result || typeof result !== "object" || !("handled" in result)) {
+        throw new Error(
+          "handleLink plugin must return an object with a 'handled' property (e.g., { handled: true } or { handled: false })",
+        );
+      }
+
+      if (result.handled) {
+        return;
+      }
     }
   }
 

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -1,6 +1,7 @@
 import querystring from "querystring";
 import _ from "underscore";
 
+import { SDK_GLOBAL_PLUGINS } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isCypressActive, isStorybookActive } from "metabase/env";
 import MetabaseSettings from "metabase/lib/settings";
@@ -319,6 +320,12 @@ export function open(
   } = {},
 ) {
   url = ignoreSiteUrl ? url : getWithSiteUrl(url);
+
+  // In the react sdk, we allow the host app to override how to open links
+  if (isEmbeddingSdk() && SDK_GLOBAL_PLUGINS.handleLink) {
+    SDK_GLOBAL_PLUGINS.handleLink(url);
+    return;
+  }
 
   if (shouldOpenInBlankWindow(url, options)) {
     openInBlankWindow(url);

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -324,10 +324,9 @@ export function open(
   // In the react sdk, we allow the host app to override how to open links
   if (isEmbeddingSdk()) {
     const globalPlugins = getSdkGlobalPlugins();
-    if (globalPlugins?.handleLink) {
-      if (globalPlugins.handleLink(url)) {
-        return; // the plugin should return true to prevent the default behavior
-      }
+    if (globalPlugins?.handleLink && globalPlugins.handleLink(url)) {
+      // If the plugin returns true, it means they handled the link and we should not continue with the default behavior
+      return;
     }
   }
 

--- a/frontend/src/metabase/lib/formatting/url.tsx
+++ b/frontend/src/metabase/lib/formatting/url.tsx
@@ -1,5 +1,6 @@
 import cx from "classnames";
 
+import { handleLinkSdkPlugin } from "embedding-sdk-shared/lib/sdk-global-plugins";
 import ExternalLink from "metabase/common/components/ExternalLink";
 import Link from "metabase/common/components/Link";
 import CS from "metabase/css/core/index.css";
@@ -51,8 +52,19 @@ export function formatUrl(value: string, options: OptionsType = {}) {
         </Link>
       );
     }
+
+    const onClickCaptureInSdk = isEmbeddingSdk()
+      ? {
+          onClickCapture: (e: React.MouseEvent<HTMLAnchorElement>) => {
+            if (handleLinkSdkPlugin(url).handled) {
+              e.preventDefault();
+            }
+          },
+        }
+      : {};
+
     return (
-      <ExternalLink className={className} href={url}>
+      <ExternalLink className={className} href={url} {...onClickCaptureInSdk}>
         {text}
       </ExternalLink>
     );

--- a/frontend/test/metabase/lib/dom.unit.spec.js
+++ b/frontend/test/metabase/lib/dom.unit.spec.js
@@ -115,22 +115,6 @@ describe("open()", () => {
     jest.restoreAllMocks();
   });
 
-  it("should call handleLink plugin in the SDK", () => {
-    const handleLink = jest.fn().mockReturnValue(true);
-    getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
-
-    const openInSameWindow = jest.fn();
-    const openInBlankWindow = jest.fn();
-    const url = "https://example.com/dashboard/1";
-
-    open(url, {
-      openInSameWindow,
-      openInBlankWindow,
-    });
-
-    expect(handleLink).toHaveBeenCalledWith(url);
-  });
-
   it("should prevent default behavior when handleLink returns true", () => {
     const handleLink = jest.fn().mockReturnValue(true);
     getSdkGlobalPluginsMock.mockReturnValue({ handleLink });

--- a/frontend/test/metabase/lib/dom.unit.spec.js
+++ b/frontend/test/metabase/lib/dom.unit.spec.js
@@ -119,10 +119,13 @@ describe("open()", () => {
     const handleLink = jest.fn().mockReturnValue(true);
     getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
 
+    const openInSameWindow = jest.fn();
+    const openInBlankWindow = jest.fn();
     const url = "https://example.com/dashboard/1";
+
     open(url, {
-      openInSameWindow: jest.fn(),
-      openInBlankWindow: jest.fn(),
+      openInSameWindow,
+      openInBlankWindow,
     });
 
     expect(handleLink).toHaveBeenCalledWith(url);
@@ -134,8 +137,8 @@ describe("open()", () => {
 
     const openInSameWindow = jest.fn();
     const openInBlankWindow = jest.fn();
-
     const url = "https://example.com/dashboard/1";
+
     open(url, {
       openInSameWindow,
       openInBlankWindow,
@@ -150,11 +153,12 @@ describe("open()", () => {
     const handleLink = jest.fn().mockReturnValue(false);
     getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
 
+    const openInSameWindow = jest.fn();
     const openInBlankWindow = jest.fn();
-
     const url = "https://example.com/dashboard/1";
+
     open(url, {
-      openInSameWindow: jest.fn(),
+      openInSameWindow,
       openInBlankWindow,
     });
 
@@ -167,11 +171,12 @@ describe("open()", () => {
     const handleLink = jest.fn();
     getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
 
+    const openInSameWindow = jest.fn();
     const openInBlankWindow = jest.fn();
-
     const url = "https://example.com/dashboard/1";
+
     open(url, {
-      openInSameWindow: jest.fn(),
+      openInSameWindow,
       openInBlankWindow,
     });
 

--- a/frontend/test/metabase/lib/dom.unit.spec.js
+++ b/frontend/test/metabase/lib/dom.unit.spec.js
@@ -166,6 +166,23 @@ describe("open()", () => {
     expect(openInBlankWindow).toHaveBeenCalledWith(url);
   });
 
+  it("should allow default behavior when handleLink returns undefined", () => {
+    const handleLink = jest.fn().mockReturnValue(undefined);
+    getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
+
+    const openInSameWindow = jest.fn();
+    const openInBlankWindow = jest.fn();
+    const url = "https://example.com/dashboard/1";
+
+    open(url, {
+      openInSameWindow,
+      openInBlankWindow,
+    });
+
+    expect(handleLink).toHaveBeenCalledWith(url);
+    expect(openInBlankWindow).toHaveBeenCalledWith(url);
+  });
+
   it("should not call handleLink when not in embedding SDK", async () => {
     await mockIsEmbeddingSdk(false);
     const handleLink = jest.fn();

--- a/frontend/test/metabase/lib/dom.unit.spec.js
+++ b/frontend/test/metabase/lib/dom.unit.spec.js
@@ -1,3 +1,4 @@
+import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
 import {
   getSelectionPosition,
@@ -98,26 +99,22 @@ describe("getUrlTarget", () => {
 });
 
 describe("open()", () => {
-  let getSdkGlobalPluginsMock;
-
   beforeEach(async () => {
     await mockIsEmbeddingSdk();
-    const sdkPluginsModule = await import(
-      "embedding-sdk-shared/lib/sdk-global-plugins"
-    );
-    getSdkGlobalPluginsMock = jest.spyOn(
-      sdkPluginsModule,
-      "getSdkGlobalPlugins",
-    );
+    // Ensure a clean store before each test
+    ensureMetabaseProviderPropsStore().cleanup();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    ensureMetabaseProviderPropsStore().cleanup();
   });
 
   it("should prevent default behavior when handleLink returns { handled: true }", () => {
     const handleLink = jest.fn().mockReturnValue({ handled: true });
-    getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
+    ensureMetabaseProviderPropsStore().setProps({
+      pluginsConfig: { handleLink },
+    });
 
     const openInSameWindow = jest.fn();
     const openInBlankWindow = jest.fn();
@@ -135,7 +132,9 @@ describe("open()", () => {
 
   it("should allow default behavior when handleLink returns { handled: false }", () => {
     const handleLink = jest.fn().mockReturnValue({ handled: false });
-    getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
+    ensureMetabaseProviderPropsStore().setProps({
+      pluginsConfig: { handleLink },
+    });
 
     const openInSameWindow = jest.fn();
     const openInBlankWindow = jest.fn();
@@ -152,7 +151,9 @@ describe("open()", () => {
 
   it("should throw error when handleLink returns invalid value", () => {
     const handleLink = jest.fn().mockReturnValue(true);
-    getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
+    ensureMetabaseProviderPropsStore().setProps({
+      pluginsConfig: { handleLink },
+    });
 
     const openInSameWindow = jest.fn();
     const openInBlankWindow = jest.fn();
@@ -173,7 +174,9 @@ describe("open()", () => {
   it("should not call handleLink when not in embedding SDK", async () => {
     await mockIsEmbeddingSdk(false);
     const handleLink = jest.fn();
-    getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
+    ensureMetabaseProviderPropsStore().setProps({
+      pluginsConfig: { handleLink },
+    });
 
     const openInSameWindow = jest.fn();
     const openInBlankWindow = jest.fn();

--- a/frontend/test/metabase/lib/dom.unit.spec.js
+++ b/frontend/test/metabase/lib/dom.unit.spec.js
@@ -115,8 +115,8 @@ describe("open()", () => {
     jest.restoreAllMocks();
   });
 
-  it("should prevent default behavior when handleLink returns true", () => {
-    const handleLink = jest.fn().mockReturnValue(true);
+  it("should prevent default behavior when handleLink returns { handled: true }", () => {
+    const handleLink = jest.fn().mockReturnValue({ handled: true });
     getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
 
     const openInSameWindow = jest.fn();
@@ -133,8 +133,8 @@ describe("open()", () => {
     expect(openInBlankWindow).not.toHaveBeenCalled();
   });
 
-  it("should allow default behavior when handleLink returns false", () => {
-    const handleLink = jest.fn().mockReturnValue(false);
+  it("should allow default behavior when handleLink returns { handled: false }", () => {
+    const handleLink = jest.fn().mockReturnValue({ handled: false });
     getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
 
     const openInSameWindow = jest.fn();
@@ -150,21 +150,24 @@ describe("open()", () => {
     expect(openInBlankWindow).toHaveBeenCalledWith(url);
   });
 
-  it("should allow default behavior when handleLink returns undefined", () => {
-    const handleLink = jest.fn().mockReturnValue(undefined);
+  it("should throw error when handleLink returns invalid value", () => {
+    const handleLink = jest.fn().mockReturnValue(true);
     getSdkGlobalPluginsMock.mockReturnValue({ handleLink });
 
     const openInSameWindow = jest.fn();
     const openInBlankWindow = jest.fn();
     const url = "https://example.com/dashboard/1";
 
-    open(url, {
-      openInSameWindow,
-      openInBlankWindow,
-    });
+    expect(() =>
+      open(url, {
+        openInSameWindow,
+        openInBlankWindow,
+      }),
+    ).toThrow(
+      "handleLink plugin must return an object with a 'handled' property",
+    );
 
     expect(handleLink).toHaveBeenCalledWith(url);
-    expect(openInBlankWindow).toHaveBeenCalledWith(url);
   });
 
   it("should not call handleLink when not in embedding SDK", async () => {

--- a/frontend/test/metabase/lib/formatting/url.unit.spec.tsx
+++ b/frontend/test/metabase/lib/formatting/url.unit.spec.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "__support__/ui";
+import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
+import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
+import { formatUrl } from "metabase/lib/formatting/url";
+
+describe("formatUrl", () => {
+  afterEach(() => {
+    ensureMetabaseProviderPropsStore().cleanup();
+    jest.restoreAllMocks();
+  });
+
+  it("calls handleLinkSdkPlugin and prevents default in SDK", async () => {
+    await mockIsEmbeddingSdk(true);
+
+    const url = "https://example.com/dashboard/1";
+    const handleLink = jest.fn().mockReturnValue({ handled: true });
+
+    ensureMetabaseProviderPropsStore().setProps({
+      pluginsConfig: { handleLink },
+    });
+
+    const node = formatUrl(url, { jsx: true, rich: true, view_as: "link" });
+    render(node as unknown as JSX.Element);
+
+    const link = screen.getByRole("link");
+    // Manually creating the event instead of using fireEvent.click because we need to inspect
+    // the defaultPrevented property of the event.
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    link.dispatchEvent(event);
+
+    expect(handleLink).toHaveBeenCalledWith(url);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not call handleLinkSdkPlugin in core app", async () => {
+    await mockIsEmbeddingSdk(false);
+
+    const url = "https://example.com/dashboard/2";
+    const handleLink = jest.fn();
+
+    ensureMetabaseProviderPropsStore().setProps({
+      pluginsConfig: { handleLink },
+    });
+
+    const node = formatUrl(url, { jsx: true, rich: true, view_as: "link" });
+    render(node as unknown as JSX.Element);
+
+    const link = screen.getByRole("link");
+    // Manually creating the event instead of using fireEvent.click because we need to inspect
+    // the defaultPrevented property of the event.
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    link.dispatchEvent(event);
+
+    expect(handleLink).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/rspack.static-viz.config.js
+++ b/rspack.static-viz.config.js
@@ -13,6 +13,8 @@ const CLJS_SRC_PATH_DEV = __dirname + "/target/cljs_dev";
 const LIB_SRC_PATH = __dirname + "/frontend/src/metabase-lib";
 const TYPES_SRC_PATH = __dirname + "/frontend/src/metabase-types";
 const EMBEDDING_SRC_PATH = __dirname + "/enterprise/frontend/src/embedding";
+const SDK_SHARED_SRC_PATH =
+  __dirname + "/enterprise/frontend/src/embedding-sdk-shared";
 const SDK_BUNDLE_SRC_PATH =
   __dirname + "/enterprise/frontend/src/embedding-sdk-bundle";
 const ENTERPRISE_SRC_PATH =
@@ -122,6 +124,7 @@ module.exports = (env) => {
         "metabase-types": TYPES_SRC_PATH,
         embedding: EMBEDDING_SRC_PATH,
         "embedding-sdk-bundle": SDK_BUNDLE_SRC_PATH,
+        "embedding-sdk-shared": SDK_SHARED_SRC_PATH,
         "process/browser": require.resolve("process/browser"),
         "ee-overrides":
           process.env.MB_EDITION === "ee"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-921/implement-handlelink-global-plugin

Slack discussion: https://metaboat.slack.com/archives/C063Q3F1HPF/p1761236665403269

TLDR: implement an easy way for SDK devs to customize how links should be handled, the use case is supporting links to the same domain (ie: they link to a sub page of the react app where they're using the sdk) to allow them to open the links in the same page with client side routing, but also to allow them to do things based on which links is clicked. For example open internal links with client side routing, external links in a new tab, but open links to youtube with a model that embeds the video.

This is only supported at the provider level, not at the component level.

Example usage:
```tsx
export default function App() {
  const navigate = useNavigate();

  const plugins = {
    handleLink: (urlString: string) => {
      const url = new URL(urlString, window.location.origin);
      const isInternal = url.origin === window.location.origin;
      if (isInternal) {
        // client side navigation
        navigate(url.pathname + url.search + url.hash);
        return { handled: true }; // prevent default navigation
      }
      return { handled: false }; // let the sdk do the default behavior
    },
  };

  return (
    <MetabaseProvider authConfig={authConfig} pluginsConfig={plugins}>
      <nav style={{ display: "flex", gap: 12, padding: 12 }}>
        <Link to="/">Home</Link>
        <Link to="/question">Question</Link>
        <Link to="/about">About</Link>
      </nav>
      <div style={{ padding: 12 }}>
        <Outlet />
      </div>
    </MetabaseProvider>
  );
}
```