### PR TITLE
Enable Trunk Quarantine for drivers

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -46,3 +46,4 @@ runs:
         name: test-logs-${{ github.job }}
         path: logs/test-log.json
         retention-days: 1
+      continue-on-error: true

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -28,7 +28,11 @@ runs:
       run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
       id: run-test
-      continue-on-error: true # this is crucial for the Trunk Quarantine to work
+      # Trunk Quarantine controls the final state of the run in the CI!
+      # Even if this step fails, we let it pass and then `trunk-io/analytics-uploader` determines whether to fail or to
+      # pass the whole job, based on the quarantine list.
+      # We only want to "continue on error" (ignore failures) when the Trunk upload is active - i.e. not on drafts!
+      continue-on-error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.draft == true) }}
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
       if: ${{ steps.run-test.outcome == 'failure' }}
@@ -46,4 +50,5 @@ runs:
         name: test-logs-${{ github.job }}
         path: logs/test-log.json
         retention-days: 1
+      # Failing to upload the artifact should never affect the outcome of the whole test run.
       continue-on-error: true

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -27,9 +27,11 @@ runs:
     - name: Test database driver
       run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
+      id: run-test
+      continue-on-error: true # this is crucial for the Trunk Quarantine to work
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
-      if: failure()
+      if: ${{ steps.run-test.outcome == 'failure' }}
       with:
         path: "target/junit/**/*_test.xml"
         name: JUnit Test Report ${{ inputs.junit-name }}
@@ -38,7 +40,7 @@ runs:
         list-tests: failed
         fail-on-error: false
     - name: Upload Logs on Failure
-      if: always() && !success()
+      if: ${{ steps.run-test.outcome == 'failure' }}
       uses: actions/upload-artifact@v4
       with:
         name: test-logs-${{ github.job }}


### PR DESCRIPTION
This pull request updates the `.github/actions/test-driver/action.yml` workflow to improve how test failures are handled and reported in CI. The main changes ensure that test report publishing and log uploads are triggered more reliably based on the actual test outcome, and that CI jobs behave correctly when tests are quarantined or when artifacts fail to upload.

**Test failure handling and reporting:**

* The test step now uses the `id: run-test` identifier and sets `continue-on-error` dynamically, allowing quarantined tests to pass or fail the job based on the Trunk quarantine list, rather than failing immediately.
* The "Publish Test Report (JUnit)" step now checks the outcome of the test step (`steps.run-test.outcome == 'failure'`) instead of a generic `failure()` condition, ensuring reports are only published when tests actually fail.

**Artifact upload reliability:**

* The "Upload Logs on Failure" step now triggers only when the test step fails (`steps.run-test.outcome == 'failure'`) and is set to always continue on error, so failures in uploading logs do not affect the overall job outcome.

## How to test?

You can see the mechanism working here
<img width="1011" height="394" alt="Screenshot 2025-10-29 at 01 16 45" src="https://github.com/user-attachments/assets/2b1cbcbd-b7dd-44ff-b5c6-79306e83bf33" />

<img width="930" height="265" alt="image" src="https://github.com/user-attachments/assets/bd733643-3623-40f8-963d-aa3b5fa3ed56" />
