### PR TITLE
Fix undefined values in mergeVisualizerData for datasets with different lengths (#63787)

### DIFF
--- a/frontend/src/metabase/visualizer/utils/merge-data.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.ts
@@ -31,6 +31,17 @@ type MergeVisualizerSeries = {
   dataSources: VisualizerDataSource[];
 };
 
+function zipRows(rows: RowValues[]): RowValues[] {
+  if (rows.length === 0) {
+    return [];
+  }
+  //_.zip can return undefined, which is not a valid RowValue
+  const maxLength = _.max(rows.map((row) => row.length));
+  return _.range(maxLength).map((index) =>
+    rows.map((row) => row[index] ?? null),
+  );
+}
+
 /**
  * Merges data from multiple datasets into a single dataset.
  *
@@ -79,7 +90,7 @@ export function mergeVisualizerData({
 
   return {
     cols: columns,
-    rows: _.zip(...unzippedRows),
+    rows: zipRows(unzippedRows),
     results_metadata: { columns },
   };
 }

--- a/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
+++ b/frontend/src/metabase/visualizer/utils/merge-data.unit.spec.ts
@@ -1,0 +1,108 @@
+import { NumberColumn, StringColumn } from "__support__/visualizations";
+import { createMockColumn, createMockDataset } from "metabase-types/api/mocks";
+
+import { mergeVisualizerData } from "./merge-data";
+
+describe("mergeVisualizerData", () => {
+  it("should combine datasets with different lengths without introducing undefined values", () => {
+    const result = mergeVisualizerData({
+      columns: [
+        createMockColumn(StringColumn({ name: "COLUMN_1" })),
+        createMockColumn(NumberColumn({ name: "COLUMN_2" })),
+        createMockColumn(NumberColumn({ name: "COLUMN_3" })),
+        createMockColumn(StringColumn({ name: "COLUMN_4" })),
+      ],
+      columnValuesMapping: {
+        COLUMN_1: [
+          {
+            sourceId: "card:1",
+            originalName: "CREATED_AT",
+            name: "COLUMN_1",
+          },
+        ],
+        COLUMN_2: [
+          {
+            sourceId: "card:1",
+            originalName: "count",
+            name: "COLUMN_2",
+          },
+        ],
+        COLUMN_3: [
+          {
+            sourceId: "card:2",
+            originalName: "count",
+            name: "COLUMN_3",
+          },
+        ],
+        COLUMN_4: [
+          {
+            sourceId: "card:2",
+            originalName: "CREATED_AT",
+            name: "COLUMN_4",
+          },
+        ],
+      },
+      datasets: {
+        "card:1": createMockDataset({
+          data: {
+            cols: [
+              createMockColumn(StringColumn({ name: "CREATED_AT" })),
+              createMockColumn(NumberColumn({ name: "count" })),
+            ],
+            rows: [
+              ["2025-01-01", 1],
+              ["2025-01-02", 2],
+              ["2025-01-03", 3],
+            ],
+          },
+        }),
+        "card:2": createMockDataset({
+          data: {
+            cols: [
+              createMockColumn(NumberColumn({ name: "count" })),
+              createMockColumn(StringColumn({ name: "CREATED_AT" })),
+            ],
+            rows: [
+              [4, "2025-01-01"],
+              [5, "2025-01-02"],
+              [6, "2025-01-03"],
+              [7, "2025-01-04"],
+            ],
+          },
+        }),
+      },
+      dataSources: [
+        {
+          id: "card:1",
+          sourceId: 1,
+          type: "card",
+          name: "Chart 1",
+        },
+        {
+          id: "card:2",
+          sourceId: 2,
+          type: "card",
+          name: "Chart 2",
+        },
+      ],
+    });
+
+    expect(result.rows).toEqual([
+      ["2025-01-01", 1, 4, "2025-01-01"],
+      ["2025-01-02", 2, 5, "2025-01-02"],
+      ["2025-01-03", 3, 6, "2025-01-03"],
+      [null, null, 7, "2025-01-04"],
+    ]);
+  });
+
+  it("should handle being called with no data", () => {
+    const result = mergeVisualizerData({
+      columns: [],
+      columnValuesMapping: {},
+      datasets: {},
+      dataSources: [],
+    });
+
+    expect(result.rows).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #63787

### Description

`mergeVisualizerData` was using underscore's `zip` function to combine rows from multiple datasets. When datasets have different lengths, `zip` introduces `undefined` values, but `undefined` is not a valid `RowValue`. These `undefined` values eventually reach `getXAxisDateRangeFromSortedXAxisValues`, which handles `null` but not `undefined` properly, causing the bug.

This PR replaces `_.zip` with a custom `zipRows` function that converts `undefined` to `null` when datasets have different lengths.

### How to verify

Refer to #63787 for the steps to recreate. The below screenshot shows the fixed X axis after applying the change.

### Demo

<img width="1084" height="558" alt="image" src="https://github.com/user-attachments/assets/07b6c9b7-09fb-4f0d-9e94-b8778dd93fc4" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
