### PR TITLE
Remove docs/ from Docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .babel_cache
-docs/*
 target/*
 .circleci
 .cpcache


### PR DESCRIPTION
Recreating from fork PR https://github.com/metabase/metabase/pull/64928 so that we can have CI properly working.

Closes https://github.com/metabase/metabase/issues/64958

**Original description:**

Removing docs from docker ignore because they are now used in `useEngineDocMarkdownContent` with a dynamic import for

```
import(`docs/databases/connections/${docFileName}.md`)
```

# Steps to produce
- clone repo
- `docker build -t metabase`
Will fail on docs path alias not found

cc: @andsalves related to pr https://github.com/metabase/metabase/pull/63420