### PR TITLE
Fix timelines-question.cy.spec.js flakiness

### DIFF
--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -338,7 +338,7 @@ describe("scenarios > organization > timelines > question", () => {
         cy.findByLabelText("Event name").type("RC2");
         cy.findByLabelText("Date").clear().type("10/20/2023");
         cy.button("Create").click();
-        cy.wait("@createEvent");
+        waitForTimelinesAfterCreatingAnEvent("RC2");
 
         H.undoToast().icon("close").click();
         H.echartsIcon("star").should("be.visible");
@@ -413,6 +413,7 @@ describe("scenarios > organization > timelines > question", () => {
 
           cy.button("Create").click();
         });
+        waitForTimelinesAfterCreatingAnEvent("Event at the end of range");
 
         H.modal().should("not.exist"); // wait for modal to close
 
@@ -590,4 +591,10 @@ function toggleEventVisibility(eventName) {
 
 function timelineEventVisibility(eventName) {
   return timelineEventCard(eventName).findByRole("checkbox");
+}
+
+function waitForTimelinesAfterCreatingAnEvent(eventName) {
+  return timelineEventCard(eventName)
+    .findByText(/^Bobby Tables added this on/)
+    .should("be.visible");
 }


### PR DESCRIPTION
Reported [in Slack](https://metaboat.slack.com/archives/C505ZNNH4/p1761224171419739?thread_ts=1761223325.045649&cid=C505ZNNH4)
closes DEV-998
### Backport reasons
double-backporting this because the [PR that modified this test](https://github.com/metabase/metabase/pull/64801) double-backported.

### Description

Caused by https://github.com/metabase/metabase/pull/64801. Fix the race condition on our test. This happened because after clicking the checkbox, the timeline got updated from the API, so the unchecked checkbox was reset to checked again.

### How to verify

Stress tests all pass.
- [Stress test: master](https://github.com/metabase/metabase/actions/runs/18773103938) ❌ 16/20 passed
- [Stress test: PR](https://github.com/metabase/metabase/actions/runs/18774069017) ✅ 20/20 passed


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
